### PR TITLE
Remove `0.6<->0.7 translation` broadcast

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -538,8 +538,6 @@ void CPlayer::OnPredictedInput(CNetObj_PlayerInput *pNewInput)
 	// Magic number when we can hope that client has successfully identified itself
 	if(m_NumInputs == 20 && g_Config.m_SvClientSuggestion[0] != '\0' && GetClientVersion() <= VERSION_DDNET_OLD)
 		GameServer()->SendBroadcast(g_Config.m_SvClientSuggestion, m_ClientId);
-	else if(m_NumInputs == 200 && Server()->IsSixup(m_ClientId))
-		GameServer()->SendBroadcast("This server uses an experimental translation from Teeworlds 0.7 to 0.6. Please report bugs on ddnet.org/discord", m_ClientId);
 }
 
 void CPlayer::OnDirectInput(CNetObj_PlayerInput *pNewInput)


### PR DESCRIPTION
Remove the `This server uses an experimental translation from Teeworlds 0.7 to 0.6. Please report bugs on ddnet.org/discord` broadcast for 0.7 clients. The translation layer has been in use for years now and should be considered stable.

Closes #9611

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
