### PR TITLE
Fix FIFO on Windows not working with Windows linebreaks

### DIFF
--- a/src/engine/shared/fifo.cpp
+++ b/src/engine/shared/fifo.cpp
@@ -189,16 +189,23 @@ void CFifo::Update()
 		char *pCur = pBuf;
 		for(DWORD i = 0; i < Length; ++i)
 		{
-			if(pBuf[i] != '\n')
+			if(pBuf[i] != '\n' && (pBuf[i] != '\r' || pBuf[i + 1] != '\n'))
+			{
 				continue;
+			}
+			if(pBuf[i] == '\r')
+			{
+				pBuf[i] = '\0';
+				++i;
+			}
 			pBuf[i] = '\0';
-			if(str_utf8_check(pCur))
+			if(pCur[0] != '\0' && str_utf8_check(pCur))
 			{
 				m_pConsole->ExecuteLineFlag(pCur, m_Flag, -1);
 			}
 			pCur = pBuf + i + 1;
 		}
-		if(pCur < pBuf + Length && str_utf8_check(pCur)) // missed the last line
+		if(pCur < pBuf + Length && pCur[0] != '\0' && str_utf8_check(pCur)) // missed the last line
 		{
 			m_pConsole->ExecuteLineFlag(pCur, m_Flag, -1);
 		}


### PR DESCRIPTION
Carriage return `\r` characters were not properly ignored in Windows' FIFO implementation (named pipes), leading to incorrect commands being executed (including a trailing `\r`) which was causing some commands like rcon authentication and map changes to fail due to incorrect password/filename unless the arguments were escaped with quotes.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
