### PR TITLE
Use `std::unique_ptr` for `IStorage` uses in tools and tests

### DIFF
--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -957,28 +957,28 @@ IStorage *CreateStorage(IStorage::EInitializationType InitializationType, int Nu
 	return CStorage::Create(InitializationType, NumArgs, ppArguments);
 }
 
-IStorage *CreateLocalStorage()
+std::unique_ptr<IStorage> CreateLocalStorage()
 {
-	CStorage *pStorage = new CStorage();
+	std::unique_ptr<CStorage> pStorage = std::make_unique<CStorage>();
 	if(!pStorage->FindCurrentDirectory() ||
 		!pStorage->AddPath("$CURRENTDIR"))
 	{
-		delete pStorage;
-		return nullptr;
+		return std::unique_ptr<IStorage>(nullptr);
 	}
 	return pStorage;
 }
 
-IStorage *CreateTempStorage(const char *pDirectory, int NumArgs, const char **ppArguments)
+std::unique_ptr<IStorage> CreateTempStorage(const char *pDirectory, int NumArgs, const char **ppArguments)
 {
-	CStorage *pStorage = new CStorage();
 	dbg_assert(NumArgs > 0, "Expected at least one argument");
+	std::unique_ptr<CStorage> pStorage = std::make_unique<CStorage>();
 	pStorage->FindDataDirectory(ppArguments[0]);
-	pStorage->FindCurrentDirectory();
-	if(!pStorage->AddPath(pDirectory) || !pStorage->AddPath("$DATADIR") || !pStorage->AddPath("$CURRENTDIR"))
+	if(!pStorage->FindCurrentDirectory() ||
+		!pStorage->AddPath(pDirectory) ||
+		!pStorage->AddPath("$DATADIR") ||
+		!pStorage->AddPath("$CURRENTDIR"))
 	{
-		delete pStorage;
-		return nullptr;
+		return std::unique_ptr<IStorage>(nullptr);
 	}
 	return pStorage;
 }

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -8,6 +8,7 @@
 
 #include "kernel.h"
 
+#include <memory>
 #include <set>
 #include <string>
 
@@ -77,7 +78,7 @@ public:
 };
 
 extern IStorage *CreateStorage(IStorage::EInitializationType InitializationType, int NumArgs, const char **ppArguments);
-extern IStorage *CreateLocalStorage();
-extern IStorage *CreateTempStorage(const char *pDirectory, int NumArgs, const char **ppArguments);
+extern std::unique_ptr<IStorage> CreateLocalStorage();
+extern std::unique_ptr<IStorage> CreateTempStorage(const char *pDirectory, int NumArgs, const char **ppArguments);
 
 #endif

