### PR TITLE
Revert "Scale angles using MousePos with zoom"

### DIFF
--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -189,7 +189,7 @@ void CPlayers::RenderHookCollLine(
 	if(Local && !m_pClient->m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 	{
 		// just use the direct input if it's the local player we are rendering
-		Angle = angle(m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy] * m_pClient->m_Camera.m_Zoom);
+		Angle = angle(m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy]);
 	}
 	else
 	{
@@ -232,9 +232,7 @@ void CPlayers::RenderHookCollLine(
 
 			if(Local && !m_pClient->m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 			{
-				ExDirection = normalize(
-					vec2((int)((int)m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy].x * m_pClient->m_Camera.m_Zoom),
-						(int)((int)m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy].y * m_pClient->m_Camera.m_Zoom)));
+				ExDirection = normalize(vec2((int)m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy].x, (int)m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy].y));
 
 				// fix direction if mouse is exactly in the center
 				if(!(int)m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy].x && !(int)m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy].y)
@@ -456,7 +454,7 @@ void CPlayers::RenderPlayer(
 	if(Local && !m_pClient->m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 	{
 		// just use the direct input if it's the local player we are rendering
-		Angle = angle(m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy] * m_pClient->m_Camera.m_Zoom);
+		Angle = angle(m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy]);
 	}
 	else
 	{


### PR DESCRIPTION
This reverts commit e14123164bed7fe61d3cb8d0a25398aacda2d17d.

Fixes inconsistent hookcoll indicator under our new-old cursor position reported by Skeith
![DDNet_t7tjOUt3Kh](https://github.com/user-attachments/assets/9e3aa001-e601-4741-bac4-78dc313bfbb1)

We rolled back to a unscaled pointer for preserving aiming consistency in #9301.
This commit is no longer needed.

I don't have a bind handy, should also make 45 aim (or any obviously quantized angle) angle matches actually input now.
@l-ouis reported this particular visual inconsistency, he can probably test.

## Checklist

- [x] Tested the change ingame
- [] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
