### PR TITLE
Fix left and right joystick hat keys

### DIFF
--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -219,26 +219,26 @@ float CInput::CJoystick::GetAxisValue(int Axis)
 	return (SDL_JoystickGetAxis(m_pDelegate, Axis) - SDL_JOYSTICK_AXIS_MIN) / (float)(SDL_JOYSTICK_AXIS_MAX - SDL_JOYSTICK_AXIS_MIN) * 2.0f - 1.0f;
 }
 
-void CInput::CJoystick::GetJoystickHatKeys(int Hat, int HatValue, int (&HatKeys)[2])
+void CInput::CJoystick::GetJoystickHatKeys(int Hat, int HatValue, int (&aHatKeys)[2])
 {
 	if(HatValue & SDL_HAT_UP)
-		HatKeys[0] = KEY_JOY_HAT0_UP + Hat * NUM_JOYSTICK_BUTTONS_PER_HAT;
+		aHatKeys[0] = KEY_JOY_HAT0_UP + Hat * NUM_JOYSTICK_BUTTONS_PER_HAT;
 	else if(HatValue & SDL_HAT_DOWN)
-		HatKeys[0] = KEY_JOY_HAT0_DOWN + Hat * NUM_JOYSTICK_BUTTONS_PER_HAT;
+		aHatKeys[0] = KEY_JOY_HAT0_DOWN + Hat * NUM_JOYSTICK_BUTTONS_PER_HAT;
 	else
-		HatKeys[0] = KEY_UNKNOWN;
+		aHatKeys[0] = KEY_UNKNOWN;
 
 	if(HatValue & SDL_HAT_LEFT)
-		HatKeys[1] = KEY_JOY_HAT0_LEFT + Hat * NUM_JOYSTICK_BUTTONS_PER_HAT;
+		aHatKeys[1] = KEY_JOY_HAT0_LEFT + Hat * NUM_JOYSTICK_BUTTONS_PER_HAT;
 	else if(HatValue & SDL_HAT_RIGHT)
-		HatKeys[1] = KEY_JOY_HAT0_RIGHT + Hat * NUM_JOYSTICK_BUTTONS_PER_HAT;
+		aHatKeys[1] = KEY_JOY_HAT0_RIGHT + Hat * NUM_JOYSTICK_BUTTONS_PER_HAT;
 	else
-		HatKeys[1] = KEY_UNKNOWN;
+		aHatKeys[1] = KEY_UNKNOWN;
 }
 
-void CInput::CJoystick::GetHatValue(int Hat, int (&HatKeys)[2])
+void CInput::CJoystick::GetHatValue(int Hat, int (&aHatKeys)[2])
 {
-	GetJoystickHatKeys(Hat, SDL_JoystickGetHat(m_pDelegate, Hat), HatKeys);
+	GetJoystickHatKeys(Hat, SDL_JoystickGetHat(m_pDelegate, Hat), aHatKeys);
 }
 
 bool CInput::CJoystick::Relative(float *pX, float *pY)
@@ -487,18 +487,18 @@ void CInput::HandleJoystickHatMotionEvent(const SDL_JoyHatEvent &Event)
 	if(Event.hat >= NUM_JOYSTICK_HATS)
 		return;
 
-	int HatKeys[2];
-	CJoystick::GetJoystickHatKeys(Event.hat, Event.value, HatKeys);
+	int aHatKeys[2];
+	CJoystick::GetJoystickHatKeys(Event.hat, Event.value, aHatKeys);
 
 	for(int Key = KEY_JOY_HAT0_UP + Event.hat * NUM_JOYSTICK_BUTTONS_PER_HAT; Key <= KEY_JOY_HAT0_DOWN + Event.hat * NUM_JOYSTICK_BUTTONS_PER_HAT; Key++)
 	{
-		if(Key != HatKeys[0] && Key != HatKeys[1] && m_aCurrentKeyStates[Key])
+		if(Key != aHatKeys[0] && Key != aHatKeys[1] && m_aCurrentKeyStates[Key])
 		{
 			AddKeyEvent(Key, IInput::FLAG_RELEASE);
 		}
 	}
 
-	for(int CurrentKey : HatKeys)
+	for(int CurrentKey : aHatKeys)
 	{
 		if(CurrentKey != KEY_UNKNOWN && !m_aCurrentKeyStates[CurrentKey])
 		{

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -490,7 +490,7 @@ void CInput::HandleJoystickHatMotionEvent(const SDL_JoyHatEvent &Event)
 	int aHatKeys[2];
 	CJoystick::GetJoystickHatKeys(Event.hat, Event.value, aHatKeys);
 
-	for(int Key = KEY_JOY_HAT0_UP + Event.hat * NUM_JOYSTICK_BUTTONS_PER_HAT; Key <= KEY_JOY_HAT0_DOWN + Event.hat * NUM_JOYSTICK_BUTTONS_PER_HAT; Key++)
+	for(int Key = KEY_JOY_HAT0_UP + Event.hat * NUM_JOYSTICK_BUTTONS_PER_HAT; Key <= KEY_JOY_HAT0_RIGHT + Event.hat * NUM_JOYSTICK_BUTTONS_PER_HAT; Key++)
 	{
 		if(Key != aHatKeys[0] && Key != aHatKeys[1] && m_aCurrentKeyStates[Key])
 		{

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -50,11 +50,11 @@ public:
 		int GetNumBalls() const override { return m_NumBalls; }
 		int GetNumHats() const override { return m_NumHats; }
 		float GetAxisValue(int Axis) override;
-		void GetHatValue(int Hat, int (&HatKeys)[2]) override;
+		void GetHatValue(int Hat, int (&aHatKeys)[2]) override;
 		bool Relative(float *pX, float *pY) override;
 		bool Absolute(float *pX, float *pY) override;
 
-		static void GetJoystickHatKeys(int Hat, int HatValue, int (&HatKeys)[2]);
+		static void GetJoystickHatKeys(int Hat, int HatValue, int (&aHatKeys)[2]);
 	};
 
 private:

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -95,7 +95,7 @@ public:
 		virtual int GetNumBalls() const = 0;
 		virtual int GetNumHats() const = 0;
 		virtual float GetAxisValue(int Axis) = 0;
-		virtual void GetHatValue(int Hat, int (&HatKeys)[2]) = 0;
+		virtual void GetHatValue(int Hat, int (&aHatKeys)[2]) = 0;
 		virtual bool Relative(float *pX, float *pY) = 0;
 		virtual bool Absolute(float *pX, float *pY) = 0;
 	};


### PR DESCRIPTION
Regression from #9659 which made `KEY_JOY_HAT*_RIGHT` the last joystick hat key, causing the loop to skip the left and right joystick hat keys.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
