### PR TITLE
add doors to editor preview

### DIFF
--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -305,7 +305,7 @@ void CItems::RenderLaser(const CLaserData *pCurrent, bool IsPredicted)
 	RenderLaser(pCurrent->m_From, pCurrent->m_To, OuterColor, InnerColor, Ticks, TicksHead, Type);
 }
 
-void CItems::RenderLaser(vec2 From, vec2 Pos, ColorRGBA OuterColor, ColorRGBA InnerColor, float TicksBody, float TicksHead, int Type)
+void CItems::RenderLaser(vec2 From, vec2 Pos, ColorRGBA OuterColor, ColorRGBA InnerColor, float TicksBody, float TicksHead, int Type) const
 {
 	int TuneZone = (Client()->State() == IClient::STATE_ONLINE && GameClient()->m_GameWorld.m_WorldConfig.m_UseTuneZones) ? Collision()->IsTune(Collision()->GetMapIndex(From)) : 0;
 	float Len = distance(Pos, From);

--- a/src/game/client/components/items.h
+++ b/src/game/client/components/items.h
@@ -23,7 +23,7 @@ public:
 	virtual void OnInit() override;
 
 	void ReconstructSmokeTrail(const CProjectileData *pCurrent, int DestroyTick);
-	void RenderLaser(vec2 From, vec2 Pos, ColorRGBA OuterColor, ColorRGBA InnerColor, float TicksBody, float TicksHead, int Type);
+	void RenderLaser(vec2 From, vec2 Pos, ColorRGBA OuterColor, ColorRGBA InnerColor, float TicksBody, float TicksHead, int Type) const;
 
 private:
 	int m_BlueFlagOffset;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -8587,6 +8587,53 @@ void CEditor::RenderGameEntities(const std::shared_ptr<CLayerTiles> &pTiles)
 	}
 }
 
+void CEditor::RenderSwitchEntities(const std::shared_ptr<CLayerTiles> &pTiles)
+{
+	const CGameClient *pGameClient = (CGameClient *)Kernel()->RequestInterface<IGameClient>();
+	const float TileSize = 32.f;
+	CSwitchTile *pSwitchTiles = (CSwitchTile *)pTiles->m_pTiles;
+
+	auto GetIndex = [pSwitchTiles, pTiles](int y, int x, unsigned char &Number) -> unsigned char {
+		if(x < 0 || y < 0 || x >= pTiles->m_Width || y >= pTiles->m_Height)
+			return 0;
+		Number = pSwitchTiles[y * pTiles->m_Width + x].m_Type;
+		return pSwitchTiles[y * pTiles->m_Width + x].m_Number - ENTITY_OFFSET;
+	};
+
+	ivec2 aOffsets[] = {{1, 0}, {1, 1}, {0, 1}, {-1, 1}, {-1, 0}, {-1, -1}, {0, -1}, {1, -1}};
+
+	const ColorRGBA OuterColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClLaserDoorOutlineColor));
+	const ColorRGBA InnerColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClLaserDoorInnerColor));
+	const float TicksHead = Client()->GlobalTime() * Client()->GameTickSpeed();
+
+	for(int y = 0; y < pTiles->m_Height; y++)
+	{
+		for(int x = 0; x < pTiles->m_Width; x++)
+		{
+			unsigned char Number = 0;
+			const unsigned char Index = GetIndex(y, x, Number);
+
+			if(Index == ENTITY_DOOR)
+			{
+				for(size_t i = 0; i < sizeof(aOffsets) / sizeof(ivec2); ++i)
+				{
+					unsigned char NumberDoorLength = 0;
+					unsigned char IndexDoorLength = GetIndex(y + aOffsets[i].y, x + aOffsets[i].x, NumberDoorLength);
+					if(IndexDoorLength >= ENTITY_LASER_SHORT && IndexDoorLength <= ENTITY_LASER_LONG && NumberDoorLength == Number)
+					{
+						float XOff = std::cos(i * pi / 4.0f);
+						float YOff = std::sin(i * pi / 4.0f);
+						int Length = (IndexDoorLength - ENTITY_LASER_SHORT + 1) * 3;
+						vec2 Pos(x + 0.5f, y + 0.5f);
+						vec2 To(x + XOff * Length + 0.5f, y + YOff * Length + 0.5f);
+						pGameClient->m_Items.RenderLaser(To * TileSize, Pos * TileSize, OuterColor, InnerColor, 1.0f, TicksHead, (int)LASERTYPE_DOOR);
+					}
+				}
+			}
+		}
+	}
+}
+
 void CEditor::Reset(bool CreateDefault)
 {
 	Ui()->ClosePopupMenus();

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -539,6 +539,7 @@ public:
 	void UpdateColorPipette();
 	void RenderMousePointer();
 	void RenderGameEntities(const std::shared_ptr<CLayerTiles> &pTiles);
+	void RenderSwitchEntities(const std::shared_ptr<CLayerTiles> &pTiles);
 
 	std::vector<CQuad *> GetSelectedQuads();
 	std::shared_ptr<CLayer> GetSelectedLayerType(int Index, int Type) const;

--- a/src/game/editor/mapitems/layer_group.cpp
+++ b/src/game/editor/mapitems/layer_group.cpp
@@ -83,10 +83,11 @@ void CLayerGroup::Render()
 			{
 				std::shared_ptr<CLayerTiles> pTiles = std::static_pointer_cast<CLayerTiles>(pLayer);
 
-				if(g_Config.m_EdShowIngameEntities && pLayer->IsEntitiesLayer() &&
-					(pLayer == m_pMap->m_pGameLayer || pLayer == m_pMap->m_pFrontLayer))
+				if(g_Config.m_EdShowIngameEntities && pLayer->IsEntitiesLayer() && (pLayer == m_pMap->m_pGameLayer || pLayer == m_pMap->m_pFrontLayer || pLayer == m_pMap->m_pSwitchLayer))
 				{
-					m_pMap->m_pEditor->RenderGameEntities(pTiles);
+					if(pLayer != m_pMap->m_pSwitchLayer)
+						m_pMap->m_pEditor->RenderGameEntities(pTiles);
+					m_pMap->m_pEditor->RenderSwitchEntities(pTiles);
 				}
 
 				if(pTiles->m_Game || pTiles->m_Front || pTiles->m_Tele || pTiles->m_Speedup || pTiles->m_Tune || pTiles->m_Switch)


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->
Doors are not intuitive to map, since you set an origin (door) tile and a length tile next to it. This is worse with 45° doors. This PR introduces door-entities to the editor preview. It only applies to doors (not grabber or freeze doors) and only for fixed length. Feel free to do a follow up for more switch tiles.

follow up of #9057

Screenshots:
![screenshot_2025-03-26_17-42-47](https://github.com/user-attachments/assets/06828d3d-85d7-433f-ad08-fbd727405254)
![screenshot_2025-03-26_17-43-12](https://github.com/user-attachments/assets/3e7c1cd7-e421-42ff-9c4f-2c4dd41afa7e)

Test map:
[switch_test.zip](https://github.com/user-attachments/files/19471923/switch_test.zip)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
