### PR TITLE
Clear key states on alt tab

### DIFF
--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -808,6 +808,7 @@ int CInput::Update()
 				IgnoreKeys = true;
 				break;
 			case SDL_WINDOWEVENT_FOCUS_LOST:
+				std::fill(std::begin(m_aCurrentKeyStates), std::end(m_aCurrentKeyStates), false);
 				m_MouseFocus = false;
 				IgnoreKeys = true;
 				if(m_InputGrabbed)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a7ecfbf6-c739-4670-bbd4-eda5f88624d5)
![image](https://github.com/user-attachments/assets/ce28562e-4106-4fcf-982a-234c27e3b9dc)

It would go away after clicking anywhere, but it's confusing when that happens. This fix will clear all held keys when alt-tabbing. It’s still possible to keep holding hook by alt-tabbing, though I’m not sure why. But I guess that’s the desired behavior if anyone ever used it

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
