### PR TITLE
Fix incorrect loading progress due to 0.7 images

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -761,6 +761,7 @@ void CMenus::RenderLoading(const char *pCaption, const char *pContent, int Incre
 
 	const int CurLoadRenderCount = m_LoadingState.m_Current;
 	m_LoadingState.m_Current += IncreaseCounter;
+	dbg_assert(m_LoadingState.m_Current <= m_LoadingState.m_Total, "Invalid progress for RenderLoading");
 
 	// make sure that we don't render for each little thing we load
 	// because that will slow down loading if we have vsync

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -35,6 +35,11 @@ void CScoreboard::OnConsoleInit()
 	Console()->Register("+scoreboard", "", CFGFLAG_CLIENT, ConKeyScoreboard, this, "Show scoreboard");
 }
 
+void CScoreboard::OnInit()
+{
+	m_DeadTeeTexture = Graphics()->LoadTexture("deadtee.png", IStorage::TYPE_ALL);
+}
+
 void CScoreboard::OnReset()
 {
 	m_Active = false;
@@ -506,7 +511,7 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 			if(RenderDead)
 			{
 				Graphics()->BlendNormal();
-				Graphics()->TextureSet(client_data7::g_pData->m_aImages[client_data7::IMAGE_DEADTEE].m_Id);
+				Graphics()->TextureSet(m_DeadTeeTexture);
 				Graphics()->QuadsBegin();
 				if(m_pClient->m_Snap.m_pGameInfoObj->m_GameFlags & GAMEFLAG_TEAMS)
 				{

--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -4,6 +4,7 @@
 #define GAME_CLIENT_COMPONENTS_SCOREBOARD_H
 
 #include <engine/console.h>
+#include <engine/graphics.h>
 
 #include <game/client/component.h>
 #include <game/client/ui_rect.h>
@@ -32,10 +33,13 @@ class CScoreboard : public CComponent
 	bool m_Active;
 	float m_ServerRecord;
 
+	IGraphics::CTextureHandle m_DeadTeeTexture;
+
 public:
 	CScoreboard();
 	virtual int Sizeof() const override { return sizeof(*this); }
 	virtual void OnConsoleInit() override;
+	virtual void OnInit() override;
 	virtual void OnReset() override;
 	virtual void OnRender() override;
 	virtual void OnRelease() override;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -392,14 +392,6 @@ void CGameClient::OnInit()
 			g_pData->m_aImages[i].m_Id = Graphics()->LoadTexture(g_pData->m_aImages[i].m_pFilename, IStorage::TYPE_ALL);
 		m_Menus.RenderLoading(pLoadingDDNetCaption, pLoadingMessageAssets, 1);
 	}
-	for(int i = 0; i < client_data7::g_pData->m_NumImages; i++)
-	{
-		if(client_data7::g_pData->m_aImages[i].m_pFilename[0] == '\0') // handle special null image without filename
-			client_data7::g_pData->m_aImages[i].m_Id = IGraphics::CTextureHandle();
-		else if(i == client_data7::IMAGE_DEADTEE)
-			client_data7::g_pData->m_aImages[i].m_Id = Graphics()->LoadTexture(client_data7::g_pData->m_aImages[i].m_pFilename, IStorage::TYPE_ALL, 0);
-		m_Menus.RenderLoading(pLoadingDDNetCaption, Localize("Initializing assets"), 1);
-	}
 
 	m_GameWorld.m_pCollision = Collision();
 	m_GameWorld.m_pTuningList = m_aTuningList;


### PR DESCRIPTION
Load the only 0.7 image that exists in `CScoreboard` directly where it's used instead of looping over all 0.7 images and incorrectly incrementing the loading progress.

The incorrect loading progress was especially noticeable when the client is very slow, e.g. on Android emulators and when running with ASan.

See #9151. This does not address that too much unnecessary code is being generated yet.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
