### PR TITLE
Simplify rust CI, explicitly exclude `ubuntu-22.04`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,18 +103,16 @@ jobs:
       uses: Swatinem/rust-cache@v2
 
     - name: Build mastersrv
-      if: contains(matrix.os, 'latest')
+      if: "!contains(matrix.os, 'ubuntu-22.04')"
       run: |
-        mkdir mastersrv
-        cd mastersrv
-        cargo build --manifest-path=../src/mastersrv/Cargo.toml
+        cd src/mastersrv
+        cargo build
 
     - name: Build masterping
-      if: contains(matrix.os, 'latest')
+      if: "!contains(matrix.os, 'ubuntu-22.04')"
       run: |
-        mkdir masterping
-        cd masterping
-        cargo build --manifest-path=../src/masterping/Cargo.toml
+        cd src/masterping
+        cargo build
 
     - name: Build in debug mode
       run: |


### PR DESCRIPTION
Builds the programs in their respective `src` directory instead of creating a new one. Explicitly exclude `ubuntu-22.04` instead of only building on `latest` as requested in #9696

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
