### PR TITLE
Tell clangd to use angled headers

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+Style:
+  AngledHeaders: ["base/.*", "engine/.*", "game/.*"]


### PR DESCRIPTION
The auto include of clangd saves a lot of time. But sadly it uses the wrong style for the includes. There is a option for clangd to force angled includes for everything. But that also does not match the ddnet style. Luckily [clangd 20 released 40 minutes ago](https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.0) with the brand new config to specify which includes are angled.


https://github.com/user-attachments/assets/b284aebb-9e4d-457a-9901-5d6941853d7a

