### PR TITLE
Fix crash when loading very long localization lines

### DIFF
--- a/src/engine/shared/memheap.h
+++ b/src/engine/shared/memheap.h
@@ -26,7 +26,7 @@ class CHeap
 	CChunk *m_pCurrent;
 
 	void Clear();
-	void NewChunk();
+	void NewChunk(size_t ChunkSize);
 	void *AllocateFromChunk(unsigned int Size, unsigned Alignment);
 
 public:


### PR DESCRIPTION
The client previously crashed when loading a localization file with a replacement line (plus zero terminator) longer than the size of a `CHeap` chunk (65600 bytes) due to the line data being written outside the heap chunk.

This is fixed by allowing `CHeap` to allocate chunks as large as necessary to contain at least one item.

As an alternative the `CHeap` functions could be changed to return `nullptr` if the wanted allocation is too large, which would have to be handled explicitly when loading localization files.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
