### PR TITLE
Fix border not killing when overlapped with death tile in practice mode

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1430,8 +1430,10 @@ void CCharacter::HandleSkippableTiles(int Index)
 			}
 		}
 		else
+		{
 			Die(m_pPlayer->GetCid(), WEAPON_WORLD);
-		return;
+			return;
+		}
 	}
 
 	if(GameLayerClipped(m_Pos))


### PR DESCRIPTION
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
