### PR TITLE
Add /unpractice and rework sv_practice_by_default

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -710,6 +710,69 @@ void CGameContext::ConPractice(IConsole::IResult *pResult, void *pUserData)
 	}
 }
 
+void CGameContext::ConUnPractice(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(!CheckClientId(pResult->m_ClientId))
+		return;
+
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
+	if(!pPlayer)
+		return;
+
+	if(pSelf->ProcessSpamProtection(pResult->m_ClientId, false))
+		return;
+
+	CGameTeams &Teams = pSelf->m_pController->Teams();
+
+	int Team = Teams.m_Core.Team(pResult->m_ClientId);
+
+	if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && Team == TEAM_FLOCK)
+	{
+		pSelf->Console()->Print(
+			IConsole::OUTPUT_LEVEL_STANDARD,
+			"chatresp",
+			"Practice mode can't be disabled for team 0");
+		return;
+	}
+
+	if(!Teams.IsPractice(Team))
+	{
+		pSelf->Console()->Print(
+			IConsole::OUTPUT_LEVEL_STANDARD,
+			"chatresp",
+			"Team isn't in practice mode");
+		return;
+	}
+
+	if(Teams.GetSaving(Team))
+	{
+		pSelf->Console()->Print(
+			IConsole::OUTPUT_LEVEL_STANDARD,
+			"chatresp",
+			"Practice mode can't be disabled while team save or load is in progress");
+		return;
+	}
+
+	for(int i = 0; i < MAX_CLIENTS; i++)
+	{
+		if(Teams.m_Core.Team(i) == Team)
+		{
+			CPlayer *pPlayer2 = pSelf->m_apPlayers[i];
+			if(pPlayer2 && pPlayer2->m_VotedForPractice)
+				pPlayer2->m_VotedForPractice = false;
+		}
+	}
+
+	// send before kill, in case team isn't locked
+	char aBuf[256];
+	str_format(aBuf, sizeof(aBuf), "'%s' disabled practice mode for your team", pSelf->Server()->ClientName(pResult->m_ClientId));
+	pSelf->SendChatTeam(Team, aBuf);
+
+	Teams.KillSavedTeam(pResult->m_ClientId, Team);
+	Teams.SetPractice(Team, false);
+}
+
 void CGameContext::ConPracticeCmdList(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
@@ -1138,6 +1201,13 @@ void CGameContext::AttemptJoinTeam(int ClientId, int Team)
 		}
 		else
 		{
+			if(g_Config.m_SvPracticeByDefault && g_Config.m_SvTestingCommands)
+			{
+				// joined an empty team
+				if(m_pController->Teams().Count(Team) == 1)
+					m_pController->Teams().SetPractice(Team, true);
+			}
+
 			char aBuf[512];
 			str_format(aBuf, sizeof(aBuf), "'%s' joined team %d",
 				Server()->ClientName(pPlayer->GetCid()),

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1746,6 +1746,9 @@ void CGameContext::OnClientDrop(int ClientId, const char *pReason)
 
 	m_aTeamMapping[ClientId] = -1;
 
+	if(g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO && g_Config.m_SvPracticeByDefault && g_Config.m_SvTestingCommands)
+		m_pController->Teams().SetPractice(GetDDRaceTeam(ClientId), true);
+
 	m_VoteUpdate = true;
 	if(m_VoteCreator == ClientId)
 	{
@@ -3780,6 +3783,7 @@ void CGameContext::RegisterChatCommands()
 	Console()->Register("mapinfo", "?r[map]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConMapInfo, this, "Show info about the map with name r gives (current map by default)");
 	Console()->Register("timeout", "?s[code]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTimeout, this, "Set timeout protection code s");
 	Console()->Register("practice", "?i['0'|'1']", CFGFLAG_CHAT | CFGFLAG_SERVER, ConPractice, this, "Enable cheats for your current team's run, but you can't earn a rank");
+	Console()->Register("unpractice", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConUnPractice, this, "Kills team and disables practice mode");
 	Console()->Register("practicecmdlist", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConPracticeCmdList, this, "List all commands that are avaliable in practice mode");
 	Console()->Register("swap", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConSwap, this, "Request to swap your tee with another team member");
 	Console()->Register("cancelswap", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConCancelSwap, this, "Cancel your swap request");

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -440,6 +440,7 @@ private:
 	static void ConMapInfo(IConsole::IResult *pResult, void *pUserData);
 	static void ConTimeout(IConsole::IResult *pResult, void *pUserData);
 	static void ConPractice(IConsole::IResult *pResult, void *pUserData);
+	static void ConUnPractice(IConsole::IResult *pResult, void *pUserData);
 	static void ConPracticeCmdList(IConsole::IResult *pResult, void *pUserData);
 	static void ConSwap(IConsole::IResult *pResult, void *pUserData);
 	static void ConCancelSwap(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -35,6 +35,8 @@ void CGameTeams::Reset()
 		m_aTeamFlock[i] = false;
 		m_apSaveTeamResult[i] = nullptr;
 		m_aTeamSentStartWarning[i] = false;
+		if(g_Config.m_SvPracticeByDefault && g_Config.m_SvTestingCommands)
+			m_aPractice[i] = true;
 		ResetRoundState(i);
 	}
 }
@@ -45,7 +47,8 @@ void CGameTeams::ResetRoundState(int Team)
 	if(Team != TEAM_SUPER)
 		ResetSwitchers(Team);
 
-	m_aPractice[Team] = false;
+	if(!g_Config.m_SvPracticeByDefault || !g_Config.m_SvTestingCommands)
+		m_aPractice[Team] = false;
 	m_aTeamUnfinishableKillTick[Team] = -1;
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
@@ -391,7 +394,7 @@ const char *CGameTeams::SetCharacterTeam(int ClientId, int Team)
 	if(Team != TEAM_SUPER && Character(ClientId)->m_DDRaceState != DDRACE_NONE)
 		return "You have started racing already";
 	// No cheating through noob filter with practice and then leaving team
-	if(m_aPractice[m_Core.Team(ClientId)])
+	if(m_aPractice[m_Core.Team(ClientId)] && !(g_Config.m_SvPracticeByDefault && g_Config.m_SvTestingCommands))
 		return "You have used practice mode already";
 
 	// you can not join a team which is currently in the process of saving,
@@ -1155,7 +1158,8 @@ void CGameTeams::OnCharacterDeath(int ClientId, int Weapon)
 		{
 			ChangeTeamState(Team, CGameTeams::TEAMSTATE_OPEN);
 
-			m_aPractice[Team] = false;
+			if(!g_Config.m_SvPracticeByDefault || !g_Config.m_SvTestingCommands)
+				m_aPractice[Team] = false;
 
 			if(Count(Team) > 1)
 			{

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -209,7 +209,7 @@ public:
 	{
 		if(Team < TEAM_FLOCK || Team >= TEAM_SUPER)
 			return false;
-		if(g_Config.m_SvPracticeByDefault && g_Config.m_SvTestingCommands)
+		if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && Team == TEAM_FLOCK && g_Config.m_SvPracticeByDefault && g_Config.m_SvTestingCommands)
 			return true;
 		if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && Team == TEAM_FLOCK)
 			return false;


### PR DESCRIPTION
Closes #8613 
Closes #7679 (easier way to disable practice mode without causing that bug)

Adds `/unpractice`, which kills the team and disables practice mode. Compatible with `sv_solo_server`

For `sv_practice_by_default`, this resolves the following comment: https://github.com/ddnet/ddnet/pull/9251#discussion_r1885000742
Each team is treated individually, and practice mode can be turned off for them. Team 0 is always forced into practice mode.

![image](https://github.com/user-attachments/assets/6107fd2e-c4b3-4b93-a769-fbc59d0b0e17)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
