### PR TITLE
Fix Issue 9618 and improve responsiveness for projectiles to pre pr 8375 levels

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -5079,6 +5079,9 @@ int CClient::GetPredictionTick()
 		PredictionMin = PredictionTick - 1;
 	}
 
+	if(PredictionMin <= 0)
+		return PredGameTick(g_Config.m_ClDummy);
+
 	PredictionTick = PredGameTick(g_Config.m_ClDummy) - PredictionMin;
 
 	if(PredictionTick < GameTick(g_Config.m_ClDummy) + 1)

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2328,11 +2328,6 @@ void CGameClient::OnPredict()
 				m_aClients[m_PredictedDummyId].m_PrevPredicted = pDummyChar->GetCore();
 		}
 
-		if(Tick == PredictionTick)
-		{
-			m_PrevPredictedWorld.CopyWorld(&m_PredictedWorld);
-		}
-
 		// optionally allow some movement in freeze by not predicting freeze the last one to two ticks
 		if(g_Config.m_ClPredictFreeze == 2 && Client()->PredGameTick(g_Config.m_ClDummy) - 1 - Client()->PredGameTick(g_Config.m_ClDummy) % 2 <= Tick)
 			pLocalChar->m_CanMoveInFreeze = true;
@@ -2358,6 +2353,8 @@ void CGameClient::OnPredict()
 		// fetch the current characters
 		if(Tick == PredictionTick)
 		{
+			m_PrevPredictedWorld.CopyWorld(&m_PredictedWorld);
+
 			for(int i = 0; i < MAX_CLIENTS; i++)
 				if(CCharacter *pChar = m_PredictedWorld.GetCharacterById(i))
 					m_aClients[i].m_Predicted = pChar->GetCore();


### PR DESCRIPTION
This issue: fixes https://github.com/ddnet/ddnet/issues/9618
Was caused by this pr: https://github.com/ddnet/ddnet/pull/8375

This specifically happens when your client predicts ahead very little, it wouldn't meet the requirements for copying over the world, thus everything would either be frozen when your prediction becomes small enough or you just wouldn't see anything besides your own player to begin with.

I fixed that and then reread my original pr and realized that it caused you to see all antiping related stuff 1 tick later, so I changed that as well.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options (cl_antiping_percent, cl_antiping_limit, cl_antiping)
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
