### PR TITLE
refactor: use upper camel case for `isAllowPlaceUnusedTiles`

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3805,7 +3805,7 @@ void CEditor::DoColorPickerButton(const void *pId, const CUIRect *pRect, ColorRG
 	}
 }
 
-bool CEditor::isAllowPlaceUnusedTiles() const
+bool CEditor::IsAllowPlaceUnusedTiles() const
 {
 	// explicit allow and implicit allow
 	return m_AllowPlaceUnusedTiles != EUnusedEntities::NOT_ALLOWED;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -631,7 +631,7 @@ public:
 		ALLOWED_EXPLICIT = 1,
 	};
 	EUnusedEntities m_AllowPlaceUnusedTiles;
-	bool isAllowPlaceUnusedTiles() const;
+	bool IsAllowPlaceUnusedTiles() const;
 
 	bool m_BrushDrawDestructive;
 

--- a/src/game/editor/mapitems/layer_front.cpp
+++ b/src/game/editor/mapitems/layer_front.cpp
@@ -19,7 +19,7 @@ void CLayerFront::SetTile(int x, int y, CTile Tile)
 		CTile air = {TILE_AIR};
 		m_pEditor->m_Map.m_pGameLayer->CLayerTiles::SetTile(x, y, air); // NOLINT(bugprone-parent-virtual-call)
 	}
-	if(m_pEditor->isAllowPlaceUnusedTiles() || IsValidFrontTile(Tile.m_Index))
+	if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidFrontTile(Tile.m_Index))
 	{
 		CLayerTiles::SetTile(x, y, Tile);
 	}

--- a/src/game/editor/mapitems/layer_game.cpp
+++ b/src/game/editor/mapitems/layer_game.cpp
@@ -48,7 +48,7 @@ void CLayerGame::SetTile(int x, int y, CTile Tile)
 			CTile air = {TILE_AIR};
 			m_pEditor->m_Map.m_pFrontLayer->CLayerTiles::SetTile(x, y, air); // NOLINT(bugprone-parent-virtual-call)
 		}
-		if(m_pEditor->isAllowPlaceUnusedTiles() || IsValidGameTile(Tile.m_Index))
+		if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidGameTile(Tile.m_Index))
 		{
 			CLayerTiles::SetTile(x, y, Tile);
 		}

--- a/src/game/editor/mapitems/layer_speedup.cpp
+++ b/src/game/editor/mapitems/layer_speedup.cpp
@@ -59,7 +59,7 @@ bool CLayerSpeedup::IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer)
 {
 	for(int y = 0; y < pLayer->m_Height; y++)
 		for(int x = 0; x < pLayer->m_Width; x++)
-			if(m_pEditor->isAllowPlaceUnusedTiles() || IsValidSpeedupTile(pLayer->GetTile(x, y).m_Index))
+			if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidSpeedupTile(pLayer->GetTile(x, y).m_Index))
 				return false;
 
 	return true;
@@ -102,7 +102,7 @@ void CLayerSpeedup::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 				m_pSpeedupTile[Index].m_Type,
 				m_pTiles[Index].m_Index};
 
-			if((m_pEditor->isAllowPlaceUnusedTiles() || IsValidSpeedupTile(pSpeedupLayer->m_pTiles[y * pSpeedupLayer->m_Width + x].m_Index)) && pSpeedupLayer->m_pTiles[y * pSpeedupLayer->m_Width + x].m_Index != TILE_AIR)
+			if((m_pEditor->IsAllowPlaceUnusedTiles() || IsValidSpeedupTile(pSpeedupLayer->m_pTiles[y * pSpeedupLayer->m_Width + x].m_Index)) && pSpeedupLayer->m_pTiles[y * pSpeedupLayer->m_Width + x].m_Index != TILE_AIR)
 			{
 				if(m_pEditor->m_SpeedupAngle != pSpeedupLayer->m_SpeedupAngle || m_pEditor->m_SpeedupForce != pSpeedupLayer->m_SpeedupForce || m_pEditor->m_SpeedupMaxSpeed != pSpeedupLayer->m_SpeedupMaxSpeed)
 				{
@@ -256,7 +256,7 @@ void CLayerSpeedup::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CU
 				m_pSpeedupTile[TgtIndex].m_Type,
 				m_pTiles[TgtIndex].m_Index};
 
-			if(Empty || (!m_pEditor->isAllowPlaceUnusedTiles() && !IsValidSpeedupTile((pLt->m_pTiles[SrcIndex]).m_Index))) // no speed up tile chosen: reset
+			if(Empty || (!m_pEditor->IsAllowPlaceUnusedTiles() && !IsValidSpeedupTile((pLt->m_pTiles[SrcIndex]).m_Index))) // no speed up tile chosen: reset
 			{
 				m_pTiles[TgtIndex].m_Index = 0;
 				m_pSpeedupTile[TgtIndex].m_Force = 0;

--- a/src/game/editor/mapitems/layer_switch.cpp
+++ b/src/game/editor/mapitems/layer_switch.cpp
@@ -61,7 +61,7 @@ bool CLayerSwitch::IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer)
 {
 	for(int y = 0; y < pLayer->m_Height; y++)
 		for(int x = 0; x < pLayer->m_Width; x++)
-			if(m_pEditor->isAllowPlaceUnusedTiles() || IsValidSwitchTile(pLayer->GetTile(x, y).m_Index))
+			if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidSwitchTile(pLayer->GetTile(x, y).m_Index))
 				return false;
 
 	return true;
@@ -103,7 +103,7 @@ void CLayerSwitch::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 				m_pSwitchTile[Index].m_Delay,
 				m_pTiles[Index].m_Index};
 
