### PR TITLE
Support reading demo files larger than 2 GiB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3562,6 +3562,7 @@ foreach(target ${TARGETS_OWN})
   target_compile_definitions(${target} PRIVATE $<$<CONFIG:Debug>:CONF_DEBUG>)
   target_include_directories(${target} SYSTEM PRIVATE ${CURL_INCLUDE_DIRS} ${SQLite3_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS})
   target_compile_definitions(${target} PRIVATE GLEW_STATIC)
+  target_compile_definitions(${target} PRIVATE _FILE_OFFSET_BITS=64) # Ensure off_t is 64 bit for ftello and fseeko functions
   if(CRYPTO_FOUND)
     target_compile_definitions(${target} PRIVATE CONF_OPENSSL)
     target_include_directories(${target} SYSTEM PRIVATE ${CRYPTO_INCLUDE_DIRS})

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -237,7 +237,13 @@ enum
 	 * @see io_open
 	 */
 	IOFLAG_APPEND = 4,
+};
 
+/**
+ * @ingroup File-IO
+ */
+enum ESeekOrigin
+{
 	/**
 	 * Start seeking from the beginning of the file.
 	 *
@@ -294,10 +300,14 @@ unsigned io_read(IOHANDLE io, void *buffer, unsigned size);
  * @param result Receives the file's remaining contents.
  * @param result_len Receives the file's remaining length.
  *
+ * @return `true` on success, `false` on failure.
+ *
  * @remark Does NOT guarantee that there are no internal null bytes.
  * @remark The result must be freed after it has been used.
+ * @remark The function will fail if more than 1 GiB of memory would
+ * have to be allocated. Large files should not be loaded into memory.
  */
-void io_read_all(IOHANDLE io, void **result, unsigned *result_len);
+bool io_read_all(IOHANDLE io, void **result, unsigned *result_len);
 
 /**
  * Reads the rest of the file into a zero-terminated buffer with
@@ -312,6 +322,8 @@ void io_read_all(IOHANDLE io, void **result, unsigned *result_len);
  * @remark Guarantees that there are no internal null bytes.
  * @remark Guarantees that result will contain zero-termination.
  * @remark The result must be freed after it has been used.
+ * @remark The function will fail if more than 1 GiB of memory would
+ * have to be allocated. Large files should not be loaded into memory.
  */
 char *io_read_all_str(IOHANDLE io);
 
@@ -325,7 +337,7 @@ char *io_read_all_str(IOHANDLE io);
  *
  * @return 0 on success.
  */
-int io_skip(IOHANDLE io, int size);
+int io_skip(IOHANDLE io, int64_t size);
 
 /**
  * Seeks to a specified offset in the file.
@@ -338,7 +350,7 @@ int io_skip(IOHANDLE io, int size);
  *
  * @return `0` on success.
  */
-int io_seek(IOHANDLE io, int offset, int origin);
+int io_seek(IOHANDLE io, int64_t offset, ESeekOrigin origin);
 
 /**
  * Gets the current position in the file.
@@ -349,7 +361,7 @@ int io_seek(IOHANDLE io, int offset, int origin);
  *
  * @return The current position, or `-1` on failure.
  */
-long int io_tell(IOHANDLE io);
+int64_t io_tell(IOHANDLE io);
 
 /**
  * Gets the total length of the file. Resets cursor to the beginning.
@@ -360,7 +372,7 @@ long int io_tell(IOHANDLE io);
  *
  * @return The total size, or `-1` on failure.
  */
-long int io_length(IOHANDLE io);
+int64_t io_length(IOHANDLE io);
 
 /**
  * Writes data from a buffer to a file.

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -246,7 +246,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	int64_t m_BenchmarkStopTime = 0;
 
 	CChecksum m_Checksum;
-	int m_OwnExecutableSize = 0;
+	int64_t m_OwnExecutableSize = 0;
 	IOHANDLE m_OwnExecutable = 0;
 
 	// favorite command handling

--- a/src/engine/gfx/image_loader.cpp
+++ b/src/engine/gfx/image_loader.cpp
@@ -278,8 +278,13 @@ bool CImageLoader::LoadPng(IOHANDLE File, const char *pFilename, CImageInfo &Ima
 
 	void *pFileData;
 	unsigned FileDataSize;
-	io_read_all(File, &pFileData, &FileDataSize);
+	const bool ReadSuccess = io_read_all(File, &pFileData, &FileDataSize);
 	io_close(File);
+	if(!ReadSuccess)
+	{
+		log_error("png", "failed to read file. filename='%s'", pFilename);
+		return false;
+	}
 
 	CByteBufferReader ImageReader(static_cast<const uint8_t *>(pFileData), FileDataSize);
 

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -97,10 +97,10 @@ private:
 	// Playback
 	struct SKeyFrame
 	{
-		long m_Filepos;
+		int64_t m_Filepos;
 		int m_Tick;
 
-		SKeyFrame(long Filepos, int Tick) :
+		SKeyFrame(int64_t Filepos, int Tick) :
 			m_Filepos(Filepos), m_Tick(Tick)
 		{
 		}
@@ -108,7 +108,7 @@ private:
 
 	class IConsole *m_pConsole;
 	IOHANDLE m_File;
-	long m_MapOffset;
+	int64_t m_MapOffset;
 	char m_aFilename[IO_MAX_PATH_LENGTH];
 	char m_aErrorMessage[256];
 	std::vector<SKeyFrame> m_vKeyFrames;

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -559,8 +559,14 @@ public:
 			*pResultLen = 0;
 			return false;
 		}
-		io_read_all(File, ppResult, pResultLen);
+		const bool ReadSuccess = io_read_all(File, ppResult, pResultLen);
 		io_close(File);
+		if(!ReadSuccess)
+		{
+			*ppResult = nullptr;
+			*pResultLen = 0;
+			return false;
+		}
 		return true;
 	}
 

--- a/src/test/io.cpp
+++ b/src/test/io.cpp
@@ -3,22 +3,24 @@
 
 #include <base/system.h>
 
-void TestFileRead(const char *pWritten)
+static void TestFileRead(const char *pWritten)
 {
-	CTestInfo Info;
-	char aBuf[512] = {0};
-	IOHANDLE File = io_open(Info.m_aFilename, IOFLAG_WRITE);
 	const int WrittenLength = str_length(pWritten);
+
+	char aBuf[64] = {0};
+	CTestInfo Info;
+
+	IOHANDLE File = io_open(Info.m_aFilename, IOFLAG_WRITE);
 	ASSERT_TRUE(File);
 	EXPECT_EQ(io_write(File, pWritten, WrittenLength), WrittenLength);
 	EXPECT_FALSE(io_close(File));
+
 	File = io_open(Info.m_aFilename, IOFLAG_READ);
 	ASSERT_TRUE(File);
 	EXPECT_EQ(io_read(File, aBuf, sizeof(aBuf)), WrittenLength);
-	EXPECT_TRUE(mem_comp(aBuf, pWritten, WrittenLength) == 0);
+	EXPECT_EQ(mem_comp(aBuf, pWritten, WrittenLength), 0);
 	EXPECT_FALSE(io_close(File));
-
-	fs_remove(Info.m_aFilename);
+	EXPECT_FALSE(fs_remove(Info.m_aFilename));
 }
 
 TEST(Io, Read1)
@@ -38,6 +40,92 @@ TEST(Io, Read4)
 	TestFileRead("\xef\xbb\xbfxyz");
 }
 
+static void TestFileLength(const char *pWritten)
+{
+	const int WrittenLength = str_length(pWritten);
+
+	CTestInfo Info;
+
+	IOHANDLE File = io_open(Info.m_aFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(File);
+	EXPECT_EQ(io_write(File, pWritten, WrittenLength), WrittenLength);
+	EXPECT_FALSE(io_close(File));
+
+	File = io_open(Info.m_aFilename, IOFLAG_READ);
+	ASSERT_TRUE(File);
+	EXPECT_EQ(io_length(File), WrittenLength);
+	EXPECT_FALSE(io_close(File));
+	EXPECT_FALSE(fs_remove(Info.m_aFilename));
+}
+
+TEST(Io, Length1)
+{
+	TestFileLength("");
+}
+TEST(Io, Length2)
+{
+	TestFileLength("abc");
+}
+TEST(Io, Length3)
+{
+	TestFileLength("\xef\xbb\xbf");
+}
+TEST(Io, Length4)
+{
+	TestFileLength("\xef\xbb\xbfxyz");
+}
+
+TEST(Io, SeekTellSkip)
+{
+	const char *pWritten1 = "01234567890123456789";
+	const int WrittenLength1 = str_length(pWritten1);
+	const char *pWritten2 = "abc";
+	const int WrittenLength2 = str_length(pWritten2);
+	const char *pWritten3 = "def";
+	const int WrittenLength3 = str_length(pWritten3);
+	const char *pWritten4 = "ghi";
+	const int WrittenLength4 = str_length(pWritten4);
+	const char *pWritten5 = "jkl";
+	const int WrittenLength5 = str_length(pWritten5);
+	const char *pExpectedResult = "01def5ghi9abc3456789jkl";
+	const int ExpectedLength = str_length(pExpectedResult);
+
+	char aBuf[64] = {0};
+	CTestInfo Info;
+
+	IOHANDLE File = io_open(Info.m_aFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(File);
+	EXPECT_EQ(io_write(File, pWritten1, WrittenLength1), WrittenLength1);
+	EXPECT_FALSE(io_seek(File, -10, IOSEEK_CUR));
+	EXPECT_EQ(io_write(File, pWritten2, WrittenLength2), WrittenLength2);
+	EXPECT_FALSE(io_seek(File, 2, IOSEEK_START));
+	EXPECT_EQ(io_write(File, pWritten3, WrittenLength3), WrittenLength3);
+	EXPECT_FALSE(io_skip(File, 1));
+	EXPECT_EQ(io_write(File, pWritten4, WrittenLength4), WrittenLength4);
+	EXPECT_FALSE(io_seek(File, 0, IOSEEK_END));
+	EXPECT_EQ(io_write(File, pWritten5, WrittenLength5), WrittenLength5);
+	EXPECT_FALSE(io_close(File));
+
+	File = io_open(Info.m_aFilename, IOFLAG_READ);
+	ASSERT_TRUE(File);
+	EXPECT_EQ(io_read(File, aBuf, sizeof(aBuf)), ExpectedLength);
+	EXPECT_EQ(mem_comp(aBuf, pExpectedResult, ExpectedLength), 0);
+	EXPECT_FALSE(io_seek(File, -13, IOSEEK_CUR));
+	EXPECT_EQ(io_read(File, aBuf, WrittenLength2), WrittenLength2);
+	EXPECT_EQ(mem_comp(aBuf, pWritten2, WrittenLength2), 0);
+	EXPECT_FALSE(io_seek(File, 2, IOSEEK_START));
+	EXPECT_EQ(io_read(File, aBuf, WrittenLength3), WrittenLength3);
+	EXPECT_EQ(mem_comp(aBuf, pWritten3, WrittenLength3), 0);
+	EXPECT_FALSE(io_skip(File, 1));
+	EXPECT_EQ(io_read(File, aBuf, WrittenLength4), WrittenLength4);
+	EXPECT_EQ(mem_comp(aBuf, pWritten4, WrittenLength4), 0);
+	EXPECT_FALSE(io_seek(File, -3, IOSEEK_END));
+	EXPECT_EQ(io_read(File, aBuf, WrittenLength5), WrittenLength5);
+	EXPECT_EQ(mem_comp(aBuf, pWritten5, WrittenLength5), 0);
+	EXPECT_FALSE(io_close(File));
+	EXPECT_FALSE(fs_remove(Info.m_aFilename));
+}
+
 TEST(Io, CurrentExe)
 {
 	IOHANDLE CurrentExe = io_current_exe();
@@ -45,6 +133,7 @@ TEST(Io, CurrentExe)
 	EXPECT_GE(io_length(CurrentExe), 1024);
 	io_close(CurrentExe);
 }
+
 TEST(Io, SyncWorks)
 {
 	CTestInfo Info;


### PR DESCRIPTION
Use `int64_t` for file sizes and offsets of `io_seek`, `io_tell`, `io_skip` and `io_length` functions to support reading larger files, in particular Teehistorian demos larger than 2 GiB. Implement the `io_seek` function using the `_fseeki64` function on Windows and the `fseeko` function on non-Windows. Implement the `io_tell` function using the `_ftelli64` function on Windows and the `ftello` function on non-Windows. Define `_FILE_OFFSET_BITS=64` to ensure that `off_t` is a 64 bit type for the `fseeko` and `ftello` functions.

Change `io_read_all`, `io_read_all_str`, `IStorage::ReadFile` and `IStorage::ReadFileStr` functions to fail when loading files larger than 1 GiB. We should never load files that large into memory and this avoids issues with the file size exceeding `unsigned` limits.

When writing map file data to demos, check if the map file is larger than `std::numeric_limits<unsigned>::max()` which would break the demo format. In that case, record the demo without embedding the map data.

Add tests for the `io_length`, `io_seek`, `io_tell`, `io_skip` functions.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
