### PR TITLE
Add `str_valid_filename` function: improve skin and map name validation, improve tests

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2896,8 +2896,11 @@ void str_sanitize_filename(char *str_in)
 	unsigned char *str = (unsigned char *)str_in;
 	while(*str)
 	{
-		if(*str < 32 || *str == '\\' || *str == '/' || *str == '|' || *str == ':' || *str == '*' || *str == '?' || *str == '<' || *str == '>' || *str == '"')
+		if(*str <= 0x1F || *str == 0x7F || *str == '\\' || *str == '/' || *str == '|' || *str == ':' ||
+			*str == '*' || *str == '?' || *str == '<' || *str == '>' || *str == '"')
+		{
 			*str = ' ';
+		}
 		str++;
 	}
 }

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2905,6 +2905,73 @@ void str_sanitize_filename(char *str_in)
 	}
 }
 
+bool str_valid_filename(const char *str)
+{
+	// References:
+	// - https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations
+	// - https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+	if(str[0] == '\0')
+	{
+		return false; // empty name not allowed
+	}
+
+	bool prev_space = false;
+	bool prev_period = false;
+	bool first_space_checked = false;
+	const char *iterator = str;
+	while(*iterator)
+	{
+		const int code = str_utf8_decode(&iterator);
+		if(code <= 0x1F || code == 0x7F || code == '\\' || code == '/' || code == '|' || code == ':' ||
+			code == '*' || code == '?' || code == '<' || code == '>' || code == '"')
+		{
+			return false; // disallowed characters, mostly for Windows
+		}
+		else if(str_utf8_isspace(code) && code != ' ')
+		{
+			return false; // we only allow regular space characters
+		}
+		if(code == ' ')
+		{
+			if(!first_space_checked)
+			{
+				return false; // leading spaces not allowed
+			}
+			if(prev_space)
+			{
+				return false; // multiple consecutive spaces not allowed
+			}
+			prev_space = true;
+			prev_period = false;
+		}
+		else
+		{
+			prev_space = false;
+			prev_period = code == '.';
+			first_space_checked = true;
+		}
+	}
+	if(prev_space || prev_period)
+	{
+		return false; // trailing spaces and periods not allowed
+	}
+
+	static constexpr const char *RESERVED_NAMES[] = {
+		"CON", "PRN", "AUX", "NUL",
+		"COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "COM¹", "COM²", "COM³",
+		"LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9", "LPT¹", "LPT²", "LPT³"};
+	for(const char *reserved_name : RESERVED_NAMES)
+	{
+		const char *prefix = str_startswith_nocase(str, reserved_name);
+		if(prefix != nullptr && (prefix[0] == '\0' || prefix[0] == '.'))
+		{
+			return false; // reserved name not allowed when it makes up the entire filename or when followed by period
+		}
+	}
+
+	return true;
+}
+
 /* removes leading and trailing spaces and limits the use of multiple spaces */
 void str_clean_whitespaces(char *str_in)
 {

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1397,6 +1397,17 @@ void str_sanitize(char *str);
 void str_sanitize_filename(char *str);
 
 /**
+ * Checks if a string is a valid filename on all supported platforms.
+ *
+ * @param str Filename to check.
+ *
+ * @return `true` if the string is a valid filename, `false` otherwise.
+ *
+ * @remark The strings are treated as zero-terminated strings.
+ */
+bool str_valid_filename(const char *str);
+
+/**
  * Removes leading and trailing spaces and limits the use of multiple spaces.
  *
  * @ingroup Strings

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1549,13 +1549,10 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 				return;
 			}
 
-			for(int i = 0; pMap[i]; i++) // protect the player from nasty map names
+			if(!str_valid_filename(pMap))
 			{
-				if(pMap[i] == '/' || pMap[i] == '\\')
-				{
-					DisconnectWithReason("strange character in map name");
-					return;
-				}
+				DisconnectWithReason("map name is not a valid filename");
+				return;
 			}
 
 			if(m_DummyConnected && !m_DummyReconnectOnReload)

--- a/src/game/client/skin.cpp
+++ b/src/game/client/skin.cpp
@@ -134,19 +134,12 @@ CSkin::CSkin(const char *pName)
 // has to be kept in sync with m_aSkinNameRestrictions
 bool CSkin::IsValidName(const char *pName)
 {
-	if(pName[0] == '\0' || str_length(pName) >= (int)sizeof(CSkin("").m_aName))
+	if(str_length(pName) >= (int)sizeof(CSkin("").m_aName))
 	{
 		return false;
 	}
 
-	for(int i = 0; pName[i] != '\0'; ++i)
-	{
-		if(pName[i] == '"' || pName[i] == '/' || pName[i] == '\\')
-		{
-			return false;
-		}
-	}
-	return true;
+	return str_valid_filename(pName);
 }
 
 const char CSkin::m_aSkinNameRestrictions[] = "Skin names must be valid filenames shorter than 24 characters.";

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -1007,6 +1007,75 @@ TEST(Str, SanitizeFilename)
 	TestInplace<str_sanitize_filename>("\\/|:*?<>\"", "         ");
 }
 
+TEST(Str, ValidFilename)
+{
+	EXPECT_TRUE(str_valid_filename("a"));
+	EXPECT_TRUE(str_valid_filename("abc"));
+	EXPECT_TRUE(str_valid_filename("abc abc"));
+	EXPECT_TRUE(str_valid_filename("aa bb ccc dddd eeeee"));
+	EXPECT_TRUE(str_valid_filename("öüä"));
+	EXPECT_TRUE(str_valid_filename("привет Наташа"));
+	EXPECT_TRUE(str_valid_filename("ąçęįǫų"));
+	EXPECT_TRUE(str_valid_filename("DDNet最好了"));
+	EXPECT_TRUE(str_valid_filename("aβい🐘"));
+	EXPECT_TRUE(str_valid_filename("foo.bar"));
+	EXPECT_TRUE(str_valid_filename("foo.bar.baz"));
+	EXPECT_TRUE(str_valid_filename(".a..b...c....d"));
+
+	EXPECT_FALSE(str_valid_filename(""));
+	EXPECT_FALSE(str_valid_filename("aa\nbb"));
+	EXPECT_FALSE(str_valid_filename("aa\rbb"));
+	EXPECT_FALSE(str_valid_filename("aa\tbb"));
+	EXPECT_FALSE(str_valid_filename("aa\u001Cbb"));
+	EXPECT_FALSE(str_valid_filename("aa\u001Dbb"));
+	EXPECT_FALSE(str_valid_filename("aa\u001Ebb"));
+	EXPECT_FALSE(str_valid_filename("aa\u001Fbb"));
+	EXPECT_FALSE(str_valid_filename("aa\u007Fbb"));
+	EXPECT_FALSE(str_valid_filename("aa\\bb"));
+	EXPECT_FALSE(str_valid_filename("aa/bb"));
+	EXPECT_FALSE(str_valid_filename("aa|bb"));
+	EXPECT_FALSE(str_valid_filename("aa:bb"));
+	EXPECT_FALSE(str_valid_filename("aa*bb"));
+	EXPECT_FALSE(str_valid_filename("aa?bb"));
+	EXPECT_FALSE(str_valid_filename("aa<bb"));
+	EXPECT_FALSE(str_valid_filename("aa>bb"));
+	EXPECT_FALSE(str_valid_filename("aa\"bb"));
+	EXPECT_FALSE(str_valid_filename("\\/|:*?<>\""));
+	EXPECT_FALSE(str_valid_filename("aa bb")); // EM QUAD
+	EXPECT_FALSE(str_valid_filename("aa​bb")); // ZERO WIDTH SPACE
+	EXPECT_FALSE(str_valid_filename(" abc"));
+	EXPECT_FALSE(str_valid_filename("   abc"));
+	EXPECT_FALSE(str_valid_filename("abc "));
+	EXPECT_FALSE(str_valid_filename("abc   "));
+	EXPECT_FALSE(str_valid_filename("abc   abc"));
+	EXPECT_FALSE(str_valid_filename(" abc abc "));
+	EXPECT_FALSE(str_valid_filename("   abc   abc   "));
+	EXPECT_FALSE(str_valid_filename("abc."));
+	EXPECT_FALSE(str_valid_filename("abc..."));
+	EXPECT_FALSE(str_valid_filename("abc... "));
+	EXPECT_FALSE(str_valid_filename("abc ..."));
+
+	// reserved names
+	EXPECT_FALSE(str_valid_filename("con"));
+	EXPECT_FALSE(str_valid_filename("CON"));
+	EXPECT_FALSE(str_valid_filename("cOn"));
+	EXPECT_FALSE(str_valid_filename("con.txt"));
+	EXPECT_FALSE(str_valid_filename("con.tar.gz"));
+	EXPECT_FALSE(str_valid_filename("CON.TAR.GZ"));
+	EXPECT_FALSE(str_valid_filename("PRN"));
+	EXPECT_FALSE(str_valid_filename("AUX"));
+	EXPECT_FALSE(str_valid_filename("NUL"));
+	EXPECT_FALSE(str_valid_filename("COM4"));
+	EXPECT_FALSE(str_valid_filename("lpt²"));
+	// reserved names allowed as prefix if not separated by period
+	EXPECT_TRUE(str_valid_filename("console"));
+	EXPECT_TRUE(str_valid_filename("console.log"));
+	EXPECT_TRUE(str_valid_filename("console.tar.gz"));
+	EXPECT_TRUE(str_valid_filename("Auxiliary"));
+	EXPECT_TRUE(str_valid_filename("Null"));
+	EXPECT_TRUE(str_valid_filename("Null.txt"));
+}
+
 TEST(Str, CleanWhitespaces)
 {
 	TestInplace<str_clean_whitespaces>("aa bb ccc dddd eeeee", "aa bb ccc dddd eeeee");

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -4,6 +4,16 @@
 
 #include <game/gamecore.h>
 
+typedef void (*TStringArgumentFunction)(char *pStr);
+template<TStringArgumentFunction Func>
+static void TestInplace(const char *pInput, const char *pOutput)
+{
+	char aBuf[512];
+	str_copy(aBuf, pInput);
+	Func(aBuf);
+	EXPECT_STREQ(aBuf, pOutput);
+}
+
 TEST(Str, StrDelim)
 {
 	int Start, End;
@@ -927,118 +937,47 @@ TEST(Str, HasCc)
 
 TEST(Str, SanitizeCc)
 {
-	char aBuf[64];
-	str_copy(aBuf, "");
-	str_sanitize_cc(aBuf);
-	EXPECT_STREQ(aBuf, "");
-	str_copy(aBuf, "a");
-	str_sanitize_cc(aBuf);
-	EXPECT_STREQ(aBuf, "a");
-	str_copy(aBuf, "Merhaba dünya!");
-	str_sanitize_cc(aBuf);
-	EXPECT_STREQ(aBuf, "Merhaba dünya!");
-
-	str_copy(aBuf, "\n");
-	str_sanitize_cc(aBuf);
-	EXPECT_STREQ(aBuf, " ");
-	str_copy(aBuf, "\r");
-	str_sanitize_cc(aBuf);
-	EXPECT_STREQ(aBuf, " ");
-	str_copy(aBuf, "\t");
-	str_sanitize_cc(aBuf);
-	EXPECT_STREQ(aBuf, " ");
-	str_copy(aBuf, "a\n");
-	str_sanitize_cc(aBuf);
-	EXPECT_STREQ(aBuf, "a ");
-	str_copy(aBuf, "a\rb");
-	str_sanitize_cc(aBuf);
-	EXPECT_STREQ(aBuf, "a b");
-	str_copy(aBuf, "\tb");
-	str_sanitize_cc(aBuf);
-	EXPECT_STREQ(aBuf, " b");
-	str_copy(aBuf, "\n\n");
-	str_sanitize_cc(aBuf);
-	EXPECT_STREQ(aBuf, "  ");
-	str_copy(aBuf, "\x1C");
-	str_sanitize_cc(aBuf);
-	EXPECT_STREQ(aBuf, " ");
-	str_copy(aBuf, "\x1D");
-	str_sanitize_cc(aBuf);
-	EXPECT_STREQ(aBuf, " ");
-	str_copy(aBuf, "\x1E");
-	str_sanitize_cc(aBuf);
-	EXPECT_STREQ(aBuf, " ");
-	str_copy(aBuf, "\x1F");
-	str_sanitize_cc(aBuf);
-	EXPECT_STREQ(aBuf, " ");
+	TestInplace<str_sanitize_cc>("", "");
+	TestInplace<str_sanitize_cc>("a", "a");
+	TestInplace<str_sanitize_cc>("Merhaba dünya!", "Merhaba dünya!");
+	TestInplace<str_sanitize_cc>("\n", " ");
+	TestInplace<str_sanitize_cc>("\r", " ");
+	TestInplace<str_sanitize_cc>("\t", " ");
+	TestInplace<str_sanitize_cc>("a\n", "a ");
+	TestInplace<str_sanitize_cc>("a\rb", "a b");
+	TestInplace<str_sanitize_cc>("\tb", " b");
+	TestInplace<str_sanitize_cc>("\n\n", "  ");
+	TestInplace<str_sanitize_cc>("\x1C", " ");
+	TestInplace<str_sanitize_cc>("\x1D", " ");
+	TestInplace<str_sanitize_cc>("\x1E", " ");
+	TestInplace<str_sanitize_cc>("\x1F", " ");
 }
 
 TEST(Str, Sanitize)
 {
-	char aBuf[64];
-	str_copy(aBuf, "");
-	str_sanitize(aBuf);
-	EXPECT_STREQ(aBuf, "");
-	str_copy(aBuf, "a");
-	str_sanitize(aBuf);
-	EXPECT_STREQ(aBuf, "a");
-	str_copy(aBuf, "Merhaba dünya!");
-	str_sanitize(aBuf);
-	EXPECT_STREQ(aBuf, "Merhaba dünya!");
-	str_copy(aBuf, "\n");
-	str_sanitize(aBuf);
-	EXPECT_STREQ(aBuf, "\n");
-	str_copy(aBuf, "\r");
-	str_sanitize(aBuf);
-	EXPECT_STREQ(aBuf, "\r");
-	str_copy(aBuf, "\t");
-	str_sanitize(aBuf);
-	EXPECT_STREQ(aBuf, "\t");
-	str_copy(aBuf, "a\n");
-	str_sanitize(aBuf);
-	EXPECT_STREQ(aBuf, "a\n");
-	str_copy(aBuf, "a\rb");
-	str_sanitize(aBuf);
-	EXPECT_STREQ(aBuf, "a\rb");
-	str_copy(aBuf, "\tb");
-	str_sanitize(aBuf);
-	EXPECT_STREQ(aBuf, "\tb");
-	str_copy(aBuf, "\n\n");
-	str_sanitize(aBuf);
-	EXPECT_STREQ(aBuf, "\n\n");
-
-	str_copy(aBuf, "\x1C");
-	str_sanitize(aBuf);
-	EXPECT_STREQ(aBuf, " ");
-	str_copy(aBuf, "\x1D");
-	str_sanitize(aBuf);
-	EXPECT_STREQ(aBuf, " ");
-	str_copy(aBuf, "\x1E");
-	str_sanitize(aBuf);
-	EXPECT_STREQ(aBuf, " ");
-	str_copy(aBuf, "\x1F");
-	str_sanitize(aBuf);
-	EXPECT_STREQ(aBuf, " ");
+	TestInplace<str_sanitize>("", "");
+	TestInplace<str_sanitize>("a", "a");
+	TestInplace<str_sanitize>("Merhaba dünya!", "Merhaba dünya!");
+	TestInplace<str_sanitize>("\n", "\n");
+	TestInplace<str_sanitize>("\r", "\r");
+	TestInplace<str_sanitize>("\t", "\t");
+	TestInplace<str_sanitize>("a\n", "a\n");
+	TestInplace<str_sanitize>("a\rb", "a\rb");
+	TestInplace<str_sanitize>("\tb", "\tb");
+	TestInplace<str_sanitize>("\n\n", "\n\n");
+	TestInplace<str_sanitize>("\x1C", " ");
+	TestInplace<str_sanitize>("\x1D", " ");
+	TestInplace<str_sanitize>("\x1E", " ");
+	TestInplace<str_sanitize>("\x1F", " ");
 }
 
 TEST(Str, CleanWhitespaces)
 {
-	char aBuf[64];
-	str_copy(aBuf, "aa bb ccc dddd eeeee");
-	str_clean_whitespaces(aBuf);
-	EXPECT_STREQ(aBuf, "aa bb ccc dddd eeeee");
-	str_copy(aBuf, "     ");
-	str_clean_whitespaces(aBuf);
-	EXPECT_STREQ(aBuf, "");
-	str_copy(aBuf, "     aa");
-	str_clean_whitespaces(aBuf);
-	EXPECT_STREQ(aBuf, "aa");
-	str_copy(aBuf, "aa     ");
-	str_clean_whitespaces(aBuf);
-	EXPECT_STREQ(aBuf, "aa");
-	str_copy(aBuf, "  aa   bb    ccc     dddd       eeeee    ");
-	str_clean_whitespaces(aBuf);
-	EXPECT_STREQ(aBuf, "aa bb ccc dddd eeeee");
+	TestInplace<str_clean_whitespaces>("aa bb ccc dddd eeeee", "aa bb ccc dddd eeeee");
+	TestInplace<str_clean_whitespaces>("     ", "");
+	TestInplace<str_clean_whitespaces>("     aa", "aa");
+	TestInplace<str_clean_whitespaces>("aa     ", "aa");
+	TestInplace<str_clean_whitespaces>("  aa   bb    ccc     dddd       eeeee    ", "aa bb ccc dddd eeeee");
 }
 
 TEST(Str, SkipToWhitespace)

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -971,6 +971,42 @@ TEST(Str, Sanitize)
 	TestInplace<str_sanitize>("\x1F", " ");
 }
 
+TEST(Str, SanitizeFilename)
+{
+	TestInplace<str_sanitize_filename>("", "");
+	TestInplace<str_sanitize_filename>("a", "a");
+	TestInplace<str_sanitize_filename>("Merhaba dünya!", "Merhaba dünya!");
+	TestInplace<str_sanitize_filename>("привет Наташа", "привет Наташа");
+	TestInplace<str_sanitize_filename>("ąçęįǫų", "ąçęįǫų");
+	TestInplace<str_sanitize_filename>("DDNet最好了", "DDNet最好了");
+	TestInplace<str_sanitize_filename>("aβい🐘", "aβい🐘");
+	TestInplace<str_sanitize_filename>("foo.bar", "foo.bar");
+	TestInplace<str_sanitize_filename>("foo.bar.baz", "foo.bar.baz");
+	TestInplace<str_sanitize_filename>(".a..b...c....d", ".a..b...c....d");
+	TestInplace<str_sanitize_filename>("\n", " ");
+	TestInplace<str_sanitize_filename>("\r", " ");
+	TestInplace<str_sanitize_filename>("\t", " ");
+	TestInplace<str_sanitize_filename>("a\n", "a ");
+	TestInplace<str_sanitize_filename>("a\rb", "a b");
+	TestInplace<str_sanitize_filename>("\tb", " b");
+	TestInplace<str_sanitize_filename>("\n\n", "  ");
+	TestInplace<str_sanitize_filename>("\x1C", " ");
+	TestInplace<str_sanitize_filename>("\x1D", " ");
+	TestInplace<str_sanitize_filename>("\x1E", " ");
+	TestInplace<str_sanitize_filename>("\x1F", " ");
+	TestInplace<str_sanitize_filename>("\u007F", " ");
+	TestInplace<str_sanitize_filename>("\\", " ");
+	TestInplace<str_sanitize_filename>("/", " ");
+	TestInplace<str_sanitize_filename>("|", " ");
+	TestInplace<str_sanitize_filename>(":", " ");
+	TestInplace<str_sanitize_filename>("*", " ");
+	TestInplace<str_sanitize_filename>("?", " ");
+	TestInplace<str_sanitize_filename>("<", " ");
+	TestInplace<str_sanitize_filename>(">", " ");
+	TestInplace<str_sanitize_filename>("\"", " ");
+	TestInplace<str_sanitize_filename>("\\/|:*?<>\"", "         ");
+}
+
 TEST(Str, CleanWhitespaces)
 {
 	TestInplace<str_clean_whitespaces>("aa bb ccc dddd eeeee", "aa bb ccc dddd eeeee");


### PR DESCRIPTION
Add `str_valid_filename` function to check for valid filenames of skins and maps before attempting to load them to reduce cross-platform incompatibility.

Closes #6892. This issue was seemingly already resolved on the server-side, but this change will additionally ensure that skins with leading, trailing or multiple consecutive spaces will not be loaded. Checked with the names of all skins in the official database to ensure they are all considered valid.

See also #3529.

Implementation references:

- https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations
- https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