-			if((m_pEditor->isAllowPlaceUnusedTiles() || IsValidSwitchTile(pSwitchLayer->m_pTiles[y * pSwitchLayer->m_Width + x].m_Index)) && pSwitchLayer->m_pTiles[y * pSwitchLayer->m_Width + x].m_Index != TILE_AIR)
+			if((m_pEditor->IsAllowPlaceUnusedTiles() || IsValidSwitchTile(pSwitchLayer->m_pTiles[y * pSwitchLayer->m_Width + x].m_Index)) && pSwitchLayer->m_pTiles[y * pSwitchLayer->m_Width + x].m_Index != TILE_AIR)
 			{
 				if(m_pEditor->m_SwitchNum != pSwitchLayer->m_SwitchNumber || m_pEditor->m_SwitchDelay != pSwitchLayer->m_SwitchDelay)
 				{
@@ -264,7 +264,7 @@ void CLayerSwitch::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUI
 				m_pSwitchTile[TgtIndex].m_Delay,
 				m_pTiles[TgtIndex].m_Index};
 
-			if(Empty || (!m_pEditor->isAllowPlaceUnusedTiles() && !IsValidSwitchTile((pLt->m_pTiles[SrcIndex]).m_Index)))
+			if(Empty || (!m_pEditor->IsAllowPlaceUnusedTiles() && !IsValidSwitchTile((pLt->m_pTiles[SrcIndex]).m_Index)))
 			{
 				m_pTiles[TgtIndex].m_Index = 0;
 				m_pSwitchTile[TgtIndex].m_Type = 0;

--- a/src/game/editor/mapitems/layer_tele.cpp
+++ b/src/game/editor/mapitems/layer_tele.cpp
@@ -62,7 +62,7 @@ bool CLayerTele::IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer)
 {
 	for(int y = 0; y < pLayer->m_Height; y++)
 		for(int x = 0; x < pLayer->m_Width; x++)
-			if(m_pEditor->isAllowPlaceUnusedTiles() || IsValidTeleTile(pLayer->GetTile(x, y).m_Index))
+			if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidTeleTile(pLayer->GetTile(x, y).m_Index))
 				return false;
 
 	return true;
@@ -100,7 +100,7 @@ void CLayerTele::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 				m_pTiles[Index].m_Index};
 
 			unsigned char TgtIndex = pTeleLayer->m_pTiles[y * pTeleLayer->m_Width + x].m_Index;
-			if((m_pEditor->isAllowPlaceUnusedTiles() || IsValidTeleTile(TgtIndex)) && TgtIndex != TILE_AIR)
+			if((m_pEditor->IsAllowPlaceUnusedTiles() || IsValidTeleTile(TgtIndex)) && TgtIndex != TILE_AIR)
 			{
 				bool IsCheckpoint = IsTeleTileCheckpoint(TgtIndex);
 				if(!IsCheckpoint && !IsTeleTileNumberUsed(TgtIndex, false))
@@ -253,7 +253,7 @@ void CLayerTele::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRe
 				m_pTeleTile[TgtIndex].m_Type,
 				m_pTiles[TgtIndex].m_Index};
 
-			if(Empty || (!m_pEditor->isAllowPlaceUnusedTiles() && !IsValidTeleTile((pLt->m_pTiles[SrcIndex]).m_Index)))
+			if(Empty || (!m_pEditor->IsAllowPlaceUnusedTiles() && !IsValidTeleTile((pLt->m_pTiles[SrcIndex]).m_Index)))
 			{
 				m_pTiles[TgtIndex].m_Index = 0;
 				m_pTeleTile[TgtIndex].m_Type = 0;

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -235,12 +235,12 @@ bool CLayerTiles::IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer)
 			{
 				if(pLayer->m_Game)
 				{
-					if(m_pEditor->isAllowPlaceUnusedTiles() || IsValidGameTile(Index))
+					if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidGameTile(Index))
 						return false;
 				}
 				else if(pLayer->m_Front)
 				{
-					if(m_pEditor->isAllowPlaceUnusedTiles() || IsValidFrontTile(Index))
+					if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidFrontTile(Index))
 						return false;
 				}
 				else
