### PR TITLE
Fix Win32 build fail with Discord

### DIFF
--- a/src/engine/client/discord.cpp
+++ b/src/engine/client/discord.cpp
@@ -5,6 +5,12 @@
 #if defined(CONF_DISCORD)
 #include <discord_game_sdk.h>
 
+#if defined(CONF_FAMILY_WINDOWS)
+#define DISCORD_CALLBACK __stdcall
+#else
+#define DISCORD_CALLBACK
+#endif
+
 typedef enum EDiscordResult(DISCORD_API *FDiscordCreate)(DiscordVersion, struct DiscordCreateParams *, struct IDiscordCore **);
 
 #if defined(CONF_DISCORD_DYNAMIC)
@@ -178,7 +184,7 @@ public:
 		}
 	}
 
-	static void OnActivityJoin(void *pEventData, const char *pSecret)
+	static void DISCORD_CALLBACK OnActivityJoin(void *pEventData, const char *pSecret)
 	{
 		CDiscord *pSelf = static_cast<CDiscord *>(pEventData);
 		IClient *m_pClient = pSelf->Kernel()->RequestInterface<IClient>();


### PR DESCRIPTION
Fixes #9954

It should fix it, but could you test it @def- I can't build 32 bit because of rust

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
