### PR TITLE
Add delay to spectator count and exclude afk players

### DIFF
--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -80,6 +80,7 @@ void CHud::OnReset()
 	m_aPlayerSpeed[1] = 0;
 	m_aLastPlayerSpeedChange[0] = ESpeedChange::NONE;
 	m_aLastPlayerSpeedChange[1] = ESpeedChange::NONE;
+	m_LastSpectatorCountTick = 0;
 
 	ResetHudContainers();
 }
@@ -1283,6 +1284,13 @@ void CHud::RenderSpectatorCount()
 	}
 
 	if(Count == 0)
+	{
+		m_LastSpectatorCountTick = Client()->GameTick(g_Config.m_ClDummy);
+		return;
+	}
+
+	// 1 second delay
+	if(Client()->GameTick(g_Config.m_ClDummy) < m_LastSpectatorCountTick + Client()->GameTickSpeed())
 		return;
 
 	char aBuf[16];

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -76,6 +76,8 @@ class CHud : public CComponent
 
 	void PreparePlayerStateQuads();
 	void RenderPlayerState(const int ClientId);
+
+	int m_LastSpectatorCountTick;
 	void RenderSpectatorCount();
 	void RenderDummyActions();
 	void RenderMovementInformation();

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -435,8 +435,11 @@ void CPlayer::Snap(int SnappingClient)
 				int SpectatorCount = 0;
 				for(auto &pPlayer : GameServer()->m_apPlayers)
 				{
-					if(!pPlayer || pPlayer->m_ClientId == id || !(pPlayer->m_Paused || pPlayer->m_Team == TEAM_SPECTATORS))
+					if(!pPlayer || pPlayer->m_ClientId == id || pPlayer->m_Afk ||
+						!(pPlayer->m_Paused || pPlayer->m_Team == TEAM_SPECTATORS))
+					{
 						continue;
+					}
 
 					if(pPlayer->m_SpectatorId == id)
 					{


### PR DESCRIPTION
While the feature feels nice, there are some things I noticed when playing on servers with it:
It felt distracting when someone in spectator mode swept their mouse across the screen or spammed the spectate button, causing the icon to repeatedly pop up and disappear. So I added a clientside 1 second delay.
Also added, so the server won’t count afk players

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
