### PR TITLE
Minor improvements to random skin generation

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -621,6 +621,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	{
 		GameClient()->m_Skins.RandomizeSkin(m_Dummy);
 		SetNeedSendInfo();
+		m_SkinListScrollToSelected = true;
 		s_CurrentDie = rand() % std::size(s_apDice);
 	}
 	TextRender()->SetRenderFlags(0);
@@ -721,7 +722,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 				return false;
 
 			// no special skins
-			if((pSkinToBeSelected->GetName()[0] == 'x' && pSkinToBeSelected->GetName()[1] == '_'))
+			if(CSkins::IsSpecialSkin(pSkinToBeSelected->GetName()))
 				return false;
 
 			return true;

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -37,6 +37,7 @@ public:
 	void RandomizeSkin(int Dummy);
 
 	static bool IsVanillaSkin(const char *pName);
+	static bool IsSpecialSkin(const char *pName);
 
 	constexpr static const char *VANILLA_SKINS[] = {"bluekitty", "bluestripe", "brownbear",
 		"cammo", "cammostripes", "coala", "default", "limekitty",

--- a/src/game/client/components/skins7.cpp
+++ b/src/game/client/components/skins7.cpp
@@ -466,21 +466,21 @@ void CSkins7::RandomizeSkin(int Dummy) const
 
 	for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
 	{
-		std::vector<const CSkins7::CSkinPart *> vConsideredSkinParts;
+		std::vector<const CSkins7::CSkinPart *> vpConsideredSkinParts;
 		for(const CSkinPart &SkinPart : GetSkinParts(Part))
 		{
 			if((SkinPart.m_Flags & CSkins7::SKINFLAG_SPECIAL) != 0)
 				continue;
-			vConsideredSkinParts.push_back(&SkinPart);
+			vpConsideredSkinParts.push_back(&SkinPart);
 		}
 		const CSkins7::CSkinPart *pRandomPart;
-		if(vConsideredSkinParts.empty())
+		if(vpConsideredSkinParts.empty())
 		{
 			pRandomPart = FindDefaultSkinPart(Part);
 		}
 		else
 		{
-			pRandomPart = vConsideredSkinParts[rand() % vConsideredSkinParts.size()];
+			pRandomPart = vpConsideredSkinParts[rand() % vpConsideredSkinParts.size()];
 		}
 		str_copy(CSkins7::ms_apSkinVariables[Dummy][Part], pRandomPart->m_aName, protocol7::MAX_SKIN_ARRAY_SIZE);
 	}

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1598,7 +1598,7 @@ void CGameClient::OnNewSnapshot()
 
 					IntsToStr(&pInfo->m_Skin0, 6, pClient->m_aSkinName, std::size(pClient->m_aSkinName));
 					if(pClient->m_aSkinName[0] == '\0' ||
-						(!m_GameInfo.m_AllowXSkins && (pClient->m_aSkinName[0] == 'x' && pClient->m_aSkinName[1] == '_')))
+						(!m_GameInfo.m_AllowXSkins && CSkins::IsSpecialSkin(pClient->m_aSkinName)))
 					{
 						str_copy(pClient->m_aSkinName, "default");
 					}


### PR DESCRIPTION
Fix client hanging when creating random skin while only special skins are loaded.

Scroll to reveal new skin in list after creating random skin.

Extract `CSkins::IsSpecialSkin` function.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
