### PR TITLE
Use true for success in sql code

### DIFF
--- a/src/engine/server/databases/connection.h
+++ b/src/engine/server/databases/connection.h
@@ -45,14 +45,14 @@ public:
 
 	// tries to allocate the connection from the pool established
 	//
-	// returns true on failure
+	// returns true on success
 	virtual bool Connect(char *pError, int ErrorSize) = 0;
 	// has to be called to return the connection back to the pool
 	virtual void Disconnect() = 0;
 
 	// ? for Placeholders, connection has to be established, can overwrite previous prepared statements
 	//
-	// returns true on failure
+	// returns true on success
 	virtual bool PrepareStatement(const char *pStmt, char *pError, int ErrorSize) = 0;
 
 	// PrepareStatement has to be called beforehand,
@@ -69,11 +69,11 @@ public:
 	// executes the query and returns if a result row exists and selects it
 	// when called multiple times the next row is selected
 	//
-	// returns true on failure
+	// returns true on success
 	virtual bool Step(bool *pEnd, char *pError, int ErrorSize) = 0;
 	// executes the query and returns the number of rows affected by the update/insert/delete
 	//
-	// returns true on failure
+	// returns true on success
 	virtual bool ExecuteUpdate(int *pNumUpdated, char *pError, int ErrorSize) = 0;
 
 	virtual bool IsNull(int Col) = 0;

--- a/src/engine/server/databases/connection_pool.cpp
+++ b/src/engine/server/databases/connection_pool.cpp
@@ -448,7 +448,7 @@ bool CDbConnectionPool::ExecSqlFunc(IDbConnection *pConnection, CSqlExecData *pD
 		return false;
 	}
 	char aError[256] = "unknown error";
