### PR TITLE
Reduce FPS impact of community icon loading

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -563,6 +563,7 @@ protected:
 	class CCommunityIconLoadJob : public IJob, public CAbstractCommunityIconJob
 	{
 		CImageInfo m_ImageInfo;
+		CImageInfo m_ImageInfoGrayscale;
 
 	protected:
 		void Run() override;
@@ -572,6 +573,7 @@ protected:
 		~CCommunityIconLoadJob();
 
 		CImageInfo &ImageInfo() { return m_ImageInfo; }
+		CImageInfo &ImageInfoGrayscale() { return m_ImageInfoGrayscale; }
 	};
 
 	class CCommunityIconDownloadJob : public CHttpRequest, public CAbstractCommunityIconJob
@@ -586,8 +588,8 @@ protected:
 	SHA256_DIGEST m_CommunityIconsInfoSha256 = SHA256_ZEROED;
 	static int CommunityIconScan(const char *pName, int IsDir, int DirType, void *pUser);
 	const SCommunityIcon *FindCommunityIcon(const char *pCommunityId);
-	bool LoadCommunityIconFile(const char *pPath, int DirType, CImageInfo &Info, SHA256_DIGEST &Sha256);
-	void LoadCommunityIconFinish(const char *pCommunityId, CImageInfo &Info, const SHA256_DIGEST &Sha256);
+	bool LoadCommunityIconFile(const char *pPath, int DirType, CImageInfo &Info, CImageInfo &InfoGrayscale, SHA256_DIGEST &Sha256);
+	void LoadCommunityIconFinish(const char *pCommunityId, CImageInfo &Info, CImageInfo &InfoGrayscale, const SHA256_DIGEST &Sha256);
 	void RenderCommunityIcon(const SCommunityIcon *pIcon, CUIRect Rect, bool Active);
 	void UpdateCommunityIcons();
 


### PR DESCRIPTION
Also create the grayscale versions of community icons in the background jobs.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
