### PR TITLE
Refactor server's client address functions, handle debug dummies

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -3,6 +3,7 @@
 #ifndef ENGINE_SERVER_H
 #define ENGINE_SERVER_H
 
+#include <array>
 #include <optional>
 #include <type_traits>
 
@@ -60,7 +61,9 @@ public:
 	virtual bool ClientIngame(int ClientId) const = 0;
 	virtual bool GetClientInfo(int ClientId, CClientInfo *pInfo) const = 0;
 	virtual void SetClientDDNetVersion(int ClientId, int DDNetVersion) = 0;
-	virtual void GetClientAddr(int ClientId, char *pAddrStr, int Size) const = 0;
+	virtual const NETADDR *ClientAddr(int ClientId) const = 0;
+	virtual const std::array<char, NETADDR_MAXSTRSIZE> &ClientAddrStringImpl(int ClientId, bool IncludePort) const = 0;
+	inline const char *ClientAddrString(int ClientId, bool IncludePort) const { return ClientAddrStringImpl(ClientId, IncludePort).data(); }
 
 	/**
 	 * Returns the version of the client with the given client ID.
@@ -264,8 +267,6 @@ public:
 	virtual void StopRecord(int ClientId) = 0;
 	virtual bool IsRecording(int ClientId) = 0;
 	virtual void StopDemos() = 0;
-
-	virtual void GetClientAddr(int ClientId, NETADDR *pAddr) const = 0;
 
 	virtual int *GetIdMap(int ClientId) = 0;
 

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -162,6 +162,9 @@ public:
 		int m_Flags;
 		bool m_ShowIps;
 		bool m_DebugDummy;
+		NETADDR m_DebugDummyAddr;
+		std::array<char, NETADDR_MAXSTRSIZE> m_aDebugDummyAddrString;
+		std::array<char, NETADDR_MAXSTRSIZE> m_aDebugDummyAddrStringNoPort;
 
 		const IConsole::CCommandInfo *m_pRconCmdToSend;
 
@@ -300,7 +303,8 @@ public:
 	void GetMapInfo(char *pMapName, int MapNameSize, int *pMapSize, SHA256_DIGEST *pMapSha256, int *pMapCrc) override;
 	bool GetClientInfo(int ClientId, CClientInfo *pInfo) const override;
 	void SetClientDDNetVersion(int ClientId, int DDNetVersion) override;
-	void GetClientAddr(int ClientId, char *pAddrStr, int Size) const override;
+	const NETADDR *ClientAddr(int ClientId) const override;
+	const std::array<char, NETADDR_MAXSTRSIZE> &ClientAddrStringImpl(int ClientId, bool IncludePort) const override;
 	const char *ClientName(int ClientId) const override;
 	const char *ClientClan(int ClientId) const override;
 	int ClientCountry(int ClientId) const override;
@@ -445,7 +449,6 @@ public:
 
 	// DDRace
 
-	void GetClientAddr(int ClientId, NETADDR *pAddr) const override;
 	int m_aPrevStates[MAX_CLIENTS];
 	const char *GetAnnouncementLine() override;
 	void ReadAnnouncementsFile();

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -9,6 +9,8 @@
 #include <base/math.h>
 #include <base/system.h>
 
+#include <array>
+
 class CHuffman;
 class CNetBan;
 class CPacker;
@@ -265,13 +267,16 @@ private:
 	NETSOCKET m_Socket;
 	NETSTATS m_Stats;
 
-	char m_aPeerAddrStr[NETADDR_MAXSTRSIZE];
+	std::array<char, NETADDR_MAXSTRSIZE> m_aPeerAddrStr;
+	std::array<char, NETADDR_MAXSTRSIZE> m_aPeerAddrStrNoPort;
 	// client 0.7
 	static TOKEN GenerateToken7(const NETADDR *pPeerAddr);
 	class CNetBase *m_pNetBase;
 	bool IsSixup() { return m_Sixup; }
 
 	//
+	void SetPeerAddr(const NETADDR *pAddr);
+	void ClearPeerAddr();
 	void ResetStats();
 	void SetError(const char *pString);
 	void AckChunks(int Ack);
@@ -305,7 +310,10 @@ public:
 	void SignalResend();
 	int State() const { return m_State; }
 	const NETADDR *PeerAddress() const { return &m_PeerAddr; }
-	const char (*PeerAddressString() const)[NETADDR_MAXSTRSIZE] { return &m_aPeerAddrStr; }
+	const std::array<char, NETADDR_MAXSTRSIZE> &PeerAddressString(bool IncludePort) const
+	{
+		return IncludePort ? m_aPeerAddrStr : m_aPeerAddrStrNoPort;
+	}
 	void ConnectAddresses(const NETADDR **ppAddrs, int *pNumAddrs) const
 	{
 		*ppAddrs = m_aConnectAddrs;
@@ -455,7 +463,7 @@ public:
 
 	// status requests
 	const NETADDR *ClientAddr(int ClientId) const { return m_aSlots[ClientId].m_Connection.PeerAddress(); }
-	const char (*ClientAddrString(int ClientID) const)[NETADDR_MAXSTRSIZE] { return m_aSlots[ClientID].m_Connection.PeerAddressString(); }
+	const std::array<char, NETADDR_MAXSTRSIZE> &ClientAddrString(int ClientId, bool IncludePort) const { return m_aSlots[ClientId].m_Connection.PeerAddressString(IncludePort); }
 	bool HasSecurityToken(int ClientId) const { return m_aSlots[ClientId].m_Connection.SecurityToken() != NET_SECURITY_TOKEN_UNSUPPORTED; }
 	NETADDR Address() const { return m_Address; }
 	NETSOCKET Socket() const { return m_Socket; }

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -254,9 +254,7 @@ int CNetServer::TryAcceptClient(NETADDR &Addr, SECURITY_TOKEN SecurityToken, boo
 
 	if(g_Config.m_Debug)
 	{
-		char aAddrStr[NETADDR_MAXSTRSIZE];
-		net_addr_str(&Addr, aAddrStr, sizeof(aAddrStr), true);
-		dbg_msg("security", "client accepted %s", aAddrStr);
+		dbg_msg("security", "client accepted %s", m_aSlots[Slot].m_Connection.PeerAddressString(true).data());
 	}
 
 	if(VanillaAuth)

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -610,12 +610,11 @@ void CGameContext::ConVoteMute(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
-	NETADDR Addr;
-	pSelf->Server()->GetClientAddr(Victim, &Addr);
+	const NETADDR *pAddr = pSelf->Server()->ClientAddr(Victim);
 
 	int Seconds = clamp(pResult->GetInteger(1), 1, 86400);
 	const char *pReason = pResult->NumArguments() > 2 ? pResult->GetString(2) : "";
-	pSelf->VoteMute(&Addr, Seconds, pReason, pSelf->Server()->ClientName(Victim), pResult->m_ClientId);
+	pSelf->VoteMute(pAddr, Seconds, pReason, pSelf->Server()->ClientName(Victim), pResult->m_ClientId);
 }
 
 void CGameContext::ConVoteUnmute(IConsole::IResult *pResult, void *pUserData)
@@ -629,10 +628,9 @@ void CGameContext::ConVoteUnmute(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
-	NETADDR Addr;
-	pSelf->Server()->GetClientAddr(Victim, &Addr);
+	const NETADDR *pAddr = pSelf->Server()->ClientAddr(Victim);
 
-	bool Found = pSelf->VoteUnmute(&Addr, pSelf->Server()->ClientName(Victim), pResult->m_ClientId);
+	bool Found = pSelf->VoteUnmute(pAddr, pSelf->Server()->ClientName(Victim), pResult->m_ClientId);
 	if(Found)
 	{
 		char aBuf[128];
@@ -655,7 +653,7 @@ void CGameContext::ConVoteMutes(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
-	char aIpBuf[64];
+	char aIpBuf[NETADDR_MAXSTRSIZE];
 	char aBuf[128];
 	pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "votemutes",
 		"Active vote mutes:");
@@ -689,12 +687,11 @@ void CGameContext::ConMuteId(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
-	NETADDR Addr;
-	pSelf->Server()->GetClientAddr(Victim, &Addr);
+	const NETADDR *pAddr = pSelf->Server()->ClientAddr(Victim);
 
 	const char *pReason = pResult->NumArguments() > 2 ? pResult->GetString(2) : "";
 
-	pSelf->Mute(&Addr, clamp(pResult->GetInteger(1), 1, 86400),
+	pSelf->Mute(pAddr, clamp(pResult->GetInteger(1), 1, 86400),
 		pSelf->Server()->ClientName(Victim), pReason);
 }
 
@@ -721,7 +718,7 @@ void CGameContext::ConUnmute(IConsole::IResult *pResult, void *pUserData)
 	if(Index < 0 || Index >= pSelf->m_NumMutes)
 		return;
 
-	char aIpBuf[64];
+	char aIpBuf[NETADDR_MAXSTRSIZE];
 	char aBuf[64];
 	net_addr_str(&pSelf->m_aMutes[Index].m_Addr, aIpBuf, sizeof(aIpBuf), false);
 	str_format(aBuf, sizeof(aBuf), "Unmuted %s", aIpBuf);
@@ -740,14 +737,13 @@ void CGameContext::ConUnmuteId(IConsole::IResult *pResult, void *pUserData)
 	if(Victim < 0 || Victim > MAX_CLIENTS || !pSelf->m_apPlayers[Victim])
 		return;
 
-	NETADDR Addr;
-	pSelf->Server()->GetClientAddr(Victim, &Addr);
+	const NETADDR *pAddr = pSelf->Server()->ClientAddr(Victim);
 
 	for(int i = 0; i < pSelf->m_NumMutes; i++)
 	{
-		if(net_addr_comp_noport(&pSelf->m_aMutes[i].m_Addr, &Addr) == 0)
+		if(net_addr_comp_noport(&pSelf->m_aMutes[i].m_Addr, pAddr) == 0)
 		{
-			char aIpBuf[64];
+			char aIpBuf[NETADDR_MAXSTRSIZE];
 			char aBuf[64];
 			net_addr_str(&pSelf->m_aMutes[i].m_Addr, aIpBuf, sizeof(aIpBuf), false);
 			str_format(aBuf, sizeof(aBuf), "Unmuted %s", aIpBuf);
@@ -975,7 +971,7 @@ void CGameContext::LogEvent(const char *Description, int ClientId)
 	if(!pNewEntry->m_FromServer)
 	{
 		pNewEntry->m_ClientVersion = Server()->GetClientVersion(ClientId);
-		Server()->GetClientAddr(ClientId, pNewEntry->m_aClientAddrStr, sizeof(pNewEntry->m_aClientAddrStr));
+		str_copy(pNewEntry->m_aClientAddrStr, Server()->ClientAddrString(ClientId, false));
 		str_copy(pNewEntry->m_aClientName, Server()->ClientName(ClientId));
 	}
 }


### PR DESCRIPTION
Generate unique local addresses (IPv6 addresses) for debug dummies so address-based functions work with debug dummies. Every debug dummy's ULA has a randomly generated global ID such that debug dummy addresses are most likely unique. The ULA's subnet ID is set to a constant value. The ULA's interface ID is set to the dummy's client ID. See https://en.wikipedia.org/wiki/Unique_local_address for details about the format. The port is generated randomly in the same way that normal clients select their port.

Change the `const char (*::CNetServer::ClientAddrString(int ClientID) const)[NETADDR_MAXSTRSIZE]` function signature to `const std::array<char, NETADDR_MAXSTRSIZE> &ClientAddrString(int ClientId, bool IncludePort) const` and change the `const char (*CNetConnection::PeerAddressString() const)[NETADDR_MAXSTRSIZE]` function signature to `const std::array<char, NETADDR_MAXSTRSIZE> &PeerAddressString(bool IncludePort) const` to optionally include the port and because a reference to an `std::array` is more readable then a pointer/reference to a C-array. The address string is now cached separately with and without port by `CNetConnection`.

Add the `CNetConnection::SetPeerAddr` and `CNetConnection::ClearPeerAddr` functions to avoid duplicate code. Fix the peer address string not being initialized for 0.7 connections, though this is currently unused from the client-side so it had no effect.

Change the `void IServer::GetClientAddr(int ClientId, NETADDR *pAddr) const` function signature to `const NETADDR *ClientAddr(int ClientId) const`. This simplifies the usage as most address-based functions take pointers to `NETADDR` as arguments. Use this function consistently instead of the `CNetServer::ClientAddr` function, as the `IServer::ClientAddr` function has assertions and returns the generated ULA for debug dummies.

Change the `void IServer::GetClientAddr(int ClientId, char *pAddrStr, int Size) const` function signature to `const std::array<char, NETADDR_MAXSTRSIZE> &ClientAddrStringImpl(int ClientId, bool IncludePort) const` and add the `inline const char *ClientAddrString(int ClientId, bool IncludePort) const` wrapper function. This also simplifies the usage in most cases while retaining the static size information for the address strings. These functions can return the string with and without port, whereas before the string was always returned without port. Use this function consistently instead of the `CNetServer::ClientAddrString` function and instead of the `net_addr_str` function together with the `IServer::GetClientAddr` function, as the `IServer::ClientAddrString` function has assertions and returns the generated ULA strings for debug dummies. This should also slightly improves performance as the cached address strings are thereby used in all cases. Note that the `CNetServer::ClientAddrString` function previously returned the address string with port, whereas the `IServer::GetClientAddr` function returned the address string without port.

Compare `NETADDR`s directly without ports instead of converting to strings without ports when counting votes.

Closes #9554.

Example output for `status` command with `show_ips 1`:

```
2025-01-26 21:36:46 I server: id=54 addr=[fdd6:1406:a29b:c0de::36]:5959 name='Debug dummy 10' client=-1 secure=yes flags=0
2025-01-26 21:36:46 I server: id=55 addr=[fd0b:7f17:c5d5:c0de::37]:12754 name='Debug dummy 9' client=-1 secure=yes flags=0
2025-01-26 21:36:46 I server: id=56 addr=[fd3f:1d59:6f53:c0de::38]:11363 name='Debug dummy 8' client=-1 secure=yes flags=0
2025-01-26 21:36:46 I server: id=57 addr=[fd1e:cd13:ad13:c0de::39]:15014 name='Debug dummy 7' client=-1 secure=yes flags=0
2025-01-26 21:36:46 I server: id=58 addr=[fd07:655c:a342:c0de::3a]:9550 name='Debug dummy 6' client=-1 secure=yes flags=0
2025-01-26 21:36:46 I server: id=59 addr=[fd0d:456e:fbcf:c0de::3b]:23382 name='Debug dummy 5' client=-1 secure=yes flags=0
2025-01-26 21:36:46 I server: id=60 addr=[fd98:1342:fc87:c0de::3c]:18347 name='Debug dummy 4' client=-1 secure=yes flags=0
2025-01-26 21:36:46 I server: id=61 addr=[fd9b:99bf:98ab:c0de::3d]:23054 name='Debug dummy 3' client=-1 secure=yes flags=0
2025-01-26 21:36:46 I server: id=62 addr=[fd01:fca7:8388:c0de::3e]:32252 name='Debug dummy 2' client=-1 secure=yes flags=0
2025-01-26 21:36:46 I server: id=63 addr=[fd41:7a5:bda8:c0de::3f]:22056 name='Debug dummy 1' client=-1 secure=yes flags=0
``` 

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