-	if(pConnection->Connect(aError, sizeof(aError)))
+	if(!pConnection->Connect(aError, sizeof(aError)))
 	{
 		dbg_msg("sql", "failed connecting to db: %s", aError);
 		return false;
@@ -457,10 +457,10 @@ bool CDbConnectionPool::ExecSqlFunc(IDbConnection *pConnection, CSqlExecData *pD
 	switch(pData->m_Mode)
 	{
 	case CSqlExecData::READ_ACCESS:
-		Success = !pData->m_Ptr.m_pReadFunc(pConnection, pData->m_pThreadData.get(), aError, sizeof(aError));
+		Success = pData->m_Ptr.m_pReadFunc(pConnection, pData->m_pThreadData.get(), aError, sizeof(aError));
 		break;
 	case CSqlExecData::WRITE_ACCESS:
-		Success = !pData->m_Ptr.m_pWriteFunc(pConnection, pData->m_pThreadData.get(), w, aError, sizeof(aError));
+		Success = pData->m_Ptr.m_pWriteFunc(pConnection, pData->m_pThreadData.get(), w, aError, sizeof(aError));
 		break;
 	default:
 		dbg_assert(false, "unreachable");

--- a/src/engine/server/databases/sqlite.cpp
+++ b/src/engine/server/databases/sqlite.cpp
@@ -115,19 +115,19 @@ bool CSqliteConnection::Connect(char *pError, int ErrorSize)
 	{
 		dbg_assert(false, "Tried connecting while the connection is in use");
 	}
-	if(ConnectImpl(pError, ErrorSize))
+	if(!ConnectImpl(pError, ErrorSize))
 	{
 		m_InUse.store(false);
-		return true;
+		return false;
 	}
-	return false;
+	return true;
 }
 
 bool CSqliteConnection::ConnectImpl(char *pError, int ErrorSize)
 {
 	if(m_pDb != nullptr)
 	{
-		return false;
+		return true;
 	}
 
 	if(sqlite3_libversion_number() < 3025000)
@@ -139,7 +139,7 @@ bool CSqliteConnection::ConnectImpl(char *pError, int ErrorSize)
 	if(Result != SQLITE_OK)
 	{
 		str_format(pError, ErrorSize, "Can't open sqlite database: '%s'", sqlite3_errmsg(m_pDb));
-		return true;
+		return false;
 	}
 
 	// wait for database to unlock so we don't have to handle SQLITE_BUSY errors
@@ -147,37 +147,37 @@ bool CSqliteConnection::ConnectImpl(char *pError, int ErrorSize)
 
 	if(m_Setup)
 	{
-		if(Execute("PRAGMA journal_mode=WAL", pError, ErrorSize))
-			return true;
+		if(!Execute("PRAGMA journal_mode=WAL", pError, ErrorSize))
+			return false;
 		char aBuf[1024];
 		FormatCreateRace(aBuf, sizeof(aBuf), /* Backup */ false);
-		if(Execute(aBuf, pError, ErrorSize))
-			return true;
+		if(!Execute(aBuf, pError, ErrorSize))
+			return false;
 		FormatCreateTeamrace(aBuf, sizeof(aBuf), "BLOB", /* Backup */ false);
-		if(Execute(aBuf, pError, ErrorSize))
-			return true;
+		if(!Execute(aBuf, pError, ErrorSize))
+			return false;
 		FormatCreateMaps(aBuf, sizeof(aBuf));
-		if(Execute(aBuf, pError, ErrorSize))
-			return true;
+		if(!Execute(aBuf, pError, ErrorSize))
+			return false;
 		FormatCreateSaves(aBuf, sizeof(aBuf), /* Backup */ false);
-		if(Execute(aBuf, pError, ErrorSize))
-			return true;
+		if(!Execute(aBuf, pError, ErrorSize))
+			return false;
 		FormatCreatePoints(aBuf, sizeof(aBuf));
-		if(Execute(aBuf, pError, ErrorSize))
-			return true;
+		if(!Execute(aBuf, pError, ErrorSize))
+			return false;
 
 		FormatCreateRace(aBuf, sizeof(aBuf), /* Backup */ true);
-		if(Execute(aBuf, pError, ErrorSize))
-			return true;
+		if(!Execute(aBuf, pError, ErrorSize))
+			return false;
 		FormatCreateTeamrace(aBuf, sizeof(aBuf), "BLOB", /* Backup */ true);
-		if(Execute(aBuf, pError, ErrorSize))
-			return true;
+		if(!Execute(aBuf, pError, ErrorSize))
+			return false;
 		FormatCreateSaves(aBuf, sizeof(aBuf), /* Backup */ true);
-		if(Execute(aBuf, pError, ErrorSize))
-			return true;
+		if(!Execute(aBuf, pError, ErrorSize))
+			return false;
 		m_Setup = false;
 	}
-	return false;
+	return true;
 }
 
 void CSqliteConnection::Disconnect()
@@ -201,10 +201,10 @@ bool CSqliteConnection::PrepareStatement(const char *pStmt, char *pError, int Er
 		nullptr);
 	if(FormatError(Result, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	m_Done = false;
-	return false;
+	return true;
 }
 
 void CSqliteConnection::BindString(int Idx, const char *pString)
@@ -274,40 +274,40 @@ bool CSqliteConnection::Step(bool *pEnd, char *pError, int ErrorSize)
 	if(m_Done)
 	{
 		*pEnd = true;
-		return false;
+		return true;
 	}
 	int Result = sqlite3_step(m_pStmt);
 	if(Result == SQLITE_ROW)
 	{
 		*pEnd = false;
-		return false;
+		return true;
 	}
 	else if(Result == SQLITE_DONE)
 	{
 		m_Done = true;
 		*pEnd = true;
-		return false;
+		return true;
 	}
 	else
 	{
 		if(FormatError(Result, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 	}
 	*pEnd = true;
-	return false;
+	return true;
 }
 
 bool CSqliteConnection::ExecuteUpdate(int *pNumUpdated, char *pError, int ErrorSize)
 {
 	bool End;
-	if(Step(&End, pError, ErrorSize))
+	if(!Step(&End, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	*pNumUpdated = sqlite3_changes(m_pDb);
-	return false;
+	return true;
 }
 
 bool CSqliteConnection::IsNull(int Col)
@@ -368,9 +368,9 @@ bool CSqliteConnection::Execute(const char *pQuery, char *pError, int ErrorSize)
 	{
 		str_format(pError, ErrorSize, "error executing query: '%s'", pErrorMsg);
 		sqlite3_free(pErrorMsg);
-		return true;
+		return false;
 	}
-	return false;
+	return true;
 }
 
 bool CSqliteConnection::FormatError(int Result, char *pError, int ErrorSize)
@@ -401,9 +401,9 @@ bool CSqliteConnection::AddPoints(const char *pPlayer, int Points, char *pError,
 		"VALUES (?, ?) "
 		"ON CONFLICT(Name) DO UPDATE SET Points=Points+?",
 		GetPrefix());
-	if(PrepareStatement(aBuf, pError, ErrorSize))
+	if(!PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	BindString(1, pPlayer);
 	BindInt(2, Points);

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -67,24 +67,24 @@ bool CTeamrank::NextSqlResult(IDbConnection *pSqlServer, bool *pEnd, char *pErro
 	pSqlServer->GetString(2, m_aaNames[0], sizeof(m_aaNames[0]));
 	m_NumNames = 1;
 	bool End = false;
-	while(!pSqlServer->Step(&End, pError, ErrorSize) && !End)
+	while(pSqlServer->Step(&End, pError, ErrorSize) && !End)
 	{
 		CUuid TeamId;
 		pSqlServer->GetBlob(1, TeamId.m_aData, sizeof(TeamId.m_aData));
 		if(m_TeamId != TeamId)
 		{
 			*pEnd = false;
-			return false;
+			return true;
 		}
 		pSqlServer->GetString(2, m_aaNames[m_NumNames], sizeof(m_aaNames[m_NumNames]));
 		m_NumNames++;
 	}
 	if(!End)
 	{
-		return true;
+		return false;
 	}
 	*pEnd = true;
-	return false;
+	return true;
 }
 
 bool CTeamrank::SamePlayers(const std::vector<std::string> *pvSortedNames)
@@ -121,9 +121,9 @@ bool CTeamrank::GetSqlTop5Team(IDbConnection *pSqlServer, bool *pEnd, char *pErr
 				str_append(aNames, ", ");
 			else if(i == TeamSize - 2)
 				str_append(aNames, " & ");
-			if(pSqlServer->Step(&Last, pError, ErrorSize))
+			if(!pSqlServer->Step(&Last, pError, ErrorSize))
 			{
-				return true;
+				return false;
 			}
 			if(Last)
 			{
@@ -138,7 +138,7 @@ bool CTeamrank::GetSqlTop5Team(IDbConnection *pSqlServer, bool *pEnd, char *pErr
 			break;
 		}
 	}
-	return false;
+	return true;
 }
 
 bool CScoreWorker::LoadBestTime(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
@@ -151,23 +151,23 @@ bool CScoreWorker::LoadBestTime(IDbConnection *pSqlServer, const ISqlData *pGame
 	str_format(aBuf, sizeof(aBuf),
 		"SELECT Time FROM %s_race WHERE Map=? ORDER BY `Time` ASC LIMIT 1",
 		pSqlServer->GetPrefix());
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	pSqlServer->BindString(1, pData->m_aMap);
 
 	bool End;
-	if(pSqlServer->Step(&End, pError, ErrorSize))
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	if(!End)
 	{
 		pResult->m_CurrentRecord = pSqlServer->GetFloat(1);
 	}
 
-	return false;
+	return true;
 }
 
 // update stuff
@@ -191,9 +191,9 @@ bool CScoreWorker::LoadPlayerData(IDbConnection *pSqlServer, const ISqlData *pGa
 		"ORDER BY hasCP DESC, Time ASC "
 		"LIMIT 1",
 		pSqlServer->GetPrefix(), pSqlServer->GetPrefix());
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 
 	const char *pPlayer = pData->m_aName[0] != '\0' ? pData->m_aName : pData->m_aRequestingPlayer;
@@ -203,9 +203,9 @@ bool CScoreWorker::LoadPlayerData(IDbConnection *pSqlServer, const ISqlData *pGa
 	pSqlServer->BindString(4, pPlayer);
 
 	bool End;
-	if(pSqlServer->Step(&End, pError, ErrorSize))
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	if(!End)
 	{
@@ -228,15 +228,15 @@ bool CScoreWorker::LoadPlayerData(IDbConnection *pSqlServer, const ISqlData *pGa
 		"FROM %s_race "
 		"WHERE Name = ?",
 		pSqlServer->GetPrefix());
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	pSqlServer->BindString(1, pData->m_aRequestingPlayer);
 
-	if(pSqlServer->Step(&End, pError, ErrorSize))
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	if(!End && !pSqlServer->IsNull(2))
 	{
@@ -249,7 +249,7 @@ bool CScoreWorker::LoadPlayerData(IDbConnection *pSqlServer, const ISqlData *pGa
 		if(sscanf(aCurrent, "%d-%d-%d", &CurrentYear, &CurrentMonth, &CurrentDay) == 3 && sscanf(aStamp, "%d-%d-%d", &StampYear, &StampMonth, &StampDay) == 3 && CurrentMonth == StampMonth && CurrentDay == StampDay)
 			pResult->m_Data.m_Info.m_Birthday = CurrentYear - StampYear;
 	}
-	return false;
+	return true;
 }
 
 bool CScoreWorker::LoadPlayerTimeCp(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
@@ -270,9 +270,9 @@ bool CScoreWorker::LoadPlayerTimeCp(IDbConnection *pSqlServer, const ISqlData *p
 		"ORDER BY Time ASC "
 		"LIMIT 1",
 		pSqlServer->GetPrefix());
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 
 	const char *pPlayer = pData->m_aName[0] != '\0' ? pData->m_aName : pData->m_aRequestingPlayer;
@@ -280,9 +280,9 @@ bool CScoreWorker::LoadPlayerTimeCp(IDbConnection *pSqlServer, const ISqlData *p
 	pSqlServer->BindString(2, pPlayer);
 
 	bool End;
-	if(pSqlServer->Step(&End, pError, ErrorSize))
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	if(!End)
 	{
@@ -299,7 +299,7 @@ bool CScoreWorker::LoadPlayerTimeCp(IDbConnection *pSqlServer, const ISqlData *p
 		pResult->SetVariant(CScorePlayerResult::DIRECT);
 		str_format(paMessages[0], sizeof(paMessages[0]), "'%s' has no checkpoint times available", pPlayer);
 	}
-	return false;
+	return true;
 }
 
 bool CScoreWorker::MapVote(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
@@ -327,18 +327,18 @@ bool CScoreWorker::MapVote(IDbConnection *pSqlServer, const ISqlData *pGameData,
 		"  LENGTH(Map), Map "
 		"LIMIT 1",
 		pSqlServer->GetPrefix(), pSqlServer->CollateNocase());
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	pSqlServer->BindString(1, aFuzzyMap);
 	pSqlServer->BindString(2, pData->m_aName);
 	pSqlServer->BindString(3, aMapPrefix);
 
 	bool End;
-	if(pSqlServer->Step(&End, pError, ErrorSize))
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	if(!End)
 	{
@@ -360,7 +360,7 @@ bool CScoreWorker::MapVote(IDbConnection *pSqlServer, const ISqlData *pGameData,
 			"Example: /map %%castle for \"Out of Castle\"",
 			pData->m_aName);
 	}
-	return false;
+	return true;
 }
 
 bool CScoreWorker::MapInfo(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
@@ -406,9 +406,9 @@ bool CScoreWorker::MapInfo(IDbConnection *pSqlServer, const ISqlData *pGameData,
 		aTimestamp, aCurrentTimestamp, aTimestamp,
 		pSqlServer->GetPrefix(), pSqlServer->GetPrefix(),
 		pSqlServer->CollateNocase());
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	pSqlServer->BindString(1, pData->m_aRequestingPlayer);
 	pSqlServer->BindString(2, aFuzzyMap);
@@ -416,9 +416,9 @@ bool CScoreWorker::MapInfo(IDbConnection *pSqlServer, const ISqlData *pGameData,
 	pSqlServer->BindString(4, aMapPrefix);
 
 	bool End;
-	if(pSqlServer->Step(&End, pError, ErrorSize))
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	if(!End)
 	{
@@ -486,7 +486,7 @@ bool CScoreWorker::MapInfo(IDbConnection *pSqlServer, const ISqlData *pGameData,
 		str_format(pResult->m_Data.m_aaMessages[0], sizeof(pResult->m_Data.m_aaMessages[0]),
 			"No map like \"%s\" found.", pData->m_aName);
 	}
-	return false;
+	return true;
 }
 
 bool CScoreWorker::SaveScore(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize)
@@ -502,24 +502,24 @@ bool CScoreWorker::SaveScore(IDbConnection *pSqlServer, const ISqlData *pGameDat
 		str_format(aBuf, sizeof(aBuf),
 			"DELETE FROM %s_race_backup WHERE GameId=? AND Name=? AND Timestamp=%s",
 			pSqlServer->GetPrefix(), pSqlServer->InsertTimestampAsUtc());
-		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		pSqlServer->BindString(1, pData->m_aGameUuid);
 		pSqlServer->BindString(2, pData->m_aName);
 		pSqlServer->BindString(3, pData->m_aTimestamp);
 		pSqlServer->Print();
 		int NumDeleted;
-		if(pSqlServer->ExecuteUpdate(&NumDeleted, pError, ErrorSize))
+		if(!pSqlServer->ExecuteUpdate(&NumDeleted, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		if(NumDeleted == 0)
 		{
 			log_warn("sql", "Rank got moved out of backup database, will show up as duplicate rank in MySQL");
 		}
-		return false;
+		return true;
 	}
 	if(w == Write::NORMAL_FAILED)
 	{
@@ -528,40 +528,40 @@ bool CScoreWorker::SaveScore(IDbConnection *pSqlServer, const ISqlData *pGameDat
 		str_format(aBuf, sizeof(aBuf),
 			"INSERT INTO %s_race SELECT * FROM %s_race_backup WHERE GameId=? AND Name=? AND Timestamp=%s",
 			pSqlServer->GetPrefix(), pSqlServer->GetPrefix(), pSqlServer->InsertTimestampAsUtc());
-		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		pSqlServer->BindString(1, pData->m_aGameUuid);
 		pSqlServer->BindString(2, pData->m_aName);
 		pSqlServer->BindString(3, pData->m_aTimestamp);
 		pSqlServer->Print();
-		if(pSqlServer->ExecuteUpdate(&NumUpdated, pError, ErrorSize))
+		if(!pSqlServer->ExecuteUpdate(&NumUpdated, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 
 		// move to non-tmp table succeeded. delete from backup again
 		str_format(aBuf, sizeof(aBuf),
 			"DELETE FROM %s_race_backup WHERE GameId=? AND Name=? AND Timestamp=%s",
 			pSqlServer->GetPrefix(), pSqlServer->InsertTimestampAsUtc());
-		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		pSqlServer->BindString(1, pData->m_aGameUuid);
 		pSqlServer->BindString(2, pData->m_aName);
 		pSqlServer->BindString(3, pData->m_aTimestamp);
 		pSqlServer->Print();
-		if(pSqlServer->ExecuteUpdate(&NumUpdated, pError, ErrorSize))
+		if(!pSqlServer->ExecuteUpdate(&NumUpdated, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		if(NumUpdated == 0)
 		{
 			log_warn("sql", "Rank got moved out of backup database, will show up as duplicate rank in MySQL");
 		}
-		return false;
+		return true;
 	}
 
 	if(w == Write::NORMAL)
@@ -569,39 +569,39 @@ bool CScoreWorker::SaveScore(IDbConnection *pSqlServer, const ISqlData *pGameDat
 		str_format(aBuf, sizeof(aBuf),
 			"SELECT COUNT(*) AS NumFinished FROM %s_race WHERE Map=? AND Name=? ORDER BY time ASC LIMIT 1",
 			pSqlServer->GetPrefix());
-		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		pSqlServer->BindString(1, pData->m_aMap);
 		pSqlServer->BindString(2, pData->m_aName);
 
 		bool End;
-		if(pSqlServer->Step(&End, pError, ErrorSize))
+		if(!pSqlServer->Step(&End, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		int NumFinished = pSqlServer->GetInt(1);
 		if(NumFinished == 0)
 		{
 			str_format(aBuf, sizeof(aBuf), "SELECT Points FROM %s_maps WHERE Map=?", pSqlServer->GetPrefix());
-			if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+			if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 			{
-				return true;
+				return false;
 			}
 			pSqlServer->BindString(1, pData->m_aMap);
 
 			bool End2;
-			if(pSqlServer->Step(&End2, pError, ErrorSize))
+			if(!pSqlServer->Step(&End2, pError, ErrorSize))
 			{
-				return true;
+				return false;
 			}
 			if(!End2)
 			{
 				int Points = pSqlServer->GetInt(1);
-				if(pSqlServer->AddPoints(pData->m_aName, Points, pError, ErrorSize))
+				if(!pSqlServer->AddPoints(pData->m_aName, Points, pError, ErrorSize))
 				{
-					return true;
+					return false;
 				}
 				str_format(paMessages[0], sizeof(paMessages[0]),
 					"You earned %d point%s for finishing this map!",
@@ -634,9 +634,9 @@ bool CScoreWorker::SaveScore(IDbConnection *pSqlServer, const ISqlData *pGameDat
 		pData->m_aCurrentTimeCp[18], pData->m_aCurrentTimeCp[19], pData->m_aCurrentTimeCp[20],
 		pData->m_aCurrentTimeCp[21], pData->m_aCurrentTimeCp[22], pData->m_aCurrentTimeCp[23],
 		pData->m_aCurrentTimeCp[24], pSqlServer->False());
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	pSqlServer->BindString(1, pData->m_aMap);
 	pSqlServer->BindString(2, pData->m_aName);
@@ -659,9 +659,9 @@ bool CScoreWorker::SaveTeamScore(IDbConnection *pSqlServer, const ISqlData *pGam
 		str_format(aBuf, sizeof(aBuf),
 			"DELETE FROM %s_teamrace_backup WHERE Id=?",
 			pSqlServer->GetPrefix());
-		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 
 		// copy uuid, because mysql BindBlob doesn't support const buffers
@@ -669,15 +669,15 @@ bool CScoreWorker::SaveTeamScore(IDbConnection *pSqlServer, const ISqlData *pGam
 		pSqlServer->BindBlob(1, TeamrankId.m_aData, sizeof(TeamrankId.m_aData));
 		pSqlServer->Print();
 		int NumDeleted;
-		if(pSqlServer->ExecuteUpdate(&NumDeleted, pError, ErrorSize))
+		if(!pSqlServer->ExecuteUpdate(&NumDeleted, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		if(NumDeleted == 0)
 		{
 			log_warn("sql", "Teamrank got moved out of backup database, will show up as duplicate teamrank in MySQL");
 		}
-		return false;
+		return true;
 	}
 	if(w == Write::NORMAL_FAILED)
 	{
@@ -687,23 +687,23 @@ bool CScoreWorker::SaveTeamScore(IDbConnection *pSqlServer, const ISqlData *pGam
 		str_format(aBuf, sizeof(aBuf),
 			"INSERT INTO %s_teamrace SELECT * FROM %s_teamrace_backup WHERE Id=?",
 			pSqlServer->GetPrefix(), pSqlServer->GetPrefix());
-		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		pSqlServer->BindBlob(1, TeamrankId.m_aData, sizeof(TeamrankId.m_aData));
 		pSqlServer->Print();
-		if(pSqlServer->ExecuteUpdate(&NumInserted, pError, ErrorSize))
+		if(!pSqlServer->ExecuteUpdate(&NumInserted, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 
 		str_format(aBuf, sizeof(aBuf),
 			"DELETE FROM %s_teamrace_backup WHERE Id=?",
 			pSqlServer->GetPrefix());
-		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		pSqlServer->BindBlob(1, TeamrankId.m_aData, sizeof(TeamrankId.m_aData));
 		pSqlServer->Print();
@@ -727,9 +727,9 @@ bool CScoreWorker::SaveTeamScore(IDbConnection *pSqlServer, const ISqlData *pGam
 			") as l INNER JOIN %s_teamrace AS r ON l.Id = r.Id "
 			"ORDER BY l.Id, Name COLLATE %s",
 			pSqlServer->GetPrefix(), pSqlServer->False(), pSqlServer->GetPrefix(), pSqlServer->BinaryCollate());
-		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		pSqlServer->BindString(1, pData->m_aMap);
 		pSqlServer->BindString(2, pData->m_aaNames[0]);
@@ -738,9 +738,9 @@ bool CScoreWorker::SaveTeamScore(IDbConnection *pSqlServer, const ISqlData *pGam
 		float Time;
 		CTeamrank Teamrank;
 		bool End;
-		if(pSqlServer->Step(&End, pError, ErrorSize))
+		if(!pSqlServer->Step(&End, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		if(!End)
 		{
@@ -748,9 +748,9 @@ bool CScoreWorker::SaveTeamScore(IDbConnection *pSqlServer, const ISqlData *pGam
 			while(!SearchTeamEnd)
 			{
 				Time = pSqlServer->GetFloat(3);
-				if(Teamrank.NextSqlResult(pSqlServer, &SearchTeamEnd, pError, ErrorSize))
+				if(!Teamrank.NextSqlResult(pSqlServer, &SearchTeamEnd, pError, ErrorSize))
 				{
-					return true;
+					return false;
 				}
 				if(Teamrank.SamePlayers(&vNames))
 				{
@@ -767,23 +767,23 @@ bool CScoreWorker::SaveTeamScore(IDbConnection *pSqlServer, const ISqlData *pGam
 				str_format(aBuf, sizeof(aBuf),
 					"UPDATE %s_teamrace SET Time=%.2f, Timestamp=%s, DDNet7=%s, GameId=? WHERE Id = ?",
 					pSqlServer->GetPrefix(), pData->m_Time, pSqlServer->InsertTimestampAsUtc(), pSqlServer->False());
-				if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+				if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 				{
-					return true;
+					return false;
 				}
 				pSqlServer->BindString(1, pData->m_aTimestamp);
 				pSqlServer->BindString(2, pData->m_aGameUuid);
 				pSqlServer->BindBlob(3, Teamrank.m_TeamId.m_aData, sizeof(Teamrank.m_TeamId.m_aData));
 				pSqlServer->Print();
 				int NumUpdated;
-				if(pSqlServer->ExecuteUpdate(&NumUpdated, pError, ErrorSize))
+				if(!pSqlServer->ExecuteUpdate(&NumUpdated, pError, ErrorSize))
 				{
-					return true;
+					return false;
 				}
 				// return error if we didn't update any rows
-				return NumUpdated == 0;
+				return NumUpdated != 0;
 			}
-			return false;
+			return true;
 		}
 	}
 
@@ -796,9 +796,9 @@ bool CScoreWorker::SaveTeamScore(IDbConnection *pSqlServer, const ISqlData *pGam
 			pSqlServer->InsertIgnore(), pSqlServer->GetPrefix(),
 			w == Write::NORMAL ? "" : "_backup",
 			pSqlServer->InsertTimestampAsUtc(), pData->m_Time, pSqlServer->False());
-		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		pSqlServer->BindString(1, pData->m_aMap);
 		pSqlServer->BindString(2, pData->m_aaNames[i]);
@@ -809,12 +809,12 @@ bool CScoreWorker::SaveTeamScore(IDbConnection *pSqlServer, const ISqlData *pGam
 		pSqlServer->BindString(5, pData->m_aGameUuid);
 		pSqlServer->Print();
 		int NumInserted;
-		if(pSqlServer->ExecuteUpdate(&NumInserted, pError, ErrorSize))
+		if(!pSqlServer->ExecuteUpdate(&NumInserted, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 	}
-	return false;
+	return true;
 }
 
 bool CScoreWorker::ShowRank(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
@@ -840,18 +840,18 @@ bool CScoreWorker::ShowRank(IDbConnection *pSqlServer, const ISqlData *pGameData
 		"WHERE Name = ?",
 		pSqlServer->GetPrefix());
 
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	pSqlServer->BindString(1, pData->m_aMap);
 	pSqlServer->BindString(2, aServerLike);
 	pSqlServer->BindString(3, pData->m_aName);
 
 	bool End;
-	if(pSqlServer->Step(&End, pError, ErrorSize))
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 
 	char aRegionalRank[16];
@@ -866,17 +866,17 @@ bool CScoreWorker::ShowRank(IDbConnection *pSqlServer, const ISqlData *pGameData
 
 	const char *pAny = "%";
 
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	pSqlServer->BindString(1, pData->m_aMap);
 	pSqlServer->BindString(2, pAny);
 	pSqlServer->BindString(3, pData->m_aName);
 
-	if(pSqlServer->Step(&End, pError, ErrorSize))
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 
 	if(!End)
@@ -926,7 +926,7 @@ bool CScoreWorker::ShowRank(IDbConnection *pSqlServer, const ISqlData *pGameData
 		str_format(pResult->m_Data.m_aaMessages[0], sizeof(pResult->m_Data.m_aaMessages[0]),
 			"%s is not ranked", pData->m_aName);
 	}
-	return false;
+	return true;
 }
 
 bool CScoreWorker::ShowTeamRank(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
@@ -954,18 +954,18 @@ bool CScoreWorker::ShowTeamRank(IDbConnection *pSqlServer, const ISqlData *pGame
 		") AS l ON TeamRank.Id = l.Id "
 		"INNER JOIN %s_teamrace AS r ON l.Id = r.Id ",
 		pSqlServer->GetPrefix(), pSqlServer->GetPrefix(), pSqlServer->GetPrefix());
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	pSqlServer->BindString(1, pData->m_aMap);
 	pSqlServer->BindString(2, pData->m_aMap);
 	pSqlServer->BindString(3, pData->m_aName);
 
 	bool End;
-	if(pSqlServer->Step(&End, pError, ErrorSize))
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	if(!End)
 	{
@@ -975,9 +975,9 @@ bool CScoreWorker::ShowTeamRank(IDbConnection *pSqlServer, const ISqlData *pGame
 		// CEIL and FLOOR are not supported in SQLite
 		int BetterThanPercent = std::floor(100.0f - 100.0f * pSqlServer->GetFloat(5));
 		CTeamrank Teamrank;
-		if(Teamrank.NextSqlResult(pSqlServer, &End, pError, ErrorSize))
+		if(!Teamrank.NextSqlResult(pSqlServer, &End, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 
 		char aFormattedNames[512] = "";
@@ -1009,7 +1009,7 @@ bool CScoreWorker::ShowTeamRank(IDbConnection *pSqlServer, const ISqlData *pGame
 		str_format(pResult->m_Data.m_aaMessages[0], sizeof(pResult->m_Data.m_aaMessages[0]),
 			"%s has no team ranks", pData->m_aName);
 	}
-	return false;
+	return true;
 }
 
 bool CScoreWorker::ShowTop(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
@@ -1039,9 +1039,9 @@ bool CScoreWorker::ShowTop(IDbConnection *pSqlServer, const ISqlData *pGameData,
 		pOrder,
 		LimitStart);
 
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	pSqlServer->BindString(1, pData->m_aMap);
 	pSqlServer->BindString(2, pAny);
@@ -1055,7 +1055,7 @@ bool CScoreWorker::ShowTop(IDbConnection *pSqlServer, const ISqlData *pGameData,
 	char aTime[32];
 	bool End = false;
 
-	while(!pSqlServer->Step(&End, pError, ErrorSize) && !End)
+	while(pSqlServer->Step(&End, pError, ErrorSize) && !End)
 	{
 		char aName[MAX_NAME_LENGTH];
 		pSqlServer->GetString(1, aName, sizeof(aName));
@@ -1071,15 +1071,15 @@ bool CScoreWorker::ShowTop(IDbConnection *pSqlServer, const ISqlData *pGameData,
 	if(!g_Config.m_SvRegionalRankings)
 	{
 		str_copy(pResult->m_Data.m_aaMessages[Line], "-----------------------------------------", sizeof(pResult->m_Data.m_aaMessages[Line]));
-		return !End;
+		return End;
 	}
 
 	char aServerLike[16];
 	str_format(aServerLike, sizeof(aServerLike), "%%%s%%", pData->m_aServer);
 
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	pSqlServer->BindString(1, pData->m_aMap);
 	pSqlServer->BindString(2, aServerLike);
@@ -1090,7 +1090,7 @@ bool CScoreWorker::ShowTop(IDbConnection *pSqlServer, const ISqlData *pGameData,
 	Line++;
 
 	// show top
-	while(!pSqlServer->Step(&End, pError, ErrorSize) && !End)
+	while(pSqlServer->Step(&End, pError, ErrorSize) && !End)
 	{
 		char aName[MAX_NAME_LENGTH];
 		pSqlServer->GetString(1, aName, sizeof(aName));
@@ -1102,7 +1102,7 @@ bool CScoreWorker::ShowTop(IDbConnection *pSqlServer, const ISqlData *pGameData,
 		Line++;
 	}
 
-	return !End;
+	return End;
 }
 
 bool CScoreWorker::ShowTeamTop5(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
@@ -1139,9 +1139,9 @@ bool CScoreWorker::ShowTeamTop5(IDbConnection *pSqlServer, const ISqlData *pGame
 		"INNER JOIN %s_teamrace as r ON l2.Id = r.Id "
 		"ORDER BY Ranking %s, r.Id, Name ASC",
 		pSqlServer->GetPrefix(), pSqlServer->GetPrefix(), pOrder, LimitStart, pSqlServer->GetPrefix(), pOrder);
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	pSqlServer->BindString(1, pData->m_aMap);
 	pSqlServer->BindString(2, pAny);
@@ -1151,30 +1151,30 @@ bool CScoreWorker::ShowTeamTop5(IDbConnection *pSqlServer, const ISqlData *pGame
 	str_copy(paMessages[Line++], "------- Team Top 5 -------", sizeof(paMessages[Line]));
 
 	bool End;
-	if(pSqlServer->Step(&End, pError, ErrorSize))
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	if(!End)
 	{
-		if(CTeamrank::GetSqlTop5Team(pSqlServer, &End, pError, ErrorSize, paMessages, &Line, 5))
+		if(!CTeamrank::GetSqlTop5Team(pSqlServer, &End, pError, ErrorSize, paMessages, &Line, 5))
 		{
-			return true;
+			return false;
 		}
 	}
 
 	if(!g_Config.m_SvRegionalRankings)
 	{
 		str_copy(paMessages[Line], "-------------------------------", sizeof(paMessages[Line]));
-		return false;
+		return true;
 	}
 
 	char aServerLike[16];
 	str_format(aServerLike, sizeof(aServerLike), "%%%s%%", pData->m_aServer);
 
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	pSqlServer->BindString(1, pData->m_aMap);
 	pSqlServer->BindString(2, aServerLike);
@@ -1184,18 +1184,18 @@ bool CScoreWorker::ShowTeamTop5(IDbConnection *pSqlServer, const ISqlData *pGame
 		"----- %s Team Top -----", pData->m_aServer);
 	Line++;
 
-	if(pSqlServer->Step(&End, pError, ErrorSize))
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	if(!End)
 	{
-		if(CTeamrank::GetSqlTop5Team(pSqlServer, &End, pError, ErrorSize, paMessages, &Line, 3))
+		if(!CTeamrank::GetSqlTop5Team(pSqlServer, &End, pError, ErrorSize, paMessages, &Line, 3))
 		{
-			return true;
+			return false;
 		}
 	}
-	return false;
+	return true;
 }
 
 bool CScoreWorker::ShowPlayerTeamTop5(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
@@ -1228,18 +1228,18 @@ bool CScoreWorker::ShowPlayerTeamTop5(IDbConnection *pSqlServer, const ISqlData 
 		"INNER JOIN %s_teamrace AS r ON l.Id = r.Id "
 		"ORDER BY Time %s, l.Id, Name ASC",
 		pSqlServer->GetPrefix(), pSqlServer->GetPrefix(), pOrder, LimitStart, pSqlServer->GetPrefix(), pOrder);
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	pSqlServer->BindString(1, pData->m_aMap);
 	pSqlServer->BindString(2, pData->m_aMap);
 	pSqlServer->BindString(3, pData->m_aName);
 
 	bool End;
-	if(pSqlServer->Step(&End, pError, ErrorSize))
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	if(!End)
 	{
@@ -1254,9 +1254,9 @@ bool CScoreWorker::ShowPlayerTeamTop5(IDbConnection *pSqlServer, const ISqlData 
 			int Rank = pSqlServer->GetInt(4);
 			CTeamrank Teamrank;
 			bool Last;
-			if(Teamrank.NextSqlResult(pSqlServer, &Last, pError, ErrorSize))
+			if(!Teamrank.NextSqlResult(pSqlServer, &Last, pError, ErrorSize))
 			{
-				return true;
+				return false;
 			}
 
 			char aFormattedNames[512] = "";
@@ -1287,7 +1287,7 @@ bool CScoreWorker::ShowPlayerTeamTop5(IDbConnection *pSqlServer, const ISqlData 
 		else
 			str_format(paMessages[0], sizeof(paMessages[0]), "%s has no team ranks in the specified range", pData->m_aName);
 	}
-	return false;
+	return true;
 }
 
 bool CScoreWorker::ShowTimes(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
@@ -1314,9 +1314,9 @@ bool CScoreWorker::ShowTimes(IDbConnection *pSqlServer, const ISqlData *pGameDat
 			"LIMIT ?, 5",
 			aCurrentTimestamp, aTimestamp, aTimestamp,
 			pSqlServer->GetPrefix(), pOrder);
-		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		pSqlServer->BindString(1, pData->m_aMap);
 		pSqlServer->BindString(2, pData->m_aName);
@@ -1332,9 +1332,9 @@ bool CScoreWorker::ShowTimes(IDbConnection *pSqlServer, const ISqlData *pGameDat
 			"LIMIT ?, 5",
 			aCurrentTimestamp, aTimestamp, aTimestamp,
 			pSqlServer->GetPrefix(), pOrder);
-		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		pSqlServer->BindString(1, pData->m_aMap);
 		pSqlServer->BindInt(2, LimitStart);
@@ -1342,14 +1342,14 @@ bool CScoreWorker::ShowTimes(IDbConnection *pSqlServer, const ISqlData *pGameDat
 
 	// show top5
 	bool End;
-	if(pSqlServer->Step(&End, pError, ErrorSize))
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	if(End)
 	{
 		str_copy(paMessages[0], "There are no times in the specified range", sizeof(paMessages[0]));
-		return false;
+		return true;
 	}
 
 	str_copy(paMessages[0], "------------- Last Times -------------", sizeof(paMessages[0]));
@@ -1395,14 +1395,14 @@ bool CScoreWorker::ShowTimes(IDbConnection *pSqlServer, const ISqlData *pGameDat
 			}
 		}
 		Line++;
-	} while(!pSqlServer->Step(&End, pError, ErrorSize) && !End);
+	} while(pSqlServer->Step(&End, pError, ErrorSize) && !End);
 	if(!End)
 	{
-		return true;
+		return false;
 	}
 	str_copy(paMessages[Line], "-------------------------------------------", sizeof(paMessages[Line]));
 
-	return false;
+	return true;
 }
 
 bool CScoreWorker::ShowPoints(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
@@ -1419,17 +1419,17 @@ bool CScoreWorker::ShowPoints(IDbConnection *pSqlServer, const ISqlData *pGameDa
 		")) as Ranking, Points, Name "
 		"FROM %s_points WHERE Name = ?",
 		pSqlServer->GetPrefix(), pSqlServer->GetPrefix(), pSqlServer->GetPrefix());
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	pSqlServer->BindString(1, pData->m_aName);
 	pSqlServer->BindString(2, pData->m_aName);
 
 	bool End;
-	if(pSqlServer->Step(&End, pError, ErrorSize))
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	if(!End)
 	{
@@ -1447,7 +1447,7 @@ bool CScoreWorker::ShowPoints(IDbConnection *pSqlServer, const ISqlData *pGameDa
 		str_format(paMessages[0], sizeof(paMessages[0]),
 			"%s has not collected any points so far", pData->m_aName);
 	}
-	return false;
+	return true;
 }
 
 bool CScoreWorker::ShowTopPoints(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
@@ -1468,9 +1468,9 @@ bool CScoreWorker::ShowTopPoints(IDbConnection *pSqlServer, const ISqlData *pGam
 		") as a "
 		"ORDER BY Ranking ASC, Name ASC LIMIT ?, 5",
 		pSqlServer->GetPrefix());
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	pSqlServer->BindInt(1, LimitStart + 5);
 	pSqlServer->BindInt(2, LimitStart);
@@ -1480,7 +1480,7 @@ bool CScoreWorker::ShowTopPoints(IDbConnection *pSqlServer, const ISqlData *pGam
 
 	bool End = false;
 	int Line = 1;
-	while(!pSqlServer->Step(&End, pError, ErrorSize) && !End)
+	while(pSqlServer->Step(&End, pError, ErrorSize) && !End)
 	{
 		int Rank = pSqlServer->GetInt(1);
 		int Points = pSqlServer->GetInt(2);
@@ -1492,11 +1492,11 @@ bool CScoreWorker::ShowTopPoints(IDbConnection *pSqlServer, const ISqlData *pGam
 	}
 	if(!End)
 	{
-		return true;
+		return false;
 	}
 	str_copy(paMessages[Line], "-------------------------------", sizeof(paMessages[Line]));
 
-	return false;
+	return true;
 }
 
 bool CScoreWorker::RandomMap(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
@@ -1512,9 +1512,9 @@ bool CScoreWorker::RandomMap(IDbConnection *pSqlServer, const ISqlData *pGameDat
 			"WHERE Server = ? AND Map != ? AND Stars = ? "
 			"ORDER BY %s LIMIT 1",
 			pSqlServer->GetPrefix(), pSqlServer->Random());
-		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		pSqlServer->BindInt(3, pData->m_Stars);
 	}
@@ -1525,18 +1525,18 @@ bool CScoreWorker::RandomMap(IDbConnection *pSqlServer, const ISqlData *pGameDat
 			"WHERE Server = ? AND Map != ? "
 			"ORDER BY %s LIMIT 1",
 			pSqlServer->GetPrefix(), pSqlServer->Random());
-		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 	}
 	pSqlServer->BindString(1, pData->m_aServerType);
 	pSqlServer->BindString(2, pData->m_aCurrentMap);
 
 	bool End;
-	if(pSqlServer->Step(&End, pError, ErrorSize))
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	if(!End)
 	{
@@ -1546,7 +1546,7 @@ bool CScoreWorker::RandomMap(IDbConnection *pSqlServer, const ISqlData *pGameDat
 	{
 		str_copy(pResult->m_aMessage, "No maps found on this server!", sizeof(pResult->m_aMessage));
 	}
-	return false;
+	return true;
 }
 
 bool CScoreWorker::RandomUnfinishedMap(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
@@ -1567,9 +1567,9 @@ bool CScoreWorker::RandomUnfinishedMap(IDbConnection *pSqlServer, const ISqlData
 			") ORDER BY %s "
 			"LIMIT 1",
 			pSqlServer->GetPrefix(), pSqlServer->GetPrefix(), pSqlServer->Random());
-		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		pSqlServer->BindString(1, pData->m_aServerType);
 		pSqlServer->BindString(2, pData->m_aCurrentMap);
@@ -1588,9 +1588,9 @@ bool CScoreWorker::RandomUnfinishedMap(IDbConnection *pSqlServer, const ISqlData
 			") ORDER BY %s "
 			"LIMIT 1",
 			pSqlServer->GetPrefix(), pSqlServer->GetPrefix(), pSqlServer->Random());
-		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		pSqlServer->BindString(1, pData->m_aServerType);
 		pSqlServer->BindString(2, pData->m_aCurrentMap);
@@ -1598,9 +1598,9 @@ bool CScoreWorker::RandomUnfinishedMap(IDbConnection *pSqlServer, const ISqlData
 	}
 
 	bool End;
-	if(pSqlServer->Step(&End, pError, ErrorSize))
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	if(!End)
 	{
@@ -1611,7 +1611,7 @@ bool CScoreWorker::RandomUnfinishedMap(IDbConnection *pSqlServer, const ISqlData
 		str_format(aBuf, sizeof(aBuf), "%s has no more unfinished maps on this server!", pData->m_aRequestingPlayer);
 		str_copy(pResult->m_aMessage, aBuf, sizeof(pResult->m_aMessage));
 	}
-	return false;
+	return true;
 }
 
 bool CScoreWorker::SaveTeam(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize)
@@ -1626,9 +1626,9 @@ bool CScoreWorker::SaveTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 		str_format(aBuf, sizeof(aBuf),
 			"DELETE FROM %s_saves_backup WHERE Code = ?",
 			pSqlServer->GetPrefix());
-		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		pSqlServer->BindString(1, pData->m_aGeneratedCode);
 		bool End;
@@ -1642,23 +1642,23 @@ bool CScoreWorker::SaveTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 		str_format(aBuf, sizeof(aBuf),
 			"INSERT INTO %s_saves SELECT * FROM %s_saves_backup WHERE Code = ?",
 			pSqlServer->GetPrefix(), pSqlServer->GetPrefix());
-		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		pSqlServer->BindString(1, pData->m_aGeneratedCode);
-		if(pSqlServer->Step(&End, pError, ErrorSize))
+		if(!pSqlServer->Step(&End, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 
 		// move to non-tmp table succeeded. delete from backup again
 		str_format(aBuf, sizeof(aBuf),
 			"DELETE FROM %s_saves_backup WHERE Code = ?",
 			pSqlServer->GetPrefix());
-		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		pSqlServer->BindString(1, pData->m_aGeneratedCode);
 		return pSqlServer->Step(&End, pError, ErrorSize);
@@ -1689,9 +1689,9 @@ bool CScoreWorker::SaveTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 			"VALUES (?, ?, ?, CURRENT_TIMESTAMP, ?, ?, %s)",
 			pSqlServer->InsertIgnore(), pSqlServer->GetPrefix(),
 			w == Write::NORMAL ? "" : "_backup", pSqlServer->False());
-		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+		if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		pSqlServer->BindString(1, pSaveState);
 		pSqlServer->BindString(2, pData->m_aMap);
@@ -1700,9 +1700,9 @@ bool CScoreWorker::SaveTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 		pSqlServer->BindString(5, aSaveId);
 		pSqlServer->Print();
 		int NumInserted;
-		if(pSqlServer->ExecuteUpdate(&NumInserted, pError, ErrorSize))
+		if(!pSqlServer->ExecuteUpdate(&NumInserted, pError, ErrorSize))
 		{
-			return true;
+			return false;
 		}
 		if(NumInserted == 1)
 		{
@@ -1756,13 +1756,13 @@ bool CScoreWorker::SaveTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 		pResult->m_Status = CScoreSaveResult::SAVE_FAILED;
 		str_copy(pResult->m_aMessage, "This save-code already exists", sizeof(pResult->m_aMessage));
 	}
-	return false;
+	return true;
 }
 
 bool CScoreWorker::LoadTeam(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize)
 {
 	if(w == Write::NORMAL_SUCCEEDED || w == Write::BACKUP_FIRST)
-		return false;
+		return true;
 	const auto *pData = dynamic_cast<const CSqlTeamLoadRequest *>(pGameData);
 	auto *pResult = dynamic_cast<CScoreSaveResult *>(pGameData->m_pResult.get());
 	pResult->m_Status = CScoreSaveResult::LOAD_FAILED;
@@ -1779,22 +1779,22 @@ bool CScoreWorker::LoadTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 		"where Code = ? AND Map = ? AND DDNet7 = %s",
 		aCurrentTimestamp, aTimestamp,
 		pSqlServer->GetPrefix(), pSqlServer->False());
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	pSqlServer->BindString(1, pData->m_aCode);
 	pSqlServer->BindString(2, pData->m_aMap);
 
 	bool End;
-	if(pSqlServer->Step(&End, pError, ErrorSize))
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	if(End)
 	{
 		str_copy(pResult->m_aMessage, "No such savegame for this map", sizeof(pResult->m_aMessage));
-		return false;
+		return true;
 	}
 
 	pResult->m_SaveId = UUID_NO_SAVE_ID;
@@ -1805,7 +1805,7 @@ bool CScoreWorker::LoadTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 		if(ParseUuid(&pResult->m_SaveId, aSaveId) || pResult->m_SaveId == UUID_NO_SAVE_ID)
 		{
 			str_copy(pResult->m_aMessage, "Unable to load savegame: SaveId corrupted", sizeof(pResult->m_aMessage));
-			return false;
+			return true;
 		}
 	}
 
@@ -1816,7 +1816,7 @@ bool CScoreWorker::LoadTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 	if(Num != 0)
 	{
 		str_copy(pResult->m_aMessage, "Unable to load savegame: data corrupted", sizeof(pResult->m_aMessage));
-		return false;
+		return true;
 	}
 
 	bool Found = false;
@@ -1835,7 +1835,7 @@ bool CScoreWorker::LoadTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 					      "If you saved with an already used code, you get a new random save code, "
 					      "check ddnet-saves.txt in config_directory.",
 			sizeof(pResult->m_aMessage));
-		return false;
+		return true;
 	}
 
 	int Since = pSqlServer->GetInt(2);
@@ -1844,7 +1844,7 @@ bool CScoreWorker::LoadTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 		str_format(pResult->m_aMessage, sizeof(pResult->m_aMessage),
 			"You have to wait %d seconds until you can load this savegame",
 			g_Config.m_SvSaveSwapGamesDelay - Since);
-		return false;
+		return true;
 	}
 
 	bool CanLoad = pResult->m_SavedTeam.MatchPlayers(
@@ -1852,16 +1852,16 @@ bool CScoreWorker::LoadTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 		pResult->m_aMessage, sizeof(pResult->m_aMessage));
 
 	if(!CanLoad)
-		return false;
+		return true;
 
 	str_format(aBuf, sizeof(aBuf),
 		"DELETE FROM %s_saves "
 		"WHERE Code = ? AND Map = ? AND SaveId %s",
 		pSqlServer->GetPrefix(),
 		pResult->m_SaveId != UUID_NO_SAVE_ID ? "= ?" : "IS NULL");
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	pSqlServer->BindString(1, pData->m_aCode);
 	pSqlServer->BindString(2, pData->m_aMap);
@@ -1873,20 +1873,20 @@ bool CScoreWorker::LoadTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 	}
 	pSqlServer->Print();
 	int NumDeleted;
-	if(pSqlServer->ExecuteUpdate(&NumDeleted, pError, ErrorSize))
+	if(!pSqlServer->ExecuteUpdate(&NumDeleted, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 
 	if(NumDeleted != 1)
 	{
 		str_copy(pResult->m_aMessage, "Unable to load savegame: loaded on a different server", sizeof(pResult->m_aMessage));
-		return false;
+		return true;
 	}
 
 	pResult->m_Status = CScoreSaveResult::LOAD_SUCCESS;
 	str_copy(pResult->m_aMessage, "Loading successfully done", sizeof(pResult->m_aMessage));
-	return false;
+	return true;
 }
 
 bool CScoreWorker::GetSaves(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
@@ -1914,17 +1914,17 @@ bool CScoreWorker::GetSaves(IDbConnection *pSqlServer, const ISqlData *pGameData
 		"WHERE Map = ? AND Savegame LIKE ?",
 		aCurrentTimestamp, aMaxTimestamp,
 		pSqlServer->GetPrefix());
-	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
+	if(!pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	pSqlServer->BindString(1, pData->m_aMap);
 	pSqlServer->BindString(2, aSaveLike);
 
 	bool End;
-	if(pSqlServer->Step(&End, pError, ErrorSize))
+	if(!pSqlServer->Step(&End, pError, ErrorSize))
 	{
-		return true;
+		return false;
 	}
 	if(!End)
 	{
@@ -1944,5 +1944,5 @@ bool CScoreWorker::GetSaves(IDbConnection *pSqlServer, const ISqlData *pGameData
 			NumSaves, NumSaves == 1 ? "" : "s",
 			pData->m_aMap, aLastSavedString);
 	}
-	return false;
+	return true;
 }

--- a/src/test/score.cpp
+++ b/src/test/score.cpp
@@ -34,27 +34,27 @@ struct Score : public testing::TestWithParam<IDbConnection *>
 
 	void Connect()
 	{
-		ASSERT_FALSE(m_pConn->Connect(m_aError, sizeof(m_aError))) << m_aError;
+		ASSERT_TRUE(m_pConn->Connect(m_aError, sizeof(m_aError))) << m_aError;
 
 		// Delete all existing entries for persistent databases like MySQL
 		int NumInserted = 0;
-		ASSERT_FALSE(m_pConn->PrepareStatement("DELETE FROM record_race", m_aError, sizeof(m_aError))) << m_aError;
-		ASSERT_FALSE(m_pConn->ExecuteUpdate(&NumInserted, m_aError, sizeof(m_aError))) << m_aError;
-		ASSERT_FALSE(m_pConn->PrepareStatement("DELETE FROM record_teamrace", m_aError, sizeof(m_aError))) << m_aError;
-		ASSERT_FALSE(m_pConn->ExecuteUpdate(&NumInserted, m_aError, sizeof(m_aError))) << m_aError;
-		ASSERT_FALSE(m_pConn->PrepareStatement("DELETE FROM record_maps", m_aError, sizeof(m_aError))) << m_aError;
-		ASSERT_FALSE(m_pConn->ExecuteUpdate(&NumInserted, m_aError, sizeof(m_aError))) << m_aError;
-		ASSERT_FALSE(m_pConn->PrepareStatement("DELETE FROM record_points", m_aError, sizeof(m_aError))) << m_aError;
-		ASSERT_FALSE(m_pConn->ExecuteUpdate(&NumInserted, m_aError, sizeof(m_aError))) << m_aError;
-		ASSERT_FALSE(m_pConn->PrepareStatement("DELETE FROM record_saves", m_aError, sizeof(m_aError))) << m_aError;
-		ASSERT_FALSE(m_pConn->ExecuteUpdate(&NumInserted, m_aError, sizeof(m_aError))) << m_aError;
+		ASSERT_TRUE(m_pConn->PrepareStatement("DELETE FROM record_race", m_aError, sizeof(m_aError))) << m_aError;
+		ASSERT_TRUE(m_pConn->ExecuteUpdate(&NumInserted, m_aError, sizeof(m_aError))) << m_aError;
+		ASSERT_TRUE(m_pConn->PrepareStatement("DELETE FROM record_teamrace", m_aError, sizeof(m_aError))) << m_aError;
+		ASSERT_TRUE(m_pConn->ExecuteUpdate(&NumInserted, m_aError, sizeof(m_aError))) << m_aError;
+		ASSERT_TRUE(m_pConn->PrepareStatement("DELETE FROM record_maps", m_aError, sizeof(m_aError))) << m_aError;
+		ASSERT_TRUE(m_pConn->ExecuteUpdate(&NumInserted, m_aError, sizeof(m_aError))) << m_aError;
+		ASSERT_TRUE(m_pConn->PrepareStatement("DELETE FROM record_points", m_aError, sizeof(m_aError))) << m_aError;
+		ASSERT_TRUE(m_pConn->ExecuteUpdate(&NumInserted, m_aError, sizeof(m_aError))) << m_aError;
+		ASSERT_TRUE(m_pConn->PrepareStatement("DELETE FROM record_saves", m_aError, sizeof(m_aError))) << m_aError;
+		ASSERT_TRUE(m_pConn->ExecuteUpdate(&NumInserted, m_aError, sizeof(m_aError))) << m_aError;
 	}
 
 	void LoadBestTime()
 	{
 		CSqlLoadBestTimeRequest loadBestTimeReq(std::make_shared<CScoreLoadBestTimeResult>());
 		str_copy(loadBestTimeReq.m_aMap, "Kobra 3", sizeof(loadBestTimeReq.m_aMap));
-		ASSERT_FALSE(CScoreWorker::LoadBestTime(m_pConn, &loadBestTimeReq, m_aError, sizeof(m_aError))) << m_aError;
+		ASSERT_TRUE(CScoreWorker::LoadBestTime(m_pConn, &loadBestTimeReq, m_aError, sizeof(m_aError))) << m_aError;
 	}
 
 	void InsertMap(const char *pName, const char *pMapper, const char *pServer, int Points, int Stars)
@@ -66,10 +66,10 @@ struct Score : public testing::TestWithParam<IDbConnection *>
 			"%s into %s_maps(Map, Server, Mapper, Points, Stars, Timestamp) "
 			"VALUES (\"%s\", \"%s\", \"%s\", %d, %d, %s)",
 			m_pConn->InsertIgnore(), m_pConn->GetPrefix(), pName, pServer, pMapper, Points, Stars, m_pConn->InsertTimestampAsUtc());
-		ASSERT_FALSE(m_pConn->PrepareStatement(aBuf, m_aError, sizeof(m_aError))) << m_aError;
+		ASSERT_TRUE(m_pConn->PrepareStatement(aBuf, m_aError, sizeof(m_aError))) << m_aError;
 		m_pConn->BindString(1, aTimestamp);
 		int NumInserted = 0;
-		ASSERT_FALSE(m_pConn->ExecuteUpdate(&NumInserted, m_aError, sizeof(m_aError))) << m_aError;
+		ASSERT_TRUE(m_pConn->ExecuteUpdate(&NumInserted, m_aError, sizeof(m_aError))) << m_aError;
 		ASSERT_EQ(NumInserted, 1);
 	}
 
@@ -86,7 +86,7 @@ struct Score : public testing::TestWithParam<IDbConnection *>
 		for(int i = 0; i < NUM_CHECKPOINTS; i++)
 			ScoreData.m_aCurrentTimeCp[i] = WithTimeCheckPoints ? i : 0;
 		str_copy(ScoreData.m_aRequestingPlayer, "deen", sizeof(ScoreData.m_aRequestingPlayer));
-		ASSERT_FALSE(CScoreWorker::SaveScore(m_pConn, &ScoreData, Write::NORMAL, m_aError, sizeof(m_aError))) << m_aError;
+		ASSERT_TRUE(CScoreWorker::SaveScore(m_pConn, &ScoreData, Write::NORMAL, m_aError, sizeof(m_aError))) << m_aError;
 	}
 
 	void ExpectLines(const std::shared_ptr<CScorePlayerResult> &pPlayerResult, std::initializer_list<const char *> Lines, bool All = false)
@@ -128,7 +128,7 @@ struct SingleScore : public Score
 TEST_P(SingleScore, TopRegional)
 {
 	g_Config.m_SvRegionalRankings = true;
-	ASSERT_FALSE(CScoreWorker::ShowTop(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowTop(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult,
 		{"------------ Global Top ------------",
 			"1. nameless tee Time: 01:40.00",
@@ -138,7 +138,7 @@ TEST_P(SingleScore, TopRegional)
 TEST_P(SingleScore, Top)
 {
 	g_Config.m_SvRegionalRankings = false;
-	ASSERT_FALSE(CScoreWorker::ShowTop(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowTop(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult,
 		{"------------ Global Top ------------",
 			"1. nameless tee Time: 01:40.00",
@@ -148,14 +148,14 @@ TEST_P(SingleScore, Top)
 TEST_P(SingleScore, RankRegional)
 {
 	g_Config.m_SvRegionalRankings = true;
-	ASSERT_FALSE(CScoreWorker::ShowRank(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowRank(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult, {"nameless tee - 01:40.00 - better than 100% - requested by brainless tee", "Global rank 1 - GER unranked"}, true);
 }
 
 TEST_P(SingleScore, Rank)
 {
 	g_Config.m_SvRegionalRankings = false;
-	ASSERT_FALSE(CScoreWorker::ShowRank(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowRank(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult, {"nameless tee - 01:40.00 - better than 100% - requested by brainless tee", "Global rank 1"}, true);
 }
 
@@ -163,7 +163,7 @@ TEST_P(SingleScore, TopServerRegional)
 {
 	g_Config.m_SvRegionalRankings = true;
 	str_copy(m_PlayerRequest.m_aServer, "USA", sizeof(m_PlayerRequest.m_aServer));
-	ASSERT_FALSE(CScoreWorker::ShowTop(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowTop(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult,
 		{"------------ Global Top ------------",
 			"1. nameless tee Time: 01:40.00",
@@ -175,7 +175,7 @@ TEST_P(SingleScore, TopServer)
 {
 	g_Config.m_SvRegionalRankings = false;
 	str_copy(m_PlayerRequest.m_aServer, "USA", sizeof(m_PlayerRequest.m_aServer));
-	ASSERT_FALSE(CScoreWorker::ShowTop(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowTop(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult,
 		{"------------ Global Top ------------",
 			"1. nameless tee Time: 01:40.00",
@@ -186,7 +186,7 @@ TEST_P(SingleScore, RankServerRegional)
 {
 	g_Config.m_SvRegionalRankings = true;
 	str_copy(m_PlayerRequest.m_aServer, "USA", sizeof(m_PlayerRequest.m_aServer));
-	ASSERT_FALSE(CScoreWorker::ShowRank(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowRank(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult, {"nameless tee - 01:40.00 - better than 100% - requested by brainless tee", "Global rank 1 - USA rank 1"}, true);
 }
 
@@ -194,7 +194,7 @@ TEST_P(SingleScore, RankServer)
 {
 	g_Config.m_SvRegionalRankings = false;
 	str_copy(m_PlayerRequest.m_aServer, "USA", sizeof(m_PlayerRequest.m_aServer));
-	ASSERT_FALSE(CScoreWorker::ShowRank(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowRank(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult, {"nameless tee - 01:40.00 - better than 100% - requested by brainless tee", "Global rank 1"}, true);
 }
 
@@ -202,7 +202,7 @@ TEST_P(SingleScore, LoadPlayerData)
 {
 	InsertRank(120.0, true);
 	str_copy(m_PlayerRequest.m_aName, "", sizeof(m_PlayerRequest.m_aRequestingPlayer));
-	ASSERT_FALSE(CScoreWorker::LoadPlayerData(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::LoadPlayerData(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 
 	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::PLAYER_INFO);
 	ASSERT_FALSE(m_pPlayerResult->m_Data.m_Info.m_Time.has_value());
@@ -213,7 +213,7 @@ TEST_P(SingleScore, LoadPlayerData)
 
 	str_copy(m_PlayerRequest.m_aRequestingPlayer, "nameless tee", sizeof(m_PlayerRequest.m_aRequestingPlayer));
 	str_copy(m_PlayerRequest.m_aName, "", sizeof(m_PlayerRequest.m_aRequestingPlayer));
-	ASSERT_FALSE(CScoreWorker::LoadPlayerData(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::LoadPlayerData(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 
 	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::PLAYER_INFO);
 	ASSERT_TRUE(m_pPlayerResult->m_Data.m_Info.m_Time.has_value());
@@ -225,7 +225,7 @@ TEST_P(SingleScore, LoadPlayerData)
 
 	str_copy(m_PlayerRequest.m_aRequestingPlayer, "finishless", sizeof(m_PlayerRequest.m_aRequestingPlayer));
 	str_copy(m_PlayerRequest.m_aName, "nameless tee", sizeof(m_PlayerRequest.m_aRequestingPlayer));
-	ASSERT_FALSE(CScoreWorker::LoadPlayerData(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::LoadPlayerData(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 
 	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::PLAYER_INFO);
 	ASSERT_FALSE(m_pPlayerResult->m_Data.m_Info.m_Time.has_value());
@@ -237,7 +237,7 @@ TEST_P(SingleScore, LoadPlayerData)
 
 TEST_P(SingleScore, TimesExists)
 {
-	ASSERT_FALSE(CScoreWorker::ShowTimes(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowTimes(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::DIRECT);
 	EXPECT_STREQ(m_pPlayerResult->m_Data.m_aaMessages[0], "------------- Last Times -------------");
 	char aBuf[128];
@@ -256,7 +256,7 @@ TEST_P(SingleScore, TimesExists)
 TEST_P(SingleScore, TimesDoesntExist)
 {
 	str_copy(m_PlayerRequest.m_aName, "foo", sizeof(m_PlayerRequest.m_aMap));
-	ASSERT_FALSE(CScoreWorker::ShowTimes(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowTimes(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult, {"There are no times in the specified range"});
 }
 
@@ -285,7 +285,7 @@ struct TeamScore : public Score
 		str_copy(ScoreData.m_aTimestamp, "2021-11-24 19:24:08", sizeof(ScoreData.m_aTimestamp));
 		for(int i = 0; i < NUM_CHECKPOINTS; i++)
 			ScoreData.m_aCurrentTimeCp[i] = 0;
-		ASSERT_FALSE(CScoreWorker::SaveTeamScore(m_pConn, &teamScoreData, Write::NORMAL, m_aError, sizeof(m_aError))) << m_aError;
+		ASSERT_TRUE(CScoreWorker::SaveTeamScore(m_pConn, &teamScoreData, Write::NORMAL, m_aError, sizeof(m_aError))) << m_aError;
 
 		str_copy(m_PlayerRequest.m_aMap, "Kobra 3", sizeof(m_PlayerRequest.m_aMap));
 		str_copy(m_PlayerRequest.m_aRequestingPlayer, "brainless tee", sizeof(m_PlayerRequest.m_aRequestingPlayer));
@@ -293,10 +293,10 @@ struct TeamScore : public Score
 
 		str_copy(ScoreData.m_aName, "nameless tee", sizeof(ScoreData.m_aName));
 		ScoreData.m_ClientId = 0;
-		ASSERT_FALSE(CScoreWorker::SaveScore(m_pConn, &ScoreData, Write::NORMAL, m_aError, sizeof(m_aError))) << m_aError;
+		ASSERT_TRUE(CScoreWorker::SaveScore(m_pConn, &ScoreData, Write::NORMAL, m_aError, sizeof(m_aError))) << m_aError;
 		str_copy(ScoreData.m_aName, "brainless tee", sizeof(ScoreData.m_aName));
 		ScoreData.m_ClientId = 1;
-		ASSERT_FALSE(CScoreWorker::SaveScore(m_pConn, &ScoreData, Write::NORMAL, m_aError, sizeof(m_aError))) << m_aError;
+		ASSERT_TRUE(CScoreWorker::SaveScore(m_pConn, &ScoreData, Write::NORMAL, m_aError, sizeof(m_aError))) << m_aError;
 		m_PlayerRequest.m_Offset = 0;
 	}
 };
@@ -304,7 +304,7 @@ struct TeamScore : public Score
 TEST_P(TeamScore, All)
 {
 	g_Config.m_SvRegionalRankings = false;
-	ASSERT_FALSE(CScoreWorker::ShowTeamTop5(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowTeamTop5(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult,
 		{"------- Team Top 5 -------",
 			"1. brainless tee & nameless tee Team Time: 01:40.00",
@@ -315,7 +315,7 @@ TEST_P(TeamScore, TeamTop5Regional)
 {
 	g_Config.m_SvRegionalRankings = true;
 	str_copy(m_PlayerRequest.m_aServer, "USA", sizeof(m_PlayerRequest.m_aServer));
-	ASSERT_FALSE(CScoreWorker::ShowTeamTop5(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowTeamTop5(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult,
 		{"------- Team Top 5 -------",
 			"1. brainless tee & nameless tee Team Time: 01:40.00",
@@ -326,7 +326,7 @@ TEST_P(TeamScore, TeamTop5Regional)
 TEST_P(TeamScore, PlayerExists)
 {
 	str_copy(m_PlayerRequest.m_aName, "brainless tee", sizeof(m_PlayerRequest.m_aName));
-	ASSERT_FALSE(CScoreWorker::ShowPlayerTeamTop5(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowPlayerTeamTop5(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult,
 		{"------- Team Top 5 -------",
 			"1. brainless tee & nameless tee Team Time: 01:40.00",
@@ -336,7 +336,7 @@ TEST_P(TeamScore, PlayerExists)
 TEST_P(TeamScore, PlayerDoesntExist)
 {
 	str_copy(m_PlayerRequest.m_aName, "foo", sizeof(m_PlayerRequest.m_aName));
-	ASSERT_FALSE(CScoreWorker::ShowPlayerTeamTop5(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowPlayerTeamTop5(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult, {"foo has no team ranks"});
 }
 
@@ -344,7 +344,7 @@ TEST_P(TeamScore, RankUpdates)
 {
 	InsertTeamRank(98.0);
 	str_copy(m_PlayerRequest.m_aName, "brainless tee", sizeof(m_PlayerRequest.m_aName));
-	ASSERT_FALSE(CScoreWorker::ShowPlayerTeamTop5(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowPlayerTeamTop5(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult,
 		{"------- Team Top 5 -------",
 			"1. brainless tee & nameless tee Team Time: 01:38.00",
@@ -362,7 +362,7 @@ struct MapInfo : public Score
 TEST_P(MapInfo, ExactNoFinish)
 {
 	str_copy(m_PlayerRequest.m_aName, "Kobra 3", sizeof(m_PlayerRequest.m_aName));
-	ASSERT_FALSE(CScoreWorker::MapInfo(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::MapInfo(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 
 	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::DIRECT);
 	EXPECT_THAT(m_pPlayerResult->m_Data.m_aaMessages[0], testing::MatchesRegex("\"Kobra 3\" by Zerodin on Novice, ★★★★★, 5 points, released .* ago, 0 finishes by 0 tees"));
@@ -376,7 +376,7 @@ TEST_P(MapInfo, ExactFinish)
 {
 	InsertRank();
 	str_copy(m_PlayerRequest.m_aName, "Kobra 3", sizeof(m_PlayerRequest.m_aName));
-	ASSERT_FALSE(CScoreWorker::MapInfo(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::MapInfo(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 
 	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::DIRECT);
 	EXPECT_THAT(m_pPlayerResult->m_Data.m_aaMessages[0], testing::MatchesRegex("\"Kobra 3\" by Zerodin on Novice, ★★★★★, 5 points, released .* ago, 1 finish by 1 tee in 01:40 median"));
@@ -390,7 +390,7 @@ TEST_P(MapInfo, Fuzzy)
 {
 	InsertRank();
 	str_copy(m_PlayerRequest.m_aName, "k3", sizeof(m_PlayerRequest.m_aName));
-	ASSERT_FALSE(CScoreWorker::MapInfo(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::MapInfo(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 
 	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::DIRECT);
 	EXPECT_THAT(m_pPlayerResult->m_Data.m_aaMessages[0], testing::MatchesRegex("\"Kobra 3\" by Zerodin on Novice, ★★★★★, 5 points, released .* ago, 1 finish by 1 tee in 01:40 median"));
@@ -405,7 +405,7 @@ TEST_P(MapInfo, FuzzyCase)
 	InsertMap("Reflect", "DarkOort", "Dummy", 20, 3);
 	InsertMap("reflects", "Ninjed & Pipou", "Solo", 16, 4);
 	str_copy(m_PlayerRequest.m_aName, "reflect", sizeof(m_PlayerRequest.m_aName));
-	ASSERT_FALSE(CScoreWorker::MapInfo(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::MapInfo(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 
 	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::DIRECT);
 	EXPECT_THAT(m_pPlayerResult->m_Data.m_aaMessages[0], testing::MatchesRegex("\"Reflect\" by DarkOort on Dummy, ★★★✰✰, 20 points, released .* ago, 0 finishes by 0 tees"));
@@ -418,7 +418,7 @@ TEST_P(MapInfo, FuzzyCase)
 TEST_P(MapInfo, DoesntExit)
 {
 	str_copy(m_PlayerRequest.m_aName, "f", sizeof(m_PlayerRequest.m_aName));
-	ASSERT_FALSE(CScoreWorker::MapInfo(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::MapInfo(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult, {"No map like \"f\" found."});
 }
 
@@ -433,7 +433,7 @@ struct MapVote : public Score
 TEST_P(MapVote, Exact)
 {
 	str_copy(m_PlayerRequest.m_aName, "Kobra 3", sizeof(m_PlayerRequest.m_aName));
-	ASSERT_FALSE(CScoreWorker::MapVote(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::MapVote(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::MAP_VOTE);
 	EXPECT_STREQ(m_pPlayerResult->m_Data.m_MapVote.m_aMap, "Kobra 3");
 	EXPECT_STREQ(m_pPlayerResult->m_Data.m_MapVote.m_aReason, "/map");
@@ -443,7 +443,7 @@ TEST_P(MapVote, Exact)
 TEST_P(MapVote, Fuzzy)
 {
 	str_copy(m_PlayerRequest.m_aName, "k3", sizeof(m_PlayerRequest.m_aName));
-	ASSERT_FALSE(CScoreWorker::MapVote(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::MapVote(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::MAP_VOTE);
 	EXPECT_STREQ(m_pPlayerResult->m_Data.m_MapVote.m_aMap, "Kobra 3");
 	EXPECT_STREQ(m_pPlayerResult->m_Data.m_MapVote.m_aReason, "/map");
@@ -455,7 +455,7 @@ TEST_P(MapVote, FuzzyCase)
 	InsertMap("Reflect", "DarkOort", "Dummy", 20, 3);
 	InsertMap("reflects", "Ninjed & Pipou", "Solo", 16, 4);
 	str_copy(m_PlayerRequest.m_aName, "reflect", sizeof(m_PlayerRequest.m_aName));
-	ASSERT_FALSE(CScoreWorker::MapVote(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::MapVote(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::MAP_VOTE);
 	EXPECT_STREQ(m_pPlayerResult->m_Data.m_MapVote.m_aMap, "Reflect");
 	EXPECT_STREQ(m_pPlayerResult->m_Data.m_MapVote.m_aReason, "/map");
@@ -465,7 +465,7 @@ TEST_P(MapVote, FuzzyCase)
 TEST_P(MapVote, DoesntExist)
 {
 	str_copy(m_PlayerRequest.m_aName, "f", sizeof(m_PlayerRequest.m_aName));
-	ASSERT_FALSE(CScoreWorker::MapVote(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::MapVote(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult, {"No map like \"f\" found. Try adding a '%' at the start if you don't know the first character. Example: /map %castle for \"Out of Castle\""});
 }
 
@@ -481,13 +481,13 @@ struct Points : public Score
 
 TEST_P(Points, NoPoints)
 {
-	ASSERT_FALSE(CScoreWorker::ShowPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult, {"nameless tee has not collected any points so far"});
 }
 
 TEST_P(Points, NoPointsTop)
 {
-	ASSERT_FALSE(CScoreWorker::ShowTopPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowTopPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult, {"-------- Top Points --------",
 					     "-------------------------------"});
 }
@@ -495,14 +495,14 @@ TEST_P(Points, NoPointsTop)
 TEST_P(Points, OnePoints)
 {
 	m_pConn->AddPoints("nameless tee", 2, m_aError, sizeof(m_aError));
-	ASSERT_FALSE(CScoreWorker::ShowPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult, {"1. nameless tee Points: 2, requested by brainless tee"}, true);
 }
 
 TEST_P(Points, OnePointsTop)
 {
 	m_pConn->AddPoints("nameless tee", 2, m_aError, sizeof(m_aError));
-	ASSERT_FALSE(CScoreWorker::ShowTopPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowTopPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult,
 		{"-------- Top Points --------",
 			"1. nameless tee Points: 2",
@@ -513,7 +513,7 @@ TEST_P(Points, TwoPoints)
 {
 	m_pConn->AddPoints("nameless tee", 2, m_aError, sizeof(m_aError));
 	m_pConn->AddPoints("brainless tee", 3, m_aError, sizeof(m_aError));
-	ASSERT_FALSE(CScoreWorker::ShowPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult, {"2. nameless tee Points: 2, requested by brainless tee"}, true);
 }
 
@@ -521,7 +521,7 @@ TEST_P(Points, TwoPointsTop)
 {
 	m_pConn->AddPoints("nameless tee", 2, m_aError, sizeof(m_aError));
 	m_pConn->AddPoints("brainless tee", 3, m_aError, sizeof(m_aError));
-	ASSERT_FALSE(CScoreWorker::ShowTopPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowTopPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult,
 		{"-------- Top Points --------",
 			"1. brainless tee Points: 3",
@@ -534,7 +534,7 @@ TEST_P(Points, EqualPoints)
 	m_pConn->AddPoints("nameless tee", 2, m_aError, sizeof(m_aError));
 	m_pConn->AddPoints("brainless tee", 3, m_aError, sizeof(m_aError));
 	m_pConn->AddPoints("nameless tee", 1, m_aError, sizeof(m_aError));
-	ASSERT_FALSE(CScoreWorker::ShowPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult, {"1. nameless tee Points: 3, requested by brainless tee"}, true);
 }
 
@@ -543,7 +543,7 @@ TEST_P(Points, EqualPointsTop)
 	m_pConn->AddPoints("nameless tee", 2, m_aError, sizeof(m_aError));
 	m_pConn->AddPoints("brainless tee", 3, m_aError, sizeof(m_aError));
 	m_pConn->AddPoints("nameless tee", 1, m_aError, sizeof(m_aError));
-	ASSERT_FALSE(CScoreWorker::ShowTopPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::ShowTopPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult,
 		{"-------- Top Points --------",
 			"1. brainless tee Points: 3",
@@ -567,7 +567,7 @@ struct RandomMap : public Score
 TEST_P(RandomMap, NoStars)
 {
 	m_RandomMapRequest.m_Stars = -1;
-	ASSERT_FALSE(CScoreWorker::RandomMap(m_pConn, &m_RandomMapRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::RandomMap(m_pConn, &m_RandomMapRequest, m_aError, sizeof(m_aError))) << m_aError;
 	EXPECT_EQ(m_pRandomMapResult->m_ClientId, 0);
 	EXPECT_STREQ(m_pRandomMapResult->m_aMap, "Kobra 3");
 	EXPECT_STREQ(m_pRandomMapResult->m_aMessage, "");
@@ -576,7 +576,7 @@ TEST_P(RandomMap, NoStars)
 TEST_P(RandomMap, StarsExists)
 {
 	m_RandomMapRequest.m_Stars = 5;
-	ASSERT_FALSE(CScoreWorker::RandomMap(m_pConn, &m_RandomMapRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::RandomMap(m_pConn, &m_RandomMapRequest, m_aError, sizeof(m_aError))) << m_aError;
 	EXPECT_EQ(m_pRandomMapResult->m_ClientId, 0);
 	EXPECT_STREQ(m_pRandomMapResult->m_aMap, "Kobra 3");
 	EXPECT_STREQ(m_pRandomMapResult->m_aMessage, "");
@@ -585,7 +585,7 @@ TEST_P(RandomMap, StarsExists)
 TEST_P(RandomMap, StarsDoesntExist)
 {
 	m_RandomMapRequest.m_Stars = 3;
-	ASSERT_FALSE(CScoreWorker::RandomMap(m_pConn, &m_RandomMapRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::RandomMap(m_pConn, &m_RandomMapRequest, m_aError, sizeof(m_aError))) << m_aError;
 	EXPECT_EQ(m_pRandomMapResult->m_ClientId, 0);
 	EXPECT_STREQ(m_pRandomMapResult->m_aMap, "");
 	EXPECT_STREQ(m_pRandomMapResult->m_aMessage, "No maps found on this server!");
@@ -594,7 +594,7 @@ TEST_P(RandomMap, StarsDoesntExist)
 TEST_P(RandomMap, UnfinishedExists)
 {
 	m_RandomMapRequest.m_Stars = -1;
-	ASSERT_FALSE(CScoreWorker::RandomUnfinishedMap(m_pConn, &m_RandomMapRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::RandomUnfinishedMap(m_pConn, &m_RandomMapRequest, m_aError, sizeof(m_aError))) << m_aError;
 	EXPECT_EQ(m_pRandomMapResult->m_ClientId, 0);
 	EXPECT_STREQ(m_pRandomMapResult->m_aMap, "Kobra 3");
 	EXPECT_STREQ(m_pRandomMapResult->m_aMessage, "");
@@ -603,7 +603,7 @@ TEST_P(RandomMap, UnfinishedExists)
 TEST_P(RandomMap, UnfinishedDoesntExist)
 {
 	InsertRank();
-	ASSERT_FALSE(CScoreWorker::RandomUnfinishedMap(m_pConn, &m_RandomMapRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ASSERT_TRUE(CScoreWorker::RandomUnfinishedMap(m_pConn, &m_RandomMapRequest, m_aError, sizeof(m_aError))) << m_aError;
 	EXPECT_EQ(m_pRandomMapResult->m_ClientId, 0);
 	EXPECT_STREQ(m_pRandomMapResult->m_aMap, "");
 	EXPECT_STREQ(m_pRandomMapResult->m_aMessage, "nameless tee has no more unfinished maps on this server!");


### PR DESCRIPTION
# ddnet

Tested it in game and it works so far so good.

Fixed the [ddnet code style](https://github.com/ddnet/ddnet/blob/c0d34923d04a15d119eb48d6d3e984108334576d/CONTRIBUTING.md#use-true-for-success) violation of using false for success.

Closed https://github.com/ddnet/ddnet/issues/9890

# ddnet forks

This will be annoying for downstreams that make use of the sql code from ddnet. So the entire diff in scoreworker.cpp was generated with a ruby script which can be run by downstreams after the merge too so they do not have to manually rewrite their entire sql code.

https://github.com/ddnet-community/src-upgrade-scripts/blob/master/sql_true_for_success.rb

It worked flawlessly for the ddnet code base.

I tested the ruby script in the following ruby versions:
- 2.6.10 shipped by macOS by default
- 2.7 shipped by [debian 11+](https://wiki.debian.org/Ruby) and ubuntu
- 3.4.2 latest release

I tested it on the following ddnet server forks:
- [0XF](https://github.com/0xf-teeworlds) 2836 line diff in 25 files (lots of warnings but still compiled, did not test functionality)
- [ddnet++](https://github.com/DDNetPP/DDNetPP) 146 line diff in 1 file (no manual adjustments needed at all)
- [ddnet-insta](https://github.com/ddnet-insta/ddnet-insta) 166 line diff in 1 file (2 false positive warnings only action needed was to delete the 2 warning lines from the code)

## what does the script do

What the script does is it searches for all sql worker thread methods and flips the returned bools in their body and flips the bool on their call sites too. The script works best if you follow the ddnet code style so using ``./scripts/fix_style.py`` before merge is recommended. Also it uses heuristics to detect which methods are sql workers. It right now assumes all methods that return a bool and take the arguments ``IDbConnection``, ``pError`` and ``ErrorSize`` to be one of these sql workers that has to be flipped. So if your methods have different signatures you can just patch the script [here](https://github.com/ddnet-community/src-upgrade-scripts/blob/858fae5d55d22c866a93c83918bf78e691583919/sql_true_for_success.rb#L115).

Because the script flips bools from true to false and false to true. It can not be run multiple times. It would revert it self. By default the script does not edit the scoreworker.cpp file because that already got flipped in ddnet. If your fork edited the scoreworker.cpp file you have to do it by hand! The recommend action is to extract your edits into a extra file before the merge.

For all bools that can not safely be processed automatically it will add a TODO comment and a compiler warning in that place.
This allows the user to quickly find all edge cases without forgetting any. Edge cases include lambdas and more complicated statements that return to true or false. This warning has false positives for method calls to other sql workers that were added in the custom fork. The script can flip these correctly but still throws a warning. If you get a bunch of these you just have to delete the warning from the code.

## tl;dr how to merge a custom ddnet server fork

It is recommended to first run the ddnet style fixer

```
./scripts/fix_style.py
```

Then merge into latest ddnet. After that download and run the helper script.
If you do not have ruby installed your package manager should have it. For example ``sudo apt-get install ruby``

```
cd root_of_your_repo
wget https://raw.githubusercontent.com/ddnet-community/src-upgrade-scripts/refs/heads/master/sql_true_for_success.rb -O /tmp/sql_true_for_success.rb
ruby /tmp/sql_true_for_success.rb
```

Have a look at the git diff and compiler warnings if there are any. Make sure your unit testes still pass and your database connection still works.

Be warned there is absolutely no guarantee that the script covers all cases and also not that it covers them correctly. It is just there to reduce the manual effort you still have to think about it.