### PR TITLE
Fix server not starting on Android 12 and older versions, refactoring

### DIFF
--- a/scripts/android/files/java/org/ddnet/client/ServerService.java
+++ b/scripts/android/files/java/org/ddnet/client/ServerService.java
@@ -2,8 +2,9 @@ package org.ddnet.client;
 
 import java.io.File;
 
-import androidx.core.app.RemoteInput;
 import androidx.core.app.NotificationCompat;
+import androidx.core.app.RemoteInput;
+import androidx.core.app.ServiceCompat;
 
 import android.app.*;
 import android.content.*;
@@ -63,19 +64,12 @@ public class ServerService extends Service {
 
 		createNotificationChannel();
 
-		Notification notification = createRunningNotification();
-		if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-			startForeground(
-				NOTIFICATION_ID,
-				notification,
-				ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST
-			);
-		} else {
-			startForeground(
-				NOTIFICATION_ID,
-				notification
-			);
-		}
+		ServiceCompat.startForeground(
+			this,
+			NOTIFICATION_ID,
+			createRunningNotification(),
+			ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST
+		);
 
 		thread = new NativeServerThread(this);
 		thread.start();

--- a/src/android/android_main.cpp
+++ b/src/android/android_main.cpp
@@ -241,8 +241,9 @@ bool StartAndroidServer()
 {
 	// We need the notification-permission to show a notification for the foreground service.
 	// We use SDL for this instead of doing it on the Java side because this function blocks
-	// until the user made a choice, which is easier to handle.
-	if(!SDL_AndroidRequestPermission("android.permission.POST_NOTIFICATIONS"))
+	// until the user made a choice, which is easier to handle. Only Android 13 (API 33) and
+	// newer support requesting this permission at runtime.
+	if(SDL_GetAndroidSDKVersion() >= 33 && !SDL_AndroidRequestPermission("android.permission.POST_NOTIFICATIONS"))
 	{
 		return false;
 	}


### PR DESCRIPTION
Only request the notification permission on Android 13 and newer, as on older Android versions it was not a permission but a part of the notification system. The `SDLActivity` does not use the recommended `ContextCompat` and `ActivityCompat` for permissions so requesting the unknown permission fails.

## Checklist

- [X] Tested the change ingame (Android 11, 12, 13, 14)
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
