### PR TITLE
Add input type flag

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -4,7 +4,7 @@
 from datatypes import Enum, Flags, NetArray, NetBool, NetEvent, NetEventEx, NetIntAny, NetIntRange, NetMessage, NetMessageEx, NetObject, NetObjectEx, NetString, NetStringHalfStrict, NetStringStrict, NetTick
 
 Emotes = ["NORMAL", "PAIN", "HAPPY", "SURPRISE", "ANGRY", "BLINK"]
-PlayerFlags = ["PLAYING", "IN_MENU", "CHATTING", "SCOREBOARD", "AIM", "SPEC_CAM"]
+PlayerFlags = ["PLAYING", "IN_MENU", "CHATTING", "SCOREBOARD", "AIM", "SPEC_CAM", "INPUT_ABSOLUTE"]
 GameFlags = ["TEAMS", "FLAGS"]
 GameStateFlags = ["GAMEOVER", "SUDDENDEATH", "PAUSED", "RACETIME"]
 CharacterFlags = ["SOLO", "JETPACK", "COLLISION_DISABLED", "ENDLESS_HOOK", "ENDLESS_JUMP", "SUPER",

--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -315,6 +315,7 @@ void CCamera::OnRender()
 		{
 			m_aLastPos[g_Config.m_ClDummy] = m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy];
 			m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy] = m_PrevCenter;
+			m_pClient->m_Controls.m_aInputType[g_Config.m_ClDummy] = CControls::INPUT_TYPE_AUTOMATED;
 			m_pClient->m_Controls.ClampMousePos();
 			m_CamType = CAMTYPE_SPEC;
 		}
@@ -325,6 +326,7 @@ void CCamera::OnRender()
 		if(m_CamType != CAMTYPE_PLAYER)
 		{
 			m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy] = m_aLastPos[g_Config.m_ClDummy];
+			m_pClient->m_Controls.m_aInputType[g_Config.m_ClDummy] = CControls::INPUT_TYPE_AUTOMATED;
 			m_pClient->m_Controls.ClampMousePos();
 			m_CamType = CAMTYPE_PLAYER;
 		}
@@ -338,6 +340,7 @@ void CCamera::OnRender()
 	if(m_ForceFreeview && m_CamType == CAMTYPE_SPEC)
 	{
 		m_Center = m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy] = m_ForceFreeviewPos;
+		m_pClient->m_Controls.m_aInputType[g_Config.m_ClDummy] = CControls::INPUT_TYPE_AUTOMATED;
 		m_ForceFreeview = false;
 	}
 	else

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -22,6 +22,7 @@ CControls::CControls()
 	mem_zero(m_aMousePos, sizeof(m_aMousePos));
 	mem_zero(m_aMousePosOnAction, sizeof(m_aMousePosOnAction));
 	mem_zero(m_aTargetPos, sizeof(m_aTargetPos));
+	mem_zero(m_aInputType, sizeof(m_aInputType));
 }
 
 void CControls::OnReset()
@@ -197,6 +198,11 @@ int CControls::SnapInput(int *pData)
 	if(Client()->ServerCapAnyPlayerFlag() && m_pClient->m_Camera.CamType() == CCamera::CAMTYPE_SPEC)
 		m_aInputData[g_Config.m_ClDummy].m_PlayerFlags |= PLAYERFLAG_SPEC_CAM;
 
+	if(m_aInputType[g_Config.m_ClDummy] != CControls::INPUT_TYPE_RELATIVE)
+	{
+		m_aInputData[g_Config.m_ClDummy].m_PlayerFlags |= PLAYERFLAG_INPUT_ABSOLUTE;
+	}
+
 	bool Send = m_aLastData[g_Config.m_ClDummy].m_PlayerFlags != m_aInputData[g_Config.m_ClDummy].m_PlayerFlags;
 
 	m_aLastData[g_Config.m_ClDummy].m_PlayerFlags = m_aInputData[g_Config.m_ClDummy].m_PlayerFlags;
@@ -370,7 +376,10 @@ bool CControls::OnCursorMove(float x, float y, IInput::ECursorType CursorType)
 	{
 		vec2 AbsoluteDirection;
 		if(Input()->GetActiveJoystick()->Absolute(&AbsoluteDirection.x, &AbsoluteDirection.y))
+		{
 			m_aMousePos[g_Config.m_ClDummy] = AbsoluteDirection * GetMaxMouseDistance();
+			m_pClient->m_Controls.m_aInputType[g_Config.m_ClDummy] = CControls::INPUT_TYPE_ABSOLUTE;
+		}
 		return true;
 	}
 
@@ -400,6 +409,7 @@ bool CControls::OnCursorMove(float x, float y, IInput::ECursorType CursorType)
 		Factor *= m_pClient->m_Camera.m_Zoom;
 
 	m_aMousePos[g_Config.m_ClDummy] += vec2(x, y) * Factor;
