### PR TITLE
Improve order of CI style checks, minor refactoring

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,7 +243,7 @@ jobs:
     - name: Validate Gradle Wrapper
       uses: gradle/actions/wrapper-validation@v4
 
-    - name: Prepare
+    - name: Prepare Linux
       run: |
         sudo apt-get update -y
         sudo apt-get install cmake ninja-build openjdk-21-jdk p7zip-full curl glslang-tools openssl
@@ -277,7 +277,10 @@ jobs:
         mv cmdline-tools latest
         yes | latest/bin/sdkmanager --licenses
 
-    - name: Build
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
+
+    - name: Build Android app
       env:
         TW_KEY_NAME: /home/runner/DDNet.jks
         TW_KEY_ALIAS: DDNet-Key

--- a/.github/workflows/clang-sanitizer.yml
+++ b/.github/workflows/clang-sanitizer.yml
@@ -14,16 +14,19 @@ jobs:
     env:
       CARGO_HTTP_MULTIPLEXING: false
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
       with:
         submodules: true
 
-    - name: Prepare linux
+    - name: Prepare Linux
       run: |
         sudo apt-get update -y
         sudo apt-get install pkg-config cmake ninja-build libfreetype6-dev libnotify-dev libsdl2-dev libsqlite3-dev libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev libx264-dev libvulkan-dev glslang-tools spirv-tools libglew-dev -y
+
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
+
     - name: Build with ASan and UBSan
       run: |
         mkdir clang-sanitizer
@@ -34,6 +37,7 @@ jobs:
         export CFLAGS="-fsanitize=address,undefined -fsanitize-recover=address,undefined -fno-omit-frame-pointer"
         cmake -DCMAKE_BUILD_TYPE=Debug -DHEADLESS_CLIENT=ON -Werror=dev -DDOWNLOAD_GTEST=ON -DDEV=ON -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG=. ..
         make -j"$(nproc)"
+
     - name: Run server and headless client with ASan and UBSan
       run: |
         cd clang-sanitizer
@@ -47,6 +51,7 @@ jobs:
           cat ./SAN.*
           exit 1
         fi
+
     - name: Run unit tests with ASan and UBSan
       run: |
         cd clang-sanitizer
@@ -57,6 +62,7 @@ jobs:
           cat ./SAN.*
           exit 1
         fi
+
     - name: Run integration tests with ASan and UBSan
       run: |
         cd clang-sanitizer

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -14,11 +14,12 @@ jobs:
     env:
       CARGO_HTTP_MULTIPLEXING: false
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
       with:
         submodules: true
 
-    - name: Install clang-tidy
+    - name: Prepare Linux
       run: |
         sudo apt-get update -y
         sudo apt-get install pkg-config cmake ninja-build libfreetype6-dev libnotify-dev libsdl2-dev libsqlite3-dev libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev libx264-dev clang-tidy libvulkan-dev glslang-tools spirv-tools libglew-dev -y

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,8 @@ jobs:
     env:
       CARGO_HTTP_MULTIPLEXING: false
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
     - name: Run Rustdoc
@@ -22,8 +23,13 @@ jobs:
 
   rustfmt:
     runs-on: ubuntu-latest
+    env:
+      CARGO_HTTP_MULTIPLEXING: false
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
     - name: Run Rustfmt
       run:
         cargo fmt -- --check
@@ -37,11 +43,10 @@ jobs:
         checks:
           - advisories
           - bans licenses sources
-
     continue-on-error: ${{ matrix.checks == 'advisories' }}
-
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
     - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -14,10 +14,12 @@ jobs:
     env:
       CARGO_HTTP_MULTIPLEXING: false
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository
+      uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Prepare
+
+    - name: Prepare Linux
       run: |
         sudo apt-get update -y
         sudo apt-get install ddnet-tools shellcheck pkg-config cmake ninja-build libfreetype6-dev libnotify-dev libsdl2-dev libsqlite3-dev libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev libx264-dev python3-clang libvulkan-dev glslang-tools spirv-tools libglew-dev -y
@@ -29,48 +31,42 @@ jobs:
         chmod +x ~/.local/bin/clang-format
         wget -O ~/.local/bin/shfmt https://github.com/mvdan/sh/releases/download/v3.8.0/shfmt_v3.8.0_linux_amd64
         chmod +x ~/.local/bin/shfmt
