### PR TITLE
Used (int) cast for sizeof(CTile) instead of %ld to print it correctly

### DIFF
--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -111,7 +111,7 @@ bool CMap::Load(const char *pMapName)
 
 					if(((int)TilemapCount / pTilemap->m_Width != pTilemap->m_Height) || (TilemapSize / sizeof(CTile) != TilemapCount))
 					{
-						log_error("map/load", "map layer too big (%d * %d * %ld causes an integer overflow)", pTilemap->m_Width, pTilemap->m_Height, sizeof(CTile));
+						log_error("map/load", "map layer too big (%d * %d * %d causes an integer overflow)", pTilemap->m_Width, pTilemap->m_Height, (int)sizeof(CTile));
 						return false;
 					}
 					CTile *pTiles = static_cast<CTile *>(malloc(TilemapSize));


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
close #9630 
~~Use PRIzu is better than zu. Because using zu can be unexpected on older compilers such as MINGW32~~
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
