### PR TITLE
Fix 'all' and 'me' not passing parameter validation in rcon

### DIFF
--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -235,6 +235,12 @@ int CConsole::ParseArgs(CResult *pResult, const char *pFormat, bool IsColor)
 					if(!IsColor)
 					{
 						int Value;
+						if(str_comp(pResult->GetString(pResult->NumArguments() - 1), "all") == 0 ||
+							str_comp(pResult->GetString(pResult->NumArguments() - 1), "me") == 0)
+						{
+							Error = PARSEARGS_OK;
+							break;
+						}
 						if(!str_toint(pResult->GetString(pResult->NumArguments() - 1), &Value) ||
 							Value == std::numeric_limits<int>::max() || Value == std::numeric_limits<int>::min())
 						{


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
**Fix 'all' and 'me' not passing parameter validation in rcon** -> https://github.com/ddnet/ddnet/issues/9278#issue-2686044523

**After this pr:**
![screenshot](https://github.com/user-attachments/assets/e9dfc433-ce2f-4abe-ba5e-48c20b30b003)

fix #9278 
_I can assure there won't be any problems this time ;)_
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
