### PR TITLE
Add flip and rotate to speedup arrow angle

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -9307,7 +9307,8 @@ void CEditor::RedoLastAction()
 
 void CEditor::AdjustBrushSpecialTiles(bool UseNextFree, int Adjust)
 {
-	// Adjust m_Number field of tune, switch and tele tiles by `Adjust` if `UseNextFree` is false
+	// Adjust m_Angle of speedup or m_Number field of tune, switch and tele tiles by `Adjust` if `UseNextFree` is false
+	// If `Adjust` is 0 and `UseNextFree` is false, then update numbers of brush tiles to global values
 	// If true, then use the next free number instead
 
 	auto &&AdjustNumber = [Adjust](auto &Number, short Limit = 255) {
@@ -9393,18 +9394,29 @@ void CEditor::AdjustBrushSpecialTiles(bool UseNextFree, int Adjust)
 				}
 			}
 		}
-		else if(pLayerTiles->m_Speedup && !UseNextFree && Adjust != 0)
+		else if(pLayerTiles->m_Speedup)
 		{
-			std::shared_ptr<CLayerSpeedup> pSpeedupLayer = std::static_pointer_cast<CLayerSpeedup>(pLayer);
-			for(int y = 0; y < pSpeedupLayer->m_Height; y++)
+			if(!UseNextFree)
 			{
-				for(int x = 0; x < pSpeedupLayer->m_Width; x++)
+				std::shared_ptr<CLayerSpeedup> pSpeedupLayer = std::static_pointer_cast<CLayerSpeedup>(pLayer);
+				for(int y = 0; y < pSpeedupLayer->m_Height; y++)
 				{
-					int i = y * pSpeedupLayer->m_Width + x;
-					if(!IsValidSpeedupTile(pSpeedupLayer->m_pTiles[i].m_Index))
-						continue;
+					for(int x = 0; x < pSpeedupLayer->m_Width; x++)
+					{
+						int i = y * pSpeedupLayer->m_Width + x;
+						if(!IsValidSpeedupTile(pSpeedupLayer->m_pTiles[i].m_Index))
+							continue;
 
-					AdjustNumber(pSpeedupLayer->m_pSpeedupTile[i].m_Angle, 359);
+						if(Adjust != 0)
+						{
+							AdjustNumber(pSpeedupLayer->m_pSpeedupTile[i].m_Angle, 359);
+						}
+						else
+						{
+							pSpeedupLayer->m_pSpeedupTile[i].m_Angle = m_SpeedupAngle;
+							pSpeedupLayer->m_SpeedupAngle = m_SpeedupAngle;
+						}
+					}
 				}
 			}
 		}

--- a/src/game/editor/mapitems/layer_speedup.cpp
+++ b/src/game/editor/mapitems/layer_speedup.cpp
@@ -175,12 +175,28 @@ void CLayerSpeedup::BrushFlipX()
 {
 	CLayerTiles::BrushFlipX();
 	BrushFlipXImpl(m_pSpeedupTile);
+
+	auto &&AngleFlipX = [](auto &Number) {
+		Number = (180 - Number % 360 + 360) % 360;
+	};
+
+	for(int y = 0; y < m_Height; y++)
+		for(int x = 0; x < m_Width; x++)
+			AngleFlipX(m_pSpeedupTile[y * m_Width + x].m_Angle);
 }
 
 void CLayerSpeedup::BrushFlipY()
 {
 	CLayerTiles::BrushFlipY();
 	BrushFlipYImpl(m_pSpeedupTile);
+
+	auto &&AngleFlipY = [](auto &Number) {
+		Number = (360 - Number % 360 + 360) % 360;
+	};
+
+	for(int y = 0; y < m_Height; y++)
+		for(int x = 0; x < m_Width; x++)
+			AngleFlipY(m_pSpeedupTile[y * m_Width + x].m_Angle);
 }
 
 void CLayerSpeedup::BrushRotate(float Amount)
@@ -188,6 +204,12 @@ void CLayerSpeedup::BrushRotate(float Amount)
 	int Rotation = (round_to_int(360.0f * Amount / (pi * 2)) / 90) % 4; // 0=0°, 1=90°, 2=180°, 3=270°
 	if(Rotation < 0)
 		Rotation += 4;
+
+	// 1 and 3 are both adjusted by 90, because for 3 the brush is also flipped
+	int Adjust = (Rotation == 0) ? 0 : (Rotation == 2) ? 180 : 90;
+	auto &&AdjustAngle = [Adjust](auto &Number) {
+		Number = (Number + Adjust % 360 + 360) % 360;
+	};
 
 	if(Rotation == 1 || Rotation == 3)
 	{
@@ -201,6 +223,7 @@ void CLayerSpeedup::BrushRotate(float Amount)
 		for(int x = 0; x < m_Width; ++x)
 			for(int y = m_Height - 1; y >= 0; --y, ++pDst1, ++pDst2)
 			{
+				AdjustAngle(pTempData1[y * m_Width + x].m_Angle);
 				*pDst1 = pTempData1[y * m_Width + x];
 				*pDst2 = pTempData2[y * m_Width + x];
 			}

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -2754,6 +2754,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSpeedup(void *pContext, CUIRect View
 	else if(Prop == PROP_ANGLE)
 	{
 		pEditor->m_SpeedupAngle = clamp(NewVal, 0, 359);
+		pEditor->AdjustBrushSpecialTiles(false);
 	}
 
 	return CUi::POPUP_KEEP_OPEN;


### PR DESCRIPTION
This adds so it's now possible to flip and rotate the speedup arrow (R,T and N,M keybinds)

https://github.com/user-attachments/assets/2db22663-ef34-459e-959f-56571d9697c5


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
