### PR TITLE
Support passing launch arguments to Android server

### DIFF
--- a/scripts/android/files/java/org/ddnet/client/ClientActivity.java
+++ b/scripts/android/files/java/org/ddnet/client/ClientActivity.java
@@ -96,12 +96,12 @@ public class ClientActivity extends SDLActivity {
 	}
 
 	// Called from native code, see android_main.cpp
-	public void startServer() {
+	public void startServer(String[] arguments) {
 		synchronized(serverServiceMonitor) {
 			if(serverServiceMessenger != null) {
 				return;
 			}
-			Intent startIntent = new Intent(this, ServerService.class);
+			Intent startIntent = ServerService.createStartIntent(this, arguments);
 			ContextCompat.startForegroundService(this, startIntent);
 			bindService(startIntent, serverServiceConnection, 0);
 		}
@@ -114,9 +114,7 @@ public class ClientActivity extends SDLActivity {
 				return;
 			}
 			try {
-				Message message = Message.obtain(null, ServerService.MESSAGE_CODE_EXECUTE_COMMAND, 0, 0);
-				message.getData().putString(ServerService.MESSAGE_EXTRA_COMMAND, command);
-				serverServiceMessenger.send(message);
+				serverServiceMessenger.send(ServerService.createExecuteCommandMessage(command));
 			} catch (RemoteException e) {
 				// Connection broken
 				unbindService(serverServiceConnection);

--- a/scripts/android/files/java/org/ddnet/client/ServerService.java
+++ b/scripts/android/files/java/org/ddnet/client/ServerService.java
@@ -18,11 +18,12 @@ public class ServerService extends Service {
 	private static final String NOTIFICATION_CHANNEL_ID = "LOCAL_SERVER_CHANNEL_ID";
 	private static final int NOTIFICATION_ID = 1;
 
-	public static final int MESSAGE_CODE_EXECUTE_COMMAND = 1;
-	public static final String MESSAGE_EXTRA_COMMAND = "command";
+	private static final int MESSAGE_CODE_EXECUTE_COMMAND = 1;
+	private static final String MESSAGE_EXTRA_COMMAND = "command";
 
-	public static final String INTENT_ACTION_EXECUTE = "execute";
-	public static final String INTENT_EXTRA_COMMAND = "command";
+	private static final String INTENT_ACTION_START = "start";
+	private static final String INTENT_ACTION_EXECUTE = "execute";
+	private static final String INTENT_EXTRA_COMMANDS = "commands";
 	private static final String KEY_EXECUTE_TEXT_REPLY = "execute-command-reply";
 
 	static {
@@ -70,16 +71,19 @@ public class ServerService extends Service {
 			createRunningNotification(),
 			ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST
 		);
-
-		thread = new NativeServerThread(this);
-		thread.start();
 	}
 
 	@Override
 	public int onStartCommand(Intent intent, int flags, int startId) {
 		if(intent != null) {
 			String action = intent.getAction();
-			if(INTENT_ACTION_EXECUTE.equals(action)) {
+			if(INTENT_ACTION_START.equals(action)) {
+				String[] commands = intent.getStringArrayExtra(INTENT_EXTRA_COMMANDS);
+				if(commands != null) {
+					thread = new NativeServerThread(this, commands);
+					thread.start();
+				}
+			} else if(INTENT_ACTION_EXECUTE.equals(action)) {
 				Bundle remoteInput = RemoteInput.getResultsFromIntent(intent);
 				if(remoteInput != null) {
 					CharSequence remoteCommand = remoteInput.getCharSequence(KEY_EXECUTE_TEXT_REPLY);
@@ -92,12 +96,17 @@ public class ServerService extends Service {
 						notificationManager.notify(NOTIFICATION_ID, createRunningNotification());
 					}
 				} else {
-					String command = intent.getStringExtra(INTENT_EXTRA_COMMAND);
-					if(command != null) {
-						executeCommand(command);
+					String[] commands = intent.getStringArrayExtra(INTENT_EXTRA_COMMANDS);
+					if(commands != null) {
+						for(String command : commands) {
+							executeCommand(command);
+						}
 					}
 				}
 			}
+		}
+		if(thread == null) {
+			stopSelf();
 		}
 		return START_NOT_STICKY;
 	}
@@ -159,7 +168,7 @@ public class ServerService extends Service {
 
 		Intent stopIntent = new Intent(this, ServerService.class);
 		stopIntent.setAction(INTENT_ACTION_EXECUTE);
-		stopIntent.putExtra(INTENT_EXTRA_COMMAND, "shutdown");
+		stopIntent.putExtra(INTENT_EXTRA_COMMANDS, new String[] {"shutdown"});
 
 		PendingIntent stopActionIntent = PendingIntent.getService(
 			this,
@@ -241,6 +250,19 @@ public class ServerService extends Service {
 		}
 		NativeServer.executeCommand(command);
 	}
+
+	public static Intent createStartIntent(Context context, String[] arguments) {
+		Intent intent = new Intent(context, ServerService.class);
+		intent.setAction(INTENT_ACTION_START);
+		intent.putExtra(INTENT_EXTRA_COMMANDS, arguments);
+		return intent;
+	}
+
+	public static Message createExecuteCommandMessage(String command) {
+		Message message = Message.obtain(null, MESSAGE_CODE_EXECUTE_COMMAND, 0, 0);
+		message.getData().putString(MESSAGE_EXTRA_COMMAND, command);
+		return message;
+	}
 }
 
 /**
@@ -251,9 +273,11 @@ public class ServerService extends Service {
 class NativeServerThread extends Thread {
 
 	private final Context applicationContext;
+	private final String[] arguments;
 
-	public NativeServerThread(Context context) {
+	public NativeServerThread(Context context, String[] arguments) {
 		this.applicationContext = context.getApplicationContext();
+		this.arguments = arguments;
 	}
 
 	@Override
@@ -267,7 +291,7 @@ class NativeServerThread extends Thread {
 			return;
 		}
 
-		int Result = NativeServer.runServer(workingDirectory.getAbsolutePath());
+		int Result = NativeServer.runServer(workingDirectory.getAbsolutePath(), arguments);
 		new Handler(applicationContext.getMainLooper()).post(() -> {
 			if(Result != 0) {
 				Toast.makeText(applicationContext, applicationContext.getString(R.string.server_error_exit_code, Result), Toast.LENGTH_LONG).show();
@@ -297,9 +321,10 @@ class NativeServer {
 	 * exit code on completion.
 	 *
 	 * @param workingDirectory The working directory for the server, which must be the
-	 * external storage directory of the app and already contains all data files.
+	 * external storage directory of the app and already contain all data files.
+	 * @param arguments Arguments to supply to the server when launching it.
 	 */
-	public static native int runServer(String workingDirectory);
+	public static native int runServer(String workingDirectory, String[] arguments);
 
 	/**
 	 * Adds a command to the execution queue of the native server.

--- a/src/android/android_main.cpp
+++ b/src/android/android_main.cpp
@@ -237,7 +237,7 @@ void RestartAndroidApp()
 	SDL_AndroidSendMessage(COMMAND_RESTART_APP, 0);
 }
 
-bool StartAndroidServer()
+bool StartAndroidServer(const char **ppArguments, size_t NumArguments)
 {
 	// We need the notification-permission to show a notification for the foreground service.
 	// We use SDL for this instead of doing it on the Java side because this function blocks
@@ -252,9 +252,20 @@ bool StartAndroidServer()
 	jobject Activity = (jobject)SDL_AndroidGetActivity();
 	jclass ActivityClass = pEnv->GetObjectClass(Activity);
 
-	jmethodID MethodId = pEnv->GetMethodID(ActivityClass, "startServer", "()V");
-	pEnv->CallVoidMethod(Activity, MethodId);
+	jclass StringClass = pEnv->FindClass("java/lang/String");
+	jobjectArray ArgumentsArray = pEnv->NewObjectArray(NumArguments, StringClass, nullptr);
+	pEnv->DeleteLocalRef(StringClass);
+	for(size_t ArgumentIndex = 0; ArgumentIndex < NumArguments; ArgumentIndex++)
+	{
+		jstring ArgumentString = pEnv->NewStringUTF(ppArguments[ArgumentIndex]);
+		pEnv->SetObjectArrayElement(ArgumentsArray, ArgumentIndex, ArgumentString);
+		pEnv->DeleteLocalRef(ArgumentString);
+	}
 
+	jmethodID MethodId = pEnv->GetMethodID(ActivityClass, "startServer", "([Ljava/lang/String;)V");
+	pEnv->CallVoidMethod(Activity, MethodId, ArgumentsArray);
+
+	pEnv->DeleteLocalRef(ArgumentsArray);
 	pEnv->DeleteLocalRef(Activity);
 	pEnv->DeleteLocalRef(ActivityClass);
 

--- a/src/android/android_main.h
+++ b/src/android/android_main.h
@@ -51,9 +51,12 @@ void RestartAndroidApp();
  * This will request the notification-permission as it is required for
  * foreground services to show a notification.
  *
+ * @param ppArguments Array of arguments to pass to the server on launch.
+ * @param NumArguments The number of arguments.
+ *
  * @return `true` on success, `false` on error.
  */
-bool StartAndroidServer();
+bool StartAndroidServer(const char **ppArguments, size_t NumArguments);
 
 /**
  * Adds a command to the execution queue of the local server.

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -273,7 +273,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 void CMenus::RunServer()
 {
 #if defined(CONF_PLATFORM_ANDROID)
-	if(StartAndroidServer())
+	if(StartAndroidServer({}, 0))
 	{
 		m_ForceRefreshLanPage = true;
 	}


### PR DESCRIPTION
Currently no arguments are passed when launching the server though. This is for supporting #9092.

## Checklist

- [X] Tested the change ingame (by manually specifying arguments)
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
