### PR TITLE
Add support for checking mapbugs in client prediction, refactoring

### DIFF
--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -14,6 +14,7 @@
 #include <game/collision.h>
 #include <game/gamecore.h>
 #include <game/layers.h>
+#include <game/mapbugs.h>
 #include <game/teamscore.h>
 
 #include <game/client/prediction/gameworld.h>
@@ -233,6 +234,7 @@ private:
 	static void ConchainSpecialDummy(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
 	static void ConTuneZone(IConsole::IResult *pResult, void *pUserData);
+	static void ConMapbug(IConsole::IResult *pResult, void *pUserData);
 
 	static void ConchainMenuMap(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
@@ -852,6 +854,7 @@ private:
 	int m_aSwitchStateTeam[NUM_DUMMIES];
 
 	void LoadMapSettings();
+	CMapBugs m_MapBugs;
 	CTuningParams m_aTuningList[NUM_TUNEZONES];
 	CTuningParams *TuningList() { return m_aTuningList; }
 

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -8,12 +8,14 @@
 #include "entities/pickup.h"
 #include "entities/projectile.h"
 #include "entity.h"
-#include <algorithm>
 #include <engine/shared/config.h>
 #include <game/client/laser_data.h>
 #include <game/client/pickup_data.h>
 #include <game/client/projectile_data.h>
+#include <game/mapbugs.h>
 #include <game/mapitems.h>
+
+#include <algorithm>
 #include <utility>
 
 //////////////////////////////////////////////////
@@ -597,6 +599,7 @@ void CGameWorld::CopyWorld(CGameWorld *pFrom)
 		m_Core.m_aTuning[i] = pFrom->m_Core.m_aTuning[i];
 	}
 	m_pTuningList = pFrom->m_pTuningList;
+	m_pMapBugs = pFrom->m_pMapBugs;
 	m_Teams = pFrom->m_Teams;
 	m_Core.m_vSwitchers = pFrom->m_Core.m_vSwitchers;
 	// delete the previous entities
@@ -707,4 +710,9 @@ void CGameWorld::Clear()
 	for(auto &pFirstEntityType : m_apFirstEntityTypes)
 		while(pFirstEntityType)
 			delete pFirstEntityType; // NOLINT(clang-analyzer-cplusplus.NewDelete)
+}
+
+bool CGameWorld::EmulateBug(int Bug) const
+{
+	return m_pMapBugs->Contains(Bug);
 }

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -12,6 +12,7 @@
 class CCollision;
 class CCharacter;
 class CEntity;
+class CMapBugs;
 
 class CGameWorld
 {
@@ -102,6 +103,9 @@ public:
 	CTuningParams *m_pTuningList;
 	CTuningParams *TuningList() { return m_pTuningList; }
 	CTuningParams *GetTuning(int i) { return &TuningList()[i]; }
+
+	const CMapBugs *m_pMapBugs;
+	bool EmulateBug(int Bug) const;
 
 private:
 	void RemoveEntities();

--- a/src/game/mapbugs.cpp
+++ b/src/game/mapbugs.cpp
@@ -45,7 +45,7 @@ static CMapBugsInternal MAP_BUGS[] =
 	{
 		{{"Binary", 2022597, s("65b410e197fd2298ec270e89a84b762f6739d1d18089529f8ef6cf2104d3d600")}, BugToFlag(BUG_GRENADE_DOUBLEEXPLOSION)}};
 
-CMapBugs GetMapBugs(const char *pName, int Size, SHA256_DIGEST Sha256)
+CMapBugs CMapBugs::Create(const char *pName, int Size, SHA256_DIGEST Sha256)
 {
 	CMapDescription Map = {pName, Size, Sha256};
 	CMapBugs Result;
@@ -72,7 +72,7 @@ bool CMapBugs::Contains(int Bug) const
 	return IsBugFlagSet(Bug, pInternal->m_BugFlags);
 }
 
-int CMapBugs::Update(const char *pBug)
+EMapBugUpdate CMapBugs::Update(const char *pBug)
 {
 	CMapBugsInternal *pInternal = (CMapBugsInternal *)m_pData;
 	int Bug = -1;
@@ -83,14 +83,14 @@ int CMapBugs::Update(const char *pBug)
 #undef MAPBUG
 	if(Bug == -1)
 	{
-		return MAPBUGUPDATE_NOTFOUND;
+		return EMapBugUpdate::NOTFOUND;
 	}
 	if(pInternal)
 	{
-		return MAPBUGUPDATE_OVERRIDDEN;
+		return EMapBugUpdate::OVERRIDDEN;
 	}
 	m_Extra |= BugToFlag(Bug);
-	return MAPBUGUPDATE_OK;
+	return EMapBugUpdate::OK;
 }
 
 void CMapBugs::Dump() const

--- a/src/game/mapbugs.h
+++ b/src/game/mapbugs.h
@@ -11,24 +11,23 @@ enum
 	NUM_BUGS,
 };
 
-enum
+enum class EMapBugUpdate
 {
-	MAPBUGUPDATE_OK,
-	MAPBUGUPDATE_NOTFOUND,
-	MAPBUGUPDATE_OVERRIDDEN,
+	OK,
+	NOTFOUND,
+	OVERRIDDEN,
 };
 
 class CMapBugs
 {
-	friend CMapBugs GetMapBugs(const char *pName, int Size, SHA256_DIGEST Sha256);
-	void *m_pData;
-	unsigned int m_Extra;
+	void *m_pData = nullptr;
+	unsigned int m_Extra = 0;
 
 public:
+	static CMapBugs Create(const char *pName, int Size, SHA256_DIGEST Sha256);
 	bool Contains(int Bug) const;
-	int Update(const char *pBug);
+	EMapBugUpdate Update(const char *pBug);
 	void Dump() const;
 };
 
