### PR TITLE
Add new ninja tunes (duration, movetime, velocity)

### DIFF
--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -710,8 +710,9 @@ void CHud::PrepareAmmoHealthAndArmorQuads()
 	Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, Array, 10);
 }
 
-void CHud::RenderAmmoHealthAndArmor(const CNetObj_Character *pCharacter)
+void CHud::RenderAmmoHealthAndArmor(int ClientId)
 {
+	const CNetObj_Character *pCharacter = &GameClient()->m_Snap.m_aCharacters[ClientId].m_Cur;
 	if(!pCharacter)
 		return;
 
@@ -726,9 +727,10 @@ void CHud::RenderAmmoHealthAndArmor(const CNetObj_Character *pCharacter)
 		// 0.7 only
 		if(CurWeapon == WEAPON_NINJA)
 		{
-			if(!GameClient()->m_GameInfo.m_HudDDRace && Client()->IsSixup())
+			CCharacter *pWorldChar = GameClient()->m_GameWorld.GetCharacterById(ClientId);
+			if(!GameClient()->m_GameInfo.m_HudDDRace && Client()->IsSixup() && pWorldChar)
 			{
-				const int Max = g_pData->m_Weapons.m_Ninja.m_Duration * Client()->GameTickSpeed() / 1000;
+				const int Max = pWorldChar->GetTuning(pWorldChar->GetOverriddenTuneZone())->m_NinjaDuration * Client()->GameTickSpeed() / 1000;
 				float NinjaProgress = std::clamp(pCharacter->m_AmmoCount - Client()->GameTick(g_Config.m_ClDummy), 0, Max) / (float)Max;
 				RenderNinjaBarPos(5 + 10 * 12, 5, 6.f, 24.f, NinjaProgress);
 			}
@@ -930,11 +932,15 @@ void CHud::RenderPlayerState(const int ClientId)
 		}
 		if(pCharacter->m_aWeapons[WEAPON_NINJA].m_Got)
 		{
-			const int Max = g_pData->m_Weapons.m_Ninja.m_Duration * Client()->GameTickSpeed() / 1000;
-			float NinjaProgress = std::clamp(pCharacter->m_Ninja.m_ActivationTick + g_pData->m_Weapons.m_Ninja.m_Duration * Client()->GameTickSpeed() / 1000 - Client()->GameTick(g_Config.m_ClDummy), 0, Max) / (float)Max;
-			if(NinjaProgress > 0.0f && GameClient()->m_Snap.m_aCharacters[ClientId].m_HasExtendedDisplayInfo)
+			CCharacter *pWorldChar = GameClient()->m_PredictedWorld.GetCharacterById(ClientId);
+			if(pWorldChar)
 			{
-				RenderNinjaBarPos(x, y - 12, 6.f, 24.f, NinjaProgress);
+				const int Max = pWorldChar->GetTuning(pWorldChar->GetOverriddenTuneZone())->m_NinjaDuration * Client()->GameTickSpeed() / 1000;
+				float NinjaProgress = std::clamp(pCharacter->m_Ninja.m_ActivationTick + static_cast<int>(pWorldChar->GetTuning(pWorldChar->GetOverriddenTuneZone())->m_NinjaDuration) * Client()->GameTickSpeed() / 1000 - Client()->GameTick(g_Config.m_ClDummy), 0, Max) / (float)Max;
+				if(NinjaProgress > 0.0f && GameClient()->m_Snap.m_aCharacters[ClientId].m_HasExtendedDisplayInfo)
+				{
+					RenderNinjaBarPos(x, y - 12, 6.f, 24.f, NinjaProgress);
+				}
 			}
 		}
 	}
