### PR TITLE
Move skin favorite and UI list handling to `CSkins`

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -963,13 +963,6 @@ void CMenus::OnInit()
 	Graphics()->QuadContainerUpload(m_DirectionQuadContainerIndex);
 }
 
-void CMenus::OnConsoleInit()
-{
-	ConfigManager()->RegisterCallback(CMenus::ConfigSaveCallback, this);
-	Console()->Register("add_favorite_skin", "s[skin_name]", CFGFLAG_CLIENT, Con_AddFavoriteSkin, this, "Add a skin as a favorite");
-	Console()->Register("remove_favorite_skin", "s[skin_name]", CFGFLAG_CLIENT, Con_RemFavoriteSkin, this, "Remove a skin from the favorites");
-}
-
 void CMenus::ConchainBackgroundEntities(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
 {
 	pfnCallback(pResult, pCallbackUserData);

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -9,7 +9,6 @@
 #include <chrono>
 #include <deque>
 #include <optional>
-#include <unordered_set>
 #include <vector>
 
 #include <engine/console.h>
@@ -101,7 +100,6 @@ class CMenus : public CComponent
 	void DoJoystickAxisPicker(CUIRect View);
 	void DoJoystickBar(const CUIRect *pRect, float Current, float Tolerance, bool Active);
 
-	std::optional<std::chrono::nanoseconds> m_SkinListLastRefreshTime;
 	bool m_SkinListScrollToSelected = false;
 	std::optional<std::chrono::nanoseconds> m_SkinList7LastRefreshTime;
 	std::optional<std::chrono::nanoseconds> m_SkinPartsList7LastRefreshTime;
@@ -600,13 +598,6 @@ protected:
 	void RenderCommunityIcon(const SCommunityIcon *pIcon, CUIRect Rect, bool Active);
 	void UpdateCommunityIcons();
 
-	// skin favorite list
-	std::unordered_set<std::string> m_SkinFavorites;
-	static void Con_AddFavoriteSkin(IConsole::IResult *pResult, void *pUserData);
-	static void Con_RemFavoriteSkin(IConsole::IResult *pResult, void *pUserData);
-	static void ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData);
-	void OnConfigSave(IConfigManager *pConfigManager);
-
 	// found in menus_settings.cpp
 	void RenderLanguageSettings(CUIRect MainView);
 	bool RenderLanguageSelection(CUIRect MainView);
@@ -688,7 +679,6 @@ public:
 	bool IsServerRunning() const;
 
 	virtual void OnInit() override;
-	void OnConsoleInit() override;
 
 	virtual void OnStateChange(int NewState, int OldState) override;
 	virtual void OnWindowResize() override;

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -22,6 +22,19 @@
 
 using namespace std::chrono_literals;
 
+bool CSkins::CSkinListEntry::operator<(const CSkins::CSkinListEntry &Other) const
+{
+	if(m_Favorite && !Other.m_Favorite)
+	{
+		return true;
+	}
+	if(!m_Favorite && Other.m_Favorite)
+	{
+		return false;
+	}
+	return str_comp_nocase(m_pSkin->GetName(), Other.m_pSkin->GetName()) < 0;
+}
+
 CSkins::CSkins() :
 	m_PlaceholderSkin("dummy")
 {
@@ -303,6 +316,13 @@ const CSkin *CSkins::LoadSkin(const char *pName, CImageInfo &Info)
 	return SkinInsertIt.first->second.get();
 }
 
+void CSkins::OnConsoleInit()
+{
+	ConfigManager()->RegisterCallback(CSkins::ConfigSaveCallback, this);
+	Console()->Register("add_favorite_skin", "s[skin_name]", CFGFLAG_CLIENT, ConAddFavoriteSkin, this, "Add a skin as a favorite");
+	Console()->Register("remove_favorite_skin", "s[skin_name]", CFGFLAG_CLIENT, ConRemFavoriteSkin, this, "Remove a skin from the favorites");
+}
+
 void CSkins::OnInit()
 {
 	m_aEventSkinPrefix[0] = '\0';
@@ -371,6 +391,38 @@ void CSkins::Refresh(TSkinLoadedCallback &&SkinLoadedCallback)
 	Storage()->ListDirectory(IStorage::TYPE_ALL, "skins", SkinScan, &SkinScanUser);
 
 	m_LastRefreshTime = time_get_nanoseconds();
+}
+
+const std::vector<CSkins::CSkinListEntry> &CSkins::SkinList()
+{
+	if(m_SkinListLastRefreshTime.has_value() && m_SkinListLastRefreshTime.value() == m_LastRefreshTime)
+	{
+		return m_vSkinList;
+	}
+
+	m_vSkinList.clear();
+	for(const auto &[_, pSkin] : m_Skins)
+	{
+		if(g_Config.m_ClSkinFilterString[0] != '\0' && !str_utf8_find_nocase(pSkin->GetName(), g_Config.m_ClSkinFilterString))
+		{
+			continue;
+		}
+
+		if(IsSpecialSkin(pSkin->GetName()))
+		{
+			continue;
+		}
+
+		m_vSkinList.emplace_back(pSkin.get(), IsFavorite(pSkin->GetName()));
+	}
+
+	std::sort(m_vSkinList.begin(), m_vSkinList.end());
+	return m_vSkinList;
+}
+
+void CSkins::ForceRefreshSkinList()
+{
+	m_SkinListLastRefreshTime = std::nullopt;
 }
 
 const CSkin *CSkins::Find(const char *pName)
@@ -444,6 +496,37 @@ const CSkin *CSkins::FindImpl(const char *pName)
 	auto &&pLoadingSkin = std::make_unique<CLoadingSkin>(std::move(LoadingSkin));
 	m_LoadingSkins.insert({pLoadingSkin->Name(), std::move(pLoadingSkin)});
 	return nullptr;
+}
+
+void CSkins::AddFavorite(const char *pName)
+{
+	if(!CSkin::IsValidName(pName))
+	{
+		log_error("skins", "Favorite skin name '%s' is not valid", pName);
+		log_error("skins", "%s", CSkin::m_aSkinNameRestrictions);
+		return;
+	}
+
+	const auto &[_, Inserted] = m_Favorites.emplace(pName);
+	if(Inserted)
+	{
+		m_SkinListLastRefreshTime = std::nullopt;
+	}
+}
+
+void CSkins::RemoveFavorite(const char *pName)
+{
+	const auto FavoriteIt = m_Favorites.find(pName);
+	if(FavoriteIt != m_Favorites.end())
+	{
+		m_Favorites.erase(FavoriteIt);
+		m_SkinListLastRefreshTime = std::nullopt;
+	}
+}
+
+bool CSkins::IsFavorite(const char *pName) const
+{
+	return m_Favorites.find(pName) != m_Favorites.end();
 }
 
 void CSkins::RandomizeSkin(int Dummy)
