### PR TITLE
Separate infjump and invincible

### DIFF
--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1040,9 +1040,9 @@ void CCharacter::DDRacePostCoreTick()
 		m_Core.m_Jumped = 1;
 	}
 
-	if((m_Core.m_Super || m_Core.m_Invincible || m_Core.m_EndlessJump) && m_Core.m_Jumped > 1)
+	if((m_Core.m_Super || m_Core.m_EndlessJump) && m_Core.m_Jumped > 1)
 	{
-		// Super players, invincible players and players with infinite jumps always have light feet
+		// Super players and players with infinite jumps always have light feet
 		m_Core.m_Jumped = 1;
 	}
 

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -199,6 +199,8 @@ void CCharacter::SetInvincible(bool Invincible)
 	m_Core.m_Invincible = Invincible;
 	if(Invincible)
 		UnFreeze();
+
+	SetEndlessJump(Invincible);
 }
 
 void CCharacter::SetLiveFrozen(bool Active)
@@ -2188,9 +2190,9 @@ void CCharacter::DDRacePostCoreTick()
 		m_Core.m_Jumped = 1;
 	}
 
-	if((m_Core.m_Super || m_Core.m_Invincible || m_Core.m_EndlessJump) && m_Core.m_Jumped > 1)
+	if((m_Core.m_Super || m_Core.m_EndlessJump) && m_Core.m_Jumped > 1)
 	{
-		// Super players, invincible players and players with infinite jumps always have light feet
+		// Super players and players with infinite jumps always have light feet
 		m_Core.m_Jumped = 1;
 	}
 

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -494,7 +494,7 @@ bool CSaveHotReloadTee::Load(CCharacter *pChr, int Team, bool IsSwap)
 {
 	bool Result = m_SaveTee.Load(pChr, Team, IsSwap);
 	pChr->SetSuper(m_Super);
-	pChr->SetInvincible(m_Invincible);
+	pChr->m_Core.m_Invincible = m_Invincible;
 	pChr->GetPlayer()->m_LastTeleTee = m_SavedTeleTee;
 
 	return Result;


### PR DESCRIPTION
Fixes #9517 Maybe fixes #9586
Keeps `infjump` enabled by default for backward compatibility. However, it unfortunately breaks prediction for 18.7 - 18.9 clients if infjumps are disabled with invincible enabled - the sound and jump particles play but the local player doesn't jump (no rubberbanding) I think it's fine as it doesn't affect gameplay and the feature is rarely used.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
