### PR TITLE
Add error message to `auth_add`/`auth_add_p` when username too long, increase length of rcon username to 64 bytes on client side

### DIFF
--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -116,7 +116,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	int m_aAckGameTick[NUM_DUMMIES] = {-1, -1};
 	int m_aCurrentRecvTick[NUM_DUMMIES] = {0, 0};
 	int m_aRconAuthed[NUM_DUMMIES] = {0, 0};
-	char m_aRconUsername[32] = "";
+	char m_aRconUsername[64] = "";
 	char m_aRconPassword[sizeof(g_Config.m_SvRconPassword)] = "";
 	int m_UseTempRconCommands = 0;
 	int m_ExpectedRconCommands = -1;

--- a/src/engine/server/authmanager.cpp
+++ b/src/engine/server/authmanager.cpp
@@ -120,6 +120,11 @@ const char *CAuthManager::KeyIdent(int Slot) const
 	return m_vKeys[Slot].m_aIdent;
 }
 
+bool CAuthManager::IsValidIdent(const char *pIdent) const
+{
+	return str_length(pIdent) < (int)sizeof(CKey().m_aIdent);
+}
+
 void CAuthManager::UpdateKeyHash(int Slot, MD5_DIGEST Hash, const unsigned char *pSalt, int AuthLevel)
 {
 	if(Slot < 0 || Slot >= (int)m_vKeys.size())

--- a/src/engine/server/authmanager.h
+++ b/src/engine/server/authmanager.h
@@ -36,6 +36,7 @@ public:
 	int DefaultKey(int AuthLevel) const;
 	int KeyLevel(int Slot) const;
 	const char *KeyIdent(int Slot) const;
+	bool IsValidIdent(const char *pIdent) const;
 	void UpdateKeyHash(int Slot, MD5_DIGEST Hash, const unsigned char *pSalt, int AuthLevel);
 	void UpdateKey(int Slot, const char *pPw, int AuthLevel);
 	void ListKeys(FListCallback pfnListCallbac, void *pUser);

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3392,6 +3392,12 @@ void CServer::ConAuthAdd(IConsole::IResult *pResult, void *pUser)
 	const char *pLevel = pResult->GetString(1);
 	const char *pPw = pResult->GetString(2);
 
+	if(!pManager->IsValidIdent(pIdent))
+	{
+		pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "auth", "ident is invalid");
+		return;
+	}
+
 	int Level = GetAuthLevel(pLevel);
 	if(Level == -1)
 	{
@@ -3419,6 +3425,12 @@ void CServer::ConAuthAddHashed(IConsole::IResult *pResult, void *pUser)
 	const char *pLevel = pResult->GetString(1);
 	const char *pPw = pResult->GetString(2);
 	const char *pSalt = pResult->GetString(3);
+
+	if(!pManager->IsValidIdent(pIdent))
+	{
+		pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "auth", "ident is invalid");
+		return;
+	}
 
 	int Level = GetAuthLevel(pLevel);
 	if(Level == -1)

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -73,7 +73,7 @@ class CGameConsole : public CComponent
 		int m_CompletionCommandStart = 0;
 		int m_CompletionCommandEnd = 0;
 
-		char m_aUser[32];
+		char m_aUser[64];
 		bool m_UserGot;
 		bool m_UsernameReq;
 


### PR DESCRIPTION
Previously, rcon keys could be added with usernames longer than 63 non-null characters, which would be truncated and could not be used.

Use same maximum length for the rcon username on the client side as on the server side, to allow authenticating with usernames of the maximum length.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
