### PR TITLE
Move DDRace HUD title to correct pane, Refactor in game cursor rendering

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2393,7 +2393,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		// ***** DDRace HUD ***** //
 		Ui()->DoLabel_AutoLineSize(Localize("DDRace HUD"), HeadlineFontSize,
-			TEXTALIGN_ML, &LeftView, HeadlineHeight);
+			TEXTALIGN_ML, &RightView, HeadlineHeight);
 		RightView.HSplitTop(MarginSmall, nullptr, &RightView);
 
 		// Switches of various DDRace HUD elements


### PR DESCRIPTION
## Cursor rendering

I also attempted to clean up the cursor code, I tested everything I could think off.

The only bug I found was with smooth dyncam not being exactly correct, but that isn't a regression

Just to make sure, @TsFreddie please check :)

## Menu

For some reason, "DDNet Hud" shows on the left pane, that has been fixed

### Before

![image](https://github.com/user-attachments/assets/1039ccca-9ea7-43e1-892d-308c143bf4a3)

### After

![image](https://github.com/user-attachments/assets/cf4d2b65-2ffd-4544-854b-65431997f281)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)