### PR TITLE
Support importing touch controls with no "label-type"

### DIFF
--- a/src/game/client/components/touch_controls.cpp
+++ b/src/game/client/components/touch_controls.cpp
@@ -1490,18 +1490,25 @@ std::unique_ptr<CTouchControls::CBindTouchButtonBehavior> CTouchControls::ParseB
 	}
 
 	const json_value &LabelType = BehaviorObject["label-type"];
-	if(LabelType.type != json_string)
+	if(LabelType.type != json_string && LabelType.type != json_none)
 	{
 		log_error("touch_controls", "Failed to parse touch button behavior of type '%s': attribute 'label-type' must specify a string", CBindTouchButtonBehavior::BEHAVIOR_TYPE);
 		return {};
 	}
 	CButtonLabel::EType ParsedLabelType = CButtonLabel::EType::NUM_TYPES;
-	for(int CurrentType = (int)CButtonLabel::EType::PLAIN; CurrentType < (int)CButtonLabel::EType::NUM_TYPES; ++CurrentType)
+	if(LabelType.type == json_none)
 	{
-		if(str_comp(LabelType.u.string.ptr, LABEL_TYPE_NAMES[CurrentType]) == 0)
+		ParsedLabelType = CButtonLabel::EType::PLAIN;
+	}
+	else
+	{
+		for(int CurrentType = (int)CButtonLabel::EType::PLAIN; CurrentType < (int)CButtonLabel::EType::NUM_TYPES; ++CurrentType)
 		{
-			ParsedLabelType = (CButtonLabel::EType)CurrentType;
-			break;
+			if(str_comp(LabelType.u.string.ptr, LABEL_TYPE_NAMES[CurrentType]) == 0)
+			{
+				ParsedLabelType = (CButtonLabel::EType)CurrentType;
+				break;
+			}
 		}
 	}
 	if(ParsedLabelType == CButtonLabel::EType::NUM_TYPES)
@@ -1548,18 +1555,25 @@ std::unique_ptr<CTouchControls::CBindToggleTouchButtonBehavior> CTouchControls::
 		}
 
 		const json_value &LabelType = CommandObject["label-type"];
-		if(LabelType.type != json_string)
+		if(LabelType.type != json_string && LabelType.type != json_none)
 		{
 			log_error("touch_controls", "Failed to parse touch button behavior of type '%s': failed to parse command at index '%d': attribute 'label-type' must specify a string", CBindToggleTouchButtonBehavior::BEHAVIOR_TYPE, CommandIndex);
 			return {};
 		}
 		CButtonLabel::EType ParsedLabelType = CButtonLabel::EType::NUM_TYPES;
-		for(int CurrentType = (int)CButtonLabel::EType::PLAIN; CurrentType < (int)CButtonLabel::EType::NUM_TYPES; ++CurrentType)
+		if(LabelType.type == json_none)
 		{
-			if(str_comp(LabelType.u.string.ptr, LABEL_TYPE_NAMES[CurrentType]) == 0)
+			ParsedLabelType = CButtonLabel::EType::PLAIN;
+		}
+		else
+		{
+			for(int CurrentType = (int)CButtonLabel::EType::PLAIN; CurrentType < (int)CButtonLabel::EType::NUM_TYPES; ++CurrentType)
 			{
-				ParsedLabelType = (CButtonLabel::EType)CurrentType;
-				break;
+				if(str_comp(LabelType.u.string.ptr, LABEL_TYPE_NAMES[CurrentType]) == 0)
+				{
+					ParsedLabelType = (CButtonLabel::EType)CurrentType;
+					break;
+				}
 			}
 		}
 		if(ParsedLabelType == CButtonLabel::EType::NUM_TYPES)


### PR DESCRIPTION
When no "label-type" is given on buttons with "bind" or "bind-toggle", the client will give them a default "label-type" as "plain". This is more convenient when people need to write their touch controls manually.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
