### PR TITLE
Fix editor weapon shield preview for custom entities

### DIFF
--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -15,16 +15,6 @@
 #include <game/localization.h>
 #include <game/mapitems.h>
 
-const char *const gs_apModEntitiesNames[] = {
-	"ddnet",
-	"ddrace",
-	"race",
-	"blockworlds",
-	"fng",
-	"vanilla",
-	"f-ddrace",
-};
-
 CMapImages::CMapImages()
 {
 	m_Count = 0;

--- a/src/game/client/components/mapimages.h
+++ b/src/game/client/components/mapimages.h
@@ -30,7 +30,15 @@ enum EMapImageModType
 	MAP_IMAGE_MOD_TYPE_COUNT,
 };
 
-extern const char *const gs_apModEntitiesNames[];
+constexpr const char *const gs_apModEntitiesNames[] = {
+	"ddnet",
+	"ddrace",
+	"race",
+	"blockworlds",
+	"fng",
+	"vanilla",
+	"f-ddrace",
+};
 
 class CMapImages : public CComponent
 {

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -8463,6 +8463,10 @@ void CEditor::RenderGameEntities(const std::shared_ptr<CLayerTiles> &pTiles)
 				   (Index >= ENTITY_ARMOR_SHOTGUN && Index <= ENTITY_ARMOR_LASER)))
 				continue;
 
+			const bool DDNetOrCustomEntities = std::find_if(std::begin(gs_apModEntitiesNames), std::end(gs_apModEntitiesNames),
+								   [&](const char *pEntitiesName) { return str_comp_nocase(m_SelectEntitiesImage.c_str(), pEntitiesName) == 0 &&
+													   str_comp_nocase(pEntitiesName, "ddnet") != 0; }) == std::end(gs_apModEntitiesNames);
+
 			vec2 Pos(x * TileSize, y * TileSize);
 			vec2 Scale;
 			int VisualSize;
@@ -8518,29 +8522,34 @@ void CEditor::RenderGameEntities(const std::shared_ptr<CLayerTiles> &pTiles)
 				VisualSize = 128;
 				Pos.x -= 10.0f;
 			}
-			else if(Index == ENTITY_ARMOR_SHOTGUN)
+			else if(DDNetOrCustomEntities)
 			{
-				Graphics()->TextureSet(pGameClient->m_GameSkin.m_SpritePickupArmorShotgun);
-				RenderTools()->GetSpriteScale(SPRITE_PICKUP_ARMOR_SHOTGUN, Scale.x, Scale.y);
-				VisualSize = 64;
-			}
-			else if(Index == ENTITY_ARMOR_GRENADE)
-			{
-				Graphics()->TextureSet(pGameClient->m_GameSkin.m_SpritePickupArmorGrenade);
-				RenderTools()->GetSpriteScale(SPRITE_PICKUP_ARMOR_GRENADE, Scale.x, Scale.y);
-				VisualSize = 64;
-			}
-			else if(Index == ENTITY_ARMOR_NINJA)
-			{
-				Graphics()->TextureSet(pGameClient->m_GameSkin.m_SpritePickupArmorNinja);
-				RenderTools()->GetSpriteScale(SPRITE_PICKUP_ARMOR_NINJA, Scale.x, Scale.y);
-				VisualSize = 64;
-			}
-			else if(Index == ENTITY_ARMOR_LASER)
-			{
-				Graphics()->TextureSet(pGameClient->m_GameSkin.m_SpritePickupArmorLaser);
-				RenderTools()->GetSpriteScale(SPRITE_PICKUP_ARMOR_LASER, Scale.x, Scale.y);
-				VisualSize = 64;
+				if(Index == ENTITY_ARMOR_SHOTGUN)
+				{
+					Graphics()->TextureSet(pGameClient->m_GameSkin.m_SpritePickupArmorShotgun);
+					RenderTools()->GetSpriteScale(SPRITE_PICKUP_ARMOR_SHOTGUN, Scale.x, Scale.y);
+					VisualSize = 64;
+				}
+				else if(Index == ENTITY_ARMOR_GRENADE)
+				{
+					Graphics()->TextureSet(pGameClient->m_GameSkin.m_SpritePickupArmorGrenade);
+					RenderTools()->GetSpriteScale(SPRITE_PICKUP_ARMOR_GRENADE, Scale.x, Scale.y);
+					VisualSize = 64;
+				}
+				else if(Index == ENTITY_ARMOR_NINJA)
+				{
+					Graphics()->TextureSet(pGameClient->m_GameSkin.m_SpritePickupArmorNinja);
+					RenderTools()->GetSpriteScale(SPRITE_PICKUP_ARMOR_NINJA, Scale.x, Scale.y);
+					VisualSize = 64;
+				}
+				else if(Index == ENTITY_ARMOR_LASER)
+				{
+					Graphics()->TextureSet(pGameClient->m_GameSkin.m_SpritePickupArmorLaser);
+					RenderTools()->GetSpriteScale(SPRITE_PICKUP_ARMOR_LASER, Scale.x, Scale.y);
+					VisualSize = 64;
+				}
+				else
+					continue;
 			}
 			else
 				continue;


### PR DESCRIPTION
"Show ingame entities" option will now only render weapon shields for DDNet and custom entities, as F-DDrace uses different tiles instead of shields

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
