### PR TITLE
Fix undo for hookthrough's front layer

### DIFF
--- a/src/game/editor/mapitems/layer_game.cpp
+++ b/src/game/editor/mapitems/layer_game.cpp
@@ -3,6 +3,7 @@
 #include "layer_game.h"
 
 #include <game/editor/editor.h>
+#include <game/editor/editor_actions.h>
 
 CLayerGame::CLayerGame(CEditor *pEditor, int w, int h) :
 	CLayerTiles(pEditor, w, h)
@@ -35,6 +36,9 @@ void CLayerGame::SetTile(int x, int y, CTile Tile)
 			std::shared_ptr<CLayer> pLayerFront = std::make_shared<CLayerFront>(m_pEditor, m_Width, m_Height);
 			m_pEditor->m_Map.MakeFrontLayer(pLayerFront);
 			m_pEditor->m_Map.m_pGameGroup->AddLayer(pLayerFront);
+			int GameGroupIndex = std::find(m_pEditor->m_Map.m_vpGroups.begin(), m_pEditor->m_Map.m_vpGroups.end(), m_pEditor->m_Map.m_pGameGroup) - m_pEditor->m_Map.m_vpGroups.begin();
+			int LayerIndex = m_pEditor->m_Map.m_vpGroups[GameGroupIndex]->m_vpLayers.size() - 1;
+			m_pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(m_pEditor, GameGroupIndex, LayerIndex));
 		}
 		CTile nohook = {TILE_NOHOOK};
 		CLayerTiles::SetTile(x, y, nohook);


### PR DESCRIPTION
Fixes #9907
Just adds the front layer creation to undo history

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
