### PR TITLE
Fix unexpected cursor jumps

### DIFF
--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -158,6 +158,7 @@ void CCamera::UpdateCamera()
 		{
 			m_Zoom = m_ZoomSmoothingTarget;
 			m_Zooming = false;
+			m_AutoSpecCameraZooming = false;
 		}
 		else
 		{
@@ -167,6 +168,7 @@ void CCamera::UpdateCamera()
 			{
 				m_Zoom = m_ZoomSmoothingTarget;
 				m_Zooming = false;
+				m_AutoSpecCameraZooming = false;
 			}
 		}
 		m_Zoom = clamp(m_Zoom, MinZoomLevel(), MaxZoomLevel());
@@ -177,6 +179,7 @@ void CCamera::UpdateCamera()
 		m_ZoomSet = false;
 		m_Zoom = 1.0f;
 		m_Zooming = false;
+		m_AutoSpecCameraZooming = false;
 	}
 	else if(!m_ZoomSet && g_Config.m_ClDefaultZoom != 10)
 	{
@@ -390,6 +393,7 @@ void CCamera::OnReset()
 
 	m_Zoom = CCamera::ZoomStepsToValue(g_Config.m_ClDefaultZoom - 10);
 	m_Zooming = false;
+	m_AutoSpecCameraZooming = false;
 	m_UserZoomTarget = CCamera::ZoomStepsToValue(g_Config.m_ClDefaultZoom - 10);
 	m_SpecZoomTarget = CCamera::ZoomStepsToValue(g_Config.m_ClDefaultZoom - 10);
 }


### PR DESCRIPTION
Fixes this reported by Skeith

![DDNet_7r6pQFO76d](https://github.com/user-attachments/assets/9370c6ac-47a9-488c-8891-a9cfdb7c2a3e)

This happens where `m_AutoSpecCameraZooming` may not reset properly in some cases and zooming will cause cursor to use camera zoom when camera zoom does not match `m_SpecInfo.m_Zoom` since AUTO is off.

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
