### PR TITLE
use local user for local test server

### DIFF
--- a/src/game/editor/quick_actions.cpp
+++ b/src/game/editor/quick_actions.cpp
@@ -261,17 +261,24 @@ void CEditor::TestMapLocally()
 	{
 		char aRegister[] = "sv_register 0";
 
+		char aServerPassCmd[64];
+		char aServerPass[32];
 		char aRandomPass[17];
+		char aUser[] = "editor-local-server";
+		char aAuthLevel[] = "admin";
 		secure_random_password(aRandomPass, sizeof(aRandomPass), 16);
 		char aPass[64];
-		str_format(aPass, sizeof(aPass), "sv_rcon_password %s", aRandomPass);
+		str_format(aPass, sizeof(aPass), "auth_add %s %s %s", aUser, aAuthLevel, aRandomPass);
+
+		str_format(aServerPass, sizeof(aServerPass), "%s:%s", aUser, aRandomPass);
+		str_format(aServerPassCmd, sizeof(aServerPassCmd), "password %s", aServerPass);
 
 		str_format(aBuf, sizeof(aBuf), "change_map %s", aFileNameNoExt);
-		const char *apArguments[] = {aRegister, aPass, aBuf};
+		const char *apArguments[] = {aRegister, aPass, aBuf, aServerPassCmd};
 		pGameClient->m_Menus.RunServer(apArguments, std::size(apArguments));
 		OnClose();
 		g_Config.m_ClEditor = 0;
-		Client()->Connect("localhost");
-		Client()->RconAuth("", aRandomPass, g_Config.m_ClDummy);
+		Client()->Connect("localhost", aServerPass);
+		Client()->RconAuth(aUser, aRandomPass, g_Config.m_ClDummy);
 	}
 }


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->
Add a local user for the local test server (which you start with "Test map locally" button in Editor). This allows you to still have a global rcon config in a server config.

Also this PR changes the server password as this causes issues.

![screenshot_2025-03-06_13-03-10](https://github.com/user-attachments/assets/fef3811a-bb81-4bbb-ba44-e5bb1a5c8f2f)

closes #9746 and #9814 

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots ~~if it is a visual change~~
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
