### PR TITLE
Show position in freeview

### DIFF
--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1309,6 +1309,8 @@ inline int CHud::GetDigitsIndex(int Value, int Max)
 
 inline float CHud::GetMovementInformationBoxHeight()
 {
+	if(m_pClient->m_Snap.m_SpecInfo.m_Active && m_pClient->m_Snap.m_SpecInfo.m_SpectatorId == SPEC_FREEVIEW)
+		return g_Config.m_ClShowhudPlayerPosition ? 3 * MOVEMENT_INFORMATION_LINE_HEIGHT + 2 : 0;
 	float BoxHeight = 3 * MOVEMENT_INFORMATION_LINE_HEIGHT * (g_Config.m_ClShowhudPlayerPosition + g_Config.m_ClShowhudPlayerSpeed) + 2 * MOVEMENT_INFORMATION_LINE_HEIGHT * g_Config.m_ClShowhudPlayerAngle;
 	if(g_Config.m_ClShowhudPlayerPosition || g_Config.m_ClShowhudPlayerSpeed || g_Config.m_ClShowhudPlayerAngle)
 	{
@@ -1341,9 +1343,10 @@ void CHud::RenderMovementInformationTextContainer(STextContainerIndex &TextConta
 
 void CHud::RenderMovementInformation(const int ClientId)
 {
+	bool Freeview = ClientId == SPEC_FREEVIEW;
 	// Draw the infomations depending on settings: Position, speed and target angle
 	// This display is only to present the available information from the last snapshot, not to interpolate or predict
-	if(!g_Config.m_ClShowhudPlayerPosition && !g_Config.m_ClShowhudPlayerSpeed && !g_Config.m_ClShowhudPlayerAngle)
+	if(!g_Config.m_ClShowhudPlayerPosition && (Freeview || (!g_Config.m_ClShowhudPlayerSpeed && !g_Config.m_ClShowhudPlayerAngle)))
 	{
 		return;
 	}
@@ -1362,40 +1365,50 @@ void CHud::RenderMovementInformation(const int ClientId)
 
 	Graphics()->DrawRect(StartX, StartY, BoxWidth, BoxHeight, ColorRGBA(0.0f, 0.0f, 0.0f, 0.4f), IGraphics::CORNER_L, 5.0f);
 
-	const CNetObj_Character *pPrevChar = &m_pClient->m_Snap.m_aCharacters[ClientId].m_Prev;
-	const CNetObj_Character *pCurChar = &m_pClient->m_Snap.m_aCharacters[ClientId].m_Cur;
-	const float IntraTick = Client()->IntraGameTick(g_Config.m_ClDummy);
+	vec2 Pos;
+	float DisplaySpeedX{}, DisplaySpeedY{}, DisplayAngle{};
 
-	// To make the player position relative to blocks we need to divide by the block size
-	const vec2 Pos = mix(vec2(pPrevChar->m_X, pPrevChar->m_Y), vec2(pCurChar->m_X, pCurChar->m_Y), IntraTick) / 32.0f;
-
-	const vec2 Vel = mix(vec2(pPrevChar->m_VelX, pPrevChar->m_VelY), vec2(pCurChar->m_VelX, pCurChar->m_VelY), IntraTick);
-
-	float VelspeedX = Vel.x / 256.0f * Client()->GameTickSpeed();
-	if(Vel.x >= -1 && Vel.x <= 1)
+	if(Freeview)
 	{
-		VelspeedX = 0;
+		Pos = m_pClient->m_Camera.m_Center / 32.f;
 	}
-	float VelspeedY = Vel.y / 256.0f * Client()->GameTickSpeed();
-	if(Vel.y >= -128 && Vel.y <= 128)
+	else
 	{
-		VelspeedY = 0;
-	}
-	// We show the speed in Blocks per Second (Bps) and therefore have to divide by the block size
-	float DisplaySpeedX = VelspeedX / 32;
-	float VelspeedLength = length(vec2(Vel.x, Vel.y) / 256.0f) * Client()->GameTickSpeed();
-	// Todo: Use Velramp tuning of each individual player
-	// Since these tuning parameters are almost never changed, the default values are sufficient in most cases
-	float Ramp = VelocityRamp(VelspeedLength, m_pClient->m_aTuning[g_Config.m_ClDummy].m_VelrampStart, m_pClient->m_aTuning[g_Config.m_ClDummy].m_VelrampRange, m_pClient->m_aTuning[g_Config.m_ClDummy].m_VelrampCurvature);
-	DisplaySpeedX *= Ramp;
-	float DisplaySpeedY = VelspeedY / 32;
+		const CNetObj_Character *pPrevChar = &m_pClient->m_Snap.m_aCharacters[ClientId].m_Prev;
+		const CNetObj_Character *pCurChar = &m_pClient->m_Snap.m_aCharacters[ClientId].m_Cur;
+		const float IntraTick = Client()->IntraGameTick(g_Config.m_ClDummy);
 
-	float Angle = m_pClient->m_Players.GetPlayerTargetAngle(pPrevChar, pCurChar, ClientId, IntraTick);
-	if(Angle < 0)
-	{
-		Angle += 2.0f * pi;
+		// To make the player position relative to blocks we need to divide by the block size
+		Pos = mix(vec2(pPrevChar->m_X, pPrevChar->m_Y), vec2(pCurChar->m_X, pCurChar->m_Y), IntraTick) / 32.0f;
+
+		const vec2 Vel = mix(vec2(pPrevChar->m_VelX, pPrevChar->m_VelY), vec2(pCurChar->m_VelX, pCurChar->m_VelY), IntraTick);
+
+		float VelspeedX = Vel.x / 256.0f * Client()->GameTickSpeed();
+		if(Vel.x >= -1 && Vel.x <= 1)
+		{
+			VelspeedX = 0;
+		}
+		float VelspeedY = Vel.y / 256.0f * Client()->GameTickSpeed();
+		if(Vel.y >= -128 && Vel.y <= 128)
+		{
+			VelspeedY = 0;
+		}
+		// We show the speed in Blocks per Second (Bps) and therefore have to divide by the block size
+		DisplaySpeedX = VelspeedX / 32;
+		float VelspeedLength = length(vec2(Vel.x, Vel.y) / 256.0f) * Client()->GameTickSpeed();
+		// Todo: Use Velramp tuning of each individual player
+		// Since these tuning parameters are almost never changed, the default values are sufficient in most cases
+		float Ramp = VelocityRamp(VelspeedLength, m_pClient->m_aTuning[g_Config.m_ClDummy].m_VelrampStart, m_pClient->m_aTuning[g_Config.m_ClDummy].m_VelrampRange, m_pClient->m_aTuning[g_Config.m_ClDummy].m_VelrampCurvature);
+		DisplaySpeedX *= Ramp;
+		DisplaySpeedY = VelspeedY / 32;
+
+		float Angle = m_pClient->m_Players.GetPlayerTargetAngle(pPrevChar, pCurChar, ClientId, IntraTick);
+		if(Angle < 0)
+		{
+			Angle += 2.0f * pi;
+		}
+		DisplayAngle = Angle * 180.0f / pi;
 	}
-	float DisplayAngle = Angle * 180.0f / pi;
 
 	float y = StartY + LineSpacer * 2;
 	float xl = StartX + 2;
@@ -1416,6 +1429,9 @@ void CHud::RenderMovementInformation(const int ClientId)
 		RenderMovementInformationTextContainer(m_aPlayerPositionContainers[1], TextRender()->DefaultTextColor(), xr, y);
 		y += MOVEMENT_INFORMATION_LINE_HEIGHT;
 	}
+
+	if(Freeview)
+		return;
 
 	if(g_Config.m_ClShowhudPlayerSpeed)
 	{
@@ -1598,10 +1614,7 @@ void CHud::OnRender()
 			{
 				RenderPlayerState(SpectatorId);
 			}
-			if(SpectatorId != SPEC_FREEVIEW)
-			{
-				RenderMovementInformation(SpectatorId);
-			}
+			RenderMovementInformation(SpectatorId);
 			RenderSpectatorHud();
 		}
 


### PR DESCRIPTION
Knowing position infomation in freeview helps navigating long-range flights when you don't know the destination coordinates. I came up with two designs and chose the current as the corner location is less distracting. The other design is listed for comparison.

Before:
![图片](https://github.com/user-attachments/assets/2926affa-789e-4b3b-b3d0-175a4a2093d1)

After:
![图片](https://github.com/user-attachments/assets/0b9e3688-e08e-420e-a55a-79a570a05853)

The other design:
![图片](https://github.com/user-attachments/assets/01409ae3-1514-460f-9ebe-0ca3d9626e19)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
