### PR TITLE
Add chat command /afk

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1442,6 +1442,18 @@ void CGameContext::ConEyeEmote(IConsole::IResult *pResult, void *pUserData)
 	}
 }
 
+void CGameContext::ConAfk(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(!CheckClientId(pResult->m_ClientId))
+		return;
+
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
+	if(!pPlayer)
+		return;
+	pPlayer->ForceAfk();
+}
+
 void CGameContext::ConNinjaJetpack(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3766,6 +3766,7 @@ void CGameContext::RegisterChatCommands()
 	Console()->Register("rules", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConRules, this, "Shows the server rules");
 	Console()->Register("emote", "?s[emote name] i[duration in seconds]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConEyeEmote, this, "Sets your tee's eye emote");
 	Console()->Register("eyeemote", "?s['on'|'off'|'toggle']", CFGFLAG_CHAT | CFGFLAG_SERVER, ConSetEyeEmote, this, "Toggles use of standard eye-emotes on/off, eyeemote s, where s = on for on, off for off, toggle for toggle and nothing to show current status");
+	Console()->Register("afk", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConAfk, this, "Marks your tee as AFK (Away From Keyboard).");
 	Console()->Register("settings", "?s[configname]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConSettings, this, "Shows gameplay information for this server");
 	Console()->Register("help", "?r[command]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConHelp, this, "Shows help to command r, general help if left blank");
 	Console()->Register("info", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConInfo, this, "Shows info about this server");

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -463,6 +463,7 @@ private:
 	static void ConConverse(IConsole::IResult *pResult, void *pUserData);
 	static void ConSetEyeEmote(IConsole::IResult *pResult, void *pUserData);
 	static void ConEyeEmote(IConsole::IResult *pResult, void *pUserData);
+	static void ConAfk(IConsole::IResult *pResult, void *pUserData);
 	static void ConShowOthers(IConsole::IResult *pResult, void *pUserData);
 	static void ConShowAll(IConsole::IResult *pResult, void *pUserData);
 	static void ConSpecTeam(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -73,6 +73,7 @@ void CPlayer::Reset()
 
 	m_DefEmote = EMOTE_NORMAL;
 	m_Afk = true;
+	m_ForceAfkTime = 0;
 	m_LastWhisperTo = -1;
 	m_LastSetSpectatorMode = 0;
 	m_aTimeoutCode[0] = '\0';
@@ -726,7 +727,15 @@ void CPlayer::UpdatePlaytime()
 
 void CPlayer::AfkTimer()
 {
-	SetAfk(g_Config.m_SvMaxAfkTime != 0 && m_LastPlaytime < time_get() - time_freq() * g_Config.m_SvMaxAfkTime);
+	if(m_ForceAfkTime == 0 || m_ForceAfkTime < time_get())
+	{
+		m_ForceAfkTime = 0;
+		SetAfk(g_Config.m_SvMaxAfkTime != 0 && m_LastPlaytime < time_get() - time_freq() * g_Config.m_SvMaxAfkTime);
+	}
+	else
+	{
+		m_LastPlaytime = time_get() - time_freq() * g_Config.m_SvMaxAfkTime - 1;
+	}
 }
 
 void CPlayer::SetAfk(bool Afk)
@@ -753,6 +762,12 @@ void CPlayer::SetInitialAfk(bool Afk)
 		m_LastPlaytime = time_get() - time_freq() * g_Config.m_SvMaxAfkTime - 1;
 	else
 		m_LastPlaytime = time_get();
+}
+
+void CPlayer::ForceAfk()
+{
+	m_ForceAfkTime = time_get() + time_freq();
+	SetInitialAfk(true);
 }
 
 int CPlayer::GetDefaultEmote() const

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -138,6 +138,7 @@ private:
 	int64_t m_ForcePauseTime;
 	int64_t m_LastPause;
 	bool m_Afk;
+	int64_t m_ForceAfkTime;
 
 	int m_DefEmote;
 	int m_OverrideEmote;
@@ -205,6 +206,7 @@ public:
 	void AfkTimer();
 	void SetAfk(bool Afk);
 	void SetInitialAfk(bool Afk);
+	void ForceAfk();
 	bool IsAfk() const { return m_Afk; }
 
 	int64_t m_LastPlaytime;


### PR DESCRIPTION
Implements chat command `/afk`, closes #9270.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
