### PR TITLE
Add entities overlay hint

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -620,6 +620,7 @@ MACRO_CONFIG_INT(SvResetPickups, sv_reset_pickups, 0, 0, 1, CFGFLAG_SERVER | CFG
 MACRO_CONFIG_INT(ClShowOthers, cl_show_others, 0, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show players in other teams (2 to show own team only)")
 MACRO_CONFIG_INT(ClShowOthersAlpha, cl_show_others_alpha, 40, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show players in other teams (alpha value, 0 invisible, 100 fully visible)")
 MACRO_CONFIG_INT(ClOverlayEntities, cl_overlay_entities, 0, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Overlay game tiles with a percentage of opacity")
+MACRO_CONFIG_INT(ClOverlayEntitiesHint, cl_overlay_entities_hint, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Display a hint about entities overlay")
 MACRO_CONFIG_INT(ClShowQuads, cl_showquads, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show quads (only interesting for mappers, or if your system has extremely bad performance)")
 MACRO_CONFIG_COL(ClBackgroundColor, cl_background_color, 128, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Background color") // 0 0 128
 MACRO_CONFIG_COL(ClBackgroundEntitiesColor, cl_background_entities_color, 128, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Background (entities) color") // 0 0 128

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -862,6 +862,7 @@ void CMenus::OnInit()
 	{
 		m_Popup = POPUP_LANGUAGE;
 		m_CreateDefaultFavoriteCommunities = true;
+		g_Config.m_ClOverlayEntitiesHint = 1;
 	}
 
 	if(g_Config.m_UiPage >= PAGE_FAVORITE_COMMUNITY_1 && g_Config.m_UiPage <= PAGE_FAVORITE_COMMUNITY_5 &&
@@ -2275,6 +2276,9 @@ void CMenus::OnRender()
 		SetActive(true);
 		PopupMessage(Localize("Disconnected"), Localize("The server is running a non-standard tuning on a pure game type."), Localize("Ok"));
 	}
+
+	if(!IsActive() || m_GamePage == PAGE_GAME)
+		RenderEntitiesHint();
 
 	if(!IsActive())
 	{

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -495,6 +495,7 @@ protected:
 	bool RenderServerControlKick(CUIRect MainView, bool FilterSpectators, bool UpdateScroll);
 	bool RenderServerControlServer(CUIRect MainView, bool UpdateScroll);
 	void RenderIngameHint();
+	void RenderEntitiesHint();
 
 	// found in menus_browser.cpp
 	int m_SelectedIndex;

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -1597,3 +1597,32 @@ void CMenus::RenderIngameHint()
 	TextRender()->Text(5, 280, 5, Localize("Menu opened. Press Esc key again to close menu."), -1.0f);
 	Ui()->MapScreen();
 }
+
+void CMenus::RenderEntitiesHint()
+{
+	if(!g_Config.m_ClOverlayEntitiesHint || g_Config.m_Debug || Client()->State() != IClient::STATE_ONLINE || !GameClient()->CanDisplayWarning())
+		return;
+
+	static bool s_WasEnabled = false;
+
+	if(g_Config.m_ClOverlayEntities)
+	{
+		s_WasEnabled = true;
+
+		const float Height = 300.0f;
+		const float Width = Height * Graphics()->ScreenAspect();
+		Graphics()->MapScreen(0.0f, 0.0f, Width, Height);
+
+		const float FontSize = 5.0f;
+		const float Spacing = 5.0f;
+
+		char aBuf[256];
+		char aKey[64];
+		m_pClient->m_Binds.GetKey("toggle cl_overlay_entities 0 100", aKey, sizeof(aKey));
+		str_format(aBuf, sizeof(aBuf), Localize("Entities overlay is enabled. To disable, press %s or enter 'cl_overlay_entities 0' in the console."), aKey);
+		TextRender()->TextColor(TextRender()->DefaultTextColor());
+		TextRender()->Text(Spacing, Height - FontSize - Spacing, FontSize, aBuf);
+	}
+	else if(s_WasEnabled)
+		g_Config.m_ClOverlayEntitiesHint = 0;
+}


### PR DESCRIPTION
Closes #8422
Prevents new players from pressing the default bind accidentally and then googling or asking about it on Discord.

The hint is only shown once for new players (detected by the welcome screen, where they select their name) and is turned off permanently once entities are disabled for the first time. This change does not affect existing players

![image](https://github.com/user-attachments/assets/ccf621b8-7aa5-4bfd-a722-e7469b95c8ae)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
