### PR TITLE
Fix left and right joystick hats

### DIFF
--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -50,11 +50,9 @@ public:
 		int GetNumBalls() const override { return m_NumBalls; }
 		int GetNumHats() const override { return m_NumHats; }
 		float GetAxisValue(int Axis) override;
-		void GetHatValue(int Hat, int (&HatKeys)[2]) override;
+		unsigned char GetHatValue(int Hat) override;
 		bool Relative(float *pX, float *pY) override;
 		bool Absolute(float *pX, float *pY) override;
-
-		static void GetJoystickHatKeys(int Hat, int HatValue, int (&HatKeys)[2]);
 	};
 
 private:

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -95,7 +95,7 @@ public:
 		virtual int GetNumBalls() const = 0;
 		virtual int GetNumHats() const = 0;
 		virtual float GetAxisValue(int Axis) = 0;
-		virtual void GetHatValue(int Hat, int (&HatKeys)[2]) = 0;
+		virtual unsigned char GetHatValue(int Hat) = 0;
 		virtual bool Relative(float *pX, float *pY) = 0;
 		virtual bool Absolute(float *pX, float *pY) = 0;
 	};


### PR DESCRIPTION
Joystick left and right hats didn't seem to work.

I couldn't figure out how the original code worked, so I replaced it and it works

~~This does let [left and right] and [up and down] to be pressed at the same time, doesn't change anything in game. Might make it easier to fat finger binds on either one~~ (no it doesn't)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
