### PR TITLE
Reset velocity when using move commands

### DIFF
--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -78,6 +78,7 @@ void CGameContext::MoveCharacter(int ClientId, int X, int Y, bool Raw)
 		return;
 
 	pChr->Move(vec2((Raw ? 1 : 32) * X, (Raw ? 1 : 32) * Y));
+	pChr->ResetVelocity();
 	pChr->m_DDRaceState = DDRACE_CHEAT;
 }
 


### PR DESCRIPTION
I use binds for `rcon left` `rcon right` `rcon up` and `rcon down` a lot and i found it quite annoying that i cant always reach some high spots with those binds due to gravity

I think those commands should resets the players velocity just like `telecursor` does

Before:

https://github.com/user-attachments/assets/739e21a9-0973-453d-8718-3d42a6396f04



After:

https://github.com/user-attachments/assets/27fa3d6a-efa3-4f57-877e-9c59e5d859a7




- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
