### PR TITLE
Name plate move direction to bottom again and fix direction transparency

### DIFF
--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -108,9 +108,9 @@ public:
 	void Render(CGameClient &This, float X, float Y) const override
 	{
 		IGraphics::CQuadItem QuadItem(X - Size().x / 2.0f, Y - Size().y / 2.0f, Size().x, Size().y);
-		This.Graphics()->SetColor(m_Color);
 		This.Graphics()->TextureSet(m_Texture);
 		This.Graphics()->QuadsBegin();
+		This.Graphics()->SetColor(m_Color);
 		This.Graphics()->QuadsSetRotation(m_Rotation);
 		This.Graphics()->QuadsDrawTL(&QuadItem, 1);
 		This.Graphics()->QuadsEnd();
@@ -211,6 +211,7 @@ public:
 			m_Offset.y = m_Size.y / 4.0f;
 			break;
 		}
+		m_Color.a = Data.m_Color.a;
 	}
 };
 
@@ -464,6 +465,11 @@ private:
 			return;
 		m_Inited = true;
 
+		AddPart<CNamePlatePartDirection>(This, DIRECTION_LEFT);
+		AddPart<CNamePlatePartDirection>(This, DIRECTION_UP);
+		AddPart<CNamePlatePartDirection>(This, DIRECTION_RIGHT);
+		AddPart<CNamePlatePartNewLine>(This);
+
 		AddPart<CNamePlatePartClientId>(This, false);
 		AddPart<CNamePlatePartFriendMark>(This);
 		AddPart<CNamePlatePartName>(This);
@@ -477,11 +483,6 @@ private:
 
 		AddPart<CNamePlatePartHookStrongWeak>(This);
 		AddPart<CNamePlatePartHookStrongWeakId>(This);
-		AddPart<CNamePlatePartNewLine>(This);
-
-		AddPart<CNamePlatePartDirection>(This, DIRECTION_LEFT);
-		AddPart<CNamePlatePartDirection>(This, DIRECTION_UP);
-		AddPart<CNamePlatePartDirection>(This, DIRECTION_RIGHT);
 	}
 	void Update(CGameClient &This, const CNamePlateRenderData *pData)
 	{


### PR DESCRIPTION
(If you're looking for images for release notes goto #9601 )

Thanks to @Pioooooo for reporting this

Before:

![image](https://github.com/user-attachments/assets/cd87bd56-9381-4742-9b8f-dbd90499e232)

* Transparency isn't applied to other players
* Directions are actually meant to be at the bottom

After:

![image](https://github.com/user-attachments/assets/6218103c-acce-406e-9b93-3fa484a1615e)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
