### PR TITLE
Move special weapon enums to protocol.h

### DIFF
--- a/datasrc/compile.py
+++ b/datasrc/compile.py
@@ -86,6 +86,13 @@ def gen_network_header():
 	EmitEnum([f"WEAPON_{i.name.value.upper()}" for i in content.container.weapons.id.items], "NUM_WEAPONS")
 
 	print("""
+enum
+{
+	WEAPON_GAME = -3, // team switching etc
+	WEAPON_SELF = -2, // console kill command
+	WEAPON_WORLD = -1, // death tiles etc
+};
+
 class CNetObjHandler
 {
 	const char *m_pMsgFailedOn;

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -407,7 +407,7 @@ Messages = [
 	NetMessage("Sv_KillMsg", [
 		NetIntRange("m_Killer", 0, 'MAX_CLIENTS-1'),
 		NetIntRange("m_Victim", 0, 'MAX_CLIENTS-1'),
-		NetIntRange("m_Weapon", -3, 'NUM_WEAPONS-1'),
+		NetIntRange("m_Weapon", 'WEAPON_GAME', 'NUM_WEAPONS-1'),
 		NetIntAny("m_ModeSpecial"),
 	]),
 

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -6,13 +6,7 @@
 #include <game/client/prediction/entity.h>
 
 #include <game/gamecore.h>
-
-enum
-{
-	WEAPON_GAME = -3, // team switching etc
-	WEAPON_SELF = -2, // console kill command
-	WEAPON_WORLD = -1, // death tiles etc
-};
+#include <game/generated/protocol.h>
 
 enum
 {

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -4,9 +4,7 @@
 #define GAME_SERVER_PLAYER_H
 
 #include <base/vmath.h>
-
 #include <engine/shared/protocol.h>
-
 #include <game/alloc.h>
 #include <game/server/save.h>
 
@@ -20,13 +18,6 @@ class CGameContext;
 class IServer;
 struct CNetObj_PlayerInput;
 struct CScorePlayerResult;
-
-enum
-{
-	WEAPON_GAME = -3, // team switching etc
-	WEAPON_SELF = -2, // console kill command
-	WEAPON_WORLD = -1, // death tiles etc
-};
 
 // player object
 class CPlayer


### PR DESCRIPTION
~~This would be the third enums.h file I created.~~

~~There is one for the [editor](https://github.com/ddnet/ddnet/blob/e55cf2967faffa9ab79fc95fa53b870dd4fbc764/src/game/editor/enums.h) and one for [the client](https://github.com/ddnet/ddnet/blob/master/src/engine/client/enums.h) and this new one is then for the server. Maybe one day I will also propose to add src/game/enums.h for server and client shared and then it should be enough to cover all cases.~~

~~The goal here is to make including cleaner and dependency management easier. Also WEAPON_ specifically does not belong into the player class it is used all over the server code. Including player.h to get access to that enum is a bit weird and often overkill.~~

~~It is similar to the file src/base/types.h but specifically for enums only.~~

Moved to protocol.h