### PR TITLE
Add quick action "Allow unused"

### DIFF
--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -281,11 +281,11 @@ CUi::EPopupMenuFunctionResult CEditor::PopupMenuSettings(void *pContext, CUIRect
 		{
 			static int s_ButtonNo = 0;
 			static int s_ButtonYes = 0;
-			if(pEditor->DoButton_Ex(&s_ButtonNo, "No", !pEditor->m_AllowPlaceUnusedTiles, &No, 0, "[Ctrl+U] Disallow placing unused tiles.", IGraphics::CORNER_L))
+			if(pEditor->DoButton_Ex(&s_ButtonNo, "No", !pEditor->m_AllowPlaceUnusedTiles, &No, 0, pEditor->m_QuickActionAllowUnusedOff.Description(), IGraphics::CORNER_L))
 			{
 				pEditor->m_AllowPlaceUnusedTiles = false;
 			}
-			if(pEditor->DoButton_Ex(&s_ButtonYes, "Yes", pEditor->m_AllowPlaceUnusedTiles, &Yes, 0, "[Ctrl+U] Allow placing unused tiles.", IGraphics::CORNER_R))
+			if(pEditor->DoButton_Ex(&s_ButtonYes, "Yes", pEditor->m_AllowPlaceUnusedTiles, &Yes, 0, pEditor->m_QuickActionAllowUnusedOn.Description(), IGraphics::CORNER_R))
 			{
 				pEditor->m_AllowPlaceUnusedTiles = true;
 			}

--- a/src/game/editor/quick_actions.h
+++ b/src/game/editor/quick_actions.h
@@ -375,6 +375,26 @@ REGISTER_QUICK_ACTION(
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
 	"Run a local server with the current map and connect you to it.")
+REGISTER_QUICK_ACTION(
+	AllowUnusedOn,
+	"Allow unused: On",
+	[&]() {
+		m_AllowPlaceUnusedTiles = true;
+	},
+	[&]() -> bool { return m_AllowPlaceUnusedTiles == true; },
+	[&]() -> bool { return m_AllowPlaceUnusedTiles == true; },
+	DEFAULT_BTN,
+	"[Ctrl+U] Allow placing unused tiles.")
+REGISTER_QUICK_ACTION(
+	AllowUnusedOff,
+	"Allow unused: Off",
+	[&]() {
+		m_AllowPlaceUnusedTiles = false;
+	},
+	[&]() -> bool { return m_AllowPlaceUnusedTiles == false; },
+	[&]() -> bool { return m_AllowPlaceUnusedTiles == false; },
+	DEFAULT_BTN,
+	"[Ctrl+U] Disallow placing unused tiles.")
 
 #undef ALWAYS_FALSE
 #undef DEFAULT_BTN


### PR DESCRIPTION
They are listed as two on and off actions. But it feels as smooth as a toggle because the one that does nothing is always hidden.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