-CMapBugs GetMapBugs(const char *pName, int Size, SHA256_DIGEST Sha256);
 #endif // GAME_MAPBUGS_H

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3093,30 +3093,26 @@ void CGameContext::ConTuneSetZoneMsgLeave(IConsole::IResult *pResult, void *pUse
 void CGameContext::ConMapbug(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	const char *pMapBugName = pResult->GetString(0);
 
 	if(pSelf->m_pController)
 	{
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "mapbugs", "can't add map bugs after the game started");
+		log_info("mapbugs", "can't add map bugs after the game started");
 		return;
 	}
 
+	const char *pMapBugName = pResult->GetString(0);
 	switch(pSelf->m_MapBugs.Update(pMapBugName))
 	{
-	case MAPBUGUPDATE_OK:
+	case EMapBugUpdate::OK:
 		break;
-	case MAPBUGUPDATE_OVERRIDDEN:
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "mapbugs", "map-internal setting overridden by database");
+	case EMapBugUpdate::OVERRIDDEN:
+		log_info("mapbugs", "map-internal setting overridden by database");
 		break;
-	case MAPBUGUPDATE_NOTFOUND:
-	{
-		char aBuf[64];
-		str_format(aBuf, sizeof(aBuf), "unknown map bug '%s', ignoring", pMapBugName);
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "mapbugs", aBuf);
-	}
-	break;
+	case EMapBugUpdate::NOTFOUND:
+		log_info("mapbugs", "unknown map bug '%s', ignoring", pMapBugName);
+		break;
 	default:
-		dbg_assert(0, "unreachable");
+		dbg_assert(false, "unreachable");
 	}
 }
 
@@ -3898,7 +3894,7 @@ void CGameContext::OnInit(const void *pPersistentData)
 	SHA256_DIGEST MapSha256;
 	int MapCrc;
 	Server()->GetMapInfo(aMapName, sizeof(aMapName), &MapSize, &MapSha256, &MapCrc);
-	m_MapBugs = GetMapBugs(aMapName, MapSize, MapSha256);
+	m_MapBugs = CMapBugs::Create(aMapName, MapSize, MapSha256);
 
 	// Reset Tunezones
 	CTuningParams TuningParams;

--- a/src/test/mapbugs.cpp
+++ b/src/test/mapbugs.cpp
@@ -10,7 +10,7 @@ static CMapBugs GetMapBugsImpl(const char *pName, int Size, const char *pSha256)
 {
 	SHA256_DIGEST Sha256 = {{0}};
 	dbg_assert(sha256_from_str(&Sha256, pSha256) == 0, "invalid sha256 in tests");
-	return GetMapBugs(pName, Size, Sha256);
+	return CMapBugs::Create(pName, Size, Sha256);
 }
 
 TEST(MapBugs, Contains)
@@ -25,16 +25,16 @@ TEST(MapBugs, Update)
 {
 	{
 		CMapBugs Binary = GetMapBugsImpl("Binary", 2022597, BINARY_SHA256);
-		EXPECT_EQ(Binary.Update("grenade-doubleexplosion@ddnet.tw"), MAPBUGUPDATE_OVERRIDDEN);
-		EXPECT_EQ(Binary.Update("doesntexist@invalid"), MAPBUGUPDATE_NOTFOUND);
+		EXPECT_EQ(Binary.Update("grenade-doubleexplosion@ddnet.tw"), EMapBugUpdate::OVERRIDDEN);
+		EXPECT_EQ(Binary.Update("doesntexist@invalid"), EMapBugUpdate::NOTFOUND);
 		EXPECT_TRUE(Binary.Contains(BUG_GRENADE_DOUBLEEXPLOSION));
 	}
 	{
 		CMapBugs Dm1 = GetMapBugsImpl("dm1", 5805, DM1_SHA256);
 		EXPECT_FALSE(Dm1.Contains(BUG_GRENADE_DOUBLEEXPLOSION));
-		EXPECT_EQ(Dm1.Update("doesntexist@invalid"), MAPBUGUPDATE_NOTFOUND);
+		EXPECT_EQ(Dm1.Update("doesntexist@invalid"), EMapBugUpdate::NOTFOUND);
 		EXPECT_FALSE(Dm1.Contains(BUG_GRENADE_DOUBLEEXPLOSION));
-		EXPECT_EQ(Dm1.Update("grenade-doubleexplosion@ddnet.tw"), MAPBUGUPDATE_OK);
+		EXPECT_EQ(Dm1.Update("grenade-doubleexplosion@ddnet.tw"), EMapBugUpdate::OK);
 		EXPECT_TRUE(Dm1.Contains(BUG_GRENADE_DOUBLEEXPLOSION));
 	}
 }


### PR DESCRIPTION
Store and update `CMapBugs` on client-side for currently loaded map. Register console chain for the `mapbug` map setting to update mapbugs based on map settings.

Prediction is not adjusted for `BUG_GRENADE_DOUBLEEXPLOSION`, as this seems to work better without additional prediction, causing prediction errors otherwise.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
