### PR TITLE
Use getters and setters for reload timer

### DIFF
--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -11,6 +11,16 @@
 
 // Character, "physical" player's part
 
+int CCharacter::ReloadTimer() const
+{
+	return m_ReloadTimer;
+}
+
+void CCharacter::SetReloadTimer(int Delay)
+{
+	m_ReloadTimer = Delay;
+}
+
 void CCharacter::SetWeapon(int W)
 {
 	if(W == m_Core.m_ActiveWeapon)
@@ -190,7 +200,7 @@ void CCharacter::HandleNinja()
 void CCharacter::DoWeaponSwitch()
 {
 	// make sure we can switch
-	if(m_ReloadTimer != 0 || m_QueuedWeapon == -1 || m_Core.m_aWeapons[WEAPON_NINJA].m_Got || !m_Core.m_aWeapons[m_QueuedWeapon].m_Got)
+	if(ReloadTimer() != 0 || m_QueuedWeapon == -1 || m_Core.m_aWeapons[WEAPON_NINJA].m_Got || !m_Core.m_aWeapons[m_QueuedWeapon].m_Got)
 		return;
 
 	// switch Weapon
@@ -255,7 +265,7 @@ void CCharacter::FireWeapon()
 	if(!GameWorld()->m_WorldConfig.m_PredictWeapons)
 		return;
 
-	if(m_ReloadTimer != 0)
+	if(ReloadTimer() != 0)
 		return;
 
 	DoWeaponSwitch();
@@ -357,7 +367,7 @@ void CCharacter::FireWeapon()
 		if(Hits)
 		{
 			float FireDelay = GetTuning(GetOverriddenTuneZone())->m_HammerHitFireDelay;
-			m_ReloadTimer = FireDelay * GameWorld()->GameTickSpeed() / 1000;
+			SetReloadTimer(FireDelay * GameWorld()->GameTickSpeed() / 1000);
 		}
 	}
 	break;
@@ -458,12 +468,12 @@ void CCharacter::FireWeapon()
 
 	m_AttackTick = GameWorld()->GameTick(); // NOLINT(clang-analyzer-unix.Malloc)
 
-	if(!m_ReloadTimer)
+	if(!ReloadTimer())
 	{
 		float FireDelay;
 		GetTuning(GetOverriddenTuneZone())->Get(offsetof(CTuningParams, m_HammerFireDelay) / sizeof(CTuneParam) + m_Core.m_ActiveWeapon, &FireDelay);
 
-		m_ReloadTimer = FireDelay * GameWorld()->GameTickSpeed() / 1000;
+		SetReloadTimer(FireDelay * GameWorld()->GameTickSpeed() / 1000);
 	}
 }
 
@@ -474,9 +484,9 @@ void CCharacter::HandleWeapons()
 	HandleJetpack();
 
 	// check reload timer
-	if(m_ReloadTimer)
+	if(ReloadTimer())
 	{
-		m_ReloadTimer--;
+		SetReloadTimer(ReloadTimer() - 1);
 		return;
 	}
 
@@ -1195,7 +1205,7 @@ CCharacter::CCharacter(CGameWorld *pGameWorld, int Id, CNetObj_Character *pChar,
 	m_Core.m_Id = Id;
 	mem_zero(&m_Core.m_Ninja, sizeof(m_Core.m_Ninja));
 	m_Core.m_LeftWall = true;
-	m_ReloadTimer = 0;
+	SetReloadTimer(0);
 	m_NumObjectsHit = 0;
 	m_LastRefillJumps = false;
 	m_LastJetpackStrength = 400.0f;
@@ -1421,7 +1431,7 @@ void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtende
 			float FireDelay;
 			GetTuning(GetOverriddenTuneZone())->Get(offsetof(CTuningParams, m_HammerFireDelay) / sizeof(CTuneParam) + m_Core.m_ActiveWeapon, &FireDelay);
 			const int FireDelayTicks = FireDelay * GameWorld()->GameTickSpeed() / 1000;
-			m_ReloadTimer = maximum(0, m_AttackTick + FireDelayTicks - GameWorld()->GameTick());
+			SetReloadTimer(maximum(0, m_AttackTick + FireDelayTicks - GameWorld()->GameTick()));
 		}
 	}
 }

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -33,6 +33,8 @@ public:
 
 	bool IsGrounded();
 
