### PR TITLE
Pass more data to the antibot

### DIFF
--- a/src/antibot/antibot_data.h
+++ b/src/antibot/antibot_data.h
@@ -5,7 +5,7 @@
 
 enum
 {
-	ANTIBOT_ABI_VERSION = 10,
+	ANTIBOT_ABI_VERSION = 11,
 
 	ANTIBOT_MSGFLAG_NONVITAL = 1,
 	ANTIBOT_MSGFLAG_FLUSH = 2,
@@ -23,12 +23,25 @@ struct CAntibotMapData
 struct CAntibotPlayerData
 {
 	char m_aAddress[64];
+	bool m_Sixup;
+	bool m_DnsblNone;
+	bool m_DnsblPending;
+	bool m_DnsblBlacklisted;
+	bool m_Authed;
 };
 
 struct CAntibotInputData
 {
+	int m_Direction;
 	int m_TargetX;
 	int m_TargetY;
+	int m_Jump;
+	int m_Fire;
+	int m_Hook;
+	int m_PlayerFlags;
+	int m_WantedWeapon;
+	int m_NextWeapon;
+	int m_PrevWeapon;
 };
 
 // Defined by the network protocol, unlikely to change.

--- a/src/antibot/antibot_interface.h
+++ b/src/antibot/antibot_interface.h
@@ -27,7 +27,7 @@ ANTIBOTAPI void AntibotOnDirectInput(int ClientId);
 ANTIBOTAPI void AntibotOnCharacterTick(int ClientId);
 ANTIBOTAPI void AntibotOnHookAttach(int ClientId, bool Player);
 ANTIBOTAPI void AntibotOnEngineTick(void);
-ANTIBOTAPI void AntibotOnEngineClientJoin(int ClientId, bool Sixup);
+ANTIBOTAPI void AntibotOnEngineClientJoin(int ClientId);
 ANTIBOTAPI void AntibotOnEngineClientDrop(int ClientId, const char *pReason);
 // Returns true if the message shouldn't be processed by the server.
 ANTIBOTAPI bool AntibotOnEngineClientMessage(int ClientId, const void *pData, int Size, int Flags);

--- a/src/antibot/antibot_null.cpp
+++ b/src/antibot/antibot_null.cpp
@@ -42,7 +42,7 @@ void AntibotOnDirectInput(int /*ClientId*/) {}
 void AntibotOnCharacterTick(int /*ClientId*/) {}
 void AntibotOnHookAttach(int /*ClientId*/, bool /*Player*/) {}
 void AntibotOnEngineTick(void) {}
-void AntibotOnEngineClientJoin(int /*ClientId*/, bool /*Sixup*/) {}
+void AntibotOnEngineClientJoin(int /*ClientId*/) {}
 void AntibotOnEngineClientDrop(int /*ClientId*/, const char * /*pReason*/) {}
 bool AntibotOnEngineClientMessage(int /*ClientId*/, const void * /*pData*/, int /*Size*/, int /*Flags*/) { return false; }
 bool AntibotOnEngineServerMessage(int /*ClientId*/, const void * /*pData*/, int /*Size*/, int /*Flags*/) { return false; }

--- a/src/engine/antibot.h
+++ b/src/engine/antibot.h
@@ -35,7 +35,7 @@ public:
 
 	// Hooks
 	virtual void OnEngineTick() = 0;
-	virtual void OnEngineClientJoin(int ClientId, bool Sixup) = 0;
+	virtual void OnEngineClientJoin(int ClientId) = 0;
 	virtual void OnEngineClientDrop(int ClientId, const char *pReason) = 0;
 	virtual bool OnEngineClientMessage(int ClientId, const void *pData, int Size, int Flags) = 0;
 	virtual bool OnEngineServerMessage(int ClientId, const void *pData, int Size, int Flags) = 0;

--- a/src/engine/server/antibot.cpp
+++ b/src/engine/server/antibot.cpp
@@ -166,10 +166,10 @@ void CAntibot::OnEngineTick()
 	Update();
 	AntibotOnEngineTick();
 }