@@ -550,7 +550,7 @@ void CLayerTiles::BrushFlipX()
 	if(m_Tele || m_Speedup || m_Tune)
 		return;
 
-	bool Rotate = !(m_Game || m_Front || m_Switch) || m_pEditor->isAllowPlaceUnusedTiles();
+	bool Rotate = !(m_Game || m_Front || m_Switch) || m_pEditor->IsAllowPlaceUnusedTiles();
 	for(int y = 0; y < m_Height; y++)
 		for(int x = 0; x < m_Width; x++)
 			if(!Rotate && !IsRotatableTile(m_pTiles[y * m_Width + x].m_Index))
@@ -566,7 +566,7 @@ void CLayerTiles::BrushFlipY()
 	if(m_Tele || m_Speedup || m_Tune)
 		return;
 
-	bool Rotate = !(m_Game || m_Front || m_Switch) || m_pEditor->isAllowPlaceUnusedTiles();
+	bool Rotate = !(m_Game || m_Front || m_Switch) || m_pEditor->IsAllowPlaceUnusedTiles();
 	for(int y = 0; y < m_Height; y++)
 		for(int x = 0; x < m_Width; x++)
 			if(!Rotate && !IsRotatableTile(m_pTiles[y * m_Width + x].m_Index))
@@ -587,7 +587,7 @@ void CLayerTiles::BrushRotate(float Amount)
 		CTile *pTempData = new CTile[m_Width * m_Height];
 		mem_copy(pTempData, m_pTiles, (size_t)m_Width * m_Height * sizeof(CTile));
 		CTile *pDst = m_pTiles;
-		bool Rotate = !(m_Game || m_Front) || m_pEditor->isAllowPlaceUnusedTiles();
+		bool Rotate = !(m_Game || m_Front) || m_pEditor->IsAllowPlaceUnusedTiles();
 		for(int x = 0; x < m_Width; ++x)
 			for(int y = m_Height - 1; y >= 0; --y, ++pDst)
 			{

--- a/src/game/editor/mapitems/layer_tune.cpp
+++ b/src/game/editor/mapitems/layer_tune.cpp
@@ -59,7 +59,7 @@ bool CLayerTune::IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer)
 {
 	for(int y = 0; y < pLayer->m_Height; y++)
 		for(int x = 0; x < pLayer->m_Width; x++)
-			if(m_pEditor->isAllowPlaceUnusedTiles() || IsValidTuneTile(pLayer->GetTile(x, y).m_Index))
+			if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidTuneTile(pLayer->GetTile(x, y).m_Index))
 				return false;
 
 	return true;
@@ -98,7 +98,7 @@ void CLayerTune::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 				m_pTuneTile[Index].m_Type,
 				m_pTiles[Index].m_Index};
 
-			if((m_pEditor->isAllowPlaceUnusedTiles() || IsValidTuneTile(pTuneLayer->m_pTiles[y * pTuneLayer->m_Width + x].m_Index)) && pTuneLayer->m_pTiles[y * pTuneLayer->m_Width + x].m_Index != TILE_AIR)
+			if((m_pEditor->IsAllowPlaceUnusedTiles() || IsValidTuneTile(pTuneLayer->m_pTiles[y * pTuneLayer->m_Width + x].m_Index)) && pTuneLayer->m_pTiles[y * pTuneLayer->m_Width + x].m_Index != TILE_AIR)
 			{
 				if(m_pEditor->m_TuningNum != pTuneLayer->m_TuningNumber)
 				{
@@ -233,7 +233,7 @@ void CLayerTune::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRe
 				m_pTuneTile[TgtIndex].m_Type,
 				m_pTiles[TgtIndex].m_Index};
 
-			if(Empty || (!m_pEditor->isAllowPlaceUnusedTiles() && !IsValidTuneTile((pLt->m_pTiles[SrcIndex]).m_Index)))
+			if(Empty || (!m_pEditor->IsAllowPlaceUnusedTiles() && !IsValidTuneTile((pLt->m_pTiles[SrcIndex]).m_Index)))
 			{
 				m_pTiles[TgtIndex].m_Index = 0;
 				m_pTuneTile[TgtIndex].m_Type = 0;


### PR DESCRIPTION
use upper camel case for `isAllowPlaceUnusedTiles` method


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
