### PR TITLE
CI: Pin a specific twmap revision

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -94,11 +94,7 @@ jobs:
 
     - name: Build twmap tool
       run: |
-        git clone https://gitlab.com/Patiga/twmap.git/
-        cd twmap/twmap-tools
-        cargo install --locked --path=.
-        cd ../..
-        rm -rf twmap
+        cargo install twmap-tools --git https://gitlab.com/Patiga/twmap.git/ --rev 1f192def57429a1f64ddb3ac8580744476cfdf1c --locked
 
     - name: Check maps
       run: |


### PR DESCRIPTION
This allows us to upgrade twmap without being bound by its upgrade schedule. It also fixes the current CI breakage.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
