### PR TITLE
Always automatically rcon auth on local server

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -1371,6 +1371,20 @@ int net_addr_from_url(NETADDR *addr, const char *string, char *host_buf, size_t 
 	return failure;
 }
 
+bool net_addr_is_local(const NETADDR *addr)
+{
+	char addr_str[NETADDR_MAXSTRSIZE];
+	net_addr_str(addr, addr_str, sizeof(addr_str), true);
+
+	if(addr->ip[0] == 127 || addr->ip[0] == 10 || (addr->ip[0] == 192 && addr->ip[1] == 168) || (addr->ip[0] == 172 && (addr->ip[1] >= 16 && addr->ip[1] <= 31)))
+		return true;
+
+	if(str_startswith(addr_str, "[fe80:") || str_startswith(addr_str, "[::1"))
+		return true;
+
+	return false;
+}
+
 int net_addr_from_str(NETADDR *addr, const char *string)
 {
 	const char *str = string;

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -897,6 +897,15 @@ void net_addr_str(const NETADDR *addr, char *string, int max_length, bool add_po
 int net_addr_from_url(NETADDR *addr, const char *string, char *host_buf, size_t host_buf_size);
 
 /**
+ * Checks if an address is local.
+ *
+ * @param addr Address to check.
+ *
+ * @return `true` if the address is local, `false` otherwise.
+ */
+bool net_addr_is_local(const NETADDR *addr);
+
+/**
  * Turns string into a network address.
  *
  * @param addr Address to fill in.

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -31,6 +31,8 @@
 
 #include <game/client/components/skins7.h>
 
+static constexpr const char *DEFAULT_SAVED_RCON_USER = "local-server";
+
 struct CServerProcess
 {
 #if !defined(CONF_PLATFORM_ANDROID)

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -142,10 +142,17 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 		if(IsServerRunning())
 		{
 			KillServer();
+			GameClient()->m_aSavedLocalRconPassword[0] = '\0';
 		}
 		else
 		{
-			RunServer();
+			char aRandomPass[17];
+			secure_random_password(aRandomPass, sizeof(aRandomPass), 16);
+			char aPass[64];
+			str_format(aPass, sizeof(aPass), "auth_add %s admin %s", DEFAULT_SAVED_RCON_USER, aRandomPass);
+			const char *apArguments[] = {aPass};
+			RunServer(apArguments, std::size(apArguments));
+			str_copy(GameClient()->m_aSavedLocalRconPassword, aRandomPass);
 		}
 	}
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -585,8 +585,14 @@ void CGameClient::OnConnected()
 	ConfigManager()->ResetGameSettings();
 	LoadMapSettings();
 
-	if(Client()->State() != IClient::STATE_DEMOPLAYBACK && g_Config.m_ClAutoDemoOnConnect)
-		Client()->DemoRecorder_HandleAutoStart();
+	if(Client()->State() != IClient::STATE_DEMOPLAYBACK)
+	{
+		if(g_Config.m_ClAutoDemoOnConnect)
+			Client()->DemoRecorder_HandleAutoStart();
+
+		if(m_Menus.IsServerRunning() && m_aSavedLocalRconPassword[0] != '\0' && net_addr_is_local(&Client()->ServerAddress()))
+			Client()->RconAuth(DEFAULT_SAVED_RCON_USER, m_aSavedLocalRconPassword, g_Config.m_ClDummy);
+	}
 }
 
 void CGameClient::OnReset()

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -305,6 +305,8 @@ public:
 	int m_ServerMode;
 	CGameInfo m_GameInfo;
 
+	char m_aSavedLocalRconPassword[sizeof(g_Config.m_SvRconPassword)] = "";
+
 	int m_DemoSpecId;
 
 	vec2 m_LocalCharacterPos;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -8945,19 +8945,7 @@ void CEditor::HandleWriterFinishJobs()
 		CServerInfo CurrentServerInfo;
 		Client()->GetServerInfo(&CurrentServerInfo);
 
-		NETADDR pAddr = Client()->ServerAddress();
-		char aAddrStr[NETADDR_MAXSTRSIZE];
-		net_addr_str(&Client()->ServerAddress(), aAddrStr, sizeof(aAddrStr), true);
-
-		// and if we're on a local address
-		bool IsLocalAddress = false;
-		if(pAddr.ip[0] == 127 || pAddr.ip[0] == 10 || (pAddr.ip[0] == 192 && pAddr.ip[1] == 168) || (pAddr.ip[0] == 172 && (pAddr.ip[1] >= 16 && pAddr.ip[1] <= 31)))
-			IsLocalAddress = true;
-
-		if(str_startswith(aAddrStr, "[fe80:") || str_startswith(aAddrStr, "[::1"))
-			IsLocalAddress = true;
-
-		if(IsLocalAddress)
+		if(net_addr_is_local(&Client()->ServerAddress()))
 		{
 			char aMapName[128];
 			IStorage::StripPathAndExtension(pJob->GetRealFileName(), aMapName, sizeof(aMapName));

--- a/src/game/editor/quick_actions.cpp
+++ b/src/game/editor/quick_actions.cpp
@@ -231,18 +231,7 @@ void CEditor::TestMapLocally()
 
 	if(Client()->RconAuthed())
 	{
-		NETADDR Addr = Client()->ServerAddress();
-		char aAddrStr[NETADDR_MAXSTRSIZE];
-		net_addr_str(&Client()->ServerAddress(), aAddrStr, sizeof(aAddrStr), true);
-
-		bool IsLocalAddress = false;
-		if(Addr.ip[0] == 127 || Addr.ip[0] == 10 || (Addr.ip[0] == 192 && Addr.ip[1] == 168) || (Addr.ip[0] == 172 && (Addr.ip[1] >= 16 && Addr.ip[1] <= 31)))
-			IsLocalAddress = true;
-
-		if(str_startswith(aAddrStr, "[fe80:") || str_startswith(aAddrStr, "[::1"))
-			IsLocalAddress = true;
-
-		if(IsLocalAddress)
+		if(net_addr_is_local(&Client()->ServerAddress()))
 		{
 			OnClose();
 			g_Config.m_ClEditor = 0;

--- a/src/game/editor/quick_actions.cpp
+++ b/src/game/editor/quick_actions.cpp
@@ -254,7 +254,8 @@ void CEditor::TestMapLocally()
 		char aRandomPass[17];
 		secure_random_password(aRandomPass, sizeof(aRandomPass), 16);
 		char aPass[64];
-		str_format(aPass, sizeof(aPass), "sv_rcon_password %s", aRandomPass);
+		str_format(aPass, sizeof(aPass), "auth_add %s admin %s", DEFAULT_SAVED_RCON_USER, aRandomPass);
+		str_copy(pGameClient->m_aSavedLocalRconPassword, aRandomPass);
 
 		str_format(aBuf, sizeof(aBuf), "change_map %s", aFileNameNoExt);
 		const char *apArguments[] = {aRegister, aPass, aBuf};
@@ -262,6 +263,5 @@ void CEditor::TestMapLocally()
 		OnClose();
 		g_Config.m_ClEditor = 0;
 		Client()->Connect("localhost");
-		Client()->RconAuth("", aRandomPass, g_Config.m_ClDummy);
 	}
 }

--- a/src/test/netaddr.cpp
+++ b/src/test/netaddr.cpp
@@ -153,3 +153,25 @@ TEST(NetAddrDeathTest, StrInvalid2)
 	},
 		"");
 }
+
+TEST(NetAddr, IsLocal)
+{
+	NETADDR Addr;
+	net_addr_from_str(&Addr, "127.0.0.1");
+	EXPECT_TRUE(net_addr_is_local(&Addr));
+
+	net_addr_from_str(&Addr, "[::1]");
+	EXPECT_TRUE(net_addr_is_local(&Addr));
+
+	net_addr_from_str(&Addr, "192.168.1.1");
+	EXPECT_TRUE(net_addr_is_local(&Addr));
+
+	net_addr_from_str(&Addr, "10.0.0.1");
+	EXPECT_TRUE(net_addr_is_local(&Addr));
+
+	net_addr_from_str(&Addr, "8.8.8.8");
+	EXPECT_FALSE(net_addr_is_local(&Addr));
+
+	net_addr_from_str(&Addr, "[2001:db8::1]");
+	EXPECT_FALSE(net_addr_is_local(&Addr));
+}


### PR DESCRIPTION
Fixes #9746, Closes #9815 
Saves rcon password when starting a server and auths when joining a local ip server

Also, refactor the IsLocalAddress check, as it would have been repeated for the third time now

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
