### PR TITLE
Trivial name plate changes to fix #9808

### DIFF
--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -702,7 +702,7 @@ void CNamePlates::RenderNamePlateGame(vec2 Position, const CNetObj_PlayerInfo *p
 		}
 	}
 
-	m_aNamePlates[pPlayerInfo->m_ClientId].Render(*GameClient(), &Data);
+	m_pNamePlates[pPlayerInfo->m_ClientId].Render(*GameClient(), &Data);
 }
 
 void CNamePlates::RenderNamePlatePreview(vec2 Position, int Dummy)
@@ -785,7 +785,7 @@ void CNamePlates::RenderNamePlatePreview(vec2 Position, int Dummy)
 void CNamePlates::ResetNamePlates()
 {
 	for(int i = 0; i < MAX_CLIENTS; ++i)
-		m_aNamePlates[i].Reset(*GameClient());
+		m_pNamePlates[i].Reset(*GameClient());
 }
 
 void CNamePlates::OnRender()
@@ -842,12 +842,12 @@ void CNamePlates::OnWindowResize()
 	ResetNamePlates();
 }
 
-void CNamePlates::OnInit()
+CNamePlates::CNamePlates()
 {
-	m_aNamePlates = new CNamePlate[MAX_CLIENTS];
+	m_pNamePlates = new CNamePlate[MAX_CLIENTS];
 }
 
 CNamePlates::~CNamePlates()
 {
-	delete[] m_aNamePlates;
+	delete[] m_pNamePlates;
 }

--- a/src/game/client/components/nameplates.h
+++ b/src/game/client/components/nameplates.h
@@ -47,7 +47,7 @@ class CNamePlate;
 class CNamePlates : public CComponent
 {
 private:
-	CNamePlate *m_aNamePlates = nullptr;
+	CNamePlate *m_pNamePlates;
 
 public:
 	void RenderNamePlateGame(vec2 Position, const CNetObj_PlayerInfo *pPlayerInfo, float Alpha);
@@ -55,8 +55,8 @@ public:
 	void ResetNamePlates();
 	int Sizeof() const override { return sizeof(*this); }
 	void OnWindowResize() override;
-	void OnInit() override;
 	void OnRender() override;
+	CNamePlates();
 	~CNamePlates();
 };
 


### PR DESCRIPTION
`m_pNamePlates` is now inited in constructer instead of OnInit so it can handle resize's before OnInit

Should close #9808 @Zwelf 

Also renamed `m_aNamePlates` to `m_pNamePlates`

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
