### PR TITLE
Fix assertion when sound fails to be loaded

### DIFF
--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -637,13 +637,25 @@ void CSound::UnloadSample(int SampleId)
 	if(SampleId == -1)
 		return;
 
-	Stop(SampleId);
-
-	// Free data
+	dbg_assert(SampleId >= 0 && SampleId < NUM_SAMPLES, "SampleId invalid");
 	const CLockScope LockScope(m_SoundLock);
 	CSample &Sample = m_aSamples[SampleId];
-	free(Sample.m_pData);
-	Sample.m_pData = nullptr;
+
+	if(Sample.IsLoaded())
+	{
+		// Stop voices using this sample
+		for(auto &Voice : m_aVoices)
+		{
+			if(Voice.m_pSample == &Sample)
+			{
+				Voice.m_pSample = nullptr;
+			}
+		}
+
+		// Free data
+		free(Sample.m_pData);
+		Sample.m_pData = nullptr;
+	}
 
 	// Free slot
 	if(Sample.m_NextFreeSampleIndex == SAMPLE_INDEX_USED)


### PR DESCRIPTION
Conditionally stop the sample in the `UnloadSample` function instead of calling the separate `Stop` function which is not supposed to be used for samples which are not loaded. The `UnloadSample` function also needs to handle samples which are not (fully) loaded to free the sample index when the sound failed to be loaded.

Regression from #9431.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