--- a/src/test/datafile.cpp
+++ b/src/test/datafile.cpp
@@ -8,7 +8,9 @@
 
 TEST(Datafile, ExtendedType)
 {
-	auto pStorage = std::unique_ptr<IStorage>(CreateLocalStorage());
+	std::unique_ptr<IStorage> pStorage = CreateLocalStorage();
+	ASSERT_NE(pStorage, nullptr) << "Error creating local storage";
+
 	CTestInfo Info;
 
 	CMapItemTest ItemTest;
@@ -63,7 +65,9 @@ TEST(Datafile, ExtendedType)
 
 TEST(Datafile, StringData)
 {
-	auto pStorage = std::unique_ptr<IStorage>(CreateLocalStorage());
+	std::unique_ptr<IStorage> pStorage = CreateLocalStorage();
+	ASSERT_NE(pStorage, nullptr) << "Error creating local storage";
+
 	CTestInfo Info;
 
 	{

--- a/src/test/gameworld.cpp
+++ b/src/test/gameworld.cpp
@@ -40,6 +40,7 @@ public:
 	CServer *m_pServer = nullptr;
 	std::unique_ptr<IKernel> m_pKernel;
 	CTestInfo m_TestInfo;
+	std::unique_ptr<IStorage> m_pStorage;
 
 	CGameContext *GameServer()
 	{
@@ -58,9 +59,9 @@ public:
 		m_pKernel->RegisterInterface(pEngine);
 
 		m_TestInfo.m_DeleteTestStorageFilesOnSuccess = true;
-		IStorage *pStorage = m_TestInfo.CreateTestStorage();
-		EXPECT_NE(pStorage, nullptr);
-		m_pKernel->RegisterInterface(pStorage);
+		m_pStorage = m_TestInfo.CreateTestStorage();
+		EXPECT_NE(m_pStorage, nullptr);
+		m_pKernel->RegisterInterface(m_pStorage.get(), false);
 
 		IConsole *pConsole = CreateConsole(CFGFLAG_SERVER | CFGFLAG_ECON).release();
 		m_pKernel->RegisterInterface(pConsole);

--- a/src/test/serverbrowser.cpp
+++ b/src/test/serverbrowser.cpp
@@ -16,7 +16,8 @@ TEST(ServerBrowser, PingCache)
 	Info.m_DeleteTestStorageFilesOnSuccess = true;
 
 	auto pConsole = CreateConsole(CFGFLAG_CLIENT);
-	auto pStorage = std::unique_ptr<IStorage>(Info.CreateTestStorage());
+	std::unique_ptr<IStorage> pStorage = Info.CreateTestStorage();
+	ASSERT_NE(pStorage, nullptr) << "Error creating test storage";
 	auto pPingCache = std::unique_ptr<IServerBrowserPingCache>(CreateServerBrowserPingCache(pConsole.get(), pStorage.get()));
 
 	NETADDR Localhost4, Localhost6, OtherLocalhost4, OtherLocalhost6;

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -36,7 +36,7 @@ void CTestInfo::Filename(char *pBuffer, size_t BufferLength, const char *pSuffix
 	str_format(pBuffer, BufferLength, "%s%s", m_aFilenamePrefix, pSuffix);
 }
 
-IStorage *CTestInfo::CreateTestStorage()
+std::unique_ptr<IStorage> CTestInfo::CreateTestStorage()
 {
 	bool Error = fs_makedir(m_aFilename);
 	EXPECT_FALSE(Error);
@@ -47,7 +47,7 @@ IStorage *CTestInfo::CreateTestStorage()
 	char aTestPath[IO_MAX_PATH_LENGTH];
 	str_copy(aTestPath, ::testing::internal::GetArgvs().front().c_str());
 	const char *apArgs[] = {aTestPath};
-	return CreateTempStorage(m_aFilename, 1, apArgs);
+	return CreateTempStorage(m_aFilename, std::size(apArgs), apArgs);
 }
 
 class CTestInfoPath

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -2,6 +2,7 @@
 #define TEST_TEST_H
 
 #include <cstddef>
+#include <memory>
 
 class IStorage;
 
@@ -10,7 +11,7 @@ class CTestInfo
 public:
 	CTestInfo();
 	~CTestInfo();
-	IStorage *CreateTestStorage();
+	std::unique_ptr<IStorage> CreateTestStorage();
 	bool m_DeleteTestStorageFilesOnSuccess = false;
 	void Filename(char *pBuffer, size_t BufferLength, const char *pSuffix);
 	char m_aFilenamePrefix[128];

--- a/src/tools/config_common.h
+++ b/src/tools/config_common.h
@@ -50,9 +50,12 @@ int main(int argc, const char **argv) // NOLINT(misc-definitions-in-headers)
 	CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 
-	IStorage *pStorage = CreateLocalStorage();
+	std::unique_ptr<IStorage> pStorage = CreateLocalStorage();
 	if(!pStorage)
+	{
+		log_error("config_common", "Error creating local storage");
 		return -1;
+	}
 
 	if(argc == 1)
 	{
@@ -62,13 +65,13 @@ int main(int argc, const char **argv) // NOLINT(misc-definitions-in-headers)
 	}
 	else if(argc == 2 && fs_is_dir(argv[1]))
 	{
-		SListDirectoryContext Context = {argv[1], pStorage};
+		SListDirectoryContext Context = {argv[1], pStorage.get()};
 		pStorage->ListDirectory(IStorage::TYPE_ALL, argv[1], ListdirCallback, &Context);
 	}
 
 	for(int i = 1; i < argc; i++)
 	{
-		ProcessItem(argv[i], pStorage);
+		ProcessItem(argv[i], pStorage.get());
 	}
 	return 0;
 }

--- a/src/tools/demo_extract_chat.cpp
+++ b/src/tools/demo_extract_chat.cpp
@@ -231,7 +231,7 @@ static int ExtractDemoChat(const char *pDemoFilePath, IStorage *pStorage)
 int main(int argc, const char *argv[])
 {
 	// Create storage before setting logger to avoid log messages from storage creation
-	IStorage *pStorage = CreateLocalStorage();
+	std::unique_ptr<IStorage> pStorage = CreateLocalStorage();
 
 	CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
@@ -248,5 +248,5 @@ int main(int argc, const char *argv[])
 		return -1;
 	}
 
-	return ExtractDemoChat(argv[1], pStorage);
+	return ExtractDemoChat(argv[1], pStorage.get());
 }

--- a/src/tools/dummy_map.cpp
+++ b/src/tools/dummy_map.cpp
@@ -110,9 +110,14 @@ int main(int argc, const char **argv)
 {
 	CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
-	IStorage *pStorage = CreateStorage(IStorage::EInitializationType::SERVER, argc, argv);
+
+	std::unique_ptr<IStorage> pStorage = std::unique_ptr<IStorage>(CreateStorage(IStorage::EInitializationType::SERVER, argc, argv));
 	if(!pStorage)
+	{
+		log_error("dummy_map", "Error creating server storage");
 		return -1;
-	CreateEmptyMap(pStorage);
+	}
+
+	CreateEmptyMap(pStorage.get());
 	return 0;
 }

--- a/src/tools/map_convert_07.cpp
+++ b/src/tools/map_convert_07.cpp
@@ -114,10 +114,10 @@ int main(int argc, const char **argv)
 		return -1;
 	}
 
-	IStorage *pStorage = CreateStorage(IStorage::EInitializationType::BASIC, argc, argv);
+	std::unique_ptr<IStorage> pStorage = std::unique_ptr<IStorage>(CreateStorage(IStorage::EInitializationType::BASIC, argc, argv));
 	if(!pStorage)
 	{
-		dbg_msg("map_convert_07", "error loading storage");
+		log_error("map_convert_07", "Error creating basic storage");
 		return -1;
 	}
 
@@ -146,13 +146,13 @@ int main(int argc, const char **argv)
 		}
 	}
 