-void CAntibot::OnEngineClientJoin(int ClientId, bool Sixup)
+void CAntibot::OnEngineClientJoin(int ClientId)
 {
 	Update();
-	AntibotOnEngineClientJoin(ClientId, Sixup);
+	AntibotOnEngineClientJoin(ClientId);
 }
 void CAntibot::OnEngineClientDrop(int ClientId, const char *pReason)
 {
@@ -256,7 +256,7 @@ void CAntibot::OnCharacterTick(int ClientId) {}
 void CAntibot::OnHookAttach(int ClientId, bool Player) {}
 
 void CAntibot::OnEngineTick() {}
-void CAntibot::OnEngineClientJoin(int ClientId, bool Sixup) {}
+void CAntibot::OnEngineClientJoin(int ClientId) {}
 void CAntibot::OnEngineClientDrop(int ClientId, const char *pReason) {}
 bool CAntibot::OnEngineClientMessage(int ClientId, const void *pData, int Size, int Flags) { return false; }
 bool CAntibot::OnEngineServerMessage(int ClientId, const void *pData, int Size, int Flags) { return false; }

--- a/src/engine/server/antibot.h
+++ b/src/engine/server/antibot.h
@@ -33,7 +33,7 @@ public:
 	void Init() override;
 
 	void OnEngineTick() override;
-	void OnEngineClientJoin(int ClientId, bool Sixup) override;
+	void OnEngineClientJoin(int ClientId) override;
 	void OnEngineClientDrop(int ClientId, const char *pReason) override;
 	bool OnEngineClientMessage(int ClientId, const void *pData, int Size, int Flags) override;
 	bool OnEngineServerMessage(int ClientId, const void *pData, int Size, int Flags) override;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1074,7 +1074,7 @@ int CServer::ClientRejoinCallback(int ClientId, void *pUser)
 
 	pThis->GameServer()->TeehistorianRecordPlayerRejoin(ClientId);
 	pThis->Antibot()->OnEngineClientDrop(ClientId, "rejoin");
-	pThis->Antibot()->OnEngineClientJoin(ClientId, false);
+	pThis->Antibot()->OnEngineClientJoin(ClientId);
 
 	pThis->SendMap(ClientId);
 
@@ -1105,7 +1105,7 @@ int CServer::NewClientNoAuthCallback(int ClientId, void *pUser)
 	pThis->m_aClients[ClientId].Reset();
 
 	pThis->GameServer()->TeehistorianRecordPlayerJoin(ClientId, false);
-	pThis->Antibot()->OnEngineClientJoin(ClientId, false);
+	pThis->Antibot()->OnEngineClientJoin(ClientId);
 
 	pThis->SendCapabilities(ClientId);
 	pThis->SendMap(ClientId);
@@ -1140,7 +1140,7 @@ int CServer::NewClientCallback(int ClientId, void *pUser, bool Sixup)
 	pThis->m_aClients[ClientId].Reset();
 
 	pThis->GameServer()->TeehistorianRecordPlayerJoin(ClientId, Sixup);
-	pThis->Antibot()->OnEngineClientJoin(ClientId, Sixup);
+	pThis->Antibot()->OnEngineClientJoin(ClientId);
 
 	pThis->m_aClients[ClientId].m_Sixup = Sixup;
 
@@ -2454,6 +2454,11 @@ void CServer::FillAntibot(CAntibotRoundData *pData)
 			static_assert(std::size((CAntibotPlayerData{}).m_aAddress) >= NETADDR_MAXSTRSIZE);
 			static_assert(std::is_same_v<decltype(CServer{}.ClientAddrStringImpl(ClientId, true)), const std::array<char, NETADDR_MAXSTRSIZE> &>);
 			mem_copy(pPlayer->m_aAddress, ClientAddrStringImpl(ClientId, true).data(), NETADDR_MAXSTRSIZE);
+			pPlayer->m_Sixup = m_aClients[ClientId].m_Sixup;
+			pPlayer->m_DnsblNone = m_aClients[ClientId].m_DnsblState == CClient::DNSBL_STATE_NONE;
+			pPlayer->m_DnsblPending = m_aClients[ClientId].m_DnsblState == CClient::DNSBL_STATE_PENDING;
+			pPlayer->m_DnsblBlacklisted = m_aClients[ClientId].m_DnsblState == CClient::DNSBL_STATE_BLACKLISTED;
+			pPlayer->m_Authed = m_aClients[ClientId].m_Authed > AUTHED_NO;
 		}
 	}
 }

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1344,12 +1344,42 @@ void CCharacter::FillAntibot(CAntibotCharacterData *pData)
 	pData->m_HookedPlayer = m_Core.HookedPlayer();
 	pData->m_SpawnTick = m_SpawnTick;
 	pData->m_WeaponChangeTick = m_WeaponChangeTick;
