### PR TITLE
update community info

### DIFF
--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -1105,10 +1105,10 @@ Assets directory
 == 资源目录
 
 https://ddnet.org/discord
-== http://chat.teeworlds.cn/
+== https://chat.teeworlds.cn/
 
 Discord
-== 开黑啦
+== 加入社区
 
 The width of texture %s is not divisible by %d, or the height is not divisible by %d, which might cause visual bugs.
 == 纹理文件 %s 的宽度无法被 %d 整除，或者高度无法被 %d 整除，这可能会导致显示错误。


### PR DESCRIPTION
"开黑啦" as a service has renamed themselves a few years ago, and their software is getting worse and the user base is consistently smaller than the tencent ones, we've been updating the url redirect since. We didn't change the button before because the phrase is actually not bad for indicating what it was for (translated to "let's play together")

I finally started hosting the join page myself instead of just using a DNS providers redirect. so it finally supports https now.

Rename the button to "join community" instead.

And I feel like we shouldn't just have a backbox url that one person secretly controls. So the page is now opensource here: 
https://github.com/TeeworldsCN/join

You can check the current join page for CHN here: https://chat.teeworlds.cn

