### PR TITLE
Fix cursor and auto spec cam in demo

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -3119,7 +3119,7 @@ void CGameClient::UpdatePrediction()
 void CGameClient::UpdateSpectatorCursor()
 {
 	int CursorOwnerId = m_Snap.m_LocalClientId;
-	if(m_Snap.m_SpecInfo.m_Active || Client()->State() == IClient::STATE_DEMOPLAYBACK)
+	if(m_Snap.m_SpecInfo.m_Active)
 	{
 		CursorOwnerId = m_Snap.m_SpecInfo.m_SpectatorId;
 	}


### PR DESCRIPTION
Fixed two demo related issues.

1. cursor doesn't work properl in follow mode if player's client id isn't 0
2. auto zoom will instant snap in follow mode for recorded local player

Reference demos: (demo provided by always (@alw5) on discord
[demos.zip](https://github.com/user-attachments/files/18300815/demos.zip)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
