### PR TITLE
refactor(editor): change some variable names and types in CLayerTiles

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3140,12 +3140,12 @@ void CEditor::DoMapEditor(CUIRect View)
 				m_pTilesetPicker->m_Color = {255, 255, 255, 255};
 			}
 
-			m_pTilesetPicker->m_Game = pTileLayer->m_Game;
-			m_pTilesetPicker->m_Tele = pTileLayer->m_Tele;
-			m_pTilesetPicker->m_Speedup = pTileLayer->m_Speedup;
-			m_pTilesetPicker->m_Front = pTileLayer->m_Front;
-			m_pTilesetPicker->m_Switch = pTileLayer->m_Switch;
-			m_pTilesetPicker->m_Tune = pTileLayer->m_Tune;
+			m_pTilesetPicker->m_HasGame = pTileLayer->m_HasGame;
+			m_pTilesetPicker->m_HasTele = pTileLayer->m_HasTele;
+			m_pTilesetPicker->m_HasSpeedup = pTileLayer->m_HasSpeedup;
+			m_pTilesetPicker->m_HasFront = pTileLayer->m_HasFront;
+			m_pTilesetPicker->m_HasSwitch = pTileLayer->m_HasSwitch;
+			m_pTilesetPicker->m_HasTune = pTileLayer->m_HasTune;
 
 			m_pTilesetPicker->Render(true);
 
@@ -3343,7 +3343,7 @@ void CEditor::DoMapEditor(CUIRect View)
 									std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(apEditLayers[k].second);
 									std::shared_ptr<CLayerTiles> pBrushLayer = std::static_pointer_cast<CLayerTiles>(m_pBrush->m_vpLayers[BrushIndex]);
 
-									if(pLayer->m_Tele <= pBrushLayer->m_Tele && pLayer->m_Speedup <= pBrushLayer->m_Speedup && pLayer->m_Front <= pBrushLayer->m_Front && pLayer->m_Game <= pBrushLayer->m_Game && pLayer->m_Switch <= pBrushLayer->m_Switch && pLayer->m_Tune <= pBrushLayer->m_Tune)
+									if((!pLayer->m_HasTele || pBrushLayer->m_HasTele) && (!pLayer->m_HasSpeedup || pBrushLayer->m_HasSpeedup) && (!pLayer->m_HasFront || pBrushLayer->m_HasFront) && (!pLayer->m_HasGame || pBrushLayer->m_HasGame) && (!pLayer->m_HasSwitch || pBrushLayer->m_HasSwitch) && (!pLayer->m_HasTune || pBrushLayer->m_HasTune))
 										pLayer->BrushDraw(pBrushLayer, vec2(wx, wy));
 								}
 								else
@@ -8266,7 +8266,7 @@ void CEditor::Render()
 		if(!m_pBrush->IsEmpty())
 		{
 			const bool HasTeleTiles = std::any_of(m_pBrush->m_vpLayers.begin(), m_pBrush->m_vpLayers.end(), [](auto pLayer) {
-				return pLayer->m_Type == LAYERTYPE_TILES && std::static_pointer_cast<CLayerTiles>(pLayer)->m_Tele;
+				return pLayer->m_Type == LAYERTYPE_TILES && std::static_pointer_cast<CLayerTiles>(pLayer)->m_HasTele;
 			});
 			if(HasTeleTiles)
 				str_copy(m_aTooltip, "Use shift+mouse wheel up/down to adjust the tele numbers. Use ctrl+f to change all tele numbers to the first unused number.");
@@ -8598,7 +8598,7 @@ void CEditor::RenderSwitchEntities(const std::shared_ptr<CLayerTiles> &pTiles)
 	const float TileSize = 32.f;
 
 	std::function<unsigned char(int, int, unsigned char &)> GetIndex;
-	if(pTiles->m_Switch)
+	if(pTiles->m_HasSwitch)
 	{
 		CLayerSwitch *pSwitchLayer = ((CLayerSwitch *)(pTiles.get()));
 		GetIndex = [pSwitchLayer](int y, int x, unsigned char &Number) -> unsigned char {
@@ -9388,7 +9388,7 @@ void CEditor::AdjustBrushSpecialTiles(bool UseNextFree, int Adjust)
 
 		std::shared_ptr<CLayerTiles> pLayerTiles = std::static_pointer_cast<CLayerTiles>(pLayer);
 
-		if(pLayerTiles->m_Tele)
+		if(pLayerTiles->m_HasTele)
 		{
 			int NextFreeTeleNumber = FindNextFreeTeleNumber();
 			int NextFreeCPNumber = FindNextFreeTeleNumber(true);
@@ -9422,7 +9422,7 @@ void CEditor::AdjustBrushSpecialTiles(bool UseNextFree, int Adjust)
 				}
 			}
 		}
-		else if(pLayerTiles->m_Tune)
+		else if(pLayerTiles->m_HasTune)
 		{
 			if(!UseNextFree)
 			{
@@ -9440,7 +9440,7 @@ void CEditor::AdjustBrushSpecialTiles(bool UseNextFree, int Adjust)
 				}
 			}
 		}
-		else if(pLayerTiles->m_Switch)
+		else if(pLayerTiles->m_HasSwitch)
 		{
 			int NextFreeNumber = FindNextFreeSwitchNumber();
 
@@ -9460,7 +9460,7 @@ void CEditor::AdjustBrushSpecialTiles(bool UseNextFree, int Adjust)
 				}
 			}
 		}
