### PR TITLE
Initialize color picker popup state field

### DIFF
--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -757,7 +757,7 @@ public:
 		const char m_ColorPickerId = 0;
 		const char m_aValueSelectorIds[5] = {0};
 		CButtonContainer m_aModeButtons[(int)MODE_HSLA + 1];
-		EEditState m_State;
+		EEditState m_State = EEditState::NONE;
 	};
 	void ShowPopupColorPicker(float X, float Y, SColorPickerPopupContext *pContext);
 


### PR DESCRIPTION
Initialize the field to fix valgrind warning:
```
==130041== Conditional jump or move depends on uninitialised value(s)
==130041==    at 0x7A0C5A: CEditor::DoColorPickerButton(void const*, CUIRect const*, ColorRGBA, std::function<void (ColorRGBA)> const&) (editor.cpp:3793)
==130041==    by 0x791D55: CEditor::DoToolbarLayers(CUIRect) (editor.cpp:1311)
==130041==    by 0x7BBDD3: CEditor::Render() (editor.cpp:8062)
==130041==    by 0x7C0D5A: CEditor::OnRender() (editor.cpp:9020)
==130041==    by 0x5002B9: CClient::Render() (client.cpp:1050)
==130041==    by 0x509E8D: CClient::Run() (client.cpp:3292)
==130041==    by 0x51275C: main (client.cpp:4940)
```

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
