### PR TITLE
Support changing touch button background color

### DIFF
--- a/data/touch_controls.json
+++ b/data/touch_controls.json
@@ -1,6 +1,8 @@
 {
 	"direct-touch-ingame": "action",
 	"direct-touch-spectate": "aim",
+	"background-color-inactive": "00000040",
+	"background-color-active": "33333340",
 	"touch-buttons": [
 		{
 			"x": 0,

--- a/src/game/client/components/touch_controls.h
+++ b/src/game/client/components/touch_controls.h
@@ -1,6 +1,7 @@
 #ifndef GAME_CLIENT_COMPONENTS_TOUCH_CONTROLS_H
 #define GAME_CLIENT_COMPONENTS_TOUCH_CONTROLS_H
 
+#include <base/color.h>
 #include <base/vmath.h>
 
 #include <engine/input.h>
@@ -474,6 +475,20 @@ private:
 	EDirectTouchSpectateMode m_DirectTouchSpectate = EDirectTouchSpectateMode::AIM;
 
 	/**
+	 * Background color of inactive touch buttons.
+	 *
+	 * Saved to the touch controls configuration.
+	 */
+	ColorRGBA m_BackgroundColorInactive = ColorRGBA(0.0f, 0.0f, 0.0f, 0.25f);
+
+	/**
+	 * Background color of active touch buttons.
+	 *
+	 * Saved to the touch controls configuration.
+	 */
+	ColorRGBA m_BackgroundColorActive = ColorRGBA(0.2f, 0.2f, 0.2f, 0.25f);
+
+	/**
 	 * All touch buttons.
 	 *
 	 * Saved to the touch controls configuration.
@@ -536,6 +551,7 @@ private:
 	bool ParseConfiguration(const void *pFileData, unsigned FileLength);
 	std::optional<EDirectTouchIngameMode> ParseDirectTouchIngameMode(const json_value *pModeValue);
 	std::optional<EDirectTouchSpectateMode> ParseDirectTouchSpectateMode(const json_value *pModeValue);
+	std::optional<ColorRGBA> ParseColor(const json_value *pColorValue, const char *pAttributeName, std::optional<ColorRGBA> DefaultColor) const;
 	std::optional<CTouchButton> ParseButton(const json_value *pButtonObject);
 	std::unique_ptr<CTouchButtonBehavior> ParseBehavior(const json_value *pBehaviorObject);
 	std::unique_ptr<CPredefinedTouchButtonBehavior> ParsePredefinedBehavior(const json_value *pBehaviorObject);


### PR DESCRIPTION
Add properties to the root object of the touch controls configuration to adjust the background color of all touch buttons:

- `"background-color-inactive"`: specifies the background color of inactive touch buttons.
- `"background-color-active"`: specifies the background color of active touch buttons.

For backwards compatibility these properties are allowed to be unset in which case the previous default values will be used.

Colors are specified as hexadecimal strings in the formats `RRGGBBAA`, `RRGGBB`, `RGBA` and `RGB` without any prefix like `#`, e.g. `"A526C440"`. If the alpha value is omitted then it is set to full opacity by default.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