-		else if(pLayerTiles->m_Speedup)
+		else if(pLayerTiles->m_HasSpeedup)
 		{
 			if(!UseNextFree)
 			{

--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -545,15 +545,15 @@ void CEditorActionAddLayer::Undo()
 	if(m_pLayer->m_Type == LAYERTYPE_TILES)
 	{
 		std::shared_ptr<CLayerTiles> pLayerTiles = std::static_pointer_cast<CLayerTiles>(m_pLayer);
-		if(pLayerTiles->m_Front)
+		if(pLayerTiles->m_HasFront)
 			m_pEditor->m_Map.m_pFrontLayer = nullptr;
-		else if(pLayerTiles->m_Tele)
+		else if(pLayerTiles->m_HasTele)
 			m_pEditor->m_Map.m_pTeleLayer = nullptr;
-		else if(pLayerTiles->m_Speedup)
+		else if(pLayerTiles->m_HasSpeedup)
 			m_pEditor->m_Map.m_pSpeedupLayer = nullptr;
-		else if(pLayerTiles->m_Switch)
+		else if(pLayerTiles->m_HasSwitch)
 			m_pEditor->m_Map.m_pSwitchLayer = nullptr;
-		else if(pLayerTiles->m_Tune)
+		else if(pLayerTiles->m_HasTune)
 			m_pEditor->m_Map.m_pTuneLayer = nullptr;
 	}
 
@@ -574,15 +574,15 @@ void CEditorActionAddLayer::Redo()
 	if(m_pLayer->m_Type == LAYERTYPE_TILES)
 	{
 		std::shared_ptr<CLayerTiles> pLayerTiles = std::static_pointer_cast<CLayerTiles>(m_pLayer);
-		if(pLayerTiles->m_Front)
+		if(pLayerTiles->m_HasFront)
 			m_pEditor->m_Map.m_pFrontLayer = std::static_pointer_cast<CLayerFront>(m_pLayer);
-		else if(pLayerTiles->m_Tele)
+		else if(pLayerTiles->m_HasTele)
 			m_pEditor->m_Map.m_pTeleLayer = std::static_pointer_cast<CLayerTele>(m_pLayer);
-		else if(pLayerTiles->m_Speedup)
+		else if(pLayerTiles->m_HasSpeedup)
 			m_pEditor->m_Map.m_pSpeedupLayer = std::static_pointer_cast<CLayerSpeedup>(m_pLayer);
-		else if(pLayerTiles->m_Switch)
+		else if(pLayerTiles->m_HasSwitch)
 			m_pEditor->m_Map.m_pSwitchLayer = std::static_pointer_cast<CLayerSwitch>(m_pLayer);
-		else if(pLayerTiles->m_Tune)
+		else if(pLayerTiles->m_HasTune)
 			m_pEditor->m_Map.m_pTuneLayer = std::static_pointer_cast<CLayerTune>(m_pLayer);
 	}
 
@@ -607,15 +607,15 @@ void CEditorActionDeleteLayer::Redo()
 	if(m_pLayer->m_Type == LAYERTYPE_TILES)
 	{
 		std::shared_ptr<CLayerTiles> pLayerTiles = std::static_pointer_cast<CLayerTiles>(m_pLayer);
-		if(pLayerTiles->m_Front)
+		if(pLayerTiles->m_HasFront)
 			m_pEditor->m_Map.m_pFrontLayer = nullptr;
-		else if(pLayerTiles->m_Tele)
+		else if(pLayerTiles->m_HasTele)
 			m_pEditor->m_Map.m_pTeleLayer = nullptr;
-		else if(pLayerTiles->m_Speedup)
+		else if(pLayerTiles->m_HasSpeedup)
 			m_pEditor->m_Map.m_pSpeedupLayer = nullptr;
-		else if(pLayerTiles->m_Switch)
+		else if(pLayerTiles->m_HasSwitch)
 			m_pEditor->m_Map.m_pSwitchLayer = nullptr;
-		else if(pLayerTiles->m_Tune)
+		else if(pLayerTiles->m_HasTune)
 			m_pEditor->m_Map.m_pTuneLayer = nullptr;
 	}
 
@@ -636,15 +636,15 @@ void CEditorActionDeleteLayer::Undo()
 	if(m_pLayer->m_Type == LAYERTYPE_TILES)
 	{
 		std::shared_ptr<CLayerTiles> pLayerTiles = std::static_pointer_cast<CLayerTiles>(m_pLayer);
-		if(pLayerTiles->m_Front)
+		if(pLayerTiles->m_HasFront)
 			m_pEditor->m_Map.m_pFrontLayer = std::static_pointer_cast<CLayerFront>(m_pLayer);
-		else if(pLayerTiles->m_Tele)
+		else if(pLayerTiles->m_HasTele)
 			m_pEditor->m_Map.m_pTeleLayer = std::static_pointer_cast<CLayerTele>(m_pLayer);
-		else if(pLayerTiles->m_Speedup)
+		else if(pLayerTiles->m_HasSpeedup)
 			m_pEditor->m_Map.m_pSpeedupLayer = std::static_pointer_cast<CLayerSpeedup>(m_pLayer);
-		else if(pLayerTiles->m_Switch)
+		else if(pLayerTiles->m_HasSwitch)
 			m_pEditor->m_Map.m_pSwitchLayer = std::static_pointer_cast<CLayerSwitch>(m_pLayer);
-		else if(pLayerTiles->m_Tune)
+		else if(pLayerTiles->m_HasTune)
 			m_pEditor->m_Map.m_pTuneLayer = std::static_pointer_cast<CLayerTune>(m_pLayer);
 	}
 
@@ -885,19 +885,19 @@ void CEditorActionEditLayerTilesProp::Undo()
 			pLayerTiles->Resize(m_Previous, pLayerTiles->m_Height);
 
 		RestoreLayer(LAYERTYPE_TILES, pLayerTiles);
-		if(pLayerTiles->m_Game || pLayerTiles->m_Front || pLayerTiles->m_Switch || pLayerTiles->m_Speedup || pLayerTiles->m_Tune)
+		if(pLayerTiles->m_HasGame || pLayerTiles->m_HasFront || pLayerTiles->m_HasSwitch || pLayerTiles->m_HasSpeedup || pLayerTiles->m_HasTune)
 		{
-			if(m_pEditor->m_Map.m_pFrontLayer && !pLayerTiles->m_Front)
+			if(m_pEditor->m_Map.m_pFrontLayer && !pLayerTiles->m_HasFront)
 				RestoreLayer(LAYERTYPE_FRONT, m_pEditor->m_Map.m_pFrontLayer);
-			if(m_pEditor->m_Map.m_pTeleLayer && !pLayerTiles->m_Tele)
+			if(m_pEditor->m_Map.m_pTeleLayer && !pLayerTiles->m_HasTele)
 				RestoreLayer(LAYERTYPE_TELE, m_pEditor->m_Map.m_pTeleLayer);
-			if(m_pEditor->m_Map.m_pSwitchLayer && !pLayerTiles->m_Switch)
+			if(m_pEditor->m_Map.m_pSwitchLayer && !pLayerTiles->m_HasSwitch)
 				RestoreLayer(LAYERTYPE_SWITCH, m_pEditor->m_Map.m_pSwitchLayer);
-			if(m_pEditor->m_Map.m_pSpeedupLayer && !pLayerTiles->m_Speedup)
+			if(m_pEditor->m_Map.m_pSpeedupLayer && !pLayerTiles->m_HasSpeedup)
 				RestoreLayer(LAYERTYPE_SPEEDUP, m_pEditor->m_Map.m_pSpeedupLayer);
-			if(m_pEditor->m_Map.m_pTuneLayer && !pLayerTiles->m_Tune)
+			if(m_pEditor->m_Map.m_pTuneLayer && !pLayerTiles->m_HasTune)
 				RestoreLayer(LAYERTYPE_TUNE, m_pEditor->m_Map.m_pTuneLayer);
-			if(!pLayerTiles->m_Game)
+			if(!pLayerTiles->m_HasGame)
 				RestoreLayer(LAYERTYPE_GAME, m_pEditor->m_Map.m_pGameLayer);
 		}
 	}
@@ -965,19 +965,19 @@ void CEditorActionEditLayerTilesProp::Redo()
 		else if(m_Prop == ETilesProp::PROP_WIDTH)
 			pLayerTiles->Resize(m_Current, pLayerTiles->m_Height);
 
-		if(pLayerTiles->m_Game || pLayerTiles->m_Front || pLayerTiles->m_Switch || pLayerTiles->m_Speedup || pLayerTiles->m_Tune)
+		if(pLayerTiles->m_HasGame || pLayerTiles->m_HasFront || pLayerTiles->m_HasSwitch || pLayerTiles->m_HasSpeedup || pLayerTiles->m_HasTune)
 		{
-			if(m_pEditor->m_Map.m_pFrontLayer && !pLayerTiles->m_Front)
+			if(m_pEditor->m_Map.m_pFrontLayer && !pLayerTiles->m_HasFront)
 				m_pEditor->m_Map.m_pFrontLayer->Resize(pLayerTiles->m_Width, pLayerTiles->m_Height);
-			if(m_pEditor->m_Map.m_pTeleLayer && !pLayerTiles->m_Tele)
+			if(m_pEditor->m_Map.m_pTeleLayer && !pLayerTiles->m_HasTele)
 				m_pEditor->m_Map.m_pTeleLayer->Resize(pLayerTiles->m_Width, pLayerTiles->m_Height);
-			if(m_pEditor->m_Map.m_pSwitchLayer && !pLayerTiles->m_Switch)
+			if(m_pEditor->m_Map.m_pSwitchLayer && !pLayerTiles->m_HasSwitch)
 				m_pEditor->m_Map.m_pSwitchLayer->Resize(pLayerTiles->m_Width, pLayerTiles->m_Height);
-			if(m_pEditor->m_Map.m_pSpeedupLayer && !pLayerTiles->m_Speedup)
+			if(m_pEditor->m_Map.m_pSpeedupLayer && !pLayerTiles->m_HasSpeedup)
 				m_pEditor->m_Map.m_pSpeedupLayer->Resize(pLayerTiles->m_Width, pLayerTiles->m_Height);
-			if(m_pEditor->m_Map.m_pTuneLayer && !pLayerTiles->m_Tune)
+			if(m_pEditor->m_Map.m_pTuneLayer && !pLayerTiles->m_HasTune)
 				m_pEditor->m_Map.m_pTuneLayer->Resize(pLayerTiles->m_Width, pLayerTiles->m_Height);
-			if(!pLayerTiles->m_Game)
+			if(!pLayerTiles->m_HasGame)
 				m_pEditor->m_Map.m_pGameLayer->Resize(pLayerTiles->m_Width, pLayerTiles->m_Height);
 		}
 	}
