### PR TITLE
Editor: Use auxiliary variables in `BrushDraw()` to replace expressions in array indices for readability

### DIFF
--- a/src/game/editor/mapitems/layer_speedup.cpp
+++ b/src/game/editor/mapitems/layer_speedup.cpp
@@ -94,67 +94,69 @@ void CLayerSpeedup::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 			if(!Destructive && GetTile(fx, fy).m_Index)
 				continue;
 
-			int Index = fy * m_Width + fx;
-			SSpeedupTileStateChange::SData Previous{
-				m_pSpeedupTile[Index].m_Force,
-				m_pSpeedupTile[Index].m_Angle,
-				m_pSpeedupTile[Index].m_MaxSpeed,
-				m_pSpeedupTile[Index].m_Type,
-				m_pTiles[Index].m_Index};
+			const int SrcIndex = y * pSpeedupLayer->m_Width + x;
+			const int TgtIndex = fy * m_Width + fx;
 
-			if((m_pEditor->IsAllowPlaceUnusedTiles() || IsValidSpeedupTile(pSpeedupLayer->m_pTiles[y * pSpeedupLayer->m_Width + x].m_Index)) && pSpeedupLayer->m_pTiles[y * pSpeedupLayer->m_Width + x].m_Index != TILE_AIR)
+			SSpeedupTileStateChange::SData Previous{
+				m_pSpeedupTile[TgtIndex].m_Force,
+				m_pSpeedupTile[TgtIndex].m_Angle,
+				m_pSpeedupTile[TgtIndex].m_MaxSpeed,
+				m_pSpeedupTile[TgtIndex].m_Type,
+				m_pTiles[TgtIndex].m_Index};
+
+			if((m_pEditor->IsAllowPlaceUnusedTiles() || IsValidSpeedupTile(pSpeedupLayer->m_pTiles[SrcIndex].m_Index)) && pSpeedupLayer->m_pTiles[SrcIndex].m_Index != TILE_AIR)
 			{
 				if(m_pEditor->m_SpeedupAngle != pSpeedupLayer->m_SpeedupAngle || m_pEditor->m_SpeedupForce != pSpeedupLayer->m_SpeedupForce || m_pEditor->m_SpeedupMaxSpeed != pSpeedupLayer->m_SpeedupMaxSpeed)
 				{
-					m_pSpeedupTile[Index].m_Force = m_pEditor->m_SpeedupForce;
-					m_pSpeedupTile[Index].m_MaxSpeed = m_pEditor->m_SpeedupMaxSpeed;
-					m_pSpeedupTile[Index].m_Angle = m_pEditor->m_SpeedupAngle;
-					m_pSpeedupTile[Index].m_Type = pSpeedupLayer->m_pTiles[y * pSpeedupLayer->m_Width + x].m_Index;
-					m_pTiles[Index].m_Index = pSpeedupLayer->m_pTiles[y * pSpeedupLayer->m_Width + x].m_Index;
+					m_pSpeedupTile[TgtIndex].m_Force = m_pEditor->m_SpeedupForce;
+					m_pSpeedupTile[TgtIndex].m_MaxSpeed = m_pEditor->m_SpeedupMaxSpeed;
+					m_pSpeedupTile[TgtIndex].m_Angle = m_pEditor->m_SpeedupAngle;
+					m_pSpeedupTile[TgtIndex].m_Type = pSpeedupLayer->m_pTiles[SrcIndex].m_Index;
+					m_pTiles[TgtIndex].m_Index = pSpeedupLayer->m_pTiles[SrcIndex].m_Index;
 				}
-				else if(pSpeedupLayer->m_pSpeedupTile[y * pSpeedupLayer->m_Width + x].m_Force)
+				else if(pSpeedupLayer->m_pSpeedupTile[SrcIndex].m_Force)
 				{
-					m_pSpeedupTile[Index].m_Force = pSpeedupLayer->m_pSpeedupTile[y * pSpeedupLayer->m_Width + x].m_Force;
-					m_pSpeedupTile[Index].m_Angle = pSpeedupLayer->m_pSpeedupTile[y * pSpeedupLayer->m_Width + x].m_Angle;
-					m_pSpeedupTile[Index].m_MaxSpeed = pSpeedupLayer->m_pSpeedupTile[y * pSpeedupLayer->m_Width + x].m_MaxSpeed;
-					m_pSpeedupTile[Index].m_Type = pSpeedupLayer->m_pTiles[y * pSpeedupLayer->m_Width + x].m_Index;
-					m_pTiles[Index].m_Index = pSpeedupLayer->m_pTiles[y * pSpeedupLayer->m_Width + x].m_Index;
+					m_pSpeedupTile[TgtIndex].m_Force = pSpeedupLayer->m_pSpeedupTile[SrcIndex].m_Force;
+					m_pSpeedupTile[TgtIndex].m_Angle = pSpeedupLayer->m_pSpeedupTile[SrcIndex].m_Angle;
+					m_pSpeedupTile[TgtIndex].m_MaxSpeed = pSpeedupLayer->m_pSpeedupTile[SrcIndex].m_MaxSpeed;
+					m_pSpeedupTile[TgtIndex].m_Type = pSpeedupLayer->m_pTiles[SrcIndex].m_Index;
+					m_pTiles[TgtIndex].m_Index = pSpeedupLayer->m_pTiles[SrcIndex].m_Index;
 				}
 				else if(m_pEditor->m_SpeedupForce)
 				{
-					m_pSpeedupTile[Index].m_Force = m_pEditor->m_SpeedupForce;
-					m_pSpeedupTile[Index].m_MaxSpeed = m_pEditor->m_SpeedupMaxSpeed;
-					m_pSpeedupTile[Index].m_Angle = m_pEditor->m_SpeedupAngle;
-					m_pSpeedupTile[Index].m_Type = pSpeedupLayer->m_pTiles[y * pSpeedupLayer->m_Width + x].m_Index;
-					m_pTiles[Index].m_Index = pSpeedupLayer->m_pTiles[y * pSpeedupLayer->m_Width + x].m_Index;
+					m_pSpeedupTile[TgtIndex].m_Force = m_pEditor->m_SpeedupForce;
+					m_pSpeedupTile[TgtIndex].m_MaxSpeed = m_pEditor->m_SpeedupMaxSpeed;
+					m_pSpeedupTile[TgtIndex].m_Angle = m_pEditor->m_SpeedupAngle;
+					m_pSpeedupTile[TgtIndex].m_Type = pSpeedupLayer->m_pTiles[SrcIndex].m_Index;
+					m_pTiles[TgtIndex].m_Index = pSpeedupLayer->m_pTiles[SrcIndex].m_Index;
 				}
 				else
 				{
-					m_pSpeedupTile[Index].m_Force = 0;
-					m_pSpeedupTile[Index].m_MaxSpeed = 0;
-					m_pSpeedupTile[Index].m_Angle = 0;
-					m_pSpeedupTile[Index].m_Type = 0;
-					m_pTiles[Index].m_Index = 0;
+					m_pSpeedupTile[TgtIndex].m_Force = 0;
+					m_pSpeedupTile[TgtIndex].m_MaxSpeed = 0;
+					m_pSpeedupTile[TgtIndex].m_Angle = 0;
+					m_pSpeedupTile[TgtIndex].m_Type = 0;
+					m_pTiles[TgtIndex].m_Index = 0;
 				}
 			}
 			else
 			{
-				m_pSpeedupTile[Index].m_Force = 0;
-				m_pSpeedupTile[Index].m_MaxSpeed = 0;
-				m_pSpeedupTile[Index].m_Angle = 0;
-				m_pSpeedupTile[Index].m_Type = 0;
-				m_pTiles[Index].m_Index = 0;
+				m_pSpeedupTile[TgtIndex].m_Force = 0;
+				m_pSpeedupTile[TgtIndex].m_MaxSpeed = 0;
+				m_pSpeedupTile[TgtIndex].m_Angle = 0;
+				m_pSpeedupTile[TgtIndex].m_Type = 0;
+				m_pTiles[TgtIndex].m_Index = 0;
 
-				if(pSpeedupLayer->m_pTiles[y * pSpeedupLayer->m_Width + x].m_Index != TILE_AIR)
+				if(pSpeedupLayer->m_pTiles[SrcIndex].m_Index != TILE_AIR)
 					ShowPreventUnusedTilesWarning();
 			}
 
 			SSpeedupTileStateChange::SData Current{
-				m_pSpeedupTile[Index].m_Force,
-				m_pSpeedupTile[Index].m_Angle,
-				m_pSpeedupTile[Index].m_MaxSpeed,
-				m_pSpeedupTile[Index].m_Type,
-				m_pTiles[Index].m_Index};
+				m_pSpeedupTile[TgtIndex].m_Force,
+				m_pSpeedupTile[TgtIndex].m_Angle,
+				m_pSpeedupTile[TgtIndex].m_MaxSpeed,
+				m_pSpeedupTile[TgtIndex].m_Type,
+				m_pTiles[TgtIndex].m_Index};
 
 			RecordStateChange(fx, fy, Previous, Current);
 		}

