### PR TITLE
Remove ``IsForceBalanced()``

### DIFF
--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -518,11 +518,6 @@ void IGameController::DoWarmup(int Seconds)
 		m_Warmup = Seconds * Server()->TickSpeed();
 }
 
-bool IGameController::IsForceBalanced()
-{
-	return false;
-}
-
 bool IGameController::CanBeMovedOnBalance(int ClientId)
 {
 	return true;

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -123,8 +123,6 @@ public:
 	void EndRound();
 	void ChangeMap(const char *pToMap);
 
-	bool IsForceBalanced();
-
 	/*
 
 	*/

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -211,9 +211,6 @@ void CGameWorld::Tick()
 
 	if(!m_Paused)
 	{
-		if(GameServer()->m_pController->IsForceBalanced())
-			GameServer()->SendChat(-1, TEAM_ALL, "Teams have been balanced");
-
 		// update all objects
 		for(int i = 0; i < NUM_ENTTYPES; i++)
 		{


### PR DESCRIPTION
Newer teeworlds also does not send any chat messages from the gameworld anymore. Which to me sound the wrong place to do it anyways.

In ddnet there are no teams so they can also never be balanced. Also ddnet forks can just implement it on tick there is no need to access the gameworld for it. Also the method was not virtual so not too interesting for custom controllers.

I intentionally kept ``bool IGameController::CanBeMovedOnBalance(int ClientId)`` because it is still used in modern teeworlds.
And it can be used in ddnet forks to implement team balancing.

This commit does NOT fall under #7777 because it is a cleanup that benefits ddnet.

The motivation behind this commit is to cleanup gameworld to make it easier to link in tests.
Which is need for:

https://github.com/ddnet/ddnet/pull/9386#issuecomment-2565473425

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
