### PR TITLE
Don't unpause when force pause timer is over

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -814,7 +814,7 @@ void CPlayer::ProcessPause()
 	if(m_ForcePauseTime && m_ForcePauseTime < Server()->Tick())
 	{
 		m_ForcePauseTime = 0;
-		Pause(PAUSE_NONE, true);
+		GameServer()->SendChatTarget(m_ClientId, "The force pause timer is now over, you can exit with /spec");
 	}
 
 	if(m_Paused == PAUSE_SPEC && !m_pCharacter->IsPaused() && CanSpec())


### PR DESCRIPTION
Usually when trying to vote an AFK to spectator on a server with `sv_pausable`, they will be force paused for `sv_vote_pause_time` (10s) and then they reappear automatically. This PR makes it so that the player has to explicitly exit spectator.

![image](https://github.com/user-attachments/assets/946fb15d-281a-435e-b4d7-429e73155d9b)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