@@ -642,4 +725,32 @@ bool CSkins::CLoadingSkin::operator<(const char *pOther) const
 bool CSkins::CLoadingSkin::operator==(const char *pOther) const
 {
 	return !str_comp(m_aName, pOther);
+}
+
+void CSkins::ConAddFavoriteSkin(IConsole::IResult *pResult, void *pUserData)
+{
+	auto *pSelf = static_cast<CSkins *>(pUserData);
+	pSelf->AddFavorite(pResult->GetString(0));
+}
+
+void CSkins::ConRemFavoriteSkin(IConsole::IResult *pResult, void *pUserData)
+{
+	auto *pSelf = static_cast<CSkins *>(pUserData);
+	pSelf->RemoveFavorite(pResult->GetString(0));
+}
+
+void CSkins::ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData)
+{
+	auto *pSelf = static_cast<CSkins *>(pUserData);
+	pSelf->OnConfigSave(pConfigManager);
+}
+
+void CSkins::OnConfigSave(IConfigManager *pConfigManager)
+{
+	for(const auto &Favorite : m_Favorites)
+	{
+		char aBuffer[32 + MAX_SKIN_LENGTH];
+		str_format(aBuffer, sizeof(aBuffer), "add_favorite_skin \"%s\"", Favorite.c_str());
+		pConfigManager->WriteLine(aBuffer);
+	}
 }


### PR DESCRIPTION
Move list for displaying skins in user interface and favorite skin handling to `CSkins` to simplify the usage.

Simplify skin list sorting by considering the favorite state within the comparison function instead of using two lists.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
