### PR TITLE
Improve server unreachable message

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1897,7 +1897,7 @@ void CMenus::RenderPopupConnecting(CUIRect Screen)
 			pConnectivityLabel = Localize("Trying to determine UDP connectivity…");
 			break;
 		case IClient::CONNECTIVITY_UNREACHABLE:
-			pConnectivityLabel = Localize("UDP seems to be filtered.");
+			pConnectivityLabel = Localize("Server is not responding. The server may be overloaded, or UDP might be filtered.");
 			break;
 		case IClient::CONNECTIVITY_DIFFERING_UDP_TCP_IP_ADDRESSES:
 			pConnectivityLabel = Localize("UDP and TCP IP addresses seem to be different. Try disabling VPN, proxy or network accelerators.");


### PR DESCRIPTION
A lot of people in the discord have this error, it's normally due to the server being ddosed

Would be nice to direct them to the /ddos command, but that isn't universal

Some servers give this error when your IP isn't verified (eg AWB)

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
