### PR TITLE
Fix uninitialized `CCamera::m_IsSpectatingPlayer` variable

### DIFF
--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -44,6 +44,7 @@ CCamera::CCamera()
 
 	m_AutoSpecCamera = true;
 	m_AutoSpecCameraZooming = false;
+	m_IsSpectatingPlayer = false;
 	m_UsingAutoSpecCamera = false;
 
 	mem_zero(m_aAutoSpecCameraTooltip, sizeof(m_aAutoSpecCameraTooltip));


### PR DESCRIPTION
Randomly caught by UBSan in the CI:

```
/home/runner/work/ddnet/ddnet/src/game/client/components/camera.cpp:271:5: runtime error: load of value 190, which is not a valid value for type 'bool'
    0 0x561f7a6063ab in CCamera::UpdateCamera() /home/runner/work/ddnet/ddnet/src/game/client/components/camera.cpp:271:5
    1 0x561f7ae91b0f in CGameClient::OnRender() /home/runner/work/ddnet/ddnet/src/game/client/gameclient.cpp:801:11
    2 0x561f7a154053 in CClient::Render() /home/runner/work/ddnet/ddnet/src/engine/client/client.cpp:1056:16
    3 0x561f7a1a2de6 in CClient::Run() /home/runner/work/ddnet/ddnet/src/engine/client/client.cpp:3292:6
    4 0x561f7a1f88f0 in main /home/runner/work/ddnet/ddnet/src/engine/client/client.cpp:4945:11

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/runner/work/ddnet/ddnet/src/game/client/components/camera.cpp:271:5
```

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
