### PR TITLE
Absolute antibot include to make it template ready

### DIFF
--- a/src/antibot/antibot_null.cpp
+++ b/src/antibot/antibot_null.cpp
@@ -1,6 +1,6 @@
 #define ANTIBOTAPI DYNAMIC_EXPORT
 
-#include "antibot_interface.h"
+#include <antibot/antibot_interface.h>
 
 #include <cstring>
 


### PR DESCRIPTION
Now antibot_null.cpp can be copied into a external repo and compiled with

```
clang++ unedited_antibot_null_copy.cpp -I../ddnet/src -I../ddnet/build/src/ -fvisibility=hidden -fPIC -shared -o libantibot.so -Og -g
```

Which seems to be the recommended way as far as I understood
