### PR TITLE
Remove unused team balance variables

### DIFF
--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -37,9 +37,6 @@ IGameController::IGameController(class CGameContext *pGameServer) :
 	m_GameFlags = 0;
 	m_aMapWish[0] = 0;
 
-	m_UnbalancedTick = -1;
-	m_ForceBalanced = false;
-
 	m_CurrentRecord = 0;
 }
 
@@ -468,7 +465,6 @@ void IGameController::StartRound()
 	m_SuddenDeath = 0;
 	m_GameOverTick = -1;
 	GameServer()->m_World.m_Paused = false;
-	m_ForceBalanced = false;
 	Server()->DemoRecorder_HandleAutoStart();
 	char aBuf[256];
 	str_format(aBuf, sizeof(aBuf), "start round type='%s' teamplay='%d'", m_pGameType, m_GameFlags & GAMEFLAG_TEAMS);
@@ -516,11 +512,6 @@ void IGameController::DoWarmup(int Seconds)
 		m_Warmup = 0;
 	else
 		m_Warmup = Seconds * Server()->TickSpeed();
-}
-
-bool IGameController::CanBeMovedOnBalance(int ClientId)
-{
-	return true;
 }
 
 void IGameController::Tick()

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -64,8 +64,6 @@ protected:
 	int m_RoundCount;
 
 	int m_GameFlags;
-	int m_UnbalancedTick;
-	bool m_ForceBalanced;
 
 public:
 	const char *m_pGameType;
@@ -126,8 +124,6 @@ public:
 	/*
 
 	*/
-	virtual bool CanBeMovedOnBalance(int ClientId);
-
 	virtual void Tick();
 
 	virtual void Snap(int SnappingClient);

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -104,7 +104,6 @@ public:
 	int m_PreviousDieTick;
 	std::optional<int> m_Score;
 	int m_JoinTick;
-	bool m_ForceBalanced;
 	int m_LastActionTick;
 	int m_TeamChangeTick;
 


### PR DESCRIPTION
Makes ddnet code base cleaner as these variables are unused. Also makes my downstream cleaner which implements team balancing.

