### PR TITLE
Always shows team size indicator

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -425,8 +425,6 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 					{
 						if(DDTeam == TEAM_SUPER)
 							str_copy(aBuf, Localize("Super"));
-						else if(CurrentDDTeamSize <= 1)
-							str_format(aBuf, sizeof(aBuf), "%d", DDTeam);
 						else
 							str_format(aBuf, sizeof(aBuf), Localize("%d\n(%d/%d)", "Team and size"), DDTeam, CurrentDDTeamSize, MaxTeamSize);
 						TextRender()->Text(State.m_TeamStartX, maximum(State.m_TeamStartY + Row.h / 2.0f - TeamFontSize, State.m_TeamStartY + 3.0f /* padding top */), TeamFontSize, aBuf);
@@ -435,10 +433,8 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 					{
 						if(DDTeam == TEAM_SUPER)
 							str_copy(aBuf, Localize("Super"));
-						else if(CurrentDDTeamSize > 1)
-							str_format(aBuf, sizeof(aBuf), Localize("Team %d (%d/%d)"), DDTeam, CurrentDDTeamSize, MaxTeamSize);
 						else
-							str_format(aBuf, sizeof(aBuf), Localize("Team %d"), DDTeam);
+							str_format(aBuf, sizeof(aBuf), Localize("Team %d (%d/%d)"), DDTeam, CurrentDDTeamSize, MaxTeamSize);
 						TextRender()->Text(Row.x + Row.w / 2.0f - TextRender()->TextWidth(TeamFontSize, aBuf) / 2.0f + 10.0f, Row.y + Row.h, TeamFontSize, aBuf);
 					}
 


### PR DESCRIPTION
When you play a new map, sometimes the team message is not received and it is hard to tell whether teaming is required, or if there is a maximum team size. I usually join a team for team size indicator, but it is not shown for 1-tee team. In my opinion, it's not looking worse adding team size indicator to them, while providing useful infomation. 

Before:
![图片](https://github.com/user-attachments/assets/3d4e5535-0cbe-4c6d-aefe-659c4d53c118)
![图片](https://github.com/user-attachments/assets/8583d21f-041a-4a37-9799-d9b23d512ed0)
After:
![图片](https://github.com/user-attachments/assets/f5c49aad-6b53-4ca8-a93b-911f10f3d0fd)
![图片](https://github.com/user-attachments/assets/f89c46ee-a1c4-4a8c-b59a-cfea0c82658c)


<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
