### PR TITLE
Add missing tile layer property

### DIFF
--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -350,6 +350,7 @@ CEditorActionEditQuadProp::CEditorActionEditQuadProp(CEditor *pEditor, int Group
 		"pos env offset",
 		"color env",
 		"color env offset"};
+	static_assert(std::size(s_apNames) == (size_t)EQuadProp::NUM_PROPS);
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Edit quad %s property in layer %d of group %d", s_apNames[(int)m_Prop], m_LayerIndex, m_GroupIndex);
 }
 
@@ -386,6 +387,7 @@ CEditorActionEditQuadPointProp::CEditorActionEditQuadPointProp(CEditor *pEditor,
 		"color",
 		"tex U",
 		"tex V"};
+	static_assert(std::size(s_apNames) == (size_t)EQuadPointProp::NUM_PROPS);
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Edit quad point %s property in layer %d of group %d", s_apNames[(int)m_Prop], m_LayerIndex, m_GroupIndex);
 }
 
@@ -714,6 +716,7 @@ CEditorActionEditGroupProp::CEditorActionEditGroupProp(CEditor *pEditor, int Gro
 		"clip Y",
 		"clip W",
 		"clip H"};
+	static_assert(std::size(s_apNames) == (size_t)EGroupProp::NUM_PROPS);
 
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Edit group %d %s property", m_GroupIndex, s_apNames[(int)Prop]);
 }
@@ -793,6 +796,7 @@ CEditorActionEditLayerProp::CEditorActionEditLayerProp(CEditor *pEditor, int Gro
 		"group",
 		"order",
 		"HQ"};
+	static_assert(std::size(s_apNames) == (size_t)ELayerProp::NUM_PROPS);
 
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Edit layer %d in group %d %s property", m_LayerIndex, m_GroupIndex, s_apNames[(int)m_Prop]);
 }
@@ -856,7 +860,9 @@ CEditorActionEditLayerTilesProp::CEditorActionEditLayerTilesProp(CEditor *pEdito
 		"color env",
 		"color env offset",
 		"automapper",
+		"automapper reference",
 		"seed"};
+	static_assert(std::size(s_apNames) == (size_t)ETilesProp::NUM_PROPS);
 
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Edit tiles layer %d in group %d %s property", m_LayerIndex, m_GroupIndex, s_apNames[(int)Prop]);
 }
@@ -1067,6 +1073,7 @@ CEditorActionEditLayerQuadsProp::CEditorActionEditLayerQuadsProp(CEditor *pEdito
 {
 	static const char *s_apNames[] = {
 		"image"};
+	static_assert(std::size(s_apNames) == (size_t)ELayerQuadsProp::NUM_PROPS);
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Edit quads layer %d in group %d %s property", m_LayerIndex, m_GroupIndex, s_apNames[(int)m_Prop]);
 }
 
@@ -1712,6 +1719,7 @@ CEditorActionEditLayerSoundsProp::CEditorActionEditLayerSoundsProp(CEditor *pEdi
 {
 	static const char *s_apNames[] = {
 		"sound"};
+	static_assert(std::size(s_apNames) == (size_t)ELayerSoundsProp::NUM_PROPS);
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Edit sounds layer %d in group %d %s property", m_LayerIndex, m_GroupIndex, s_apNames[(int)m_Prop]);
 }
 
@@ -1889,6 +1897,7 @@ CEditorActionEditSoundSourceProp::CEditorActionEditSoundSourceProp(CEditor *pEdi
 		"pos env offset",
 		"sound env",
 		"sound env offset"};
+	static_assert(std::size(s_apNames) == (size_t)ESoundProp::NUM_PROPS);
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Edit sound source %d in layer %d of group %d %s property", SourceIndex, LayerIndex, GroupIndex, s_apNames[(int)Prop]);
 }
 
@@ -1957,6 +1966,7 @@ CEditorActionEditRectSoundSourceShapeProp::CEditorActionEditRectSoundSourceShape
 	static const char *s_apNames[] = {
 		"width",
 		"height"};
+	static_assert(std::size(s_apNames) == (size_t)ERectangleShapeProp::NUM_PROPS);
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Edit sound source %d in layer %d of group %d sound shape %s property", m_SourceIndex, m_LayerIndex, m_GroupIndex, s_apNames[(int)Prop]);
 }
 
@@ -1992,6 +2002,7 @@ CEditorActionEditCircleSoundSourceShapeProp::CEditorActionEditCircleSoundSourceS
 {
 	static const char *s_apNames[] = {
 		"radius"};
+	static_assert(std::size(s_apNames) == (size_t)ECircleShapeProp::NUM_PROPS);
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Edit sound source %d in layer %d of group %d sound shape %s property", m_SourceIndex, m_LayerIndex, m_GroupIndex, s_apNames[(int)Prop]);
 }
 

--- a/src/game/editor/mapitems.h
+++ b/src/game/editor/mapitems.h
@@ -46,14 +46,14 @@ enum class ERectangleShapeProp
 	PROP_NONE = -1,
 	PROP_RECTANGLE_WIDTH,
 	PROP_RECTANGLE_HEIGHT,
-	NUM_RECTANGLE_PROPS,
+	NUM_PROPS,
 };
 
 enum class ECircleShapeProp
 {
 	PROP_NONE = -1,
 	PROP_CIRCLE_RADIUS,
-	NUM_CIRCLE_PROPS,
+	NUM_PROPS,
 };
 
 enum class ELayerProp

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1223,7 +1223,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 			{nullptr},
 		};
 
-		static int s_aCircleIds[(int)ECircleShapeProp::NUM_CIRCLE_PROPS] = {0};
+		static int s_aCircleIds[(int)ECircleShapeProp::NUM_PROPS] = {0};
 		NewVal = 0;
 		auto [LocalState, LocalProp] = pEditor->DoPropertiesWithState<ECircleShapeProp>(&View, aCircleProps, s_aCircleIds, &NewVal);
 		if(LocalProp != ECircleShapeProp::PROP_NONE && (LocalState == EEditState::END || LocalState == EEditState::ONE_GO))
@@ -1251,7 +1251,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 			{nullptr},
 		};
 
-		static int s_aRectangleIds[(int)ERectangleShapeProp::NUM_RECTANGLE_PROPS] = {0};
+		static int s_aRectangleIds[(int)ERectangleShapeProp::NUM_PROPS] = {0};
 		NewVal = 0;
 		auto [LocalState, LocalProp] = pEditor->DoPropertiesWithState<ERectangleShapeProp>(&View, aRectangleProps, s_aRectangleIds, &NewVal);
 		if(LocalProp != ERectangleShapeProp::PROP_NONE && (LocalState == EEditState::END || LocalState == EEditState::ONE_GO))


### PR DESCRIPTION
Previously if you were to change seed property of a layer, 10th element of [s_apNames](https://github.com/ddnet/ddnet/blob/94791b2d5007cd931703aee4d0d79613b443657e/src/game/editor/editor_actions.cpp#L849) array would be accessed.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
