### PR TITLE
Consistently use `class`es instead of `struct`s for all mapitems

### DIFF
--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -19,9 +19,9 @@ class CCamera;
 class CLayers;
 class CMapImages;
 class ColorRGBA;
-struct CMapItemGroup;
-struct CMapItemLayerTilemap;
-struct CMapItemLayerQuads;
+class CMapItemGroup;
+class CMapItemLayerTilemap;
+class CMapItemLayerQuads;
 
 class CMapLayers : public CComponent
 {

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -22,11 +22,11 @@ namespace client_data7 {
 struct CDataSprite;
 }
 struct CDataSprite;
-struct CEnvPoint;
-struct CEnvPointBezier;
-struct CEnvPointBezier_upstream;
-struct CMapItemGroup;
-struct CQuad;
+class CEnvPoint;
+class CEnvPointBezier;
+class CEnvPointBezier_upstream;
+class CMapItemGroup;
+class CQuad;
 
 #include <game/generated/protocol.h>
 

--- a/src/game/editor/editor_trackers.h
+++ b/src/game/editor/editor_trackers.h
@@ -13,7 +13,7 @@ class CEditor;
 class CLayerTiles;
 class CLayerGroup;
 class CLayerSounds;
-struct CSoundSource;
+class CSoundSource;
 
 class CQuadEditTracker
 {

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -16,8 +16,9 @@
 #include "sound.h"
 
 // compatibility with old sound layers
-struct CSoundSource_DEPRECATED
+class CSoundSourceDeprecated
 {
+public:
 	CPoint m_Position;
 	int m_Loop;
 	int m_TimeDelay; // in s
@@ -921,13 +922,13 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 					IntsToStr(pSoundsItem->m_aName, std::size(pSoundsItem->m_aName), pSounds->m_aName, std::size(pSounds->m_aName));
 
 					// load data
-					CSoundSource_DEPRECATED *pData = (CSoundSource_DEPRECATED *)DataFile.GetDataSwapped(pSoundsItem->m_Data);
+					CSoundSourceDeprecated *pData = (CSoundSourceDeprecated *)DataFile.GetDataSwapped(pSoundsItem->m_Data);
 					pGroup->AddLayer(pSounds);
 					pSounds->m_vSources.resize(pSoundsItem->m_NumSources);
 
 					for(int i = 0; i < pSoundsItem->m_NumSources; i++)
 					{
-						CSoundSource_DEPRECATED *pOldSource = &pData[i];
+						CSoundSourceDeprecated *pOldSource = &pData[i];
 
 						CSoundSource &Source = pSounds->m_vSources[i];
 						Source.m_Position = pOldSource->m_Position;

--- a/src/game/layers.h
+++ b/src/game/layers.h
@@ -5,9 +5,9 @@
 
 class IMap;
 
-struct CMapItemGroup;
-struct CMapItemLayer;
-struct CMapItemLayerTilemap;
+class CMapItemGroup;
+class CMapItemLayer;
+class CMapItemLayerTilemap;
 
 class CLayers
 {

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -219,8 +219,9 @@ static constexpr size_t MAX_MAPSOUNDS = 64;
 typedef ivec2 CPoint; // 22.10 fixed point
 typedef ivec4 CColor;
 
-struct CQuad
+class CQuad
 {
+public:
 	CPoint m_aPoints[5];
 	CColor m_aColors[4];
 	CPoint m_aTexcoords[4];
@@ -241,8 +242,9 @@ public:
 	unsigned char m_Reserved;
 };
 
-struct CMapItemInfo
+class CMapItemInfo
 {
+public:
 	int m_Version;
 	int m_Author;
 	int m_MapVersion;
@@ -250,13 +252,15 @@ struct CMapItemInfo
 	int m_License;
 };
 
-struct CMapItemInfoSettings : CMapItemInfo
+class CMapItemInfoSettings : public CMapItemInfo
 {
+public:
 	int m_Settings;
 };
 
-struct CMapItemImage_v1
+class CMapItemImage_v1
 {
+public:
 	int m_Version;
 	int m_Width;
 	int m_Height;
@@ -265,15 +269,17 @@ struct CMapItemImage_v1
 	int m_ImageData;
 };
 
-struct CMapItemImage_v2 : public CMapItemImage_v1
+class CMapItemImage_v2 : public CMapItemImage_v1
 {
+public:
 	int m_MustBe1;
 };
 
 typedef CMapItemImage_v1 CMapItemImage;
 
-struct CMapItemGroup_v1
+class CMapItemGroup_v1
 {
+public:
 	int m_Version;
 	int m_OffsetX;
 	int m_OffsetY;
@@ -284,8 +290,9 @@ struct CMapItemGroup_v1
 	int m_NumLayers;
 };
 
-struct CMapItemGroup : public CMapItemGroup_v1
+class CMapItemGroup : public CMapItemGroup_v1
 {
+public:
 	int m_UseClipping;
 	int m_ClipX;
 	int m_ClipY;
@@ -295,15 +302,17 @@ struct CMapItemGroup : public CMapItemGroup_v1
 	int m_aName[3];
 };
 
-struct CMapItemLayer
+class CMapItemLayer
 {
+public:
 	int m_Version;
 	int m_Type;
 	int m_Flags;
 };
 
-struct CMapItemLayerTilemap
+class CMapItemLayerTilemap
 {
+public:
 	/**
 	 * @link CMapItemLayerTilemap @endlink with this version are only written to maps in upstream Teeworlds.
 	 * The tile data of tilemaps using this version must be unpacked by repeating tiles according to the
@@ -338,8 +347,9 @@ struct CMapItemLayerTilemap
 	int m_Tune;
 };
 
-struct CMapItemLayerQuads
+class CMapItemLayerQuads
 {
+public:
 	CMapItemLayer m_Layer;
 	int m_Version;
 
@@ -350,15 +360,17 @@ struct CMapItemLayerQuads
 	int m_aName[3];
 };
 
-struct CMapItemVersion
+class CMapItemVersion
 {
+public:
 	int m_Version;
 };
 
 // Represents basic information about envelope points.
 // In upstream Teeworlds, this is only used if all CMapItemEnvelope are version 1 or 2.
-struct CEnvPoint
+class CEnvPoint
 {
+public:
 	enum
 	{
 		MAX_CHANNELS = 4,
@@ -374,8 +386,9 @@ struct CEnvPoint
 // Represents additional envelope point information for CURVETYPE_BEZIER.
 // In DDNet, these are stored separately in an UUID-based map item.
 // In upstream Teeworlds, CEnvPointBezier_upstream is used instead.
-struct CEnvPointBezier
+class CEnvPointBezier
 {
+public:
 	// DeltaX in ms and DeltaY as 22.10 fxp
 	int m_aInTangentDeltaX[CEnvPoint::MAX_CHANNELS];
 	int m_aInTangentDeltaY[CEnvPoint::MAX_CHANNELS];
@@ -385,20 +398,23 @@ struct CEnvPointBezier
 
 // Written to maps on upstream Teeworlds for envelope points including bezier information instead of the basic
 // CEnvPoint items, if at least one CMapItemEnvelope with version 3 or higher exists in the map.
-struct CEnvPointBezier_upstream : public CEnvPoint
+class CEnvPointBezier_upstream : public CEnvPoint
 {
+public:
 	CEnvPointBezier m_Bezier;
 };
 
 // Used to represent all envelope point information at runtime in editor.
 // (Can eventually be different than CEnvPointBezier_upstream)
-struct CEnvPoint_runtime : public CEnvPoint
+class CEnvPoint_runtime : public CEnvPoint
 {
+public:
 	CEnvPointBezier m_Bezier;
 };
 
-struct CMapItemEnvelope_v1
+class CMapItemEnvelope_v1
 {
+public:
 	/**
 	 * @link CMapItemEnvelope @endlink with this version are only written to maps in upstream Teeworlds.
 	 * If at least one of these exists in a map, then the envelope points are represented
@@ -413,15 +429,17 @@ struct CMapItemEnvelope_v1
 	int m_aName[8];
 };
 
-struct CMapItemEnvelope_v2 : public CMapItemEnvelope_v1
+class CMapItemEnvelope_v2 : public CMapItemEnvelope_v1
 {
+public:
 	int m_Synchronized;
 };
 
 typedef CMapItemEnvelope_v2 CMapItemEnvelope;
 
-struct CSoundShape
+class CSoundShape
 {
+public:
 	enum
 	{
 		SHAPE_RECTANGLE = 0,
@@ -429,13 +447,15 @@ struct CSoundShape
 		NUM_SHAPES,
 	};
 
-	struct CRectangle
+	class CRectangle
 	{
+	public:
 		int m_Width, m_Height; // fxp 22.10
 	};
 
-	struct CCircle
+	class CCircle
 	{
+	public:
 		int m_Radius;
 	};
 
@@ -448,8 +468,9 @@ struct CSoundShape
 	};
 };
 
-struct CSoundSource
+class CSoundSource
 {
+public:
 	CPoint m_Position;
 	int m_Loop;
 	int m_Pan; // 0 - no panning, 1 - panning
@@ -464,8 +485,9 @@ struct CSoundSource
 	CSoundShape m_Shape;
 };
 
-struct CMapItemLayerSounds
+class CMapItemLayerSounds
 {
+public:
 	CMapItemLayer m_Layer;
 	int m_Version;
 
@@ -476,8 +498,9 @@ struct CMapItemLayerSounds
 	int m_aName[3];
 };
 
-struct CMapItemSound
+class CMapItemSound
 {
+public:
 	int m_Version;
 
 	int m_External;

--- a/src/game/mapitems_ex.h
+++ b/src/game/mapitems_ex.h
@@ -11,16 +11,18 @@ enum
 	END_MAPITEMTYPES_UUID,
 };
 
-struct CMapItemTest
+class CMapItemTest
 {
+public:
 	int m_Version;
 	int m_aFields[2];
 	int m_Field3;
 	int m_Field4;
 };
 
-struct CMapItemAutoMapperConfig
+class CMapItemAutoMapperConfig
 {
+public:
 	enum
 	{
 		FLAG_AUTOMATIC = 1


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
