### PR TITLE
Silence readability-math-missing-parentheses

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -76,6 +76,7 @@ Checks: >
   modernize-use-transparent-functors,
   modernize-use-uncaught-exceptions,
   readability-*,
+  -readability-math-missing-parentheses,
   -readability-braces-around-statements,
   -readability-convert-member-functions-to-static,
   -readability-else-after-return,


### PR DESCRIPTION
Reduces spam with modern clang.

iirc heinrich once said he never wanted to fix the issue so lets silence it.

I would also be cool with fixing it but the diff would be huge.

```
/home/chiller/Desktop/git/ddnet-insta/src/game/collision.cpp:995:18: error: '*' has higher precedence than '+'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses,-warnings-as-errors]
  995 |         return m_pTiles[Ny * m_Width + Nx].m_Index;
      |                         ^~~~~~~~~~~~
      |                         (           )
/home/chiller/Desktop/git/ddnet-insta/src/game/collision.cpp:1008:30: error: '*' has higher precedence than '+'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses,-warnings-as-errors]
 1008 |                         (m_pSpeedup && m_pSpeedup[Ny * m_Width + Nx].m_Force > 0))
      |                                                   ^~~~~~~~~~~~
      |                                                   (           )
/home/chiller/Desktop/git/ddnet-insta/src/game/collision.cpp:1010:11: error: '*' has higher precedence than '+'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses,-warnings-as-errors]
 1010 |                         return Ny * m_Width + Nx;
      |                                ^~~~~~~~~~~~
      |                                (           )
/home/chiller/Desktop/git/ddnet-insta/src/game/collision.cpp:1021:30: error: '*' has higher precedence than '+'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses,-warnings-as-errors]
 1021 |                         (m_pSpeedup && m_pSpeedup[Ny * m_Width + Nx].m_Force > 0))
      |                                                   ^~~~~~~~~~~~
      |                                                   (           )
/home/chiller/Desktop/git/ddnet-insta/src/game/collision.cpp:1023:11: error: '*' has higher precedence than '+'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses,-warnings-as-errors]
 1023 |                         return Ny * m_Width + Nx;
      |                                ^~~~~~~~~~~~
      |                                (           )
/home/chiller/Desktop/git/ddnet-insta/src/game/collision.cpp:1034:18: error: '*' has higher precedence than '+'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses,-warnings-as-errors]
 1034 |         return m_pFront[Ny * m_Width + Nx].m_Index;
      |                         ^~~~~~~~~~~~
      |                         (           )
/home/chiller/Desktop/git/ddnet-insta/src/game/collision.cpp:1043:14: error: '*' has higher precedence than '+'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses,-warnings-as-errors]
 1043 |         if(m_pFront[Ny * m_Width + Nx].m_Index == TILE_DEATH || m_pFront[Ny * m_Width + Nx].m_Index == TILE_NOLASER)
      |                     ^~~~~~~~~~~~
      |                     (           )
/home/chiller/Desktop/git/ddnet-insta/src/game/collision.cpp:1043:67: error: '*' has higher precedence than '+'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses,-warnings-as-errors]
 1043 |         if(m_pFront[Ny * m_Width + Nx].m_Index == TILE_DEATH || m_pFront[Ny * m_Width + Nx].m_Index == TILE_NOLASER)
      |                                                                          ^~~~~~~~~~~~
      |                                                                          (           )
/home/chiller/Desktop/git/ddnet-insta/src/game/collision.cpp:1044:19: error: '*' has higher precedence than '+'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses,-warnings-as-errors]
 1044 |                 return m_pFront[Ny * m_Width + Nx].m_Index;
      |                                 ^~~~~~~~~~~~
      |                                 (           )
/home/chiller/Desktop/git/ddnet-insta/src/game/collision.cpp:1054:20: error: '*' has higher precedence than '+'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses,-warnings-as-errors]
 1054 |         const int Index = y * m_Width + x;
      |                           ^~~~~~~~~~~
      |                           (          )
/home/chiller/Desktop/git/ddnet-insta/src/game/collision.cpp:1080:11: error: '*' has higher precedence than '+'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses,-warnings-as-errors]
 1080 |         m_pTiles[Ny * m_Width + Nx].m_Index = Index;
      |                  ^~~~~~~~~~~~
      |                  (           )
/home/chiller/Desktop/git/ddnet-insta/src/game/collision.cpp:1090:10: error: '*' has higher precedence than '+'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses,-warnings-as-errors]
 1090 |         m_pDoor[Ny * m_Width + Nx].m_Index = Type;
      |                 ^~~~~~~~~~~~
      |                 (           )
/home/chiller/Desktop/git/ddnet-insta/src/game/collision.cpp:1091:10: error: '*' has higher precedence than '+'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses,-warnings-as-errors]
 1091 |         m_pDoor[Ny * m_Width + Nx].m_Flags = Flags;
      |                 ^~~~~~~~~~~~
      |                 (           )
/home/chiller/Desktop/git/ddnet-insta/src/game/collision.cpp:1092:10: error: '*' has higher precedence than '+'; add parentheses to explicitly specify the order of operations [readability-math-missing-parentheses,-warnings-as-errors]
 1092 |         m_pDoor[Ny * m_Width + Nx].m_Number = Number;
      |                 ^~~~~~~~~~~~
      |                 (           )
```