### PR TITLE
Add 45 snap client setting

### DIFF
--- a/src/base/vmath.h
+++ b/src/base/vmath.h
@@ -155,6 +155,13 @@ inline vector2_base<float> random_direction()
 	return direction(random_angle());
 }
 
+inline vector2_base<float> snap_to_45(const vector2_base<float> &v)
+{
+	float ang = angle(v);
+	ang = round(ang / (pi / 4)) * (pi / 4);
+	return vector2_base<float>(direction(ang) * length(v));
+}
+
 typedef vector2_base<float> vec2;
 typedef vector2_base<bool> bvec2;
 typedef vector2_base<int> ivec2;

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -22,6 +22,7 @@ MACRO_CONFIG_INT(ClAntiPingSmooth, cl_antiping_smooth, 0, 0, 1, CFGFLAG_CLIENT |
 MACRO_CONFIG_INT(ClAntiPingGunfire, cl_antiping_gunfire, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Predict gunfire and show predicted weapon physics (with cl_antiping_grenade 1 and cl_antiping_weapons 1)")
 MACRO_CONFIG_INT(ClPredictionMargin, cl_prediction_margin, 10, 1, 300, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Prediction margin in ms (adds latency, can reduce lag from ping jumps)")
 MACRO_CONFIG_INT(ClSubTickAiming, cl_sub_tick_aiming, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Send aiming data at sub-tick accuracy")
+MACRO_CONFIG_INT(ClSnapAimTo45, cl_snap_aim_to_45, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Snap aim to 45 degree angles")
 #if defined(CONF_PLATFORM_ANDROID)
 MACRO_CONFIG_INT(ClTouchControls, cl_touch_controls, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable ingame touch controls")
 #else

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -229,6 +229,13 @@ int CControls::SnapInput(int *pData)
 			m_aMousePosOnAction[g_Config.m_ClDummy] = vec2(0.0f, 0.0f);
 		}
 
+		if(g_Config.m_ClSnapAimTo45)
+		{
+			vec2 SnappedVec = snap_to_45(vec2(m_aInputData[g_Config.m_ClDummy].m_TargetX, m_aInputData[g_Config.m_ClDummy].m_TargetY));
+			m_aInputData[g_Config.m_ClDummy].m_TargetX = (int)SnappedVec.x;
+			m_aInputData[g_Config.m_ClDummy].m_TargetY = (int)SnappedVec.y;
+		}
+
 		if(!m_aInputData[g_Config.m_ClDummy].m_TargetX && !m_aInputData[g_Config.m_ClDummy].m_TargetY)
 		{
 			m_aInputData[g_Config.m_ClDummy].m_TargetX = 1;
@@ -340,6 +347,20 @@ void CControls::OnRender()
 			}
 			if(Weapon != m_pClient->m_Snap.m_pLocalCharacter->m_Weapon)
 				m_aInputData[g_Config.m_ClDummy].m_WantedWeapon = Weapon + 1;
+		}
+	}
+
+	m_aRenderedLocalTeeAngle[g_Config.m_ClDummy] = m_aMousePos[g_Config.m_ClDummy];
+
+	// render local player to snapped angles even if it doesn't align with mouse
+	if(g_Config.m_ClSnapAimTo45)
+	{
+		vec2 SnappedVec = snap_to_45(m_aMousePos[g_Config.m_ClDummy]);
+		m_aRenderedLocalTeeAngle[g_Config.m_ClDummy] = SnappedVec;
+		// update actual mouse position if action taken
+		if(m_aInputData[g_Config.m_ClDummy].m_Fire % 2 != 0 || m_aInputData[g_Config.m_ClDummy].m_Hook)
+		{
+			m_aMousePos[g_Config.m_ClDummy] = SnappedVec;
 		}
 	}
 

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -17,6 +17,7 @@ public:
 	float GetMaxMouseDistance() const;
 
 	vec2 m_aMousePos[NUM_DUMMIES];
+	vec2 m_aRenderedLocalTeeAngle[NUM_DUMMIES];
 	vec2 m_aMousePosOnAction[NUM_DUMMIES];
 	vec2 m_aTargetPos[NUM_DUMMIES];
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -876,6 +876,7 @@ static CKeyInfo gs_aKeys[] =
 		{Localizable("Fire"), "+fire", 0, 0},
 		{Localizable("Hook"), "+hook", 0, 0},
 		{Localizable("Hook collisions"), "+showhookcoll", 0, 0},
+		{Localizable("Snap Aim"), "+toggle cl_snap_aim_to_45 1 0", 0, 0},
 		{Localizable("Pause"), "say /pause", 0, 0},
 		{Localizable("Kill"), "kill", 0, 0},
 		{Localizable("Zoom in"), "zoom+", 0, 0},

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -189,7 +189,7 @@ void CPlayers::RenderHookCollLine(
 	if(Local && !m_pClient->m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 	{
 		// just use the direct input if it's the local player we are rendering
-		Angle = angle(m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy]);
+		Angle = angle(m_pClient->m_Controls.m_aRenderedLocalTeeAngle[g_Config.m_ClDummy]);
 	}
 	else
 	{
@@ -232,8 +232,7 @@ void CPlayers::RenderHookCollLine(
 
 			if(Local && !m_pClient->m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 			{
-				ExDirection = normalize(vec2((int)m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy].x, (int)m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy].y));
-
+				ExDirection = normalize(m_pClient->m_Controls.m_aRenderedLocalTeeAngle[g_Config.m_ClDummy]);
 				// fix direction if mouse is exactly in the center
 				if(!(int)m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy].x && !(int)m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy].y)
 					ExDirection = vec2(1, 0);
@@ -485,7 +484,7 @@ void CPlayers::RenderPlayer(
 	if(Local && !m_pClient->m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 	{
 		// just use the direct input if it's the local player we are rendering
-		Angle = angle(m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy]);
+		Angle = angle(m_pClient->m_Controls.m_aRenderedLocalTeeAngle[g_Config.m_ClDummy]);
 	}
 	else
 	{


### PR DESCRIPTION
😬

removes need for janky 45 deg mouse distance bind, allows this to be bound easily in settings

makes snapping to 45 degrees very easy and more convenient, can make certain parts (lasers, shotguns, gores saves) easier than they have been before

needs discussion

https://github.com/user-attachments/assets/ca00e806-3832-474a-b0df-7ad72cfdd460


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
