### PR TITLE
Break physics so konsti can cheat some maps

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2447,6 +2447,7 @@ CClientMask CCharacter::TeamMask()
 void CCharacter::SetPosition(const vec2 &Position)
 {
 	m_Core.m_Pos = Position;
+	m_Pos = Position;
 }
 
 void CCharacter::Move(vec2 RelPos)


### PR DESCRIPTION
It bothers me that SetPosition does not actually set the position.
I keep writing ``pChr->SetPosition(Pos);pChr->m_Pos = Pos`` like a crazy person.
It is not needed right now because the values are synced on tick. But to me it just seems wrong to not set the position in a method literally called SetPosition.

As a easter egg the diff between syncing the postion on call vs on tick unlocks some interesting new teleportation exploits. :rocket: :rocket: :rocket: :rocket: :rocket: :rocket: :rocket: :rocket: :rocket: :rocket: :rocket: 



![image](https://github.com/user-attachments/assets/bacb3351-45dd-488b-9ad8-ef93ac8ebcef)


## Checklist

- [ ] Tested the change ingame
- [ ] Changed no physics that affect existing maps
- [ ] Changed no physics that affect existing maps
- [ ] Changed no physics that affect existing maps
- [ ] Changed no physics that affect existing maps
- [ ] Changed no phy @Zoozti affect existing maps
- [ ] Changed no physics that affect existing maps
- [ ] Changed no physics that affect existing maps
- [ ] Changed no physics that affect existing maps
- [ ] Changed no physics that affect existing maps
- [ ] Changed no physics that affect existing maps

