### PR TITLE
Revert "Fix 'all' and 'me' not passing parameter validation in rcon"

### DIFF
--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -235,12 +235,6 @@ int CConsole::ParseArgs(CResult *pResult, const char *pFormat, bool IsColor)
 					if(!IsColor)
 					{
 						int Value;
-						if(str_comp(pResult->GetString(pResult->NumArguments() - 1), "all") == 0 ||
-							str_comp(pResult->GetString(pResult->NumArguments() - 1), "me") == 0)
-						{
-							Error = PARSEARGS_OK;
-							break;
-						}
 						if(!str_toint(pResult->GetString(pResult->NumArguments() - 1), &Value) ||
 							Value == std::numeric_limits<int>::max() || Value == std::numeric_limits<int>::min())
 						{


### PR DESCRIPTION
This reverts commit 52beb0855c76516a0b29a33f78e71bf4fc9735de.

Just making sure we don't forget about it
See https://github.com/ddnet/ddnet/pull/9415#issuecomment-2558084274

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
