### PR TITLE
Change nameplate text outlines to have 0.5 opacity again

### DIFF
--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -40,6 +40,8 @@ public:
 
 using PartsVector = std::vector<std::unique_ptr<CNamePlatePart>>;
 
+static const ColorRGBA s_OutlineColor = ColorRGBA(0.0f, 0.0f, 0.0f, 0.5f);
+
 class CNamePlatePartText : public CNamePlatePart
 {
 protected:
@@ -88,7 +90,7 @@ public:
 		if(!m_TextContainerIndex.Valid())
 			return;
 
-		ColorRGBA OutlineColor = This.TextRender()->DefaultTextOutlineColor().WithMultipliedAlpha(m_Color.a);
+		ColorRGBA OutlineColor = s_OutlineColor.WithMultipliedAlpha(m_Color.a);
 
 		This.TextRender()->RenderTextContainer(m_TextContainerIndex,
 			m_Color, OutlineColor,


### PR DESCRIPTION
Closes #9894

## with this pr

![image](https://github.com/user-attachments/assets/8858cc33-9022-4e1e-80b6-106595af30e5)

## new

![new](https://zillyhuhn.com/cs/.1742424044.png)

## old

![old](https://zillyhuhn.com/cs/.1742424553.png)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
