### PR TITLE
mastersrv: Add config file and hot-reloading of it

### DIFF
--- a/src/mastersrv/Cargo.lock
+++ b/src/mastersrv/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +185,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,7 +280,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.8.1",
  "slab",
  "tokio",
  "tokio-util 0.7.1",
@@ -280,6 +292,12 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "headers"
@@ -426,7 +444,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -490,6 +518,7 @@ dependencies = [
 name = "mastersrv"
 version = "0.0.1"
 dependencies = [
+ "arc-swap",
  "arrayvec",
  "base64",
  "bytes",
@@ -497,6 +526,7 @@ dependencies = [
  "env_logger",
  "headers",
  "hex",
+ "ipnet",
  "libloc",
  "log",
  "mime",
@@ -506,6 +536,7 @@ dependencies = [
  "sha2",
  "tokio",
  "tokio-stream",
+ "toml",
  "url",
  "warp",
 ]
@@ -727,22 +758,22 @@ checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.92",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -751,9 +782,18 @@ version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f972498cf015f7c0746cac89ebe1d6ef10c293b94175a243a2d9442c163d9944"
 dependencies = [
- "indexmap",
+ "indexmap 1.8.1",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+dependencies = [
  "serde",
 ]
 
@@ -789,6 +829,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -907,7 +956,9 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "once_cell",
  "pin-project-lite",
+ "signal-hook-registry",
  "tokio-macros",
  "winapi",
 ]
@@ -960,6 +1011,40 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+dependencies = [
+ "indexmap 2.6.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1275,6 +1360,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winnow"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "yoke"

--- a/src/mastersrv/Cargo.toml
+++ b/src/mastersrv/Cargo.toml
@@ -9,6 +9,7 @@ license = "Zlib"
 [workspace]
 
 [dependencies]
+arc-swap = "1.7.1"
 arrayvec = { version = "0.5.2", features = ["serde"] }
 base64 = "0.13.0"
 bytes = "1.1.0"
@@ -19,6 +20,7 @@ clap = { version = "2.34.0", default-features = false, features = [
 env_logger = "0.8.3"
 headers = "0.3.7"
 hex = "0.4.3"
+ipnet = "2.9.0"
 libloc = "0.1.0"
 log = "0.4.17"
 mime = "0.3.16"
@@ -30,7 +32,13 @@ serde_json = { version = "1.0.64", features = [
   "raw_value",
 ] }
 sha2 = "0.10.0"
-tokio = { version = "1.6.0", features = ["macros", "rt", "rt-multi-thread"] }
+toml = "0.8.19"
+tokio = { version = "1.6.0", features = [
+  "macros",
+  "rt",
+  "rt-multi-thread",
+  "signal",
+] }
 tokio-stream = { version = "0.1.8", features = ["net"] }
 url = { version = "2.2.2", features = ["serde"] }
 warp = { version = "0.3.1", default-features = false }

--- a/src/mastersrv/src/locations.rs
+++ b/src/mastersrv/src/locations.rs
@@ -1,4 +1,5 @@
 use arrayvec::ArrayString;
+use std::fmt;
 use std::net::IpAddr;
 use std::path::Path;
 
@@ -8,22 +9,22 @@ pub type Location = ArrayString<[u8; 12]>;
 #[derive(Debug)]
 pub struct LocationsError(String);
 
+#[derive(Default)]
 pub struct Locations {
     inner: Option<libloc::Locations>,
 }
 
-impl Locations {
-    pub fn empty() -> Locations {
-        Locations {
-            inner: None,
-        }
+impl fmt::Display for LocationsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
     }
+}
+
+impl Locations {
     pub fn read(filename: &Path) -> Result<Locations, LocationsError> {
         let inner = libloc::Locations::open(filename)
             .map_err(|e| LocationsError(format!("error opening {:?}: {}", filename, e)))?;
-        Ok(Locations {
-            inner: Some(inner),
-        })
+        Ok(Locations { inner: Some(inner) })
     }
     pub fn lookup(&self, addr: IpAddr) -> Option<Location> {
         self.inner.as_ref().and_then(|inner| {


### PR DESCRIPTION
This allows to add bans and port forward exceptions without restarting the mastersrv itself.

It also allows reloading the locations database (with the important caveat that it is mmap-ed, and as such must be removed before being overridden in the file system).

## Checklist

- [x] Tested the change ~ingame~
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
