### PR TITLE
sv_save_worse_scores: Don't save reruns with same time

### DIFF
--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -804,7 +804,7 @@ void CGameTeams::OnFinish(CPlayer *Player, int TimeTicks, const char *pTimestamp
 
 	bool CallSaveScore = g_Config.m_SvSaveWorseScores;
 	bool NeedToSendNewPersonalRecord = false;
-	if(!pData->m_BestTime || Time < pData->m_BestTime)
+	if(!pData->m_BestTime || Time <= pData->m_BestTime)
 	{
 		// update the score
 		pData->Set(Time, GetCurrentTimeCp(Player));


### PR DESCRIPTION
Very easy to spam database with them too

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
