### PR TITLE
Add assertions to `CServer::GetClientAddr` functions, avoid string-based address comparison for `sv_vote_kick_min`

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -621,8 +621,9 @@ void CServer::SetClientDDNetVersion(int ClientId, int DDNetVersion)
 
 void CServer::GetClientAddr(int ClientId, char *pAddrStr, int Size) const
 {
-	if(ClientId >= 0 && ClientId < MAX_CLIENTS && m_aClients[ClientId].m_State == CClient::STATE_INGAME)
-		net_addr_str(m_NetServer.ClientAddr(ClientId), pAddrStr, Size, false);
+	NETADDR Addr;
+	GetClientAddr(ClientId, &Addr);
+	net_addr_str(&Addr, pAddrStr, Size, false);
 }
 
 const char *CServer::ClientName(int ClientId) const
@@ -3968,10 +3969,9 @@ CServer *CreateServer() { return new CServer(); }
 
 void CServer::GetClientAddr(int ClientId, NETADDR *pAddr) const
 {
-	if(ClientId >= 0 && ClientId < MAX_CLIENTS && m_aClients[ClientId].m_State == CClient::STATE_INGAME)
-	{
-		*pAddr = *m_NetServer.ClientAddr(ClientId);
-	}
+	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "ClientId is not valid");
+	dbg_assert(m_aClients[ClientId].m_State != CServer::CClient::STATE_EMPTY, "Client slot is empty");
+	*pAddr = *m_NetServer.ClientAddr(ClientId);
 }
 
 void CServer::ReadAnnouncementsFile()

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2326,12 +2326,12 @@ void CGameContext::OnCallVoteNetMessage(const CNetMsg_Cl_CallVote *pMsg, int Cli
 
 		if(g_Config.m_SvVoteKickMin && !GetDDRaceTeam(ClientId))
 		{
-			char aaAddresses[MAX_CLIENTS][NETADDR_MAXSTRSIZE] = {{0}};
+			NETADDR aAddresses[MAX_CLIENTS];
 			for(int i = 0; i < MAX_CLIENTS; i++)
 			{
 				if(m_apPlayers[i])
 				{
-					Server()->GetClientAddr(i, aaAddresses[i], NETADDR_MAXSTRSIZE);
+					Server()->GetClientAddr(i, &aAddresses[i]);
 				}
 			}
 			int NumPlayers = 0;
@@ -2344,7 +2344,7 @@ void CGameContext::OnCallVoteNetMessage(const CNetMsg_Cl_CallVote *pMsg, int Cli
 					{
 						if(m_apPlayers[j] && m_apPlayers[j]->GetTeam() != TEAM_SPECTATORS && !GetDDRaceTeam(j))
 						{
-							if(str_comp(aaAddresses[i], aaAddresses[j]) == 0)
+							if(!net_addr_comp_noport(&aAddresses[i], &aAddresses[j]))
 							{
 								NumPlayers--;
 								break;


### PR DESCRIPTION
Prevent use of uninitialized memory if the functions are used for a player that is not yet ingame. The check for the ingame state is also unnecessarily restrictive, as the client address should be available immediately.

Compare client addresses directly to determine the distinct client count excluding spectators. This is consistent with the `IServer::DistinctClientCount` function though this does not check for spectators.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