-	if(!g_DataReader.Open(pStorage, pSourceFileName, IStorage::TYPE_ABSOLUTE))
+	if(!g_DataReader.Open(pStorage.get(), pSourceFileName, IStorage::TYPE_ABSOLUTE))
 	{
 		dbg_msg("map_convert_07", "failed to open source map. filename='%s'", pSourceFileName);
 		return -1;
 	}
 
-	if(!g_DataWriter.Open(pStorage, aDestFileName, IStorage::TYPE_ABSOLUTE))
+	if(!g_DataWriter.Open(pStorage.get(), aDestFileName, IStorage::TYPE_ABSOLUTE))
 	{
 		dbg_msg("map_convert_07", "failed to open destination map. filename='%s'", aDestFileName);
 		return -1;

--- a/src/tools/map_create_pixelart.cpp
+++ b/src/tools/map_create_pixelart.cpp
@@ -318,15 +318,20 @@ CQuad CreateNewQuad(const float PosX, const float PosY, const int Width, const i
 
 bool OpenMaps(const char pMapNames[2][IO_MAX_PATH_LENGTH], CDataFileReader &InputMap, CDataFileWriter &OutputMap)
 {
-	IStorage *pStorage = CreateLocalStorage();
+	std::unique_ptr<IStorage> pStorage = CreateLocalStorage();
+	if(!pStorage)
+	{
+		log_error("map_create_pixelart", "Error creating local storage");
+		return false;
+	}
 
-	if(!InputMap.Open(pStorage, pMapNames[0], IStorage::TYPE_ABSOLUTE))
+	if(!InputMap.Open(pStorage.get(), pMapNames[0], IStorage::TYPE_ABSOLUTE))
 	{
 		dbg_msg("map_create_pixelart", "ERROR: unable to open map '%s'", pMapNames[0]);
 		return false;
 	}
 
-	if(!OutputMap.Open(pStorage, pMapNames[1], IStorage::TYPE_ABSOLUTE))
+	if(!OutputMap.Open(pStorage.get(), pMapNames[1], IStorage::TYPE_ABSOLUTE))
 	{
 		dbg_msg("map_create_pixelart", "ERROR: unable to open map '%s'", pMapNames[1]);
 		return false;

--- a/src/tools/map_diff.cpp
+++ b/src/tools/map_diff.cpp
@@ -117,9 +117,12 @@ int main(int argc, const char *argv[])
 		return -1;
 	}
 
-	IStorage *pStorage = CreateLocalStorage();
+	std::unique_ptr<IStorage> pStorage = CreateLocalStorage();
 	if(!pStorage)
+	{
+		log_error("map_diff", "Error creating local storage");
 		return -1;
+	}
 
-	return Process(pStorage, &argv[1]) ? 0 : 1;
+	return Process(pStorage.get(), &argv[1]) ? 0 : 1;
 }

--- a/src/tools/map_extract.cpp
+++ b/src/tools/map_extract.cpp
@@ -134,9 +134,12 @@ int main(int argc, const char *argv[])
 	CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 
-	IStorage *pStorage = CreateLocalStorage();
+	std::unique_ptr<IStorage> pStorage = CreateLocalStorage();
 	if(!pStorage)
+	{
+		log_error("map_extract", "Error creating local storage");
 		return -1;
+	}
 
 	const char *pDir;
 	if(argc == 2)
@@ -159,6 +162,5 @@ int main(int argc, const char *argv[])
 		return -1;
 	}
 
-	int Result = ExtractMap(pStorage, argv[1], pDir) ? 0 : 1;
-	return Result;
+	return ExtractMap(pStorage.get(), argv[1], pDir) ? 0 : 1;
 }