--- a/src/game/editor/mapitems/layer_switch.cpp
+++ b/src/game/editor/mapitems/layer_switch.cpp
@@ -95,68 +95,70 @@ void CLayerSwitch::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 			if(!Destructive && GetTile(fx, fy).m_Index)
 				continue;
 
-			int Index = fy * m_Width + fx;
-			SSwitchTileStateChange::SData Previous{
-				m_pSwitchTile[Index].m_Number,
-				m_pSwitchTile[Index].m_Type,
-				m_pSwitchTile[Index].m_Flags,
-				m_pSwitchTile[Index].m_Delay,
-				m_pTiles[Index].m_Index};
+			const int SrcIndex = y * pSwitchLayer->m_Width + x;
+			const int TgtIndex = fy * m_Width + fx;
 
-			if((m_pEditor->IsAllowPlaceUnusedTiles() || IsValidSwitchTile(pSwitchLayer->m_pTiles[y * pSwitchLayer->m_Width + x].m_Index)) && pSwitchLayer->m_pTiles[y * pSwitchLayer->m_Width + x].m_Index != TILE_AIR)
+			SSwitchTileStateChange::SData Previous{
+				m_pSwitchTile[TgtIndex].m_Number,
+				m_pSwitchTile[TgtIndex].m_Type,
+				m_pSwitchTile[TgtIndex].m_Flags,
+				m_pSwitchTile[TgtIndex].m_Delay,
+				m_pTiles[TgtIndex].m_Index};
+
+			if((m_pEditor->IsAllowPlaceUnusedTiles() || IsValidSwitchTile(pSwitchLayer->m_pTiles[SrcIndex].m_Index)) && pSwitchLayer->m_pTiles[SrcIndex].m_Index != TILE_AIR)
 			{
 				if(m_pEditor->m_SwitchNum != pSwitchLayer->m_SwitchNumber || m_pEditor->m_SwitchDelay != pSwitchLayer->m_SwitchDelay)
 				{
-					m_pSwitchTile[Index].m_Number = m_pEditor->m_SwitchNum;
-					m_pSwitchTile[Index].m_Delay = m_pEditor->m_SwitchDelay;
+					m_pSwitchTile[TgtIndex].m_Number = m_pEditor->m_SwitchNum;
+					m_pSwitchTile[TgtIndex].m_Delay = m_pEditor->m_SwitchDelay;
 				}
-				else if(pSwitchLayer->m_pSwitchTile[y * pSwitchLayer->m_Width + x].m_Number)
+				else if(pSwitchLayer->m_pSwitchTile[SrcIndex].m_Number)
 				{
-					m_pSwitchTile[Index].m_Number = pSwitchLayer->m_pSwitchTile[y * pSwitchLayer->m_Width + x].m_Number;
-					m_pSwitchTile[Index].m_Delay = pSwitchLayer->m_pSwitchTile[y * pSwitchLayer->m_Width + x].m_Delay;
+					m_pSwitchTile[TgtIndex].m_Number = pSwitchLayer->m_pSwitchTile[SrcIndex].m_Number;
+					m_pSwitchTile[TgtIndex].m_Delay = pSwitchLayer->m_pSwitchTile[SrcIndex].m_Delay;
 				}
 				else
 				{
-					m_pSwitchTile[Index].m_Number = m_pEditor->m_SwitchNum;
-					m_pSwitchTile[Index].m_Delay = m_pEditor->m_SwitchDelay;
+					m_pSwitchTile[TgtIndex].m_Number = m_pEditor->m_SwitchNum;
+					m_pSwitchTile[TgtIndex].m_Delay = m_pEditor->m_SwitchDelay;
 				}
 
-				m_pSwitchTile[Index].m_Type = pSwitchLayer->m_pTiles[y * pSwitchLayer->m_Width + x].m_Index;
-				m_pSwitchTile[Index].m_Flags = pSwitchLayer->m_pTiles[y * pSwitchLayer->m_Width + x].m_Flags;
-				m_pTiles[Index].m_Index = pSwitchLayer->m_pTiles[y * pSwitchLayer->m_Width + x].m_Index;
-				m_pTiles[Index].m_Flags = pSwitchLayer->m_pTiles[y * pSwitchLayer->m_Width + x].m_Flags;
+				m_pSwitchTile[TgtIndex].m_Type = pSwitchLayer->m_pTiles[SrcIndex].m_Index;
+				m_pSwitchTile[TgtIndex].m_Flags = pSwitchLayer->m_pTiles[SrcIndex].m_Flags;
+				m_pTiles[TgtIndex].m_Index = pSwitchLayer->m_pTiles[SrcIndex].m_Index;
+				m_pTiles[TgtIndex].m_Flags = pSwitchLayer->m_pTiles[SrcIndex].m_Flags;
 
-				if(!IsSwitchTileFlagsUsed(pSwitchLayer->m_pTiles[y * pSwitchLayer->m_Width + x].m_Index))
+				if(!IsSwitchTileFlagsUsed(pSwitchLayer->m_pTiles[SrcIndex].m_Index))
 				{
-					m_pSwitchTile[Index].m_Flags = 0;
+					m_pSwitchTile[TgtIndex].m_Flags = 0;
 				}
-				if(!IsSwitchTileNumberUsed(pSwitchLayer->m_pTiles[y * pSwitchLayer->m_Width + x].m_Index))
+				if(!IsSwitchTileNumberUsed(pSwitchLayer->m_pTiles[SrcIndex].m_Index))
 				{
-					m_pSwitchTile[Index].m_Number = 0;
+					m_pSwitchTile[TgtIndex].m_Number = 0;
 				}
-				if(!IsSwitchTileDelayUsed(pSwitchLayer->m_pTiles[y * pSwitchLayer->m_Width + x].m_Index))
+				if(!IsSwitchTileDelayUsed(pSwitchLayer->m_pTiles[SrcIndex].m_Index))
 				{
-					m_pSwitchTile[Index].m_Delay = 0;
+					m_pSwitchTile[TgtIndex].m_Delay = 0;
 				}
 			}
 			else
 			{
-				m_pSwitchTile[Index].m_Number = 0;
-				m_pSwitchTile[Index].m_Type = 0;
-				m_pSwitchTile[Index].m_Flags = 0;
-				m_pSwitchTile[Index].m_Delay = 0;
-				m_pTiles[Index].m_Index = 0;
+				m_pSwitchTile[TgtIndex].m_Number = 0;
+				m_pSwitchTile[TgtIndex].m_Type = 0;
+				m_pSwitchTile[TgtIndex].m_Flags = 0;
+				m_pSwitchTile[TgtIndex].m_Delay = 0;
+				m_pTiles[TgtIndex].m_Index = 0;
 
-				if(pSwitchLayer->m_pTiles[y * pSwitchLayer->m_Width + x].m_Index != TILE_AIR)
+				if(pSwitchLayer->m_pTiles[SrcIndex].m_Index != TILE_AIR)
 					ShowPreventUnusedTilesWarning();
 			}
 
 			SSwitchTileStateChange::SData Current{
-				m_pSwitchTile[Index].m_Number,
-				m_pSwitchTile[Index].m_Type,
-				m_pSwitchTile[Index].m_Flags,
-				m_pSwitchTile[Index].m_Delay,
-				m_pTiles[Index].m_Index};
+				m_pSwitchTile[TgtIndex].m_Number,
+				m_pSwitchTile[TgtIndex].m_Type,
+				m_pSwitchTile[TgtIndex].m_Flags,
+				m_pSwitchTile[TgtIndex].m_Delay,
+				m_pTiles[TgtIndex].m_Index};
 
 			RecordStateChange(fx, fy, Previous, Current);
 		}

