### PR TITLE
Auto spec menu

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -83,6 +83,7 @@ MACRO_CONFIG_INT(ClEyeDuration, cl_eye_duration, 999999, 1, 999999, CFGFLAG_CLIE
 MACRO_CONFIG_INT(ClFreezeStars, cl_freeze_stars, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show old star particles for frozen tees")
 
 MACRO_CONFIG_INT(ClSpecCursor, cl_spec_cursor, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable the cursor of spectating player if available")
+MACRO_CONFIG_INT(ClSpecAutoSync, cl_spec_auto_sync, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Automatically synchronize with spectating players's camera setting if available (0 = disable, 1 = enable on reset zoom)")
 
 MACRO_CONFIG_INT(ClAirjumpindicator, cl_airjumpindicator, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show the air jump indicator")
 MACRO_CONFIG_INT(ClThreadsoundloading, cl_threadsoundloading, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Load sound files threaded")

--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -8,6 +8,7 @@
 #include <base/vmath.h>
 #include <game/client/gameclient.h>
 #include <game/collision.h>
+#include <game/localization.h>
 #include <game/mapitems.h>
 
 #include "camera.h"
@@ -44,6 +45,8 @@ CCamera::CCamera()
 	m_AutoSpecCamera = true;
 	m_AutoSpecCameraZooming = false;
 	m_UsingAutoSpecCamera = false;
+
+	mem_zero(m_aAutoSpecCameraTooltip, sizeof(m_aAutoSpecCameraTooltip));
 }
 
 float CCamera::CameraSmoothingProgress(float CurrentTime) const
@@ -62,10 +65,7 @@ void CCamera::ScaleZoom(float Factor)
 	float CurrentTarget = m_Zooming ? m_ZoomSmoothingTarget : m_Zoom;
 	ChangeZoom(CurrentTarget * Factor, m_pClient->m_Snap.m_SpecInfo.m_Active && GameClient()->m_MultiViewActivated ? g_Config.m_ClMultiViewZoomSmoothness : g_Config.m_ClSmoothZoomTime, true);
 
-	if(m_IsSpectatingPlayer)
-	{
-		m_AutoSpecCamera = false;
-	}
+	m_AutoSpecCamera = false;
 }
 
 float CCamera::MaxZoomLevel()
@@ -444,18 +444,13 @@ void CCamera::ConZoom(IConsole::IResult *pResult, void *pUserData)
 		return;
 
 	bool IsReset = !pResult->NumArguments();
-	bool IsSpectating = pSelf->m_IsSpectatingPlayer;
 
 	float TargetLevel = !IsReset ? pResult->GetFloat(0) : g_Config.m_ClDefaultZoom;
-	if(IsSpectating && IsReset)
-		pSelf->ResetAutoSpecCamera();
-	else
+
+	if(!pSelf->CanUseAutoSpecCamera() || !pSelf->m_IsSpectatingPlayer)
 		pSelf->ChangeZoom(CCamera::ZoomStepsToValue(TargetLevel - 10.0f), pSelf->m_pClient->m_Snap.m_SpecInfo.m_Active && pSelf->GameClient()->m_MultiViewActivated ? g_Config.m_ClMultiViewZoomSmoothness : g_Config.m_ClSmoothZoomTime, true);
 
-	if(IsSpectating && !IsReset)
-	{
-		pSelf->m_AutoSpecCamera = false;
-	}
+	pSelf->m_AutoSpecCamera = IsReset;
 
 	if(pSelf->GameClient()->m_MultiViewActivated && pSelf->m_pClient->m_Snap.m_SpecInfo.m_Active)
 		pSelf->GameClient()->m_MultiViewPersonalZoom = TargetLevel - 10.0f;
@@ -625,5 +620,40 @@ bool CCamera::CanUseAutoSpecCamera() const
 		return m_pClient->m_Snap.m_SpecInfo.m_HasCameraInfo && m_pClient->m_DemoSpecId == SPEC_FOLLOW;
 	}
 
-	return m_pClient->m_Snap.m_SpecInfo.m_HasCameraInfo && m_pClient->m_Snap.m_SpecInfo.m_SpectatorId != m_pClient->m_Snap.m_LocalClientId;
+	return g_Config.m_ClSpecAutoSync && m_pClient->m_Snap.m_SpecInfo.m_HasCameraInfo &&
+	       m_pClient->m_Snap.m_SpecInfo.m_SpectatorId != m_pClient->m_aLocalIds[0] &&
+	       (!m_pClient->Client()->DummyConnected() || m_pClient->m_Snap.m_SpecInfo.m_SpectatorId != m_pClient->m_aLocalIds[1]);
+}
+
+void CCamera::ToggleAutoSpecCamera()
+{
+	if(!g_Config.m_ClSpecAutoSync)
+	{
+		g_Config.m_ClSpecAutoSync = 1;
+		m_pClient->m_Camera.m_AutoSpecCamera = true;
+	}
+	else if(m_pClient->m_Camera.m_AutoSpecCamera && m_pClient->m_Camera.SpectatingPlayer() && m_pClient->m_Camera.CanUseAutoSpecCamera())
+	{
+		m_pClient->m_Camera.m_AutoSpecCamera = false;
+	}
+	else
+	{
+		g_Config.m_ClSpecAutoSync = 0;
+	}
+}
+
+void CCamera::UpdateAutoSpecCameraTooltip()
+{
+	const char *pFeatureText = Localize("Auto-sync player camera");
+
+	if(!g_Config.m_ClSpecAutoSync)
+		str_format(m_aAutoSpecCameraTooltip, sizeof(m_aAutoSpecCameraTooltip), "%s: %s", pFeatureText, Localize("Disabled", "Auto camera"));
+	else if(!SpectatingPlayer())
+		str_format(m_aAutoSpecCameraTooltip, sizeof(m_aAutoSpecCameraTooltip), "%s: %s", pFeatureText, Localize("Enabled", "Auto camera"));
+	else if(!CanUseAutoSpecCamera())
+		str_format(m_aAutoSpecCameraTooltip, sizeof(m_aAutoSpecCameraTooltip), "%s: %s", pFeatureText, Localize("Unavailable for this player", "Auto camera"));
+	else if(!m_AutoSpecCamera)
+		str_format(m_aAutoSpecCameraTooltip, sizeof(m_aAutoSpecCameraTooltip), "%s: %s", pFeatureText, Localize("Inactive", "Auto camera"));
+	else
+		str_format(m_aAutoSpecCameraTooltip, sizeof(m_aAutoSpecCameraTooltip), "%s: %s", pFeatureText, Localize("Active", "Auto camera"));
 }

--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -77,7 +77,6 @@ public:
 	bool m_AutoSpecCameraZooming;
 	bool m_AutoSpecCamera;
 	float m_UserZoomTarget;
-	float m_SpecZoomTarget;
 
 	vec2 m_DyncamTargetCameraOffset;
 	vec2 m_aDyncamCurrentCameraOffset[NUM_DUMMIES];

--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -57,6 +57,8 @@ private:
 	bool m_IsSpectatingPlayer;
 	bool m_UsingAutoSpecCamera;
 
+	char m_aAutoSpecCameraTooltip[512];
+
 public:
 	static constexpr float ZOOM_STEP = 0.866025f;
 
@@ -105,6 +107,10 @@ public:
 	void ResetAutoSpecCamera();
 	bool SpectatingPlayer() const { return m_IsSpectatingPlayer; }
 	bool CanUseAutoSpecCamera() const;
+	void ToggleAutoSpecCamera();
+	void UpdateAutoSpecCameraTooltip();
+
+	const char *AutoSpecCameraTooltip() { return m_aAutoSpecCameraTooltip; }
 
 private:
 	static void ConZoomPlus(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1471,7 +1471,7 @@ void CHud::RenderSpectatorHud()
 	TextRender()->Text(m_Width - 174.0f, m_Height - 15.0f + (15.f - 8.f) / 2.f, 8.0f, aBuf, -1.0f);
 
 	// draw the camera info
-	if(m_pClient->m_Camera.SpectatingPlayer() && m_pClient->m_Camera.CanUseAutoSpecCamera())
+	if(m_pClient->m_Camera.SpectatingPlayer() && m_pClient->m_Camera.CanUseAutoSpecCamera() && g_Config.m_ClSpecAutoSync)
 	{
 		bool AutoSpecCameraEnabled = m_pClient->m_Camera.m_AutoSpecCamera;
 		const char *pLabelText = Localize("AUTO", "Spectating Camera Mode Icon");
@@ -1482,7 +1482,7 @@ void CHud::RenderSpectatorHud()
 		constexpr float Padding = 3.0f;
 		const float TagWidth = IconWidth + TextWidth + Padding * 3.0f;
 		const float TagX = m_Width - RightMargin - TagWidth;
-		Graphics()->DrawRect(TagX, m_Height - 12.0f, TagWidth, 10.0f, ColorRGBA(0.84f, 0.53f, 0.17f, AutoSpecCameraEnabled ? 0.85f : 0.25f), IGraphics::CORNER_ALL, 2.5f);
+		Graphics()->DrawRect(TagX, m_Height - 12.0f, TagWidth, 10.0f, ColorRGBA(1.0f, 1.0f, 1.0f, AutoSpecCameraEnabled ? 0.50f : 0.10f), IGraphics::CORNER_ALL, 2.5f);
 		TextRender()->TextColor(1, 1, 1, AutoSpecCameraEnabled ? 1.0f : 0.65f);
 		TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
 		TextRender()->Text(TagX + Padding, m_Height - 10.0f, 6.0f, FontIcons::FONT_ICON_CAMERA, -1.0f);

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -214,6 +214,23 @@ void CMenus::RenderGame(CUIRect MainView)
 		}
 	}
 
+	if(m_pClient->m_Snap.m_pLocalInfo && (m_pClient->m_Snap.m_pLocalInfo->m_Team == TEAM_SPECTATORS || Paused || Spec))
+	{
+		ButtonBar.VSplitLeft(32.0f, &Button, &ButtonBar);
+		ButtonBar.VSplitLeft(5.0f, nullptr, &ButtonBar);
+
+		static CButtonContainer s_AutoCameraButton;
+
+		bool Active = m_pClient->m_Camera.m_AutoSpecCamera && m_pClient->m_Camera.SpectatingPlayer() && m_pClient->m_Camera.CanUseAutoSpecCamera();
+		bool Enabled = g_Config.m_ClSpecAutoSync;
+		if(DoButton_FontIcon(&s_AutoCameraButton, FONT_ICON_CAMERA, !Active, &Button, IGraphics::CORNER_ALL, Enabled))
+		{
+			m_pClient->m_Camera.ToggleAutoSpecCamera();
+		}
+		m_pClient->m_Camera.UpdateAutoSpecCameraTooltip();
+		GameClient()->m_Tooltips.DoToolTip(&s_AutoCameraButton, &Button, m_pClient->m_Camera.AutoSpecCameraTooltip());
+	}
+
 	if(g_Config.m_ClTouchControls)
 	{
 		ButtonBar2.VSplitLeft(200.0f, &Button, &ButtonBar2);


### PR DESCRIPTION
Depends on #9466. Check commit for diff from that PR.

Full video demo: https://streamable.com/zva2i4

After some feedback on 18.9 RC, and given how confusing and polarizing the feature is, i think it is now pretty important to add a visible toggle and a permanent setting (`cl_spec_auto_sync`, please check the description on whether it is clear enough)

Adds a in-game menu button for toggling this feature (it toggles both ingame state and the config, only shown in spectator mode)
![image](https://github.com/user-attachments/assets/d6771193-3bbe-4944-a0b6-5fed7a4a01a1)

Along with these status tooltips:
* `Active`
* `Inactive`
* `Disabled`
* `Enabled` (when it is not possible to activate)
* `Unavailable for this player` (when spectating older clients))

This is quite a few localization strings but I think it is worth it for clarity.

This button toggles between three or two states depends on the context. Either `Active` - `Inactive` - `Disabled` or just `Enabled` - `Disabled`.

When the feature is not disabled, assume player do not mind the feature and currently taking Skeith suggestion to automatically turn on when player reset's zoom, and disable after zoom+ or zoom-. I did not check whether current zoom is default because:
1. it is hard to do due to floating point comparison
2. it is harder to guess player's intention why they just zoomed out and zoomed in)

Also updated the indicator icon's color to match the button and make it less distracting. And it will completely hide if player disabled the feature.
![image](https://github.com/user-attachments/assets/3c8f22eb-d1af-43ee-b001-2eabe42b88b2)

I'd like this to be in 18.9, even though this is a pretty big change, but it came from discord feedback. Review carefully.

*Demo menu is unchanged because I think it doesn't make sense to follow the config.*

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