+	m_pClient->m_Controls.m_aInputType[g_Config.m_ClDummy] = CControls::INPUT_TYPE_RELATIVE;
 	ClampMousePos();
 	return true;
 }

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -16,9 +16,18 @@ public:
 	float GetMinMouseDistance() const;
 	float GetMaxMouseDistance() const;
 
+	enum EInputType
+	{
+		INPUT_TYPE_ABSOLUTE,
+		INPUT_TYPE_RELATIVE,
+		INPUT_TYPE_AUTOMATED,
+	};
+
 	vec2 m_aMousePos[NUM_DUMMIES];
 	vec2 m_aMousePosOnAction[NUM_DUMMIES];
 	vec2 m_aTargetPos[NUM_DUMMIES];
+
+	EInputType m_aInputType[NUM_DUMMIES];
 
 	int m_aAmmoCount[NUM_WEAPONS];
 

--- a/src/game/client/components/touch_controls.cpp
+++ b/src/game/client/components/touch_controls.cpp
@@ -556,6 +556,7 @@ void CTouchControls::CJoystickTouchButtonBehavior::OnUpdate()
 		vec2 WorldScreenSize;
 		m_pTouchControls->RenderTools()->CalcScreenParams(m_pTouchControls->Graphics()->ScreenAspect(), m_pTouchControls->GameClient()->m_Camera.m_Zoom, &WorldScreenSize.x, &WorldScreenSize.y);
 		Controls.m_aMousePos[g_Config.m_ClDummy] += -m_AccumulatedDelta * WorldScreenSize;
+		Controls.m_aInputType[g_Config.m_ClDummy] = CControls::INPUT_TYPE_RELATIVE;
 		Controls.m_aMousePos[g_Config.m_ClDummy].x = clamp(Controls.m_aMousePos[g_Config.m_ClDummy].x, -201.0f * 32, (m_pTouchControls->Collision()->GetWidth() + 201.0f) * 32.0f);
 		Controls.m_aMousePos[g_Config.m_ClDummy].y = clamp(Controls.m_aMousePos[g_Config.m_ClDummy].y, -201.0f * 32, (m_pTouchControls->Collision()->GetHeight() + 201.0f) * 32.0f);
 		m_AccumulatedDelta = vec2(0.0f, 0.0f);
@@ -564,6 +565,7 @@ void CTouchControls::CJoystickTouchButtonBehavior::OnUpdate()
 	{
 		const vec2 AbsolutePosition = (m_ActivePosition - vec2(0.5f, 0.5f)) * 2.0f;
 		Controls.m_aMousePos[g_Config.m_ClDummy] = AbsolutePosition * (Controls.GetMaxMouseDistance() - Controls.GetMinMouseDistance()) + normalize(AbsolutePosition) * Controls.GetMinMouseDistance();
+		Controls.m_aInputType[g_Config.m_ClDummy] = CControls::INPUT_TYPE_ABSOLUTE;
 		if(length(Controls.m_aMousePos[g_Config.m_ClDummy]) < 0.001f)
 		{
 			Controls.m_aMousePos[g_Config.m_ClDummy].x = 0.001f;
@@ -1056,12 +1058,14 @@ void CTouchControls::UpdateButtons(const std::vector<IInput::CTouchFingerState> 
 		if(m_pClient->m_Snap.m_SpecInfo.m_Active)
 		{
 			Controls.m_aMousePos[g_Config.m_ClDummy] += -DirectFingerState.m_Delta * WorldScreenSize;
+			Controls.m_aInputType[g_Config.m_ClDummy] = CControls::INPUT_TYPE_RELATIVE;
 			Controls.m_aMousePos[g_Config.m_ClDummy].x = clamp(Controls.m_aMousePos[g_Config.m_ClDummy].x, -201.0f * 32, (Collision()->GetWidth() + 201.0f) * 32.0f);
 			Controls.m_aMousePos[g_Config.m_ClDummy].y = clamp(Controls.m_aMousePos[g_Config.m_ClDummy].y, -201.0f * 32, (Collision()->GetHeight() + 201.0f) * 32.0f);
 		}
 		else
 		{
 			Controls.m_aMousePos[g_Config.m_ClDummy] = (DirectFingerState.m_Position - vec2(0.5f, 0.5f)) * WorldScreenSize;
+			Controls.m_aInputType[g_Config.m_ClDummy] = CControls::INPUT_TYPE_ABSOLUTE;
 		}
 	}
 


### PR DESCRIPTION
was trying something for spectator cursor, then I already had this so i'll just put it here. someone can takeover this if it haven't been worked on yet and i didn't do it entirely wrong.

i've split the type into three: relative, absolute and automated (where the mousepos is forcefully set in anyway). the playerflags however only has an absolute flag where i treated automated input as absolute.

i didn't spent too much time checking on AB, but i couldn't tell if it syncs playerflags, but i don't feel confident touching that.

closes #9376

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