--- a/src/game/editor/mapitems/layer_tele.cpp
+++ b/src/game/editor/mapitems/layer_tele.cpp
@@ -93,65 +93,66 @@ void CLayerTele::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 			if(!Destructive && GetTile(fx, fy).m_Index)
 				continue;
 
-			int Index = fy * m_Width + fx;
-			STeleTileStateChange::SData Previous{
-				m_pTeleTile[Index].m_Number,
-				m_pTeleTile[Index].m_Type,
-				m_pTiles[Index].m_Index};
+			const int SrcIndex = y * pTeleLayer->m_Width + x;
+			const int TgtIndex = fy * m_Width + fx;
 
-			unsigned char TgtIndex = pTeleLayer->m_pTiles[y * pTeleLayer->m_Width + x].m_Index;
-			if((m_pEditor->IsAllowPlaceUnusedTiles() || IsValidTeleTile(TgtIndex)) && TgtIndex != TILE_AIR)
+			STeleTileStateChange::SData Previous{
+				m_pTeleTile[TgtIndex].m_Number,
+				m_pTeleTile[TgtIndex].m_Type,
+				m_pTiles[TgtIndex].m_Index};
+
+			if((m_pEditor->IsAllowPlaceUnusedTiles() || IsValidTeleTile(pTeleLayer->m_pTiles[SrcIndex].m_Index)) && pTeleLayer->m_pTiles[SrcIndex].m_Index != TILE_AIR)
 			{
-				bool IsCheckpoint = IsTeleTileCheckpoint(TgtIndex);
-				if(!IsCheckpoint && !IsTeleTileNumberUsed(TgtIndex, false))
+				bool IsCheckpoint = IsTeleTileCheckpoint(pTeleLayer->m_pTiles[SrcIndex].m_Index);
+				if(!IsCheckpoint && !IsTeleTileNumberUsed(pTeleLayer->m_pTiles[SrcIndex].m_Index, false))
 				{
 					// Tele tile number is unused. Set a known value which is not 0,
 					// as tiles with number 0 would be ignored by previous versions.
-					m_pTeleTile[Index].m_Number = 255;
+					m_pTeleTile[TgtIndex].m_Number = 255;
 				}
-				else if(pTeleLayer->m_pTeleTile[y * pTeleLayer->m_Width + x].m_Number)
+				else if(pTeleLayer->m_pTeleTile[SrcIndex].m_Number)
 				{
-					m_pTeleTile[Index].m_Number = pTeleLayer->m_pTeleTile[y * pTeleLayer->m_Width + x].m_Number;
+					m_pTeleTile[TgtIndex].m_Number = pTeleLayer->m_pTeleTile[SrcIndex].m_Number;
 				}
 				else
 				{
 					if((!IsCheckpoint && !m_pEditor->m_TeleNumber) || (IsCheckpoint && !m_pEditor->m_TeleCheckpointNumber))
 					{
-						m_pTeleTile[Index].m_Number = 0;
-						m_pTeleTile[Index].m_Type = 0;
-						m_pTiles[Index].m_Index = 0;
+						m_pTeleTile[TgtIndex].m_Number = 0;
+						m_pTeleTile[TgtIndex].m_Type = 0;
+						m_pTiles[TgtIndex].m_Index = 0;
 
 						STeleTileStateChange::SData Current{
-							m_pTeleTile[Index].m_Number,
-							m_pTeleTile[Index].m_Type,
-							m_pTiles[Index].m_Index};
+							m_pTeleTile[TgtIndex].m_Number,
+							m_pTeleTile[TgtIndex].m_Type,
+							m_pTiles[TgtIndex].m_Index};
 
 						RecordStateChange(fx, fy, Previous, Current);
 						continue;
 					}
 					else
 					{
-						m_pTeleTile[Index].m_Number = IsCheckpoint ? m_pEditor->m_TeleCheckpointNumber : m_pEditor->m_TeleNumber;
+						m_pTeleTile[TgtIndex].m_Number = IsCheckpoint ? m_pEditor->m_TeleCheckpointNumber : m_pEditor->m_TeleNumber;
 					}
 				}
 
