### PR TITLE
Also print errors/warnings for `png_create_read_struct` function

### DIFF
--- a/src/engine/gfx/image_loader.cpp
+++ b/src/engine/gfx/image_loader.cpp
@@ -138,7 +138,12 @@ bool CImageLoader::LoadPng(CByteBufferReader &Reader, const char *pContextName, 
 {
 	CUserErrorStruct UserErrorStruct = {&Reader, pContextName, {}};
 
-	png_structp pPngStruct = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+	if(setjmp(UserErrorStruct.m_JmpBuf))
+	{
+		return false;
+	}
+
+	png_structp pPngStruct = png_create_read_struct(PNG_LIBPNG_VER_STRING, &UserErrorStruct, PngErrorCallback, PngWarningCallback);
 	if(pPngStruct == nullptr)
 	{
 		log_error("png", "libpng internal failure: png_create_read_struct failed.");
@@ -168,7 +173,6 @@ bool CImageLoader::LoadPng(CByteBufferReader &Reader, const char *pContextName, 
 		Cleanup();
 		return false;
 	}
-	png_set_error_fn(pPngStruct, &UserErrorStruct, PngErrorCallback, PngWarningCallback);
 
 	pPngInfo = png_create_info_struct(pPngStruct);
 	if(pPngInfo == nullptr)


### PR DESCRIPTION
Set the error and warning handling functions as early as possible to also get more detailed errors and warnings when the `png_create_read_struct` function fails, e.g. due to libpng version mismatch.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
