### PR TITLE
Update Discord Rich Presence

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -18,6 +18,9 @@
 #include <functional>
 #include <optional>
 
+#define CONNECTLINK_DOUBLE_SLASH "ddnet://"
+#define CONNECTLINK_NO_SLASH "ddnet:"
+
 struct SWarning;
 
 enum

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -430,9 +430,12 @@ void CClient::SetState(EClientState State)
 
 	if(State == IClient::STATE_ONLINE)
 	{
-		const bool AnnounceAddr = m_ServerBrowser.IsRegistered(ServerAddress());
-		Discord()->SetGameInfo(ServerAddress(), m_aCurrentMap, AnnounceAddr);
-		Steam()->SetGameInfo(ServerAddress(), m_aCurrentMap, AnnounceAddr);
+		const bool Registered = m_ServerBrowser.IsRegistered(ServerAddress());
+		CServerInfo CurrentServerInfo;
+		GetServerInfo(&CurrentServerInfo);
+
+		Discord()->SetGameInfo(CurrentServerInfo, m_aCurrentMap, Registered);
+		Steam()->SetGameInfo(ServerAddress(), m_aCurrentMap, Registered);
 	}
 	else if(OldState == IClient::STATE_ONLINE)
 	{
@@ -1380,6 +1383,7 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 			{
 				m_CurrentServerInfo = Info;
 				m_CurrentServerInfoRequestTime = -1;
+				Discord()->UpdateServerInfo(Info, m_aCurrentMap);
 			}
 
 			bool ValidPong = false;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -45,9 +45,6 @@ class INotifications;
 class IStorage;
 class IUpdater;
 
-#define CONNECTLINK_DOUBLE_SLASH "ddnet://"
-#define CONNECTLINK_NO_SLASH "ddnet:"
-
 class CServerCapabilities
 {
 public:

--- a/src/engine/client/discord.cpp
+++ b/src/engine/client/discord.cpp
@@ -1,4 +1,5 @@
 #include <base/system.h>
+#include <engine/client.h>
 #include <engine/discord.h>
 
 #if defined(CONF_DISCORD)
@@ -26,6 +27,10 @@ FDiscordCreate GetDiscordCreate()
 
 class CDiscord : public IDiscord
 {
+	DiscordActivity m_Activity;
+	bool m_UpdateActivity = false;
+	int64_t m_LastActivityUpdate = 0;
+
 	IDiscordCore *m_pCore;
 	IDiscordActivityEvents m_ActivityEvents;
 	IDiscordActivityManager *m_pActivityManager;
@@ -35,6 +40,8 @@ public:
 	{
 		m_pCore = 0;
 		mem_zero(&m_ActivityEvents, sizeof(m_ActivityEvents));
+
+		m_ActivityEvents.on_activity_join = &CDiscord::OnActivityJoin;
 		m_pActivityManager = 0;
 
 		DiscordCreateParams Params;
@@ -44,6 +51,7 @@ public:
 		Params.flags = EDiscordCreateFlags::DiscordCreateFlags_NoRequireDiscord;
 		Params.event_data = this;
 		Params.activity_events = &m_ActivityEvents;
+
 		int Error = pfnDiscordCreate(DISCORD_VERSION, &Params, &m_pCore);
 		if(Error != DiscordResult_Ok)
 		{
@@ -52,33 +60,129 @@ public:
 		}
 
 		m_pActivityManager = m_pCore->get_activity_manager(m_pCore);
+
+		// which application to launch when joining activity
+		m_pActivityManager->register_command(m_pActivityManager, CONNECTLINK_DOUBLE_SLASH);
+		m_pActivityManager->register_steam(m_pActivityManager, 412220); // steam id
+
 		ClearGameInfo();
+
 		return false;
 	}
+
 	void Update() override
 	{
+		// update every 5 seconds, rate limit is 5 updates per 20 seconds
+		if(m_UpdateActivity && time_get() > m_LastActivityUpdate + time_freq() * 5)
+		{
+			m_UpdateActivity = false;
+			m_LastActivityUpdate = time_get();
+
+			m_pActivityManager->update_activity(m_pActivityManager, &m_Activity, 0, 0);
+		}
+
 		m_pCore->run_callbacks(m_pCore);
 	}
+
 	void ClearGameInfo() override
 	{
-		DiscordActivity Activity;
-		mem_zero(&Activity, sizeof(DiscordActivity));
-		str_copy(Activity.assets.large_image, "ddnet_logo", sizeof(Activity.assets.large_image));
-		str_copy(Activity.assets.large_text, "DDNet logo", sizeof(Activity.assets.large_text));
-		Activity.timestamps.start = time_timestamp();
-		str_copy(Activity.details, "Offline", sizeof(Activity.details));
-		m_pActivityManager->update_activity(m_pActivityManager, &Activity, 0, 0);
+		mem_zero(&m_Activity, sizeof(DiscordActivity));
+
+		str_copy(m_Activity.assets.large_image, "ddnet_logo", sizeof(m_Activity.assets.large_image));
+		str_copy(m_Activity.assets.large_text, "DDNet logo", sizeof(m_Activity.assets.large_text));
+		m_Activity.timestamps.start = time_timestamp();
+		str_copy(m_Activity.details, "Offline", sizeof(m_Activity.details));
+		m_Activity.instance = false;
+
+		m_UpdateActivity = true;
 	}
-	void SetGameInfo(const NETADDR &ServerAddr, const char *pMapName, bool AnnounceAddr) override
+
+	void SetGameInfo(const CServerInfo &ServerInfo, const char *pMapName, bool Registered) override
 	{
-		DiscordActivity Activity;
-		mem_zero(&Activity, sizeof(DiscordActivity));
-		str_copy(Activity.assets.large_image, "ddnet_logo", sizeof(Activity.assets.large_image));
-		str_copy(Activity.assets.large_text, "DDNet logo", sizeof(Activity.assets.large_text));
-		Activity.timestamps.start = time_timestamp();
-		str_copy(Activity.details, "Online", sizeof(Activity.details));
-		str_copy(Activity.state, pMapName, sizeof(Activity.state));
-		m_pActivityManager->update_activity(m_pActivityManager, &Activity, 0, 0);
+		mem_zero(&m_Activity, sizeof(DiscordActivity));
+
+		str_copy(m_Activity.assets.large_image, "ddnet_logo", sizeof(m_Activity.assets.large_image));
+		str_copy(m_Activity.assets.large_text, "DDNet logo", sizeof(m_Activity.assets.large_text));
+		m_Activity.timestamps.start = time_timestamp();
+		str_copy(m_Activity.name, "Online", sizeof(m_Activity.name));
+		m_Activity.instance = true;
+
+		str_copy(m_Activity.details, ServerInfo.m_aName, sizeof(m_Activity.details));
+		str_copy(m_Activity.state, pMapName, sizeof(m_Activity.state));
+		m_Activity.party.size.current_size = ServerInfo.m_NumClients;
+		m_Activity.party.size.max_size = ServerInfo.m_MaxClients;
+		// private makes it so the game isn't public to join, but there's 'Ask to Join' button instead
+		m_Activity.party.privacy = Registered ? DiscordActivityPartyPrivacy_Public : DiscordActivityPartyPrivacy_Private;
+
+		if(!Registered)
+		{
+			// private parties have random id to not leak the server ip
+			char aPartyId[sizeof(m_Activity.party.id)];
+			secure_random_password(aPartyId, sizeof(aPartyId), 64);
+			str_copy(m_Activity.party.id, aPartyId, sizeof(m_Activity.party.id));
+		}
+		UpdateServerIp(ServerInfo);
+
+		m_UpdateActivity = true;
+	}
+
+	void UpdateServerInfo(const CServerInfo &ServerInfo, const char *pMapName)
+	{
+		if(!m_Activity.instance)
+			return;
+
+		UpdateServerIp(ServerInfo);
+
+		str_copy(m_Activity.details, ServerInfo.m_aName, sizeof(m_Activity.details));
+		str_copy(m_Activity.state, pMapName, sizeof(m_Activity.state));
+		m_Activity.party.size.max_size = ServerInfo.m_MaxClients;
+		m_UpdateActivity = true;
+	}
+
+	void UpdatePlayerCount(int Count)
+	{
+		if(!m_Activity.instance)
+			return;
+
+		if(m_Activity.party.size.current_size == Count)
+			return;
+
+		m_Activity.party.size.current_size = Count;
+		m_UpdateActivity = true;
+	}
+
+	void UpdateServerIp(const CServerInfo &ServerInfo)
+	{
+		if(!m_Activity.instance)
+			return;
+
+		// secret is only shared when player is joining the game, or when he's invited for private games
+		if(str_length(ServerInfo.m_aAddress) < (int)sizeof(m_Activity.secrets.join))
+		{
+			str_copy(m_Activity.secrets.join, ServerInfo.m_aAddress, sizeof(m_Activity.secrets.join));
+		}
+		else
+		{
+			char aAddr[NETADDR_MAXSTRSIZE];
+			net_addr_str(&ServerInfo.m_aAddresses[0], aAddr, sizeof(aAddr), true);
+			str_copy(m_Activity.secrets.join, aAddr, sizeof(m_Activity.secrets.join));
+		}
+
+		if(m_Activity.party.privacy == DiscordActivityPartyPrivacy_Public)
+		{
+			// id is sha256, because it didn't work with the ':' character
+			char aPartyId[SHA256_MAXSTRSIZE];
+			SHA256_DIGEST PartyIdSha256 = sha256(m_Activity.secrets.join, str_length(m_Activity.secrets.join));
+			sha256_str(PartyIdSha256, aPartyId, sizeof(aPartyId));
+			str_copy(m_Activity.party.id, aPartyId, sizeof(m_Activity.party.id));
+		}
+	}
+
+	static void OnActivityJoin(void *pEventData, const char *pSecret)
+	{
+		CDiscord *pSelf = static_cast<CDiscord *>(pEventData);
+		IClient *m_pClient = pSelf->Kernel()->RequestInterface<IClient>();
+		m_pClient->Connect(pSecret);
 	}
 };
 
@@ -108,7 +212,9 @@ class CDiscordStub : public IDiscord
 {
 	void Update() override {}
 	void ClearGameInfo() override {}
-	void SetGameInfo(const NETADDR &ServerAddr, const char *pMapName, bool AnnounceAddr) override {}
+	void SetGameInfo(const CServerInfo &ServerInfo, const char *pMapName, bool Registered) override {}
+	void UpdateServerInfo(const CServerInfo &ServerInfo, const char *pMapName) override {}
+	void UpdatePlayerCount(int Count) override {}
 };
 
 IDiscord *CreateDiscord()

--- a/src/engine/discord.h
+++ b/src/engine/discord.h
@@ -3,6 +3,7 @@
 
 #include "kernel.h"
 #include <base/types.h>
+#include <engine/serverbrowser.h>
 
 class IDiscord : public IInterface
 {
@@ -11,7 +12,9 @@ public:
 	virtual void Update() = 0;
 
 	virtual void ClearGameInfo() = 0;
-	virtual void SetGameInfo(const NETADDR &ServerAddr, const char *pMapName, bool AnnounceAddr) = 0;
+	virtual void SetGameInfo(const CServerInfo &ServerInfo, const char *pMapName, bool Registered) = 0;
+	virtual void UpdateServerInfo(const CServerInfo &ServerInfo, const char *pMapName) = 0;
+	virtual void UpdatePlayerCount(int Count) = 0;
 };
 
 IDiscord *CreateDiscord();

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -7,6 +7,7 @@
 #include <engine/client/checksum.h>
 #include <engine/client/enums.h>
 #include <engine/demo.h>
+#include <engine/discord.h>
 #include <engine/editor.h>
 #include <engine/engine.h>
 #include <engine/favorites.h>
@@ -105,6 +106,7 @@ void CGameClient::OnConsoleInit()
 	m_pFavorites = Kernel()->RequestInterface<IFavorites>();
 	m_pFriends = Kernel()->RequestInterface<IFriends>();
 	m_pFoes = Client()->Foes();
+	m_pDiscord = Kernel()->RequestInterface<IDiscord>();
 #if defined(CONF_AUTOUPDATE)
 	m_pUpdater = Kernel()->RequestInterface<IUpdater>();
 #endif
@@ -1959,6 +1961,11 @@ void CGameClient::OnNewSnapshot()
 			m_aClients[i].Reset();
 			m_aStats[i].Reset();
 		}
+	}
+
+	if(Client()->State() == IClient::STATE_ONLINE)
+	{
+		m_pDiscord->UpdatePlayerCount(m_Snap.m_NumPlayers);
 	}
 
 	for(int i = 0; i < MAX_CLIENTS; ++i)

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -196,6 +196,7 @@ private:
 	class IEditor *m_pEditor;
 	class IFriends *m_pFriends;
 	class IFriends *m_pFoes;
+	class IDiscord *m_pDiscord;
 #if defined(CONF_AUTOUPDATE)
 	class IUpdater *m_pUpdater;
 #endif


### PR DESCRIPTION
- It will now display the server name, map name, and the number of players
- You can join and invite others to your server. However, joining without Steam sometimes does not automatically open the game, I'm not sure why. When game is open it will automatically connect

![image](https://github.com/user-attachments/assets/347a6b7b-2700-40d2-b37b-24660882f8a2)
![image](https://github.com/user-attachments/assets/c73b11c5-fce4-498d-aba2-4ab55e802392)
![image](https://github.com/user-attachments/assets/fdc733dc-7fa2-492e-ac87-ba2b4eef2cef)
![image](https://github.com/user-attachments/assets/0f425744-dee6-4d2b-a011-e14475564722)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
