### PR TITLE
Revert Tele popup

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -448,15 +448,9 @@ public:
 
 		// DDRace
 
-		m_ViewTeleNumber = 1;
-		m_TeleNumbers = {
-			{TILE_TELEINEVIL, 1},
-			{TILE_TELEINWEAPON, 1},
-			{TILE_TELEINHOOK, 1},
-			{TILE_TELEIN, 1},
-			{TILE_TELEOUT, 1},
-			{TILE_TELECHECK, 1},
-			{TILE_TELECHECKOUT, 1}};
+		m_TeleNumber = 1;
+		m_TeleCheckpointNumber = 1;
+		m_ViewTeleNumber = 0;
 
 		m_SwitchNum = 1;
 		m_TuningNum = 1;
@@ -1158,8 +1152,9 @@ public:
 	IGraphics::CTextureHandle GetSwitchTexture();
 	IGraphics::CTextureHandle GetTuneTexture();
 
+	unsigned char m_TeleNumber;
+	unsigned char m_TeleCheckpointNumber;
 	unsigned char m_ViewTeleNumber;
-	std::map<int, unsigned char> m_TeleNumbers;
 
 	unsigned char m_TuningNum;
 
@@ -1173,7 +1168,7 @@ public:
 
 	void AdjustBrushSpecialTiles(bool UseNextFree, int Adjust = 0);
 	int FindNextFreeSwitchNumber();
-	int FindNextFreeTeleNumber(int Index);
+	int FindNextFreeTeleNumber(bool Checkpoint = false);
 
 	// Undo/Redo
 	CEditorHistory m_EditorHistory;

--- a/src/game/editor/mapitems/layer_tele.cpp
+++ b/src/game/editor/mapitems/layer_tele.cpp
@@ -77,7 +77,7 @@ void CLayerTele::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 	int sx = ConvertX(WorldPos.x);
 	int sy = ConvertY(WorldPos.y);
 	if(str_comp(pTeleLayer->m_aFileName, m_pEditor->m_aFileName))
-		m_pEditor->m_TeleNumbers = pTeleLayer->m_TeleNumbers;
+		m_pEditor->m_TeleNumber = pTeleLayer->m_TeleNum;
 
 	bool Destructive = m_pEditor->m_BrushDrawDestructive || IsEmpty(pTeleLayer);
 
@@ -115,7 +115,7 @@ void CLayerTele::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 				}
 				else
 				{
-					if(!m_pEditor->m_TeleNumbers[TgtIndex])
+					if((!IsCheckpoint && !m_pEditor->m_TeleNumber) || (IsCheckpoint && !m_pEditor->m_TeleCheckpointNumber))
 					{
 						m_pTeleTile[Index].m_Number = 0;
 						m_pTeleTile[Index].m_Type = 0;
@@ -131,7 +131,7 @@ void CLayerTele::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 					}
 					else
 					{
-						m_pTeleTile[Index].m_Number = m_pEditor->m_TeleNumbers[TgtIndex];
+						m_pTeleTile[Index].m_Number = IsCheckpoint ? m_pEditor->m_TeleCheckpointNumber : m_pEditor->m_TeleNumber;
 					}
 				}
 
@@ -276,8 +276,10 @@ void CLayerTele::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRe
 						// as tiles with number 0 would be ignored by previous versions.
 						m_pTeleTile[TgtIndex].m_Number = 255;
 					}
-					else if((pLt->m_pTeleTile[SrcIndex].m_Number == 0 && m_pEditor->m_TeleNumbers[m_pTiles[TgtIndex].m_Index]))
-						m_pTeleTile[TgtIndex].m_Number = m_pEditor->m_TeleNumbers[m_pTiles[TgtIndex].m_Index];
+					else if(!IsCheckpoint && ((pLt->m_pTeleTile[SrcIndex].m_Number == 0 && m_pEditor->m_TeleNumber) || m_pEditor->m_TeleNumber != pLt->m_TeleNum))
+						m_pTeleTile[TgtIndex].m_Number = m_pEditor->m_TeleNumber;
+					else if(IsCheckpoint && ((pLt->m_pTeleTile[SrcIndex].m_Number == 0 && m_pEditor->m_TeleCheckpointNumber) || m_pEditor->m_TeleCheckpointNumber != pLt->m_TeleCheckpointNum))
+						m_pTeleTile[TgtIndex].m_Number = m_pEditor->m_TeleCheckpointNumber;
 					else
 						m_pTeleTile[TgtIndex].m_Number = pLt->m_pTeleTile[SrcIndex].m_Number;
 				}
