### PR TITLE
FPS counter makeover

### DIFF
--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -27,7 +27,7 @@
 CHud::CHud()
 {
 	// won't work if zero
-	m_FrameTimeAvg = 0.0f;
+	m_FpsLastUpdate = 0.0f;
 	m_FPSTextContainerIndex.Reset();
 	m_DDRaceEffectsTextContainerIndex.Reset();
 	m_PlayerAngleTextContainerIndex.Reset();
@@ -519,43 +519,42 @@ void CHud::RenderTextInfo()
 	if(IVideo::Current())
 		Showfps = 0;
 #endif
+	constexpr float FontSize = 5.0f;
+
 	if(Showfps)
 	{
-		// calculate avg. fps
-		m_FrameTimeAvg = m_FrameTimeAvg * 0.9f + Client()->RenderFrameTime() * 0.1f;
-		char aBuf[64];
-		int FrameTime = (int)(1.0f / m_FrameTimeAvg + 0.5f);
-		str_format(aBuf, sizeof(aBuf), "%d", FrameTime);
+		const float FrameTime = Client()->RenderFrameTime();
 
-		static float s_TextWidth0 = TextRender()->TextWidth(12.f, "0", -1, -1.0f);
-		static float s_TextWidth00 = TextRender()->TextWidth(12.f, "00", -1, -1.0f);
-		static float s_TextWidth000 = TextRender()->TextWidth(12.f, "000", -1, -1.0f);
-		static float s_TextWidth0000 = TextRender()->TextWidth(12.f, "0000", -1, -1.0f);
-		static float s_TextWidth00000 = TextRender()->TextWidth(12.f, "00000", -1, -1.0f);
-		static const float s_aTextWidth[5] = {s_TextWidth0, s_TextWidth00, s_TextWidth000, s_TextWidth0000, s_TextWidth00000};
+		if(Client()->GlobalTime() - m_FpsLastUpdate >= 0.15f) // Update counter every 150ms
+		{
+			const int FpsValue = round_to_int(1.0f / FrameTime);
+			m_FpsLastUpdate = Client()->GlobalTime();
 
-		int DigitIndex = GetDigitsIndex(FrameTime, 4);
+			char aBuf[64];
+			str_format(aBuf, sizeof(aBuf), Localize("%d FPS"), FpsValue);
 
-		CTextCursor Cursor;
-		TextRender()->SetCursor(&Cursor, m_Width - 10 - s_aTextWidth[DigitIndex], 5, 12, TEXTFLAG_RENDER);
-		Cursor.m_LineWidth = -1;
-		auto OldFlags = TextRender()->GetRenderFlags();
-		TextRender()->SetRenderFlags(OldFlags | TEXT_RENDER_FLAG_ONE_TIME_USE);
-		if(m_FPSTextContainerIndex.Valid())
-			TextRender()->RecreateTextContainerSoft(m_FPSTextContainerIndex, &Cursor, aBuf);
-		else
-			TextRender()->CreateTextContainer(m_FPSTextContainerIndex, &Cursor, "0");
-		TextRender()->SetRenderFlags(OldFlags);
+			CTextCursor Cursor;
+			TextRender()->SetCursor(&Cursor, 2.0f, 2.0f, FontSize, TEXTFLAG_RENDER);
+			Cursor.m_LineWidth = -1;
+			TextRender()->RecreateTextContainer(m_FPSTextContainerIndex, &Cursor, aBuf);
+		}
+
 		if(m_FPSTextContainerIndex.Valid())
 		{
 			TextRender()->RenderTextContainer(m_FPSTextContainerIndex, TextRender()->DefaultTextColor(), TextRender()->DefaultTextOutlineColor());
 		}
 	}
+
 	if(g_Config.m_ClShowpred && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 	{
+		float PredOffset = 0.0f;
+
+		if(Showfps)
+			PredOffset = TextRender()->TextWidth(FontSize, "00000 FPS") + 2.0f;
+
 		char aBuf[64];
-		str_format(aBuf, sizeof(aBuf), "%d", Client()->GetPredictionTime());
-		TextRender()->Text(m_Width - 10 - TextRender()->TextWidth(12, aBuf, -1, -1.0f), Showfps ? 20 : 5, 12, aBuf, -1.0f);
+		str_format(aBuf, sizeof(aBuf), Localize("Pred. %d ms", "Prediction time"), Client()->GetPredictionTime());
+		TextRender()->Text(2.0f + PredOffset, 2.0f, FontSize, aBuf, -1.0f);
 	}
 }
 
@@ -1371,24 +1370,6 @@ void CHud::RenderDummyActions()
 	}
 	Graphics()->TextureSet(m_pClient->m_HudSkin.m_SpriteHudDummyCopy);
 	Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_DummyCopyOffset, x, y);
-}
-
-inline int CHud::GetDigitsIndex(int Value, int Max)
-{
-	if(Value < 0)
-	{
-		Value *= -1;
-	}
-	int DigitsIndex = std::log10((Value ? Value : 1));
-	if(DigitsIndex > Max)
-	{
-		DigitsIndex = Max;
-	}
-	if(DigitsIndex < 0)
-	{
-		DigitsIndex = 0;
-	}
-	return DigitsIndex;
 }
 
 inline float CHud::GetMovementInformationBoxHeight()

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -43,8 +43,7 @@ struct SScoreInfo
 class CHud : public CComponent
 {
 	float m_Width, m_Height;
-	float m_FrameTimeAvg;
-
+	float m_FpsLastUpdate;
 	int m_HudQuadContainerIndex;
 	SScoreInfo m_aScoreInfo[2];
 	STextContainerIndex m_FPSTextContainerIndex;
@@ -127,7 +126,6 @@ private:
 	bool m_ShowFinishTime;
 
 	inline float GetMovementInformationBoxHeight();
-	inline int GetDigitsIndex(int Value, int Max);
 
 	// Quad Offsets
 	int m_aAmmoOffset[NUM_WEAPONS];

--- a/src/game/client/components/infomessages.cpp
+++ b/src/game/client/components/infomessages.cpp
@@ -448,13 +448,8 @@ void CInfoMessages::OnRender()
 	Graphics()->MapScreen(0, 0, Width, Height);
 	Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 
-	int Showfps = g_Config.m_ClShowfps;
-#if defined(CONF_VIDEORECORDER)
-	if(IVideo::Current())
-		Showfps = 0;
-#endif
 	const float StartX = Width - 10.0f;
-	const float StartY = 30.0f + (Showfps ? 100.0f : 0.0f) + (g_Config.m_ClShowpred && Client()->State() != IClient::STATE_DEMOPLAYBACK ? 100.0f : 0.0f);
+	constexpr float StartY = 30.0f;
 
 	float y = StartY;
 	for(int i = 1; i <= MAX_INFOMSGS; i++)


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
The fps counter is really out of place, pushes down the kill feed/info messages, it changes very aggressively, and is too big. I've changed that to have the fps display in the top left, make it smaller, and also only update it every 150ms to make it more readable. I've also changed `cl_showpred` to be displayed in a similar manner.

![image](https://github.com/user-attachments/assets/ed7219b8-5a2f-445b-9a96-34e7784fc75d)
![image](https://github.com/user-attachments/assets/c734d7ad-d5e0-491c-a1eb-173c780edd8c)
![image](https://github.com/user-attachments/assets/f5ed73ac-64c9-4d6f-ae9c-9f31dd7910c2)


<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)

