### PR TITLE
Add null movement setting

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -23,6 +23,7 @@ MACRO_CONFIG_INT(ClAntiPingSmooth, cl_antiping_smooth, 0, 0, 1, CFGFLAG_CLIENT |
 MACRO_CONFIG_INT(ClAntiPingGunfire, cl_antiping_gunfire, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Predict gunfire and show predicted weapon physics (with cl_antiping_grenade 1 and cl_antiping_weapons 1)")
 MACRO_CONFIG_INT(ClPredictionMargin, cl_prediction_margin, 10, 1, 300, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Prediction margin in ms (adds latency, can reduce lag from ping jumps)")
 MACRO_CONFIG_INT(ClSubTickAiming, cl_sub_tick_aiming, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Send aiming data at sub-tick accuracy")
+MACRO_CONFIG_INT(ClNullMovement, cl_null_movement, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Holding both direction keys will cause you to move in the direction of the last one that was pressed")
 #if defined(CONF_PLATFORM_ANDROID)
 MACRO_CONFIG_INT(ClTouchControls, cl_touch_controls, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable ingame touch controls")
 #else

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -33,6 +33,7 @@ void CControls::OnReset()
 		AmmoCount = 0;
 
 	m_LastSendTime = 0;
+	m_NullMovement = false;
 }
 
 void CControls::ResetInput(int Dummy)
@@ -241,6 +242,26 @@ int CControls::SnapInput(int *pData)
 			m_aInputData[g_Config.m_ClDummy].m_Direction = -1;
 		if(!m_aInputDirectionLeft[g_Config.m_ClDummy] && m_aInputDirectionRight[g_Config.m_ClDummy])
 			m_aInputData[g_Config.m_ClDummy].m_Direction = 1;
+
+		if(g_Config.m_ClNullMovement)
+		{
+			if(m_aInputDirectionLeft[g_Config.m_ClDummy] && m_aInputDirectionRight[g_Config.m_ClDummy])
+			{
+				if(m_aLastData[g_Config.m_ClDummy].m_Direction != 0 && !m_NullMovement)
+				{
+					m_NullMovement = true;
+					m_aInputData[g_Config.m_ClDummy].m_Direction = m_aLastData[g_Config.m_ClDummy].m_Direction * -1;
+				}
+				else if(m_NullMovement)
+				{
+					m_aInputData[g_Config.m_ClDummy].m_Direction = m_aLastData[g_Config.m_ClDummy].m_Direction;
+				}
+			}
+			else
+			{
+				m_NullMovement = false;
+			}
+		}
 
 		// dummy copy moves
 		if(g_Config.m_ClDummyCopyMoves)

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -28,6 +28,7 @@ public:
 	int m_aInputDirectionLeft[NUM_DUMMIES];
 	int m_aInputDirectionRight[NUM_DUMMIES];
 	int m_aShowHookColl[NUM_DUMMIES];
+	bool m_NullMovement;
 
 	CControls();
 	virtual int Sizeof() const override { return sizeof(*this); }


### PR DESCRIPTION
Adds null movement / null bind / rapid tap / snap tap / snappy tappy (many names for the same thing)
When both direction keys are pressed at once, it will prioritize the one that was pressed last. Completely optional, just a console setting with no checkbox in the menus.



This feature is already available in many newer keyboards. While it doesn’t provide a significant advantage over other players or automatically make you better, it can help deter people from downloading scripts or macros from the internet by including this functionality directly in the client



## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
