### PR TITLE
Fix clang tidy for static member variables

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -110,15 +110,13 @@ CheckOptions:
   - key:             readability-identifier-naming.LocalConstantCase
     value:           CamelCase
   - key:             readability-identifier-naming.ClassMemberCase
-    value:           CamelCase
+    value:           UPPER_CASE
   - key:             readability-identifier-naming.MemberCase
     value:           CamelCase
   - key:             readability-identifier-naming.MemberPrefix
     value:           m_
   - key:             readability-identifier-naming.MemberIgnoredRegexp
     value:           '^(m_ap|m_v|m_p|m_a|ms_p|[a-z]$).*'
-  - key:             readability-identifier-naming.ClassMemberPrefix
-    value:           ms_
   - key:             readability-identifier-naming.StaticVariablePrefix
     value:           s_
   - key:             readability-identifier-naming.ClassMethodCase

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -951,7 +951,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 	std::vector<std::vector<std::pair<CTexture, CTexture>>> m_vvFrameDelayedTextTexturesCleanup;
 
 	size_t m_ThreadCount = 1;
-	static constexpr size_t ms_MainThreadIndex = 0;
+	static constexpr size_t MAIN_THREAD_INDEX = 0;
 	size_t m_CurCommandInPipe = 0;
 	size_t m_CurRenderCallCountInPipe = 0;
 	size_t m_CommandsInPipe = 0;
@@ -3103,7 +3103,7 @@ protected:
 		else
 		{
 			SDeviceMemoryBlock VertexBufferMemory;
-			if(!CreateStreamVertexBuffer(ms_MainThreadIndex, VertexBuffer, VertexBufferMemory, BufferOffset, pUploadData, BufferDataSize))
+			if(!CreateStreamVertexBuffer(MAIN_THREAD_INDEX, VertexBuffer, VertexBufferMemory, BufferOffset, pUploadData, BufferDataSize))
 				return false;
 		}
 		BufferObject.m_IsStreamedBuffer = IsOneFrameBuffer;


### PR DESCRIPTION
Closed #8319

Class member is not to be confused with regular members. The class member only refers to static variables. And for those we want UPPER_CASE without prefix. My local clangd kept tripping on it. Seems like the clang in the CI did not care yet but it is a correct fix either way.