### PR TITLE
Don't show add friend (clan) message when everyone is offline

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1385,11 +1385,16 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 	m_pRemoveFriend = nullptr;
 	for(auto &vFriends : m_avFriends)
 		vFriends.clear();
-
 	for(int FriendIndex = 0; FriendIndex < m_pClient->Friends()->NumFriends(); ++FriendIndex)
 	{
 		m_avFriends[FRIEND_OFF].emplace_back(m_pClient->Friends()->GetFriend(FriendIndex));
 	}
+	bool HasFriend = std::any_of(m_avFriends[FRIEND_OFF].begin(), m_avFriends[FRIEND_OFF].end(), [&](const auto &Friend) {
+		return Friend.Name()[0] != '\0';
+	}),
+	     HasClan = std::any_of(m_avFriends[FRIEND_OFF].begin(), m_avFriends[FRIEND_OFF].end(), [&](const auto &Friend) {
+		     return Friend.Name()[0] == '\0';
+	     });
 
 	for(int ServerIndex = 0; ServerIndex < ServerBrowser()->NumSortedServers(); ++ServerIndex)
 	{
@@ -1584,24 +1589,13 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 			}
 
 			// Render empty description
-			if(m_avFriends[FriendType].empty())
+			const char *pText = nullptr;
+			if(FriendType == FRIEND_PLAYER_ON && !HasFriend)
+				pText = Localize("Add friends by entering their name below or by clicking their name in the player list.");
+			else if(FriendType == FRIEND_CLAN_ON && !HasClan)
+				pText = Localize("Add clanmates by entering their clan below and leaving the name blank.");
+			if(pText != nullptr)
 			{
-				const char *pText;
-				switch(FriendType)
-				{
-				case FRIEND_PLAYER_ON:
-					pText = Localize("Add friends by entering their name below or by clicking their name in the player list.");
-					break;
-				case FRIEND_CLAN_ON:
-					pText = Localize("Add clanmates by entering their clan below and leaving the name blank.");
-					break;
-				case FRIEND_OFF:
-					pText = Localize("Offline friends and clanmates will appear here.");
-					break;
-				default:
-					dbg_assert(false, "Invalid friend state");
-					dbg_break();
-				}
 				const float DescriptionMargin = 2.0f;
 				const STextBoundingBox BoundingBox = TextRender()->TextBoundingBox(FontSize, pText, -1, List.w - 2 * DescriptionMargin);
 				CUIRect EmptyDescription;


### PR DESCRIPTION
Count offline friends when deciding whether to show add friend tooltip. Remove the useless offline tooltip.

Before:
![Before](https://github.com/user-attachments/assets/4a983d24-01ea-4e1f-91dc-d99401c630d4)
After:
![After](https://github.com/user-attachments/assets/93314de7-2e0e-4865-8c47-0c82938972d2)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
