### PR TITLE
Add translation credits to language settings

### DIFF
--- a/data/languages/german.txt
+++ b/data/languages/german.txt
@@ -1,31 +1,3 @@
-##### authors #####
-#originally created by:
-#	Dominik Geyer
-#modified by:
-#	Fujnky			2010-06-03 11:30:05
-#	Fujnky			2010-06-03 17:41:45
-#	Fujnky			2010-06-05 23:36:52
-#	Fujnky			2010-06-07 16:17:40
-#	Fujnky			2010-06-11 09:50:47
-#	Sworddragon		2010-11-21 14:25:00
-#	Fujnky			2011-01-02 19:49:22
-#	heinrich5991	2011-01-23 17:53:42
-#	Sworddragon		2011-02-09 12:54:50
-#	heinrich5991	2011-04-03 23:46:51
-#	ghost91			2011-04-04 20:47:01
-#	andi103			2011-05-02 19:12:27
-#	andi103			2011-05-03 23:25:20
-#	heinrich5991	2011-07-02 09:10:21
-#	Yared Hufkens	2012-02-03 19:57:59
-#	andi103			2012-07-14 11:31:11
-#	timakro			2014-06-30 18:26:59
-#	deen			2020-06-26 18:32:00
-#	bluesky			2022-07-05 21:00:00
-# BlaiZephyr 2024-03-23 20:55:00
-##### /authors #####
-
-##### translated strings #####
-
 %ds left
 == Noch %ds
 
@@ -2088,3 +2060,7 @@ Server could not be started. Make sure to grant the notification permission in t
 
 "%s" is not compatible with pnglite and cannot be loaded by old DDNet versions:
 == "%s" is nicht mit pnglite kompatibel und kann in alten DDNet-Versionen nicht geladen werden:
+
+[Translation credits: Add your own name here when you update translations]
+English translation by the DDNet Team
+== Deutsche Übersetzung von Dominik Geyer, Fujnky, Sworddragon, heinrich5991, ghost91, andi103, Yared Hufkens, timakro, deen, bluesky, BlaiZephyr, Robyt3

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1877,8 +1877,13 @@ bool CMenus::RenderLanguageSelection(CUIRect MainView)
 	}
 
 	const int OldSelected = s_SelectedLanguage;
+	const float CreditsFontSize = 14.0f;
+	const float CreditsMargin = 10.0f;
 
-	s_ListBox.DoStart(24.0f, g_Localization.Languages().size(), 1, 3, s_SelectedLanguage, &MainView);
+	CUIRect List, CreditsScroll;
+	MainView.HSplitBottom(4.0f * CreditsFontSize + 2.0f * CreditsMargin + CScrollRegion::HEIGHT_MAGIC_FIX, &List, &CreditsScroll);
+	List.HSplitBottom(5.0f, &List, nullptr);
+	s_ListBox.DoStart(24.0f, g_Localization.Languages().size(), 1, 3, s_SelectedLanguage, &List);
 
 	for(const auto &Language : g_Localization.Languages())
 	{
@@ -1902,6 +1907,36 @@ bool CMenus::RenderLanguageSelection(CUIRect MainView)
 		str_copy(g_Config.m_ClLanguagefile, g_Localization.Languages()[s_SelectedLanguage].m_FileName.c_str());
 		GameClient()->OnLanguageChange();
 	}
+
+	CreditsScroll.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.25f), IGraphics::CORNER_ALL, 5.0f);
+
+	static CScrollRegion s_CreditsScrollRegion;
+	vec2 ScrollOffset(0.0f, 0.0f);
+	CScrollRegionParams ScrollParams;
+	ScrollParams.m_ScrollUnit = CreditsFontSize;
+	s_CreditsScrollRegion.Begin(&CreditsScroll, &ScrollOffset, &ScrollParams);
+	CreditsScroll.y += ScrollOffset.y;
+
+	CTextCursor Cursor;
+	TextRender()->SetCursor(&Cursor, 0.0f, 0.0f, CreditsFontSize, TEXTFLAG_RENDER);
+	Cursor.m_LineWidth = CreditsScroll.w - 2.0f * CreditsMargin;
+
+	const unsigned OldRenderFlags = TextRender()->GetRenderFlags();
+	TextRender()->SetRenderFlags(OldRenderFlags | TEXT_RENDER_FLAG_ONE_TIME_USE);
+	STextContainerIndex CreditsTextContainer;
+	TextRender()->CreateTextContainer(CreditsTextContainer, &Cursor, Localize("English translation by the DDNet Team", "Translation credits: Add your own name here when you update translations"));
+	TextRender()->SetRenderFlags(OldRenderFlags);
+	if(CreditsTextContainer.Valid())
+	{
+		CUIRect CreditsLabel;
+		CreditsScroll.HSplitTop(TextRender()->GetBoundingBoxTextContainer(CreditsTextContainer).m_H + 2.0f * CreditsMargin, &CreditsLabel, &CreditsScroll);
+		s_CreditsScrollRegion.AddRect(CreditsLabel);
+		CreditsLabel.Margin(CreditsMargin, &CreditsLabel);
+		TextRender()->RenderTextContainer(CreditsTextContainer, TextRender()->DefaultTextColor(), TextRender()->DefaultTextOutlineColor(), CreditsLabel.x, CreditsLabel.y);
+		TextRender()->DeleteTextContainer(CreditsTextContainer);
+	}
+
+	s_CreditsScrollRegion.End();
 
 	return s_ListBox.WasItemActivated();
 }


### PR DESCRIPTION
Show credits for the selected language file in the language settings.

The credits are retrieved from the respective language file like a regular localization string. The string `"English translation by the DDNet Team"` with context `"Translation credits: Add your own name here when you update translations"` should be translated to the credits for the respective language. All language authors should be listed (without duplicates) in the order in which they first contributed to the language file. Old author comments should be removed from the file and integrated into this string.

Credits for the German translation are provided as an example.

Closes #6949.

Screenshots:

- English: 
![screenshot_2025-01-22_21-32-02](https://github.com/user-attachments/assets/7c6517dd-2f8b-4622-9720-4e0a772a1eab)
- German: 
![screenshot_2025-01-22_21-32-06](https://github.com/user-attachments/assets/c1d41fe2-e8c1-49a8-a60f-59305755f89d)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
