### PR TITLE
Apply alpha to spectating tees from other teams

### DIFF
--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -211,7 +211,7 @@ void CNamePlates::RenderNamePlate(CNamePlate &NamePlate, const CRenderNamePlateD
 	TextRender()->SetRenderFlags(0);
 }
 
-void CNamePlates::RenderNamePlateGame(vec2 Position, const CNetObj_PlayerInfo *pPlayerInfo, float Alpha, bool ForceAlpha)
+void CNamePlates::RenderNamePlateGame(vec2 Position, const CNetObj_PlayerInfo *pPlayerInfo, float Alpha)
 {
 	CRenderNamePlateData Data;
 
@@ -233,13 +233,10 @@ void CNamePlates::RenderNamePlateGame(vec2 Position, const CNetObj_PlayerInfo *p
 	Data.m_FontSizeDirection = 18.0f + 20.0f * g_Config.m_ClDirectionSize / 100.0f;
 
 	Data.m_Alpha = Alpha;
-	if(!ForceAlpha)
-	{
-		if(g_Config.m_ClNamePlatesAlways == 0)
-			Data.m_Alpha *= clamp(1.0f - std::pow(distance(m_pClient->m_Controls.m_aTargetPos[g_Config.m_ClDummy], Position) / 200.0f, 16.0f), 0.0f, 1.0f);
-		if(OtherTeam)
-			Data.m_Alpha *= (float)g_Config.m_ClShowOthersAlpha / 100.0f;
-	}
+	if(g_Config.m_ClNamePlatesAlways == 0)
+		Data.m_Alpha *= clamp(1.0f - std::pow(distance(m_pClient->m_Controls.m_aTargetPos[g_Config.m_ClDummy], Position) / 200.0f, 16.0f), 0.0f, 1.0f);
+	if(OtherTeam)
+		Data.m_Alpha *= (float)g_Config.m_ClShowOthersAlpha / 100.0f;
 
 	Data.m_Color = ColorRGBA(1.0f, 1.0f, 1.0f);
 	Data.m_OutlineColor = ColorRGBA(0.0f, 0.0f, 0.0f);
@@ -413,7 +410,7 @@ void CNamePlates::OnRender()
 			// don't render offscreen
 			if(in_range(RenderPos.x, ScreenX0, ScreenX1) && in_range(RenderPos.y, ScreenY0, ScreenY1))
 			{
-				RenderNamePlateGame(RenderPos, pInfo, 0.4f, true);
+				RenderNamePlateGame(RenderPos, pInfo, 0.4f);
 			}
 		}
 		if(m_pClient->m_Snap.m_aCharacters[i].m_Active)
@@ -423,7 +420,7 @@ void CNamePlates::OnRender()
 			// don't render offscreen
 			if(in_range(RenderPos.x, ScreenX0, ScreenX1) && in_range(RenderPos.y, ScreenY0, ScreenY1))
 			{
-				RenderNamePlateGame(RenderPos, pInfo, 1.0f, false);
+				RenderNamePlateGame(RenderPos, pInfo, 1.0f);
 			}
 		}
 	}

--- a/src/game/client/components/nameplates.h
+++ b/src/game/client/components/nameplates.h
@@ -134,7 +134,7 @@ class CNamePlates : public CComponent
 	void RenderNamePlate(CNamePlate &NamePlate, const CRenderNamePlateData &Data);
 
 public:
-	void RenderNamePlateGame(vec2 Position, const CNetObj_PlayerInfo *pPlayerInfo, float Alpha, bool ForceAlpha);
+	void RenderNamePlateGame(vec2 Position, const CNetObj_PlayerInfo *pPlayerInfo, float Alpha);
 	void RenderNamePlatePreview(vec2 Position);
 	virtual int Sizeof() const override { return sizeof(*this); }
 	virtual void OnWindowResize() override;

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -921,13 +921,24 @@ void CPlayers::OnRender()
 	}
 
 	// render spectating players
-	for(auto &Client : m_pClient->m_aClients)
+	for(const auto &Client : m_pClient->m_aClients)
 	{
 		if(!Client.m_SpecCharPresent)
 		{
 			continue;
 		}
-		RenderTools()->RenderTee(CAnimState::GetIdle(), &RenderInfoSpec, EMOTE_BLINK, vec2(1, 0), Client.m_SpecChar);
+		// don't render offscreen
+		if(!in_range(Client.m_RenderPos.x, ScreenX0, ScreenX1) || !in_range(Client.m_RenderPos.y, ScreenY0, ScreenY1))
+		{
+			continue;
+		}
+		const int ClientId = Client.ClientId();
+		float Alpha = (m_pClient->IsOtherTeam(ClientId) || ClientId < 0) ? g_Config.m_ClShowOthersAlpha / 100.f : 1.f;
+		if(ClientId == -2) // ghost
+		{
+			Alpha = g_Config.m_ClRaceGhostAlpha / 100.f;
+		}
+		RenderTools()->RenderTee(CAnimState::GetIdle(), &RenderInfoSpec, EMOTE_BLINK, vec2(1, 0), Client.m_SpecChar, Alpha);
 	}
 
 	// render everyone else's tee, then either our own or the tee we are spectating.
@@ -942,9 +953,7 @@ void CPlayers::OnRender()
 
 		RenderHookCollLine(&m_pClient->m_aClients[ClientId].m_RenderPrev, &m_pClient->m_aClients[ClientId].m_RenderCur, ClientId);
 
-		// don't render offscreen
-		vec2 *pRenderPos = &m_pClient->m_aClients[ClientId].m_RenderPos;
-		if(pRenderPos->x < ScreenX0 || pRenderPos->x > ScreenX1 || pRenderPos->y < ScreenY0 || pRenderPos->y > ScreenY1)
+		if(!in_range(m_pClient->m_aClients[ClientId].m_RenderPos.x, ScreenX0, ScreenX1) || !in_range(m_pClient->m_aClients[ClientId].m_RenderPos.y, ScreenY0, ScreenY1))
 		{
 			continue;
 		}


### PR DESCRIPTION
## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)

**Before (alpha=0, 20)**
![图片](https://github.com/user-attachments/assets/c2df4d29-4dda-49e9-bf84-bb7b1a29e924)
![图片](https://github.com/user-attachments/assets/49c37c24-3959-4afb-88cc-b609f65bac17)
**After (alpha=0, 20)**
![图片](https://github.com/user-attachments/assets/ccfd6725-6a6c-4a82-9122-bb72535bf397)
![图片](https://github.com/user-attachments/assets/d3fa2fb1-0b1e-4d1c-a804-2a9237ddc705)

Also I'd rather not have different alpha value for spectating tees.
