### PR TITLE
Fix DDNetSpectatorInfo unpack error

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -323,7 +323,7 @@ Objects = [
 		NetIntRange("m_Zoom", 0, 'max_int'),
 		NetIntRange("m_Deadzone", 0, 'max_int'),
 		NetIntRange("m_FollowFactor", 0, 'max_int'),
-		NetIntRange("m_SpectatorCount", 0, 'MAX_CLIENTS-1'),
+		NetIntRange("m_SpectatorCount", 0, 'MAX_CLIENTS-1', 0),
 	]),
 
 	## Events


### PR DESCRIPTION
Reported by @MilkeeyCat and thanks to @furo321 for helping me

Fixes this client issue on servers that are running on commits between spectator cursor and spectator count

![image](https://github.com/user-attachments/assets/6cc065d7-5c77-4607-9681-feec30a6aa16)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