--- a/src/tools/map_find_env.cpp
+++ b/src/tools/map_find_env.cpp
@@ -15,9 +15,14 @@ public:
 
 bool OpenMap(const char pMapName[64], CDataFileReader &InputMap)
 {
-	IStorage *pStorage = CreateLocalStorage();
+	std::unique_ptr<IStorage> pStorage = CreateLocalStorage();
+	if(!pStorage)
+	{
+		log_error("map_find_env", "Error creating local storage");
+		return false;
+	}
 
-	if(!InputMap.Open(pStorage, pMapName, IStorage::TYPE_ABSOLUTE))
+	if(!InputMap.Open(pStorage.get(), pMapName, IStorage::TYPE_ABSOLUTE))
 	{
 		dbg_msg("map_find_env", "ERROR: unable to open map '%s'", pMapName);
 		return false;

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -78,10 +78,14 @@ int main(int argc, const char **argv)
 	CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 
-	IStorage *pStorage = CreateStorage(IStorage::EInitializationType::BASIC, argc, argv);
-	if(!pStorage || argc <= 1 || argc > 3)
+	std::unique_ptr<IStorage> pStorage = std::unique_ptr<IStorage>(CreateStorage(IStorage::EInitializationType::BASIC, argc, argv));
+	if(!pStorage)
 	{
-		dbg_msg("map_optimize", "Invalid parameters or other unknown error.");
+		log_error("map_optimize", "Error creating basic storage");
+		return -1;
+	}
+	if(argc <= 1 || argc > 3)
+	{
 		dbg_msg("map_optimize", "Usage: map_optimize <source map filepath> [<dest map filepath>]");
 		return -1;
 	}
@@ -102,14 +106,14 @@ int main(int argc, const char **argv)
 	}
 
 	CDataFileReader Reader;
-	if(!Reader.Open(pStorage, argv[1], IStorage::TYPE_ABSOLUTE))
+	if(!Reader.Open(pStorage.get(), argv[1], IStorage::TYPE_ABSOLUTE))
 	{
 		dbg_msg("map_optimize", "Failed to open source file.");
 		return -1;
 	}
 
 	CDataFileWriter Writer;
-	if(!Writer.Open(pStorage, aFileName, IStorage::TYPE_ABSOLUTE))
+	if(!Writer.Open(pStorage.get(), aFileName, IStorage::TYPE_ABSOLUTE))
 	{
 		dbg_msg("map_optimize", "Failed to open target file.");
 		return -1;

--- a/src/tools/map_replace_area.cpp
+++ b/src/tools/map_replace_area.cpp
@@ -92,14 +92,20 @@ int main(int argc, const char *argv[])
 		aaMapNames[0], aaMapNames[1], aaaGameAreas[0][0][0], aaaGameAreas[0][1][0], aaaGameAreas[1][0][0], aaaGameAreas[1][1][0],
 		aaaGameAreas[0][0][1] - aaaGameAreas[0][0][0], aaaGameAreas[0][1][1] - aaaGameAreas[0][1][0], aaMapNames[2]);
 
-	IStorage *pStorage = CreateLocalStorage();
+	std::unique_ptr<IStorage> pStorage = CreateLocalStorage();
+	if(!pStorage)
+	{
+		log_error("map_replace_area", "Error creating local storage");
+		return -1;
+	}
+
 	for(int i = 0; i < 1024; i++)
 	{
 		g_apNewData[i] = g_apNewItem[i] = nullptr;
 		g_aNewDataSize[i] = 0;
 	}
 
-	return ReplaceArea(pStorage, aaMapNames, aaaGameAreas) ? 0 : 1;
+	return ReplaceArea(pStorage.get(), aaMapNames, aaaGameAreas) ? 0 : 1;
 }
 
 bool ReplaceArea(IStorage *pStorage, const char aaMapNames[3][64], const float aaaGameAreas[][2][2])

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -79,10 +79,10 @@ int main(int argc, const char **argv)
 		return -1;
 	}
 
