### PR TITLE
square up laser door heads

### DIFF
--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -348,6 +348,16 @@ void CItems::RenderLaser(vec2 From, vec2 Pos, ColorRGBA OuterColor, ColorRGBA In
 	}
 
 	// render head
+	if(Type == LASERTYPE_DOOR)
+	{
+		Graphics()->TextureClear();
+		Graphics()->QuadsSetRotation(0);
+		Graphics()->SetColor(OuterColor);
+		Graphics()->RenderQuadContainerEx(m_ItemsQuadContainerIndex, m_DoorHeadOffset, 1, Pos.x - 8.0f, Pos.y - 8.0f);
+		Graphics()->SetColor(InnerColor);
+		Graphics()->RenderQuadContainerEx(m_ItemsQuadContainerIndex, m_DoorHeadOffset, 1, Pos.x - 6.0f, Pos.y - 6.0f, 6.f / 8.f, 6.f / 8.f);
+	}
+	else
 	{
 		int CurParticle = (int)TicksHead % 3;
 		Graphics()->TextureSet(GameClient()->m_ParticlesSkin.m_aSpriteParticleSplat[CurParticle]);
@@ -592,6 +602,9 @@ void CItems::OnInit()
 		Graphics()->QuadsSetSubset(0, 0, 1, 1);
 		ParticleSplatOffset = RenderTools()->QuadContainerAddSprite(m_ItemsQuadContainerIndex, 24.f);
 	}
+
+	IGraphics::CQuadItem Brick(0, 0, 16.0f, 16.0f);
+	m_DoorHeadOffset = Graphics()->QuadContainerAddQuads(m_ItemsQuadContainerIndex, &Brick, 1);
 
 	Graphics()->QuadContainerUpload(m_ItemsQuadContainerIndex);
 }

--- a/src/game/client/components/items.h
+++ b/src/game/client/components/items.h
@@ -35,6 +35,7 @@ private:
 	int m_aPickupWeaponArmorOffset[4];
 	int m_aProjectileOffset[NUM_WEAPONS];
 	int m_aParticleSplatOffset[3];
+	int m_DoorHeadOffset;
 };
 
 #endif

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3053,7 +3053,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		RightView.HSplitTop(LaserPreviewHeight, &LaserPreview, &RightView);
 		RightView.HSplitTop(2 * MarginSmall, nullptr, &RightView);
-		DoLaserPreview(&LaserPreview, LaserFreezeOutlineColor, LaserFreezeInnerColor, LASERTYPE_DOOR);
+		DoLaserPreview(&LaserPreview, LaserFreezeOutlineColor, LaserFreezeInnerColor, LASERTYPE_FREEZE);
 	}
 }
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Change laser door head to a square. This allows for a better distinction between freeze doors or other laser objects, making this a small accessibility feature.

As `risu` put it:
> squares represent solidity and stability

Also it improves FPS (a bit in extreme cases), because the laser head doesn't need a new sprite every frame.

Screenshots:
![screenshot_2025-03-21_09-51-51](https://github.com/user-attachments/assets/5f0a94e5-afee-4e5d-a72a-511fef4edacb)
![screenshot_2025-03-21_09-56-34](https://github.com/user-attachments/assets/d7a085de-6273-421f-92a6-91702fa65779)

Test map in attachment
[switch_test.zip](https://github.com/user-attachments/files/19385950/switch_test.zip)

Waiting for #9898 

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
