### PR TITLE
Remove mapitems' `CURRENT_VERSION` constants

### DIFF
--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -84,7 +84,7 @@ bool CMap::Load(const char *pMapName)
 
 	// Check version
 	const CMapItemVersion *pItem = (CMapItemVersion *)NewDataFile.FindItem(MAPITEMTYPE_VERSION, 0);
-	if(pItem == nullptr || pItem->m_Version != CMapItemVersion::CURRENT_VERSION)
+	if(pItem == nullptr || pItem->m_Version != 1)
 	{
 		log_error("map/load", "Error: map version not supported.");
 		NewDataFile.Close();
@@ -104,7 +104,7 @@ bool CMap::Load(const char *pMapName)
 			if(pLayer->m_Type == LAYERTYPE_TILES)
 			{
 				CMapItemLayerTilemap *pTilemap = reinterpret_cast<CMapItemLayerTilemap *>(pLayer);
-				if(pTilemap->m_Version >= CMapItemLayerTilemap::TILE_SKIP_MIN_VERSION)
+				if(pTilemap->m_Version >= CMapItemLayerTilemap::VERSION_TEEWORLDS_TILESKIP)
 				{
 					const size_t TilemapCount = (size_t)pTilemap->m_Width * pTilemap->m_Height;
 					const size_t TilemapSize = TilemapCount * sizeof(CTile);

--- a/src/game/client/components/mapsounds.cpp
+++ b/src/game/client/components/mapsounds.cpp
@@ -104,7 +104,7 @@ void CMapSounds::OnMapLoad()
 				continue;
 
 			const CMapItemLayerSounds *pSoundLayer = reinterpret_cast<const CMapItemLayerSounds *>(pLayer);
-			if(pSoundLayer->m_Version < 1 || pSoundLayer->m_Version > CMapItemLayerSounds::CURRENT_VERSION)
+			if(pSoundLayer->m_Version < 1 || pSoundLayer->m_Version > 2)
 				continue;
 			if(pSoundLayer->m_Sound < 0 || pSoundLayer->m_Sound >= m_Count || m_aSounds[pSoundLayer->m_Sound] == -1)
 				continue;

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -30,7 +30,7 @@ CMapBasedEnvelopePointAccess::CMapBasedEnvelopePointAccess(CDataFileReader *pRea
 	for(int EnvIndex = 0; EnvIndex < EnvNum; EnvIndex++)
 	{
 		CMapItemEnvelope *pEnvelope = static_cast<CMapItemEnvelope *>(pReader->GetItem(EnvStart + EnvIndex));
-		if(pEnvelope->m_Version >= CMapItemEnvelope_v3::CURRENT_VERSION)
+		if(pEnvelope->m_Version >= CMapItemEnvelope::VERSION_TEEWORLDS_BEZIER)
 		{
 			FoundBezierEnvelope = true;
 			break;

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -115,7 +115,7 @@ void CLayerTiles::PrepareForSave()
 void CLayerTiles::ExtractTiles(int TilemapItemVersion, const CTile *pSavedTiles, size_t SavedTilesSize) const
 {
 	const size_t DestSize = (size_t)m_Width * m_Height;
-	if(TilemapItemVersion >= CMapItemLayerTilemap::TILE_SKIP_MIN_VERSION)
+	if(TilemapItemVersion >= CMapItemLayerTilemap::VERSION_TEEWORLDS_TILESKIP)
 		CMap::ExtractTiles(m_pTiles, DestSize, pSavedTiles, SavedTilesSize);
 	else if(SavedTilesSize >= DestSize)
 		mem_copy(m_pTiles, pSavedTiles, DestSize * sizeof(CTile));

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -53,7 +53,7 @@ bool CEditorMap::Save(const char *pFileName, const std::function<void(const char
 	// save version
 	{
 		CMapItemVersion Item;
-		Item.m_Version = CMapItemVersion::CURRENT_VERSION;
+		Item.m_Version = 1;
 		Writer.AddItem(MAPITEMTYPE_VERSION, 0, sizeof(Item), &Item);
 	}
 
@@ -100,7 +100,7 @@ bool CEditorMap::Save(const char *pFileName, const std::function<void(const char
 		pImg->AnalyseTileFlags();
 
 		CMapItemImage Item;
-		Item.m_Version = CMapItemImage::CURRENT_VERSION;
+		Item.m_Version = 1;
 
 		Item.m_Width = pImg->m_Width;
 		Item.m_Height = pImg->m_Height;
@@ -141,7 +141,7 @@ bool CEditorMap::Save(const char *pFileName, const std::function<void(const char
 	for(const auto &pGroup : m_vpGroups)
 	{
 		CMapItemGroup GItem;
-		GItem.m_Version = CMapItemGroup::CURRENT_VERSION;
+		GItem.m_Version = 3;
 
 		GItem.m_ParallaxX = pGroup->m_ParallaxX;
 		GItem.m_ParallaxY = pGroup->m_ParallaxY;
@@ -167,7 +167,7 @@ bool CEditorMap::Save(const char *pFileName, const std::function<void(const char
 				pLayerTiles->PrepareForSave();
 
 				CMapItemLayerTilemap Item;
-				Item.m_Version = CMapItemLayerTilemap::CURRENT_VERSION;
+				Item.m_Version = 3;
 
 				Item.m_Layer.m_Version = 0; // was previously uninitialized, do not rely on it being 0
 				Item.m_Layer.m_Flags = pLayerTiles->m_Flags;
@@ -234,7 +234,7 @@ bool CEditorMap::Save(const char *pFileName, const std::function<void(const char
 				if(!Item.m_Flags)
 				{
 					CMapItemAutoMapperConfig ItemAutomapper;
-					ItemAutomapper.m_Version = CMapItemAutoMapperConfig::CURRENT_VERSION;
+					ItemAutomapper.m_Version = 1;
 					ItemAutomapper.m_GroupId = GroupCount;
 					ItemAutomapper.m_LayerId = GItem.m_NumLayers;
 					ItemAutomapper.m_AutomapperConfig = pLayerTiles->m_AutoMapperConfig;
@@ -285,7 +285,7 @@ bool CEditorMap::Save(const char *pFileName, const std::function<void(const char
 				m_pEditor->Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "editor", "saving sounds layer");
 				std::shared_ptr<CLayerSounds> pLayerSounds = std::static_pointer_cast<CLayerSounds>(pLayer);
 				CMapItemLayerSounds Item;
-				Item.m_Version = CMapItemLayerSounds::CURRENT_VERSION;
+				Item.m_Version = 2;
 				Item.m_Layer.m_Version = 0; // was previously uninitialized, do not rely on it being 0
 				Item.m_Layer.m_Flags = pLayerSounds->m_Flags;
 				Item.m_Layer.m_Type = pLayerSounds->m_Type;
@@ -327,7 +327,7 @@ bool CEditorMap::Save(const char *pFileName, const std::function<void(const char
 	for(size_t e = 0; e < m_vpEnvelopes.size(); e++)
 	{
 		CMapItemEnvelope Item;
-		Item.m_Version = CMapItemEnvelope::CURRENT_VERSION;
+		Item.m_Version = 2;
 		Item.m_Channels = m_vpEnvelopes[e]->GetChannels();
 		Item.m_StartPoint = PointCount;
 		Item.m_NumPoints = m_vpEnvelopes[e]->m_vPoints.size();
@@ -441,7 +441,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 
 	// check version
 	const CMapItemVersion *pItemVersion = static_cast<CMapItemVersion *>(DataFile.FindItem(MAPITEMTYPE_VERSION, 0));
-	if(pItemVersion == nullptr || pItemVersion->m_Version != CMapItemVersion::CURRENT_VERSION)
+	if(pItemVersion == nullptr || pItemVersion->m_Version != 1)
 	{
 		ErrorHandler("Error: The map has an unsupported version.");
 		return false;
@@ -649,7 +649,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 		{
 			CMapItemGroup *pGItem = (CMapItemGroup *)DataFile.GetItem(Start + g);
 
-			if(pGItem->m_Version < 1 || pGItem->m_Version > CMapItemGroup::CURRENT_VERSION)
+			if(pGItem->m_Version < 1 || pGItem->m_Version > 3)
 				continue;
 
 			std::shared_ptr<CLayerGroup> pGroup = NewGroup();
@@ -877,7 +877,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 				else if(pLayerItem->m_Type == LAYERTYPE_SOUNDS)
 				{
 					const CMapItemLayerSounds *pSoundsItem = (CMapItemLayerSounds *)pLayerItem;
-					if(pSoundsItem->m_Version < 1 || pSoundsItem->m_Version > CMapItemLayerSounds::CURRENT_VERSION)
+					if(pSoundsItem->m_Version < 1 || pSoundsItem->m_Version > 2)
 						continue;
 
 					std::shared_ptr<CLayerSounds> pSounds = std::make_shared<CLayerSounds>(m_pEditor);
@@ -906,7 +906,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 				{
 					// compatibility with old sound layers
 					const CMapItemLayerSounds *pSoundsItem = (CMapItemLayerSounds *)pLayerItem;
-					if(pSoundsItem->m_Version < 1 || pSoundsItem->m_Version > CMapItemLayerSounds::CURRENT_VERSION)
+					if(pSoundsItem->m_Version < 1 || pSoundsItem->m_Version > 2)
 						continue;
 
 					std::shared_ptr<CLayerSounds> pSounds = std::make_shared<CLayerSounds>(m_pEditor);
@@ -987,7 +987,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 			if(pItem->m_aName[0] != -1) // compatibility with old maps
 				IntsToStr(pItem->m_aName, std::size(pItem->m_aName), pEnv->m_aName, std::size(pEnv->m_aName));
 			m_vpEnvelopes.push_back(pEnv);
-			if(pItem->m_Version >= CMapItemEnvelope_v2::CURRENT_VERSION)
+			if(pItem->m_Version >= 2)
 				pEnv->m_Synchronized = pItem->m_Synchronized;
 		}
 	}
@@ -999,7 +999,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 		for(int i = 0; i < AutomapperConfigNum; i++)
 		{
 			CMapItemAutoMapperConfig *pItem = (CMapItemAutoMapperConfig *)DataFile.GetItem(AutomapperConfigStart + i);
-			if(pItem->m_Version == CMapItemAutoMapperConfig::CURRENT_VERSION)
+			if(pItem->m_Version == 1)
 			{
 				if(pItem->m_GroupId >= 0 && (size_t)pItem->m_GroupId < m_vpGroups.size() &&
 					pItem->m_LayerId >= 0 && (size_t)pItem->m_LayerId < m_vpGroups[pItem->m_GroupId]->m_vpLayers.size())

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -257,11 +257,6 @@ struct CMapItemInfoSettings : CMapItemInfo
 
 struct CMapItemImage_v1
 {
-	enum
-	{
-		CURRENT_VERSION = 1,
-	};
-
 	int m_Version;
 	int m_Width;
 	int m_Height;
@@ -272,11 +267,6 @@ struct CMapItemImage_v1
 
 struct CMapItemImage_v2 : public CMapItemImage_v1
 {
-	enum
-	{
-		CURRENT_VERSION = 2,
-	};
-
 	int m_MustBe1;
 };
 
@@ -296,11 +286,6 @@ struct CMapItemGroup_v1
 
 struct CMapItemGroup : public CMapItemGroup_v1
 {
-	enum
-	{
-		CURRENT_VERSION = 3
-	};
-
 	int m_UseClipping;
 	int m_ClipX;
 	int m_ClipY;
@@ -319,11 +304,14 @@ struct CMapItemLayer
 
 struct CMapItemLayerTilemap
 {
-	enum
-	{
-		CURRENT_VERSION = 3,
-		TILE_SKIP_MIN_VERSION = 4, // supported for loading but not saving
-	};
+	/**
+	 * @link CMapItemLayerTilemap @endlink with this version are only written to maps in upstream Teeworlds.
+	 * The tile data of tilemaps using this version must be unpacked by repeating tiles according to the
+	 * @link CTile::m_Skip @endlink values of the packed tile data.
+	 *
+	 * @see CMap::ExtractTiles
+	 */
+	static constexpr int VERSION_TEEWORLDS_TILESKIP = 4;
 
 	CMapItemLayer m_Layer;
 	int m_Version;
@@ -364,11 +352,6 @@ struct CMapItemLayerQuads
 
 struct CMapItemVersion
 {
-	enum
-	{
-		CURRENT_VERSION = 1
-	};
-
 	int m_Version;
 };
 
@@ -416,10 +399,12 @@ struct CEnvPoint_runtime : public CEnvPoint
 
 struct CMapItemEnvelope_v1
 {
-	enum
-	{
-		CURRENT_VERSION = 1,
-	};
+	/**
+	 * @link CMapItemEnvelope @endlink with this version are only written to maps in upstream Teeworlds.
+	 * If at least one of these exists in a map, then the envelope points are represented
+	 * by @link CEnvPointBezier_upstream @endlink instead of @link CEnvPoint @endlink.
+	 */
+	static constexpr int VERSION_TEEWORLDS_BEZIER = 3;
 
 	int m_Version;
 	int m_Channels;
@@ -430,23 +415,7 @@ struct CMapItemEnvelope_v1
 
 struct CMapItemEnvelope_v2 : public CMapItemEnvelope_v1
 {
-	enum
-	{
-		CURRENT_VERSION = 2,
-	};
-
 	int m_Synchronized;
-};
-
-// Only written to maps in upstream Teeworlds.
-// If at least one of these exists in a map, the envelope points
-// are represented by CEnvPointBezier_upstream instead of CEnvPoint.
-struct CMapItemEnvelope_v3 : public CMapItemEnvelope_v2
-{
-	enum
-	{
-		CURRENT_VERSION = 3,
-	};
 };
 
 typedef CMapItemEnvelope_v2 CMapItemEnvelope;
@@ -497,11 +466,6 @@ struct CSoundSource
 
 struct CMapItemLayerSounds
 {
-	enum
-	{
-		CURRENT_VERSION = 2
-	};
-
 	CMapItemLayer m_Layer;
 	int m_Version;
 

--- a/src/game/mapitems_ex.h
+++ b/src/game/mapitems_ex.h
@@ -13,11 +13,6 @@ enum
 
 struct CMapItemTest
 {
-	enum
-	{
-		CURRENT_VERSION = 1
-	};
-
 	int m_Version;
 	int m_aFields[2];
 	int m_Field3;
@@ -26,10 +21,6 @@ struct CMapItemTest
 
 struct CMapItemAutoMapperConfig
 {
-	enum
-	{
-		CURRENT_VERSION = 1
-	};
 	enum
 	{
 		FLAG_AUTOMATIC = 1

--- a/src/test/datafile.cpp
+++ b/src/test/datafile.cpp
@@ -12,7 +12,7 @@ TEST(Datafile, ExtendedType)
 	CTestInfo Info;
 
 	CMapItemTest ItemTest;
-	ItemTest.m_Version = CMapItemTest::CURRENT_VERSION;
+	ItemTest.m_Version = 1;
 	ItemTest.m_aFields[0] = 1234;
 	ItemTest.m_aFields[1] = 5678;
 	ItemTest.m_Field3 = 9876;

--- a/src/tools/map_convert_07.cpp
+++ b/src/tools/map_convert_07.cpp
@@ -202,7 +202,7 @@ int main(int argc, const char **argv)
 			if(!pItem)
 				return -1;
 			Size = sizeof(CMapItemImage);
-			NewImageItem.m_Version = CMapItemImage::CURRENT_VERSION;
+			NewImageItem.m_Version = 1;
 		}
 		g_DataWriter.AddItem(Type, Id, Size, pItem, &Uuid);
 	}

--- a/src/tools/map_diff.cpp
+++ b/src/tools/map_diff.cpp
@@ -18,7 +18,7 @@ bool Process(IStorage *pStorage, const char **pMapNames)
 		}
 
 		const CMapItemVersion *pVersion = static_cast<CMapItemVersion *>(aMaps[i].FindItem(MAPITEMTYPE_VERSION, 0));
-		if(pVersion == nullptr || pVersion->m_Version != CMapItemVersion::CURRENT_VERSION)
+		if(pVersion == nullptr || pVersion->m_Version != 1)
 		{
 			dbg_msg("map_compare", "unsupported map version '%s'", pMapNames[i]);
 			return false;

--- a/src/tools/map_extract.cpp
+++ b/src/tools/map_extract.cpp
@@ -114,7 +114,7 @@ static bool ExtractMap(IStorage *pStorage, const char *pMapName, const char *pPa
 	}
 
 	const CMapItemVersion *pVersion = static_cast<CMapItemVersion *>(Reader.FindItem(MAPITEMTYPE_VERSION, 0));
-	if(pVersion == nullptr || pVersion->m_Version != CMapItemVersion::CURRENT_VERSION)
+	if(pVersion == nullptr || pVersion->m_Version != 1)
 	{
 		log_error("map_extract", "unsupported map version '%s'", pMapName);
 		return false;

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -190,7 +190,7 @@ int main(int argc, const char **argv)
 		else if(Type == MAPITEMTYPE_IMAGE)
 		{
 			CMapItemImage_v2 *pImg = (CMapItemImage_v2 *)pPtr;
-			if(!pImg->m_External && pImg->m_Version < CMapItemImage_v2::CURRENT_VERSION)
+			if(!pImg->m_External && pImg->m_Version < 2)
 			{
 				SMapOptimizeItem Item;
 				Item.m_pImage = pImg;

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -126,7 +126,7 @@ int main(int argc, const char **argv)
 			if(!pItem)
 				return -1;
 			Size = sizeof(CMapItemImage);
-			NewImageItem.m_Version = CMapItemImage::CURRENT_VERSION;
+			NewImageItem.m_Version = 1;
 		}
 
 		Writer.AddItem(Type, Id, Size, pItem, &Uuid);


### PR DESCRIPTION
Use the numerical version values for mapitem versions directly instead of constants except for compatiblity with upstream Teeworlds mapitems. See https://github.com/ddnet/ddnet/pull/8349#issuecomment-2106080227

Add documentation for upstream Teeworlds mapitem versions.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
