### PR TITLE
Fix speedtile max-speed bug

### DIFF
--- a/src/game/mapbugs.cpp
+++ b/src/game/mapbugs.cpp
@@ -43,7 +43,11 @@ static SHA256_DIGEST s(const char *pSha256)
 
 static CMapBugsInternal MAP_BUGS[] =
 	{
-		{{"Binary", 2022597, s("65b410e197fd2298ec270e89a84b762f6739d1d18089529f8ef6cf2104d3d600")}, BugToFlag(BUG_GRENADE_DOUBLEEXPLOSION)}};
+		{{"Binary", 2022597, s("65b410e197fd2298ec270e89a84b762f6739d1d18089529f8ef6cf2104d3d600")}, BugToFlag(BUG_GRENADE_DOUBLEEXPLOSION)},
+		{{"Broken brain", 301142, s("5b2c4c7839dcc86aa3fad558769fe49f00cc5bd95a53b147dec97fd3f2e5f2ca")}, BugToFlag(BUG_SPEEDTILE_MAXSPEED)},
+		{{"Pharoah", 108835, s("92c542f628caf8ef8997849c9f63b24222b7b1480cb4b82908c4767554ed798a")}, BugToFlag(BUG_SPEEDTILE_MAXSPEED)},
+		{{"Cosyris", 808948, s("45bb08fea1497936c3d566e0b97ac14bbdefcbdfbde80cbaef61eb470e245cd2")}, BugToFlag(BUG_SPEEDTILE_MAXSPEED)}
+	};
 
 CMapBugs GetMapBugs(const char *pName, int Size, SHA256_DIGEST Sha256)
 {

--- a/src/game/mapbugs.cpp
+++ b/src/game/mapbugs.cpp
@@ -46,8 +46,7 @@ static CMapBugsInternal MAP_BUGS[] =
 		{{"Binary", 2022597, s("65b410e197fd2298ec270e89a84b762f6739d1d18089529f8ef6cf2104d3d600")}, BugToFlag(BUG_GRENADE_DOUBLEEXPLOSION)},
 		{{"Broken brain", 301142, s("5b2c4c7839dcc86aa3fad558769fe49f00cc5bd95a53b147dec97fd3f2e5f2ca")}, BugToFlag(BUG_SPEEDTILE_MAXSPEED)},
 		{{"Pharoah", 108835, s("92c542f628caf8ef8997849c9f63b24222b7b1480cb4b82908c4767554ed798a")}, BugToFlag(BUG_SPEEDTILE_MAXSPEED)},
-		{{"Cosyris", 808948, s("45bb08fea1497936c3d566e0b97ac14bbdefcbdfbde80cbaef61eb470e245cd2")}, BugToFlag(BUG_SPEEDTILE_MAXSPEED)}
-	};
+		{{"Cosyris", 808948, s("45bb08fea1497936c3d566e0b97ac14bbdefcbdfbde80cbaef61eb470e245cd2")}, BugToFlag(BUG_SPEEDTILE_MAXSPEED)}};
 
 CMapBugs GetMapBugs(const char *pName, int Size, SHA256_DIGEST Sha256)
 {

--- a/src/game/mapbugs_list.h
+++ b/src/game/mapbugs_list.h
@@ -1,3 +1,4 @@
 // This file can be included several times.
 
 MAPBUG(BUG_GRENADE_DOUBLEEXPLOSION, "grenade-doubleexplosion@ddnet.tw")
+MAPBUG(BUG_SPEEDTILE_MAXSPEED, "speedtile-maxspeed@ddnet.tw")

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1432,7 +1432,7 @@ void CCharacter::HandleSkippableTiles(int Index)
 			{
 				if(Direction.x > 0.0000001f)
 					SpeederAngle = -std::atan(Direction.y / Direction.x);
-				else if(Direction.x < -0.0000001f)
+				else if(Direction.x < -0.0000001f || (GameServer()->EmulateBug(BUG_SPEEDTILE_MAXSPEED) && Direction.x < 0.0000001f))
 					SpeederAngle = std::atan(Direction.y / Direction.x) + 2.0f * std::asin(1.0f);
 				else if(Direction.y > 0.0000001f)
 					SpeederAngle = std::asin(1.0f);
@@ -1444,7 +1444,7 @@ void CCharacter::HandleSkippableTiles(int Index)
 
 				if(TempVel.x > 0.0000001f)
 					TeeAngle = -std::atan(TempVel.y / TempVel.x);
-				else if(TempVel.x < -0.0000001f)
+				else if(TempVel.x < -0.0000001f || (GameServer()->EmulateBug(BUG_SPEEDTILE_MAXSPEED) && TempVel.x < 0.0000001f))
 					TeeAngle = std::atan(TempVel.y / TempVel.x) + 2.0f * std::asin(1.0f);
 				else if(TempVel.y > 0.0000001f)
 					TeeAngle = std::asin(1.0f);

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1432,7 +1432,7 @@ void CCharacter::HandleSkippableTiles(int Index)
 			{
 				if(Direction.x > 0.0000001f)
 					SpeederAngle = -std::atan(Direction.y / Direction.x);
-				else if(Direction.x < -0.0000001f || (GameServer()->EmulateBug(BUG_SPEEDTILE_MAXSPEED) && Direction.x < 0.0000001f))
+				else if(Direction.x < (GameServer()->EmulateBug(BUG_SPEEDTILE_MAXSPEED) ? 0.0000001f : -0.0000001f))
 					SpeederAngle = std::atan(Direction.y / Direction.x) + 2.0f * std::asin(1.0f);
 				else if(Direction.y > 0.0000001f)
 					SpeederAngle = std::asin(1.0f);
@@ -1444,7 +1444,7 @@ void CCharacter::HandleSkippableTiles(int Index)
 
 				if(TempVel.x > 0.0000001f)
 					TeeAngle = -std::atan(TempVel.y / TempVel.x);
-				else if(TempVel.x < -0.0000001f || (GameServer()->EmulateBug(BUG_SPEEDTILE_MAXSPEED) && TempVel.x < 0.0000001f))
+				else if(TempVel.x < (GameServer()->EmulateBug(BUG_SPEEDTILE_MAXSPEED) ? 0.0000001f : -0.0000001f))
 					TeeAngle = std::atan(TempVel.y / TempVel.x) + 2.0f * std::asin(1.0f);
 				else if(TempVel.y > 0.0000001f)
 					TeeAngle = std::asin(1.0f);

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1432,7 +1432,7 @@ void CCharacter::HandleSkippableTiles(int Index)
 			{
 				if(Direction.x > 0.0000001f)
 					SpeederAngle = -std::atan(Direction.y / Direction.x);
-				else if(Direction.x < 0.0000001f)
+				else if(Direction.x < -0.0000001f)
 					SpeederAngle = std::atan(Direction.y / Direction.x) + 2.0f * std::asin(1.0f);
 				else if(Direction.y > 0.0000001f)
 					SpeederAngle = std::asin(1.0f);
@@ -1444,7 +1444,7 @@ void CCharacter::HandleSkippableTiles(int Index)
 
 				if(TempVel.x > 0.0000001f)
 					TeeAngle = -std::atan(TempVel.y / TempVel.x);
-				else if(TempVel.x < 0.0000001f)
+				else if(TempVel.x < -0.0000001f)
 					TeeAngle = std::atan(TempVel.y / TempVel.x) + 2.0f * std::asin(1.0f);
 				else if(TempVel.y > 0.0000001f)
 					TeeAngle = std::asin(1.0f);


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] ~~Changed no physics that affect existing maps~~
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)

I have a video of this bug, but it's to big for github. PM me if you're interested.
