### PR TITLE
Dynamic nameplate preview description

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2872,7 +2872,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		// ***** Name Plate Dummy Preview ***** //
 		RightView.HSplitBottom(LineSize, &RightView, &Button);
-		if(DoButton_CheckBox(&m_DummyNamePlatePreview, Localize("Preview dummy's name plate"), m_DummyNamePlatePreview, &Button))
+		if(DoButton_CheckBox(&m_DummyNamePlatePreview, g_Config.m_ClDummy ? Localize("Preview player's name plate") : Localize("Preview dummy's name plate"), m_DummyNamePlatePreview, &Button))
 			m_DummyNamePlatePreview = !m_DummyNamePlatePreview;
 
 		int Dummy = g_Config.m_ClDummy != (m_DummyNamePlatePreview ? 1 : 0);


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
I think there might be some issues with the design here. @SollyBunny 
1. When in main character mode (g_Config.m_ClDummy == 0):
- Checking this box shows the dummy's nameplate (as expected)
2. But when in dummy mode (g_Config.m_ClDummy == 1):
- Checking this box instead displays the main character's nameplate (which contradicts the text description)

This appears to be an intentional design choice, but nowhere else in the menu settings are there similar configurations. Instead, each setting requires manual selection to change between dummy and main character options.
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
