### PR TITLE
Don't re-scan the source tree in scripts/languages/update_all.py

### DIFF
--- a/scripts/languages/twlang.py
+++ b/scripts/languages/twlang.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import re
 from collections import OrderedDict
@@ -58,6 +59,7 @@ def check_file(path):
 	return matches
 
 
+@functools.lru_cache(None)
 def check_folder(path):
 	englishlist = OrderedDict()
 	for path2, dirs, files in os.walk(path):


### PR DESCRIPTION
Only compute the result once.

This brings down the time spent from 3.5 seconds to 700 milliseconds on my device.

## Checklist

- [x] Tested the change ~~ingame~~
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
