### PR TITLE
Add button to open Touch controls wiki page to controls editor

### DIFF
--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -262,9 +262,18 @@ void CMenus::RenderTouchControlsEditor(CUIRect MainView)
 	MainView.Draw(ms_ColorTabbarActive, IGraphics::CORNER_ALL, 10.0f);
 	MainView.Margin(10.0f, &MainView);
 
-	MainView.HSplitTop(25.0f, &Label, &MainView);
+	MainView.HSplitTop(25.0f, &Row, &MainView);
 	MainView.HSplitTop(5.0f, nullptr, &MainView);
+	Row.VSplitLeft(Row.h, nullptr, &Row);
+	Row.VSplitRight(Row.h, &Row, &Button);
+	Row.VMargin(5.0f, &Label);
 	Ui()->DoLabel(&Label, Localize("Edit touch controls"), 20.0f, TEXTALIGN_MC);
+
+	static CButtonContainer s_OpenHelpButton;
+	if(DoButton_FontIcon(&s_OpenHelpButton, FONT_ICON_QUESTION, 0, &Button))
+	{
+		Client()->ViewLink(Localize("https://wiki.ddnet.org/wiki/Touch_controls"));
+	}
 
 	MainView.HSplitTop(25.0f, &Row, &MainView);
 	MainView.HSplitTop(5.0f, nullptr, &MainView);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5d445564-b76d-45de-8045-b41f787c2d64)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
