### PR TITLE
Fix `FillSelection()` not resetting target tile properties when 'allow unused' is enabled and using empty tiles

### DIFF
--- a/src/game/editor/mapitems/layer_speedup.cpp
+++ b/src/game/editor/mapitems/layer_speedup.cpp
@@ -289,6 +289,12 @@ void CLayerSpeedup::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CU
 					else
 						m_pSpeedupTile[TgtIndex].m_MaxSpeed = pLt->m_pSpeedupTile[SrcIndex].m_MaxSpeed;
 				}
+				else
+				{
+					m_pTiles[TgtIndex].m_Index = 0;
+					m_pSpeedupTile[TgtIndex].m_Force = 0;
+					m_pSpeedupTile[TgtIndex].m_Angle = 0;
+				}
 			}
 
 			SSpeedupTileStateChange::SData Current{

--- a/src/game/editor/mapitems/layer_switch.cpp
+++ b/src/game/editor/mapitems/layer_switch.cpp
@@ -301,6 +301,13 @@ void CLayerSwitch::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUI
 					else
 						m_pSwitchTile[TgtIndex].m_Flags = pLt->m_pSwitchTile[SrcIndex].m_Flags;
 				}
+				else
+				{
+					m_pTiles[TgtIndex].m_Index = 0;
+					m_pSwitchTile[TgtIndex].m_Type = 0;
+					m_pSwitchTile[TgtIndex].m_Number = 0;
+					m_pSwitchTile[TgtIndex].m_Delay = 0;
+				}
 			}
 
 			SSwitchTileStateChange::SData Current{

--- a/src/game/editor/mapitems/layer_tele.cpp
+++ b/src/game/editor/mapitems/layer_tele.cpp
@@ -284,6 +284,12 @@ void CLayerTele::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRe
 					else
 						m_pTeleTile[TgtIndex].m_Number = pLt->m_pTeleTile[SrcIndex].m_Number;
 				}
+				else
+				{
+					m_pTiles[TgtIndex].m_Index = 0;
+					m_pTeleTile[TgtIndex].m_Type = 0;
+					m_pTeleTile[TgtIndex].m_Number = 0;
+				}
 			}
 
 			STeleTileStateChange::SData Current{

--- a/src/game/editor/mapitems/layer_tune.cpp
+++ b/src/game/editor/mapitems/layer_tune.cpp
@@ -256,6 +256,12 @@ void CLayerTune::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRe
 					else
 						m_pTuneTile[TgtIndex].m_Number = pLt->m_pTuneTile[SrcIndex].m_Number;
 				}
+				else
+				{
+					m_pTiles[TgtIndex].m_Index = 0;
+					m_pTuneTile[TgtIndex].m_Type = 0;
+					m_pTuneTile[TgtIndex].m_Number = 0;
+				}
 			}
 
 			STuneTileStateChange::SData Current{


### PR DESCRIPTION
fix #9531

this is an example from `layer_tele`. I'm pretty sure there were some cases missing after the `if(pLt->m_Tele && m_pTiles[TgtIndex].m_Index > 0)` statement. if `m_pTiles[TgtIndex].m_Index` is 0, it just does nothing.

https://github.com/ddnet/ddnet/blob/c70dcd9b57464aa1239b3223222af777c6860cf9/src/game/editor/mapitems/layer_tele.cpp#L268-L286

and this fix covers them. but I'm not sure if using `else` to handle them is appropriate.

before:
[Screencast from 2025-02-24 10-44-18.webm](https://github.com/user-attachments/assets/69695808-73e7-4133-a977-cf3fccebd393)

after:
[Screencast from 2025-02-24 10-44-47.webm](https://github.com/user-attachments/assets/d5f6a174-43fa-4771-a29f-ccf11b1c2501)

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