@@ -1041,25 +1041,25 @@ void CEditorActionEditLayerTilesProp::RestoreLayer(int Layer, const std::shared_
 		std::shared_ptr<CLayerTiles> pSavedLayerTiles = std::static_pointer_cast<CLayerTiles>(m_SavedLayers[Layer]);
 		mem_copy(pLayerTiles->m_pTiles, pSavedLayerTiles->m_pTiles, (size_t)pLayerTiles->m_Width * pLayerTiles->m_Height * sizeof(CTile));
 
-		if(pLayerTiles->m_Tele)
+		if(pLayerTiles->m_HasTele)
 		{
 			std::shared_ptr<CLayerTele> pLayerTele = std::static_pointer_cast<CLayerTele>(pLayerTiles);
 			std::shared_ptr<CLayerTele> pSavedLayerTele = std::static_pointer_cast<CLayerTele>(pSavedLayerTiles);
 			mem_copy(pLayerTele->m_pTeleTile, pSavedLayerTele->m_pTeleTile, (size_t)pLayerTiles->m_Width * pLayerTiles->m_Height * sizeof(CTeleTile));
 		}
-		else if(pLayerTiles->m_Speedup)
+		else if(pLayerTiles->m_HasSpeedup)
 		{
 			std::shared_ptr<CLayerSpeedup> pLayerSpeedup = std::static_pointer_cast<CLayerSpeedup>(pLayerTiles);
 			std::shared_ptr<CLayerSpeedup> pSavedLayerSpeedup = std::static_pointer_cast<CLayerSpeedup>(pSavedLayerTiles);
 			mem_copy(pLayerSpeedup->m_pSpeedupTile, pSavedLayerSpeedup->m_pSpeedupTile, (size_t)pLayerTiles->m_Width * pLayerTiles->m_Height * sizeof(CSpeedupTile));
 		}
-		else if(pLayerTiles->m_Switch)
+		else if(pLayerTiles->m_HasSwitch)
 		{
 			std::shared_ptr<CLayerSwitch> pLayerSwitch = std::static_pointer_cast<CLayerSwitch>(pLayerTiles);
 			std::shared_ptr<CLayerSwitch> pSavedLayerSwitch = std::static_pointer_cast<CLayerSwitch>(pSavedLayerTiles);
 			mem_copy(pLayerSwitch->m_pSwitchTile, pSavedLayerSwitch->m_pSwitchTile, (size_t)pLayerTiles->m_Width * pLayerTiles->m_Height * sizeof(CSwitchTile));
 		}
-		else if(pLayerTiles->m_Tune)
+		else if(pLayerTiles->m_HasTune)
 		{
 			std::shared_ptr<CLayerTune> pLayerTune = std::static_pointer_cast<CLayerTune>(pLayerTiles);
 			std::shared_ptr<CLayerTune> pSavedLayerTune = std::static_pointer_cast<CLayerTune>(pSavedLayerTiles);

--- a/src/game/editor/editor_trackers.cpp
+++ b/src/game/editor/editor_trackers.cpp
@@ -454,19 +454,19 @@ void CLayerTilesPropTracker::OnStart(ETilesProp Prop)
 	if(Prop == ETilesProp::PROP_WIDTH || Prop == ETilesProp::PROP_HEIGHT)
 	{
 		m_SavedLayers[LAYERTYPE_TILES] = m_pObject->Duplicate();
-		if(m_pObject->m_Game || m_pObject->m_Front || m_pObject->m_Switch || m_pObject->m_Speedup || m_pObject->m_Tune || m_pObject->m_Tele)
+		if(m_pObject->m_HasGame || m_pObject->m_HasFront || m_pObject->m_HasSwitch || m_pObject->m_HasSpeedup || m_pObject->m_HasTune || m_pObject->m_HasTele)
 		{ // Need to save all entities layers when any entity layer
-			if(m_pEditor->m_Map.m_pFrontLayer && !m_pObject->m_Front)
+			if(m_pEditor->m_Map.m_pFrontLayer && !m_pObject->m_HasFront)
 				m_SavedLayers[LAYERTYPE_FRONT] = m_pEditor->m_Map.m_pFrontLayer->Duplicate();
-			if(m_pEditor->m_Map.m_pTeleLayer && !m_pObject->m_Tele)
+			if(m_pEditor->m_Map.m_pTeleLayer && !m_pObject->m_HasTele)
 				m_SavedLayers[LAYERTYPE_TELE] = m_pEditor->m_Map.m_pTeleLayer->Duplicate();
-			if(m_pEditor->m_Map.m_pSwitchLayer && !m_pObject->m_Switch)
+			if(m_pEditor->m_Map.m_pSwitchLayer && !m_pObject->m_HasSwitch)
 				m_SavedLayers[LAYERTYPE_SWITCH] = m_pEditor->m_Map.m_pSwitchLayer->Duplicate();
-			if(m_pEditor->m_Map.m_pSpeedupLayer && !m_pObject->m_Speedup)
+			if(m_pEditor->m_Map.m_pSpeedupLayer && !m_pObject->m_HasSpeedup)
 				m_SavedLayers[LAYERTYPE_SPEEDUP] = m_pEditor->m_Map.m_pSpeedupLayer->Duplicate();
-			if(m_pEditor->m_Map.m_pTuneLayer && !m_pObject->m_Tune)
+			if(m_pEditor->m_Map.m_pTuneLayer && !m_pObject->m_HasTune)
 				m_SavedLayers[LAYERTYPE_TUNE] = m_pEditor->m_Map.m_pTuneLayer->Duplicate();
-			if(!m_pObject->m_Game)
+			if(!m_pObject->m_HasGame)
 				m_SavedLayers[LAYERTYPE_GAME] = m_pEditor->m_Map.m_pGameLayer->Duplicate();
 		}
 	}

--- a/src/game/editor/mapitems/layer_front.cpp
+++ b/src/game/editor/mapitems/layer_front.cpp
@@ -4,7 +4,7 @@ CLayerFront::CLayerFront(CEditor *pEditor, int w, int h) :
 	CLayerTiles(pEditor, w, h)
 {
 	str_copy(m_aName, "Front");
-	m_Front = 1;
+	m_HasFront = true;
 }
 
 void CLayerFront::SetTile(int x, int y, CTile Tile)

--- a/src/game/editor/mapitems/layer_game.cpp
+++ b/src/game/editor/mapitems/layer_game.cpp
@@ -9,7 +9,7 @@ CLayerGame::CLayerGame(CEditor *pEditor, int w, int h) :
 	CLayerTiles(pEditor, w, h)
 {
 	str_copy(m_aName, "Game");
-	m_Game = 1;
+	m_HasGame = true;
 }
 
 CLayerGame::~CLayerGame() = default;

--- a/src/game/editor/mapitems/layer_group.cpp
+++ b/src/game/editor/mapitems/layer_group.cpp
@@ -90,7 +90,7 @@ void CLayerGroup::Render()
 					m_pMap->m_pEditor->RenderSwitchEntities(pTiles);
 				}
 
-				if(pTiles->m_Game || pTiles->m_Front || pTiles->m_Tele || pTiles->m_Speedup || pTiles->m_Tune || pTiles->m_Switch)
+				if(pTiles->m_HasGame || pTiles->m_HasFront || pTiles->m_HasTele || pTiles->m_HasSpeedup || pTiles->m_HasTune || pTiles->m_HasSwitch)
 					continue;
 			}
 			if(m_pMap->m_pEditor->m_ShowDetail || !(pLayer->m_Flags & LAYERFLAG_DETAIL))