@@ -294,13 +296,13 @@ void CLayerTele::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRe
 	FlagModified(sx, sy, w, h);
 }
 
-bool CLayerTele::ContainsElementWithId(int Id, int Index)
+bool CLayerTele::ContainsElementWithId(int Id, bool Checkpoint)
 {
 	for(int y = 0; y < m_Height; ++y)
 	{
 		for(int x = 0; x < m_Width; ++x)
 		{
-			if(m_pTeleTile[y * m_Width + x].m_Type == Index && m_pTeleTile[y * m_Width + x].m_Number == Id)
+			if(IsTeleTileNumberUsed(m_pTeleTile[y * m_Width + x].m_Type, Checkpoint) && m_pTeleTile[y * m_Width + x].m_Number == Id)
 			{
 				return true;
 			}

--- a/src/game/editor/mapitems/layer_tele.h
+++ b/src/game/editor/mapitems/layer_tele.h
@@ -22,7 +22,8 @@ public:
 	~CLayerTele();
 
 	CTeleTile *m_pTeleTile;
-	std::map<int, unsigned char> m_TeleNumbers;
+	unsigned char m_TeleNum;
+	unsigned char m_TeleCheckpointNum;
 
 	void Resize(int NewW, int NewH) override;
 	void Shift(int Direction) override;
@@ -32,7 +33,7 @@ public:
 	void BrushFlipY() override;
 	void BrushRotate(float Amount) override;
 	void FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRect Rect) override;
-	virtual bool ContainsElementWithId(int Id, int Index);
+	virtual bool ContainsElementWithId(int Id, bool Checkpoint);
 	virtual void GetPos(int Number, int Offset, int &TeleX, int &TeleY);
 
 	int m_GotoTeleOffset;

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -311,9 +311,12 @@ int CLayerTiles::BrushGrab(std::shared_ptr<CLayerGroup> pBrush, CUIRect Rect)
 				{
 					pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x] = static_cast<CLayerTele *>(this)->m_pTeleTile[(r.y + y) * m_Width + (r.x + x)];
 					unsigned char TgtIndex = pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x].m_Type;
-					if(IsValidTeleTile(TgtIndex) && IsTeleTileNumberUsedAny(TgtIndex))
+					if(IsValidTeleTile(TgtIndex))
 					{
-						m_pEditor->m_TeleNumbers[TgtIndex] = pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x].m_Number;
+						if(IsTeleTileNumberUsed(TgtIndex, false))
+							m_pEditor->m_TeleNumber = pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x].m_Number;
+						else if(IsTeleTileNumberUsed(TgtIndex, true))
+							m_pEditor->m_TeleCheckpointNumber = pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x].m_Number;
 					}
 				}
 				else
@@ -321,13 +324,14 @@ int CLayerTiles::BrushGrab(std::shared_ptr<CLayerGroup> pBrush, CUIRect Rect)
 					CTile Tile = pGrabbed->m_pTiles[y * pGrabbed->m_Width + x];
 					if(IsValidTeleTile(Tile.m_Index) && IsTeleTileNumberUsedAny(Tile.m_Index))
 					{
-						pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x].m_Number = m_pEditor->m_TeleNumbers[Tile.m_Index];
+						pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x].m_Number = IsTeleTileCheckpoint(Tile.m_Index) ? m_pEditor->m_TeleCheckpointNumber : m_pEditor->m_TeleNumber;
 					}
 				}
 			}
 		}
 
