### PR TITLE
Allow super users hammer others & fix jumps when `m_Jumps` is -1 or 0

### DIFF
--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -300,7 +300,7 @@ void CCharacter::FireWeapon()
 		// reset objects Hit
 		m_NumObjectsHit = 0;
 
-		if(m_Core.m_HammerHitDisabled)
+		if(m_Core.m_HammerHitDisabled && !m_Core.m_Super)
 			break;
 
 		CEntity *apEnts[MAX_CLIENTS];
@@ -1018,13 +1018,15 @@ void CCharacter::DDRacePostCoreTick()
 	if(m_Core.m_DeepFrozen && !m_Core.m_Super && !m_Core.m_Invincible)
 		Freeze();
 
+	bool EndlessJump = m_Core.m_Super || m_Core.m_Invincible || m_Core.m_EndlessJump;
+
 	// following jump rules can be overridden by tiles, like Refill Jumps, Stopper and Wall Jump
-	if(m_Core.m_Jumps == -1)
+	if(m_Core.m_Jumps == -1 && !EndlessJump)
 	{
 		// The player has only one ground jump, so his feet are always dark
 		m_Core.m_Jumped |= 2;
 	}
-	else if(m_Core.m_Jumps == 0)
+	else if(m_Core.m_Jumps == 0 && !EndlessJump)
 	{
 		// The player has no jumps at all, so his feet are always dark
 		m_Core.m_Jumped |= 2;

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -491,7 +491,7 @@ void CCharacter::FireWeapon()
 
 		Antibot()->OnHammerFire(m_pPlayer->GetCid());
 
-		if(m_Core.m_HammerHitDisabled)
+		if(m_Core.m_HammerHitDisabled && !m_Core.m_Super)
 			break;
 
 		CEntity *apEnts[MAX_CLIENTS];
@@ -2166,13 +2166,15 @@ void CCharacter::DDRacePostCoreTick()
 	if(m_Core.m_DeepFrozen && !m_Core.m_Super && !m_Core.m_Invincible)
 		Freeze();
 
+	bool EndlessJump = m_Core.m_Super || m_Core.m_Invincible || m_Core.m_EndlessJump;
+
 	// following jump rules can be overridden by tiles, like Refill Jumps, Stopper and Wall Jump
-	if(m_Core.m_Jumps == -1)
+	if(m_Core.m_Jumps == -1 && !EndlessJump)
 	{
 		// The player has only one ground jump, so his feet are always dark
 		m_Core.m_Jumped |= 2;
 	}
-	else if(m_Core.m_Jumps == 0)
+	else if(m_Core.m_Jumps == 0 && !EndlessJump)
 	{
 		// The player has no jumps at all, so his feet are always dark
 		m_Core.m_Jumped |= 2;


### PR DESCRIPTION
Closes #5710

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps (probably)
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
