### PR TITLE
Fix editor automap reference popup initial selection

### DIFF
--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -2526,8 +2526,8 @@ int CEditor::PopupSelectConfigAutoMapResult()
 	return s_AutoMapConfigCurrent;
 }
 
-static int s_AutoMapReferenceSelected = -1;
-static int s_AutoMapReferenceCurrent = -1;
+static int s_AutoMapReferenceSelected = -100;
+static int s_AutoMapReferenceCurrent = -100;
 
 CUi::EPopupMenuFunctionResult CEditor::PopupSelectAutoMapReference(void *pContext, CUIRect View, bool Active)
 {
@@ -2567,7 +2567,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSelectAutoMapReference(void *pContex
 void CEditor::PopupSelectAutoMapReferenceInvoke(int Current, float x, float y)
 {
 	static SPopupMenuId s_PopupSelectAutoMapReferenceId;
-	s_AutoMapReferenceSelected = -1;
+	s_AutoMapReferenceSelected = -100;
 	s_AutoMapReferenceCurrent = Current;
 	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(GetSelectedLayer(0));
 	// Width for buttons is 120, 15 is the scrollbar width, 2 is the margin between both.


### PR DESCRIPTION
The selected value of the automap reference popup was previously always reset to "None" whenever opening the popup.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