@@ -1680,7 +1686,7 @@ void CHud::OnRender()
 		{
 			if(g_Config.m_ClShowhudHealthAmmo)
 			{
-				RenderAmmoHealthAndArmor(GameClient()->m_Snap.m_pLocalCharacter);
+				RenderAmmoHealthAndArmor(GameClient()->m_Snap.m_LocalClientId);
 			}
 			if(GameClient()->m_Snap.m_aCharacters[GameClient()->m_Snap.m_LocalClientId].m_HasExtendedData && g_Config.m_ClShowhudDDRace && GameClient()->m_GameInfo.m_HudDDRace)
 			{
@@ -1695,7 +1701,7 @@ void CHud::OnRender()
 			int SpectatorId = GameClient()->m_Snap.m_SpecInfo.m_SpectatorId;
 			if(SpectatorId != SPEC_FREEVIEW && g_Config.m_ClShowhudHealthAmmo)
 			{
-				RenderAmmoHealthAndArmor(&GameClient()->m_Snap.m_aCharacters[SpectatorId].m_Cur);
+				RenderAmmoHealthAndArmor(SpectatorId);
 			}
 			if(SpectatorId != SPEC_FREEVIEW &&
 				GameClient()->m_Snap.m_aCharacters[SpectatorId].m_HasExtendedData &&

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -72,7 +72,7 @@ class CHud : public CComponent
 	void RenderTeambalanceWarning();
 
 	void PrepareAmmoHealthAndArmorQuads();
-	void RenderAmmoHealthAndArmor(const CNetObj_Character *pCharacter);
+	void RenderAmmoHealthAndArmor(int ClientId);
 
 	void PreparePlayerStateQuads();
 	void RenderPlayerState(int ClientId);

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -105,7 +105,7 @@ void CCharacter::HandleNinja()
 	if(m_Core.m_ActiveWeapon != WEAPON_NINJA)
 		return;
 
-	if((GameWorld()->GameTick() - m_Core.m_Ninja.m_ActivationTick) > (g_pData->m_Weapons.m_Ninja.m_Duration * GameWorld()->GameTickSpeed() / 1000))
+	if((GameWorld()->GameTick() - m_Core.m_Ninja.m_ActivationTick) > (GetTuning(GetOverriddenTuneZone())->m_NinjaDuration * GameWorld()->GameTickSpeed() / 1000))
 	{
 		// time's up, return
 		RemoveNinja();
@@ -126,7 +126,7 @@ void CCharacter::HandleNinja()
 	if(m_Core.m_Ninja.m_CurrentMoveTime > 0)
 	{
 		// Set velocity
-		m_Core.m_Vel = m_Core.m_Ninja.m_ActivationDir * g_pData->m_Weapons.m_Ninja.m_Velocity;
+		m_Core.m_Vel = m_Core.m_Ninja.m_ActivationDir * GetTuning(GetOverriddenTuneZone())->m_NinjaVelocity;
 		vec2 OldPos = m_Pos;
 		Collision()->MoveBox(&m_Core.m_Pos, &m_Core.m_Vel, vec2(m_ProximityRadius, m_ProximityRadius), vec2(GetTuning(GetOverriddenTuneZone())->m_GroundElasticityX, GetTuning(GetOverriddenTuneZone())->m_GroundElasticityY));
 
@@ -446,7 +446,7 @@ void CCharacter::FireWeapon()
 		m_NumObjectsHit = 0;
 
 		m_Core.m_Ninja.m_ActivationDir = Direction;
-		m_Core.m_Ninja.m_CurrentMoveTime = g_pData->m_Weapons.m_Ninja.m_Movetime * GameWorld()->GameTickSpeed() / 1000;
+		m_Core.m_Ninja.m_CurrentMoveTime = GetTuning(GetOverriddenTuneZone())->m_NinjaMovetime * GameWorld()->GameTickSpeed() / 1000;
 
 		// clamp to prevent massive MoveBox calculation lag with SG bug
 		m_Core.m_Ninja.m_OldVelAmount = std::clamp(length(m_Core.m_Vel), 0.0f, 6000.0f);

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -286,14 +286,14 @@ void CCharacter::HandleNinja()
 	if(m_Core.m_ActiveWeapon != WEAPON_NINJA)
 		return;
 
-	if((Server()->Tick() - m_Core.m_Ninja.m_ActivationTick) > (g_pData->m_Weapons.m_Ninja.m_Duration * Server()->TickSpeed() / 1000))
+	if((Server()->Tick() - m_Core.m_Ninja.m_ActivationTick) > (GetTuning(m_TuneZone)->m_NinjaDuration * Server()->TickSpeed() / 1000))
 	{
 		// time's up, return
 		RemoveNinja();
 		return;
 	}
 
-	int NinjaTime = m_Core.m_Ninja.m_ActivationTick + (g_pData->m_Weapons.m_Ninja.m_Duration * Server()->TickSpeed() / 1000) - Server()->Tick();
+	int NinjaTime = m_Core.m_Ninja.m_ActivationTick + (GetTuning(m_TuneZone)->m_NinjaDuration * Server()->TickSpeed() / 1000) - Server()->Tick();
 
 	if(NinjaTime % Server()->TickSpeed() == 0 && NinjaTime / Server()->TickSpeed() <= 5)
 	{
@@ -316,7 +316,7 @@ void CCharacter::HandleNinja()
 	if(m_Core.m_Ninja.m_CurrentMoveTime > 0)
 	{
 		// Set velocity
-		m_Core.m_Vel = m_Core.m_Ninja.m_ActivationDir * g_pData->m_Weapons.m_Ninja.m_Velocity;
+		m_Core.m_Vel = m_Core.m_Ninja.m_ActivationDir * GetTuning(m_TuneZone)->m_NinjaVelocity;
 		vec2 OldPos = m_Pos;
 		vec2 GroundElasticity = vec2(
 			GetTuning(m_TuneZone)->m_GroundElasticityX,
@@ -622,7 +622,7 @@ void CCharacter::FireWeapon()
 		m_NumObjectsHit = 0;
 
 		m_Core.m_Ninja.m_ActivationDir = Direction;
-		m_Core.m_Ninja.m_CurrentMoveTime = g_pData->m_Weapons.m_Ninja.m_Movetime * Server()->TickSpeed() / 1000;
+		m_Core.m_Ninja.m_CurrentMoveTime = GetTuning(m_TuneZone)->m_NinjaMovetime * Server()->TickSpeed() / 1000;
 
 		// clamp to prevent massive MoveBox calculation lag with SG bug
 		m_Core.m_Ninja.m_OldVelAmount = std::clamp(length(m_Core.m_Vel), 0.0f, 6000.0f);
@@ -1184,7 +1184,7 @@ void CCharacter::SnapCharacter(int SnappingClient, int Id)
 		if(m_FreezeTime > 0 || m_Core.m_DeepFrozen)
 			pCharacter->m_AmmoCount = m_Core.m_FreezeStart + g_Config.m_SvFreezeDelay * Server()->TickSpeed();
 		else if(Weapon == WEAPON_NINJA)
-			pCharacter->m_AmmoCount = m_Core.m_Ninja.m_ActivationTick + g_pData->m_Weapons.m_Ninja.m_Duration * Server()->TickSpeed() / 1000;
+			pCharacter->m_AmmoCount = m_Core.m_Ninja.m_ActivationTick + GetTuning(m_TuneZone)->m_NinjaDuration * Server()->TickSpeed() / 1000;
 
 		pCharacter->m_Health = Health;
 		pCharacter->m_Armor = Armor;

--- a/src/game/tuning.h
+++ b/src/game/tuning.h
@@ -67,3 +67,7 @@ MACRO_TUNING_PARAM(HammerHitFireDelay, hammer_hit_fire_delay, 320, "Delay of ham
 
 MACRO_TUNING_PARAM(GroundElasticityX, ground_elasticity_x, 0, "Wall elasticity")
 MACRO_TUNING_PARAM(GroundElasticityY, ground_elasticity_y, 0, "Ground/ceiling elasticity")
+
+MACRO_TUNING_PARAM(NinjaDuration, ninja_duration, 15000, "Ninja duration (milliseconds)")
+MACRO_TUNING_PARAM(NinjaMovetime, ninja_movetime, 200, "How long the dash lasts (milliseconds)")
+MACRO_TUNING_PARAM(NinjaVelocity, ninja_velocity, 50, "Velocity of the dash")


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a83e2cbc-0901-4cfc-9a22-99e479943703)
![image](https://github.com/user-attachments/assets/c1b1fa2f-3078-40d7-a701-0666bf8c3e87)

Adds 3 new tunes for ninja powerup:
`ninja_duration` - Ninja duration in milliseconds, up to 357 minutes
`ninja_movetime` - How long the dashing motion lasts
`ninja_velocity` - Velocity of the dash, how fast you're dashing

This combined with `ninja_fire_delay` allows to customize everything related to ninja dash: length, speed, duration etc
It doesn't break existing maps or connecting to non-ddnet servers, as [default values](https://github.com/ddnet/ddnet/blob/master/datasrc/content.py#L144-L150) are kept the same.


https://github.com/user-attachments/assets/cc0c6b62-5bb1-4093-9dd2-8ceefd7a2ffe

Basic map with it: 
[ninjatune.zip](https://github.com/user-attachments/files/19410869/ninjatune.zip)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
