### PR TITLE
Revert specinfo

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -323,7 +323,7 @@ Objects = [
 		NetIntRange("m_Zoom", 0, 'max_int'),
 		NetIntRange("m_Deadzone", 0, 'max_int'),
 		NetIntRange("m_FollowFactor", 0, 'max_int'),
-		NetIntRange("m_SpectatorCount", 0, 'MAX_CLIENTS-1', 0),
+		NetIntRange("m_SpectatorCount", 0, 'MAX_CLIENTS-1'),
 	]),
 
 	## Events

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -323,7 +323,6 @@ Objects = [
 		NetIntRange("m_Zoom", 0, 'max_int'),
 		NetIntRange("m_Deadzone", 0, 'max_int'),
 		NetIntRange("m_FollowFactor", 0, 'max_int'),
-		NetIntRange("m_SpectatorCount", 0, 'MAX_CLIENTS-1'),
 	]),
 
 	## Events

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -4105,7 +4105,7 @@ void CServer::RegisterCommands()
 	Console()->Register("shutdown", "?r[reason]", CFGFLAG_SERVER, ConShutdown, this, "Shut down");
 	Console()->Register("logout", "", CFGFLAG_SERVER, ConLogout, this, "Logout of rcon");
 	Console()->Register("show_ips", "?i[show]", CFGFLAG_SERVER, ConShowIps, this, "Show IP addresses in rcon commands (1 = on, 0 = off)");
