### PR TITLE
Remove spec zoom value and use user zoom always

### DIFF
--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -77,7 +77,6 @@ public:
 	bool m_AutoSpecCameraZooming;
 	bool m_AutoSpecCamera;
 	float m_UserZoomTarget;
-	float m_SpecZoomTarget;
 
 	vec2 m_DyncamTargetCameraOffset;
 	vec2 m_aDyncamCurrentCameraOffset[NUM_DUMMIES];


### PR DESCRIPTION
People think juggling between different zoom values is tiring
Now any manually adjusted zoom will stay

Also fixed a issue where going in and out of spectating does not smooth camera movement but smooth zoom. Now it is both instant.

demo:
https://streamable.com/f17hnd

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