@@ -103,7 +103,7 @@ void CLayerGroup::Render()
 		if(pLayer->m_Visible && pLayer->m_Type == LAYERTYPE_TILES && !pLayer->IsEntitiesLayer())
 		{
 			std::shared_ptr<CLayerTiles> pTiles = std::static_pointer_cast<CLayerTiles>(pLayer);
-			if(pTiles->m_Game || pTiles->m_Front || pTiles->m_Tele || pTiles->m_Speedup || pTiles->m_Tune || pTiles->m_Switch)
+			if(pTiles->m_HasGame || pTiles->m_HasFront || pTiles->m_HasTele || pTiles->m_HasSpeedup || pTiles->m_HasTune || pTiles->m_HasSwitch)
 			{
 				pLayer->Render();
 			}

--- a/src/game/editor/mapitems/layer_speedup.cpp
+++ b/src/game/editor/mapitems/layer_speedup.cpp
@@ -6,7 +6,7 @@ CLayerSpeedup::CLayerSpeedup(CEditor *pEditor, int w, int h) :
 	CLayerTiles(pEditor, w, h)
 {
 	str_copy(m_aName, "Speedup");
-	m_Speedup = 1;
+	m_HasSpeedup = true;
 
 	m_pSpeedupTile = new CSpeedupTile[w * h];
 	mem_zero(m_pSpeedupTile, (size_t)w * h * sizeof(CSpeedupTile));
@@ -16,7 +16,7 @@ CLayerSpeedup::CLayerSpeedup(const CLayerSpeedup &Other) :
 	CLayerTiles(Other)
 {
 	str_copy(m_aName, "Speedup copy");
-	m_Speedup = 1;
+	m_HasSpeedup = true;
 
 	m_pSpeedupTile = new CSpeedupTile[m_Width * m_Height];
 	mem_copy(m_pSpeedupTile, Other.m_pSpeedupTile, (size_t)m_Width * m_Height * sizeof(CSpeedupTile));
@@ -293,7 +293,7 @@ void CLayerSpeedup::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CU
 			else
 			{
 				m_pTiles[TgtIndex] = pLt->m_pTiles[SrcIndex];
-				if(pLt->m_Speedup && m_pTiles[TgtIndex].m_Index > 0)
+				if(pLt->m_HasSpeedup && m_pTiles[TgtIndex].m_Index > 0)
 				{
 					m_pSpeedupTile[TgtIndex].m_Type = m_pTiles[TgtIndex].m_Index;
 

--- a/src/game/editor/mapitems/layer_switch.cpp
+++ b/src/game/editor/mapitems/layer_switch.cpp
@@ -6,7 +6,7 @@ CLayerSwitch::CLayerSwitch(CEditor *pEditor, int w, int h) :
 	CLayerTiles(pEditor, w, h)
 {
 	str_copy(m_aName, "Switch");
-	m_Switch = 1;
+	m_HasSwitch = true;
 
 	m_pSwitchTile = new CSwitchTile[w * h];
 	mem_zero(m_pSwitchTile, (size_t)w * h * sizeof(CSwitchTile));
@@ -18,7 +18,7 @@ CLayerSwitch::CLayerSwitch(const CLayerSwitch &Other) :
 	CLayerTiles(Other)
 {
 	str_copy(m_aName, "Switch copy");
-	m_Switch = 1;
+	m_HasSwitch = true;
 
 	m_pSwitchTile = new CSwitchTile[m_Width * m_Height];
 	mem_copy(m_pSwitchTile, Other.m_pSwitchTile, (size_t)m_Width * m_Height * sizeof(CSwitchTile));
@@ -280,7 +280,7 @@ void CLayerSwitch::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUI
 			{
 				m_pTiles[TgtIndex] = pLt->m_pTiles[SrcIndex];
 				m_pSwitchTile[TgtIndex].m_Type = m_pTiles[TgtIndex].m_Index;
-				if(pLt->m_Switch && m_pTiles[TgtIndex].m_Index > 0)
+				if(pLt->m_HasSwitch && m_pTiles[TgtIndex].m_Index > 0)
 				{
 					if(!IsSwitchTileNumberUsed(m_pSwitchTile[TgtIndex].m_Type))
 						m_pSwitchTile[TgtIndex].m_Number = 0;

--- a/src/game/editor/mapitems/layer_tele.cpp
+++ b/src/game/editor/mapitems/layer_tele.cpp
@@ -6,7 +6,7 @@ CLayerTele::CLayerTele(CEditor *pEditor, int w, int h) :
 	CLayerTiles(pEditor, w, h)
 {
 	str_copy(m_aName, "Tele");
-	m_Tele = 1;
+	m_HasTele = true;
 
 	m_pTeleTile = new CTeleTile[w * h];
 	mem_zero(m_pTeleTile, (size_t)w * h * sizeof(CTeleTile));
@@ -19,7 +19,7 @@ CLayerTele::CLayerTele(const CLayerTele &Other) :
 	CLayerTiles(Other)
 {
 	str_copy(m_aName, "Tele copy");
-	m_Tele = 1;
+	m_HasTele = true;
 
 	m_pTeleTile = new CTeleTile[m_Width * m_Height];
 	mem_copy(m_pTeleTile, Other.m_pTeleTile, (size_t)m_Width * m_Height * sizeof(CTeleTile));
@@ -266,7 +266,7 @@ void CLayerTele::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRe
 			else
 			{
 				m_pTiles[TgtIndex] = pLt->m_pTiles[SrcIndex];
-				if(pLt->m_Tele && m_pTiles[TgtIndex].m_Index > 0)
+				if(pLt->m_HasTele && m_pTiles[TgtIndex].m_Index > 0)
 				{
 					m_pTeleTile[TgtIndex].m_Type = m_pTiles[TgtIndex].m_Index;
 					bool IsCheckpoint = IsTeleTileCheckpoint(m_pTiles[TgtIndex].m_Index);

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -22,7 +22,7 @@ CLayerTiles::CLayerTiles(CEditor *pEditor, int w, int h) :
 	m_Width = w;
 	m_Height = h;
 	m_Image = -1;
-	m_Game = 0;
+	m_HasGame = false;
 	m_Color.r = 255;
 	m_Color.g = 255;
 	m_Color.b = 255;
@@ -30,11 +30,11 @@ CLayerTiles::CLayerTiles(CEditor *pEditor, int w, int h) :
 	m_ColorEnv = -1;
 	m_ColorEnvOffset = 0;
 
-	m_Tele = 0;
-	m_Speedup = 0;
-	m_Front = 0;
-	m_Switch = 0;
-	m_Tune = 0;
+	m_HasTele = false;
+	m_HasSpeedup = false;
+	m_HasFront = false;
+	m_HasSwitch = false;
+	m_HasTune = false;
 	m_AutoMapperConfig = -1;
 	m_AutoMapperReference = -1;
 	m_Seed = 0;
@@ -53,7 +53,7 @@ CLayerTiles::CLayerTiles(const CLayerTiles &Other) :
 	mem_copy(m_pTiles, Other.m_pTiles, (size_t)m_Width * m_Height * sizeof(CTile));
 
 	m_Image = Other.m_Image;
-	m_Game = Other.m_Game;
+	m_HasGame = Other.m_HasGame;
 	m_Color = Other.m_Color;
 	m_ColorEnv = Other.m_ColorEnv;
 	m_ColorEnvOffset = Other.m_ColorEnvOffset;
@@ -62,11 +62,11 @@ CLayerTiles::CLayerTiles(const CLayerTiles &Other) :
 	m_AutoMapperReference = Other.m_AutoMapperReference;
 	m_Seed = Other.m_Seed;
 	m_AutoAutoMap = Other.m_AutoAutoMap;
-	m_Tele = Other.m_Tele;
-	m_Speedup = Other.m_Speedup;
-	m_Front = Other.m_Front;
-	m_Switch = Other.m_Switch;
-	m_Tune = Other.m_Tune;
+	m_HasTele = Other.m_HasTele;
+	m_HasSpeedup = Other.m_HasSpeedup;
+	m_HasFront = Other.m_HasFront;
+	m_HasSwitch = Other.m_HasSwitch;
+	m_HasTune = Other.m_HasTune;
 
 	str_copy(m_aFileName, Other.m_aFileName);
 }
@@ -136,17 +136,17 @@ void CLayerTiles::Render(bool Tileset)
 	IGraphics::CTextureHandle Texture;
 	if(m_Image >= 0 && (size_t)m_Image < m_pEditor->m_Map.m_vpImages.size())
 		Texture = m_pEditor->m_Map.m_vpImages[m_Image]->m_Texture;
-	else if(m_Game)
+	else if(m_HasGame)
 		Texture = m_pEditor->GetEntitiesTexture();
-	else if(m_Front)
+	else if(m_HasFront)
 		Texture = m_pEditor->GetFrontTexture();
-	else if(m_Tele)
+	else if(m_HasTele)
 		Texture = m_pEditor->GetTeleTexture();
-	else if(m_Speedup)
+	else if(m_HasSpeedup)
 		Texture = m_pEditor->GetSpeedupTexture();
-	else if(m_Switch)
+	else if(m_HasSwitch)
 		Texture = m_pEditor->GetSwitchTexture();
-	else if(m_Tune)
+	else if(m_HasTune)
 		Texture = m_pEditor->GetTuneTexture();
 	Graphics()->TextureSet(Texture);
 
@@ -163,13 +163,13 @@ void CLayerTiles::Render(bool Tileset)
 	if(!Tileset)
 	{
 		int OverlayRenderFlags = g_Config.m_ClTextEntitiesEditor ? OVERLAYRENDERFLAG_TEXT : 0;
-		if(m_Tele)
+		if(m_HasTele)
 			m_pEditor->RenderTools()->RenderTeleOverlay(static_cast<CLayerTele *>(this)->m_pTeleTile, m_Width, m_Height, 32.0f, OverlayRenderFlags);
-		if(m_Speedup)
+		if(m_HasSpeedup)
 			m_pEditor->RenderTools()->RenderSpeedupOverlay(static_cast<CLayerSpeedup *>(this)->m_pSpeedupTile, m_Width, m_Height, 32.0f, OverlayRenderFlags);
-		if(m_Switch)
+		if(m_HasSwitch)
 			m_pEditor->RenderTools()->RenderSwitchOverlay(static_cast<CLayerSwitch *>(this)->m_pSwitchTile, m_Width, m_Height, 32.0f, OverlayRenderFlags);
-		if(m_Tune)
+		if(m_HasTune)
 			m_pEditor->RenderTools()->RenderTuneOverlay(static_cast<CLayerTune *>(this)->m_pTuneTile, m_Width, m_Height, 32.0f, OverlayRenderFlags);
 	}
 }
@@ -235,12 +235,12 @@ bool CLayerTiles::IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer)
 			int Index = pLayer->GetTile(x, y).m_Index;
 			if(Index)
 			{
-				if(pLayer->m_Game)
+				if(pLayer->m_HasGame)
 				{
 					if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidGameTile(Index))
 						return false;
 				}
-				else if(pLayer->m_Front)
+				else if(pLayer->m_HasFront)
 				{
 					if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidFrontTile(Index))
 						return false;
@@ -273,12 +273,12 @@ static void InitGrabbedLayer(std::shared_ptr<T> pLayer, CLayerTiles *pThisLayer)
 {
 	pLayer->m_pEditor = pThisLayer->m_pEditor;
 	pLayer->m_Image = pThisLayer->m_Image;
-	pLayer->m_Game = pThisLayer->m_Game;
-	pLayer->m_Front = pThisLayer->m_Front;
-	pLayer->m_Tele = pThisLayer->m_Tele;
-	pLayer->m_Speedup = pThisLayer->m_Speedup;
-	pLayer->m_Switch = pThisLayer->m_Switch;
-	pLayer->m_Tune = pThisLayer->m_Tune;
+	pLayer->m_HasGame = pThisLayer->m_HasGame;
+	pLayer->m_HasFront = pThisLayer->m_HasFront;
+	pLayer->m_HasTele = pThisLayer->m_HasTele;
+	pLayer->m_HasSpeedup = pThisLayer->m_HasSpeedup;
+	pLayer->m_HasSwitch = pThisLayer->m_HasSwitch;
+	pLayer->m_HasTune = pThisLayer->m_HasTune;
 	if(pThisLayer->m_pEditor->m_BrushColorEnabled)
 	{
 		pLayer->m_Color = pThisLayer->m_Color;
@@ -296,7 +296,7 @@ int CLayerTiles::BrushGrab(std::shared_ptr<CLayerGroup> pBrush, CUIRect Rect)
 		return 0;
 
 	// create new layers
-	if(this->m_Tele)
+	if(this->m_HasTele)
 	{
 		std::shared_ptr<CLayerTele> pGrabbed = std::make_shared<CLayerTele>(m_pEditor, r.w, r.h);
 		InitGrabbedLayer(pGrabbed, this);
@@ -339,7 +339,7 @@ int CLayerTiles::BrushGrab(std::shared_ptr<CLayerGroup> pBrush, CUIRect Rect)
 
 		str_copy(pGrabbed->m_aFileName, m_pEditor->m_aFileName);
 	}
-	else if(this->m_Speedup)
+	else if(this->m_HasSpeedup)
 	{
 		std::shared_ptr<CLayerSpeedup> pGrabbed = std::make_shared<CLayerSpeedup>(m_pEditor, r.w, r.h);
 		InitGrabbedLayer(pGrabbed, this);
@@ -382,7 +382,7 @@ int CLayerTiles::BrushGrab(std::shared_ptr<CLayerGroup> pBrush, CUIRect Rect)
 		pGrabbed->m_SpeedupAngle = m_pEditor->m_SpeedupAngle;
 		str_copy(pGrabbed->m_aFileName, m_pEditor->m_aFileName);
 	}
-	else if(this->m_Switch)
+	else if(this->m_HasSwitch)
 	{
 		std::shared_ptr<CLayerSwitch> pGrabbed = std::make_shared<CLayerSwitch>(m_pEditor, r.w, r.h);
 		InitGrabbedLayer(pGrabbed, this);
@@ -423,7 +423,7 @@ int CLayerTiles::BrushGrab(std::shared_ptr<CLayerGroup> pBrush, CUIRect Rect)
 		str_copy(pGrabbed->m_aFileName, m_pEditor->m_aFileName);
 	}
 
-	else if(this->m_Tune)
+	else if(this->m_HasTune)
 	{
 		std::shared_ptr<CLayerTune> pGrabbed = std::make_shared<CLayerTune>(m_pEditor, r.w, r.h);
 		InitGrabbedLayer(pGrabbed, this);
@@ -459,7 +459,7 @@ int CLayerTiles::BrushGrab(std::shared_ptr<CLayerGroup> pBrush, CUIRect Rect)
 		pGrabbed->m_TuningNumber = m_pEditor->m_TuningNum;
 		str_copy(pGrabbed->m_aFileName, m_pEditor->m_aFileName);
 	}
-	else if(this->m_Front)
+	else if(this->m_HasFront)
 	{
 		std::shared_ptr<CLayerFront> pGrabbed = std::make_shared<CLayerFront>(m_pEditor, r.w, r.h);
 		InitGrabbedLayer(pGrabbed, this);
@@ -518,11 +518,11 @@ void CLayerTiles::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIR
 			bool HasTile = GetTile(fx, fy).m_Index;
 			if(!Empty && pLt->GetTile(x % pLt->m_Width, y % pLt->m_Height).m_Index == TILE_THROUGH_CUT)
 			{
-				if(m_Game && m_pEditor->m_Map.m_pFrontLayer)
+				if(m_HasGame && m_pEditor->m_Map.m_pFrontLayer)
 				{
 					HasTile = HasTile || m_pEditor->m_Map.m_pFrontLayer->GetTile(fx, fy).m_Index;
 				}
-				else if(m_Front)
+				else if(m_HasFront)
 				{
 					HasTile = HasTile || m_pEditor->m_Map.m_pGameLayer->GetTile(fx, fy).m_Index;
 				}
@@ -561,11 +561,11 @@ void CLayerTiles::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 			bool HasTile = GetTile(fx, fy).m_Index;
 			if(pTileLayer->GetTile(x, y).m_Index == TILE_THROUGH_CUT)
 			{
-				if(m_Game && m_pEditor->m_Map.m_pFrontLayer)
+				if(m_HasGame && m_pEditor->m_Map.m_pFrontLayer)
 				{
 					HasTile = HasTile || m_pEditor->m_Map.m_pFrontLayer->GetTile(fx, fy).m_Index;
 				}
-				else if(m_Front)
+				else if(m_HasFront)
 				{
 					HasTile = HasTile || m_pEditor->m_Map.m_pGameLayer->GetTile(fx, fy).m_Index;
 				}
@@ -584,10 +584,10 @@ void CLayerTiles::BrushFlipX()
 {
 	BrushFlipXImpl(m_pTiles);
 
-	if(m_Tele || m_Speedup || m_Tune)
+	if(m_HasTele || m_HasSpeedup || m_HasTune)
 		return;
 
-	bool Rotate = !(m_Game || m_Front || m_Switch) || m_pEditor->IsAllowPlaceUnusedTiles();
+	bool Rotate = !(m_HasGame || m_HasFront || m_HasSwitch) || m_pEditor->IsAllowPlaceUnusedTiles();
 	for(int y = 0; y < m_Height; y++)
 		for(int x = 0; x < m_Width; x++)
 			if(!Rotate && !IsRotatableTile(m_pTiles[y * m_Width + x].m_Index))
@@ -600,10 +600,10 @@ void CLayerTiles::BrushFlipY()
 {
 	BrushFlipYImpl(m_pTiles);
 
-	if(m_Tele || m_Speedup || m_Tune)
+	if(m_HasTele || m_HasSpeedup || m_HasTune)
 		return;
 
-	bool Rotate = !(m_Game || m_Front || m_Switch) || m_pEditor->IsAllowPlaceUnusedTiles();
+	bool Rotate = !(m_HasGame || m_HasFront || m_HasSwitch) || m_pEditor->IsAllowPlaceUnusedTiles();
 	for(int y = 0; y < m_Height; y++)
 		for(int x = 0; x < m_Width; x++)
 			if(!Rotate && !IsRotatableTile(m_pTiles[y * m_Width + x].m_Index))
@@ -624,7 +624,7 @@ void CLayerTiles::BrushRotate(float Amount)
 		CTile *pTempData = new CTile[m_Width * m_Height];
 		mem_copy(pTempData, m_pTiles, (size_t)m_Width * m_Height * sizeof(CTile));
 		CTile *pDst = m_pTiles;
-		bool Rotate = !(m_Game || m_Front) || m_pEditor->IsAllowPlaceUnusedTiles();
+		bool Rotate = !(m_HasGame || m_HasFront) || m_pEditor->IsAllowPlaceUnusedTiles();
 		for(int x = 0; x < m_Width; ++x)
 			for(int y = m_Height - 1; y >= 0; --y, ++pDst)
 			{
@@ -676,23 +676,23 @@ void CLayerTiles::Resize(int NewW, int NewH)
 	m_Height = NewH;
 
 	// resize tele layer if available
-	if(m_Game && m_pEditor->m_Map.m_pTeleLayer && (m_pEditor->m_Map.m_pTeleLayer->m_Width != NewW || m_pEditor->m_Map.m_pTeleLayer->m_Height != NewH))
+	if(m_HasGame && m_pEditor->m_Map.m_pTeleLayer && (m_pEditor->m_Map.m_pTeleLayer->m_Width != NewW || m_pEditor->m_Map.m_pTeleLayer->m_Height != NewH))
 		m_pEditor->m_Map.m_pTeleLayer->Resize(NewW, NewH);
 
 	// resize speedup layer if available
-	if(m_Game && m_pEditor->m_Map.m_pSpeedupLayer && (m_pEditor->m_Map.m_pSpeedupLayer->m_Width != NewW || m_pEditor->m_Map.m_pSpeedupLayer->m_Height != NewH))
+	if(m_HasGame && m_pEditor->m_Map.m_pSpeedupLayer && (m_pEditor->m_Map.m_pSpeedupLayer->m_Width != NewW || m_pEditor->m_Map.m_pSpeedupLayer->m_Height != NewH))
 		m_pEditor->m_Map.m_pSpeedupLayer->Resize(NewW, NewH);
 
 	// resize front layer
-	if(m_Game && m_pEditor->m_Map.m_pFrontLayer && (m_pEditor->m_Map.m_pFrontLayer->m_Width != NewW || m_pEditor->m_Map.m_pFrontLayer->m_Height != NewH))
+	if(m_HasGame && m_pEditor->m_Map.m_pFrontLayer && (m_pEditor->m_Map.m_pFrontLayer->m_Width != NewW || m_pEditor->m_Map.m_pFrontLayer->m_Height != NewH))
 		m_pEditor->m_Map.m_pFrontLayer->Resize(NewW, NewH);
 
 	// resize switch layer if available
-	if(m_Game && m_pEditor->m_Map.m_pSwitchLayer && (m_pEditor->m_Map.m_pSwitchLayer->m_Width != NewW || m_pEditor->m_Map.m_pSwitchLayer->m_Height != NewH))
+	if(m_HasGame && m_pEditor->m_Map.m_pSwitchLayer && (m_pEditor->m_Map.m_pSwitchLayer->m_Width != NewW || m_pEditor->m_Map.m_pSwitchLayer->m_Height != NewH))
 		m_pEditor->m_Map.m_pSwitchLayer->Resize(NewW, NewH);
 
 	// resize tune layer if available
-	if(m_Game && m_pEditor->m_Map.m_pTuneLayer && (m_pEditor->m_Map.m_pTuneLayer->m_Width != NewW || m_pEditor->m_Map.m_pTuneLayer->m_Height != NewH))
+	if(m_HasGame && m_pEditor->m_Map.m_pTuneLayer && (m_pEditor->m_Map.m_pTuneLayer->m_Width != NewW || m_pEditor->m_Map.m_pTuneLayer->m_Height != NewH))
 		m_pEditor->m_Map.m_pTuneLayer->Resize(NewW, NewH);
 }
 
@@ -1173,19 +1173,19 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropSta
 				{
 					std::map<int, std::shared_ptr<CLayer>> SavedLayers;
 					SavedLayers[LAYERTYPE_TILES] = pLayer->Duplicate();
-					if(pLayer->m_Game || pLayer->m_Front || pLayer->m_Switch || pLayer->m_Speedup || pLayer->m_Tune || pLayer->m_Tele)
+					if(pLayer->m_HasGame || pLayer->m_HasFront || pLayer->m_HasSwitch || pLayer->m_HasSpeedup || pLayer->m_HasTune || pLayer->m_HasTele)
 					{ // Need to save all entities layers when any entity layer
-						if(pEditor->m_Map.m_pFrontLayer && !pLayer->m_Front)
+						if(pEditor->m_Map.m_pFrontLayer && !pLayer->m_HasFront)
 							SavedLayers[LAYERTYPE_FRONT] = pEditor->m_Map.m_pFrontLayer->Duplicate();
-						if(pEditor->m_Map.m_pTeleLayer && !pLayer->m_Tele)
+						if(pEditor->m_Map.m_pTeleLayer && !pLayer->m_HasTele)
 							SavedLayers[LAYERTYPE_TELE] = pEditor->m_Map.m_pTeleLayer->Duplicate();
-						if(pEditor->m_Map.m_pSwitchLayer && !pLayer->m_Switch)
+						if(pEditor->m_Map.m_pSwitchLayer && !pLayer->m_HasSwitch)
 							SavedLayers[LAYERTYPE_SWITCH] = pEditor->m_Map.m_pSwitchLayer->Duplicate();
-						if(pEditor->m_Map.m_pSpeedupLayer && !pLayer->m_Speedup)
+						if(pEditor->m_Map.m_pSpeedupLayer && !pLayer->m_HasSpeedup)
 							SavedLayers[LAYERTYPE_SPEEDUP] = pEditor->m_Map.m_pSpeedupLayer->Duplicate();
-						if(pEditor->m_Map.m_pTuneLayer && !pLayer->m_Tune)
+						if(pEditor->m_Map.m_pTuneLayer && !pLayer->m_HasTune)
 							SavedLayers[LAYERTYPE_TUNE] = pEditor->m_Map.m_pTuneLayer->Duplicate();
-						if(!pLayer->m_Game)
+						if(!pLayer->m_HasGame)
 							SavedLayers[LAYERTYPE_GAME] = pEditor->m_Map.m_pGameLayer->Duplicate();
 					}
 

--- a/src/game/editor/mapitems/layer_tiles.h
+++ b/src/game/editor/mapitems/layer_tiles.h
@@ -164,7 +164,7 @@ public:
 
 	void FlagModified(int x, int y, int w, int h);
 
-	int m_Game;
+	bool m_HasGame;
 	int m_Image;
 	int m_Width;
 	int m_Height;
@@ -179,11 +179,11 @@ public:
 	int m_AutoMapperReference;
 	int m_Seed;
 	bool m_AutoAutoMap;
-	int m_Tele;
-	int m_Speedup;
-	int m_Front;
-	int m_Switch;
-	int m_Tune;
+	bool m_HasTele;
+	bool m_HasSpeedup;
+	bool m_HasFront;
+	bool m_HasSwitch;
+	bool m_HasTune;
 	char m_aFileName[IO_MAX_PATH_LENGTH];
 
 	EditorTileStateChangeHistory<STileStateChange> m_TilesHistory;

--- a/src/game/editor/mapitems/layer_tune.cpp
+++ b/src/game/editor/mapitems/layer_tune.cpp
@@ -6,7 +6,7 @@ CLayerTune::CLayerTune(CEditor *pEditor, int w, int h) :
 	CLayerTiles(pEditor, w, h)
 {
 	str_copy(m_aName, "Tune");
-	m_Tune = 1;
+	m_HasTune = true;
 
 	m_pTuneTile = new CTuneTile[w * h];
 	mem_zero(m_pTuneTile, (size_t)w * h * sizeof(CTuneTile));
@@ -19,7 +19,7 @@ CLayerTune::CLayerTune(const CLayerTune &Other) :
 	CLayerTiles(Other)
 {
 	str_copy(m_aName, "Tune copy");
-	m_Tune = 1;
+	m_HasTune = true;
 
 	m_pTuneTile = new CTuneTile[m_Width * m_Height];
 	mem_copy(m_pTuneTile, Other.m_pTuneTile, (size_t)m_Width * m_Height * sizeof(CTuneTile));
@@ -250,7 +250,7 @@ void CLayerTune::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRe
 			else
 			{
 				m_pTiles[TgtIndex] = pLt->m_pTiles[SrcIndex];
-				if(pLt->m_Tune && m_pTiles[TgtIndex].m_Index > 0)
+				if(pLt->m_HasTune && m_pTiles[TgtIndex].m_Index > 0)
 				{
 					m_pTuneTile[TgtIndex].m_Type = m_pTiles[fy * m_Width + fx].m_Index;
 

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -182,18 +182,18 @@ bool CEditorMap::Save(const char *pFileName, const std::function<void(const char
 				Item.m_Height = pLayerTiles->m_Height;
 				// Item.m_Flags = pLayerTiles->m_Game ? TILESLAYERFLAG_GAME : 0;
 
-				if(pLayerTiles->m_Tele)
+				if(pLayerTiles->m_HasTele)
 					Item.m_Flags = TILESLAYERFLAG_TELE;
-				else if(pLayerTiles->m_Speedup)
+				else if(pLayerTiles->m_HasSpeedup)
 					Item.m_Flags = TILESLAYERFLAG_SPEEDUP;
-				else if(pLayerTiles->m_Front)
+				else if(pLayerTiles->m_HasFront)
 					Item.m_Flags = TILESLAYERFLAG_FRONT;
-				else if(pLayerTiles->m_Switch)
+				else if(pLayerTiles->m_HasSwitch)
 					Item.m_Flags = TILESLAYERFLAG_SWITCH;
-				else if(pLayerTiles->m_Tune)
+				else if(pLayerTiles->m_HasTune)
 					Item.m_Flags = TILESLAYERFLAG_TUNE;
 				else
-					Item.m_Flags = pLayerTiles->m_Game ? TILESLAYERFLAG_GAME : 0;
+					Item.m_Flags = pLayerTiles->m_HasGame ? TILESLAYERFLAG_GAME : 0;
 
 				Item.m_Image = pLayerTiles->m_Image;
 
@@ -204,22 +204,22 @@ bool CEditorMap::Save(const char *pFileName, const std::function<void(const char
 				Item.m_Switch = -1;
 				Item.m_Tune = -1;
 
-				if(Item.m_Flags && !(pLayerTiles->m_Game))
+				if(Item.m_Flags && !(pLayerTiles->m_HasGame))
 				{
 					CTile *pEmptyTiles = (CTile *)calloc((size_t)pLayerTiles->m_Width * pLayerTiles->m_Height, sizeof(CTile));
 					mem_zero(pEmptyTiles, (size_t)pLayerTiles->m_Width * pLayerTiles->m_Height * sizeof(CTile));
 					Item.m_Data = Writer.AddData((size_t)pLayerTiles->m_Width * pLayerTiles->m_Height * sizeof(CTile), pEmptyTiles);
 					free(pEmptyTiles);
 
-					if(pLayerTiles->m_Tele)
+					if(pLayerTiles->m_HasTele)
 						Item.m_Tele = Writer.AddData((size_t)pLayerTiles->m_Width * pLayerTiles->m_Height * sizeof(CTeleTile), std::static_pointer_cast<CLayerTele>(pLayerTiles)->m_pTeleTile);
-					else if(pLayerTiles->m_Speedup)
+					else if(pLayerTiles->m_HasSpeedup)
 						Item.m_Speedup = Writer.AddData((size_t)pLayerTiles->m_Width * pLayerTiles->m_Height * sizeof(CSpeedupTile), std::static_pointer_cast<CLayerSpeedup>(pLayerTiles)->m_pSpeedupTile);
-					else if(pLayerTiles->m_Front)
+					else if(pLayerTiles->m_HasFront)
 						Item.m_Front = Writer.AddData((size_t)pLayerTiles->m_Width * pLayerTiles->m_Height * sizeof(CTile), pLayerTiles->m_pTiles);
-					else if(pLayerTiles->m_Switch)
+					else if(pLayerTiles->m_HasSwitch)
 						Item.m_Switch = Writer.AddData((size_t)pLayerTiles->m_Width * pLayerTiles->m_Height * sizeof(CSwitchTile), std::static_pointer_cast<CLayerSwitch>(pLayerTiles)->m_pSwitchTile);
-					else if(pLayerTiles->m_Tune)
+					else if(pLayerTiles->m_HasTune)
 						Item.m_Tune = Writer.AddData((size_t)pLayerTiles->m_Width * pLayerTiles->m_Height * sizeof(CTuneTile), std::static_pointer_cast<CLayerTune>(pLayerTiles)->m_pTuneTile);
 				}
 				else
@@ -742,13 +742,13 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 
 					pGroup->AddLayer(pTiles);
 					pTiles->m_Image = pTilemapItem->m_Image;
-					pTiles->m_Game = pTilemapItem->m_Flags & TILESLAYERFLAG_GAME;
+					pTiles->m_HasGame = pTilemapItem->m_Flags & TILESLAYERFLAG_GAME;
 
 					// load layer name
 					if(pTilemapItem->m_Version >= 3)
 						IntsToStr(pTilemapItem->m_aName, std::size(pTilemapItem->m_aName), pTiles->m_aName, std::size(pTiles->m_aName));
 
-					if(pTiles->m_Tele)
+					if(pTiles->m_HasTele)
 					{
 						void *pTeleData = DataFile.GetData(pTilemapItem->m_Tele);
 						unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Tele);
@@ -767,7 +767,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 						}
 						DataFile.UnloadData(pTilemapItem->m_Tele);
 					}
-					else if(pTiles->m_Speedup)
+					else if(pTiles->m_HasSpeedup)
 					{
 						void *pSpeedupData = DataFile.GetData(pTilemapItem->m_Speedup);
 						unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Speedup);
@@ -788,14 +788,14 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 
 						DataFile.UnloadData(pTilemapItem->m_Speedup);
 					}
-					else if(pTiles->m_Front)
+					else if(pTiles->m_HasFront)
 					{
 						void *pFrontData = DataFile.GetData(pTilemapItem->m_Front);
 						unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Front);
 						pTiles->ExtractTiles(pTilemapItem->m_Version, (CTile *)pFrontData, Size);
 						DataFile.UnloadData(pTilemapItem->m_Front);
 					}
-					else if(pTiles->m_Switch)
+					else if(pTiles->m_HasSwitch)
 					{
 						void *pSwitchData = DataFile.GetData(pTilemapItem->m_Switch);
 						unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Switch);
@@ -824,7 +824,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 						}
 						DataFile.UnloadData(pTilemapItem->m_Switch);
 					}
-					else if(pTiles->m_Tune)
+					else if(pTiles->m_HasTune)
 					{
 						void *pTuneData = DataFile.GetData(pTilemapItem->m_Tune);
 						unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Tune);
@@ -1010,8 +1010,8 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 					{
 						std::shared_ptr<CLayerTiles> pTiles = std::static_pointer_cast<CLayerTiles>(m_vpGroups[pItem->m_GroupId]->m_vpLayers[pItem->m_LayerId]);
 						// only load auto mappers for tile layers (not physics layers)
-						if(!(pTiles->m_Game || pTiles->m_Tele || pTiles->m_Speedup ||
-							   pTiles->m_Front || pTiles->m_Switch || pTiles->m_Tune))
+						if(!(pTiles->m_HasGame || pTiles->m_HasTele || pTiles->m_HasSpeedup ||
+							   pTiles->m_HasFront || pTiles->m_HasSwitch || pTiles->m_HasTune))
 						{
 							pTiles->m_AutoMapperConfig = pItem->m_AutomapperConfig;
 							pTiles->m_Seed = pItem->m_AutomapperSeed;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -179,7 +179,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupMenuTools(void *pContext, CUIRect Vi
 	if(pEditor->DoButton_MenuItem(&s_BorderButton, "Place border", 0, &Slot, BUTTONFLAG_LEFT, "Place tiles in a 2-tile wide border at the edges of the selected tile layer."))
 	{
 		std::shared_ptr<CLayerTiles> pT = std::static_pointer_cast<CLayerTiles>(pEditor->GetSelectedLayerType(0, LAYERTYPE_TILES));
-		if(pT && !pT->m_Tele && !pT->m_Speedup && !pT->m_Switch && !pT->m_Front && !pT->m_Tune)
+		if(pT && !pT->m_HasTele && !pT->m_HasSpeedup && !pT->m_HasSwitch && !pT->m_HasFront && !pT->m_HasTune)
 		{
 			pEditor->m_PopupEventType = POPEVENT_PLACE_BORDER_TILES;
 			pEditor->m_PopupEventActivated = true;


### PR DESCRIPTION
close #9921

I rename `m_Tele`, `m_Speedup`, `m_Front`, `m_Switch`, `m_Tune` and `m_Game` and change their types to `bool`.
I change `pLayer->m_Tele <= pBrushLayer->m_Tele` to `!pLayer->m_Tele || pBrushLayer->m_Tele`

For `m_Game`, I think it has similar logic as other variables, so I change it too.
The only suspicious assignment is here. Other than that, `m_Game` is used as a `bool` variable:
``` cpp
pTiles->m_Game = pTilemapItem->m_Flags & TILESLAYERFLAG_GAME;
```
But I think it can still be regarded as a `bool`.


Almost all variables were renamed using the IDE, except for these two parts, which were manually modified:
one `static_pointer_cast` 
```cpp
const bool HasTeleTiles = std::any_of(m_pBrush->m_vpLayers.begin(), m_pBrush->m_vpLayers.end(), [](auto pLayer) {
		return pLayer->m_Type == LAYERTYPE_TILES && std::static_pointer_cast<CLayerTiles>(pLayer)->m_Tele;
	});
```
and one Template function
```cpp
template<typename T>
static void InitGrabbedLayer(std::shared_ptr<T> pLayer, CLayerTiles *pThisLayer)
{
	pLayer->m_pEditor = pThisLayer->m_pEditor;
	pLayer->m_Image = pThisLayer->m_Image;
	pLayer->m_Game = pThisLayer->m_Game;
	pLayer->m_Front = pThisLayer->m_Front;
	pLayer->m_Tele = pThisLayer->m_Tele;
	pLayer->m_Speedup = pThisLayer->m_Speedup;
	pLayer->m_Switch = pThisLayer->m_Switch;
	pLayer->m_Tune = pThisLayer->m_Tune;
	if(pThisLayer->m_pEditor->m_BrushColorEnabled)
	{
		pLayer->m_Color = pThisLayer->m_Color;
		pLayer->m_Color.a = 255;
	}
};
```




<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