-	Console()->Register("hide_auth_status", "?i[hide]", CFGFLAG_SERVER, ConHideAuthStatus, this, "Opt out of spectator count and hide auth status to non-authed players (1 = hidden, 0 = shown)");
+	Console()->Register("hide_auth_status", "?i[hide]", CFGFLAG_SERVER, ConHideAuthStatus, this, "Hide auth status to non-authed players (1 = hidden, 0 = shown)");
 
 	Console()->Register("record", "?s[file]", CFGFLAG_SERVER | CFGFLAG_STORE, ConRecord, this, "Record to a file");
 	Console()->Register("stoprecord", "", CFGFLAG_SERVER, ConStopRecord, this, "Stop recording");

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -63,7 +63,6 @@ MACRO_CONFIG_INT(ClShowhudHealthAmmo, cl_showhud_healthammo, 1, 0, 1, CFGFLAG_CL
 MACRO_CONFIG_INT(ClShowhudScore, cl_showhud_score, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame HUD (Score)")
 MACRO_CONFIG_INT(ClShowhudTimer, cl_showhud_timer, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame HUD (Timer)")
 MACRO_CONFIG_INT(ClShowhudTimeCpDiff, cl_showhud_time_cp_diff, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame HUD (Time Checkpoint Difference)")
-MACRO_CONFIG_INT(ClShowhudSpectatorCount, cl_showhud_spectator_count, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame HUD (Spectator Count)")
 MACRO_CONFIG_INT(ClShowhudDummyActions, cl_showhud_dummy_actions, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame HUD (Dummy Actions)")
 MACRO_CONFIG_INT(ClShowhudPlayerPosition, cl_showhud_player_position, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame HUD (Player Position)")
 MACRO_CONFIG_INT(ClShowhudPlayerSpeed, cl_showhud_player_speed, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame HUD (Player Speed)")

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1237,71 +1237,6 @@ void CHud::RenderNinjaBarPos(const float x, float y, const float Width, const fl
 	Graphics()->WrapNormal();
 }
 
-void CHud::RenderSpectatorCount()
-{
-	if(!g_Config.m_ClShowhudSpectatorCount)
-	{
-		return;
-	}
-
-	int Count = 0;
-	if(Client()->IsSixup())
-	{
-		for(int i = 0; i < MAX_CLIENTS; i++)
-		{
-			if(i == m_pClient->m_aLocalIds[0] || (m_pClient->Client()->DummyConnected() && i == m_pClient->m_aLocalIds[1]))
-				continue;
-
-			if(Client()->m_TranslationContext.m_aClients[i].m_PlayerFlags7 & protocol7::PLAYERFLAG_WATCHING)
-			{
-				Count++;
-			}
-		}
-	}
-	else
-	{
-		Count = m_pClient->m_Snap.m_SpecInfo.m_SpectatorCount;
-	}
-
-	if(Count == 0)
-		return;
-
-	char aBuf[16];
-	str_format(aBuf, sizeof(aBuf), "%d", Count);
-
-	const float Fontsize = 6.0f;
-	const float BoxHeight = 14.f;
-	const float BoxWidth = 13.f + TextRender()->TextWidth(Fontsize, aBuf);
-
-	float StartX = m_Width - BoxWidth;
-	float StartY = 285.0f - BoxHeight - 4; // 4 units distance to the next display;
-	if(g_Config.m_ClShowhudPlayerPosition || g_Config.m_ClShowhudPlayerSpeed || g_Config.m_ClShowhudPlayerAngle)
-	{
-		StartY -= 4;
-	}
-	StartY -= GetMovementInformationBoxHeight();
-
-	if(g_Config.m_ClShowhudScore)
-	{
-		StartY -= 56;
-	}
-
-	if(g_Config.m_ClShowhudDummyActions && !(m_pClient->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_GAMEOVER) && Client()->DummyConnected())
-	{
-		StartY = StartY - 29.0f - 4; // dummy actions height and padding
-	}
-
-	Graphics()->DrawRect(StartX, StartY, BoxWidth, BoxHeight, ColorRGBA(0.0f, 0.0f, 0.0f, 0.4f), IGraphics::CORNER_L, 5.0f);
-
-	float y = StartY + BoxHeight / 3;
-	float x = StartX + 2;
-
-	TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
-	TextRender()->Text(x, y, Fontsize, FontIcons::FONT_ICON_EYE, -1.0f);
-	TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
-	TextRender()->Text(x + Fontsize + 3.f, y, Fontsize, aBuf, -1.0f);
-}
-
 void CHud::RenderDummyActions()
 {
 	if(!g_Config.m_ClShowhudDummyActions || (m_pClient->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_GAMEOVER) || !Client()->DummyConnected())
@@ -1658,7 +1593,6 @@ void CHud::OnRender()
 			{
 				RenderPlayerState(m_pClient->m_Snap.m_LocalClientId);
 			}
-			RenderSpectatorCount();
 			RenderMovementInformation();
 			RenderDDRaceEffects();
 		}

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -80,7 +80,6 @@ void CHud::OnReset()
 	m_aPlayerSpeed[1] = 0;
 	m_aLastPlayerSpeedChange[0] = ESpeedChange::NONE;
 	m_aLastPlayerSpeedChange[1] = ESpeedChange::NONE;
-	m_LastSpectatorCountTick = 0;
 
 	ResetHudContainers();
 }
@@ -1265,13 +1264,6 @@ void CHud::RenderSpectatorCount()
 	}
 
 	if(Count == 0)
-	{
-		m_LastSpectatorCountTick = Client()->GameTick(g_Config.m_ClDummy);
-		return;
-	}
-
-	// 1 second delay
-	if(Client()->GameTick(g_Config.m_ClDummy) < m_LastSpectatorCountTick + Client()->GameTickSpeed())
 		return;
 
 	char aBuf[16];

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -76,7 +76,6 @@ class CHud : public CComponent
 
 	void PreparePlayerStateQuads();
 	void RenderPlayerState(const int ClientId);
-	void RenderSpectatorCount();
 	void RenderDummyActions();
 	void RenderMovementInformation();
 

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -76,8 +76,6 @@ class CHud : public CComponent
 
 	void PreparePlayerStateQuads();
 	void RenderPlayerState(const int ClientId);
-
-	int m_LastSpectatorCountTick;
 	void RenderSpectatorCount();
 	void RenderDummyActions();
 	void RenderMovementInformation();

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2302,9 +2302,6 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 			RightView.HSplitTop(LineSize, nullptr, &RightView); // Create empty space for hidden option
 		}
 
-		// Eye with a number of spectators
-		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowhudSpectatorCount, Localize("Show number of spectators"), &g_Config.m_ClShowhudSpectatorCount, &RightView, LineSize);
-
 		// Switch for dummy actions display
 		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowhudDummyActions, Localize("Show dummy actions"), &g_Config.m_ClShowhudDummyActions, &RightView, LineSize);
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1803,7 +1803,6 @@ void CGameClient::OnNewSnapshot()
 				m_Snap.m_SpecInfo.m_Zoom = pDDNetSpecInfo->m_Zoom / 1000.0f;
 				m_Snap.m_SpecInfo.m_Deadzone = pDDNetSpecInfo->m_Deadzone;
 				m_Snap.m_SpecInfo.m_FollowFactor = pDDNetSpecInfo->m_FollowFactor;
-				m_Snap.m_SpecInfo.m_SpectatorCount = pDDNetSpecInfo->m_SpectatorCount;
 			}
 			else if(Item.m_Type == NETOBJTYPE_GAMEINFO)
 			{

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -352,7 +352,6 @@ public:
 			float m_Zoom;
 			int m_Deadzone;
 			int m_FollowFactor;
-			int m_SpectatorCount;
 		} m_SpecInfo;
 
 		//

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -435,11 +435,8 @@ void CPlayer::Snap(int SnappingClient)
 				int SpectatorCount = 0;
 				for(auto &pPlayer : GameServer()->m_apPlayers)
 				{
-					if(!pPlayer || pPlayer->m_ClientId == id || pPlayer->m_Afk ||
-						!(pPlayer->m_Paused || pPlayer->m_Team == TEAM_SPECTATORS))
-					{
+					if(!pPlayer || pPlayer->m_ClientId == id || !(pPlayer->m_Paused || pPlayer->m_Team == TEAM_SPECTATORS))
 						continue;
-					}
 
 					if(pPlayer->m_SpectatorId == id)
 					{

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -436,7 +436,6 @@ void CPlayer::Snap(int SnappingClient)
 				for(auto &pPlayer : GameServer()->m_apPlayers)
 				{
 					if(!pPlayer || pPlayer->m_ClientId == id || pPlayer->m_Afk ||
-						(Server()->GetAuthedState(pPlayer->m_ClientId) && Server()->HasAuthHidden(pPlayer->m_ClientId)) ||
 						!(pPlayer->m_Paused || pPlayer->m_Team == TEAM_SPECTATORS))
 					{
 						continue;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -429,30 +429,6 @@ void CPlayer::Snap(int SnappingClient)
 			pDDNetSpectatorInfo->m_Zoom = pSpecPlayer->m_CameraInfo.m_Zoom * 1000.0f;
 			pDDNetSpectatorInfo->m_Deadzone = pSpecPlayer->m_CameraInfo.m_Deadzone;
 			pDDNetSpectatorInfo->m_FollowFactor = pSpecPlayer->m_CameraInfo.m_FollowFactor;
-
-			if(SpectatingClient == id && SnappingClient != SERVER_DEMO_CLIENT && m_Team != TEAM_SPECTATORS && !m_Paused)
-			{
-				int SpectatorCount = 0;
-				for(auto &pPlayer : GameServer()->m_apPlayers)
-				{
-					if(!pPlayer || pPlayer->m_ClientId == id || !(pPlayer->m_Paused || pPlayer->m_Team == TEAM_SPECTATORS))
-						continue;
-
-					if(pPlayer->m_SpectatorId == id)
-					{
-						SpectatorCount++;
-					}
-					else if(GameServer()->m_apPlayers[id]->GetCharacter())
-					{
-						vec2 CheckPos = GameServer()->m_apPlayers[id]->GetCharacter()->GetPos();
-						float dx = pPlayer->m_ViewPos.x - CheckPos.x;
-						float dy = pPlayer->m_ViewPos.y - CheckPos.y;
-						if(absolute(dx) < (pPlayer->m_ShowDistance.x / 2.5f) && absolute(dy) < (pPlayer->m_ShowDistance.y / 2.3f))
-							SpectatorCount++;
-					}
-				}
-				pDDNetSpectatorInfo->m_SpectatorCount = SpectatorCount;
-			}
 		}
 	}
 


### PR DESCRIPTION
The specinfo PR was merged despite there being requests to be able to disable the feature. The original PR #9488 incorrectly says that it's an optional feature — it is not, it also affects players who have the setting turned off. See also #9818.

Additionally, it seems that it was implemented by putting `m_SpectatorCount` into `CNetObj_DDNetSpectatorInfo`, a place unsuitable for this variable. The `CNetObj_DDNetSpectatorInfo` has info **about the player** who is being spectated, not info about other people spectating them, for showing their cursor etc. The variable should be put somewhere else.

I discovered this while reviewing the code for the first time, in order to write the opt-in/opt-out code. I hadn't reviewed the code before because I didn't expect the PR to be merged. Apparently the technical deficiencies were missed in the reviews.

These two reasons justify reverting the feature on their own, IMO. Both should be fixed before reintroducing the feature.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
