### PR TITLE
Make "Allow all unknown settings" allow all settings

### DIFF
--- a/src/game/editor/editor_server_settings.cpp
+++ b/src/game/editor/editor_server_settings.cpp
@@ -2191,7 +2191,7 @@ void CMapSettingsBackend::OnMapLoad()
 		if(Result == ECollisionCheckResult::REPLACE)
 			Type |= SInvalidSetting::TYPE_DUPLICATE;
 
-		m_LoadedMapSettings.m_vSettingsInvalid.emplace_back(Index, Setting.m_aCommand, Type, RealCollidingLineIndex, !LocalContext.CommandIsValid());
+		m_LoadedMapSettings.m_vSettingsInvalid.emplace_back(Index, Setting.m_aCommand, Type, RealCollidingLineIndex, !Valid || !LocalContext.CommandIsValid());
 		if(Type & SInvalidSetting::TYPE_DUPLICATE)
 			m_LoadedMapSettings.m_SettingsDuplicate[RealCollidingLineIndex].emplace_back(m_LoadedMapSettings.m_vSettingsInvalid.size() - 1);
 


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/c11a4eb4-7b32-4e41-b246-61a4217923bb)

![image](https://github.com/user-attachments/assets/1b363d8d-2178-4c87-9bc8-412f4350dbea)

Makes this button always clickable when settings are invalid, except for duplicates.
Before it was impossible to add a command with arguments that differed from the expected format. For example if a setting expected an integer but a string was input, or if the tune_zones command contained an unknown setting. This pr fixes that, unless there was a reason on why it worked like that

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