-				m_pTeleTile[Index].m_Type = pTeleLayer->m_pTiles[y * pTeleLayer->m_Width + x].m_Index;
-				m_pTiles[Index].m_Index = pTeleLayer->m_pTiles[y * pTeleLayer->m_Width + x].m_Index;
+				m_pTeleTile[TgtIndex].m_Type = pTeleLayer->m_pTiles[SrcIndex].m_Index;
+				m_pTiles[TgtIndex].m_Index = pTeleLayer->m_pTiles[SrcIndex].m_Index;
 			}
 			else
 			{
-				m_pTeleTile[Index].m_Number = 0;
-				m_pTeleTile[Index].m_Type = 0;
-				m_pTiles[Index].m_Index = 0;
+				m_pTeleTile[TgtIndex].m_Number = 0;
+				m_pTeleTile[TgtIndex].m_Type = 0;
+				m_pTiles[TgtIndex].m_Index = 0;
 
-				if(pTeleLayer->m_pTiles[y * pTeleLayer->m_Width + x].m_Index != TILE_AIR)
+				if(pTeleLayer->m_pTiles[SrcIndex].m_Index != TILE_AIR)
 					ShowPreventUnusedTilesWarning();
 			}
 
 			STeleTileStateChange::SData Current{
-				m_pTeleTile[Index].m_Number,
-				m_pTeleTile[Index].m_Type,
-				m_pTiles[Index].m_Index};
+				m_pTeleTile[TgtIndex].m_Number,
+				m_pTeleTile[TgtIndex].m_Type,
+				m_pTiles[TgtIndex].m_Index};
 
 			RecordStateChange(fx, fy, Previous, Current);
 		}

