### PR TITLE
Fix editor ctrl+right click selecting hidden layers/groups

### DIFF
--- a/src/game/editor/layer_selector.cpp
+++ b/src/game/editor/layer_selector.cpp
@@ -25,8 +25,12 @@ bool CLayerSelector::SelectByTile()
 	int MatchedLayer = -1;
 	int Matches = 0;
 	bool IsFound = false;
-	for(auto HoverTile : Editor()->HoverTiles())
+	for(const auto &HoverTile : Editor()->HoverTiles())
 	{
+		if(!Editor()->m_Map.m_vpGroups[HoverTile.m_Group]->m_Visible ||
+			!Editor()->m_Map.m_vpGroups[HoverTile.m_Group]->m_vpLayers[HoverTile.m_Layer]->m_Visible)
+			continue;
+
 		if(MatchedGroup == -1)
 		{
 			MatchedGroup = HoverTile.m_Group;


### PR DESCRIPTION
Fixes #9626


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
