### PR TITLE
Initialize GfxScreen(Width|Height) on window init

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1247,6 +1247,7 @@ int CGraphicsBackend_SDL_GL::Init(const char *pName, int *pScreen, int *pWidth, 
 		SDL_GL_GetDrawableSize(m_pWindow, pCurrentWidth, pCurrentHeight);
 	else
 		SDL_GetWindowSize(m_pWindow, pCurrentWidth, pCurrentHeight);
+	SDL_GetWindowSize(m_pWindow, pWidth, pHeight);
 
 	if(IsOpenGLFamilyBackend)
 	{


### PR DESCRIPTION
Followup to #9847 

`p(Width|Height)` = `g_Config.GfxScreen(Width|Height)`

`pCurrent(Width|Height)` = `m_Screen(Width|Height)`

I'm confused because before, m_Screen-size was initialized with a potentially scaled window size.
Afaik that was incorrect, but I might also be wrong.

This missing initialization caused the DpiScale to be calculated with an outdated GfxScreen-size, causing the crash.
With this pull request individually also fixes the crash.

Once again, I don't have a high-dpi monitor to test all of this.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