-	IStorage *pStorage = CreateStorage(IStorage::EInitializationType::BASIC, argc, argv);
+	std::unique_ptr<IStorage> pStorage = std::unique_ptr<IStorage>(CreateStorage(IStorage::EInitializationType::BASIC, argc, argv));
 	if(!pStorage)
 	{
-		dbg_msg("map_replace_image", "error loading storage");
+		log_error("map_replace_image", "Error creating basic storage");
 		return -1;
 	}
 
@@ -91,14 +91,14 @@ int main(int argc, const char **argv)
 	const char *pImageName = argv[3];
 	const char *pImageFile = argv[4];
 
-	if(!g_DataReader.Open(pStorage, pSourceFileName, IStorage::TYPE_ALL))
+	if(!g_DataReader.Open(pStorage.get(), pSourceFileName, IStorage::TYPE_ALL))
 	{
 		dbg_msg("map_replace_image", "failed to open source map. filename='%s'", pSourceFileName);
 		return -1;
 	}
 
 	CDataFileWriter Writer;
-	if(!Writer.Open(pStorage, pDestFileName))
+	if(!Writer.Open(pStorage.get(), pDestFileName))
 	{
 		dbg_msg("map_replace_image", "failed to open destination map. filename='%s'", pDestFileName);
 		return -1;

--- a/src/tools/map_resave.cpp
+++ b/src/tools/map_resave.cpp
@@ -68,12 +68,12 @@ int main(int argc, const char **argv)
 		return -1;
 	}
 
-	IStorage *pStorage = CreateStorage(IStorage::EInitializationType::BASIC, argc, argv);
+	std::unique_ptr<IStorage> pStorage = std::unique_ptr<IStorage>(CreateStorage(IStorage::EInitializationType::BASIC, argc, argv));
 	if(!pStorage)
 	{
 		log_error(TOOL_NAME, "Error creating basic storage");
 		return -1;
 	}
 
-	return ResaveMap(argv[1], argv[2], pStorage);
+	return ResaveMap(argv[1], argv[2], pStorage.get());
 }


### PR DESCRIPTION
Fix leak sanitizer warnings due to storage not being deleted in tools.

Improve error handling in tools when storage could not be initialized.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
