### PR TITLE
Fix language translations for Brazilian Portuguese

### DIFF
--- a/data/languages/brazilian_portuguese.txt
+++ b/data/languages/brazilian_portuguese.txt
@@ -1,43 +1,45 @@
 ##### authors #####
 #originally created by:
-# slinack
+#	slinack
 #modified by:
-# yemDX               2010-05-29 17:22:42
-# yemDX               2010-05-30 02:51:34
-# slinack             2010-06-02 20:57:46
-# slinack             2011-05-02 18:24:12
-# Isadora             2011-05-09 17:26:02
-# slinack             2011-07-03 00:23:26
-# Ryomou Hentai Girl  2011-07-11 11:33:42
-# Isadora             2011-07-20 21:47:11
-# HeroiAmarelo        2012-08-01 15:50:18
-# Rafael Fontenelle   2014-11-21 13:31:06
-# Rafael Fontenelle   2016-12-12 13:31:06
-# Rafael Fontenelle   2017-09-06 09:51:00
-# Rafael Fontenelle   2018-07-04 07:38:13
-# Rafael Fontenelle   2019-04-06 16:49:12
-# Rafael Fontenelle   2019-12-18 02:47:58
-# Rafael Fontenelle   2020-08-27 12:38:07
-# Rafael Fontenelle   2020-09-20 11:00:38
-# Rafael Fontenelle   2021-02-13 07:00:00
-# Rafael Fontenelle   2021-06-10 12:00:00
-# pv                  2022-06-01 20:44:00
-# Rafael Fontenelle   2022-09-17 23:23:00
-# Rafael Fontenelle   2022-10-25 11:22:00
-# Rafael Fontenelle   2023-01-09 10:33:00
-# Rafael Fontenelle   2023-03-26 19:11:00
-# Rafael Fontenelle   2023-07-07 12:11:00
-# Rafael Fontenelle   2023-08-14 14:17:00
-# Rafael Fontenelle   2023-09-25 14:23:00
-# Rafael Fontenelle   2023-12-05 17:01:00
-# Rafael Fontenelle   2024-03-02 16:20:00
-# Rafael Fontenelle   2024-04-30 14:52:00
-# Rafael Fontenelle   2024-06-11 22:43:00
-# Rafael Fontenelle   2024-07-17 12:04:00
-# Rafael Fontenelle   2024-09-02 16:02:00
-# Rafael Fontenelle   2024-09-30 07:53:00
-# Rafael Fontenelle   2024-11-01 17:21:00
-# Rafael Fontenelle   2025-01-03 07:05:00
+#	yemDX				2010-05-29 17:22:42
+#	yemDX				2010-05-30 02:51:34
+#	slinack				2010-06-02 20:57:46
+#	slinack				2011-05-02 18:24:12
+#	Isadora				2011-05-09 17:26:02
+#	slinack				2011-07-03 00:23:26
+#	Ryomou Hentai Girl	2011-07-11 11:33:42
+#	Isadora				2011-07-20 21:47:11
+#	HeroiAmarelo		2012-08-01 15:50:18
+#	Rafael Fontenelle	2014-11-21 13:31:06
+#	Rafael Fontenelle	2016-12-12 13:31:06
+#	Rafael Fontenelle	2017-09-06 09:51:00
+#	Rafael Fontenelle	2018-07-04 07:38:13
+#	Rafael Fontenelle	2019-04-06 16:49:12
+#	Rafael Fontenelle	2019-12-18 02:47:58
+#	Rafael Fontenelle	2020-08-27 12:38:07
+#	Rafael Fontenelle	2020-09-20 11:00:38
+#	Rafael Fontenelle	2021-02-13 07:00:00
+#	Rafael Fontenelle	2021-06-10 12:00:00
+#	pv					2022-06-01 20:44:00
+#	Rafael Fontenelle	2022-09-17 23:23:00
+#	Rafael Fontenelle	2022-10-25 11:22:00
+#	Rafael Fontenelle	2023-01-09 10:33:00
+#	Rafael Fontenelle	2023-03-26 19:11:00
+#	Rafael Fontenelle	2023-07-07 12:11:00
+#	Rafael Fontenelle	2023-08-14 14:17:00
+#	Rafael Fontenelle	2023-09-25 14:23:00
+#	Rafael Fontenelle	2023-12-05 17:01:00
+#	Rafael Fontenelle	2024-03-02 16:20:00
+#	Rafael Fontenelle	2024-04-30 14:52:00
+#	Rafael Fontenelle	2024-06-11 22:43:00
+#	Rafael Fontenelle	2024-07-17 12:04:00
+#	Rafael Fontenelle	2024-09-02 16:02:00
+#	Rafael Fontenelle	2024-09-30 07:53:00
+#	Rafael Fontenelle	2024-11-01 17:21:00
+#	Rafael Fontenelle	2025-01-03 07:05:00
+#	Rafael Fontenelle	2025-01-03 07:05:00
+#	DrafaKiller			2025-01-11
 ##### /authors #####
 
 ##### translated strings #####
@@ -1037,7 +1039,7 @@ Background music volume
 == Volume da música de fundo
 
 Assets
-== Ativos
+== Recursos
 
 Use current map as background
 == Usar o mapa atual como plano de fundo
@@ -1052,7 +1054,7 @@ Particles
 == Partículas
 
 Assets directory
-== Diretório de ativos
+== Diretório de recursos
 
 Manual
 == Manual
@@ -1330,7 +1332,7 @@ Initializing components
 == Inicializando componentes
 
 Initializing assets
-== Inicializando ativos
+== Inicializando recursos
 
 Initializing map logic
 == Inicializando lógica de mapa
@@ -1402,7 +1404,7 @@ A Tee
 == Um tee
 
 Loading assets
-== Carregando ativos
+== Carregando recursos
 
 Loading race demo files
 == Carregando arquivos de demo de corrida
@@ -1506,7 +1508,7 @@ Failed during initialization. Try to change gfx_backend to OpenGL or Vulkan in s
 
 [Graphics error]
 Out of VRAM. Try removing custom assets (skins, entities, etc.), especially those with high resolution.
-== VRAM insuficiente. Tente remover ativos personalizados (skins, entidades, etc.), especialmente aqueles com alta resolução.
+== VRAM insuficiente. Tente remover recursos personalizados (skins, entidades, etc.), especialmente aqueles com alta resolução.
 
 [Graphics error]
 An error during command recording occurred. Try to update your GPU drivers.
@@ -1557,7 +1559,7 @@ Unregister protocol and file extensions
 == Protoloco e arquivos de extensões não registrados
 
 Open the directory to add custom assets
-== Abre o diretório para adicionar os ativos personalizados
+== Abre o diretório para adicionar os recursos personalizados
 
 [Graphics error]
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.


### PR DESCRIPTION
## Motivation

I was translating `data/languages/portuguese.txt` when I noticed someone would likely fall into a lazy translation mistake. It's pretty obvious because it's one of the titles in the settings.

A word like `"Assets"` has a context in both finance and digital media. Most online translators choose to use the financial context, for some reason. This file translates it to the financial context, which is `"Ativos"`. The actual translation should have been `"Recursos"`.

## Screenshot (Before / After)

![Before / After](https://github.com/user-attachments/assets/fd6c1e9f-3c8b-4601-be09-fd6045df9060)