-		pGrabbed->m_TeleNumbers = m_pEditor->m_TeleNumbers;
+		pGrabbed->m_TeleNum = m_pEditor->m_TeleNumber;
+		pGrabbed->m_TeleCheckpointNum = m_pEditor->m_TeleCheckpointNumber;
 
 		str_copy(pGrabbed->m_aFileName, m_pEditor->m_aFileName);
 	}

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -2435,29 +2435,24 @@ int CEditor::PopupSelectConfigAutoMapResult()
 CUi::EPopupMenuFunctionResult CEditor::PopupTele(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
-	static const int s_NumTeleTiles = 7;
 
-	static int s_aPreviousTeleNumbers[s_NumTeleTiles];
+	static int s_PreviousTeleNumber;
+	static int s_PreviousCheckpointNumber;
 	static int s_PreviousViewTeleNumber;
 
 	CUIRect NumberPicker;
 	CUIRect FindEmptySlot;
-	CUIRect FindFreeViewSlot;
-	CUIRect aFindFreeTeleSlots[s_NumTeleTiles];
+	CUIRect FindFreeTeleSlot, FindFreeCheckpointSlot, FindFreeViewSlot;
 
 	View.VSplitRight(15.f, &NumberPicker, &FindEmptySlot);
 	NumberPicker.VSplitRight(2.f, &NumberPicker, nullptr);
 
-	for(auto &Slot : aFindFreeTeleSlots)
-	{
-		FindEmptySlot.HSplitTop(13.0f, &Slot, &FindEmptySlot);
-	}
+	FindEmptySlot.HSplitTop(13.0f, &FindFreeTeleSlot, &FindEmptySlot);
+	FindEmptySlot.HSplitTop(13.0f, &FindFreeCheckpointSlot, &FindEmptySlot);
 	FindEmptySlot.HSplitTop(13.0f, &FindFreeViewSlot, &FindEmptySlot);
 
-	for(auto &Slot : aFindFreeTeleSlots)
-	{
-		Slot.HMargin(1.0f, &Slot);
-	}
+	FindFreeTeleSlot.HMargin(1.0f, &FindFreeTeleSlot);
+	FindFreeCheckpointSlot.HMargin(1.0f, &FindFreeCheckpointSlot);
 	FindFreeViewSlot.HMargin(1.0f, &FindFreeViewSlot);
 
 	auto ViewTele = [](CEditor *pEd) -> bool {
@@ -2473,83 +2468,91 @@ CUi::EPopupMenuFunctionResult CEditor::PopupTele(void *pContext, CUIRect View, b
 		return false;
 	};
 
-	static std::vector<ColorRGBA> s_vColors(s_NumTeleTiles + 1, ColorRGBA(0.5f, 1, 0.5f, 0.5f));
+	static std::vector<ColorRGBA> s_vColors = {
+		ColorRGBA(0.5f, 1, 0.5f, 0.5f),
+		ColorRGBA(0.5f, 1, 0.5f, 0.5f),
+		ColorRGBA(1, 0.5f, 0.5f, 0.5f),
+	};
+	enum
+	{
+		PROP_TELE = 0,
+		PROP_TELE_CP,
+		PROP_TELE_VIEW,
+		NUM_PROPS,
+	};
 
 	// find next free numbers buttons
 	{
-		static int s_aNextFreeTeleButtonIds[s_NumTeleTiles] = {0};
-		for(int i = 0; i < s_NumTeleTiles; i++)
-		{
-			if(pEditor->DoButton_Editor(&s_aNextFreeTeleButtonIds[i], "F", 0, &aFindFreeTeleSlots[i], 0, "[ctrl+f] Find next free tele number") ||
-				(Active && pEditor->Input()->ModifierIsPressed() && pEditor->Input()->KeyPress(KEY_F)))
-			{
-				int Tile = (*std::next(pEditor->m_TeleNumbers.begin(), i)).first;
-				int TeleNumber = pEditor->FindNextFreeTeleNumber(Tile);
+		// Pressing ctrl+f will find next free numbers for both tele and checkpoints
 
-				if(TeleNumber != -1)
-				{
-					pEditor->m_TeleNumbers[Tile] = TeleNumber;
-					pEditor->AdjustBrushSpecialTiles(false);
-				}
+		static int s_NextFreeTelePid = 0;
+		if(pEditor->DoButton_Editor(&s_NextFreeTelePid, "F", 0, &FindFreeTeleSlot, 0, "[ctrl+f] Find next free tele number") || (Active && pEditor->Input()->ModifierIsPressed() && pEditor->Input()->KeyPress(KEY_F)))
+		{
+			int TeleNumber = pEditor->FindNextFreeTeleNumber();
+
+			if(TeleNumber != -1)
+			{
+				pEditor->m_TeleNumber = TeleNumber;
+				pEditor->AdjustBrushSpecialTiles(false);
+			}
+		}
+
+		static int s_NextFreeCheckpointPid = 0;
+		if(pEditor->DoButton_Editor(&s_NextFreeCheckpointPid, "F", 0, &FindFreeCheckpointSlot, 0, "[ctrl+f] Find next free checkpoint number") || (Active && pEditor->Input()->ModifierIsPressed() && pEditor->Input()->KeyPress(KEY_F)))
+		{
+			int CPNumber = pEditor->FindNextFreeTeleNumber(true);
+
+			if(CPNumber != -1)
+			{
+				pEditor->m_TeleCheckpointNumber = CPNumber;
+				pEditor->AdjustBrushSpecialTiles(false);
 			}
 		}
 
 		static int s_NextFreeViewPid = 0;
 		int btn = pEditor->DoButton_Editor(&s_NextFreeViewPid, "N", 0, &FindFreeViewSlot, 0, "[n] Show next tele with this number");
 		if(btn || (Active && pEditor->Input()->KeyPress(KEY_N)))
-			s_vColors[s_NumTeleTiles] = ViewTele(pEditor) ? ColorRGBA(0.5f, 1, 0.5f, 0.5f) : ColorRGBA(1, 0.5f, 0.5f, 0.5f);
+			s_vColors[PROP_TELE_VIEW] = ViewTele(pEditor) ? ColorRGBA(0.5f, 1, 0.5f, 0.5f) : ColorRGBA(1, 0.5f, 0.5f, 0.5f);
 	}
 
 	// number picker
 	{
-		static const char *s_apTeleLabelText[] = {
-			"Red Tele", // TILE_TELEINEVIL
-			"Weapon Tele", // TILE_TELEINWEAPON
-			"Hook Tele", // TILE_TELEINHOOK
-			"Blue Tele", // TILE_TELEIN
-			"Tele To", // TILE_TELEOUT
-			"CP Tele", // TILE_TELECHECK
-			"CP Tele To", // TILE_TELECHECKOUT
+		CProperty aProps[] = {
+			{"Number", pEditor->m_TeleNumber, PROPTYPE_INT, 1, 255},
+			{"Checkpoint", pEditor->m_TeleCheckpointNumber, PROPTYPE_INT, 1, 255},
+			{"View", pEditor->m_ViewTeleNumber, PROPTYPE_INT, 1, 255},
+			{nullptr},
 		};
 
-		std::vector<CProperty> vProps;
-		for(int i = 0; i < s_NumTeleTiles; i++)
-		{
-			unsigned char TeleNumber = (*std::next(pEditor->m_TeleNumbers.begin(), i)).second;
-			vProps.emplace_back(s_apTeleLabelText[i], TeleNumber, PROPTYPE_INT, 1, 255);
-		}
-		vProps.emplace_back("View", pEditor->m_ViewTeleNumber, PROPTYPE_INT, 1, 255);
-		vProps.emplace_back(nullptr);
-
-		static int s_aIds[s_NumTeleTiles + 2] = {0};
+		static int s_aIds[NUM_PROPS] = {0};
 
 		int NewVal = 0;
-		int Prop = pEditor->DoProperties(&NumberPicker, vProps.data(), s_aIds, &NewVal, s_vColors);
-
-		if(Prop >= 0 && Prop < s_NumTeleTiles)
+		int Prop = pEditor->DoProperties(&NumberPicker, aProps, s_aIds, &NewVal, s_vColors);
+		if(Prop == PROP_TELE)
 		{
-			auto Tele = (*std::next(pEditor->m_TeleNumbers.begin(), Prop));
-			pEditor->m_TeleNumbers[Tele.first] = (NewVal - 1 + 255) % 255 + 1;
+			pEditor->m_TeleNumber = (NewVal - 1 + 255) % 255 + 1;
 			pEditor->AdjustBrushSpecialTiles(false);
 		}
-		else if(Prop == s_NumTeleTiles)
+		else if(Prop == PROP_TELE_CP)
+		{
+			pEditor->m_TeleCheckpointNumber = (NewVal - 1 + 255) % 255 + 1;
+			pEditor->AdjustBrushSpecialTiles(false);
+		}
+		else if(Prop == PROP_TELE_VIEW)
 			pEditor->m_ViewTeleNumber = (NewVal - 1 + 255) % 255 + 1;
 
-		for(int i = 0; i < s_NumTeleTiles; i++)
-		{
-			auto Tele = (*std::next(pEditor->m_TeleNumbers.begin(), i));
-			if(s_aPreviousTeleNumbers[i] == 1 || s_aPreviousTeleNumbers[i] != Tele.second)
-				s_vColors[i] = pEditor->m_Map.m_pTeleLayer->ContainsElementWithId(Tele.second, Tele.first) ? ColorRGBA(1, 0.5f, 0.5f, 0.5f) : ColorRGBA(0.5f, 1, 0.5f, 0.5f);
-		}
+		if(s_PreviousTeleNumber == 1 || s_PreviousTeleNumber != pEditor->m_TeleNumber)
+			s_vColors[PROP_TELE] = pEditor->m_Map.m_pTeleLayer->ContainsElementWithId(pEditor->m_TeleNumber, false) ? ColorRGBA(1, 0.5f, 0.5f, 0.5f) : ColorRGBA(0.5f, 1, 0.5f, 0.5f);
+
+		if(s_PreviousCheckpointNumber == 1 || s_PreviousCheckpointNumber != pEditor->m_TeleCheckpointNumber)
+			s_vColors[PROP_TELE_CP] = pEditor->m_Map.m_pTeleLayer->ContainsElementWithId(pEditor->m_TeleCheckpointNumber, true) ? ColorRGBA(1, 0.5f, 0.5f, 0.5f) : ColorRGBA(0.5f, 1, 0.5f, 0.5f);
 
 		if(s_PreviousViewTeleNumber != pEditor->m_ViewTeleNumber)
-			s_vColors[s_NumTeleTiles] = ViewTele(pEditor) ? ColorRGBA(0.5f, 1, 0.5f, 0.5f) : ColorRGBA(1, 0.5f, 0.5f, 0.5f);
+			s_vColors[PROP_TELE_VIEW] = ViewTele(pEditor) ? ColorRGBA(0.5f, 1, 0.5f, 0.5f) : ColorRGBA(1, 0.5f, 0.5f, 0.5f);
 	}
 
-	for(int i = 0; i < s_NumTeleTiles; i++)
-	{
-		s_aPreviousTeleNumbers[i] = (*std::next(pEditor->m_TeleNumbers.begin(), i)).second;
-	}
+	s_PreviousTeleNumber = pEditor->m_TeleNumber;
+	s_PreviousCheckpointNumber = pEditor->m_TeleCheckpointNumber;
 	s_PreviousViewTeleNumber = pEditor->m_ViewTeleNumber;
 
 	return CUi::POPUP_KEEP_OPEN;


### PR DESCRIPTION
Since an additional setting was deemed evil in #9249, this completely reverts the popup while keeping the bugfix to always show the correct number next to the brush
![image](https://github.com/user-attachments/assets/597e7696-bf96-42b6-bded-d998ff3f43ef)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
