### PR TITLE
Show spec cursor in screenspace when user is more zoomed in than spectating player.

### DIFF
--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -151,6 +151,7 @@ MAYBE_UNUSED static const char *FONT_ICON_ARROWS_ROTATE = "\xEF\x80\xA1";
 MAYBE_UNUSED static const char *FONT_ICON_QUESTION = "?";
 
 MAYBE_UNUSED static const char *FONT_ICON_CAMERA = "\xEF\x80\xB0";
+MAYBE_UNUSED static const char *FONT_ICON_CROSSHAIR = "\xEF\x81\x9B";
 } // end namespace FontIcons
 
 enum ETextCursorSelectionMode

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -231,6 +231,20 @@ void CMenus::RenderGame(CUIRect MainView)
 		GameClient()->m_Tooltips.DoToolTip(&s_AutoCameraButton, &Button, m_pClient->m_Camera.AutoSpecCameraTooltip());
 	}
 
+	if(m_pClient->m_Snap.m_pLocalInfo && (m_pClient->m_Snap.m_pLocalInfo->m_Team == TEAM_SPECTATORS || Paused || Spec))
+	{
+		ButtonBar.VSplitLeft(32.0f, &Button, &ButtonBar);
+		ButtonBar.VSplitLeft(5.0f, nullptr, &ButtonBar);
+
+		static CButtonContainer s_SpecCursorButton;
+
+		if(DoButton_FontIcon(&s_SpecCursorButton, FONT_ICON_CROSSHAIR, !g_Config.m_ClSpecCursor, &Button, IGraphics::CORNER_ALL, g_Config.m_ClSpecCursor))
+		{
+			g_Config.m_ClSpecCursor = !g_Config.m_ClSpecCursor;
+		}
+		GameClient()->m_Tooltips.DoToolTip(&s_SpecCursorButton, &Button, Localize("Toggle spectating cursor"));
+	}
+
 	if(g_Config.m_ClTouchControls)
 	{
 		ButtonBar2.VSplitLeft(200.0f, &Button, &ButtonBar2);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -3241,6 +3241,10 @@ void CGameClient::UpdateSpectatorCursor()
 	// if we are in auto spec mode, use camera zoom to smooth out cursor transitions
 	const float Zoom = (m_Camera.m_Zooming && m_Camera.m_AutoSpecCameraZooming) ? m_Camera.m_Zoom : m_Snap.m_SpecInfo.m_Zoom;
 	m_CursorInfo.m_WorldTarget = m_CursorInfo.m_Position + (m_CursorInfo.m_Target - TargetCameraOffset) * Zoom + TargetCameraOffset;
+
+	// update the screen target and compensate it for dyncam
+	vec2 DyncamOffsetDelta = TargetCameraOffset - m_Camera.m_aDyncamCurrentCameraOffset[g_Config.m_ClDummy];
+	m_CursorInfo.m_ScreenTarget = m_CursorInfo.m_Position + m_CursorInfo.m_Target - DyncamOffsetDelta + DyncamOffsetDelta / m_Camera.m_Zoom;
 }
 
 void CGameClient::UpdateRenderedCharacters()

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -393,6 +393,7 @@ public:
 		int m_Weapon;
 		vec2 m_Target;
 		vec2 m_WorldTarget;
+		vec2 m_ScreenTarget;
 		vec2 m_Position;
 
 	public:
@@ -400,6 +401,7 @@ public:
 		int Weapon() const { return m_Weapon; }
 		vec2 Target() const { return m_Target; }
 		vec2 WorldTarget() const { return m_WorldTarget; }
+		vec2 ScreenTarget() const { return m_ScreenTarget; }
 		vec2 Position() const { return m_Position; }
 	} m_CursorInfo;
 


### PR DESCRIPTION
The original purpose of auto spec cam is to make spec cursor more visible to new players where it forces the camera settings to show the cursor in world space.

Auto spec cam now evolved into a player perspective recording and observing feature.

This PR provides a less intrusive solution to the original goal of making spec cursor more visible. This breaks the notion of auto spec cam being a complimentary feature of spec cursor, and auto spec cam is just a separate feature now.

Every non-world-space cursor will be drawn with transparency as a hint.

Demo video shows a default 10 zoom client spectating a zoom 7 client where the cursor would be out of screen before this PR.

https://github.com/user-attachments/assets/8a3e3a9a-0cef-4538-a6b6-1aed5df2aaaf

Also adds a spec cursor toggle in the in-game menu instead of the settings for easier access due to the new change can put cursors on screen more than before. so people wanting to toggle it quickly can do so more easily without navigating more menus.

Now the whole "new spectating features" package lives there.

![image](https://github.com/user-attachments/assets/f62057be-df8e-4f18-919f-75bb270600d8)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
