### PR TITLE
Fix Android crashes when map gets unloaded by system

### DIFF
--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -589,21 +589,31 @@ int CDataFileReader::NumItems() const
 
 SHA256_DIGEST CDataFileReader::Sha256() const
 {
-	dbg_assert(m_pDataFile != nullptr, "File not open");
+	if(!m_pDataFile)
+	{
+		static const SHA256_DIGEST s_EmptySha256 = {{0}};
+		return s_EmptySha256;
+	}
 
 	return m_pDataFile->m_Sha256;
 }
 
 unsigned CDataFileReader::Crc() const
 {
-	dbg_assert(m_pDataFile != nullptr, "File not open");
+	if(!m_pDataFile)
+	{
+		return 0;
+	}
 
 	return m_pDataFile->m_Crc;
 }
 
 int CDataFileReader::MapSize() const
 {
-	dbg_assert(m_pDataFile != nullptr, "File not open");
+	if(!m_pDataFile)
+	{
+		return 0;
+	}
 
 	return m_pDataFile->m_Header.m_Size + m_pDataFile->m_Header.SizeOffset();
 }


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
this is a defensive programming. It adds null checks to key methods. When the data file is null, these methods return default values instead of crashing. Resolves crashes on resource reclamation or after map unload. 

Fixes #9882 
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
