### PR TITLE
Disable pylints too many arguments lint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -23,3 +23,4 @@ disable=
   W0511, # fixme
   W0603, # global-statement
   R0022, # useless-option-value
+  R0917, # too-many-positional-arguments


### PR DESCRIPTION
Fixed this pylint 3.3.3 error:

```
************* Module seven.content
datasrc/seven/content.py:34:1: R0917: Too many positional arguments (7/5) (too-many-positional-arguments)
************* Module content
datasrc/content.py:34:1: R0917: Too many positional arguments (7/5) (too-many-positional-arguments)

------------------------------------------------------------------
Your code has been rated at 9.99/10 (previous run: 9.99/10, +0.00)
```

Could also refactor the code to take a struct instead of many arguments.

```python
class Sprite(Struct):
	def __init__(self, name="", Set=None, x=0, y=0, w=0, h=0):
```

But I do not think adding a huge diff in 16 year old code just for that is worth it.

Closed #9428