-        git clone https://gitlab.com/Patiga/twmap.git/
-        cd twmap/twmap-tools
-        cargo install --locked --path=.
-        cd ../..
-        rm -rf twmap
-        mkdir release
-        cd release
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DDOWNLOAD_GTEST=OFF -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=. ..
-        cmake --build . --config Release --target dilate
-    - name: Check clang-format
-      run: clang-format -version
-    - name: Check fix_style
-      run: scripts/fix_style.py --dry-run
-    - name: Check header guards
-      run: scripts/check_header_guards.py
-    - name: Validate Languages
-      run: scripts/languages/validate.py
-    - name: Check languages
-      run: scripts/languages/update_all.py
-    - name: Check dilated images
-      run: scripts/check_dilate.py release data
-    - name: Check absolute includes
-      run: "! grep --exclude-dir rust-bridge -rE '^#include \"(antibot|base|engine|game|steam|test)/' src/"
-    - name: Check standard header includes
-      run: scripts/check_standard_headers.sh
-    - name: Check config variables
-      run: scripts/check_config_variables.py
-    # TODO: Enable on release branches
-    #- name: Out-of-date translations
-    #  run: |
-    #    cp -a data/languages data/languages.orig
-    #    scripts/languages/update_all.py
-    #    diff_lang=$(diff data/languages.orig data/languages)
-    #    if [ -n "$diff_lang" ]; then
-    #      echo "Update translations:\n$diff_lang"
-    #      exit 1
-    #    fi
+
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
+
+    - name: Check code style (ClangFormat)
+      run: |
+        clang-format -version
+        scripts/fix_style.py --dry-run
+
     - name: Shellcheck
       run: find . -type f -name '*.sh' -print0 | xargs -0 shellcheck
+
     - name: Shell format (shfmt)
       run: find . -type f -name '*.sh' -print0 | xargs -0 shfmt -d
-    - name: Check log error case
+
+    - name: Pylint
+      run: |
+        pylint --version
+        find . -type f -name "*.py" -not -path './ddnet-libs/*' -not -path './googletest-src/*' -print0 | xargs -0 pylint
+
+    - name: Check header guards
+      run: scripts/check_header_guards.py
+
+    - name: Unused header files
+      run: scripts/check_unused_header_files.py
+
+    - name: Check standard header includes
+      run: scripts/check_standard_headers.sh
+
+    - name: Check absolute includes
+      run: "! grep --exclude-dir rust-bridge -rE '^#include \"(antibot|base|engine|game|steam|test)/' src/"
+
+    - name: Check config variables
+      run: scripts/check_config_variables.py
+
+    - name: Check log error format
       run: |
         if grep -Eqr '(msg|Print).*\(.*"[Ee]rror:' src/;
         then
@@ -79,12 +75,31 @@ jobs:
           grep -Er '(msg|Print).*\(.*"[Ee]rror:' src/
           exit 1
         fi
-    - name: Pylint
+
+    - name: Validate languages
+      run: scripts/languages/validate.py
+
+    - name: Check languages
+      run: scripts/languages/update_all.py
+
+    - name: Build dilate tool
       run: |
-        pylint --version
-        find . -type f -name "*.py" -not -path './ddnet-libs/*' -not -path './googletest-src/*' -print0 | xargs -0 pylint
-    - name: Unused header files
-      run: scripts/check_unused_header_files.py
+        mkdir release
+        cd release
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DDOWNLOAD_GTEST=OFF -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=. ..
+        cmake --build . --config Release --target dilate
+
+    - name: Check dilated images
+      run: scripts/check_dilate.py release data
+
+    - name: Build twmap tool
+      run: |
+        git clone https://gitlab.com/Patiga/twmap.git/
+        cd twmap/twmap-tools
+        cargo install --locked --path=.
+        cd ../..
+        rm -rf twmap
+
     - name: Check maps
       run: |
         findings=$(find data -type f -name '*.map' ! -wholename 'data/maps/coverage.map' -print0 | xargs -0 ~/.cargo/bin/twmap-check-ddnet 2>&1 | \


### PR DESCRIPTION
Reorder and group steps of style CI to avoid unnecessary work when checks fail and to improve readability. First only install the necessary Linux dependencies and code formatters. Then perform various code format checks with ClangFormat, Shellcheck, shfmt and Pylint. Next perform additional code checks using custom scripts for headers files, includes, config variables and error messages. Last check languages, images, maps. Compile the dilate and twmap tools in separate steps directly before they are being used to avoid unnecessary work when previous checks fail.

Consistently name CI steps.

Consistently cache Rust dependencies in every CI run.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
