### PR TITLE
Overhaul skin loading and refreshing, improvements for 0.7 skins

### DIFF
--- a/src/game/client/component.h
+++ b/src/game/client/component.h
@@ -170,10 +170,6 @@ public:
 	 */
 	virtual void OnWindowResize() {}
 	/**
-	 * Called when skins have been invalidated and must be updated.
-	 */
-	virtual void OnRefreshSkins() {}
-	/**
 	 * Called when the component should get rendered.
 	 *
 	 * The render order depends on the component insertion order.

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -106,7 +106,7 @@ void CChat::ClearLines()
 		Line.m_aName[0] = 0;
 		Line.m_Friend = false;
 		Line.m_TimesRepeated = 0;
-		Line.m_HasRenderTee = false;
+		Line.m_pManagedTeeRenderInfo = nullptr;
 	}
 	m_PrevScoreBoardShowed = false;
 	m_PrevShowChat = false;
@@ -758,8 +758,8 @@ void CChat::AddLine(int ClientId, int Team, const char *pLine)
 	pCurrentLine->m_Whisper = Team >= 2;
 	pCurrentLine->m_NameColor = -2;
 	pCurrentLine->m_Friend = false;
-	pCurrentLine->m_HasRenderTee = false;
 	pCurrentLine->m_CustomColor = CustomColor;
+	pCurrentLine->m_pManagedTeeRenderInfo = nullptr;
 
 	TextRender()->DeleteTextContainer(pCurrentLine->m_TextContainerIndex);
 	Graphics()->DeleteQuadContainer(pCurrentLine->m_QuadContainerIndex);
@@ -831,12 +831,7 @@ void CChat::AddLine(int ClientId, int Team, const char *pLine)
 
 		if(pCurrentLine->m_aName[0] != '\0')
 		{
-			if(!g_Config.m_ClChatOld)
-			{
-				str_copy(pCurrentLine->m_aSkinName, LineAuthor.m_aSkinName);
-				pCurrentLine->m_TeeRenderInfo = LineAuthor.m_RenderInfo;
-				pCurrentLine->m_HasRenderTee = true;
-			}
+			pCurrentLine->m_pManagedTeeRenderInfo = GameClient()->CreateManagedTeeRenderInfo(LineAuthor);
 		}
 	}
 
@@ -894,21 +889,6 @@ void CChat::AddLine(int ClientId, int Team, const char *pLine)
 				m_pClient->m_Sounds.Play(CSounds::CHN_GUI, SOUND_CHAT_CLIENT, 1.0f);
 				m_aLastSoundPlayed[CHAT_CLIENT] = Now;
 			}
-		}
-	}
-}
-
-void CChat::OnRefreshSkins()
-{
-	for(auto &Line : m_aLines)
-	{
-		if(Line.m_HasRenderTee)
-		{
-			Line.m_TeeRenderInfo.Apply(m_pClient->m_Skins.Find(Line.m_aSkinName));
-		}
-		else
-		{
-			Line.m_TeeRenderInfo.Reset();
 		}
 	}
 }
@@ -985,11 +965,6 @@ void CChat::OnPrepareLines(float y)
 			{
 				pText = "Team successfully saved by ***. Use '/load ***' to continue";
 			}
-		}
-
-		if(g_Config.m_ClChatOld)
-		{
-			Line.m_HasRenderTee = false;
 		}
 
 		// get the y offset (calculate it if we haven't done that yet)
@@ -1288,10 +1263,11 @@ void CChat::OnRender()
 
 		if(Line.m_TextContainerIndex.Valid())
 		{
-			if(!g_Config.m_ClChatOld && Line.m_HasRenderTee)
+			if(!g_Config.m_ClChatOld && Line.m_pManagedTeeRenderInfo != nullptr)
 			{
+				CTeeRenderInfo &TeeRenderInfo = Line.m_pManagedTeeRenderInfo->TeeRenderInfo();
 				const int TeeSize = MessageTeeSize();
-				Line.m_TeeRenderInfo.m_Size = TeeSize;
+				TeeRenderInfo.m_Size = TeeSize;
 
 				float RowHeight = FontSize() + RealMsgPaddingY;
 				float OffsetTeeY = TeeSize / 2.0f;
@@ -1299,9 +1275,9 @@ void CChat::OnRender()
 
 				const CAnimState *pIdleState = CAnimState::GetIdle();
 				vec2 OffsetToMid;
-				CRenderTools::GetRenderTeeOffsetToRenderedTee(pIdleState, &Line.m_TeeRenderInfo, OffsetToMid);
+				CRenderTools::GetRenderTeeOffsetToRenderedTee(pIdleState, &TeeRenderInfo, OffsetToMid);
 				vec2 TeeRenderPos(x + (RealMsgPaddingX + TeeSize) / 2.0f, y + OffsetTeeY + FullHeightMinusTee / 2.0f + OffsetToMid.y);
-				RenderTools()->RenderTee(pIdleState, &Line.m_TeeRenderInfo, EMOTE_NORMAL, vec2(1, 0.1f), TeeRenderPos, Blend);
+				RenderTools()->RenderTee(pIdleState, &TeeRenderInfo, EMOTE_NORMAL, vec2(1, 0.1f), TeeRenderPos, Blend);
 			}
 
 			const ColorRGBA TextColor = TextRender()->DefaultTextColor().WithMultipliedAlpha(Blend);

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -48,9 +48,7 @@ class CChat : public CComponent
 		STextContainerIndex m_TextContainerIndex;
 		int m_QuadContainerIndex;
 
-		char m_aSkinName[std::size(g_Config.m_ClPlayerSkin)];
-		bool m_HasRenderTee;
-		CTeeRenderInfo m_TeeRenderInfo;
+		std::shared_ptr<CManagedTeeRenderInfo> m_pManagedTeeRenderInfo;
 
 		float m_TextYOffset;
 
@@ -164,7 +162,6 @@ public:
 	void OnWindowResize() override;
 	void OnConsoleInit() override;
 	void OnStateChange(int NewState, int OldState) override;
-	void OnRefreshSkins() override;
 	void OnRender() override;
 	void OnPrepareLines(float y);
 	void Reset();

--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -217,11 +217,27 @@ void CEffects::PlayerDeath(vec2 Pos, int ClientId, float Alpha)
 		// m_RenderInfo.m_CustomColoredSkin Defines if in the context of the game the color is being customized,
 		// Using this value if the game is teams (red and blue), this value will be true even if the skin is with the normal color.
 		// And will use the team body color to create player death effect instead of tee color
-		if(m_pClient->m_aClients[ClientId].m_RenderInfo.m_CustomColoredSkin)
-			BloodColor = m_pClient->m_aClients[ClientId].m_RenderInfo.m_ColorBody;
+		if(m_pClient->Client()->IsSixup())
+		{
+			if(m_pClient->m_aClients[ClientId].m_RenderInfo.m_aSixup[g_Config.m_ClDummy].m_aUseCustomColors[protocol7::SKINPART_BODY])
+			{
+				BloodColor = m_pClient->m_aClients[ClientId].m_RenderInfo.m_aSixup[g_Config.m_ClDummy].m_aColors[protocol7::SKINPART_BODY];
+			}
+			else
+			{
+				BloodColor = m_pClient->m_aClients[ClientId].m_RenderInfo.m_aSixup[g_Config.m_ClDummy].m_BloodColor;
+			}
+		}
 		else
 		{
-			BloodColor = m_pClient->m_aClients[ClientId].m_RenderInfo.m_BloodColor;
+			if(m_pClient->m_aClients[ClientId].m_RenderInfo.m_CustomColoredSkin)
+			{
+				BloodColor = m_pClient->m_aClients[ClientId].m_RenderInfo.m_ColorBody;
+			}
+			else
+			{
+				BloodColor = m_pClient->m_aClients[ClientId].m_RenderInfo.m_BloodColor;
+			}
 		}
 	}
 

--- a/src/game/client/components/ghost.h
+++ b/src/game/client/components/ghost.h
@@ -21,12 +21,7 @@ enum
 
 struct CGhostSkin
 {
-	int m_Skin0;
-	int m_Skin1;
-	int m_Skin2;
-	int m_Skin3;
-	int m_Skin4;
-	int m_Skin5;
+	int m_aSkin[6];
 	int m_UseCustomColor;
 	int m_ColorBody;
 	int m_ColorFeet;
@@ -87,7 +82,7 @@ private:
 	class CGhostItem
 	{
 	public:
-		CTeeRenderInfo m_RenderInfo;
+		std::shared_ptr<CManagedTeeRenderInfo> m_pManagedTeeRenderInfo;
 		CGhostSkin m_Skin;
 		CGhostPath m_Path;
 		int m_StartTick;
@@ -99,6 +94,7 @@ private:
 		bool Empty() const { return m_Path.Size() == 0; }
 		void Reset()
 		{
+			m_pManagedTeeRenderInfo = nullptr;
 			m_Path.Reset();
 			m_StartTick = -1;
 			m_PlaybackPos = -1;
@@ -122,7 +118,7 @@ private:
 	bool m_Rendering = false;
 	bool m_RenderingStartedByServer = false;
 
-	static void GetGhostSkin(CGhostSkin *pSkin, const char *pSkinName, int UseCustomColor, int ColorBody, int ColorFeet);
+	static void SetGhostSkinData(CGhostSkin *pSkin, const char *pSkinName, int UseCustomColor, int ColorBody, int ColorFeet);
 	static void GetGhostCharacter(CGhostCharacter *pGhostChar, const CNetObj_Character *pChar, const CNetObj_DDNetCharacter *pDDnetChar);
 	static void GetNetObjCharacter(CNetObj_Character *pChar, const CGhostCharacter *pGhostChar);
 
@@ -140,7 +136,7 @@ private:
 	void StartRender(int Tick);
 	void StopRender();
 
-	void InitRenderInfos(CGhostItem *pGhost);
+	void UpdateTeeRenderInfo(CGhostItem &Ghost);
 
 	static void ConGPlay(IConsole::IResult *pResult, void *pUserData);
 
@@ -152,7 +148,6 @@ public:
 	virtual void OnRender() override;
 	virtual void OnConsoleInit() override;
 	virtual void OnReset() override;
-	virtual void OnRefreshSkins() override;
 	virtual void OnMessage(int MsgType, void *pRawMsg) override;
 	virtual void OnMapLoad() override;
 	virtual void OnShutdown() override;

--- a/src/game/client/components/infomessages.h
+++ b/src/game/client/components/infomessages.h
@@ -32,11 +32,11 @@ class CInfoMessages : public CComponent
 		int m_VictimDDTeam;
 		char m_aVictimName[64];
 		STextContainerIndex m_VictimTextContainerIndex;
-		CTeeRenderInfo m_aVictimRenderInfo[MAX_KILLMSG_TEAM_MEMBERS];
+		std::shared_ptr<CManagedTeeRenderInfo> m_apVictimManagedTeeRenderInfos[MAX_KILLMSG_TEAM_MEMBERS];
 		int m_KillerId;
 		char m_aKillerName[64];
 		STextContainerIndex m_KillerTextContainerIndex;
-		CTeeRenderInfo m_KillerRenderInfo;
+		std::shared_ptr<CManagedTeeRenderInfo> m_pKillerManagedTeeRenderInfo;
 
 		// kill msg
 		int m_Weapon;
@@ -67,11 +67,11 @@ class CInfoMessages : public CComponent
 
 	void CreateTextContainersIfNotCreated(CInfoMsg &InfoMsg);
 	void DeleteTextContainers(CInfoMsg &InfoMsg);
+	void ResetMessage(CInfoMsg &InfoMsg);
 
 public:
 	virtual int Sizeof() const override { return sizeof(*this); }
 	virtual void OnWindowResize() override;
-	virtual void OnRefreshSkins() override;
 	virtual void OnReset() override;
 	virtual void OnRender() override;
 	virtual void OnMessage(int MsgType, void *pRawMsg) override;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -536,21 +536,21 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	if(DoButton_CheckBox(&g_Config.m_ClDownloadSkins, Localize("Download skins"), g_Config.m_ClDownloadSkins, &Button))
 	{
 		g_Config.m_ClDownloadSkins ^= 1;
-		m_pClient->RefreshSkins();
+		m_pClient->RefreshSkins(CSkinDescriptor::FLAG_SIX);
 	}
 
 	Checkboxes.HSplitTop(20.0f, &Button, &Checkboxes);
 	if(DoButton_CheckBox(&g_Config.m_ClDownloadCommunitySkins, Localize("Download community skins"), g_Config.m_ClDownloadCommunitySkins, &Button))
 	{
 		g_Config.m_ClDownloadCommunitySkins ^= 1;
-		m_pClient->RefreshSkins();
+		m_pClient->RefreshSkins(CSkinDescriptor::FLAG_SIX);
 	}
 
 	Checkboxes.HSplitTop(20.0f, &Button, &Checkboxes);
 	if(DoButton_CheckBox(&g_Config.m_ClVanillaSkinsOnly, Localize("Vanilla skins only"), g_Config.m_ClVanillaSkinsOnly, &Button))
 	{
 		g_Config.m_ClVanillaSkinsOnly ^= 1;
-		m_pClient->RefreshSkins();
+		m_pClient->RefreshSkins(CSkinDescriptor::FLAG_SIX);
 	}
 
 	Checkboxes.HSplitTop(20.0f, &Button, &Checkboxes);
@@ -865,7 +865,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 		// reset render flags for possible loading screen
 		TextRender()->SetRenderFlags(0);
 		TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
-		m_pClient->RefreshSkins();
+		m_pClient->RefreshSkins(CSkinDescriptor::FLAG_SIX);
 	}
 	TextRender()->SetRenderFlags(0);
 	TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -29,7 +29,7 @@
 
 void CPlayers::RenderHand(const CTeeRenderInfo *pInfo, vec2 CenterPos, vec2 Dir, float AngleOffset, vec2 PostRotOffset, float Alpha)
 {
-	if(pInfo->m_aSixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_BODY].IsValid())
+	if(pInfo->m_aSixup[g_Config.m_ClDummy].PartTexture(protocol7::SKINPART_BODY).IsValid())
 		RenderHand7(pInfo, CenterPos, Dir, AngleOffset, PostRotOffset, Alpha);
 	else
 		RenderHand6(pInfo, CenterPos, Dir, AngleOffset, PostRotOffset, Alpha);
@@ -61,7 +61,7 @@ void CPlayers::RenderHand7(const CTeeRenderInfo *pInfo, vec2 CenterPos, vec2 Dir
 	IGraphics::CQuadItem QuadOutline(HandPos.x, HandPos.y, 2 * BaseSize, 2 * BaseSize);
 	IGraphics::CQuadItem QuadHand = QuadOutline;
 
-	Graphics()->TextureSet(pInfo->m_aSixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_HANDS]);
+	Graphics()->TextureSet(pInfo->m_aSixup[g_Config.m_ClDummy].PartTexture(protocol7::SKINPART_HANDS));
 	Graphics()->QuadsBegin();
 	Graphics()->SetColor(Color);
 	Graphics()->QuadsSetRotation(Angle);
@@ -760,8 +760,7 @@ void CPlayers::RenderPlayer(
 				vec2(m_pClient->m_Snap.m_aCharacters[ClientId].m_Cur.m_X, m_pClient->m_Snap.m_aCharacters[ClientId].m_Cur.m_Y),
 				Client()->IntraGameTick(g_Config.m_ClDummy));
 
-		CTeeRenderInfo Shadow = RenderInfo;
-		RenderTools()->RenderTee(&State, &Shadow, Player.m_Emote, Direction, ShadowPosition, 0.5f); // render ghost
+		RenderTools()->RenderTee(&State, &RenderInfo, Player.m_Emote, Direction, ShadowPosition, 0.5f); // render ghost
 	}
 
 	RenderTools()->RenderTee(&State, &RenderInfo, Player.m_Emote, Direction, Position, Alpha);

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -26,6 +26,7 @@ public:
 	int Sizeof() const override { return sizeof(*this); }
 	void OnInit() override;
 	void OnShutdown() override;
+	void OnRender() override;
 
 	void Refresh(TSkinLoadedCallback &&SkinLoadedCallback);
 	std::chrono::nanoseconds LastRefreshTime() const { return m_LastRefreshTime; }
@@ -39,12 +40,12 @@ public:
 	static bool IsVanillaSkin(const char *pName);
 	static bool IsSpecialSkin(const char *pName);
 
+private:
 	constexpr static const char *VANILLA_SKINS[] = {"bluekitty", "bluestripe", "brownbear",
 		"cammo", "cammostripes", "coala", "default", "limekitty",
 		"pinky", "redbopp", "redstripe", "saddo", "toptri",
 		"twinbop", "twintri", "warpaint", "x_ninja", "x_spec"};
 
-private:
 	class CSkinDownloadJob : public IJob
 	{
 	public:

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -169,6 +169,14 @@ void CGameClient::OnConsoleInit()
 						  &m_TouchControls,
 						  &m_Binds});
 
+	// initialize client data
+	for(int ClientId = 0; ClientId < MAX_CLIENTS; ClientId++)
+	{
+		CClientData &Client = m_aClients[ClientId];
+		Client.m_pGameClient = this;
+		Client.m_ClientId = ClientId;
+	}
+
 	// add basic console commands
 	Console()->Register("team", "i[team-id]", CFGFLAG_CLIENT, ConTeam, this, "Switch team");
 	Console()->Register("kill", "", CFGFLAG_CLIENT, ConKill, this, "Kill yourself to restart");
@@ -876,6 +884,8 @@ void CGameClient::OnRender()
 			}
 		}
 	}
+
+	UpdateManagedTeeRenderInfos();
 }
 
 void CGameClient::OnDummyDisconnect()
@@ -1608,11 +1618,6 @@ void CGameClient::OnNewSnapshot()
 					pClient->m_UseCustomColor = pInfo->m_UseCustomColor;
 					pClient->m_ColorBody = pInfo->m_ColorBody;
 					pClient->m_ColorFeet = pInfo->m_ColorFeet;
-
-					pClient->m_SkinInfo.m_Size = 64;
-					pClient->m_SkinInfo.Apply(m_Skins.Find(pClient->m_aSkinName));
-					pClient->m_SkinInfo.ApplyColors(pClient->m_UseCustomColor, pClient->m_ColorBody, pClient->m_ColorFeet);
-					pClient->UpdateRenderInfo(IsTeamPlay());
 				}
 			}
 			else if(Item.m_Type == NETOBJTYPE_PLAYERINFO)
@@ -1648,8 +1653,6 @@ void CGameClient::OnNewSnapshot()
 					}
 					else if(m_aStats[pInfo->m_ClientId].IsActive())
 						m_aStats[pInfo->m_ClientId].JoinSpec(Client()->GameTick(g_Config.m_ClDummy));
-
-					UpdateBotSkinDecoration(pInfo->m_ClientId);
 				}
 			}
 			else if(Item.m_Type == NETOBJTYPE_DDNETPLAYER)
@@ -1893,6 +1896,11 @@ void CGameClient::OnNewSnapshot()
 	if(!FoundGameInfoEx)
 	{
 		m_GameInfo = GetGameInfo(nullptr, 0, &ServerInfo);
+	}
+
+	for(CClientData &Client : m_aClients)
+	{
+		Client.UpdateSkinInfo();
 	}
 
 	// setup local pointers
@@ -2534,17 +2542,73 @@ void CGameClient::CClientStats::Reset()
 	m_FlagCaptures = 0;
 }
 
-void CGameClient::CClientData::UpdateRenderInfo(bool IsTeamPlay)
+void CGameClient::CClientData::UpdateSkinInfo()
 {
-	m_RenderInfo = m_SkinInfo;
+	const CSkinDescriptor SkinDescriptor = ToSkinDescriptor();
+	if(SkinDescriptor.m_Flags == 0)
+	{
+		return;
+	}
+
+	const auto &&ApplySkinProperties = [&]() {
+		if(SkinDescriptor.m_Flags & CSkinDescriptor::FLAG_SIX)
+		{
+			m_pSkinInfo->TeeRenderInfo().ApplyColors(m_UseCustomColor, m_ColorBody, m_ColorFeet);
+		}
+		if(SkinDescriptor.m_Flags & CSkinDescriptor::FLAG_SEVEN)
+		{
+			for(int Dummy = 0; Dummy < NUM_DUMMIES; Dummy++)
+			{
+				const CClientData::CSixup &SixupData = m_aSixup[Dummy];
+				CTeeRenderInfo::CSixup &SixupSkinInfo = m_pSkinInfo->TeeRenderInfo().m_aSixup[Dummy];
+				for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
+				{
+					m_pGameClient->m_Skins7.ApplyColorTo(SixupSkinInfo, SixupData.m_aUseCustomColors[Part], SixupData.m_aSkinPartColors[Part], Part);
+				}
+				UpdateSkin7HatSprite(Dummy);
+				UpdateSkin7BotDecoration(Dummy);
+			}
+		}
+		m_pSkinInfo->TeeRenderInfo().m_Size = 64.0f;
+	};
+
+	if(m_pSkinInfo == nullptr)
+	{
+		CTeeRenderInfo TeeRenderInfo;
+		m_pSkinInfo = m_pGameClient->CreateManagedTeeRenderInfo(TeeRenderInfo, SkinDescriptor);
+		m_pSkinInfo->SetRefreshCallback([&]() { UpdateRenderInfo(); });
+		ApplySkinProperties();
+		m_pSkinInfo->m_RefreshCallback();
+	}
+	else if(m_pSkinInfo->SkinDescriptor() != SkinDescriptor)
+	{
+		m_pSkinInfo->m_SkinDescriptor = SkinDescriptor;
+		m_pGameClient->RefreshSkin(m_pSkinInfo);
+		ApplySkinProperties();
+	}
+	else
+	{
+		ApplySkinProperties();
+		m_pSkinInfo->m_RefreshCallback();
+	}
+}
+
+void CGameClient::CClientData::UpdateRenderInfo()
+{
+	m_RenderInfo = m_pSkinInfo->TeeRenderInfo();
 
 	// force team colors
-	if(IsTeamPlay)
+	if(m_pGameClient->IsTeamPlay())
 	{
 		m_RenderInfo.m_CustomColoredSkin = true;
-		const int aTeamColors[2] = {65461, 10223541};
+		for(auto &Sixup : m_RenderInfo.m_aSixup)
+		{
+			std::fill(std::begin(Sixup.m_aUseCustomColors), std::end(Sixup.m_aUseCustomColors), true);
+		}
+
 		if(m_Team >= TEAM_RED && m_Team <= TEAM_BLUE)
 		{
+			const int aTeamColors[2] = {65461, 10223541};
 			m_RenderInfo.m_ColorBody = color_cast<ColorRGBA>(ColorHSLA(aTeamColors[m_Team]));
 			m_RenderInfo.m_ColorFeet = color_cast<ColorRGBA>(ColorHSLA(aTeamColors[m_Team]));
 
@@ -2559,9 +2623,13 @@ void CGameClient::CClientData::UpdateRenderInfo(bool IsTeamPlay)
 					ColorRGBA(0.345f, 0.514f, 0.824f, 1.0f)};
 				float MarkingAlpha = Sixup.m_aColors[protocol7::SKINPART_MARKING].a;
 				for(auto &Color : Sixup.m_aColors)
+				{
 					Color = aTeamColorsSixup[m_Team];
+				}
 				if(MarkingAlpha > 0.1f)
+				{
 					Sixup.m_aColors[protocol7::SKINPART_MARKING] = aMarkingColorsSixup[m_Team];
+				}
 			}
 		}
 		else
@@ -2569,8 +2637,12 @@ void CGameClient::CClientData::UpdateRenderInfo(bool IsTeamPlay)
 			m_RenderInfo.m_ColorBody = color_cast<ColorRGBA>(ColorHSLA(12829350));
 			m_RenderInfo.m_ColorFeet = color_cast<ColorRGBA>(ColorHSLA(12829350));
 			for(auto &Sixup : m_RenderInfo.m_aSixup)
+			{
 				for(auto &Color : Sixup.m_aColors)
+				{
 					Color = color_cast<ColorRGBA>(ColorHSLA(12829350));
+				}
+			}
 		}
 	}
 }
@@ -2614,7 +2686,7 @@ void CGameClient::CClientData::Reset()
 	m_Predicted.Reset();
 	m_PrevPredicted.Reset();
 
-	m_SkinInfo.Reset();
+	m_pSkinInfo = nullptr;
 	m_RenderInfo.Reset();
 
 	m_Angle = 0.0f;
@@ -2648,6 +2720,34 @@ void CGameClient::CClientData::Reset()
 
 	for(auto &Info : m_aSixup)
 		Info.Reset();
+}
+
+CSkinDescriptor CGameClient::CClientData::ToSkinDescriptor() const
+{
+	CSkinDescriptor SkinDescriptor;
+
+	if(m_Active)
+	{
+		SkinDescriptor.m_Flags |= CSkinDescriptor::FLAG_SIX;
+		str_copy(SkinDescriptor.m_aSkinName, m_aSkinName);
+	}
+
+	CTranslationContext::CClientData &TranslatedClient = m_pGameClient->m_pClient->m_TranslationContext.m_aClients[ClientId()];
+	if(TranslatedClient.m_Active)
+	{
+		SkinDescriptor.m_Flags |= CSkinDescriptor::FLAG_SEVEN;
+		for(int Dummy = 0; Dummy < NUM_DUMMIES; Dummy++)
+		{
+			for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
+			{
+				str_copy(SkinDescriptor.m_aSixup[Dummy].m_aaSkinPartNames[Part], m_aSixup[Dummy].m_aaSkinPartNames[Part]);
+			}
+			SkinDescriptor.m_aSixup[Dummy].m_XmasHat = time_season() == SEASON_XMAS;
+			SkinDescriptor.m_aSixup[Dummy].m_BotDecoration = (TranslatedClient.m_PlayerFlags7 & protocol7::PLAYERFLAG_BOT) != 0;
+		}
+	}
+
+	return SkinDescriptor;
 }
 
 void CGameClient::CClientData::CSixup::Reset()
@@ -4006,25 +4106,121 @@ void CGameClient::LoadExtrasSkin(const char *pPath, bool AsDir)
 	ImgInfo.Free();
 }
 
-void CGameClient::RefreshSkins()
+void CGameClient::RefreshSkin(const std::shared_ptr<CManagedTeeRenderInfo> &pManagedTeeRenderInfo)
 {
+	CTeeRenderInfo &TeeInfo = pManagedTeeRenderInfo->TeeRenderInfo();
+	const CSkinDescriptor &SkinDescriptor = pManagedTeeRenderInfo->SkinDescriptor();
+
+	if(SkinDescriptor.m_Flags & CSkinDescriptor::FLAG_SIX)
+	{
+		TeeInfo.Apply(m_Skins.Find(SkinDescriptor.m_aSkinName));
+	}
+
+	if(SkinDescriptor.m_Flags & CSkinDescriptor::FLAG_SEVEN)
+	{
+		for(int Dummy = 0; Dummy < NUM_DUMMIES; Dummy++)
+		{
+			for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
+			{
+				m_Skins7.FindSkinPart(Part, SkinDescriptor.m_aSixup[Dummy].m_aaSkinPartNames[Part], true)->ApplyTo(TeeInfo.m_aSixup[Dummy]);
+
+				if(SkinDescriptor.m_aSixup[Dummy].m_XmasHat)
+				{
+					TeeInfo.m_aSixup[Dummy].m_HatTexture = m_Skins7.XmasHatTexture();
+				}
+				else
+				{
+					TeeInfo.m_aSixup[Dummy].m_HatTexture.Invalidate();
+				}
+
+				if(SkinDescriptor.m_aSixup[Dummy].m_BotDecoration)
+				{
+					TeeInfo.m_aSixup[Dummy].m_BotTexture = m_Skins7.BotDecorationTexture();
+				}
+				else
+				{
+					TeeInfo.m_aSixup[Dummy].m_BotTexture.Invalidate();
+				}
+			}
+		}
+	}
+
+	if(SkinDescriptor.m_Flags != 0 && pManagedTeeRenderInfo->m_RefreshCallback)
+	{
+		pManagedTeeRenderInfo->m_RefreshCallback();
+	}
+}
+
+void CGameClient::RefreshSkins(int SkinDescriptorFlags)
+{
+	dbg_assert(SkinDescriptorFlags != 0, "SkinDescriptorFlags invalid");
+
 	const auto SkinStartLoadTime = time_get_nanoseconds();
-	m_Skins.Refresh([&]() {
+	const auto &&ProgressCallback = [&]() {
 		// if skin refreshing takes to long, swap to a loading screen
 		if(time_get_nanoseconds() - SkinStartLoadTime > 500ms)
 		{
 			m_Menus.RenderLoading(Localize("Loading skin files"), "", 0);
 		}
-	});
-
-	for(auto &Client : m_aClients)
+	};
+	if(SkinDescriptorFlags & CSkinDescriptor::FLAG_SIX)
 	{
-		Client.m_SkinInfo.Apply(m_Skins.Find(Client.m_aSkinName));
-		Client.UpdateRenderInfo(IsTeamPlay());
+		m_Skins.Refresh(ProgressCallback);
+	}
+	if(SkinDescriptorFlags & CSkinDescriptor::FLAG_SEVEN)
+	{
+		m_Skins7.Refresh(ProgressCallback);
 	}
 
-	for(auto &pComponent : m_vpAll)
-		pComponent->OnRefreshSkins();
+	for(std::shared_ptr<CManagedTeeRenderInfo> &pManagedTeeRenderInfo : m_vpManagedTeeRenderInfos)
+	{
+		if(!(pManagedTeeRenderInfo->SkinDescriptor().m_Flags & SkinDescriptorFlags))
+		{
+			continue;
+		}
+		RefreshSkin(pManagedTeeRenderInfo);
+	}
+}
+
+void CGameClient::OnSkinUpdate(const char *pSkinName)
+{
+	for(std::shared_ptr<CManagedTeeRenderInfo> &pManagedTeeRenderInfo : m_vpManagedTeeRenderInfos)
+	{
+		if(!(pManagedTeeRenderInfo->SkinDescriptor().m_Flags & CSkinDescriptor::FLAG_SIX) ||
+			str_comp(pManagedTeeRenderInfo->SkinDescriptor().m_aSkinName, pSkinName) != 0)
+		{
+			continue;
+		}
+		RefreshSkin(pManagedTeeRenderInfo);
+	}
+}
+
+std::shared_ptr<CManagedTeeRenderInfo> CGameClient::CreateManagedTeeRenderInfo(const CTeeRenderInfo &TeeRenderInfo, const CSkinDescriptor &SkinDescriptor)
+{
+	std::shared_ptr<CManagedTeeRenderInfo> pManagedTeeRenderInfo = std::make_shared<CManagedTeeRenderInfo>(TeeRenderInfo, SkinDescriptor);
+	RefreshSkin(pManagedTeeRenderInfo);
+	m_vpManagedTeeRenderInfos.emplace_back(pManagedTeeRenderInfo);
+	return pManagedTeeRenderInfo;
+}
+
+std::shared_ptr<CManagedTeeRenderInfo> CGameClient::CreateManagedTeeRenderInfo(const CClientData &Client)
+{
+	return CreateManagedTeeRenderInfo(Client.m_RenderInfo, Client.ToSkinDescriptor());
+}
+
+void CGameClient::UpdateManagedTeeRenderInfos()
+{
+	while(!m_vpManagedTeeRenderInfos.empty())
+	{
+		auto UnusedInfo = std::find_if(m_vpManagedTeeRenderInfos.begin(), m_vpManagedTeeRenderInfos.end(), [&](const auto &pItem) {
+			return pItem.use_count() <= 1;
+		});
+		if(UnusedInfo == m_vpManagedTeeRenderInfos.end())
+		{
+			break;
+		}
+		m_vpManagedTeeRenderInfos.erase(UnusedInfo);
+	}
 }
 
 void CGameClient::ConchainRefreshSkins(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
@@ -4033,7 +4229,7 @@ void CGameClient::ConchainRefreshSkins(IConsole::IResult *pResult, void *pUserDa
 	pfnCallback(pResult, pCallbackUserData);
 	if(pResult->NumArguments() && pThis->m_Menus.IsInit())
 	{
-		pThis->RefreshSkins();
+		pThis->RefreshSkins(CSkinDescriptor::FLAG_SIX);
 	}
 }
 

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -17,6 +17,78 @@
 
 #include <game/mapitems.h>
 
+CSkinDescriptor::CSkinDescriptor()
+{
+	Reset();
+}
+
+void CSkinDescriptor::Reset()
+{
+	m_Flags = 0;
+	m_aSkinName[0] = '\0';
+	for(auto &Sixup : m_aSixup)
+	{
+		Sixup.Reset();
+	}
+}
+
+bool CSkinDescriptor::IsValid() const
+{
+	return (m_Flags & (FLAG_SIX | FLAG_SEVEN)) != 0;
+}
+
+bool CSkinDescriptor::operator==(const CSkinDescriptor &Other) const
+{
+	if(m_Flags != Other.m_Flags)
+	{
+		return false;
+	}
+
+	if(m_Flags & FLAG_SIX)
+	{
+		if(str_comp(m_aSkinName, Other.m_aSkinName) != 0)
+		{
+			return false;
+		}
+	}
+
+	if(m_Flags & FLAG_SEVEN)
+	{
+		for(int Dummy = 0; Dummy < NUM_DUMMIES; Dummy++)
+		{
+			if(m_aSixup[Dummy] != Other.m_aSixup[Dummy])
+			{
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+void CSkinDescriptor::CSixup::Reset()
+{
+	for(auto &aSkinPartName : m_aaSkinPartNames)
+	{
+		aSkinPartName[0] = '\0';
+	}
+	m_BotDecoration = false;
+	m_XmasHat = false;
+}
+
+bool CSkinDescriptor::CSixup::operator==(const CSixup &Other) const
+{
+	for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
+	{
+		if(str_comp(m_aaSkinPartNames[Part], Other.m_aaSkinPartNames[Part]) != 0)
+		{
+			return false;
+		}
+	}
+	return m_BotDecoration == Other.m_BotDecoration &&
+	       m_XmasHat == Other.m_XmasHat;
+}
+
 static float gs_SpriteWScale;
 static float gs_SpriteHScale;
 
@@ -270,7 +342,7 @@ void CRenderTools::GetRenderTeeOffsetToRenderedTee(const CAnimState *pAnim, cons
 
 void CRenderTools::RenderTee(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha) const
 {
-	if(pInfo->m_aSixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_BODY].IsValid())
+	if(pInfo->m_aSixup[g_Config.m_ClDummy].PartTexture(protocol7::SKINPART_BODY).IsValid())
 		RenderTee7(pAnim, pInfo, Emote, Dir, Pos, Alpha);
 	else
 		RenderTee6(pAnim, pInfo, Emote, Dir, Pos, Alpha);
@@ -329,9 +401,10 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 				}
 
 				// draw decoration
-				if(pInfo->m_aSixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_DECORATION].IsValid())
+				const IGraphics::CTextureHandle &DecorationTexture = pInfo->m_aSixup[g_Config.m_ClDummy].PartTexture(protocol7::SKINPART_DECORATION);
+				if(DecorationTexture.IsValid())
 				{
-					Graphics()->TextureSet(pInfo->m_aSixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_DECORATION]);
+					Graphics()->TextureSet(DecorationTexture);
 					Graphics()->QuadsBegin();
 					Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle * pi * 2);
 					Graphics()->SetColor(pInfo->m_aSixup[g_Config.m_ClDummy].m_aColors[protocol7::SKINPART_DECORATION].WithAlpha(Alpha));
@@ -342,7 +415,8 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 				}
 
 				// draw body (behind marking)
-				Graphics()->TextureSet(pInfo->m_aSixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_BODY]);
+				const IGraphics::CTextureHandle &BodyTexture = pInfo->m_aSixup[g_Config.m_ClDummy].PartTexture(protocol7::SKINPART_BODY);
+				Graphics()->TextureSet(BodyTexture);
 				Graphics()->QuadsBegin();
 				Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle * pi * 2);
 				if(OutLine)
@@ -360,9 +434,10 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 				Graphics()->QuadsEnd();
 
 				// draw marking
-				if(pInfo->m_aSixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_MARKING].IsValid() && !OutLine)
+				const IGraphics::CTextureHandle &MarkingTexture = pInfo->m_aSixup[g_Config.m_ClDummy].PartTexture(protocol7::SKINPART_MARKING);
+				if(MarkingTexture.IsValid() && !OutLine)
 				{
-					Graphics()->TextureSet(pInfo->m_aSixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_MARKING]);
+					Graphics()->TextureSet(MarkingTexture);
 					Graphics()->QuadsBegin();
 					Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle * pi * 2);
 					ColorRGBA MarkingColor = pInfo->m_aSixup[g_Config.m_ClDummy].m_aColors[protocol7::SKINPART_MARKING];
@@ -376,7 +451,7 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 				// draw body (in front of marking)
 				if(!OutLine)
 				{
-					Graphics()->TextureSet(pInfo->m_aSixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_BODY]);
+					Graphics()->TextureSet(BodyTexture);
 					Graphics()->QuadsBegin();
 					Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle * pi * 2);
 					Graphics()->SetColor(1.0f, 1.0f, 1.0f, Alpha);
@@ -390,7 +465,7 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 				}
 
 				// draw eyes
-				Graphics()->TextureSet(pInfo->m_aSixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_EYES]);
+				Graphics()->TextureSet(pInfo->m_aSixup[g_Config.m_ClDummy].PartTexture(protocol7::SKINPART_EYES));
 				Graphics()->QuadsBegin();
 				Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle * pi * 2);
 				if(IsBot)
@@ -460,7 +535,7 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 			}
 
 			// draw feet
-			Graphics()->TextureSet(pInfo->m_aSixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_FEET]);
+			Graphics()->TextureSet(pInfo->m_aSixup[g_Config.m_ClDummy].PartTexture(protocol7::SKINPART_FEET));
 			Graphics()->QuadsBegin();
 			const CAnimKeyframe *pFoot = Filling ? pAnim->GetFrontFoot() : pAnim->GetBackFoot();
 

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -12,6 +12,9 @@
 #include <game/client/ui_rect.h>
 #include <game/generated/protocol7.h>
 
+#include <functional>
+#include <memory>
+
 class CAnimState;
 class CSpeedupTile;
 class CSwitchTile;
@@ -29,6 +32,38 @@ class CMapItemGroup;
 class CQuad;
 
 #include <game/generated/protocol.h>
+
+class CSkinDescriptor
+{
+public:
+	enum
+	{
+		FLAG_SIX = 1,
+		FLAG_SEVEN = 2,
+	};
+	unsigned m_Flags;
+
+	char m_aSkinName[MAX_SKIN_LENGTH];
+
+	class CSixup
+	{
+	public:
+		char m_aaSkinPartNames[protocol7::NUM_SKINPARTS][protocol7::MAX_SKIN_LENGTH];
+		bool m_BotDecoration;
+		bool m_XmasHat;
+
+		void Reset();
+		bool operator==(const CSixup &Other) const;
+		bool operator!=(const CSixup &Other) const { return !(*this == Other); }
+	};
+	CSixup m_aSixup[NUM_DUMMIES];
+
+	CSkinDescriptor();
+	void Reset();
+	bool IsValid() const;
+	bool operator==(const CSkinDescriptor &Other) const;
+	bool operator!=(const CSkinDescriptor &Other) const { return !(*this == Other); }
+};
 
 class CTeeRenderInfo
 {
@@ -104,33 +139,60 @@ public:
 	public:
 		void Reset()
 		{
-			for(auto &Texture : m_aTextures)
-				Texture = IGraphics::CTextureHandle();
-			m_BotTexture = IGraphics::CTextureHandle();
-			for(ColorRGBA &PartColor : m_aColors)
+			for(auto &Texture : m_aOriginalTextures)
 			{
-				PartColor = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+				Texture.Invalidate();
 			}
+			for(auto &Texture : m_aColorableTextures)
+			{
+				Texture.Invalidate();
+			}
+			std::fill(std::begin(m_aUseCustomColors), std::end(m_aUseCustomColors), false);
+			std::fill(std::begin(m_aColors), std::end(m_aColors), ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f));
+			m_BloodColor = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+			m_HatTexture.Invalidate();
+			m_BotTexture.Invalidate();
 			m_HatSpriteIndex = 0;
 			m_BotColor = ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f);
 		}
-		bool Valid() const
-		{
-			for(const auto &Texture : m_aTextures)
-				if(!Texture.IsValid())
-					return false;
-			return true;
-		}
 
-		IGraphics::CTextureHandle m_aTextures[protocol7::NUM_SKINPARTS];
+		IGraphics::CTextureHandle m_aOriginalTextures[protocol7::NUM_SKINPARTS];
+		IGraphics::CTextureHandle m_aColorableTextures[protocol7::NUM_SKINPARTS];
+		bool m_aUseCustomColors[protocol7::NUM_SKINPARTS];
 		ColorRGBA m_aColors[protocol7::NUM_SKINPARTS];
+		ColorRGBA m_BloodColor;
 		IGraphics::CTextureHandle m_HatTexture;
 		IGraphics::CTextureHandle m_BotTexture;
 		int m_HatSpriteIndex;
 		ColorRGBA m_BotColor;
+
+		const IGraphics::CTextureHandle &PartTexture(int Part) const
+		{
+			return (m_aUseCustomColors[Part] ? m_aColorableTextures : m_aOriginalTextures)[Part];
+		}
 	};
 
 	CSixup m_aSixup[NUM_DUMMIES];
+};
+
+class CManagedTeeRenderInfo
+{
+	friend class CGameClient;
+	CTeeRenderInfo m_TeeRenderInfo;
+	CSkinDescriptor m_SkinDescriptor;
+	std::function<void()> m_RefreshCallback = nullptr;
+
+public:
+	CManagedTeeRenderInfo(const CTeeRenderInfo &TeeRenderInfo, const CSkinDescriptor &SkinDescriptor) :
+		m_TeeRenderInfo(TeeRenderInfo),
+		m_SkinDescriptor(SkinDescriptor)
+	{
+	}
+
+	CTeeRenderInfo &TeeRenderInfo() { return m_TeeRenderInfo; }
+	const CTeeRenderInfo &TeeRenderInfo() const { return m_TeeRenderInfo; }
+	const CSkinDescriptor &SkinDescriptor() const { return m_SkinDescriptor; }
+	void SetRefreshCallback(const std::function<void()> &RefreshCallback) { m_RefreshCallback = RefreshCallback; }
 };
 
 // Tee Render Flags


### PR DESCRIPTION
Skin loading and refreshing
---------------------------

Add `CSkinDescriptor` class to describe the information related to the skin textures of a `CTeeRenderInfo` so the skin textures can be refreshed independently from the other attributes. Add `CManagedTeeRenderInfo` class as wrapper for a `CTeeRenderInfo` and a corresponding `CSkinDescriptor`. Instances of `CManagedTeeRenderInfo` are managed as `std::shared_ptr`s by the gameclient. This allows skin textures of all `CManagedTeeRenderInfo`s to be refreshed dynamically when the underlying skin is refreshed. This replaces the existing `CComponent::OnRefreshSkin` callback function in which all skins had to be refreshed. This allows dynamically loading and unloading individual skins, to support lazy loading and unloading of skins in the future. This fixes skins not being shown for existing chat messages when toggling the `cl_chat_old` setting. This also fixes downloaded skins not being updated for info messages, chat messages and ghosts.

Improve the skin loading by finishing the jobs of downloaded skins at the beginning of each frame instead of whenever skins are being retrieved. This avoids jobs never being finished if a skin currently being loaded stops being used. Furthermore, this allows to limit the number of skins being loaded per frame based on the elapsed frame time to reduce the FPS impact of skin loading.

Avoid refreshing the skin info of active players every time that a player info snap object is processed. Instead, update the skin info of active players after processing all snap objects but only update the skin textures when the skin was changed to avoid many `CSkins::Find` calls happening every frame for every player.

0.7 skin improvements
---------------------

Support refreshing 0.7 skins, skin parts, as well as the xmas hat and bot decoration and refactor the 0.7 skin loading in general. Refreshing 0.7 skins is implemented as described above for 0.6 skins. The `CSkinDescriptor` class describes the textures of both 0.6 and 0.7 skins. Also log the skin part type in error messages as the part name alone is not unique. Closes #8750.

Use the correct skin blood color for the player death effect with 0.7 skins, which was previously the default color white.

Move operator definitions to the source file to avoid the implicit `system.h` dependency in header. Avoid duplicate code by adding `CSkins7::ApplyColorTo` and `CSkins7::CSkinPart::ApplyTo` functions. Extract `CSkins7::LoadSkin` and `CSkins7::LoadSkinPart` functions for readability.

General changes
---------------

Add member variable for client ID and pointer to gameclient to the `CClientData` class. This avoids passing `IsTeamPlay` as a parameter to the `CClientData::UpdateRenderInfo` function and allows adding more functions directly to the `CClientData` class for better modularity.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
