### PR TITLE
Switch style check and ASan/UBSan CI from Ubuntu 20.04 to latest

### DIFF
--- a/.github/workflows/clang-sanitizer.yml
+++ b/.github/workflows/clang-sanitizer.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   check-clang-san:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CARGO_HTTP_MULTIPLEXING: false
     steps:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   check-style:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CARGO_HTTP_MULTIPLEXING: false
     steps:
@@ -20,9 +20,13 @@ jobs:
     - name: Prepare
       run: |
         sudo apt-get update -y
-        sudo apt-get install clang-format imagemagick ddnet-tools shellcheck pkg-config cmake ninja-build libfreetype6-dev libnotify-dev libsdl2-dev libsqlite3-dev libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev libx264-dev python3-clang libvulkan-dev glslang-tools spirv-tools libglew-dev -y
+        sudo apt-get install imagemagick ddnet-tools shellcheck pkg-config cmake ninja-build libfreetype6-dev libnotify-dev libsdl2-dev libsqlite3-dev libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev libx264-dev python3-clang libvulkan-dev glslang-tools spirv-tools libglew-dev -y
         rustup default stable
         pip3 install pylint
+        wget https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-46b8640/clang-format-10_linux-amd64
+        echo "b8ed0cfc9cded28f8c0c9dd0da402d1287453b7d55a68bf243b432035aebcaa4720bfff22440d1f1c5d4c82f7b8d85948214cca85a2aa976589b88459e440521 clang-format-10_linux-amd64" | sha512sum -c
+        mv clang-format-10_linux-amd64 ~/.local/bin/clang-format
+        chmod +x ~/.local/bin/clang-format
         wget -O ~/.local/bin/shfmt https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64
         chmod +x ~/.local/bin/shfmt
         git clone https://gitlab.com/Patiga/twmap.git/


### PR DESCRIPTION
Follow-up for #9640. Ubuntu 20.04 runners will be deprecated in April. Download clang-format-10 from https://github.com/muttleyxd/clang-tools-static-binaries/releases as it's not available from the package manager after Ubuntu 20.04.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
