### PR TITLE
Remove unused `m_SkinColor` variables from client data

### DIFF
--- a/src/engine/shared/translation_context.h
+++ b/src/engine/shared/translation_context.h
@@ -69,7 +69,6 @@ public:
 			m_aClan[0] = '\0';
 			m_Country = 0;
 			m_aSkinName[0] = '\0';
-			m_SkinColor = 0;
 			m_Team = 0;
 			m_PlayerFlags7 = 0;
 		}
@@ -84,7 +83,6 @@ public:
 		char m_aClan[MAX_CLAN_LENGTH];
 		int m_Country;
 		char m_aSkinName[protocol7::MAX_SKIN_LENGTH];
-		int m_SkinColor;
 		int m_Team;
 		int m_PlayerFlags7;
 	};

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2682,7 +2682,6 @@ void CGameClient::CClientData::Reset()
 	m_aClan[0] = '\0';
 	m_Country = -1;
 	m_aSkinName[0] = '\0';
-	m_SkinColor = 0;
 
 	m_Team = 0;
 	m_Emoticon = 0;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -429,7 +429,6 @@ public:
 		char m_aClan[MAX_CLAN_LENGTH];
 		int m_Country;
 		char m_aSkinName[MAX_SKIN_LENGTH];
-		int m_SkinColor;
 		int m_Team;
 		int m_Emoticon;
 		float m_EmoticonStartFraction;


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