--- a/src/game/editor/mapitems/layer_tune.cpp
+++ b/src/game/editor/mapitems/layer_tune.cpp
@@ -92,50 +92,52 @@ void CLayerTune::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 			if(!Destructive && GetTile(fx, fy).m_Index)
 				continue;
 
-			int Index = fy * m_Width + fx;
-			STuneTileStateChange::SData Previous{
-				m_pTuneTile[Index].m_Number,
-				m_pTuneTile[Index].m_Type,
-				m_pTiles[Index].m_Index};
+			const int SrcIndex = y * pTuneLayer->m_Width + x;
+			const int TgtIndex = fy * m_Width + fx;
 
-			if((m_pEditor->IsAllowPlaceUnusedTiles() || IsValidTuneTile(pTuneLayer->m_pTiles[y * pTuneLayer->m_Width + x].m_Index)) && pTuneLayer->m_pTiles[y * pTuneLayer->m_Width + x].m_Index != TILE_AIR)
+			STuneTileStateChange::SData Previous{
+				m_pTuneTile[TgtIndex].m_Number,
+				m_pTuneTile[TgtIndex].m_Type,
+				m_pTiles[TgtIndex].m_Index};
+
+			if((m_pEditor->IsAllowPlaceUnusedTiles() || IsValidTuneTile(pTuneLayer->m_pTiles[SrcIndex].m_Index)) && pTuneLayer->m_pTiles[SrcIndex].m_Index != TILE_AIR)
 			{
 				if(m_pEditor->m_TuningNum != pTuneLayer->m_TuningNumber)
 				{
-					m_pTuneTile[Index].m_Number = m_pEditor->m_TuningNum;
+					m_pTuneTile[TgtIndex].m_Number = m_pEditor->m_TuningNum;
 				}
-				else if(pTuneLayer->m_pTuneTile[y * pTuneLayer->m_Width + x].m_Number)
-					m_pTuneTile[Index].m_Number = pTuneLayer->m_pTuneTile[y * pTuneLayer->m_Width + x].m_Number;
+				else if(pTuneLayer->m_pTuneTile[SrcIndex].m_Number)
+					m_pTuneTile[TgtIndex].m_Number = pTuneLayer->m_pTuneTile[SrcIndex].m_Number;
 				else
 				{
 					if(!m_pEditor->m_TuningNum)
 					{
-						m_pTuneTile[Index].m_Number = 0;
-						m_pTuneTile[Index].m_Type = 0;
-						m_pTiles[Index].m_Index = 0;
+						m_pTuneTile[TgtIndex].m_Number = 0;
+						m_pTuneTile[TgtIndex].m_Type = 0;
+						m_pTiles[TgtIndex].m_Index = 0;
 						continue;
 					}
 					else
-						m_pTuneTile[Index].m_Number = m_pEditor->m_TuningNum;
+						m_pTuneTile[TgtIndex].m_Number = m_pEditor->m_TuningNum;
 				}
 
-				m_pTuneTile[Index].m_Type = pTuneLayer->m_pTiles[y * pTuneLayer->m_Width + x].m_Index;
-				m_pTiles[Index].m_Index = pTuneLayer->m_pTiles[y * pTuneLayer->m_Width + x].m_Index;
+				m_pTuneTile[TgtIndex].m_Type = pTuneLayer->m_pTiles[SrcIndex].m_Index;
+				m_pTiles[TgtIndex].m_Index = pTuneLayer->m_pTiles[SrcIndex].m_Index;
 			}
 			else
 			{
-				m_pTuneTile[Index].m_Number = 0;
-				m_pTuneTile[Index].m_Type = 0;
-				m_pTiles[Index].m_Index = 0;
+				m_pTuneTile[TgtIndex].m_Number = 0;
+				m_pTuneTile[TgtIndex].m_Type = 0;
+				m_pTiles[TgtIndex].m_Index = 0;
 
-				if(pTuneLayer->m_pTiles[y * pTuneLayer->m_Width + x].m_Index != TILE_AIR)
+				if(pTuneLayer->m_pTiles[SrcIndex].m_Index != TILE_AIR)
 					ShowPreventUnusedTilesWarning();
 			}
 
 			STuneTileStateChange::SData Current{
-				m_pTuneTile[Index].m_Number,
-				m_pTuneTile[Index].m_Type,
-				m_pTiles[Index].m_Index};
+				m_pTuneTile[TgtIndex].m_Number,
+				m_pTuneTile[TgtIndex].m_Type,
+				m_pTiles[TgtIndex].m_Index};
 
 			RecordStateChange(fx, fy, Previous, Current);
 		}


### PR DESCRIPTION
Use auxiliary variables in `BrushDraw()` to replace expressions in array indices, similar to `FillSelection()`, for improved readability.

The `BrushDraw()` and `FillSelection()` functions in `layer_xxx.cpp` have quite a few similarities. In `FillSelection()`, the part where the index is calculated is placed in auxiliary variables for better readability. I think it would make sense to unify this approach.

Except for the `TgtIndex` variable already existing in `layer_tele.cpp` (which is only used in a few lines), which needs to be removed, everything else works well.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