+	int ReloadTimer() const;
+	void SetReloadTimer(int Delay);
 	void SetWeapon(int W);
 	void SetSolo(bool Solo);
 	void SetSuper(bool Super);

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -135,6 +135,16 @@ void CCharacter::Destroy()
 	SetSolo(false);
 }
 
+int CCharacter::ReloadTimer() const
+{
+	return m_ReloadTimer;
+}
+
+void CCharacter::SetReloadTimer(int Delay)
+{
+	m_ReloadTimer = Delay;
+}
+
 void CCharacter::SetWeapon(int W)
 {
 	if(W == m_Core.m_ActiveWeapon)
@@ -365,7 +375,7 @@ void CCharacter::HandleNinja()
 void CCharacter::DoWeaponSwitch()
 {
 	// make sure we can switch
-	if(m_ReloadTimer != 0 || m_QueuedWeapon == -1 || m_Core.m_aWeapons[WEAPON_NINJA].m_Got || !m_Core.m_aWeapons[m_QueuedWeapon].m_Got)
+	if(ReloadTimer() != 0 || m_QueuedWeapon == -1 || m_Core.m_aWeapons[WEAPON_NINJA].m_Got || !m_Core.m_aWeapons[m_QueuedWeapon].m_Got)
 		return;
 
 	// switch Weapon
@@ -421,7 +431,7 @@ void CCharacter::HandleWeaponSwitch()
 
 void CCharacter::FireWeapon()
 {
-	if(m_ReloadTimer != 0)
+	if(ReloadTimer() != 0)
 	{
 		if(m_LatestInput.m_Fire & 1)
 		{
@@ -535,7 +545,7 @@ void CCharacter::FireWeapon()
 		if(Hits)
 		{
 			float FireDelay = GetTuning(m_TuneZone)->m_HammerHitFireDelay;
-			m_ReloadTimer = FireDelay * Server()->TickSpeed() / 1000;
+			SetReloadTimer(FireDelay * Server()->TickSpeed() / 1000);
 		}
 	}
 	break;
@@ -619,11 +629,11 @@ void CCharacter::FireWeapon()
 
 	m_AttackTick = Server()->Tick();
 
-	if(!m_ReloadTimer)
+	if(!ReloadTimer())
 	{
 		float FireDelay;
 		GetTuning(m_TuneZone)->Get(offsetof(CTuningParams, m_HammerFireDelay) / sizeof(CTuneParam) + m_Core.m_ActiveWeapon, &FireDelay);
-		m_ReloadTimer = FireDelay * Server()->TickSpeed() / 1000;
+		SetReloadTimer(FireDelay * Server()->TickSpeed() / 1000);
 	}
 }
 
@@ -637,9 +647,9 @@ void CCharacter::HandleWeapons()
 		m_PainSoundTimer--;
 
 	// check reload timer
-	if(m_ReloadTimer)
+	if(ReloadTimer())
 	{
-		m_ReloadTimer--;
+		SetReloadTimer(ReloadTimer() - 1);
 		return;
 	}
 

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -48,6 +48,8 @@ public:
 
 	bool IsGrounded();
 
+	int ReloadTimer() const;
+	void SetReloadTimer(int Delay);
 	void SetWeapon(int W);
 	void SetJetpack(bool Active);
 	void SetEndlessJump(bool Active);


### PR DESCRIPTION
This falls under #7777! :warning: 

I would like to introduce a per weapon reload timer in my downstream. And do not like the amount of git diff that is required to do so. Which makes updating to newer ddnet versions harder! This pr would help with that.

Since it was decided in #7777 that downstreams are not supported by ddnet this should only be merged if you think that a getter and setter is an improvement for ddnet.