### PR TITLE
Fix crash with `sv_dnsbl_vote 1` and debug dummies

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -726,30 +726,27 @@ int CServer::DistinctClientCount() const
 	const NETADDR *apAddresses[MAX_CLIENTS];
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
-		if(m_aClients[i].m_State != CClient::STATE_EMPTY)
-		{
-			apAddresses[i] = ClientAddr(i);
-		}
+		// connecting clients with spoofed ips can clog slots without being ingame
+		apAddresses[i] = ClientIngame(i) ? ClientAddr(i) : nullptr;
 	}
 
 	int ClientCount = 0;
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
-		// connecting clients with spoofed ips can clog slots without being ingame
-		if(ClientIngame(i))
+		if(apAddresses[i] == nullptr)
 		{
-			ClientCount++;
-			for(int j = 0; j < i; j++)
+			continue;
+		}
+		ClientCount++;
+		for(int j = 0; j < i; j++)
+		{
+			if(apAddresses[j] != nullptr && !net_addr_comp_noport(apAddresses[i], apAddresses[j]))
 			{
-				if(!net_addr_comp_noport(apAddresses[i], apAddresses[j]))
-				{
-					ClientCount--;
-					break;
-				}
+				ClientCount--;
+				break;
 			}
 		}
 	}
-
 	return ClientCount;
 }
 


### PR DESCRIPTION
In the `CServer::DistinctClientCount` function a check for the address being `nullptr` was missing in the inner loop. Before #9591 this was comparing addresses from uninitialized memory instead. Duplicate checks of the client state are avoided by first fetching the addesses of all clients which are ingame.

Closes #9597.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
