### PR TITLE
Add community support to mastersrv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -865,6 +865,7 @@ set_src(RUST_BRIDGE_SHARED GLOB_RECURSE src/rust-bridge
 
 set_glob(RUST_MASTERSRV GLOB "rs;toml" src/mastersrv/src
   addr.rs
+  community_token.rs
   config.rs
   locations.rs
   main.rs

--- a/scripts/generate_community_token.py
+++ b/scripts/generate_community_token.py
@@ -1,0 +1,49 @@
+from hashlib import sha256
+import argparse
+import base64
+import binascii
+import secrets
+
+def _crc32(bytes):
+	return binascii.crc32(bytes).to_bytes(4, "big")
+
+def _add_crc32(s):
+	return s + _urlsafe_encode(_crc32(s.encode("ascii")))
+
+def _urlsafe_encode(bytes):
+	return base64.urlsafe_b64encode(bytes).decode("ascii").rstrip("=")
+
+def _generate_token_impl():
+	token = secrets.token_urlsafe(22)
+	shared_prefix = token[:6]
+	user_token = _add_crc32(f"ddtc_{token}")
+
+	half_sha256 = _urlsafe_encode(sha256(user_token.encode("ascii")).digest()[:16])
+	mastersrv_token = _add_crc32(f"ddvc_{shared_prefix}{half_sha256}")
+	return user_token, mastersrv_token
+
+def _unwanted_token(token):
+	return "-" in token or token.count("_") > 1
+
+def generate_token(verbose=False):
+	while True:
+		if verbose:
+			print(".", end="", flush=True)
+		user_token, mastersrv_token = _generate_token_impl()
+		if _unwanted_token(user_token) or _unwanted_token(mastersrv_token):
+			continue
+		return user_token, mastersrv_token
+
+def main():
+	parser = argparse.ArgumentParser(description="Generate a community token for use with the mastersrv")
+	parser.add_argument("-v", "--verbose", action="store_true", help="Show generation tries")
+	args = parser.parse_args()
+
+	user_token, mastersrv_token = generate_token(verbose=args.verbose)
+	if args.verbose:
+		print()
+	print(f"user:      {user_token}")
+	print(f"mastersrv: {mastersrv_token}")
+
+if __name__ == "__main__":
+	main()

--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -128,6 +128,9 @@ class CRegister : public IRegister
 	bool m_aProtocolEnabled[NUM_PROTOCOLS] = {true, true, true, true};
 	CProtocol m_aProtocols[NUM_PROTOCOLS];
 
+	bool m_GotCommunityToken = false;
+	char m_aCommunityToken[128];
+
 	int m_NumExtraHeaders = 0;
 	char m_aaExtraHeaders[8][128];
 
@@ -304,6 +307,10 @@ void CRegister::CProtocol::SendRegister()
 		pRegister->HeaderString("Challenge-Token", m_aChallengeToken);
 	}
 	pRegister->HeaderInt("Info-Serial", InfoSerial);
+	if(m_pParent->m_GotCommunityToken)
+	{
+		pRegister->HeaderString("Community-Token", m_pParent->m_aCommunityToken);
+	}
 	for(int i = 0; i < m_pParent->m_NumExtraHeaders; i++)
 	{
 		pRegister->Header(m_pParent->m_aaExtraHeaders[i]);
@@ -534,6 +541,7 @@ CRegister::CRegister(CConfig *pConfig, IConsole *pConsole, IEngine *pEngine, IHt
 	m_pConsole->Chain("sv_register", ConchainOnConfigChange, this);
 	m_pConsole->Chain("sv_register_extra", ConchainOnConfigChange, this);
 	m_pConsole->Chain("sv_register_url", ConchainOnConfigChange, this);
+	m_pConsole->Chain("sv_register_community_token", ConchainOnConfigChange, this);
 	m_pConsole->Chain("sv_sixup", ConchainOnConfigChange, this);
 	m_pConsole->Chain("sv_ipv4only", ConchainOnConfigChange, this);
 }
@@ -636,6 +644,11 @@ void CRegister::OnConfigChange()
 	{
 		m_aProtocolEnabled[PROTOCOL_TW6_IPV6] = false;
 		m_aProtocolEnabled[PROTOCOL_TW7_IPV6] = false;
+	}
+	m_GotCommunityToken = (bool)m_pConfig->m_SvRegisterCommunityToken[0];
+	if(m_GotCommunityToken)
+	{
+		str_copy(m_aCommunityToken, m_pConfig->m_SvRegisterCommunityToken);
 	}
 	m_NumExtraHeaders = 0;
 	const char *pRegisterExtra = m_pConfig->m_SvRegisterExtra;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2625,6 +2625,15 @@ void CServer::UpdateRegisterServerInfo()
 	JsonWriter.WriteAttribute("game_type");
 	JsonWriter.WriteStrValue(GameServer()->GameType());
 
+	if(g_Config.m_SvRegisterCommunityToken[0])
+	{
+		if(g_Config.m_SvFlag != -1)
+		{
+			JsonWriter.WriteAttribute("flag");
+			JsonWriter.WriteIntValue(g_Config.m_SvFlag);
+		}
+	}
+
 	JsonWriter.WriteAttribute("name");
 	JsonWriter.WriteStrValue(g_Config.m_SvName);
 
@@ -2636,6 +2645,11 @@ void CServer::UpdateRegisterServerInfo()
 	JsonWriter.WriteStrValue(aMapSha256);
 	JsonWriter.WriteAttribute("size");
 	JsonWriter.WriteIntValue(m_aCurrentMapSize[MAP_TYPE_SIX]);
+	if(m_aMapDownloadUrl[0])
+	{
+		JsonWriter.WriteAttribute("url");
+		JsonWriter.WriteStrValue(m_aMapDownloadUrl);
+	}
 	JsonWriter.EndObject();
 
 	JsonWriter.WriteAttribute("version");

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -465,6 +465,8 @@ MACRO_CONFIG_STR(SvRegister, sv_register, 16, "1", CFGFLAG_SERVER, "Register ser
 MACRO_CONFIG_STR(SvRegisterExtra, sv_register_extra, 256, "", CFGFLAG_SERVER, "Extra headers to send to the register endpoint, comma-separated 'Header: Value' pairs")
 MACRO_CONFIG_STR(SvRegisterUrl, sv_register_url, 128, "https://master1.ddnet.org/ddnet/15/register", CFGFLAG_SERVER, "Masterserver URL to register to")
 MACRO_CONFIG_INT(SvRegisterPort, sv_register_port, 0, 0, 65535, CFGFLAG_SERVER, "Port for the master server to register the server with, useful if you are behind NAT, otherwise you only need sv_port")
+MACRO_CONFIG_STR(SvRegisterCommunityToken, sv_register_community_token, 128, "", CFGFLAG_SERVER, "Token to register this server to a particular community")
+MACRO_CONFIG_INT(SvFlag, sv_flag, -1, -1, 999, CFGFLAG_SERVER, "Country flag to group this community under (ISO 3166-1 numeric)")
 MACRO_CONFIG_STR(SvMapsBaseUrl, sv_maps_base_url, 128, "", CFGFLAG_SERVER, "Base path used to provide HTTPS map download URL to the clients")
 MACRO_CONFIG_STR(SvRconPassword, sv_rcon_password, 128, "", CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, "Remote console password (full access)")
 MACRO_CONFIG_STR(SvRconModPassword, sv_rcon_mod_password, 128, "", CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, "Remote console password for moderators (limited access)")

--- a/src/mastersrv/Cargo.lock
+++ b/src/mastersrv/Cargo.lock
@@ -167,6 +167,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +185,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -556,6 +571,8 @@ dependencies = [
  "base64",
  "bytes",
  "clap",
+ "constant_time_eq",
+ "crc32fast",
  "env_logger",
  "headers",
  "hex",

--- a/src/mastersrv/Cargo.toml
+++ b/src/mastersrv/Cargo.toml
@@ -17,6 +17,8 @@ clap = { version = "2.34.0", default-features = false, features = [
   "suggestions",
   "wrap_help",
 ] }
+constant_time_eq = "0.4.2"
+crc32fast = "1.5.0"
 env_logger = "0.8.3"
 headers = "0.3.7"
 hex = "0.4.3"

--- a/src/mastersrv/src/community_token.rs
+++ b/src/mastersrv/src/community_token.rs
@@ -1,0 +1,128 @@
+use arrayvec::ArrayString;
+use constant_time_eq::constant_time_eq;
+use sha2::Digest as _;
+use sha2::Sha256;
+use std::str::FromStr;
+
+fn strip_crc32(s: &str) -> Option<&str> {
+    if s.len() < 6 || !s.is_char_boundary(s.len() - 6) {
+        return None;
+    }
+    let (result, encoded_crc32) = s.split_at(s.len() - 6);
+    let mut crc32 = [0; 4];
+    assert_eq!(
+        base64::decode_config_slice(encoded_crc32, base64::URL_SAFE_NO_PAD, &mut crc32).ok()?,
+        4
+    );
+    if crc32fast::hash(result.as_bytes()).to_be_bytes() != crc32 {
+        return None;
+    }
+    Some(result)
+}
+
+fn token(s: &str) -> Option<(&str, &str)> {
+    let mut underscore = None;
+    for (i, b) in s.bytes().enumerate() {
+        match b {
+            b'0'..=b'9' => {}
+            b'A'..=b'Z' => {}
+            b'a'..=b'z' => {}
+            b'-' => return None, // tokens are generated to not contain -
+            b'_' if underscore.is_none() => underscore = Some(i),
+            b'_' => return None, // only one underscore allowed
+            _ => return None,    // invalid base64 urlsafe
+        }
+    }
+    let underscore = underscore?;
+    let s = strip_crc32(s)?;
+    if s.len() < underscore {
+        return None;
+    }
+    Some((&s[..underscore], &s[underscore + 1..]))
+}
+
+const PLAIN_PREFIX_LEN: usize = 6;
+const TOKEN_LEN: usize = 30;
+const VERIFICATION_LEN: usize = 28;
+
+pub fn get_plain_prefix_from_token(s: &str) -> Option<&str> {
+    let (prefix, token) = token(s)?;
+    if prefix != "ddtc" || token.len() != TOKEN_LEN || !token.is_char_boundary(PLAIN_PREFIX_LEN) {
+        return None;
+    }
+    Some(&token[..PLAIN_PREFIX_LEN])
+}
+
+pub type PlainPrefix = ArrayString<[u8; PLAIN_PREFIX_LEN]>;
+pub struct Hash([u8; 16]);
+
+fn half_sha256(input: &[u8]) -> Hash {
+    let sha256: [u8; 32] = Sha256::digest(input).into();
+    let mut half = [0; 16];
+    half.copy_from_slice(&sha256[..16]);
+    Hash(half)
+}
+
+impl Hash {
+    pub fn verify(&self, token: &str) -> Result<(), ()> {
+        if self.constant_time_eq(&half_sha256(token.as_bytes())) {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+    fn constant_time_eq(&self, other: &Hash) -> bool {
+        constant_time_eq(&self.0, &other.0)
+    }
+}
+
+pub struct Verification {
+    pub plain_prefix: PlainPrefix,
+    pub hash: Hash,
+}
+
+impl Verification {
+    fn from_str_impl(s: &str) -> Option<Verification> {
+        let (prefix, token) = token(s)?;
+        if prefix != "ddvc"
+            || token.len() != VERIFICATION_LEN
+            || !token.is_char_boundary(PLAIN_PREFIX_LEN)
+        {
+            return None;
+        }
+        let (plain_prefix, hash_base64) = token.split_at(PLAIN_PREFIX_LEN);
+        let plain_prefix = PlainPrefix::from(plain_prefix).unwrap();
+        let mut hash = Hash([0; 16]);
+        assert_eq!(
+            base64::decode_config_slice(hash_base64, base64::URL_SAFE_NO_PAD, &mut hash.0,).ok()?,
+            16,
+        );
+        Some(Verification { plain_prefix, hash })
+    }
+}
+
+impl FromStr for Verification {
+    type Err = &'static str;
+    fn from_str(s: &str) -> Result<Verification, &'static str> {
+        Verification::from_str_impl(s).ok_or("invalid verification token")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::get_plain_prefix_from_token;
+    use super::Verification;
+
+    #[test]
+    fn verification() {
+        let token = "ddtc_6DnZq5Ix0J2kvDHbkPNtb6bsZxOVQg4ly2jw";
+        let verification = "ddvc_6DnZq51fypqX9ldrEFCF9aJdpi6wjgh6YA";
+
+        let verification: Verification = verification.parse().unwrap();
+        assert_eq!(
+            get_plain_prefix_from_token(token).unwrap(),
+            &*verification.plain_prefix
+        );
+        assert!(verification.hash.verify(token).is_ok());
+    }
+}

--- a/src/mastersrv/src/main.rs
+++ b/src/mastersrv/src/main.rs
@@ -53,6 +53,7 @@ use crate::locations::Locations;
 // Naming convention: Always use the abbreviation `addr` except in user-facing
 // (e.g. serialized) identifiers.
 mod addr;
+mod community_token;
 mod config;
 mod locations;
 
@@ -67,6 +68,7 @@ struct Register {
     connless_request_token: Option<ShortString>,
     challenge_secret: ShortString,
     challenge_token: Option<ShortString>,
+    community_token: Option<ShortString>,
     info_serial: i64,
     info: Option<json::Value>,
 }
@@ -166,12 +168,15 @@ impl Timekeeper {
 
 #[derive(Debug, Serialize)]
 struct SerializedServers<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub communities: Option<&'a json::value::RawValue>,
     pub servers: Vec<SerializedServer<'a>>,
 }
 
 impl<'a> SerializedServers<'a> {
-    fn new() -> SerializedServers<'a> {
+    fn new(communities: Option<&'a json::value::RawValue>) -> SerializedServers<'a> {
         SerializedServers {
+            communities,
             servers: Vec::new(),
         }
     }
@@ -181,6 +186,8 @@ impl<'a> SerializedServers<'a> {
 struct SerializedServer<'a> {
     pub addresses: &'a [Addr],
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub community: Option<ShortString>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub location: Option<Location>,
     pub info: &'a json::value::RawValue,
 }
@@ -189,6 +196,7 @@ impl<'a> SerializedServer<'a> {
     fn new(server: &'a Server, location: Option<Location>) -> SerializedServer<'a> {
         SerializedServer {
             addresses: &server.addresses,
+            community: server.community,
             location,
             info: &server.info,
         }
@@ -199,6 +207,8 @@ impl<'a> SerializedServer<'a> {
 struct DumpServer<'a> {
     pub info_serial: i64,
     pub info: Cow<'a, json::value::RawValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub community: Option<ShortString>,
 }
 
 impl<'a> From<&'a Server> for DumpServer<'a> {
@@ -206,6 +216,7 @@ impl<'a> From<&'a Server> for DumpServer<'a> {
         DumpServer {
             info_serial: server.info_serial,
             info: Cow::Borrowed(&server.info),
+            community: server.community,
         }
     }
 }
@@ -333,7 +344,7 @@ impl<'a> Shared<'a> {
 /// Maintains a mapping from server addresses to server info.
 ///
 /// Also maintains a mapping from addresses to corresponding server addresses.
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone)]
 struct Servers {
     pub addresses: HashMap<Addr, AddrInfo>,
     pub servers: HashMap<ShortString, Server>,
@@ -366,6 +377,7 @@ impl Servers {
         a_info: AddrInfo,
         info_serial: i64,
         info: Option<Cow<'_, json::value::RawValue>>,
+        community: Option<&ShortString>,
     ) -> AddResult {
         let need_info = self
             .servers
@@ -409,6 +421,7 @@ impl Servers {
                     addresses: vec![addr],
                     info_serial,
                     info: info.unwrap().into_owned(),
+                    community: community.cloned(),
                 });
             }
             hash_map::Entry::Occupied(mut o) => {
@@ -420,6 +433,7 @@ impl Servers {
                 if info_serial > server.info_serial {
                     server.info_serial = info_serial;
                     server.info = info.unwrap().into_owned();
+                    server.community = community.cloned();
                 }
             }
         }
@@ -469,6 +483,7 @@ impl Servers {
                 a_info.clone(),
                 server.info_serial,
                 Some(Cow::Borrowed(&server.info)),
+                server.community.as_ref(),
             );
         }
     }
@@ -485,6 +500,7 @@ impl Servers {
                             addresses: vec![],
                             info_serial: server.info_serial,
                             info: server.info.into_owned(),
+                            community: server.community,
                         },
                     )
                 })
@@ -510,11 +526,12 @@ impl Servers {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug)]
 struct Server {
     pub addresses: Vec<Addr>,
     pub info_serial: i64,
     pub info: Box<json::value::RawValue>,
+    pub community: Option<ShortString>,
 }
 
 async fn handle_periodic_reseed(challenger: Arc<Mutex<Challenger>>) {
@@ -562,8 +579,8 @@ async fn overwrite_atomically(
     Ok(())
 }
 
-fn servers_json(now: Timestamp, mut servers: Servers) -> String {
-    let mut serialized = SerializedServers::new();
+fn servers_json(config: &Config, now: Timestamp, mut servers: Servers) -> String {
+    let mut serialized = SerializedServers::new(config.communities.as_deref());
     servers.prune_before(now.minus_seconds(SERVER_TIMEOUT_SECONDS), false);
     serialized.servers.extend(servers.servers.values().map(|s| {
         // Get the location of the first registered address. Since
@@ -580,6 +597,7 @@ fn servers_json(now: Timestamp, mut servers: Servers) -> String {
 }
 
 async fn handle_test_servers_json(
+    config: Arc<Config>,
     servers: Arc<Mutex<Servers>>,
     dumps_dir: Option<String>,
     timekeeper: Timekeeper,
@@ -596,10 +614,11 @@ async fn handle_test_servers_json(
     for other_dump in &other_dumps {
         servers.merge(other_dump);
     }
-    servers_json(now, servers)
+    servers_json(&config, now, servers)
 }
 
 async fn handle_periodic_writeout(
+    config: Arc<ArcSwap<Config>>,
     servers: Arc<Mutex<Servers>>,
     dumps_dir: Option<String>,
     dump_filename: Option<String>,
@@ -622,6 +641,7 @@ async fn handle_periodic_writeout(
 
     loop {
         let now = timekeeper.now();
+        let config = config.load();
         let mut servers = {
             let mut servers = servers.lock().unwrap_or_else(|poison| poison.into_inner());
             servers.prune_before(now.minus_seconds(SERVER_TIMEOUT_SECONDS), true);
@@ -664,7 +684,7 @@ async fn handle_periodic_writeout(
                 servers.merge(other_dump);
             }
             drop(other_dumps);
-            let json = servers_json(now, servers);
+            let json = servers_json(&config, now, servers);
             overwrite_atomically(&servers_filename, servers_filename_temp, json.as_bytes())
                 .await
                 .unwrap();
@@ -777,6 +797,15 @@ fn handle_register(
             .map(|ct| ct != challenge.current())
             .unwrap_or(true);
 
+    let community = register
+        .community_token
+        .and_then(|t| shared.config.community_for_token(&t).transpose())
+        .transpose()
+        .map_err(RegisterError::new)?
+        .map(|c| ArrayString::from(c))
+        .transpose()
+        .map_err(|_| "invalid community name length")?;
+
     let result = if correct_challenge {
         let raw_info = register
             .info
@@ -798,6 +827,7 @@ fn handle_register(
             },
             register.info_serial,
             raw_info.map(Cow::Owned),
+            community.as_ref(),
         );
         match add_result {
             AddResult::Added => debug!("successfully registered {}", addr),
@@ -887,6 +917,7 @@ fn register_from_headers(
         connless_request_token: parse_opt(headers, "Connless-Token")?,
         challenge_secret: parse(headers, "Challenge-Secret")?,
         challenge_token: parse_opt(headers, "Challenge-Token")?,
+        community_token: parse_opt(headers, "Community-Token")?,
         info_serial: parse(headers, "Info-Serial")?,
         info: if !info.is_empty() {
             match headers
@@ -1077,6 +1108,7 @@ async fn main() {
 
     let task_reseed = tokio::spawn(handle_periodic_reseed(challenger.clone()));
     let task_writeout = tokio::spawn(handle_periodic_writeout(
+        config.clone(),
         servers.clone(),
         read_dump_dir.clone(),
         matches
@@ -1136,6 +1168,7 @@ async fn main() {
         .and(warp::body::content_length_limit(32 * 1024)) // limit body size to 32 KiB
         .and(warp::body::bytes())
         .map({
+            let config = config.clone();
             let servers = servers.clone();
             move |headers: warp::http::HeaderMap, addr: Option<SocketAddr>, info: bytes::Bytes| {
                 build_response(|| {
@@ -1166,14 +1199,20 @@ async fn main() {
         });
     let test_servers = warp::path!("ddnet" / "15" / "test-servers.json")
         .and(warp::get())
-        .and_then(move || {
+        .and_then({
+            let config = config.clone();
             let servers = servers.clone();
             let read_dump_dir = read_dump_dir.clone();
-            async move {
-                if test_servers_route {
-                    Ok(handle_test_servers_json(servers, read_dump_dir, timekeeper).await)
-                } else {
-                    Err(warp::reject())
+            move || {
+                let config = config.clone();
+                let servers = servers.clone();
+                let read_dump_dir = read_dump_dir.clone();
+                async move {
+                    if test_servers_route {
+                        Ok(handle_test_servers_json(config.load_full(), servers, read_dump_dir, timekeeper).await)
+                    } else {
+                        Err(warp::reject())
+                    }
                 }
             }
         });


### PR DESCRIPTION
This will allow us to automate community handling.

My plan is to split https://info.ddnet.org/info into three parts. The finish information, to be served under a different URL, e.g.
https://finishes.ddnet.org/finishes?name=nameless%20tee, the static info without any DB acess, maybe https://info.ddnet.org/info2, and the community metadata and server info data, into https://master1.ddnet.org/ddnet/15/servers.json. There will be a
`communities` key in the top level with the static community information like name, icon, etc. The servers will get a new `community` key that is only set when the masterserver recognizes the community API token sent by the server (configured in the masterserver config). Other per-server community information like flag or server type is moved into the server info instead.

This does not yet contain a client implementation, nor the backward compatibility necessary to support non-HTTPS-registered server.

## Checklist

- [x] Tested the change ~ingame~
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
