### PR TITLE
Add delay to mouseclick spectate in pvp modes

### DIFF
--- a/src/game/client/components/spectator.h
+++ b/src/game/client/components/spectator.h
@@ -26,6 +26,8 @@ class CSpectator : public CComponent
 
 	float m_MultiViewActivateDelay;
 
+	int m_LastAliveTick;
+
 	bool CanChangeSpectatorId();
 	void SpectateNext(bool Reverse);
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1453,6 +1453,7 @@ static CGameInfo GetGameInfo(const CNetObj_GameInfoEx *pInfoEx, int InfoExSize, 
 	Info.m_NoWeakHookAndBounce = false;
 	Info.m_NoSkinChangeForFrozen = false;
 	Info.m_DDRaceTeam = false;
+	Info.m_SpecAfterDeath = !Vanilla && !Race;
 
 	if(Version >= 0)
 	{

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -110,6 +110,8 @@ public:
 	bool m_NoSkinChangeForFrozen;
 
 	bool m_DDRaceTeam;
+
+	bool m_SpecAfterDeath;
 };
 
 class CSnapEntities


### PR DESCRIPTION
Closes #9733
When playing zCatch, spamming the left mouse button to shoot would always accidentally switch the target upon getting killed. This adds a 1 second delay in pvp modes after the character dies. I'm not sure if checking `m_pLocalCharacter->m_Tick` is the best way to implement this

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
