### PR TITLE
Remove `CNetServer::SendConnlessSixup` method

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2642,13 +2642,7 @@ void CServer::PumpNetwork(bool PacketWaiting)
 						CPacker Packer;
 						GetServerInfoSixup(&Packer, SrvBrwsToken, RateLimitServerInfoConnless());
 
-						CNetChunk Response;
-						Response.m_ClientId = -1;
-						Response.m_Address = Packet.m_Address;
-						Response.m_Flags = NETSENDFLAG_CONNLESS;
-						Response.m_pData = Packer.Data();
-						Response.m_DataSize = Packer.Size();
-						m_NetServer.SendConnlessSixup(&Response, ResponseToken);
+						CNetBase::SendPacketConnlessWithToken7(m_NetServer.Socket(), &Packet.m_Address, Packer.Data(), Packer.Size(), ResponseToken, m_NetServer.GetToken(Packet.m_Address));
 					}
 					else if(Type != -1)
 					{

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -463,7 +463,6 @@ public:
 	int MaxClients() const { return m_MaxClients; }
 
 	void SendTokenSixup(NETADDR &Addr, SECURITY_TOKEN Token);
-	int SendConnlessSixup(CNetChunk *pChunk, SECURITY_TOKEN ResponseToken);
 
 	//
 	void SetMaxClientsPerIp(int Max);

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -762,22 +762,6 @@ void CNetServer::SendTokenSixup(NETADDR &Addr, SECURITY_TOKEN Token)
 	CNetBase::SendControlMsg(m_Socket, &Addr, 0, 5, aBuf, Size, Token, true);
 }
 
-int CNetServer::SendConnlessSixup(CNetChunk *pChunk, SECURITY_TOKEN ResponseToken)
-{
-	if(pChunk->m_DataSize > NET_MAX_PACKETSIZE - 9)
-		return -1;
-
-	unsigned char aBuffer[NET_MAX_PACKETSIZE];
-	aBuffer[0] = NET_PACKETFLAG_CONNLESS << 2 | 1;
-	SECURITY_TOKEN Token = GetToken(pChunk->m_Address);
-	WriteSecurityToken(aBuffer + 1, ResponseToken);
-	WriteSecurityToken(aBuffer + 5, Token);
-	mem_copy(aBuffer + 9, pChunk->m_pData, pChunk->m_DataSize);
-	net_udp_send(m_Socket, &pChunk->m_Address, aBuffer, pChunk->m_DataSize + 9);
-
-	return 0;
-}
-
 void CNetServer::SetMaxClientsPerIp(int Max)
 {
 	// clamp


### PR DESCRIPTION
Remove `CNetServer::SendConnlessSixup` and use `CNetBase::SendPacketConnlessWithToken7` instead.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