+
+	// 0
+	pData->m_aLatestInputs[0].m_Direction = m_LatestInput.m_Direction;
 	pData->m_aLatestInputs[0].m_TargetX = m_LatestInput.m_TargetX;
 	pData->m_aLatestInputs[0].m_TargetY = m_LatestInput.m_TargetY;
+	pData->m_aLatestInputs[0].m_Jump = m_LatestInput.m_Jump;
+	pData->m_aLatestInputs[0].m_Fire = m_LatestInput.m_Fire;
+	pData->m_aLatestInputs[0].m_Hook = m_LatestInput.m_Hook;
+	pData->m_aLatestInputs[0].m_PlayerFlags = m_LatestInput.m_PlayerFlags;
+	pData->m_aLatestInputs[0].m_WantedWeapon = m_LatestInput.m_WantedWeapon;
+	pData->m_aLatestInputs[0].m_NextWeapon = m_LatestInput.m_NextWeapon;
+	pData->m_aLatestInputs[0].m_PrevWeapon = m_LatestInput.m_PrevWeapon;
+
+	// 1
+	pData->m_aLatestInputs[1].m_Direction = m_LatestPrevInput.m_Direction;
 	pData->m_aLatestInputs[1].m_TargetX = m_LatestPrevInput.m_TargetX;
 	pData->m_aLatestInputs[1].m_TargetY = m_LatestPrevInput.m_TargetY;
+	pData->m_aLatestInputs[1].m_Jump = m_LatestPrevInput.m_Jump;
+	pData->m_aLatestInputs[1].m_Fire = m_LatestPrevInput.m_Fire;
+	pData->m_aLatestInputs[1].m_Hook = m_LatestPrevInput.m_Hook;
+	pData->m_aLatestInputs[1].m_PlayerFlags = m_LatestPrevInput.m_PlayerFlags;
+	pData->m_aLatestInputs[1].m_WantedWeapon = m_LatestPrevInput.m_WantedWeapon;
+	pData->m_aLatestInputs[1].m_NextWeapon = m_LatestPrevInput.m_NextWeapon;
+	pData->m_aLatestInputs[1].m_PrevWeapon = m_LatestPrevInput.m_PrevWeapon;
+
+	// 2
+	pData->m_aLatestInputs[2].m_Direction = m_LatestPrevPrevInput.m_Direction;
 	pData->m_aLatestInputs[2].m_TargetX = m_LatestPrevPrevInput.m_TargetX;
 	pData->m_aLatestInputs[2].m_TargetY = m_LatestPrevPrevInput.m_TargetY;
+	pData->m_aLatestInputs[2].m_Jump = m_LatestPrevPrevInput.m_Jump;
+	pData->m_aLatestInputs[2].m_Fire = m_LatestPrevPrevInput.m_Fire;
+	pData->m_aLatestInputs[2].m_Hook = m_LatestPrevPrevInput.m_Hook;
+	pData->m_aLatestInputs[2].m_PlayerFlags = m_LatestPrevPrevInput.m_PlayerFlags;
+	pData->m_aLatestInputs[2].m_WantedWeapon = m_LatestPrevPrevInput.m_WantedWeapon;
+	pData->m_aLatestInputs[2].m_NextWeapon = m_LatestPrevPrevInput.m_NextWeapon;
+	pData->m_aLatestInputs[2].m_PrevWeapon = m_LatestPrevPrevInput.m_PrevWeapon;
 }
 
 void CCharacter::HandleBroadcast()

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -233,8 +233,16 @@ void CGameContext::FillAntibot(CAntibotRoundData *pData)
 		CAntibotCharacterData *pChar = &pData->m_aCharacters[i];
 		for(auto &LatestInput : pChar->m_aLatestInputs)
 		{
+			LatestInput.m_Direction = 0;
 			LatestInput.m_TargetX = -1;
 			LatestInput.m_TargetY = -1;
+			LatestInput.m_Jump = -1;
+			LatestInput.m_Fire = -1;
+			LatestInput.m_Hook = -1;
+			LatestInput.m_PlayerFlags = -1;
+			LatestInput.m_WantedWeapon = -1;
+			LatestInput.m_NextWeapon = -1;
+			LatestInput.m_PrevWeapon = -1;
 		}
 		pChar->m_Alive = false;
 		pChar->m_Pause = false;


### PR DESCRIPTION
Currently there is a limited amount of variables you can analyze in your antibot. This PR adds all of the inputs instead of just the aim position.

This also passes the SixUp, DNSBL and authed state to the antibot to be able to make special cases with those.

Reopen of the PR #9096

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
