### PR TITLE
Fix ping cache for 0.7 servers

### DIFF
--- a/src/engine/client/serverbrowser_ping_cache.cpp
+++ b/src/engine/client/serverbrowser_ping_cache.cpp
@@ -119,15 +119,16 @@ int CServerBrowserPingCache::NumEntries() const
 
 void CServerBrowserPingCache::CachePing(const NETADDR &Addr, int Ping)
 {
-	NETADDR AddrWithoutPort = Addr;
-	AddrWithoutPort.port = 0;
-	m_Entries[AddrWithoutPort] = Ping;
+	NETADDR StoredAddr = Addr;
+	StoredAddr.type &= ~NETTYPE_TW7;
+	StoredAddr.port = 0;
+	m_Entries[StoredAddr] = Ping;
 	if(m_pDisk)
 	{
 		sqlite3 *pSqlite = m_pDisk.get();
 		IConsole *pConsole = m_pConsole;
 		char aAddr[NETADDR_MAXSTRSIZE];
-		net_addr_str(&AddrWithoutPort, aAddr, sizeof(aAddr), false);
+		net_addr_str(&StoredAddr, aAddr, sizeof(aAddr), false);
 
 		bool Error = false;
 		Error = Error || !m_pStoreStmt;
@@ -147,9 +148,10 @@ int CServerBrowserPingCache::GetPing(const NETADDR *pAddrs, int NumAddrs) const
 	int Ping = -1;
 	for(int i = 0; i < NumAddrs; i++)
 	{
-		NETADDR Addr = pAddrs[i];
-		Addr.port = 0;
-		auto Entry = m_Entries.find(Addr);
+		NETADDR LookupAddr = pAddrs[i];
+		LookupAddr.type &= ~NETTYPE_TW7;
+		LookupAddr.port = 0;
+		auto Entry = m_Entries.find(LookupAddr);
 		if(Entry == m_Entries.end())
 		{
 			continue;


### PR DESCRIPTION
Depends on #8992 which adds support for 0.7 server info which is used to determine the ping that will be saved to the cache.

With #8992 the ping is saved correctly to the database, but the lookup in the `std::unordered_map` fails because `NETTYPE_TW7` is not ignored.

Closes #9176.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
