### PR TITLE
Fix crash due to changed sound sample assertion

### DIFF
--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -286,7 +286,7 @@ CSample *CSound::AllocSample()
 
 	CSample *pSample = &m_aSamples[m_FirstFreeSampleIndex];
 	dbg_assert(
-		pSample->m_pData && pSample->m_NextFreeSampleIndex != SAMPLE_INDEX_USED,
+		pSample->m_pData == nullptr && pSample->m_NextFreeSampleIndex != SAMPLE_INDEX_USED,
 		"Sample was not unloaded (index=%d, next=%d, duration=%f, data=%p)",
 		pSample->m_Index, pSample->m_NextFreeSampleIndex, pSample->TotalTime(), pSample->m_pData);
 	m_FirstFreeSampleIndex = pSample->m_NextFreeSampleIndex;


### PR DESCRIPTION
From #9857. The sound sample slot is supposed to be unloaded and unused when allocated.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
