### PR TITLE
Touch controls editor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2381,6 +2381,8 @@ if(CLIENT)
     components/menus_browser.cpp
     components/menus_demo.cpp
     components/menus_ingame.cpp
+    components/menus_ingame_touch_controls.cpp
+    components/menus_ingame_touch_controls.h
     components/menus_settings.cpp
     components/menus_settings7.cpp
     components/menus_settings_assets.cpp

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -883,6 +883,7 @@ void CMenus::OnInterfacesInit(CGameClient *pClient)
 	CComponentInterfaces::OnInterfacesInit(pClient);
 	m_CommunityIcons.OnInterfacesInit(pClient);
 	m_MenusStart.OnInterfacesInit(pClient);
+	m_MenusIngameTouchControls.OnInterfacesInit(pClient);
 }
 
 void CMenus::OnInit()

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -20,6 +20,7 @@
 
 #include <game/client/component.h>
 #include <game/client/components/mapimages.h>
+#include <game/client/components/menus_ingame_touch_controls.h>
 #include <game/client/lineinput.h>
 #include <game/client/render.h>
 #include <game/client/ui.h>
@@ -499,6 +500,12 @@ protected:
 	void PopupConfirmDiscardTouchControlsChanges();
 	void PopupConfirmResetTouchControls();
 	void PopupConfirmImportTouchControlsClipboard();
+	void PopupConfirmDeleteButton();
+	void PopupCancelDeselectButton();
+	void PopupConfirmSelectedNotVisible();
+	void PopupConfirmChangeSelectedButton();
+	void PopupCancelChangeSelectedButton();
+	void PopupConfirmTurnOffEditor();
 	void RenderPlayers(CUIRect MainView);
 	void RenderServerInfo(CUIRect MainView);
 	void RenderServerInfoMotd(CUIRect Motd);
@@ -792,6 +799,8 @@ public:
 private:
 	CCommunityIcons m_CommunityIcons;
 	CMenusStart m_MenusStart;
+	CMenusIngameTouchControls m_MenusIngameTouchControls;
+	friend CMenusIngameTouchControls;
 
 	static int GhostlistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int StorageType, void *pUser);
 

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -1,5 +1,6 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include <base/color.h>
 #include <base/math.h>
 #include <base/system.h>
 
@@ -237,7 +238,25 @@ void CMenus::RenderGame(CUIRect MainView)
 		static char s_TouchControlsEditCheckbox;
 		if(DoButton_CheckBox(&s_TouchControlsEditCheckbox, Localize("Edit touch controls"), GameClient()->m_TouchControls.IsEditingActive(), &Button))
 		{
-			GameClient()->m_TouchControls.SetEditingActive(!GameClient()->m_TouchControls.IsEditingActive());
+			if(GameClient()->m_TouchControls.IsEditingActive() && m_MenusIngameTouchControls.UnsavedChanges())
+			{
+				m_MenusIngameTouchControls.m_pOldSelectedButton = GameClient()->m_TouchControls.SelectedButton();
+				m_MenusIngameTouchControls.m_pNewSelectedButton = nullptr;
+				PopupConfirm(Localize("Unsaved changes"), Localize("Save all changes before turning off the editor?"), Localize("Save"), Localize("Cancel"), &CMenus::PopupConfirmTurnOffEditor);
+			}
+			else
+			{
+				GameClient()->m_TouchControls.SetEditingActive(!GameClient()->m_TouchControls.IsEditingActive());
+				if(GameClient()->m_TouchControls.IsEditingActive())
+				{
+					GameClient()->m_TouchControls.ResetVirtualVisibilities();
+					m_MenusIngameTouchControls.m_EditElement = CMenusIngameTouchControls::EElementType::LAYOUT;
+				}
+				else
+				{
+					m_MenusIngameTouchControls.ResetButtonPointers();
+				}
+			}
 		}
 
 		ButtonBar2.VSplitRight(80.0f, &ButtonBar2, &Button);
@@ -262,149 +281,47 @@ void CMenus::RenderGame(CUIRect MainView)
 		{
 			Console()->ExecuteLine("toggle_local_console");
 		}
-
+		// Only when these are all false, the preview page is rendered. Once the page is not rendered, update is needed upon next rendering.
+		if(!GameClient()->m_TouchControls.IsEditingActive() || m_MenusIngameTouchControls.m_CurrentMenu != CMenusIngameTouchControls::EMenuType::MENU_BUTTONS || GameClient()->m_TouchControls.IsButtonEditing())
+			m_MenusIngameTouchControls.m_NeedUpdatePreview = true;
+		// Quit preview all buttons automatically.
+		if(!GameClient()->m_TouchControls.IsEditingActive() || m_MenusIngameTouchControls.m_CurrentMenu != CMenusIngameTouchControls::EMenuType::MENU_PREVIEW)
+			GameClient()->m_TouchControls.SetPreviewAllButtons(false);
 		if(GameClient()->m_TouchControls.IsEditingActive())
 		{
-			CUIRect TouchControlsEditor;
-			MainView.VMargin((MainView.w - 505.0f) / 2.0f, &TouchControlsEditor);
-			TouchControlsEditor.HMargin((TouchControlsEditor.h - 230.0f) / 2.0f, &TouchControlsEditor);
-			RenderTouchControlsEditor(TouchControlsEditor);
+			// Resolve issues if needed before rendering, so the elements could have a correct value on this frame.
+			// Issues need to be resolved before popup. So CheckCachedSettings could not be bad.
+			m_MenusIngameTouchControls.ResolveIssues();
+			// Do Popups if needed.
+			CTouchControls::CPopupParam PopupParam = GameClient()->m_TouchControls.RequiredPopup();
+			if(PopupParam.m_PopupType != CTouchControls::EPopupType::NUM_POPUPS)
+			{
+				m_MenusIngameTouchControls.DoPopupType(PopupParam);
+				return;
+			}
+			if(m_MenusIngameTouchControls.m_FirstEnter)
+			{
+				m_MenusIngameTouchControls.m_aCachedVisibilities[(int)CTouchControls::EButtonVisibility::DEMO_PLAYER] = CMenusIngameTouchControls::EVisibilityType::EXCLUDE;
+				m_MenusIngameTouchControls.m_ColorActive = color_cast<ColorHSLA>(GameClient()->m_TouchControls.BackgroundColorActive()).Pack(true);
+				m_MenusIngameTouchControls.m_ColorInactive = color_cast<ColorHSLA>(GameClient()->m_TouchControls.BackgroundColorInactive()).Pack(true);
+				m_MenusIngameTouchControls.m_FirstEnter = false;
+			}
+			// Their width is all 505.0f, height is adjustable, you can directly change its h value, so no need for changing where tab is.
+			CUIRect SelectingTab;
+			MainView.HSplitTop(40.0f, nullptr, &MainView);
+			MainView.VMargin((MainView.w - CMenusIngameTouchControls::BUTTON_EDITOR_WIDTH) / 2.0f, &MainView);
+			MainView.HSplitTop(25.0f, &SelectingTab, &MainView);
+
+			m_MenusIngameTouchControls.RenderSelectingTab(SelectingTab);
+			switch(m_MenusIngameTouchControls.m_CurrentMenu)
+			{
+			case CMenusIngameTouchControls::EMenuType::MENU_FILE: m_MenusIngameTouchControls.RenderTouchControlsEditor(MainView); break;
+			case CMenusIngameTouchControls::EMenuType::MENU_BUTTONS: m_MenusIngameTouchControls.RenderTouchButtonEditor(MainView); break;
+			case CMenusIngameTouchControls::EMenuType::MENU_SETTINGS: m_MenusIngameTouchControls.RenderConfigSettings(MainView); break;
+			case CMenusIngameTouchControls::EMenuType::MENU_PREVIEW: m_MenusIngameTouchControls.RenderPreviewSettings(MainView); break;
+			default: dbg_assert(false, "Unknown selected tab value = %d.", (int)m_MenusIngameTouchControls.m_CurrentMenu);
+			}
 		}
-	}
-}
-
-void CMenus::RenderTouchControlsEditor(CUIRect MainView)
-{
-	CUIRect Label, Button, Row;
-	MainView.Draw(ms_ColorTabbarActive, IGraphics::CORNER_ALL, 10.0f);
-	MainView.Margin(10.0f, &MainView);
-
-	MainView.HSplitTop(25.0f, &Row, &MainView);
-	MainView.HSplitTop(5.0f, nullptr, &MainView);
-	Row.VSplitLeft(Row.h, nullptr, &Row);
-	Row.VSplitRight(Row.h, &Row, &Button);
-	Row.VMargin(5.0f, &Label);
-	Ui()->DoLabel(&Label, Localize("Edit touch controls"), 20.0f, TEXTALIGN_MC);
-
-	static CButtonContainer s_OpenHelpButton;
-	if(Ui()->DoButton_FontIcon(&s_OpenHelpButton, FONT_ICON_QUESTION, 0, &Button, BUTTONFLAG_LEFT))
-	{
-		Client()->ViewLink(Localize("https://wiki.ddnet.org/wiki/Touch_controls"));
-	}
-
-	MainView.HSplitTop(25.0f, &Row, &MainView);
-	MainView.HSplitTop(5.0f, nullptr, &MainView);
-
-	Row.VSplitLeft(240.0f, &Button, &Row);
-	static CButtonContainer s_SaveConfigurationButton;
-	if(DoButton_Menu(&s_SaveConfigurationButton, Localize("Save changes"), GameClient()->m_TouchControls.HasEditingChanges() ? 0 : 1, &Button))
-	{
-		if(GameClient()->m_TouchControls.SaveConfigurationToFile())
-		{
-			GameClient()->m_TouchControls.SetEditingChanges(false);
-		}
-		else
-		{
-			SWarning Warning(Localize("Error saving touch controls"), Localize("Could not save touch controls to file. See local console for details."));
-			Warning.m_AutoHide = false;
-			Client()->AddWarning(Warning);
-		}
-	}
-
-	Row.VSplitLeft(5.0f, nullptr, &Row);
-	Row.VSplitLeft(240.0f, &Button, &Row);
-	if(GameClient()->m_TouchControls.HasEditingChanges())
-	{
-		TextRender()->TextColor(ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f));
-		Ui()->DoLabel(&Button, Localize("Unsaved changes"), 14.0f, TEXTALIGN_MC);
-		TextRender()->TextColor(TextRender()->DefaultTextColor());
-	}
-
-	MainView.HSplitTop(25.0f, &Row, &MainView);
-	MainView.HSplitTop(5.0f, nullptr, &MainView);
-
-	Row.VSplitLeft(240.0f, &Button, &Row);
-	static CButtonContainer s_DiscardChangesButton;
-	if(DoButton_Menu(&s_DiscardChangesButton, Localize("Discard changes"), GameClient()->m_TouchControls.HasEditingChanges() ? 0 : 1, &Button))
-	{
-		PopupConfirm(Localize("Discard changes"),
-			Localize("Are you sure that you want to discard the current changes to the touch controls?"),
-			Localize("Yes"), Localize("No"),
-			&CMenus::PopupConfirmDiscardTouchControlsChanges);
-	}
-
-	Row.VSplitLeft(5.0f, nullptr, &Row);
-	Row.VSplitLeft(240.0f, &Button, &Row);
-	static CButtonContainer s_ResetButton;
-	if(DoButton_Menu(&s_ResetButton, Localize("Reset to defaults"), 0, &Button))
-	{
-		PopupConfirm(Localize("Reset to defaults"),
-			Localize("Are you sure that you want to reset the touch controls to default?"),
-			Localize("Yes"), Localize("No"),
-			&CMenus::PopupConfirmResetTouchControls);
-	}
-
-	MainView.HSplitTop(25.0f, &Row, &MainView);
-	MainView.HSplitTop(10.0f, nullptr, &MainView);
-
-	Row.VSplitLeft(240.0f, &Button, &Row);
-	static CButtonContainer s_ClipboardImportButton;
-	if(DoButton_Menu(&s_ClipboardImportButton, Localize("Import from clipboard"), 0, &Button))
-	{
-		PopupConfirm(Localize("Import from clipboard"),
-			Localize("Are you sure that you want to import the touch controls from the clipboard? This will overwrite your current touch controls."),
-			Localize("Yes"), Localize("No"),
-			&CMenus::PopupConfirmImportTouchControlsClipboard);
-	}
-
-	Row.VSplitLeft(5.0f, nullptr, &Row);
-	Row.VSplitLeft(240.0f, &Button, &Row);
-	static CButtonContainer s_ClipboardExportButton;
-	if(DoButton_Menu(&s_ClipboardExportButton, Localize("Export to clipboard"), 0, &Button))
-	{
-		GameClient()->m_TouchControls.SaveConfigurationToClipboard();
-	}
-
-	MainView.HSplitTop(25.0f, &Label, &MainView);
-	MainView.HSplitTop(5.0f, nullptr, &MainView);
-	Ui()->DoLabel(&Label, Localize("Settings"), 20.0f, TEXTALIGN_MC);
-
-	MainView.HSplitTop(25.0f, &Row, &MainView);
-	MainView.HSplitTop(5.0f, nullptr, &MainView);
-
-	Row.VSplitLeft(300.0f, &Label, &Row);
-	Ui()->DoLabel(&Label, Localize("Direct touch input while ingame"), 16.0f, TEXTALIGN_ML);
-
-	Row.VSplitLeft(5.0f, nullptr, &Row);
-	Row.VSplitLeft(180.0f, &Button, &Row);
-	const char *apIngameTouchModes[(int)CTouchControls::EDirectTouchIngameMode::NUM_STATES] = {Localize("Disabled", "Direct touch input"), Localize("Active action", "Direct touch input"), Localize("Aim", "Direct touch input"), Localize("Fire", "Direct touch input"), Localize("Hook", "Direct touch input")};
-	const CTouchControls::EDirectTouchIngameMode OldDirectTouchIngame = GameClient()->m_TouchControls.DirectTouchIngame();
-	static CUi::SDropDownState s_DirectTouchIngameDropDownState;
-	static CScrollRegion s_DirectTouchIngameDropDownScrollRegion;
-	s_DirectTouchIngameDropDownState.m_SelectionPopupContext.m_pScrollRegion = &s_DirectTouchIngameDropDownScrollRegion;
-	const CTouchControls::EDirectTouchIngameMode NewDirectTouchIngame = (CTouchControls::EDirectTouchIngameMode)Ui()->DoDropDown(&Button, (int)OldDirectTouchIngame, apIngameTouchModes, std::size(apIngameTouchModes), s_DirectTouchIngameDropDownState);
-	if(OldDirectTouchIngame != NewDirectTouchIngame)
-	{
-		GameClient()->m_TouchControls.SetDirectTouchIngame(NewDirectTouchIngame);
-	}
-
-	MainView.HSplitTop(25.0f, &Row, &MainView);
-	MainView.HSplitTop(5.0f, nullptr, &MainView);
-
-	Row.VSplitLeft(300.0f, &Label, &Row);
-	Ui()->DoLabel(&Label, Localize("Direct touch input while spectating"), 16.0f, TEXTALIGN_ML);
-
-	Row.VSplitLeft(5.0f, nullptr, &Row);
-	Row.VSplitLeft(180.0f, &Button, &Row);
-	const char *apSpectateTouchModes[(int)CTouchControls::EDirectTouchSpectateMode::NUM_STATES] = {Localize("Disabled", "Direct touch input"), Localize("Aim", "Direct touch input")};
-	const CTouchControls::EDirectTouchSpectateMode OldDirectTouchSpectate = GameClient()->m_TouchControls.DirectTouchSpectate();
-	static CUi::SDropDownState s_DirectTouchSpectateDropDownState;
-	static CScrollRegion s_DirectTouchSpectateDropDownScrollRegion;
-	s_DirectTouchSpectateDropDownState.m_SelectionPopupContext.m_pScrollRegion = &s_DirectTouchSpectateDropDownScrollRegion;
-	const CTouchControls::EDirectTouchSpectateMode NewDirectTouchSpectate = (CTouchControls::EDirectTouchSpectateMode)Ui()->DoDropDown(&Button, (int)OldDirectTouchSpectate, apSpectateTouchModes, std::size(apSpectateTouchModes), s_DirectTouchSpectateDropDownState);
-	if(OldDirectTouchSpectate != NewDirectTouchSpectate)
-	{
-		GameClient()->m_TouchControls.SetDirectTouchSpectate(NewDirectTouchSpectate);
 	}
 }
 
@@ -423,6 +340,8 @@ void CMenus::PopupConfirmDiscardTouchControlsChanges()
 {
 	if(GameClient()->m_TouchControls.LoadConfigurationFromFile(IStorage::TYPE_ALL))
 	{
+		m_MenusIngameTouchControls.m_ColorActive = color_cast<ColorHSLA>(GameClient()->m_TouchControls.BackgroundColorActive()).Pack(true);
+		m_MenusIngameTouchControls.m_ColorInactive = color_cast<ColorHSLA>(GameClient()->m_TouchControls.BackgroundColorInactive()).Pack(true);
 		GameClient()->m_TouchControls.SetEditingChanges(false);
 	}
 	else
@@ -446,6 +365,8 @@ void CMenus::PopupConfirmResetTouchControls()
 	}
 	if(Success)
 	{
+		m_MenusIngameTouchControls.m_ColorActive = color_cast<ColorHSLA>(GameClient()->m_TouchControls.BackgroundColorActive()).Pack(true);
+		m_MenusIngameTouchControls.m_ColorInactive = color_cast<ColorHSLA>(GameClient()->m_TouchControls.BackgroundColorInactive()).Pack(true);
 		GameClient()->m_TouchControls.SetEditingChanges(true);
 	}
 	else
@@ -460,6 +381,8 @@ void CMenus::PopupConfirmImportTouchControlsClipboard()
 {
 	if(GameClient()->m_TouchControls.LoadConfigurationFromClipboard())
 	{
+		m_MenusIngameTouchControls.m_ColorActive = color_cast<ColorHSLA>(GameClient()->m_TouchControls.BackgroundColorActive()).Pack(true);
+		m_MenusIngameTouchControls.m_ColorInactive = color_cast<ColorHSLA>(GameClient()->m_TouchControls.BackgroundColorInactive()).Pack(true);
 		GameClient()->m_TouchControls.SetEditingChanges(true);
 	}
 	else
@@ -467,6 +390,83 @@ void CMenus::PopupConfirmImportTouchControlsClipboard()
 		SWarning Warning(Localize("Error loading touch controls"), Localize("Could not load touch controls from clipboard. See local console for details."));
 		Warning.m_AutoHide = false;
 		Client()->AddWarning(Warning);
+	}
+}
+
+void CMenus::PopupConfirmDeleteButton()
+{
+	GameClient()->m_TouchControls.DeleteSelectedButton();
+	m_MenusIngameTouchControls.ResetCachedSettings();
+	GameClient()->m_TouchControls.SetEditingChanges(true);
+}
+
+void CMenus::PopupCancelDeselectButton()
+{
+	m_MenusIngameTouchControls.ResetButtonPointers();
+	m_MenusIngameTouchControls.SetUnsavedChanges(false);
+	m_MenusIngameTouchControls.ResetCachedSettings();
+}
+
+void CMenus::PopupConfirmSelectedNotVisible()
+{
+	if(m_MenusIngameTouchControls.UnsavedChanges())
+	{
+		// The m_pSelectedButton can't nullptr, because this function is triggered when selected button not visible.
+		m_MenusIngameTouchControls.m_pOldSelectedButton = GameClient()->m_TouchControls.SelectedButton();
+		m_MenusIngameTouchControls.m_pNewSelectedButton = nullptr;
+		m_MenusIngameTouchControls.m_CloseMenu = true;
+		m_MenusIngameTouchControls.ChangeSelectedButtonWhileHavingUnsavedChanges();
+	}
+	else
+	{
+		m_MenusIngameTouchControls.ResetButtonPointers();
+		GameClient()->m_Menus.SetActive(false);
+	}
+}
+
+void CMenus::PopupConfirmChangeSelectedButton()
+{
+	if(m_MenusIngameTouchControls.CheckCachedSettings())
+	{
+		GameClient()->m_TouchControls.SetSelectedButton(m_MenusIngameTouchControls.m_pNewSelectedButton);
+		if(m_MenusIngameTouchControls.m_pOldSelectedButton == nullptr)
+		{
+			m_MenusIngameTouchControls.m_pOldSelectedButton = GameClient()->m_TouchControls.NewButton();
+		}
+		m_MenusIngameTouchControls.SaveCachedSettingsToTarget(m_MenusIngameTouchControls.m_pOldSelectedButton);
+		// Update wild pointer.
+		if(m_MenusIngameTouchControls.m_pNewSelectedButton != nullptr)
+			m_MenusIngameTouchControls.m_pNewSelectedButton = GameClient()->m_TouchControls.SelectedButton();
+		GameClient()->m_TouchControls.SetEditingChanges(true);
+		m_MenusIngameTouchControls.SetUnsavedChanges(false);
+		PopupCancelChangeSelectedButton();
+	}
+}
+
+void CMenus::PopupCancelChangeSelectedButton()
+{
+	GameClient()->m_TouchControls.SetSelectedButton(m_MenusIngameTouchControls.m_pNewSelectedButton);
+	m_MenusIngameTouchControls.CacheAllSettingsFromTarget(m_MenusIngameTouchControls.m_pNewSelectedButton);
+	m_MenusIngameTouchControls.SetUnsavedChanges(false);
+	if(m_MenusIngameTouchControls.m_pNewSelectedButton != nullptr)
+	{
+		m_MenusIngameTouchControls.UpdateSampleButton();
+	}
+	else
+	{
+		m_MenusIngameTouchControls.ResetButtonPointers();
+	}
+	if(m_MenusIngameTouchControls.m_CloseMenu)
+		GameClient()->m_Menus.SetActive(false);
+}
+
+void CMenus::PopupConfirmTurnOffEditor()
+{
+	if(m_MenusIngameTouchControls.CheckCachedSettings())
+	{
+		m_MenusIngameTouchControls.SaveCachedSettingsToTarget(m_MenusIngameTouchControls.m_pOldSelectedButton);
+		GameClient()->m_TouchControls.SetEditingActive(!GameClient()->m_TouchControls.IsEditingActive());
+		m_MenusIngameTouchControls.ResetButtonPointers();
 	}
 }
 

--- a/src/game/client/components/menus_ingame_touch_controls.cpp
+++ b/src/game/client/components/menus_ingame_touch_controls.cpp
@@ -1,0 +1,1513 @@
+#include "menus_ingame_touch_controls.h"
+
+#include <base/color.h>
+#include <base/math.h>
+#include <base/system.h>
+
+#include <engine/graphics.h>
+#include <engine/shared/localization.h>
+#include <engine/textrender.h>
+
+#include <engine/external/json-parser/json.h>
+#include <engine/shared/jsonwriter.h>
+
+#include <game/client/components/touch_controls.h>
+#include <game/client/gameclient.h>
+#include <game/client/lineinput.h>
+#include <game/client/ui.h>
+#include <game/client/ui_listbox.h>
+#include <game/client/ui_rect.h>
+#include <game/client/ui_scrollregion.h>
+#include <game/localization.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+
+static const constexpr float MAINMARGIN = 10.0f;
+static const constexpr float SUBMARGIN = 5.0f;
+static const constexpr float ROWSIZE = 25.0f;
+static const constexpr float ROWGAP = 5.0f;
+static const constexpr float FONTSIZE = 15.0f;
+
+const CMenusIngameTouchControls::CBehaviorFactoryEditor CMenusIngameTouchControls::BEHAVIOR_FACTORIES_EDITOR[] = {
+	{CTouchControls::CIngameMenuTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CIngameMenuTouchButtonBehavior>(); }},
+	{CTouchControls::CExtraMenuTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CExtraMenuTouchButtonBehavior>(0); }},
+	{CTouchControls::CEmoticonTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CEmoticonTouchButtonBehavior>(); }},
+	{CTouchControls::CSpectateTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CSpectateTouchButtonBehavior>(); }},
+	{CTouchControls::CSwapActionTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CSwapActionTouchButtonBehavior>(); }},
+	{CTouchControls::CUseActionTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CUseActionTouchButtonBehavior>(); }},
+	{CTouchControls::CJoystickActionTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CJoystickActionTouchButtonBehavior>(); }},
+	{CTouchControls::CJoystickAimTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CJoystickAimTouchButtonBehavior>(); }},
+	{CTouchControls::CJoystickFireTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CJoystickFireTouchButtonBehavior>(); }},
+	{CTouchControls::CJoystickHookTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CJoystickHookTouchButtonBehavior>(); }}};
+
+void CMenusIngameTouchControls::RenderTouchButtonEditor(CUIRect MainView)
+{
+	if(!GameClient()->m_TouchControls.IsButtonEditing())
+	{
+		RenderTouchButtonBrowser(MainView);
+		return;
+	}
+	// Used to decide if need to update the Samplebutton.
+	bool Changed = false;
+	CUIRect Functional, LeftButton, MiddleButton, RightButton, EditBox, Block;
+	MainView.h = 600.0f - 40.0f - MainView.y;
+	MainView.Draw(CMenus::ms_ColorTabbarActive, IGraphics::CORNER_B, 10.0f);
+	MainView.VMargin(MAINMARGIN, &MainView);
+	MainView.HSplitTop(MAINMARGIN, nullptr, &MainView);
+	MainView.HSplitTop(ROWSIZE, &EditBox, &MainView);
+
+	MainView.HSplitBottom(2 * ROWSIZE + 2 * ROWGAP + MAINMARGIN, &Block, &Functional);
+	Functional.HSplitTop(ROWGAP, nullptr, &Functional);
+	Functional.HSplitBottom(MAINMARGIN, &Functional, nullptr);
+
+	// Choosing which to edit.
+	EditBox.VSplitLeft(EditBox.w / 3.0f, &RightButton, &EditBox);
+	EditBox.VSplitMid(&LeftButton, &MiddleButton);
+
+	if(GameClient()->m_Menus.DoButton_MenuTab(m_aEditElementIds.data(), Localize("Layout"), m_EditElement == EElementType::LAYOUT, &RightButton, IGraphics::CORNER_TL, nullptr, nullptr, nullptr, nullptr, 5.0f))
+	{
+		m_EditElement = EElementType::LAYOUT;
+	}
+	if(GameClient()->m_Menus.DoButton_MenuTab(&m_aEditElementIds[1], Localize("Visibility"), m_EditElement == EElementType::VISIBILITY, &LeftButton, IGraphics::CORNER_NONE, nullptr, nullptr, nullptr, nullptr, 5.0f))
+	{
+		m_EditElement = EElementType::VISIBILITY;
+	}
+	if(GameClient()->m_Menus.DoButton_MenuTab(&m_aEditElementIds[2], Localize("Behavior"), m_EditElement == EElementType::BEHAVIOR, &MiddleButton, IGraphics::CORNER_TR, nullptr, nullptr, nullptr, nullptr, 5.0f))
+	{
+		m_EditElement = EElementType::BEHAVIOR;
+	}
+
+	// Edit blocks.
+	Block.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f), IGraphics::CORNER_B, 5.0f);
+	Block.HSplitTop(ROWGAP, nullptr, &Block);
+	Block.VMargin(SUBMARGIN, &Block);
+	switch(m_EditElement)
+	{
+	case EElementType::LAYOUT: Changed |= RenderLayoutSettingBlock(Block); break;
+	case EElementType::VISIBILITY: Changed |= RenderVisibilitySettingBlock(Block); break;
+	case EElementType::BEHAVIOR: Changed |= RenderBehaviorSettingBlock(Block); break;
+	default: dbg_assert(false, "Unknown m_EditElement = %d.", m_EditElement);
+	}
+
+	// Save & Cancel & Hint.
+	Functional.HSplitTop(ROWSIZE, &EditBox, &Functional);
+	const float ButtonWidth = (EditBox.w - SUBMARGIN * 2.0f) / 3.0f;
+	EditBox.VSplitLeft(ButtonWidth, &LeftButton, &EditBox);
+	EditBox.VSplitLeft(SUBMARGIN, nullptr, &EditBox);
+	static CButtonContainer s_ConfirmButton;
+	// After touching this button, the button is then added into the button vector. Or it is still virtual.
+	if(GameClient()->m_Menus.DoButton_Menu(&s_ConfirmButton, Localize("Save changes"), UnsavedChanges() ? 0 : 1, &LeftButton))
+	{
+		if(UnsavedChanges())
+		{
+			m_pOldSelectedButton = GameClient()->m_TouchControls.SelectedButton();
+			if(CheckCachedSettings())
+			{
+				if(m_pOldSelectedButton == nullptr)
+				{
+					m_pOldSelectedButton = GameClient()->m_TouchControls.NewButton();
+				}
+				SaveCachedSettingsToTarget(m_pOldSelectedButton);
+				GameClient()->m_TouchControls.SetSelectedButton(m_pOldSelectedButton);
+				GameClient()->m_TouchControls.SetEditingChanges(true);
+				SetUnsavedChanges(false);
+			}
+		}
+	}
+	EditBox.VSplitLeft(ButtonWidth, &LeftButton, &EditBox);
+	EditBox.VSplitLeft(SUBMARGIN, nullptr, &MiddleButton);
+	if(UnsavedChanges())
+	{
+		TextRender()->TextColor(ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f));
+		Ui()->DoLabel(&LeftButton, Localize("Unsaved changes"), 14.0f, TEXTALIGN_MC);
+		TextRender()->TextColor(TextRender()->DefaultTextColor());
+	}
+
+	static CButtonContainer s_CancelButton;
+	if(GameClient()->m_Menus.DoButton_Menu(&s_CancelButton, Localize("Discard changes"), UnsavedChanges() ? 0 : 1, &MiddleButton))
+	{
+		// Since the settings are canceled, reset the cached settings to m_pSelectedButton though selected button didn't change.
+		// Reset changes to default if the button is still virtual.
+		if(UnsavedChanges())
+		{
+			CacheAllSettingsFromTarget(GameClient()->m_TouchControls.SelectedButton());
+			Changed = true;
+			if(!GameClient()->m_TouchControls.NoRealButtonSelected())
+			{
+				SetUnsavedChanges(false);
+			}
+		}
+		// Cancel does nothing if nothing is unsaved.
+	}
+
+	// Functional Buttons.
+	Functional.HSplitTop(ROWGAP, nullptr, &Functional);
+	Functional.HSplitTop(ROWSIZE, &EditBox, &Functional);
+	EditBox.VSplitLeft(ButtonWidth, &LeftButton, &EditBox);
+	EditBox.VSplitLeft(SUBMARGIN, nullptr, &EditBox);
+	static CButtonContainer s_RemoveButton;
+	if(GameClient()->m_Menus.DoButton_Menu(&s_RemoveButton, Localize("Delete"), 0, &LeftButton))
+	{
+		GameClient()->m_Menus.PopupConfirm(Localize("Delete button"), Localize("Are you sure that you want to delete this button?"), Localize("Delete"), Localize("Cancel"), &CMenus::PopupConfirmDeleteButton);
+	}
+
+	EditBox.VSplitLeft(ButtonWidth, &LeftButton, &EditBox);
+	EditBox.VSplitLeft(SUBMARGIN, nullptr, &MiddleButton);
+	// Create a new button with current cached settings. New button will be automatically moved to nearest empty space.
+	static CButtonContainer s_CopyPasteButton;
+	bool Checked = GameClient()->m_TouchControls.NoRealButtonSelected();
+	if(GameClient()->m_Menus.DoButton_Menu(&s_CopyPasteButton, Localize("Duplicate"), UnsavedChanges() || Checked ? 1 : 0, &LeftButton))
+	{
+		if(Checked)
+		{
+			GameClient()->m_Menus.PopupMessage(Localize("New button already created"), Localize("A new button has already been created, please save or delete it before creating another one."), Localize("Ok"));
+		}
+		else if(UnsavedChanges())
+		{
+			GameClient()->m_Menus.PopupMessage(Localize("Unsaved changes"), Localize("Please save your changes before duplicating a button."), Localize("Ok"));
+		}
+		else
+		{
+			CTouchControls::CUnitRect FreeRect = GameClient()->m_TouchControls.UpdatePosition(GameClient()->m_TouchControls.ShownRect().value(), true);
+			if(FreeRect.m_X == -1)
+			{
+				FreeRect.m_W = CTouchControls::BUTTON_SIZE_MINIMUM;
+				FreeRect.m_H = CTouchControls::BUTTON_SIZE_MINIMUM;
+				FreeRect = GameClient()->m_TouchControls.UpdatePosition(FreeRect, true);
+				if(FreeRect.m_X == -1)
+				{
+					GameClient()->m_Menus.PopupMessage(Localize("No space for button"), Localize("There is not enough space available to place another button."), Localize("Ok"));
+				}
+				else
+				{
+					GameClient()->m_Menus.PopupMessage(Localize("No space for button"), Localize("There is not enough space available to place another button with this size. The button has been resized."), Localize("Ok"));
+				}
+			}
+			if(FreeRect.m_X != -1) // FreeRect might change. Don't use else here.
+			{
+				ResetButtonPointers();
+				SetPosInputs(FreeRect);
+				Changed = true;
+				SetUnsavedChanges(true);
+			}
+		}
+	}
+
+	// Deselect a button.
+	static CButtonContainer s_DeselectButton;
+	if(GameClient()->m_Menus.DoButton_Menu(&s_DeselectButton, Localize("Deselect"), 0, &MiddleButton))
+	{
+		m_pOldSelectedButton = GameClient()->m_TouchControls.SelectedButton();
+		m_pNewSelectedButton = nullptr;
+		if(UnsavedChanges())
+		{
+			GameClient()->m_Menus.PopupConfirm(Localize("Unsaved changes"), Localize("You'll lose unsaved changes after deselecting."), Localize("Deselect"), Localize("Cancel"), &CMenus::PopupCancelDeselectButton);
+		}
+		else
+		{
+			GameClient()->m_Menus.PopupCancelDeselectButton();
+		}
+	}
+
+	// This ensures m_pSampleButton being updated always.
+	if(Changed)
+	{
+		UpdateSampleButton();
+	}
+}
+
+bool CMenusIngameTouchControls::RenderLayoutSettingBlock(CUIRect Block)
+{
+	bool Changed = false;
+	CUIRect EditBox, LeftButton, RightButton, PosX, PosY, PosW, PosH;
+	Block.HSplitTop(ROWSIZE, &EditBox, &Block);
+	Block.HSplitTop(ROWGAP, nullptr, &Block);
+	EditBox.VSplitMid(&PosX, &EditBox);
+	if(Ui()->DoClearableEditBox(&m_InputX, &EditBox, FONTSIZE))
+	{
+		InputPosFunction(&m_InputX);
+		Changed = true;
+	}
+
+	// Auto check if the input value contains char that is not digit. If so delete it.
+	Block.HSplitTop(ROWSIZE, &EditBox, &Block);
+	Block.HSplitTop(ROWGAP, nullptr, &Block);
+	EditBox.VSplitMid(&PosY, &EditBox);
+	if(Ui()->DoClearableEditBox(&m_InputY, &EditBox, FONTSIZE))
+	{
+		InputPosFunction(&m_InputY);
+		Changed = true;
+	}
+
+	Block.HSplitTop(ROWSIZE, &EditBox, &Block);
+	Block.HSplitTop(ROWGAP, nullptr, &Block);
+	EditBox.VSplitMid(&PosW, &EditBox);
+	if(Ui()->DoClearableEditBox(&m_InputW, &EditBox, FONTSIZE))
+	{
+		InputPosFunction(&m_InputW);
+		Changed = true;
+	}
+
+	Block.HSplitTop(ROWSIZE, &EditBox, &Block);
+	Block.HSplitTop(ROWGAP, nullptr, &Block);
+	EditBox.VSplitMid(&PosH, &EditBox);
+	if(Ui()->DoClearableEditBox(&m_InputH, &EditBox, FONTSIZE))
+	{
+		InputPosFunction(&m_InputH);
+		Changed = true;
+	}
+	int X = m_InputX.GetInteger();
+	int Y = m_InputY.GetInteger();
+	int W = m_InputW.GetInteger();
+	int H = m_InputH.GetInteger();
+	auto DoValidatedLabel = [&](const CUIRect &LabelBlock, const char *pLabel, int Size, bool Valid) {
+		if(pLabel == nullptr)
+			return;
+		if(!Valid)
+			TextRender()->TextColor(ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f));
+		Ui()->DoLabel(&LabelBlock, pLabel, Size, TEXTALIGN_ML);
+		if(!Valid)
+			TextRender()->TextColor(TextRender()->DefaultTextColor());
+	};
+
+	DoValidatedLabel(PosX, "X:", FONTSIZE, 0 <= X && X + W <= CTouchControls::BUTTON_SIZE_SCALE);
+	DoValidatedLabel(PosY, "Y:", FONTSIZE, 0 <= Y && Y + H <= CTouchControls::BUTTON_SIZE_SCALE);
+	// There're strings without ":" below, so don't localize these with ":" together.
+	char aBuf[64];
+	str_format(aBuf, sizeof(aBuf), "%s:", Localize("Width"));
+	DoValidatedLabel(PosW, aBuf, FONTSIZE, CTouchControls::BUTTON_SIZE_MINIMUM <= W && W <= CTouchControls::BUTTON_SIZE_MAXIMUM);
+	str_format(aBuf, sizeof(aBuf), "%s:", Localize("Height"));
+	DoValidatedLabel(PosH, aBuf, FONTSIZE, CTouchControls::BUTTON_SIZE_MINIMUM <= H && H < +CTouchControls::BUTTON_SIZE_MAXIMUM);
+
+	// Drop down menu for shapes
+	Block.HSplitTop(ROWSIZE, &EditBox, &Block);
+	Block.HSplitTop(ROWGAP, nullptr, &Block);
+	EditBox.VSplitMid(&LeftButton, &RightButton);
+	str_format(aBuf, sizeof(aBuf), "%s:", Localize("Shape"));
+	const char *apShapes[] = {Localize("Rectangle", "Touch button shape"), Localize("Circle", "Touch button shape")};
+	static_assert(std::size(apShapes) == (size_t)CTouchControls::EButtonShape::NUM_SHAPES, "Insufficient shape names");
+	Ui()->DoLabel(&LeftButton, aBuf, FONTSIZE, TEXTALIGN_ML);
+	static CUi::SDropDownState s_ButtonShapeDropDownState;
+	static CScrollRegion s_ButtonShapeDropDownScrollRegion;
+	s_ButtonShapeDropDownState.m_SelectionPopupContext.m_pScrollRegion = &s_ButtonShapeDropDownScrollRegion;
+	const CTouchControls::EButtonShape NewButtonShape = (CTouchControls::EButtonShape)Ui()->DoDropDown(&RightButton, (int)m_CachedShape, apShapes, (int)CTouchControls::EButtonShape::NUM_SHAPES, s_ButtonShapeDropDownState);
+	if(NewButtonShape != m_CachedShape)
+	{
+		m_CachedShape = NewButtonShape;
+		SetUnsavedChanges(true);
+		Changed = true;
+	}
+	return Changed;
+}
+
+bool CMenusIngameTouchControls::RenderBehaviorSettingBlock(CUIRect Block)
+{
+	const char *apLabelTypes[] = {Localize("Plain", "Touch button label type"), Localize("Localized", "Touch button label type"), Localize("Icon", "Touch button label type")};
+	static_assert(std::size(apLabelTypes) == (size_t)CTouchControls::CButtonLabel::EType::NUM_TYPES, "Insufficient label type names");
+	bool Changed = false;
+	CUIRect EditBox, LeftButton, MiddleButton, RightButton;
+	Block.HSplitTop(ROWSIZE, &EditBox, &Block);
+	Block.HSplitTop(ROWGAP, nullptr, &Block);
+	EditBox.VSplitMid(&LeftButton, &MiddleButton);
+	char aBuf[128];
+	str_format(aBuf, sizeof(aBuf), "%s:", Localize("Behavior type"));
+	Ui()->DoLabel(&LeftButton, aBuf, FONTSIZE, TEXTALIGN_ML);
+	static CUi::SDropDownState s_ButtonBehaviorDropDownState;
+	static CScrollRegion s_ButtonBehaviorDropDownScrollRegion;
+	s_ButtonBehaviorDropDownState.m_SelectionPopupContext.m_pScrollRegion = &s_ButtonBehaviorDropDownScrollRegion;
+	const char *apBehaviors[] = {Localize("Bind", "Touch button behavior"), Localize("Bind Toggle", "Touch button behavior"), Localize("Predefined", "Touch button behavior")};
+	const EBehaviorType NewButtonBehavior = (EBehaviorType)Ui()->DoDropDown(&MiddleButton, (int)m_EditBehaviorType, apBehaviors, std::size(apBehaviors), s_ButtonBehaviorDropDownState);
+	if(NewButtonBehavior != m_EditBehaviorType)
+	{
+		m_EditBehaviorType = NewButtonBehavior;
+		if(m_EditBehaviorType == EBehaviorType::BIND)
+		{
+			m_vBehaviorElements[0]->UpdateInputs();
+		}
+		SetUnsavedChanges(true);
+		Changed = true;
+	}
+	if(m_EditBehaviorType != EBehaviorType::BIND_TOGGLE)
+	{
+		Block.HSplitTop(ROWSIZE, &EditBox, &Block);
+		Block.HSplitTop(ROWGAP, nullptr, &Block);
+		EditBox.VSplitMid(&LeftButton, &MiddleButton);
+		if(m_EditBehaviorType == EBehaviorType::BIND)
+		{
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Command"));
+			Ui()->DoLabel(&LeftButton, aBuf, FONTSIZE, TEXTALIGN_ML);
+			if(Ui()->DoClearableEditBox(&m_vBehaviorElements[0]->m_InputCommand, &MiddleButton, 10.0f))
+			{
+				m_vBehaviorElements[0]->UpdateCommand();
+				SetUnsavedChanges(true);
+				Changed = true;
+			}
+		}
+		else if(m_EditBehaviorType == EBehaviorType::PREDEFINED)
+		{
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Type"));
+			Ui()->DoLabel(&LeftButton, aBuf, FONTSIZE, TEXTALIGN_ML);
+			static CUi::SDropDownState s_ButtonPredefinedDropDownState;
+			static CScrollRegion s_ButtonPredefinedDropDownScrollRegion;
+			const char **apPredefineds = PredefinedNames();
+			s_ButtonPredefinedDropDownState.m_SelectionPopupContext.m_pScrollRegion = &s_ButtonPredefinedDropDownScrollRegion;
+			const EPredefinedType NewPredefined = (EPredefinedType)Ui()->DoDropDown(&MiddleButton, (int)m_PredefinedBehaviorType, apPredefineds, std::size(BEHAVIOR_FACTORIES_EDITOR), s_ButtonPredefinedDropDownState);
+			if(NewPredefined != m_PredefinedBehaviorType)
+			{
+				m_PredefinedBehaviorType = NewPredefined;
+				SetUnsavedChanges(true);
+				Changed = true;
+			}
+		}
+		Block.HSplitTop(ROWSIZE, &EditBox, &Block);
+		Block.HSplitTop(ROWGAP, nullptr, &Block);
+		EditBox.VSplitMid(&LeftButton, &MiddleButton);
+		if(m_EditBehaviorType == EBehaviorType::BIND)
+		{
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Label"));
+			Ui()->DoLabel(&LeftButton, aBuf, FONTSIZE, TEXTALIGN_ML);
+			if(Ui()->DoClearableEditBox(&m_vBehaviorElements[0]->m_InputLabel, &MiddleButton, 10.0f))
+			{
+				m_vBehaviorElements[0]->UpdateLabel();
+				SetUnsavedChanges(true);
+				Changed = true;
+			}
+		}
+		else if(m_EditBehaviorType == EBehaviorType::PREDEFINED && m_PredefinedBehaviorType == EPredefinedType::EXTRA_MENU) // Extra menu type, needs to input number.
+		{
+			// Increase & Decrease button share 1/2 width, the rest is for label.
+			EditBox.VSplitLeft(ROWSIZE, &LeftButton, &MiddleButton);
+			static CButtonContainer s_ExtraMenuDecreaseButton;
+			if(Ui()->DoButton_FontIcon(&s_ExtraMenuDecreaseButton, FontIcons::FONT_ICON_MINUS, 0, &LeftButton, BUTTONFLAG_LEFT))
+			{
+				if(m_CachedExtraMenuNumber > 0)
+				{
+					// Menu Number also counts from 1, but written as 0.
+					m_CachedExtraMenuNumber--;
+					SetUnsavedChanges(true);
+					Changed = true;
+				}
+			}
+
+			MiddleButton.VSplitRight(ROWSIZE, &LeftButton, &MiddleButton);
+			Ui()->DoLabel(&LeftButton, std::to_string(m_CachedExtraMenuNumber + 1).c_str(), FONTSIZE, TEXTALIGN_MC);
+			static CButtonContainer s_ExtraMenuIncreaseButton;
+			if(Ui()->DoButton_FontIcon(&s_ExtraMenuIncreaseButton, FontIcons::FONT_ICON_PLUS, 0, &MiddleButton, BUTTONFLAG_LEFT))
+			{
+				if(m_CachedExtraMenuNumber < CTouchControls::MAX_EXTRA_MENU_NUMBER - 1)
+				{
+					m_CachedExtraMenuNumber++;
+					SetUnsavedChanges(true);
+					Changed = true;
+				}
+			}
+		}
+		Block.HSplitTop(ROWSIZE, &EditBox, &Block);
+		Block.HSplitTop(ROWGAP, nullptr, &Block);
+		EditBox.VSplitMid(&LeftButton, &MiddleButton);
+		if(m_EditBehaviorType == EBehaviorType::BIND)
+		{
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Label type"));
+			Ui()->DoLabel(&LeftButton, aBuf, FONTSIZE, TEXTALIGN_ML);
+			CTouchControls::CButtonLabel::EType NewButtonLabelType = m_vBehaviorElements[0]->m_CachedCommands.m_LabelType;
+			MiddleButton.VSplitLeft(MiddleButton.w / 3.0f, &LeftButton, &MiddleButton);
+			MiddleButton.VSplitMid(&MiddleButton, &RightButton);
+			if(GameClient()->m_Menus.DoButton_Menu(&m_vBehaviorElements[0]->m_aLabelTypeRadios[0], apLabelTypes[0], NewButtonLabelType == CTouchControls::CButtonLabel::EType::PLAIN ? 1 : 0, &LeftButton, BUTTONFLAG_LEFT, nullptr, IGraphics::CORNER_L))
+				NewButtonLabelType = CTouchControls::CButtonLabel::EType::PLAIN;
+			if(GameClient()->m_Menus.DoButton_Menu(&m_vBehaviorElements[0]->m_aLabelTypeRadios[1], apLabelTypes[1], NewButtonLabelType == CTouchControls::CButtonLabel::EType::LOCALIZED ? 1 : 0, &MiddleButton, BUTTONFLAG_LEFT, nullptr, IGraphics::CORNER_NONE))
+				NewButtonLabelType = CTouchControls::CButtonLabel::EType::LOCALIZED;
+			if(GameClient()->m_Menus.DoButton_Menu(&m_vBehaviorElements[0]->m_aLabelTypeRadios[2], apLabelTypes[2], NewButtonLabelType == CTouchControls::CButtonLabel::EType::ICON ? 1 : 0, &RightButton, BUTTONFLAG_LEFT, nullptr, IGraphics::CORNER_R))
+				NewButtonLabelType = CTouchControls::CButtonLabel::EType::ICON;
+			if(NewButtonLabelType != m_vBehaviorElements[0]->m_CachedCommands.m_LabelType)
+			{
+				Changed = true;
+				SetUnsavedChanges(true);
+				m_vBehaviorElements[0]->m_CachedCommands.m_LabelType = NewButtonLabelType;
+			}
+		}
+	}
+	else
+	{
+		static CScrollRegion s_BindToggleScrollRegion;
+		CScrollRegionParams ScrollParam;
+		ScrollParam.m_ScrollUnit = 90.0f;
+		vec2 ScrollOffset(0.0f, 0.0f);
+		s_BindToggleScrollRegion.Begin(&Block, &ScrollOffset, &ScrollParam);
+		Block.y += ScrollOffset.y;
+		for(unsigned CommandIndex = 0; CommandIndex < m_vBehaviorElements.size(); CommandIndex++)
+		{
+			Block.HSplitTop(ROWSIZE, &EditBox, &Block);
+			if(s_BindToggleScrollRegion.AddRect(EditBox))
+			{
+				EditBox.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f), IGraphics::CORNER_T, 5.0f);
+				EditBox.VSplitMid(&EditBox, &RightButton);
+				RightButton.VSplitLeft(ScrollParam.m_ScrollbarWidth / 2.0f, nullptr, &RightButton);
+				EditBox.VSplitLeft(ROWSIZE, &MiddleButton, &EditBox);
+				EditBox.VSplitLeft(SUBMARGIN, nullptr, &LeftButton);
+				Ui()->DoLabel(&LeftButton, Localize("Add command"), FONTSIZE, TEXTALIGN_ML);
+				if(Ui()->DoButton_FontIcon(&m_vBehaviorElements[CommandIndex]->m_BindToggleAddButtons, FontIcons::FONT_ICON_PLUS, 0, &MiddleButton, BUTTONFLAG_LEFT))
+				{
+					m_vBehaviorElements.emplace(m_vBehaviorElements.begin() + CommandIndex, std::make_unique<CBehaviorElements>());
+					m_vBehaviorElements[CommandIndex]->UpdateInputs();
+					Changed = true;
+					SetUnsavedChanges(true);
+				}
+				RightButton.VSplitLeft(ROWSIZE, &MiddleButton, &RightButton);
+				RightButton.VSplitLeft(SUBMARGIN, nullptr, &LeftButton);
+				Ui()->DoLabel(&LeftButton, Localize("Delete command"), FONTSIZE, TEXTALIGN_ML);
+				if(Ui()->DoButton_FontIcon(&m_vBehaviorElements[CommandIndex]->m_BindToggleDeleteButtons, FontIcons::FONT_ICON_TRASH, 0, &MiddleButton, BUTTONFLAG_LEFT))
+				{
+					if(m_vBehaviorElements.size() > 2)
+					{
+						if(Ui()->CheckActiveItem(&m_vBehaviorElements[CommandIndex]->m_InputCommand) || Ui()->CheckActiveItem(&m_vBehaviorElements[CommandIndex]->m_InputLabel))
+							Ui()->SetActiveItem(nullptr);
+						m_vBehaviorElements.erase(m_vBehaviorElements.begin() + CommandIndex);
+						continue;
+					}
+					else
+					{
+						m_vBehaviorElements[CommandIndex]->Reset();
+					}
+					SetUnsavedChanges(true);
+					Changed = true;
+				}
+			}
+			Block.HSplitTop(ROWGAP, &EditBox, &Block);
+			if(s_BindToggleScrollRegion.AddRect(EditBox))
+			{
+				EditBox.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f), IGraphics::CORNER_NONE, 0.0f);
+			}
+			Block.HSplitTop(ROWSIZE, &EditBox, &Block);
+			if(s_BindToggleScrollRegion.AddRect(EditBox))
+			{
+				EditBox.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f), IGraphics::CORNER_NONE, 0.0f);
+				EditBox.VSplitMid(&LeftButton, &MiddleButton);
+				MiddleButton.VSplitLeft(ScrollParam.m_ScrollbarWidth / 2.0f, nullptr, &MiddleButton);
+				str_format(aBuf, sizeof(aBuf), "%s:", Localize("Command"));
+				Ui()->DoLabel(&LeftButton, aBuf, FONTSIZE, TEXTALIGN_ML);
+				if(Ui()->DoClearableEditBox(&m_vBehaviorElements[CommandIndex]->m_InputCommand, &MiddleButton, 10.0f))
+				{
+					m_vBehaviorElements[CommandIndex]->UpdateCommand();
+					SetUnsavedChanges(true);
+					Changed = true;
+				}
+			}
+			Block.HSplitTop(ROWGAP, &EditBox, &Block);
+			if(s_BindToggleScrollRegion.AddRect(EditBox))
+			{
+				EditBox.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f), IGraphics::CORNER_NONE, 0.0f);
+			}
+			Block.HSplitTop(ROWSIZE, &EditBox, &Block);
+			if(s_BindToggleScrollRegion.AddRect(EditBox))
+			{
+				EditBox.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f), IGraphics::CORNER_NONE, 0.0f);
+				EditBox.VSplitMid(&LeftButton, &MiddleButton);
+				MiddleButton.VSplitLeft(ScrollParam.m_ScrollbarWidth / 2.0f, nullptr, &MiddleButton);
+				str_format(aBuf, sizeof(aBuf), "%s:", Localize("Label"));
+				Ui()->DoLabel(&LeftButton, aBuf, FONTSIZE, TEXTALIGN_ML);
+				if(Ui()->DoClearableEditBox(&m_vBehaviorElements[CommandIndex]->m_InputLabel, &MiddleButton, 10.0f))
+				{
+					m_vBehaviorElements[CommandIndex]->UpdateLabel();
+					SetUnsavedChanges(true);
+					Changed = true;
+				}
+			}
+			Block.HSplitTop(ROWGAP, &EditBox, &Block);
+			if(s_BindToggleScrollRegion.AddRect(EditBox))
+			{
+				EditBox.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f), IGraphics::CORNER_NONE, 0.0f);
+			}
+			Block.HSplitTop(ROWSIZE, &EditBox, &Block);
+			if(s_BindToggleScrollRegion.AddRect(EditBox))
+			{
+				EditBox.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f), IGraphics::CORNER_B, 5.0f);
+				EditBox.VSplitMid(&LeftButton, &MiddleButton);
+				MiddleButton.VSplitLeft(ScrollParam.m_ScrollbarWidth / 2.0f, nullptr, &MiddleButton);
+				str_format(aBuf, sizeof(aBuf), "%s:", Localize("Label type"));
+				Ui()->DoLabel(&LeftButton, aBuf, FONTSIZE, TEXTALIGN_ML);
+				CTouchControls::CButtonLabel::EType NewButtonLabelType = m_vBehaviorElements[CommandIndex]->m_CachedCommands.m_LabelType;
+				MiddleButton.VSplitLeft(MiddleButton.w / 3.0f, &LeftButton, &MiddleButton);
+				MiddleButton.VSplitMid(&MiddleButton, &RightButton);
+				if(GameClient()->m_Menus.DoButton_Menu(&m_vBehaviorElements[CommandIndex]->m_aLabelTypeRadios[0], apLabelTypes[0], NewButtonLabelType == CTouchControls::CButtonLabel::EType::PLAIN ? 1 : 0, &LeftButton, BUTTONFLAG_LEFT, nullptr, IGraphics::CORNER_L))
+					NewButtonLabelType = CTouchControls::CButtonLabel::EType::PLAIN;
+				if(GameClient()->m_Menus.DoButton_Menu(&m_vBehaviorElements[CommandIndex]->m_aLabelTypeRadios[1], apLabelTypes[1], NewButtonLabelType == CTouchControls::CButtonLabel::EType::LOCALIZED ? 1 : 0, &MiddleButton, BUTTONFLAG_LEFT, nullptr, IGraphics::CORNER_NONE))
+					NewButtonLabelType = CTouchControls::CButtonLabel::EType::LOCALIZED;
+				if(GameClient()->m_Menus.DoButton_Menu(&m_vBehaviorElements[CommandIndex]->m_aLabelTypeRadios[2], apLabelTypes[2], NewButtonLabelType == CTouchControls::CButtonLabel::EType::PLAIN ? 1 : 0, &RightButton, BUTTONFLAG_LEFT, nullptr, IGraphics::CORNER_R))
+					NewButtonLabelType = CTouchControls::CButtonLabel::EType::ICON;
+				if(NewButtonLabelType != m_vBehaviorElements[CommandIndex]->m_CachedCommands.m_LabelType)
+				{
+					Changed = true;
+					SetUnsavedChanges(true);
+					m_vBehaviorElements[CommandIndex]->m_CachedCommands.m_LabelType = NewButtonLabelType;
+				}
+			}
+			Block.HSplitTop(ROWGAP, nullptr, &Block);
+		}
+		Block.HSplitTop(ROWSIZE, &EditBox, &Block);
+		if(s_BindToggleScrollRegion.AddRect(EditBox))
+		{
+			EditBox.VSplitLeft(ROWSIZE, &MiddleButton, &EditBox);
+			EditBox.VSplitLeft(SUBMARGIN, nullptr, &LeftButton);
+			Ui()->DoLabel(&LeftButton, Localize("Add command"), FONTSIZE, TEXTALIGN_ML);
+			static CButtonContainer s_FinalAddButton;
+			if(Ui()->DoButton_FontIcon(&s_FinalAddButton, FontIcons::FONT_ICON_PLUS, 0, &MiddleButton, BUTTONFLAG_LEFT))
+			{
+				m_vBehaviorElements.emplace_back(std::make_unique<CBehaviorElements>());
+				Changed = true;
+				SetUnsavedChanges(true);
+			}
+		}
+		s_BindToggleScrollRegion.End();
+	}
+	return Changed;
+}
+
+bool CMenusIngameTouchControls::RenderVisibilitySettingBlock(CUIRect Block)
+{
+	// Visibilities time. This is button's visibility, not virtual.
+	bool Changed = false;
+	CUIRect EditBox, LeftButton, MiddleButton, RightButton;
+
+	// Block.HSplitTop(ROWGAP, nullptr, &Block);
+	static CScrollRegion s_VisibilityScrollRegion;
+	CScrollRegionParams ScrollParam;
+	ScrollParam.m_ScrollUnit = 90.0f;
+	vec2 ScrollOffset(0.0f, 0.0f);
+	s_VisibilityScrollRegion.Begin(&Block, &ScrollOffset, &ScrollParam);
+	Block.y += ScrollOffset.y;
+
+	static std::vector<CButtonContainer> s_avVisibilitySelector[(int)CTouchControls::EButtonVisibility::NUM_VISIBILITIES];
+	if(s_avVisibilitySelector[0].empty())
+		std::for_each_n(s_avVisibilitySelector, (int)CTouchControls::EButtonVisibility::NUM_VISIBILITIES, [](auto &Element) {
+			Element.resize(3);
+		});
+	const char **ppVisibilities = VisibilityNames();
+	for(unsigned Current = 0; Current < (unsigned)CTouchControls::EButtonVisibility::NUM_VISIBILITIES; ++Current)
+	{
+		Block.HSplitTop(ROWSIZE, &EditBox, &Block);
+		Block.HSplitTop(ROWGAP, nullptr, &Block);
+		if(s_VisibilityScrollRegion.AddRect(EditBox))
+		{
+			EditBox.VSplitMid(&LeftButton, &MiddleButton);
+			MiddleButton.VSplitLeft(ScrollParam.m_ScrollbarWidth / 2.0f, nullptr, &MiddleButton);
+			if(Current < (unsigned)CTouchControls::EButtonVisibility::EXTRA_MENU_1)
+				Ui()->DoLabel(&LeftButton, ppVisibilities[Current], FONTSIZE, TEXTALIGN_ML);
+			else
+			{
+				unsigned ExtraMenuNumber = Current - (unsigned)CTouchControls::EButtonVisibility::EXTRA_MENU_1 + 1;
+				char aBuf[64];
+				str_format(aBuf, sizeof(aBuf), "%s %d", ppVisibilities[(int)CTouchControls::EButtonVisibility::EXTRA_MENU_1], ExtraMenuNumber);
+				Ui()->DoLabel(&LeftButton, aBuf, FONTSIZE, TEXTALIGN_ML);
+			}
+			MiddleButton.VSplitLeft(MiddleButton.w / 3.0f, &LeftButton, &MiddleButton);
+			MiddleButton.VSplitMid(&MiddleButton, &RightButton);
+			if(GameClient()->m_Menus.DoButton_Menu(&s_avVisibilitySelector[Current][(int)EVisibilityType::INCLUDE], Localize("Included", "Touch button visibility preview"), m_aCachedVisibilities[Current] == EVisibilityType::INCLUDE, &LeftButton, BUTTONFLAG_LEFT, nullptr, IGraphics::CORNER_L))
+			{
+				m_aCachedVisibilities[Current] = EVisibilityType::INCLUDE;
+				SetUnsavedChanges(true);
+				Changed = true;
+			}
+			if(GameClient()->m_Menus.DoButton_Menu(&s_avVisibilitySelector[Current][(int)EVisibilityType::EXCLUDE], Localize("Excluded", "Touch button visibility preview"), m_aCachedVisibilities[Current] == EVisibilityType::EXCLUDE, &MiddleButton, BUTTONFLAG_LEFT, nullptr, IGraphics::CORNER_NONE))
+			{
+				m_aCachedVisibilities[Current] = EVisibilityType::EXCLUDE;
+				SetUnsavedChanges(true);
+				Changed = true;
+			}
+			if(GameClient()->m_Menus.DoButton_Menu(&s_avVisibilitySelector[Current][(int)EVisibilityType::IGNORE], Localize("Ignore", "Touch button visibility preview"), m_aCachedVisibilities[Current] == EVisibilityType::IGNORE, &RightButton, BUTTONFLAG_LEFT, nullptr, IGraphics::CORNER_R))
+			{
+				m_aCachedVisibilities[Current] = EVisibilityType::IGNORE;
+				SetUnsavedChanges(true);
+				Changed = true;
+			}
+		}
+	}
+	s_VisibilityScrollRegion.End();
+	return Changed;
+}
+
+void CMenusIngameTouchControls::RenderTouchButtonBrowser(CUIRect MainView)
+{
+	CUIRect LeftButton, MiddleButton, RightButton, EditBox, LabelRect, CommandRect, X, Y, W, H;
+	MainView.h = 600.0f - 40.0f - MainView.y;
+	MainView.Draw(CMenus::ms_ColorTabbarActive, IGraphics::CORNER_B, 10.0f);
+	MainView.Margin(MAINMARGIN, &MainView);
+	MainView.HSplitTop(ROWSIZE, &RightButton, &MainView);
+	Ui()->DoLabel(&RightButton, Localize("Long press on a touch button to select it."), 15.0f, TEXTALIGN_MC);
+	MainView.HSplitTop(MAINMARGIN, nullptr, &MainView);
+	MainView.HSplitTop(ROWSIZE, &EditBox, &MainView);
+	EditBox.VSplitLeft((EditBox.w - SUBMARGIN) / 2.0f, &LeftButton, &EditBox);
+	static CButtonContainer s_NewButton;
+	if(GameClient()->m_Menus.DoButton_Menu(&s_NewButton, Localize("New button"), 0, &LeftButton))
+		NewVirtualButton();
+	EditBox.VSplitLeft(SUBMARGIN, nullptr, &MiddleButton);
+	static CButtonContainer s_SelecteButton;
+	if(GameClient()->m_Menus.DoButton_Menu(&s_SelecteButton, Localize("Select button by touch"), 0, &MiddleButton))
+		GameClient()->m_Menus.SetActive(false);
+
+	MainView.HSplitBottom(ROWSIZE, &MainView, &EditBox);
+	MainView.HSplitBottom(ROWGAP, &MainView, nullptr);
+	EditBox.VSplitLeft(ROWSIZE, &LeftButton, &EditBox);
+	TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
+	TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING);
+	Ui()->DoLabel(&LeftButton, FontIcons::FONT_ICON_MAGNIFYING_GLASS, FONTSIZE, TEXTALIGN_ML);
+	TextRender()->SetRenderFlags(0);
+	TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
+	EditBox.VSplitLeft(SUBMARGIN, nullptr, &EditBox);
+	EditBox.VSplitLeft(EditBox.w / 3.0f, &LeftButton, &EditBox);
+	char aBufSearch[64];
+	str_format(aBufSearch, sizeof(aBufSearch), "%s:", Localize("Search"));
+	Ui()->DoLabel(&LeftButton, aBufSearch, FONTSIZE, TEXTALIGN_ML);
+
+	if(Ui()->DoClearableEditBox(&m_FilterInput, &EditBox, FONTSIZE))
+		m_NeedFilter = true;
+
+	MainView.HSplitTop(ROWGAP, nullptr, &MainView);
+	// Makes the header labels looks better.
+	MainView.HSplitTop(FONTSIZE / CUi::ms_FontmodHeight, &EditBox, &MainView);
+	static CListBox s_PreviewListBox;
+	EditBox.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), IGraphics::CORNER_T, 5.0f);
+	EditBox.VSplitRight(s_PreviewListBox.ScrollbarWidthMax(), &EditBox, nullptr);
+	EditBox.VSplitLeft(ROWSIZE, nullptr, &EditBox);
+
+	float PosWidth = EditBox.w * 4.0f / 9.0f; // Total pos width.
+	const float ButtonWidth = (EditBox.w - PosWidth - SUBMARGIN) / 2.0f;
+	PosWidth = (PosWidth - SUBMARGIN * 4.0f) / 4.0f; // Divided pos width.
+	EditBox.VSplitLeft(ButtonWidth, &LabelRect, &EditBox);
+	EditBox.VSplitLeft(SUBMARGIN, nullptr, &EditBox);
+	EditBox.VSplitLeft(ButtonWidth, &CommandRect, &EditBox);
+	EditBox.VSplitLeft(SUBMARGIN, nullptr, &EditBox);
+	EditBox.VSplitLeft(ButtonWidth, &RightButton, &EditBox);
+	RightButton.VSplitLeft(PosWidth, &X, &RightButton);
+	RightButton.VSplitLeft(SUBMARGIN, nullptr, &RightButton);
+	RightButton.VSplitLeft(PosWidth, &Y, &RightButton);
+	RightButton.VSplitLeft(SUBMARGIN, nullptr, &RightButton);
+	RightButton.VSplitLeft(PosWidth, &W, &RightButton);
+	RightButton.VSplitLeft(SUBMARGIN, nullptr, &RightButton);
+	RightButton.VSplitLeft(PosWidth, &H, &RightButton);
+	RightButton.VSplitLeft(SUBMARGIN, nullptr, &RightButton);
+	const std::array<std::pair<CUIRect *, const char *>, (unsigned)ESortType::NUM_SORTS> aHeaderDatas = {
+		{{&LabelRect, Localize("Label")},
+			{&X, "X"},
+			{&Y, "Y"},
+			{&W, Localize("Width")},
+			{&H, Localize("Height")}}};
+	std::array<std::function<bool(CTouchControls::CTouchButton *, CTouchControls::CTouchButton *)>, (unsigned)ESortType::NUM_SORTS> aSortFunctions = {
+		[](CTouchControls::CTouchButton *pLhs, CTouchControls::CTouchButton *pRhs) {
+			if(pLhs->m_VisibilityCached == pRhs->m_VisibilityCached)
+				return str_comp(pLhs->m_pBehavior->GetLabel().m_pLabel, pRhs->m_pBehavior->GetLabel().m_pLabel) < 0;
+			return pLhs->m_VisibilityCached;
+		},
+		[](CTouchControls::CTouchButton *pLhs, CTouchControls::CTouchButton *pRhs) {
+			if(pLhs->m_VisibilityCached == pRhs->m_VisibilityCached)
+				return pLhs->m_UnitRect.m_X < pRhs->m_UnitRect.m_X;
+			return pLhs->m_VisibilityCached;
+		},
+		[](CTouchControls::CTouchButton *pLhs, CTouchControls::CTouchButton *pRhs) {
+			if(pLhs->m_VisibilityCached == pRhs->m_VisibilityCached)
+				return pLhs->m_UnitRect.m_Y < pRhs->m_UnitRect.m_Y;
+			return pLhs->m_VisibilityCached;
+		},
+		[](CTouchControls::CTouchButton *pLhs, CTouchControls::CTouchButton *pRhs) {
+			if(pLhs->m_VisibilityCached == pRhs->m_VisibilityCached)
+				return pLhs->m_UnitRect.m_W < pRhs->m_UnitRect.m_W;
+			return pLhs->m_VisibilityCached;
+		},
+		[](CTouchControls::CTouchButton *pLhs, CTouchControls::CTouchButton *pRhs) {
+			if(pLhs->m_VisibilityCached == pRhs->m_VisibilityCached)
+				return pLhs->m_UnitRect.m_H < pRhs->m_UnitRect.m_H;
+			return pLhs->m_VisibilityCached;
+		}};
+	for(unsigned HeaderIndex = (unsigned)ESortType::LABEL; HeaderIndex < (unsigned)ESortType::NUM_SORTS; HeaderIndex++)
+	{
+		if(GameClient()->m_Menus.DoButton_GridHeader(&m_aSortHeaderIds[HeaderIndex], "",
+			   (unsigned)m_SortType == HeaderIndex, aHeaderDatas[HeaderIndex].first))
+		{
+			if(m_SortType != (ESortType)HeaderIndex)
+			{
+				m_NeedSort = true;
+				m_SortType = (ESortType)HeaderIndex;
+			}
+		}
+		Ui()->DoLabel(aHeaderDatas[HeaderIndex].first, aHeaderDatas[HeaderIndex].second, FONTSIZE, TEXTALIGN_ML);
+	}
+	// Can't sort buttons basing on command, that's meaning less and too slow.
+	Ui()->DoLabel(&CommandRect, Localize("Command"), FONTSIZE, TEXTALIGN_ML);
+
+	if(m_NeedUpdatePreview)
+	{
+		m_NeedUpdatePreview = false;
+		m_vpButtons = GameClient()->m_TouchControls.GetButtonsEditor();
+		m_NeedSort = true;
+		m_NeedFilter = true;
+	}
+
+	if(m_NeedFilter || m_NeedSort)
+	{
+		// Sorting can be done directly.
+		if(m_NeedSort)
+		{
+			m_NeedSort = false;
+			m_NeedFilter = true;
+			std::sort(m_vpButtons.begin(), m_vpButtons.end(), aSortFunctions[(unsigned)m_SortType]);
+		}
+
+		m_vpMutableButtons = m_vpButtons;
+
+		// Filtering should be done separately.
+		if(m_NeedFilter && !m_FilterInput.IsEmpty())
+		{
+			// Both label and command will be considered.
+			const auto DeleteIt = std::remove_if(m_vpMutableButtons.begin(), m_vpMutableButtons.end(), [&](CTouchControls::CTouchButton *pButton) {
+				if(str_utf8_find_nocase(pButton->m_pBehavior->GetLabel().m_pLabel, m_FilterInput.GetString()) != nullptr)
+					return false;
+				std::string Command = DetermineTouchButtonCommandLabel(pButton);
+				if(str_utf8_find_nocase(Command.c_str(), m_FilterInput.GetString()) != nullptr)
+					return false;
+				return true;
+			});
+			m_vpMutableButtons.erase(DeleteIt, m_vpMutableButtons.end());
+		}
+		m_NeedFilter = false;
+	}
+
+	if(!m_vpMutableButtons.empty())
+	{
+		s_PreviewListBox.SetActive(true);
+		s_PreviewListBox.DoStart(ROWSIZE, m_vpMutableButtons.size(), 1, 4, m_SelectedPreviewButtonIndex, &MainView, true, IGraphics::CORNER_B);
+		for(unsigned ButtonIndex = 0; ButtonIndex < m_vpMutableButtons.size(); ButtonIndex++)
+		{
+			CTouchControls::CTouchButton *pButton = m_vpMutableButtons[ButtonIndex];
+			const CListboxItem ListItem = s_PreviewListBox.DoNextItem(&m_vpMutableButtons[ButtonIndex], m_SelectedPreviewButtonIndex == (int)ButtonIndex);
+			if(ListItem.m_Visible)
+			{
+				EditBox = ListItem.m_Rect;
+				EditBox.VSplitLeft(ROWSIZE, &LeftButton, &EditBox);
+				TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
+				TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING);
+				Ui()->DoLabel(&LeftButton, m_vpMutableButtons[ButtonIndex]->m_VisibilityCached ? FontIcons::FONT_ICON_EYE : FontIcons::FONT_ICON_EYE_SLASH, FONTSIZE, TEXTALIGN_ML);
+				TextRender()->SetRenderFlags(0);
+				TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
+				EditBox.VSplitLeft(LabelRect.w, &LeftButton, &EditBox);
+				const char *pLabel = pButton->m_pBehavior->GetLabel().m_pLabel;
+				const auto LabelType = pButton->m_pBehavior->GetLabel().m_Type;
+				if(LabelType == CTouchControls::CButtonLabel::EType::PLAIN)
+				{
+					SLabelProperties Props;
+					Props.m_MaxWidth = LeftButton.w;
+					Props.m_EnableWidthCheck = false;
+					Props.m_EllipsisAtEnd = true;
+					Ui()->DoLabel(&LeftButton, pLabel, FONTSIZE, TEXTALIGN_ML, Props);
+				}
+				else if(LabelType == CTouchControls::CButtonLabel::EType::LOCALIZED)
+				{
+					pLabel = Localize(pLabel);
+					SLabelProperties Props;
+					Props.m_MaxWidth = LeftButton.w;
+					Props.m_EnableWidthCheck = false;
+					Props.m_EllipsisAtEnd = true;
+					Ui()->DoLabel(&LeftButton, pLabel, FONTSIZE, TEXTALIGN_ML, Props);
+				}
+				else if(LabelType == CTouchControls::CButtonLabel::EType::ICON)
+				{
+					SLabelProperties Props;
+					Props.m_MaxWidth = LeftButton.w;
+					Props.m_EnableWidthCheck = false;
+					Props.m_EllipsisAtEnd = true;
+					TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
+					TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING);
+					Ui()->DoLabel(&LeftButton, pLabel, FONTSIZE, TEXTALIGN_ML, Props);
+					TextRender()->SetRenderFlags(0);
+					TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
+				}
+				EditBox.VSplitLeft(SUBMARGIN, nullptr, &EditBox);
+				EditBox.VSplitLeft(CommandRect.w, &LeftButton, &EditBox);
+				std::string Command = DetermineTouchButtonCommandLabel(pButton);
+				SLabelProperties Props;
+				Props.m_MaxWidth = LeftButton.w;
+				Props.m_EnableWidthCheck = false;
+				Props.m_EllipsisAtEnd = true;
+				Ui()->DoLabel(&LeftButton, Command.c_str(), FONTSIZE, TEXTALIGN_ML, Props);
+				EditBox.VSplitLeft(SUBMARGIN, nullptr, &EditBox);
+				EditBox.VSplitLeft(X.w, &LeftButton, &EditBox);
+				Ui()->DoLabel(&LeftButton, std::to_string(pButton->m_UnitRect.m_X).c_str(), FONTSIZE, TEXTALIGN_ML);
+				EditBox.VSplitLeft(SUBMARGIN, nullptr, &EditBox);
+				EditBox.VSplitLeft(Y.w, &LeftButton, &EditBox);
+				Ui()->DoLabel(&LeftButton, std::to_string(pButton->m_UnitRect.m_Y).c_str(), FONTSIZE, TEXTALIGN_ML);
+				EditBox.VSplitLeft(SUBMARGIN, nullptr, &EditBox);
+				EditBox.VSplitLeft(W.w, &LeftButton, &EditBox);
+				Ui()->DoLabel(&LeftButton, std::to_string(pButton->m_UnitRect.m_W).c_str(), FONTSIZE, TEXTALIGN_ML);
+				EditBox.VSplitLeft(SUBMARGIN, nullptr, &EditBox);
+				EditBox.VSplitLeft(H.w, &LeftButton, &EditBox);
+				Ui()->DoLabel(&LeftButton, std::to_string(pButton->m_UnitRect.m_H).c_str(), FONTSIZE, TEXTALIGN_ML);
+			}
+		}
+
+		m_SelectedPreviewButtonIndex = s_PreviewListBox.DoEnd();
+		if(s_PreviewListBox.WasItemActivated())
+		{
+			GameClient()->m_TouchControls.SetSelectedButton(m_vpMutableButtons[m_SelectedPreviewButtonIndex]);
+			CacheAllSettingsFromTarget(m_vpMutableButtons[m_SelectedPreviewButtonIndex]);
+			SetUnsavedChanges(false);
+			UpdateSampleButton();
+		}
+	}
+	else
+	{
+		// Copied from menus_browser.cpp
+		MainView.HMargin((MainView.h - (16.0f + 18.0f + 8.0f)) / 2.0f, &LeftButton);
+		LeftButton.HSplitTop(16.0f, &LeftButton, &MiddleButton);
+		MiddleButton.HSplitTop(8.0f, nullptr, &MiddleButton);
+		MiddleButton.VMargin((MiddleButton.w - 200.0f) / 2.0f, &MiddleButton);
+		Ui()->DoLabel(&LeftButton, Localize("No buttons match your filter criteria"), 16.0f, TEXTALIGN_MC);
+		static CButtonContainer s_ResetButton;
+		if(GameClient()->m_Menus.DoButton_Menu(&s_ResetButton, Localize("Reset filter"), 0, &MiddleButton))
+		{
+			m_FilterInput.Clear();
+			m_NeedUpdatePreview = true;
+		}
+	}
+}
+
+void CMenusIngameTouchControls::RenderSelectingTab(CUIRect SelectingTab)
+{
+	CUIRect LeftButton;
+	SelectingTab.VSplitLeft(SelectingTab.w / 4.0f, &LeftButton, &SelectingTab);
+	static CButtonContainer s_FileTab;
+	if(GameClient()->m_Menus.DoButton_MenuTab(&s_FileTab, Localize("File"), m_CurrentMenu == EMenuType::MENU_FILE, &LeftButton, IGraphics::CORNER_TL))
+		m_CurrentMenu = EMenuType::MENU_FILE;
+	SelectingTab.VSplitLeft(SelectingTab.w / 3.0f, &LeftButton, &SelectingTab);
+	static CButtonContainer s_ButtonTab;
+	if(GameClient()->m_Menus.DoButton_MenuTab(&s_ButtonTab, Localize("Buttons"), m_CurrentMenu == EMenuType::MENU_BUTTONS, &LeftButton, IGraphics::CORNER_NONE))
+		m_CurrentMenu = EMenuType::MENU_BUTTONS;
+	SelectingTab.VSplitLeft(SelectingTab.w / 2.0f, &LeftButton, &SelectingTab);
+	static CButtonContainer s_SettingsMenuTab;
+	if(GameClient()->m_Menus.DoButton_MenuTab(&s_SettingsMenuTab, Localize("Settings"), m_CurrentMenu == EMenuType::MENU_SETTINGS, &LeftButton, IGraphics::CORNER_NONE))
+		m_CurrentMenu = EMenuType::MENU_SETTINGS;
+	SelectingTab.VSplitLeft(SelectingTab.w / 1.0f, &LeftButton, &SelectingTab);
+	static CButtonContainer s_PreviewTab;
+	if(GameClient()->m_Menus.DoButton_MenuTab(&s_PreviewTab, Localize("Preview"), m_CurrentMenu == EMenuType::MENU_PREVIEW, &LeftButton, IGraphics::CORNER_TR))
+		m_CurrentMenu = EMenuType::MENU_PREVIEW;
+}
+
+void CMenusIngameTouchControls::RenderConfigSettings(CUIRect MainView)
+{
+	CUIRect EditBox, Row, Label, Button;
+	MainView.h = 2 * MAINMARGIN + 4 * ROWSIZE + 3 * ROWGAP;
+	MainView.Draw(CMenus::ms_ColorTabbarActive, IGraphics::CORNER_B, 10.0f);
+	MainView.VMargin(MAINMARGIN, &MainView);
+	MainView.HSplitTop(MAINMARGIN, nullptr, &MainView);
+	MainView.HSplitTop(ROWSIZE, &EditBox, &MainView);
+	static CButtonContainer s_ActiveColorPicker;
+	ColorHSLA ColorTest = GameClient()->m_Menus.DoLine_ColorPicker(&s_ActiveColorPicker, ROWSIZE, 15.0f, 5.0f, &EditBox, Localize("Active color"), &m_ColorActive, GameClient()->m_TouchControls.DefaultBackgroundColorActive(), false, nullptr, true);
+	GameClient()->m_TouchControls.SetBackgroundColorActive(color_cast<ColorRGBA>(ColorHSLA(m_ColorActive, true)));
+	if(color_cast<ColorRGBA>(ColorTest) != GameClient()->m_TouchControls.BackgroundColorActive())
+		GameClient()->m_TouchControls.SetEditingChanges(true);
+
+	MainView.HSplitTop(ROWGAP, nullptr, &MainView);
+	MainView.HSplitTop(ROWSIZE, &EditBox, &MainView);
+	static CButtonContainer s_InactiveColorPicker;
+	ColorTest = GameClient()->m_Menus.DoLine_ColorPicker(&s_InactiveColorPicker, ROWSIZE, 15.0f, 5.0f, &EditBox, Localize("Inactive color"), &m_ColorInactive, GameClient()->m_TouchControls.DefaultBackgroundColorInactive(), false, nullptr, true);
+	GameClient()->m_TouchControls.SetBackgroundColorInactive(color_cast<ColorRGBA>(ColorHSLA(m_ColorInactive, true)));
+	if(color_cast<ColorRGBA>(ColorTest) != GameClient()->m_TouchControls.BackgroundColorInactive())
+		GameClient()->m_TouchControls.SetEditingChanges(true);
+
+	MainView.HSplitTop(ROWGAP, nullptr, &MainView);
+	MainView.HSplitTop(ROWSIZE, &Row, &MainView);
+	Row.VSplitMid(&Label, &Button);
+	Ui()->DoLabel(&Label, Localize("Direct touch input while ingame"), FONTSIZE, TEXTALIGN_ML);
+
+	const char *apIngameTouchModes[(int)CTouchControls::EDirectTouchIngameMode::NUM_STATES] = {Localize("Disabled", "Direct touch input"), Localize("Active action", "Direct touch input"), Localize("Aim", "Direct touch input"), Localize("Fire", "Direct touch input"), Localize("Hook", "Direct touch input")};
+	const CTouchControls::EDirectTouchIngameMode OldDirectTouchIngame = GameClient()->m_TouchControls.DirectTouchIngame();
+	static CUi::SDropDownState s_DirectTouchIngameDropDownState;
+	static CScrollRegion s_DirectTouchIngameDropDownScrollRegion;
+	s_DirectTouchIngameDropDownState.m_SelectionPopupContext.m_pScrollRegion = &s_DirectTouchIngameDropDownScrollRegion;
+	const CTouchControls::EDirectTouchIngameMode NewDirectTouchIngame = (CTouchControls::EDirectTouchIngameMode)Ui()->DoDropDown(&Button, (int)OldDirectTouchIngame, apIngameTouchModes, std::size(apIngameTouchModes), s_DirectTouchIngameDropDownState);
+	if(OldDirectTouchIngame != NewDirectTouchIngame)
+	{
+		GameClient()->m_TouchControls.SetDirectTouchIngame(NewDirectTouchIngame);
+	}
+
+	MainView.HSplitTop(ROWGAP, nullptr, &MainView);
+	MainView.HSplitTop(ROWSIZE, &Row, &MainView);
+	Row.VSplitMid(&Label, &Button);
+	Ui()->DoLabel(&Label, Localize("Direct touch input while spectating"), FONTSIZE, TEXTALIGN_ML);
+
+	const char *apSpectateTouchModes[(int)CTouchControls::EDirectTouchSpectateMode::NUM_STATES] = {Localize("Disabled", "Direct touch input"), Localize("Aim", "Direct touch input")};
+	const CTouchControls::EDirectTouchSpectateMode OldDirectTouchSpectate = GameClient()->m_TouchControls.DirectTouchSpectate();
+	static CUi::SDropDownState s_DirectTouchSpectateDropDownState;
+	static CScrollRegion s_DirectTouchSpectateDropDownScrollRegion;
+	s_DirectTouchSpectateDropDownState.m_SelectionPopupContext.m_pScrollRegion = &s_DirectTouchSpectateDropDownScrollRegion;
+	const CTouchControls::EDirectTouchSpectateMode NewDirectTouchSpectate = (CTouchControls::EDirectTouchSpectateMode)Ui()->DoDropDown(&Button, (int)OldDirectTouchSpectate, apSpectateTouchModes, std::size(apSpectateTouchModes), s_DirectTouchSpectateDropDownState);
+	if(OldDirectTouchSpectate != NewDirectTouchSpectate)
+	{
+		GameClient()->m_TouchControls.SetDirectTouchSpectate(NewDirectTouchSpectate);
+	}
+}
+
+void CMenusIngameTouchControls::RenderPreviewSettings(CUIRect MainView)
+{
+	CUIRect EditBox;
+	MainView.h = 600.0f - 40.0f - MainView.y;
+	MainView.Draw(CMenus::ms_ColorTabbarActive, IGraphics::CORNER_B, 10.0f);
+	MainView.VMargin(MAINMARGIN, &MainView);
+	MainView.HMargin(MAINMARGIN, &MainView);
+	MainView.HSplitTop(ROWSIZE, &EditBox, &MainView);
+	Ui()->DoLabel(&EditBox, Localize("Preview button visibility while the editor is active."), FONTSIZE, TEXTALIGN_MC);
+	MainView.HSplitBottom(ROWSIZE, &MainView, &EditBox);
+	MainView.HSplitBottom(ROWGAP, &MainView, nullptr);
+	EditBox.VSplitLeft(MAINMARGIN, nullptr, &EditBox);
+	static CButtonContainer s_PreviewAllCheckBox;
+	bool Preview = GameClient()->m_TouchControls.PreviewAllButtons();
+	if(GameClient()->m_Menus.DoButton_CheckBox(&s_PreviewAllCheckBox, Localize("Show all buttons"), Preview ? 1 : 0, &EditBox))
+	{
+		GameClient()->m_TouchControls.SetPreviewAllButtons(!Preview);
+	}
+	MainView.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f), IGraphics::CORNER_ALL, 10.0f);
+	MainView.VMargin(MAINMARGIN, &MainView);
+	MainView.HMargin(ROWGAP, &MainView);
+	static CScrollRegion s_VirtualVisibilityScrollRegion;
+	CScrollRegionParams ScrollParam;
+	ScrollParam.m_ScrollUnit = 90.0f;
+	vec2 ScrollOffset(0.0f, 0.0f);
+	s_VirtualVisibilityScrollRegion.Begin(&MainView, &ScrollOffset, &ScrollParam);
+	MainView.y += ScrollOffset.y;
+	std::array<bool, (size_t)CTouchControls::EButtonVisibility::NUM_VISIBILITIES> aVirtualVisibilities = GameClient()->m_TouchControls.VirtualVisibilities();
+	const char **ppVisibilities = VisibilityNames();
+	for(unsigned Current = 0; Current < (unsigned)CTouchControls::EButtonVisibility::NUM_VISIBILITIES; ++Current)
+	{
+		MainView.HSplitTop(ROWSIZE + ROWGAP, &EditBox, &MainView);
+		if(s_VirtualVisibilityScrollRegion.AddRect(EditBox))
+		{
+			EditBox.HSplitTop(ROWGAP, nullptr, &EditBox);
+			if(Current < (unsigned)CTouchControls::EButtonVisibility::EXTRA_MENU_1)
+			{
+				if(GameClient()->m_Menus.DoButton_CheckBox(&m_aVisibilityIds[Current], ppVisibilities[Current], aVirtualVisibilities[Current] == 1, &EditBox))
+					GameClient()->m_TouchControls.ReverseVirtualVisibilities(Current);
+			}
+			else
+			{
+				unsigned ExtraMenuNumber = Current - (unsigned)CTouchControls::EButtonVisibility::EXTRA_MENU_1 + 1;
+				char aBuf[64];
+				str_format(aBuf, sizeof(aBuf), "%s %d", ppVisibilities[(int)CTouchControls::EButtonVisibility::EXTRA_MENU_1], ExtraMenuNumber);
+				if(GameClient()->m_Menus.DoButton_CheckBox(&m_aVisibilityIds[Current], aBuf, aVirtualVisibilities[Current] == 1, &EditBox))
+					GameClient()->m_TouchControls.ReverseVirtualVisibilities(Current);
+			}
+		}
+	}
+	s_VirtualVisibilityScrollRegion.End();
+}
+
+void CMenusIngameTouchControls::RenderTouchControlsEditor(CUIRect MainView)
+{
+	CUIRect Label, Button, Row;
+	MainView.h = 2 * MAINMARGIN + 4 * ROWSIZE + 3 * ROWGAP;
+	MainView.Draw(CMenus::ms_ColorTabbarActive, IGraphics::CORNER_B, 10.0f);
+	MainView.Margin(MAINMARGIN, &MainView);
+
+	MainView.HSplitTop(ROWSIZE, &Row, &MainView);
+	MainView.HSplitTop(ROWGAP, nullptr, &MainView);
+	Row.VSplitLeft(Row.h, nullptr, &Row);
+	Row.VSplitRight(Row.h, &Row, &Button);
+	Row.VMargin(5.0f, &Label);
+	Ui()->DoLabel(&Label, Localize("Edit touch controls"), 20.0f, TEXTALIGN_MC);
+
+	static CButtonContainer s_OpenHelpButton;
+	if(Ui()->DoButton_FontIcon(&s_OpenHelpButton, FontIcons::FONT_ICON_QUESTION, 0, &Button, BUTTONFLAG_LEFT))
+	{
+		Client()->ViewLink(Localize("https://wiki.ddnet.org/wiki/Touch_controls"));
+	}
+
+	MainView.HSplitTop(ROWSIZE, &Row, &MainView);
+	MainView.HSplitTop(ROWGAP, nullptr, &MainView);
+
+	Row.VSplitLeft((Row.w - SUBMARGIN) / 2.0f, &Button, &Row);
+	static CButtonContainer s_SaveConfigurationButton;
+	if(GameClient()->m_Menus.DoButton_Menu(&s_SaveConfigurationButton, Localize("Save changes"), GameClient()->m_TouchControls.HasEditingChanges() ? 0 : 1, &Button))
+	{
+		if(GameClient()->m_TouchControls.SaveConfigurationToFile())
+		{
+			GameClient()->m_TouchControls.SetEditingChanges(false);
+		}
+		else
+		{
+			SWarning Warning(Localize("Error saving touch controls"), Localize("Could not save touch controls to file. See local console for details."));
+			Warning.m_AutoHide = false;
+			Client()->AddWarning(Warning);
+		}
+	}
+
+	Row.VSplitLeft(SUBMARGIN, nullptr, &Button);
+	if(GameClient()->m_TouchControls.HasEditingChanges())
+	{
+		TextRender()->TextColor(ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f));
+		Ui()->DoLabel(&Button, Localize("Unsaved changes"), 14.0f, TEXTALIGN_MC);
+		TextRender()->TextColor(TextRender()->DefaultTextColor());
+	}
+
+	MainView.HSplitTop(ROWSIZE, &Row, &MainView);
+	MainView.HSplitTop(ROWGAP, nullptr, &MainView);
+
+	Row.VSplitLeft((Row.w - SUBMARGIN) / 2.0f, &Button, &Row);
+	static CButtonContainer s_DiscardChangesButton;
+	if(GameClient()->m_Menus.DoButton_Menu(&s_DiscardChangesButton, Localize("Discard changes"), GameClient()->m_TouchControls.HasEditingChanges() ? 0 : 1, &Button))
+	{
+		GameClient()->m_Menus.PopupConfirm(Localize("Discard changes"),
+			Localize("Are you sure that you want to discard the current changes to the touch controls?"),
+			Localize("Yes"), Localize("No"),
+			&CMenus::PopupConfirmDiscardTouchControlsChanges);
+	}
+
+	Row.VSplitLeft(SUBMARGIN, nullptr, &Button);
+	static CButtonContainer s_ResetButton;
+	if(GameClient()->m_Menus.DoButton_Menu(&s_ResetButton, Localize("Reset to defaults"), 0, &Button))
+	{
+		GameClient()->m_Menus.PopupConfirm(Localize("Reset to defaults"),
+			Localize("Are you sure that you want to reset the touch controls to default?"),
+			Localize("Yes"), Localize("No"),
+			&CMenus::PopupConfirmResetTouchControls);
+	}
+
+	MainView.HSplitTop(ROWSIZE, &Row, &MainView);
+	MainView.HSplitTop(MAINMARGIN, nullptr, &MainView);
+
+	Row.VSplitLeft((Row.w - SUBMARGIN) / 2.0f, &Button, &Row);
+	static CButtonContainer s_ClipboardImportButton;
+	if(GameClient()->m_Menus.DoButton_Menu(&s_ClipboardImportButton, Localize("Import from clipboard"), 0, &Button))
+	{
+		GameClient()->m_Menus.PopupConfirm(Localize("Import from clipboard"),
+			Localize("Are you sure that you want to import the touch controls from the clipboard? This will overwrite your current touch controls."),
+			Localize("Yes"), Localize("No"),
+			&CMenus::PopupConfirmImportTouchControlsClipboard);
+	}
+
+	Row.VSplitLeft(SUBMARGIN, nullptr, &Button);
+	static CButtonContainer s_ClipboardExportButton;
+	if(GameClient()->m_Menus.DoButton_Menu(&s_ClipboardExportButton, Localize("Export to clipboard"), 0, &Button))
+	{
+		GameClient()->m_TouchControls.SaveConfigurationToClipboard();
+	}
+}
+
+// Check if CTouchControls need CMenus to open any popups.
+void CMenusIngameTouchControls::DoPopupType(CTouchControls::CPopupParam PopupParam)
+{
+	m_pOldSelectedButton = PopupParam.m_pOldSelectedButton;
+	m_pNewSelectedButton = PopupParam.m_pNewSelectedButton;
+	m_CloseMenu = !PopupParam.m_KeepMenuOpen;
+	switch(PopupParam.m_PopupType)
+	{
+	case CTouchControls::EPopupType::BUTTON_CHANGED: ChangeSelectedButtonWhileHavingUnsavedChanges(); break;
+	case CTouchControls::EPopupType::NO_SPACE: NoSpaceForOverlappingButton(); break;
+	case CTouchControls::EPopupType::BUTTON_INVISIBLE: SelectedButtonNotVisible(); break;
+	// The NUM_POPUPS will not call the function.
+	default: dbg_assert(false, "Unknown popup type = %d.", (int)PopupParam.m_PopupType);
+	}
+}
+
+void CMenusIngameTouchControls::ChangeSelectedButtonWhileHavingUnsavedChanges() const
+{
+	// Both old and new button pointer can be nullptr.
+	// Saving settings to the old selected button(nullptr = create), then switch to new selected button(new = haven't created).
+	GameClient()->m_Menus.PopupConfirm(Localize("Unsaved changes"), Localize("Save all changes before switching selected button?"), Localize("Save"), Localize("Discard"), &CMenus::PopupConfirmChangeSelectedButton, CMenus::POPUP_NONE, &CMenus::PopupCancelChangeSelectedButton);
+}
+
+void CMenusIngameTouchControls::NoSpaceForOverlappingButton() const
+{
+	GameClient()->m_Menus.PopupMessage(Localize("No space for button"), Localize("There is not enough space available for the button. Check its visibilities and size."), Localize("Ok"));
+}
+
+void CMenusIngameTouchControls::SelectedButtonNotVisible()
+{
+	// Cancel shouldn't do anything but open ingame menu, the menu is already opened now.
+	m_CloseMenu = false;
+	GameClient()->m_Menus.PopupConfirm(Localize("Selected button not visible"), Localize("The selected button is not visible. Do you want to deselect it or edit its visibility?"), Localize("Deselect"), Localize("Edit"), &CMenus::PopupConfirmSelectedNotVisible);
+}
+
+bool CMenusIngameTouchControls::UnsavedChanges() const
+{
+	return GameClient()->m_TouchControls.HasUnsavedChanges();
+}
+
+void CMenusIngameTouchControls::SetUnsavedChanges(bool UnsavedChanges)
+{
+	GameClient()->m_TouchControls.SetUnsavedChanges(UnsavedChanges);
+}
+
+// Check if cached settings are legal.
+bool CMenusIngameTouchControls::CheckCachedSettings() const
+{
+	std::vector<const char *> vpErrors;
+	char aBuf[256];
+	int X = m_InputX.GetInteger();
+	int Y = m_InputY.GetInteger();
+	int W = m_InputW.GetInteger();
+	int H = m_InputH.GetInteger();
+	// Illegal size settings.
+	if(W < CTouchControls::BUTTON_SIZE_MINIMUM || W > CTouchControls::BUTTON_SIZE_MAXIMUM || H < CTouchControls::BUTTON_SIZE_MINIMUM || H > CTouchControls::BUTTON_SIZE_MAXIMUM)
+	{
+		str_format(aBuf, sizeof(aBuf), Localize("Width and height are required to be within the range from %d to %d."), CTouchControls::BUTTON_SIZE_MINIMUM, CTouchControls::BUTTON_SIZE_MAXIMUM);
+		vpErrors.emplace_back(aBuf);
+	}
+	if(X < 0 || Y < 0 || X + W > CTouchControls::BUTTON_SIZE_SCALE || Y + H > CTouchControls::BUTTON_SIZE_SCALE)
+	{
+		vpErrors.emplace_back(Localize("Button position is outside of the screen."));
+	}
+	if(GameClient()->m_TouchControls.IsRectOverlapping({X, Y, W, H}))
+	{
+		vpErrors.emplace_back(Localize("The selected button is overlapping with other buttons."));
+	}
+	if(!vpErrors.empty())
+	{
+		char aErrorMessage[1024] = "";
+		for(const char *pError : vpErrors)
+		{
+			if(aErrorMessage[0] != '\0')
+				str_append(aErrorMessage, "\n");
+			str_append(aErrorMessage, pError);
+		}
+		GameClient()->m_Menus.PopupMessage(Localize("Wrong button settings"), aErrorMessage, Localize("Ok"));
+		return false;
+	}
+	else
+	{
+		return true;
+	}
+}
+
+// All default settings are here.
+void CMenusIngameTouchControls::ResetCachedSettings()
+{
+	// Reset all cached values.
+	m_EditBehaviorType = EBehaviorType::BIND;
+	m_PredefinedBehaviorType = EPredefinedType::EXTRA_MENU;
+	m_CachedExtraMenuNumber = 0;
+	m_vBehaviorElements.clear();
+	m_vBehaviorElements.emplace_back(std::make_unique<CBehaviorElements>());
+	m_vBehaviorElements.emplace_back(std::make_unique<CBehaviorElements>());
+	m_aCachedVisibilities.fill(EVisibilityType::IGNORE); // 2 means don't have the visibility, true:1,false:0
+	m_aCachedVisibilities[(int)CTouchControls::EButtonVisibility::DEMO_PLAYER] = EVisibilityType::EXCLUDE;
+	// These things can't be empty. std::stoi can't cast empty string.
+	SetPosInputs({0, 0, CTouchControls::BUTTON_SIZE_MINIMUM, CTouchControls::BUTTON_SIZE_MINIMUM});
+	m_CachedShape = CTouchControls::EButtonShape::RECT;
+}
+
+// This is called when the Touch button editor is rendered as well when selectedbutton changes. Used for updating all cached settings.
+void CMenusIngameTouchControls::CacheAllSettingsFromTarget(CTouchControls::CTouchButton *pTargetButton)
+{
+	ResetCachedSettings();
+	if(pTargetButton == nullptr)
+	{
+		return; // Nothing to cache.
+	}
+	// These values can't be null. The constructor has been updated. Default:{0,0,CTouchControls::BUTTON_SIZE_MINIMUM,CTouchControls::BUTTON_SIZE_MINIMUM}, shape = rect.
+	SetPosInputs(pTargetButton->m_UnitRect);
+	m_CachedShape = pTargetButton->m_Shape;
+	for(const auto &Visibility : pTargetButton->m_vVisibilities)
+	{
+		dbg_assert((int)Visibility.m_Type < (int)CTouchControls::EButtonVisibility::NUM_VISIBILITIES, "Target button has out of bound visibility type: %d", (int)Visibility.m_Type);
+		m_aCachedVisibilities[(int)Visibility.m_Type] = Visibility.m_Parity ? EVisibilityType::INCLUDE : EVisibilityType::EXCLUDE;
+	}
+
+	// These are behavior values.
+	if(pTargetButton->m_pBehavior != nullptr)
+	{
+		const char *pBehaviorType = pTargetButton->m_pBehavior->GetBehaviorType();
+		if(str_comp(pBehaviorType, CTouchControls::CBindTouchButtonBehavior::BEHAVIOR_TYPE) == 0)
+		{
+			m_EditBehaviorType = EBehaviorType::BIND;
+			auto *pTargetBehavior = static_cast<CTouchControls::CBindTouchButtonBehavior *>(pTargetButton->m_pBehavior.get());
+			// m_LabelType must not be null. Default value is PLAIN.
+			m_vBehaviorElements[0]->m_CachedCommands = {pTargetBehavior->GetLabel().m_pLabel, pTargetBehavior->GetLabel().m_Type, pTargetBehavior->GetCommand()};
+			m_vBehaviorElements[0]->UpdateInputs();
+		}
+		else if(str_comp(pBehaviorType, CTouchControls::CBindToggleTouchButtonBehavior::BEHAVIOR_TYPE) == 0)
+		{
+			m_EditBehaviorType = EBehaviorType::BIND_TOGGLE;
+			auto *pTargetBehavior = static_cast<CTouchControls::CBindToggleTouchButtonBehavior *>(pTargetButton->m_pBehavior.get());
+			auto TargetCommands = pTargetBehavior->GetCommand();
+			// Can't use resize here :(
+			while(m_vBehaviorElements.size() > maximum<size_t>(TargetCommands.size(), 2))
+				m_vBehaviorElements.pop_back();
+			while(m_vBehaviorElements.size() < maximum<size_t>(TargetCommands.size(), 2))
+				m_vBehaviorElements.emplace_back(std::make_unique<CBehaviorElements>());
+			for(unsigned CommandIndex = 0; CommandIndex < TargetCommands.size(); CommandIndex++)
+			{
+				m_vBehaviorElements[CommandIndex]->m_CachedCommands = TargetCommands[CommandIndex];
+				m_vBehaviorElements[CommandIndex]->UpdateInputs();
+			}
+		}
+		else if(str_comp(pBehaviorType, CTouchControls::CPredefinedTouchButtonBehavior::BEHAVIOR_TYPE) == 0)
+		{
+			m_EditBehaviorType = EBehaviorType::PREDEFINED;
+			auto *pTargetBehavior = static_cast<CTouchControls::CPredefinedTouchButtonBehavior *>(pTargetButton->m_pBehavior.get());
+			const char *pPredefinedType = pTargetBehavior->GetPredefinedType();
+			if(pPredefinedType == nullptr)
+				m_PredefinedBehaviorType = EPredefinedType::EXTRA_MENU;
+			else
+				m_PredefinedBehaviorType = (EPredefinedType)CalculatePredefinedType(pPredefinedType);
+			dbg_assert(m_PredefinedBehaviorType != EPredefinedType::NUM_PREDEFINEDS, "Detected out of bound m_PredefinedBehaviorType. pPredefinedType = %s", pPredefinedType);
+
+			if(m_PredefinedBehaviorType == EPredefinedType::EXTRA_MENU)
+			{
+				auto *pExtraMenuBehavior = static_cast<CTouchControls::CExtraMenuTouchButtonBehavior *>(pTargetButton->m_pBehavior.get());
+				m_CachedExtraMenuNumber = pExtraMenuBehavior->GetNumber();
+			}
+		}
+		else // Empty
+			dbg_assert(false, "Detected out of bound value in m_EditBehaviorType");
+	}
+}
+
+// Will override everything in the button. If nullptr is passed, a new button will be created.
+void CMenusIngameTouchControls::SaveCachedSettingsToTarget(CTouchControls::CTouchButton *pTargetButton) const
+{
+	dbg_assert(pTargetButton != nullptr, "Target button to recieve is nullptr.");
+	pTargetButton->m_UnitRect.m_W = std::clamp(m_InputW.GetInteger(), CTouchControls::BUTTON_SIZE_MINIMUM, CTouchControls::BUTTON_SIZE_MAXIMUM);
+	pTargetButton->m_UnitRect.m_H = std::clamp(m_InputH.GetInteger(), CTouchControls::BUTTON_SIZE_MINIMUM, CTouchControls::BUTTON_SIZE_MAXIMUM);
+	pTargetButton->m_UnitRect.m_X = std::clamp(m_InputX.GetInteger(), 0, CTouchControls::BUTTON_SIZE_SCALE - pTargetButton->m_UnitRect.m_W);
+	pTargetButton->m_UnitRect.m_Y = std::clamp(m_InputY.GetInteger(), 0, CTouchControls::BUTTON_SIZE_SCALE - pTargetButton->m_UnitRect.m_H);
+	pTargetButton->m_vVisibilities.clear();
+	for(unsigned Iterator = (unsigned)CTouchControls::EButtonVisibility::INGAME; Iterator < (unsigned)CTouchControls::EButtonVisibility::NUM_VISIBILITIES; ++Iterator)
+	{
+		if(m_aCachedVisibilities[Iterator] != EVisibilityType::IGNORE)
+			pTargetButton->m_vVisibilities.emplace_back((CTouchControls::EButtonVisibility)Iterator, m_aCachedVisibilities[Iterator] == EVisibilityType::INCLUDE);
+	}
+	pTargetButton->m_Shape = m_CachedShape;
+	pTargetButton->UpdateScreenFromUnitRect();
+
+	// Make a new behavior class instead of modify the original one.
+	if(m_EditBehaviorType == EBehaviorType::BIND)
+	{
+		pTargetButton->m_pBehavior = std::make_unique<CTouchControls::CBindTouchButtonBehavior>(
+			m_vBehaviorElements[0]->m_CachedCommands.m_Label.c_str(),
+			m_vBehaviorElements[0]->m_CachedCommands.m_LabelType,
+			m_vBehaviorElements[0]->m_CachedCommands.m_Command.c_str());
+	}
+	else if(m_EditBehaviorType == EBehaviorType::BIND_TOGGLE)
+	{
+		std::vector<CTouchControls::CBindToggleTouchButtonBehavior::CCommand> vMovingBehavior;
+		vMovingBehavior.reserve(m_vBehaviorElements.size());
+		for(const auto &Element : m_vBehaviorElements)
+			vMovingBehavior.emplace_back(Element->m_CachedCommands);
+		pTargetButton->m_pBehavior = std::make_unique<CTouchControls::CBindToggleTouchButtonBehavior>(std::move(vMovingBehavior));
+	}
+	else if(m_EditBehaviorType == EBehaviorType::PREDEFINED)
+	{
+		if(m_PredefinedBehaviorType == EPredefinedType::EXTRA_MENU)
+			pTargetButton->m_pBehavior = std::make_unique<CTouchControls::CExtraMenuTouchButtonBehavior>(CTouchControls::CExtraMenuTouchButtonBehavior(m_CachedExtraMenuNumber));
+		else
+			pTargetButton->m_pBehavior = BEHAVIOR_FACTORIES_EDITOR[(int)m_PredefinedBehaviorType].m_Factory();
+	}
+	else
+	{
+		dbg_assert(false, "Unknown m_EditBehaviorType = %d", (int)m_EditBehaviorType);
+	}
+	pTargetButton->UpdatePointers();
+}
+
+// Used for setting the value of four position input box to the unitrect.
+void CMenusIngameTouchControls::SetPosInputs(CTouchControls::CUnitRect MyRect)
+{
+	m_InputX.SetInteger(MyRect.m_X);
+	m_InputY.SetInteger(MyRect.m_Y);
+	m_InputW.SetInteger(MyRect.m_W);
+	m_InputH.SetInteger(MyRect.m_H);
+}
+
+// Used to make sure the input box is numbers only, also clamp the value.
+void CMenusIngameTouchControls::InputPosFunction(CLineInputNumber *pInput)
+{
+	int InputValue = pInput->GetInteger();
+	// Deal with the "-1" FindPositionXY give.
+	InputValue = std::clamp(InputValue, 0, CTouchControls::BUTTON_SIZE_SCALE);
+	pInput->SetInteger(InputValue);
+	SetUnsavedChanges(true);
+}
+
+// Update m_pSampleButton in CTouchControls. The Samplebutton is used for showing on screen.
+void CMenusIngameTouchControls::UpdateSampleButton()
+{
+	GameClient()->m_TouchControls.RemakeSampleButton();
+	SaveCachedSettingsToTarget(GameClient()->m_TouchControls.SampleButton());
+	GameClient()->m_TouchControls.SetShownRect(GameClient()->m_TouchControls.SampleButton()->m_UnitRect);
+}
+
+// Not inline so there's no more includes in menus.h. A shortcut to the function in CTouchControls.
+void CMenusIngameTouchControls::ResetButtonPointers()
+{
+	GameClient()->m_TouchControls.ResetButtonPointers();
+}
+
+// New button doesn't create a real button, instead it reset the Samplebutton to cache every setting. When saving a the Samplebutton then a real button will be created.
+void CMenusIngameTouchControls::NewVirtualButton()
+{
+	CTouchControls::CUnitRect FreeRect = GameClient()->m_TouchControls.UpdatePosition({0, 0, CTouchControls::BUTTON_SIZE_MINIMUM, CTouchControls::BUTTON_SIZE_MINIMUM}, true);
+	ResetButtonPointers();
+	ResetCachedSettings();
+	SetPosInputs(FreeRect);
+	UpdateSampleButton();
+	SetUnsavedChanges(true);
+}
+
+// Used for updating cached settings or something else only when opening the editor, to reduce lag. Issues come from CTouchControls.
+void CMenusIngameTouchControls::ResolveIssues()
+{
+	if(GameClient()->m_TouchControls.AnyIssueNotResolved())
+	{
+		std::array<CTouchControls::CIssueParam, (unsigned)CTouchControls::EIssueType::NUM_ISSUES> aIssues = GameClient()->m_TouchControls.Issues();
+		for(unsigned Current = 0; Current < (unsigned)CTouchControls::EIssueType::NUM_ISSUES; Current++)
+		{
+			if(aIssues[Current].m_Resolved == true)
+				continue;
+			switch(Current)
+			{
+			case(int)CTouchControls::EIssueType::CACHE_SETTINGS: CacheAllSettingsFromTarget(aIssues[Current].m_pTargetButton); break;
+			case(int)CTouchControls::EIssueType::SAVE_SETTINGS:
+			{
+				if(aIssues[Current].m_pTargetButton == nullptr)
+					aIssues[Current].m_pTargetButton = GameClient()->m_TouchControls.NewButton();
+				SaveCachedSettingsToTarget(aIssues[Current].m_pTargetButton);
+				break;
+			}
+			case(int)CTouchControls::EIssueType::CACHE_POSITION: SetPosInputs(aIssues[Current].m_pTargetButton->m_UnitRect); break;
+			default: dbg_assert(false, "Unknown Issue type: %d", Current);
+			}
+		}
+	}
+}
+
+// Turn predefined behavior strings like "joystick-hook" into integers according to the enum.
+int CMenusIngameTouchControls::CalculatePredefinedType(const char *pType) const
+{
+	int IntegerType;
+	for(IntegerType = (int)EPredefinedType::EXTRA_MENU; IntegerType < (int)EPredefinedType::NUM_PREDEFINEDS; IntegerType++)
+	{
+		if(str_comp(pType, BEHAVIOR_FACTORIES_EDITOR[IntegerType].m_pId) == 0)
+			return IntegerType;
+	}
+	dbg_assert(false, "Unknown predefined type %s.", pType == nullptr ? "nullptr" : pType);
+}
+
+std::string CMenusIngameTouchControls::DetermineTouchButtonCommandLabel(CTouchControls::CTouchButton *pButton) const
+{
+	const char *pBehaviorType = pButton->m_pBehavior->GetBehaviorType();
+	if(str_comp(pBehaviorType, CTouchControls::CBindTouchButtonBehavior::BEHAVIOR_TYPE) == 0)
+	{
+		return static_cast<CTouchControls::CBindTouchButtonBehavior *>(pButton->m_pBehavior.get())->GetCommand();
+	}
+	else if(str_comp(pBehaviorType, CTouchControls::CBindToggleTouchButtonBehavior::BEHAVIOR_TYPE) == 0)
+	{
+		const auto *pBehavior = static_cast<CTouchControls::CBindToggleTouchButtonBehavior *>(pButton->m_pBehavior.get());
+		return pBehavior->GetCommand()[pBehavior->GetActiveCommandIndex()].m_Command;
+	}
+	else if(str_comp(pBehaviorType, CTouchControls::CPredefinedTouchButtonBehavior::BEHAVIOR_TYPE) == 0)
+	{
+		auto *pTargetBehavior = static_cast<CTouchControls::CPredefinedTouchButtonBehavior *>(pButton->m_pBehavior.get());
+		const char *pPredefinedType = pTargetBehavior->GetPredefinedType();
+		const char **apPredefineds = PredefinedNames();
+		std::string Command = apPredefineds[CalculatePredefinedType(pPredefinedType)];
+		if(str_comp(pPredefinedType, CTouchControls::CExtraMenuTouchButtonBehavior::BEHAVIOR_ID) == 0)
+		{
+			const auto *pExtraMenuBehavior = static_cast<CTouchControls::CExtraMenuTouchButtonBehavior *>(pTargetBehavior);
+			Command.append(" ");
+			Command.append(std::to_string(pExtraMenuBehavior->GetNumber()));
+		}
+		return Command;
+	}
+	else
+	{
+		dbg_assert(false, "Detected unknown behavior type in CMenusIngameTouchControls::GetCommand()");
+	}
+}
+
+// Used for making json chars like \n or \uf3ce visible.
+std::string CMenusIngameTouchControls::CBehaviorElements::ParseLabel(const char *pLabel) const
+{
+	json_settings JsonSettings{};
+	char aError[256];
+	char aJsonString[1048];
+	str_format(aJsonString, sizeof(aJsonString), "\"%s\"", pLabel);
+	json_value *pJsonLabel = json_parse_ex(&JsonSettings, aJsonString, str_length(aJsonString), aError);
+	if(pJsonLabel == nullptr || pJsonLabel->type != json_string)
+	{
+		return pLabel;
+	}
+	std::string ParsedString = pJsonLabel->u.string.ptr;
+	json_value_free(pJsonLabel);
+	return ParsedString;
+}
+
+CMenusIngameTouchControls::CBehaviorElements::CBehaviorElements() noexcept
+{
+	Reset();
+}
+
+CMenusIngameTouchControls::CBehaviorElements::CBehaviorElements(CBehaviorElements &&Other) noexcept :
+	m_InputCommand(std::move(Other.m_InputCommand)), m_InputLabel(std::move(Other.m_InputLabel)), m_CachedCommands(std::move(Other.m_CachedCommands))
+{
+}
+
+CMenusIngameTouchControls::CBehaviorElements::~CBehaviorElements()
+{
+	m_InputCommand.Deactivate();
+	m_InputLabel.Deactivate();
+}
+
+CMenusIngameTouchControls::CBehaviorElements &CMenusIngameTouchControls::CBehaviorElements::operator=(CBehaviorElements &&Other) noexcept
+{
+	if(this == &Other)
+	{
+		return *this;
+	}
+	m_InputCommand = std::move(Other.m_InputCommand);
+	m_InputLabel = std::move(Other.m_InputLabel);
+	m_CachedCommands = std::move(Other.m_CachedCommands);
+	return *this;
+}
+
+void CMenusIngameTouchControls::CBehaviorElements::UpdateInputs()
+{
+	m_InputLabel.Set(ParseLabel(m_CachedCommands.m_Label.c_str()).c_str());
+	m_InputCommand.Set(m_CachedCommands.m_Command.c_str());
+}
+
+void CMenusIngameTouchControls::CBehaviorElements::Reset()
+{
+	m_CachedCommands = {};
+	m_InputCommand.Clear();
+	m_InputLabel.Clear();
+}
+
+const char **CMenusIngameTouchControls::VisibilityNames() const
+{
+	static const char *s_apVisibilities[8];
+	s_apVisibilities[0] = Localize("Ingame", "Touch button visibilities");
+	s_apVisibilities[1] = Localize("Zoom Allowed", "Touch button visibilities");
+	s_apVisibilities[2] = Localize("Vote Active", "Touch button visibilities");
+	s_apVisibilities[3] = Localize("Dummy Allowed", "Touch button visibilities");
+	s_apVisibilities[4] = Localize("Dummy Connected", "Touch button visibilities");
+	s_apVisibilities[5] = Localize("Rcon Authed", "Touch button visibilities");
+	s_apVisibilities[6] = Localize("Demo Player", "Touch button visibilities");
+	s_apVisibilities[7] = Localize("Extra Menu", "Touch button visibilities");
+	static_assert(std::size(s_apVisibilities) == (size_t)CTouchControls::EButtonVisibility::NUM_VISIBILITIES - CTouchControls::MAX_EXTRA_MENU_NUMBER + 1, "Insufficient visibility names");
+	return s_apVisibilities;
+}
+
+const char **CMenusIngameTouchControls::PredefinedNames() const
+{
+	static const char *s_apPredefineds[10];
+	s_apPredefineds[0] = Localize("Ingame Menu", "Predefined touch button behaviors");
+	s_apPredefineds[1] = Localize("Extra Menu", "Predefined touch button behaviors");
+	s_apPredefineds[2] = Localize("Emoticon", "Predefined touch button behaviors");
+	s_apPredefineds[3] = Localize("Spectate", "Predefined touch button behaviors");
+	s_apPredefineds[4] = Localize("Swap Action", "Predefined touch button behaviors");
+	s_apPredefineds[5] = Localize("Use Action", "Predefined touch button behaviors");
+	s_apPredefineds[6] = Localize("Joystick Action", "Predefined touch button behaviors");
+	s_apPredefineds[7] = Localize("Joystick Aim", "Predefined touch button behaviors");
+	s_apPredefineds[8] = Localize("Joystick Fire", "Predefined touch button behaviors");
+	s_apPredefineds[9] = Localize("Joystick Hook", "Predefined touch button behaviors");
+	dbg_assert(std::size(s_apPredefineds) == std::size(BEHAVIOR_FACTORIES_EDITOR), "Insufficient predefined names");
+	return s_apPredefineds;
+}

--- a/src/game/client/components/menus_ingame_touch_controls.h
+++ b/src/game/client/components/menus_ingame_touch_controls.h
@@ -1,0 +1,183 @@
+#ifndef GAME_CLIENT_COMPONENTS_MENUS_INGAME_TOUCH_CONTROLS_H
+#define GAME_CLIENT_COMPONENTS_MENUS_INGAME_TOUCH_CONTROLS_H
+#include <game/client/component.h>
+#include <game/client/components/touch_controls.h>
+#include <game/client/ui.h>
+#include <memory>
+
+class CMenusIngameTouchControls : public CComponentInterfaces
+{
+public:
+	static constexpr const float BUTTON_EDITOR_WIDTH = 700.0f;
+	enum class EBehaviorType
+	{
+		BIND,
+		BIND_TOGGLE,
+		PREDEFINED,
+		NUM_BEHAVIORS
+	};
+
+	enum class EPredefinedType
+	{
+		INGAME_MENU,
+		EXTRA_MENU,
+		EMOTICON,
+		SPECTATE,
+		SWAP_ACTION,
+		USE_ACTION,
+		JOYSTICK_ACTION,
+		JOYSTICK_AIM,
+		JOYSTICK_FIRE,
+		JOYSTICK_HOOK,
+		NUM_PREDEFINEDS
+	};
+
+	// Which menu is selected.
+	enum class EMenuType
+	{
+		MENU_FILE,
+		MENU_BUTTONS,
+		MENU_SETTINGS,
+		MENU_PREVIEW,
+		NUM_MENUS
+	};
+	EMenuType m_CurrentMenu = EMenuType::MENU_FILE;
+
+	enum class ESortType
+	{
+		LABEL,
+		X,
+		Y,
+		W,
+		H,
+		NUM_SORTS
+	};
+	ESortType m_SortType = ESortType::LABEL;
+
+	enum class EElementType
+	{
+		LAYOUT,
+		VISIBILITY,
+		BEHAVIOR,
+		NUM_ELEMENTS
+	};
+	EElementType m_EditElement = EElementType::LAYOUT;
+
+	enum class EVisibilityType
+	{
+		EXCLUDE,
+		INCLUDE,
+		IGNORE,
+		NUM_VISIBILITIES
+	};
+	std::array<EVisibilityType, (size_t)CTouchControls::EButtonVisibility::NUM_VISIBILITIES> m_aCachedVisibilities; // 0:-, 1:+, 2:Ignored.
+
+	// Mainly for passing values in popups.
+	CTouchControls::CTouchButton *m_pOldSelectedButton = nullptr;
+	CTouchControls::CTouchButton *m_pNewSelectedButton = nullptr;
+
+	// Storing everything you are editing.
+	CLineInputNumber m_InputX;
+	CLineInputNumber m_InputY;
+	CLineInputNumber m_InputW;
+	CLineInputNumber m_InputH;
+	CTouchControls::EButtonShape m_CachedShape;
+
+	EBehaviorType m_EditBehaviorType = EBehaviorType::BIND;
+	EPredefinedType m_PredefinedBehaviorType = EPredefinedType::EXTRA_MENU;
+	int m_CachedExtraMenuNumber = 0;
+
+	class CBehaviorElements
+	{
+	public:
+		CLineInputBuffered<1024> m_InputCommand;
+		CLineInputBuffered<1024> m_InputLabel;
+		CTouchControls::CBindToggleTouchButtonBehavior::CCommand m_CachedCommands;
+		CButtonContainer m_BindToggleAddButtons;
+		CButtonContainer m_BindToggleDeleteButtons;
+		CButtonContainer m_aLabelTypeRadios[(int)CTouchControls::CButtonLabel::EType::NUM_TYPES];
+
+		CBehaviorElements() noexcept;
+		CBehaviorElements(CBehaviorElements &&Other) noexcept;
+		~CBehaviorElements();
+		CBehaviorElements &operator=(CBehaviorElements &&Other) noexcept;
+
+		CBehaviorElements &operator=(const CBehaviorElements &) = delete;
+		CBehaviorElements(const CBehaviorElements &Other) = delete;
+
+		std::string ParseLabel(const char *pLabel) const;
+		void UpdateInputs();
+		void UpdateLabel() { m_CachedCommands.m_Label = ParseLabel(m_InputLabel.GetString()); }
+		void UpdateCommand() { m_CachedCommands.m_Command = m_InputCommand.GetString(); }
+		void Reset();
+	};
+	std::vector<std::unique_ptr<CBehaviorElements>> m_vBehaviorElements;
+
+	unsigned m_ColorActive = 0;
+	unsigned m_ColorInactive = 0;
+
+	// Used for creating ui elements.
+	std::array<CButtonContainer, (unsigned)CTouchControls::EButtonVisibility::NUM_VISIBILITIES> m_aVisibilityIds = {};
+	std::array<CButtonContainer, (unsigned)ESortType::NUM_SORTS> m_aSortHeaderIds = {};
+	std::array<CButtonContainer, (unsigned)EElementType::NUM_ELEMENTS> m_aEditElementIds = {};
+
+	// Functional variables.
+	bool m_FirstEnter = true; // Execute something when first opening the editor.
+	bool m_CloseMenu = false; // Decide if closing menu after the popup confirm.
+	bool m_NeedUpdatePreview = true; // Whether to reload the button being previewed.
+	bool m_NeedSort = true; // Whether to sort all previewed buttons.
+	bool m_NeedFilter = false; // Whether to exclude some buttons from preview.
+	std::vector<CTouchControls::CTouchButton *> m_vpButtons;
+	std::vector<CTouchControls::CTouchButton *> m_vpMutableButtons;
+	CLineInputBuffered<1024> m_FilterInput;
+	int m_SelectedPreviewButtonIndex = -1;
+
+	void RenderTouchButtonEditor(CUIRect MainView);
+	bool RenderLayoutSettingBlock(CUIRect Block);
+	bool RenderBehaviorSettingBlock(CUIRect Block);
+	bool RenderVisibilitySettingBlock(CUIRect Block);
+	void RenderTouchButtonBrowser(CUIRect MainView);
+	void RenderPreviewButton(CUIRect MainView);
+
+	void RenderSelectingTab(CUIRect SelectingTab);
+	void RenderConfigSettings(CUIRect MainView);
+	void RenderPreviewSettings(CUIRect MainView);
+	void RenderTouchControlsEditor(CUIRect MainView);
+
+	// Confirm, Cancel only decide if saving cached settings.
+	void DoPopupType(CTouchControls::CPopupParam PopupParam);
+	void ChangeSelectedButtonWhileHavingUnsavedChanges() const;
+	void NoSpaceForOverlappingButton() const;
+	void SelectedButtonNotVisible();
+
+	// Getter and setters.
+	bool UnsavedChanges() const;
+	void SetUnsavedChanges(bool UnsavedChanges);
+
+	// Convenient functions.
+	bool CheckCachedSettings() const;
+	void ResetCachedSettings();
+	void CacheAllSettingsFromTarget(CTouchControls::CTouchButton *pTargetButton);
+	void SaveCachedSettingsToTarget(CTouchControls::CTouchButton *pTargetButton) const;
+	void SetPosInputs(CTouchControls::CUnitRect MyRect);
+	void InputPosFunction(CLineInputNumber *pInput);
+	void UpdateSampleButton();
+	void ResetButtonPointers();
+	void NewVirtualButton();
+	void ResolveIssues();
+	int CalculatePredefinedType(const char *pType) const;
+	std::string DetermineTouchButtonCommandLabel(CTouchControls::CTouchButton *pButton) const;
+	const char **VisibilityNames() const;
+	const char **PredefinedNames() const;
+
+	class CBehaviorFactoryEditor
+	{
+	public:
+		const char *m_pId;
+		std::function<std::unique_ptr<CTouchControls::CPredefinedTouchButtonBehavior>()> m_Factory;
+	};
+
+	static const CBehaviorFactoryEditor BEHAVIOR_FACTORIES_EDITOR[10];
+};
+
+#endif

--- a/src/game/client/components/touch_controls.cpp
+++ b/src/game/client/components/touch_controls.cpp
@@ -1,5 +1,6 @@
 #include "touch_controls.h"
 
+#include <base/color.h>
 #include <base/log.h>
 #include <base/system.h>
 
@@ -18,12 +19,16 @@
 #include <game/client/components/spectator.h>
 #include <game/client/components/voting.h>
 #include <game/client/gameclient.h>
-#include <game/client/ui.h>
 #include <game/localization.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <functional>
+#include <iterator>
+#include <queue>
 
 using namespace std::chrono_literals;
 
-// TODO: Add user interface to adjust button layout
 // TODO: Add combined weapon picker button that shows all currently available weapons
 // TODO: Add "joystick-aim-relative", a virtual joystick that moves the mouse pointer relatively. And add "aim-relative" ingame direct touch input.
 // TODO: Add "choice" predefined behavior which shows a selection popup for 2 or more other behaviors?
@@ -38,9 +43,6 @@ static constexpr std::chrono::milliseconds BIND_REPEAT_INITIAL_DELAY = 250ms;
 static constexpr std::chrono::nanoseconds BIND_REPEAT_RATE = std::chrono::nanoseconds(1s) / 15;
 
 static constexpr const char *const CONFIGURATION_FILENAME = "touch_controls.json";
-static constexpr int BUTTON_SIZE_SCALE = 1000000;
-static constexpr int BUTTON_SIZE_MINIMUM = 50000;
-static constexpr int BUTTON_SIZE_MAXIMUM = 500000;
 
 /* This is required for the localization script to find the labels of the default bind buttons specified in the configuration file:
 Localizable("Move left") Localizable("Move right") Localizable("Jump") Localizable("Prev. weapon") Localizable("Next weapon")
@@ -50,6 +52,9 @@ Localizable("Vote yes") Localizable("Vote no") Localizable("Toggle dummy")
 
 CTouchControls::CTouchButton::CTouchButton(CTouchControls *pTouchControls) :
 	m_pTouchControls(pTouchControls),
+	m_UnitRect({0, 0, BUTTON_SIZE_MINIMUM, BUTTON_SIZE_MINIMUM}),
+	m_Shape(EButtonShape::RECT),
+	m_pBehavior(nullptr),
 	m_VisibilityCached(false)
 {
 }
@@ -63,10 +68,16 @@ CTouchControls::CTouchButton::CTouchButton(CTouchButton &&Other) noexcept :
 	m_VisibilityCached(false)
 {
 	Other.m_pTouchControls = nullptr;
+	UpdatePointers();
+	UpdateScreenFromUnitRect();
 }
 
 CTouchControls::CTouchButton &CTouchControls::CTouchButton::operator=(CTouchButton &&Other) noexcept
 {
+	if(this == &Other)
+	{
+		return *this;
+	}
 	m_pTouchControls = Other.m_pTouchControls;
 	Other.m_pTouchControls = nullptr;
 	m_UnitRect = Other.m_UnitRect;
@@ -74,6 +85,8 @@ CTouchControls::CTouchButton &CTouchControls::CTouchButton::operator=(CTouchButt
 	m_vVisibilities = Other.m_vVisibilities;
 	m_pBehavior = std::move(Other.m_pBehavior);
 	m_VisibilityCached = false;
+	UpdatePointers();
+	UpdateScreenFromUnitRect();
 	return *this;
 }
 
@@ -84,26 +97,34 @@ void CTouchControls::CTouchButton::UpdatePointers()
 
 void CTouchControls::CTouchButton::UpdateScreenFromUnitRect()
 {
-	const vec2 ScreenSize = m_pTouchControls->CalculateScreenSize();
-	m_ScreenRect.x = m_UnitRect.m_X * ScreenSize.x / BUTTON_SIZE_SCALE;
-	m_ScreenRect.y = m_UnitRect.m_Y * ScreenSize.y / BUTTON_SIZE_SCALE;
-	m_ScreenRect.w = m_UnitRect.m_W * ScreenSize.x / BUTTON_SIZE_SCALE;
-	m_ScreenRect.h = m_UnitRect.m_H * ScreenSize.y / BUTTON_SIZE_SCALE;
+	m_ScreenRect = m_pTouchControls->CalculateScreenFromUnitRect(m_UnitRect, m_Shape);
+}
+
+CUIRect CTouchControls::CalculateScreenFromUnitRect(CUnitRect Unit, EButtonShape Shape) const
+{
+	const vec2 ScreenSize = CalculateScreenSize();
+	CUIRect ScreenRect;
+	ScreenRect.x = Unit.m_X * ScreenSize.x / BUTTON_SIZE_SCALE;
+	ScreenRect.y = Unit.m_Y * ScreenSize.y / BUTTON_SIZE_SCALE;
+	ScreenRect.w = Unit.m_W * ScreenSize.x / BUTTON_SIZE_SCALE;
+	ScreenRect.h = Unit.m_H * ScreenSize.y / BUTTON_SIZE_SCALE;
 
 	// Enforce circle shape so the screen rect can be used for mapping the touch input position
-	if(m_Shape == EButtonShape::CIRCLE)
+	if(Shape == EButtonShape::CIRCLE)
 	{
-		if(m_ScreenRect.h > m_ScreenRect.w)
+		if(ScreenRect.h > ScreenRect.w)
 		{
-			m_ScreenRect.y += (m_ScreenRect.h - m_ScreenRect.w) / 2.0f;
-			m_ScreenRect.h = m_ScreenRect.w;
+			ScreenRect.y += (ScreenRect.h - ScreenRect.w) / 2.0f;
+			ScreenRect.h = ScreenRect.w;
 		}
-		else if(m_ScreenRect.w > m_ScreenRect.h)
+		else if(ScreenRect.w > ScreenRect.h)
 		{
-			m_ScreenRect.x += (m_ScreenRect.w - m_ScreenRect.h) / 2.0f;
-			m_ScreenRect.w = m_ScreenRect.h;
+			ScreenRect.x += (ScreenRect.w - ScreenRect.h) / 2.0f;
+			ScreenRect.w = ScreenRect.h;
 		}
 	}
+
+	return ScreenRect;
 }
 
 void CTouchControls::CTouchButton::UpdateBackgroundCorners()
@@ -208,11 +229,23 @@ bool CTouchControls::CTouchButton::IsInside(vec2 TouchPosition) const
 	}
 }
 
-void CTouchControls::CTouchButton::UpdateVisibility()
+void CTouchControls::CTouchButton::UpdateVisibilityGame()
 {
 	const bool PrevVisibility = m_VisibilityCached;
-	m_VisibilityCached = m_pTouchControls->m_EditingActive || std::all_of(m_vVisibilities.begin(), m_vVisibilities.end(), [&](CButtonVisibility Visibility) {
+	m_VisibilityCached = std::all_of(m_vVisibilities.begin(), m_vVisibilities.end(), [&](CButtonVisibility Visibility) {
 		return m_pTouchControls->m_aVisibilityFunctions[(int)Visibility.m_Type].m_Function() == Visibility.m_Parity;
+	});
+	if(m_VisibilityCached && !PrevVisibility)
+	{
+		m_VisibilityStartTime = time_get_nanoseconds();
+	}
+}
+
+void CTouchControls::CTouchButton::UpdateVisibilityEditor()
+{
+	const bool PrevVisibility = m_VisibilityCached;
+	m_VisibilityCached = std::all_of(m_vVisibilities.begin(), m_vVisibilities.end(), [&](CButtonVisibility Visibility) {
+		return m_pTouchControls->m_aVirtualVisibilities[(int)Visibility.m_Type] == Visibility.m_Parity;
 	});
 	if(m_VisibilityCached && !PrevVisibility)
 	{
@@ -226,21 +259,31 @@ bool CTouchControls::CTouchButton::IsVisible() const
 }
 
 // TODO: Optimization: Use text and quad containers for rendering
-void CTouchControls::CTouchButton::Render() const
+void CTouchControls::CTouchButton::Render(std::optional<bool> Selected, std::optional<CUnitRect> Rect) const
 {
-	const ColorRGBA ButtonColor = m_pBehavior->IsActive() ? m_pTouchControls->m_BackgroundColorActive : m_pTouchControls->m_BackgroundColorInactive;
+	dbg_assert(m_pBehavior != nullptr, "Touch button behavior is nullptr");
+	CUIRect ScreenRect;
+	if(Rect.has_value())
+		ScreenRect = m_pTouchControls->CalculateScreenFromUnitRect(*Rect, m_Shape);
+	else
+		ScreenRect = m_ScreenRect;
 
+	ColorRGBA ButtonColor;
+	// "Selected" can decide which color to use, while not disturbing the original color check.
+	ButtonColor = m_pBehavior->IsActive() || Selected.value_or(false) ? m_pTouchControls->m_BackgroundColorActive : m_pTouchControls->m_BackgroundColorInactive;
+	if(!Selected.value_or(true))
+		ButtonColor = m_pTouchControls->m_BackgroundColorInactive;
 	switch(m_Shape)
 	{
 	case EButtonShape::RECT:
 	{
-		m_ScreenRect.Draw(ButtonColor, m_BackgroundCorners, 10.0f);
+		ScreenRect.Draw(ButtonColor, m_pTouchControls->m_EditingActive ? IGraphics::CORNER_NONE : m_BackgroundCorners, 10.0f);
 		break;
 	}
 	case EButtonShape::CIRCLE:
 	{
-		const vec2 Center = m_ScreenRect.Center();
-		const float Radius = minimum(m_ScreenRect.w, m_ScreenRect.h) / 2.0f;
+		const vec2 Center = ScreenRect.Center();
+		const float Radius = minimum(ScreenRect.w, ScreenRect.h) / 2.0f;
 		m_pTouchControls->Graphics()->TextureClear();
 		m_pTouchControls->Graphics()->QuadsBegin();
 		m_pTouchControls->Graphics()->SetColor(ButtonColor);
@@ -256,7 +299,7 @@ void CTouchControls::CTouchButton::Render() const
 	const float FontSize = 22.0f;
 	CButtonLabel LabelData = m_pBehavior->GetLabel();
 	CUIRect LabelRect;
-	m_ScreenRect.Margin(10.0f, &LabelRect);
+	ScreenRect.Margin(10.0f, &LabelRect);
 	SLabelProperties LabelProps;
 	LabelProps.m_MaxWidth = LabelRect.w;
 	if(LabelData.m_Type == CButtonLabel::EType::ICON)
@@ -474,20 +517,18 @@ CTouchControls::CButtonLabel CTouchControls::CSwapActionTouchButtonBehavior::Get
 	{
 		return {CButtonLabel::EType::LOCALIZED, ACTION_NAMES[m_ActiveAction]};
 	}
-	else if(m_pTouchControls->m_pPrimaryJoystickTouchButtonBehavior != nullptr &&
-		m_pTouchControls->m_pPrimaryJoystickTouchButtonBehavior->ActiveAction() != NUM_ACTIONS)
+	else if(m_pTouchControls->m_JoystickPressCount != 0)
 	{
-		return {CButtonLabel::EType::LOCALIZED, ACTION_NAMES[m_pTouchControls->NextActiveAction(m_pTouchControls->m_pPrimaryJoystickTouchButtonBehavior->ActiveAction())]};
+		return {CButtonLabel::EType::LOCALIZED, ACTION_NAMES[m_pTouchControls->NextActiveAction(m_pTouchControls->m_ActionSelected)]};
 	}
 	return {CButtonLabel::EType::LOCALIZED, ACTION_SWAP_NAMES[m_pTouchControls->m_ActionSelected]};
 }
 
 void CTouchControls::CSwapActionTouchButtonBehavior::OnActivate()
 {
-	if(m_pTouchControls->m_pPrimaryJoystickTouchButtonBehavior != nullptr &&
-		m_pTouchControls->m_pPrimaryJoystickTouchButtonBehavior->ActiveAction() != NUM_ACTIONS)
+	if(m_pTouchControls->m_JoystickPressCount != 0)
 	{
-		m_ActiveAction = m_pTouchControls->NextActiveAction(m_pTouchControls->m_pPrimaryJoystickTouchButtonBehavior->ActiveAction());
+		m_ActiveAction = m_pTouchControls->NextActiveAction(m_pTouchControls->m_ActionSelected);
 		m_pTouchControls->Console()->ExecuteLineStroked(1, ACTION_COMMANDS[m_ActiveAction]);
 	}
 	else
@@ -545,6 +586,7 @@ void CTouchControls::CJoystickTouchButtonBehavior::OnActivate()
 	{
 		m_pTouchControls->Console()->ExecuteLineStroked(1, ACTION_COMMANDS[m_ActiveAction]);
 	}
+	m_pTouchControls->m_JoystickPressCount++;
 }
 
 void CTouchControls::CJoystickTouchButtonBehavior::OnDeactivate(bool ByFinger)
@@ -554,6 +596,7 @@ void CTouchControls::CJoystickTouchButtonBehavior::OnDeactivate(bool ByFinger)
 		m_pTouchControls->Console()->ExecuteLineStroked(0, ACTION_COMMANDS[m_ActiveAction]);
 	}
 	m_ActiveAction = NUM_ACTIONS;
+	m_pTouchControls->m_JoystickPressCount--;
 }
 
 void CTouchControls::CJoystickTouchButtonBehavior::OnUpdate()
@@ -580,11 +623,10 @@ void CTouchControls::CJoystickTouchButtonBehavior::OnUpdate()
 	}
 }
 
-// Joystick that uses the active action. Registers itself as the primary joystick.
+// Joystick that uses the active action.
 void CTouchControls::CJoystickActionTouchButtonBehavior::Init(CTouchButton *pTouchButton)
 {
 	CPredefinedTouchButtonBehavior::Init(pTouchButton);
-	m_pTouchControls->m_pPrimaryJoystickTouchButtonBehavior = this;
 }
 
 int CTouchControls::CJoystickActionTouchButtonBehavior::SelectedAction() const
@@ -737,13 +779,17 @@ bool CTouchControls::OnTouchState(const std::vector<IInput::CTouchFingerState> &
 		GameClient()->m_GameConsole.IsActive() ||
 		GameClient()->m_Menus.IsActive() ||
 		GameClient()->m_Emoticon.IsActive() ||
-		GameClient()->m_Spectator.IsActive())
+		GameClient()->m_Spectator.IsActive() ||
+		m_PreviewAllButtons)
 	{
 		ResetButtons();
 		return false;
 	}
 
-	UpdateButtons(vTouchFingerStates);
+	if(m_EditingActive)
+		UpdateButtonsEditor(vTouchFingerStates);
+	else
+		UpdateButtonsGame(vTouchFingerStates);
 	return true;
 }
 
@@ -763,7 +809,16 @@ void CTouchControls::OnRender()
 	const vec2 ScreenSize = CalculateScreenSize();
 	Graphics()->MapScreen(0.0f, 0.0f, ScreenSize.x, ScreenSize.y);
 
-	RenderButtons();
+	if(m_EditingActive)
+	{
+		RenderButtonsEditor();
+		return;
+	}
+	// If not editing, deselect it.
+	m_pSelectedButton = nullptr;
+	m_pSampleButton = nullptr;
+	m_UnsavedChanges = false;
+	RenderButtonsGame();
 }
 
 bool CTouchControls::LoadConfigurationFromFile(int StorageType)
@@ -911,12 +966,12 @@ int CTouchControls::NextDirectTouchAction() const
 	}
 }
 
-void CTouchControls::UpdateButtons(const std::vector<IInput::CTouchFingerState> &vTouchFingerStates)
+void CTouchControls::UpdateButtonsGame(const std::vector<IInput::CTouchFingerState> &vTouchFingerStates)
 {
 	// Update cached button visibilities and store time that buttons become visible.
 	for(CTouchButton &TouchButton : m_vTouchButtons)
 	{
-		TouchButton.UpdateVisibility();
+		TouchButton.UpdateVisibilityGame();
 	}
 
 	const int DirectTouchAction = NextDirectTouchAction();
@@ -1124,11 +1179,11 @@ void CTouchControls::ResetButtons()
 	}
 }
 
-void CTouchControls::RenderButtons()
+void CTouchControls::RenderButtonsGame()
 {
 	for(CTouchButton &TouchButton : m_vTouchButtons)
 	{
-		TouchButton.UpdateVisibility();
+		TouchButton.UpdateVisibilityGame();
 	}
 	for(CTouchButton &TouchButton : m_vTouchButtons)
 	{
@@ -1137,6 +1192,7 @@ void CTouchControls::RenderButtons()
 			continue;
 		}
 		TouchButton.UpdateBackgroundCorners();
+		TouchButton.UpdateScreenFromUnitRect();
 		TouchButton.Render();
 	}
 }
@@ -1225,7 +1281,6 @@ bool CTouchControls::ParseConfiguration(const void *pFileData, unsigned FileLeng
 	m_BackgroundColorInactive = ParsedBackgroundColorInactive.value();
 	m_BackgroundColorActive = ParsedBackgroundColorActive.value();
 
-	m_pPrimaryJoystickTouchButtonBehavior = nullptr;
 	m_vTouchButtons = std::move(vParsedTouchButtons);
 	for(CTouchButton &TouchButton : m_vTouchButtons)
 	{
@@ -1234,6 +1289,11 @@ bool CTouchControls::ParseConfiguration(const void *pFileData, unsigned FileLeng
 	}
 
 	json_value_free(pConfiguration);
+
+	// If successfully parsing buttons, deselect it.
+	m_pSelectedButton = nullptr;
+	m_pSampleButton = nullptr;
+	m_UnsavedChanges = false;
 
 	return true;
 }
@@ -1508,11 +1568,10 @@ std::unique_ptr<CTouchControls::CExtraMenuTouchButtonBehavior> CTouchControls::P
 	const json_value &BehaviorObject = *pBehaviorObject;
 	const json_value &MenuNumber = BehaviorObject["number"];
 	// TODO: Remove json_none backwards compatibility
-	const int MaxNumber = (int)EButtonVisibility::EXTRA_MENU_5 - (int)EButtonVisibility::EXTRA_MENU_1 + 1;
-	if(MenuNumber.type != json_none && (MenuNumber.type != json_integer || !in_range<json_int_t>(MenuNumber.u.integer, 1, MaxNumber)))
+	if(MenuNumber.type != json_none && (MenuNumber.type != json_integer || !in_range<json_int_t>(MenuNumber.u.integer, 1, MAX_EXTRA_MENU_NUMBER)))
 	{
 		log_error("touch_controls", "Failed to parse touch button behavior of type '%s' and ID '%s': attribute 'number' must specify an integer between '%d' and '%d'",
-			CPredefinedTouchButtonBehavior::BEHAVIOR_TYPE, CExtraMenuTouchButtonBehavior::BEHAVIOR_ID, 1, MaxNumber);
+			CPredefinedTouchButtonBehavior::BEHAVIOR_TYPE, CExtraMenuTouchButtonBehavior::BEHAVIOR_ID, 1, MAX_EXTRA_MENU_NUMBER);
 		return nullptr;
 	}
 	int ParsedMenuNumber = MenuNumber.type == json_none ? 0 : (MenuNumber.u.integer - 1);
@@ -1662,4 +1721,777 @@ void CTouchControls::WriteConfiguration(CJsonWriter *pWriter)
 	pWriter->EndArray();
 
 	pWriter->EndObject();
+}
+
+// This is called when the checkbox "Edit touch controls" is selected, so virtual visibility could be set as the real visibility on entering.
+void CTouchControls::ResetVirtualVisibilities()
+{
+	// Update virtual visibilities.
+	for(int Visibility = (int)EButtonVisibility::INGAME; Visibility < (int)EButtonVisibility::NUM_VISIBILITIES; ++Visibility)
+		m_aVirtualVisibilities[Visibility] = m_aVisibilityFunctions[Visibility].m_Function();
+}
+
+void CTouchControls::UpdateButtonsEditor(const std::vector<IInput::CTouchFingerState> &vTouchFingerStates)
+{
+	std::vector<CUnitRect> vVisibleButtonRects;
+	const vec2 ScreenSize = CalculateScreenSize();
+	bool LongPress = false;
+	for(CTouchButton &TouchButton : m_vTouchButtons)
+	{
+		TouchButton.UpdateVisibilityEditor();
+	}
+
+	if(vTouchFingerStates.empty())
+		m_PreventSaving = false;
+
+	// Remove if the finger deleted has released.
+	if(!m_vDeletedFingerState.empty())
+	{
+		const auto &Remove = std::remove_if(m_vDeletedFingerState.begin(), m_vDeletedFingerState.end(), [&vTouchFingerStates](const auto &TargetState) {
+			return std::none_of(vTouchFingerStates.begin(), vTouchFingerStates.end(), [&](const auto &State) {
+				return State.m_Finger == TargetState.m_Finger;
+			});
+		});
+		m_vDeletedFingerState.erase(Remove, m_vDeletedFingerState.end());
+	}
+	// Delete fingers if they are press later. So they cant be the longpress finger.
+	if(vTouchFingerStates.size() > 1)
+	{
+		std::for_each(vTouchFingerStates.begin() + 1, vTouchFingerStates.end(), [&](const auto &State) {
+			m_vDeletedFingerState.push_back(State);
+		});
+	}
+
+	// If released, and there is finger on screen, and the "first finger" is not deleted(new finger), then it can be a LongPress candidate.
+	if(!vTouchFingerStates.empty() && !std::any_of(m_vDeletedFingerState.begin(), m_vDeletedFingerState.end(), [&vTouchFingerStates](const auto &State) {
+		   return vTouchFingerStates[0].m_Finger == State.m_Finger;
+	   }))
+	{
+		// If has different finger, reset the accumulated delta.
+		if(m_LongPressFingerState.has_value() && (*m_LongPressFingerState).m_Finger != vTouchFingerStates[0].m_Finger)
+			m_AccumulatedDelta = vec2(0.0f, 0.0f);
+		// Update the LongPress candidate state.
+		m_LongPressFingerState = vTouchFingerStates[0];
+	}
+	// If no suitable finger for long press, then clear it.
+	else
+	{
+		m_LongPressFingerState = std::nullopt;
+	}
+
+	// Find long press button. LongPress == true means the first fingerstate long pressed.
+	if(m_LongPressFingerState.has_value())
+	{
+		m_AccumulatedDelta += (*m_LongPressFingerState).m_Delta;
+		// If slided, then delete.
+		if(length(m_AccumulatedDelta) > 0.005f)
+		{
+			m_AccumulatedDelta = vec2(0.0f, 0.0f);
+			m_vDeletedFingerState.push_back(*m_LongPressFingerState);
+			m_LongPressFingerState = std::nullopt;
+			m_PreventSaving = true;
+		}
+		// Till now, this else contains: if the finger hasn't slided, have no fingers that remain pressed down when it pressed, hasn't been a longpress already, the candidate is always the first finger.
+		else
+		{
+			const auto Now = time_get_nanoseconds();
+			if(!m_PreventSaving && Now - (*m_LongPressFingerState).m_PressTime > LONG_TOUCH_DURATION)
+			{
+				LongPress = true;
+				m_vDeletedFingerState.push_back(*m_LongPressFingerState);
+				// LongPress will be used this frame for sure, so reset delta.
+				m_AccumulatedDelta = vec2(0.0f, 0.0f);
+			}
+		}
+	}
+
+	// Update active and zoom fingerstate. The first finger will be used for moving button.
+	if(!vTouchFingerStates.empty())
+		m_ActiveFingerState = vTouchFingerStates[0];
+	else
+	{
+		m_ActiveFingerState = std::nullopt;
+		if(m_pSampleButton != nullptr && m_ShownRect.has_value())
+			m_pSampleButton->m_UnitRect = (*m_ShownRect);
+	}
+	// Only the second finger will be used for zooming button.
+	if(vTouchFingerStates.size() > 1)
+	{
+		// If zoom finger is pressed now, reset the zoom startpos
+		if(!m_ZoomFingerState.has_value())
+			m_ZoomStartPos = m_ActiveFingerState.value().m_Position - vTouchFingerStates[1].m_Position;
+		m_ZoomFingerState = vTouchFingerStates[1];
+		m_PreventSaving = true;
+
+		// If Zooming started, update it's x,y value so it's width and height could be calculated correctly.
+		if(m_pSampleButton != nullptr && m_ShownRect.has_value())
+		{
+			m_pSampleButton->m_UnitRect.m_X = (*m_ShownRect).m_X;
+			m_pSampleButton->m_UnitRect.m_Y = (*m_ShownRect).m_Y;
+		}
+	}
+	else
+	{
+		m_ZoomFingerState = std::nullopt;
+		m_ZoomStartPos = vec2(0.0f, 0.0f);
+		if(m_pSampleButton != nullptr && m_ShownRect.has_value())
+		{
+			m_pSampleButton->m_UnitRect.m_W = (*m_ShownRect).m_W;
+			m_pSampleButton->m_UnitRect.m_H = (*m_ShownRect).m_H;
+		}
+	}
+	for(auto &TouchButton : m_vTouchButtons)
+	{
+		if(TouchButton.m_VisibilityCached)
+		{
+			if(m_pSelectedButton == &TouchButton)
+				continue;
+			// Only Long Pressed finger "in visible button" is used for selecting a button.
+			if(LongPress && !vTouchFingerStates.empty() && TouchButton.IsInside((*m_LongPressFingerState).m_Position * ScreenSize))
+			{
+				// If m_pSelectedButton changes, Confirm if saving changes, then change.
+				// LongPress used.
+				LongPress = false;
+				// Note: Even after the popup is opened by ChangeSelectedButtonWhile..., the fingerstate still exists. So we have to add it to m_vDeletedFingerState.
+				m_vDeletedFingerState.push_back(*m_LongPressFingerState);
+				m_LongPressFingerState = std::nullopt;
+				if(m_UnsavedChanges)
+				{
+					// Update sample button before saving, or sample button's position value might be not updated.
+					if(m_pSampleButton != nullptr && m_ShownRect.has_value())
+						m_pSampleButton->m_UnitRect = *m_ShownRect;
+					m_PopupParam.m_KeepMenuOpen = false;
+					m_PopupParam.m_pOldSelectedButton = m_pSelectedButton;
+					m_PopupParam.m_pNewSelectedButton = &TouchButton;
+					m_PopupParam.m_PopupType = EPopupType::BUTTON_CHANGED;
+					GameClient()->m_Menus.SetActive(true);
+					// End the function.
+					return;
+				}
+				m_pSelectedButton = &TouchButton;
+				// Update illegal position when Long press the button. Or later it will keep saying unsavedchanges.
+				if(IsRectOverlapping(TouchButton.m_UnitRect))
+				{
+					TouchButton.m_UnitRect = UpdatePosition(TouchButton.m_UnitRect);
+					if(TouchButton.m_UnitRect.m_X == -1)
+					{
+						m_PopupParam.m_PopupType = EPopupType::NO_SPACE;
+						m_PopupParam.m_KeepMenuOpen = true;
+						GameClient()->m_Menus.SetActive(true);
+						return;
+					}
+					TouchButton.UpdateScreenFromUnitRect();
+				}
+				m_aIssueParam[(int)EIssueType::CACHE_SETTINGS].m_pTargetButton = m_pSelectedButton;
+				m_aIssueParam[(int)EIssueType::CACHE_SETTINGS].m_Resolved = false;
+				RemakeSampleButton();
+				UpdateSampleButton(*m_pSelectedButton);
+				// Don't insert the long pressed button. It is selected button now.
+				continue;
+			}
+			// Insert visible but not selected buttons.
+			vVisibleButtonRects.emplace_back(TouchButton.m_UnitRect);
+		}
+		// If selected button not visible, unselect it.
+		else if(m_pSelectedButton == &TouchButton && !GameClient()->m_Menus.IsActive())
+		{
+			m_PopupParam.m_PopupType = EPopupType::BUTTON_INVISIBLE;
+			GameClient()->m_Menus.SetActive(true);
+			return;
+		}
+	}
+
+	// Nothing left to do if no button selected.
+	if(m_pSampleButton == nullptr)
+		return;
+
+	// If LongPress == true, LongPress finger has to be outside of all visible buttons.(Except m_pSampleButton. This button hasn't been checked)
+	if(LongPress)
+	{
+		// LongPress should be set to false, but to pass clang-tidy check, this shouldn't be set now
+		// LongPress = false;
+		bool IsInside = CalculateScreenFromUnitRect(*m_ShownRect).Inside(m_LongPressFingerState->m_Position * ScreenSize);
+		m_vDeletedFingerState.push_back(*m_LongPressFingerState);
+		m_LongPressFingerState = std::nullopt;
+		if(m_UnsavedChanges && !IsInside)
+		{
+			m_pSampleButton->m_UnitRect = *m_ShownRect;
+			m_PopupParam.m_pNewSelectedButton = nullptr;
+			m_PopupParam.m_pOldSelectedButton = m_pSelectedButton;
+			m_PopupParam.m_KeepMenuOpen = false;
+			m_PopupParam.m_PopupType = EPopupType::BUTTON_CHANGED;
+			GameClient()->m_Menus.SetActive(true);
+		}
+		else if(!IsInside)
+		{
+			m_UnsavedChanges = false;
+			ResetButtonPointers();
+			// No need for caching settings issue. So the issue is set to finished.
+			m_aIssueParam[(int)EIssueType::CACHE_SETTINGS].m_Resolved = true;
+			m_aIssueParam[(int)EIssueType::SAVE_SETTINGS].m_Resolved = true;
+			m_aIssueParam[(int)EIssueType::CACHE_POSITION].m_Resolved = true;
+		}
+	}
+
+	if(m_pSampleButton != nullptr)
+	{
+		if(m_ActiveFingerState.has_value() && m_ZoomFingerState == std::nullopt)
+		{
+			vec2 UnitXYDelta = m_ActiveFingerState->m_Delta * BUTTON_SIZE_SCALE;
+			m_pSampleButton->m_UnitRect.m_X += UnitXYDelta.x;
+			m_pSampleButton->m_UnitRect.m_Y += UnitXYDelta.y;
+			m_ShownRect = FindPositionXY(vVisibleButtonRects, m_pSampleButton->m_UnitRect);
+			if(m_pSelectedButton != nullptr)
+			{
+				unsigned Movement = std::abs(m_pSelectedButton->m_UnitRect.m_X - m_ShownRect->m_X) + std::abs(m_pSelectedButton->m_UnitRect.m_Y - m_ShownRect->m_Y);
+				if(Movement > 10000)
+				{
+					// Moved a lot, meaning changes made.
+					m_UnsavedChanges = true;
+				}
+			}
+		}
+		else if(m_ActiveFingerState.has_value() && m_ZoomFingerState.has_value())
+		{
+			m_ShownRect = m_pSampleButton->m_UnitRect;
+			vec2 UnitWHDelta;
+			UnitWHDelta.x = (std::abs(m_ActiveFingerState.value().m_Position.x - m_ZoomFingerState.value().m_Position.x) - std::abs(m_ZoomStartPos.x)) * BUTTON_SIZE_SCALE;
+			UnitWHDelta.y = (std::abs(m_ActiveFingerState.value().m_Position.y - m_ZoomFingerState.value().m_Position.y) - std::abs(m_ZoomStartPos.y)) * BUTTON_SIZE_SCALE;
+			(*m_ShownRect).m_W = m_pSampleButton->m_UnitRect.m_W + UnitWHDelta.x;
+			(*m_ShownRect).m_H = m_pSampleButton->m_UnitRect.m_H + UnitWHDelta.y;
+			(*m_ShownRect).m_W = std::clamp((*m_ShownRect).m_W, BUTTON_SIZE_MINIMUM, BUTTON_SIZE_MAXIMUM);
+			(*m_ShownRect).m_H = std::clamp((*m_ShownRect).m_H, BUTTON_SIZE_MINIMUM, BUTTON_SIZE_MAXIMUM);
+			if((*m_ShownRect).m_W + (*m_ShownRect).m_X > BUTTON_SIZE_SCALE)
+				(*m_ShownRect).m_W = BUTTON_SIZE_SCALE - (*m_ShownRect).m_X;
+			if((*m_ShownRect).m_H + (*m_ShownRect).m_Y > BUTTON_SIZE_SCALE)
+				(*m_ShownRect).m_H = BUTTON_SIZE_SCALE - (*m_ShownRect).m_Y;
+			// Clamp the biggest W and H so they won't overlap with other buttons. Known as "FindPositionWH".
+			std::optional<int> BiggestW;
+			std::optional<int> BiggestH;
+			std::optional<int> LimitH, LimitW;
+			for(const auto &Rect : vVisibleButtonRects)
+			{
+				// If Overlap
+				if(!(Rect.m_X + Rect.m_W <= (*m_ShownRect).m_X || (*m_ShownRect).m_X + (*m_ShownRect).m_W <= Rect.m_X || Rect.m_Y + Rect.m_H <= (*m_ShownRect).m_Y || (*m_ShownRect).m_Y + (*m_ShownRect).m_H <= Rect.m_Y))
+				{
+					// Calculate the biggest Height and Width it could have.
+					LimitH = Rect.m_Y - (*m_ShownRect).m_Y;
+					LimitW = Rect.m_X - (*m_ShownRect).m_X;
+					if(LimitH < BUTTON_SIZE_MINIMUM)
+						LimitH = std::nullopt;
+					if(LimitW < BUTTON_SIZE_MINIMUM)
+						LimitW = std::nullopt;
+					if(LimitH.has_value() && LimitW.has_value())
+					{
+						if(std::abs(*LimitH - (*m_ShownRect).m_H) < std::abs(*LimitW - (*m_ShownRect).m_W))
+						{
+							BiggestH = std::min(*LimitH, BiggestH.value_or(BUTTON_SIZE_SCALE));
+						}
+						else
+						{
+							BiggestW = std::min(*LimitW, BiggestW.value_or(BUTTON_SIZE_SCALE));
+						}
+					}
+					else
+					{
+						if(LimitH.has_value())
+							BiggestH = std::min(*LimitH, BiggestH.value_or(BUTTON_SIZE_SCALE));
+						else if(LimitW.has_value())
+							BiggestW = std::min(*LimitW, BiggestW.value_or(BUTTON_SIZE_SCALE));
+						else
+						{
+							/*
+							 * LimitH and W can be nullopt at the same time, because two buttons may be overlapping.
+							 * Holding for long press while another finger is pressed.
+							 * Then it will instantly enter zoom mode while buttons are overlapping with each other.
+							 */
+							m_ShownRect = FindPositionXY(vVisibleButtonRects, m_pSampleButton->m_UnitRect);
+							BiggestW = std::nullopt;
+							BiggestH = std::nullopt;
+							break;
+						}
+					}
+				}
+			}
+			(*m_ShownRect).m_W = BiggestW.value_or((*m_ShownRect).m_W);
+			(*m_ShownRect).m_H = BiggestH.value_or((*m_ShownRect).m_H);
+			m_UnsavedChanges = true;
+		}
+		// No finger on screen, then show it as is.
+		else
+		{
+			m_ShownRect = m_pSampleButton->m_UnitRect;
+		}
+		// Finished moving, no finger on screen.
+		if(vTouchFingerStates.empty())
+		{
+			m_AccumulatedDelta = vec2(0.0f, 0.0f);
+			m_ShownRect = FindPositionXY(vVisibleButtonRects, m_pSampleButton->m_UnitRect);
+			m_pSampleButton->m_UnitRect = (*m_ShownRect);
+			m_aIssueParam[(int)EIssueType::CACHE_POSITION].m_pTargetButton = m_pSampleButton.get();
+			m_aIssueParam[(int)EIssueType::CACHE_POSITION].m_Resolved = false;
+			m_pSampleButton->UpdateScreenFromUnitRect();
+		}
+		if(m_ShownRect->m_X == -1)
+		{
+			m_PopupParam.m_PopupType = EPopupType::NO_SPACE;
+			m_PopupParam.m_KeepMenuOpen = true;
+			GameClient()->m_Menus.SetActive(true);
+			return;
+		}
+		m_pSampleButton->UpdateScreenFromUnitRect();
+	}
+}
+
+void CTouchControls::RenderButtonsEditor()
+{
+	for(auto &TouchButton : m_vTouchButtons)
+	{
+		if(&TouchButton == m_pSelectedButton)
+			continue;
+		TouchButton.UpdateVisibilityEditor();
+		if(TouchButton.m_VisibilityCached || m_PreviewAllButtons)
+		{
+			TouchButton.UpdateScreenFromUnitRect();
+			TouchButton.Render(false);
+		}
+	}
+
+	if(m_pSampleButton != nullptr && m_ShownRect.has_value())
+	{
+		m_pSampleButton->Render(true, m_ShownRect);
+	}
+}
+
+CTouchControls::CUnitRect CTouchControls::FindPositionXY(std::vector<CUnitRect> &vVisibleButtonRects, CUnitRect MyRect)
+{
+	// Border clamp
+	MyRect.m_X = std::clamp(MyRect.m_X, 0, BUTTON_SIZE_SCALE - MyRect.m_W);
+	MyRect.m_Y = std::clamp(MyRect.m_Y, 0, BUTTON_SIZE_SCALE - MyRect.m_H);
+	// Not overlapping with any rects
+	{
+		bool IfOverlap = std::any_of(vVisibleButtonRects.begin(), vVisibleButtonRects.end(), [&MyRect](const auto &Rect) {
+			return MyRect.IsOverlap(Rect);
+		});
+		if(!IfOverlap)
+			return MyRect;
+	}
+	if(vVisibleButtonRects != m_vLastUpdateRects || MyRect.m_W != m_LastWidth || MyRect.m_H != m_LastHeight)
+	{
+		m_LastWidth = MyRect.m_W;
+		m_LastHeight = MyRect.m_H;
+		m_vLastUpdateRects = vVisibleButtonRects;
+		BuildPositionXY(m_vLastUpdateRects, MyRect);
+	}
+	CUnitRect Result = {-1, -1, MyRect.m_W, MyRect.m_H}, SampleRect;
+	for(const ivec2 &Target : m_vTargets)
+	{
+		SampleRect = {Target.x, Target.y, MyRect.m_W, MyRect.m_H};
+		if(Result.m_X == -1 || MyRect.Distance(Result) > MyRect.Distance(SampleRect))
+			Result = SampleRect;
+	}
+	int BestXPosition = -BUTTON_SIZE_SCALE, BestYPosition = -BUTTON_SIZE_SCALE, Cur = 0;
+	std::vector<CUnitRect> vTargetRects;
+	vTargetRects.reserve(m_vLastUpdateRects.size());
+	std::copy_if(m_vXSortedRects.begin(), m_vXSortedRects.end(), std::back_inserter(vTargetRects), [&](const CUnitRect &Rect) {
+		return !(Rect.m_Y + Rect.m_H <= MyRect.m_Y || MyRect.m_Y + MyRect.m_H <= Rect.m_Y);
+	});
+	for(const CUnitRect &Rect : vTargetRects)
+	{
+		if(Cur >= Rect.m_X + Rect.m_W)
+			continue;
+		SampleRect = {Cur, MyRect.m_Y, MyRect.m_W, MyRect.m_H};
+		if(Cur + MyRect.m_W <= BUTTON_SIZE_SCALE && !SampleRect.IsOverlap(Rect))
+		{
+			BestXPosition = std::abs(Cur - MyRect.m_X) < std::abs(BestXPosition - MyRect.m_X) ? Cur : BestXPosition;
+			BestXPosition = std::abs(Rect.m_X - MyRect.m_W - MyRect.m_X) < std::abs(BestXPosition - MyRect.m_X) ? Rect.m_X - MyRect.m_W : BestXPosition;
+		}
+		Cur = Rect.m_X + Rect.m_W;
+	}
+	if(Cur + MyRect.m_W <= BUTTON_SIZE_SCALE)
+	{
+		BestXPosition = std::abs(Cur - MyRect.m_X) < std::abs(BestXPosition - MyRect.m_X) ? Cur : BestXPosition;
+	}
+
+	vTargetRects.clear();
+	std::copy_if(m_vYSortedRects.begin(), m_vYSortedRects.end(), std::back_inserter(vTargetRects), [&](const CUnitRect &Rect) {
+		return !(Rect.m_X + Rect.m_W <= MyRect.m_X || MyRect.m_X + MyRect.m_W <= Rect.m_X);
+	});
+	Cur = 0;
+	for(const CUnitRect &Rect : vTargetRects)
+	{
+		if(Cur >= Rect.m_Y + Rect.m_H)
+			continue;
+		SampleRect = {MyRect.m_X, Cur, MyRect.m_W, MyRect.m_H};
+		if(Cur + MyRect.m_H <= BUTTON_SIZE_SCALE && !SampleRect.IsOverlap(Rect))
+		{
+			BestYPosition = std::abs(Cur - MyRect.m_Y) < std::abs(BestYPosition - MyRect.m_Y) ? Cur : BestYPosition;
+			BestYPosition = std::abs(Rect.m_Y - MyRect.m_H - MyRect.m_Y) < std::abs(BestYPosition - MyRect.m_Y) ? Rect.m_Y - MyRect.m_H : BestYPosition;
+		}
+		Cur = Rect.m_Y + Rect.m_H;
+	}
+	if(Cur + MyRect.m_H <= BUTTON_SIZE_SCALE)
+	{
+		BestYPosition = std::abs(Cur - MyRect.m_Y) < std::abs(BestYPosition - MyRect.m_Y) ? Cur : BestYPosition;
+	}
+
+	if(BestXPosition != -BUTTON_SIZE_SCALE)
+	{
+		SampleRect = {BestXPosition, MyRect.m_Y, MyRect.m_W, MyRect.m_H};
+		if(Result.m_X == -1 || MyRect.Distance(Result) > MyRect.Distance(SampleRect))
+			Result = SampleRect;
+	}
+	if(BestYPosition != -BUTTON_SIZE_SCALE)
+	{
+		SampleRect = {MyRect.m_X, BestYPosition, MyRect.m_W, MyRect.m_H};
+		if(Result.m_X == -1 || MyRect.Distance(Result) > MyRect.Distance(SampleRect))
+			Result = SampleRect;
+	}
+	return Result;
+}
+
+void CTouchControls::BuildPositionXY(std::vector<CUnitRect> vVisibleButtonRects, CUnitRect MyRect)
+{
+	m_vTargets.clear();
+	m_vTargets.reserve(vVisibleButtonRects.size() * 4);
+	m_vXSortedRects = m_vYSortedRects = vVisibleButtonRects;
+	std::sort(m_vXSortedRects.begin(), m_vXSortedRects.end(), [](const CUnitRect &Lhs, const CUnitRect &Rhs) {
+		return Lhs.m_X < Rhs.m_X;
+	});
+	std::sort(m_vYSortedRects.begin(), m_vYSortedRects.end(), [](const CUnitRect &Lhs, const CUnitRect &Rhs) {
+		return Lhs.m_Y < Rhs.m_Y;
+	});
+	std::sort(vVisibleButtonRects.begin(), vVisibleButtonRects.end(), [](const CUnitRect &Lhs, const CUnitRect &Rhs) {
+		return Lhs.m_X < Rhs.m_X;
+	});
+	class CTree
+	{
+	public:
+		void Init(const std::vector<CUnitRect> &vRects)
+		{
+			m_vOrder.reserve(vRects.size() * 2);
+			for(const CUnitRect &Rect : vRects)
+			{
+				m_vOrder.emplace_back(Rect.m_Y);
+				m_vOrder.emplace_back(Rect.m_Y + Rect.m_H);
+			}
+			m_vOrder.emplace_back(0);
+			m_vOrder.emplace_back(BUTTON_SIZE_SCALE);
+			std::sort(m_vOrder.begin(), m_vOrder.end());
+			m_vOrder.erase(std::unique(m_vOrder.begin(), m_vOrder.end()), m_vOrder.end());
+			m_vTree.resize(m_vOrder.size() * 4, {-1, -1, 0, 0});
+			New(0, m_vOrder.size() - 2, 0);
+			m_vZone.reserve(m_vTree.size());
+		}
+		void New(int Start, int End, unsigned Cur)
+		{
+			if(m_vTree[Cur].x != -1)
+				return;
+			m_vTree[Cur].x = Start;
+			m_vTree[Cur].y = End;
+			m_vTree[Cur].z = 0;
+			m_vTree[Cur].w = 0;
+		}
+		void Add(int Start, int End, unsigned Cur)
+		{
+			m_vTree[Cur].z++;
+			if(m_vTree[Cur].x == Start && m_vTree[Cur].y == End)
+			{
+				m_vTree[Cur].w++;
+				return;
+			}
+			int Mid = (m_vTree[Cur].x + m_vTree[Cur].y) / 2;
+			New(Mid + 1, m_vTree[Cur].y, Cur * 2 + 2);
+			New(m_vTree[Cur].x, Mid, Cur * 2 + 1);
+			if(Start <= Mid)
+			{
+				Add(Start, minimum<int>(Mid, End), Cur * 2 + 1);
+			}
+			if(End >= Mid + 1)
+			{
+				Add(maximum<int>(Mid + 1, Start), End, Cur * 2 + 2);
+			}
+		}
+		void Delete(int Start, int End, unsigned Cur)
+		{
+			m_vTree[Cur].z--;
+			if(m_vTree[Cur].x == Start && m_vTree[Cur].y == End)
+			{
+				m_vTree[Cur].w--;
+				return;
+			}
+			int Mid = (m_vTree[Cur].x + m_vTree[Cur].y) / 2;
+			if(Start <= Mid)
+			{
+				Delete(Start, minimum<int>(Mid, End), Cur * 2 + 1);
+			}
+			if(End >= Mid + 1)
+			{
+				Delete(maximum<int>(Mid + 1, Start), End, Cur * 2 + 2);
+			}
+		}
+		void InnerQuery(unsigned Start)
+		{
+			std::vector<unsigned> vStack;
+			vStack.reserve(BUTTON_SIZE_SCALE / BUTTON_SIZE_MINIMUM);
+			vStack.push_back(Start);
+			while(!vStack.empty())
+			{
+				unsigned Cur = vStack.back();
+				vStack.pop_back();
+				if(m_vTree[Cur].w > 0)
+				{
+					m_vZone.emplace_back(m_vTree[Cur].x, m_vTree[Cur].y);
+					continue;
+				}
+				if(m_vTree[Cur].x == m_vTree[Cur].y || m_vTree[Cur].z == 0)
+					continue;
+				if(m_vTree[Cur * 2 + 2].x != -1 && m_vTree[Cur * 2 + 2].z > 0)
+				{
+					vStack.push_back((Cur << 1) + 2);
+				}
+				if(m_vTree[Cur * 2 + 1].x != -1 && m_vTree[Cur * 2 + 1].z > 0)
+				{
+					vStack.push_back((Cur << 1) + 1);
+				}
+			}
+		}
+		std::vector<ivec2> Query(int Length)
+		{
+			m_vZone.clear();
+			InnerQuery(0);
+			if(m_vZone.empty())
+			{
+				return {{0, BUTTON_SIZE_SCALE}};
+			}
+
+			// Inverse discretization
+			for(ivec2 &Zone : m_vZone)
+			{
+				Zone.x = m_vOrder[Zone.x];
+				Zone.y = m_vOrder[Zone.y + 1];
+			}
+			if(m_vZone[0].x < Length)
+				m_vZone[0].x = 0;
+			// Merge segments.
+			for(unsigned Index = 1; Index < m_vZone.size(); Index++)
+			{
+				if(m_vZone[Index - 1].y + Length <= m_vZone[Index].x)
+					continue;
+				m_vZone[Index].x = m_vZone[Index - 1].x;
+				m_vZone[Index - 1].x = -1;
+			}
+			if(m_vZone.back().y + Length > BUTTON_SIZE_SCALE)
+				m_vZone.back().y = BUTTON_SIZE_SCALE;
+			m_vZone.erase(std::remove_if(m_vZone.begin(), m_vZone.end(), [](const ivec2 &Zone) { return Zone.x == -1; }),
+				m_vZone.end());
+			// Result stores obstacles, now turn it into free spaces.
+			std::vector<ivec2> vFree;
+			vFree.reserve(m_vZone.size());
+			if(m_vZone[0].x != 0)
+				vFree.emplace_back(0, m_vZone[0].x);
+			for(unsigned Index = 1; Index < m_vZone.size(); Index++)
+			{
+				vFree.emplace_back(m_vZone[Index - 1].y, m_vZone[Index].x);
+			}
+			if(m_vZone.back().y != BUTTON_SIZE_SCALE)
+				vFree.emplace_back(m_vZone.back().y, BUTTON_SIZE_SCALE);
+			return vFree;
+		}
+		ivec2 Discretization(int Start, int End)
+		{
+			ivec2 Result;
+			auto It = std::lower_bound(m_vOrder.begin(), m_vOrder.end(), Start);
+			Result.x = std::distance(m_vOrder.begin(), It);
+			It = std::lower_bound(m_vOrder.begin(), m_vOrder.end(), End);
+			Result.y = std::distance(m_vOrder.begin(), It) - 1;
+			return Result;
+		}
+
+	private:
+		std::vector<int> m_vOrder;
+		std::vector<ivec4> m_vTree;
+		std::vector<ivec2> m_vZone;
+	} Tree;
+
+	std::set<int> CandidateX;
+	for(const CUnitRect &Rect : vVisibleButtonRects)
+	{
+		// Rect right border.
+		int Pos = Rect.m_X + Rect.m_W;
+		if(Pos + MyRect.m_W <= BUTTON_SIZE_SCALE)
+			CandidateX.insert(Pos);
+		// Rect left border.
+		Pos = Rect.m_X - MyRect.m_W;
+		if(Pos >= 0)
+			CandidateX.insert(Pos);
+	}
+	CandidateX.insert(CandidateX.begin(), 0);
+	CandidateX.insert(BUTTON_SIZE_SCALE - MyRect.m_W);
+	Tree.Init(vVisibleButtonRects);
+
+	auto Cmp = [&vVisibleButtonRects](int Lhs, int Rhs) -> bool {
+		return vVisibleButtonRects[Lhs].m_X + vVisibleButtonRects[Lhs].m_W > vVisibleButtonRects[Rhs].m_X + vVisibleButtonRects[Rhs].m_W;
+	};
+	std::priority_queue<int, std::vector<int>, decltype(Cmp)> Out(Cmp);
+
+	unsigned Index = 0;
+
+	for(int CurrentX : CandidateX)
+	{
+		while(Index < vVisibleButtonRects.size() && vVisibleButtonRects[Index].m_X < CurrentX + MyRect.m_W)
+		{
+			auto Segment = Tree.Discretization(vVisibleButtonRects[Index].m_Y, vVisibleButtonRects[Index].m_Y + vVisibleButtonRects[Index].m_H);
+			Tree.Add(Segment.x, Segment.y, 0);
+			Out.emplace(Index++);
+		}
+		while(!Out.empty() && vVisibleButtonRects[Out.top()].m_X + vVisibleButtonRects[Out.top()].m_W <= CurrentX)
+		{
+			auto Segment = Tree.Discretization(vVisibleButtonRects[Out.top()].m_Y, vVisibleButtonRects[Out.top()].m_Y + vVisibleButtonRects[Out.top()].m_H);
+			Tree.Delete(Segment.x, Segment.y, 0);
+			Out.pop();
+		}
+		auto Spaces = Tree.Query(MyRect.m_H);
+		for(ivec2 &Space : Spaces)
+		{
+			m_vTargets.emplace_back(CurrentX, Space.x);
+			m_vTargets.emplace_back(CurrentX, Space.y - MyRect.m_H);
+		}
+	}
+}
+
+// Create a new button and push_back to m_vTouchButton, then return a pointer.
+CTouchControls::CTouchButton *CTouchControls::NewButton()
+{
+	// Ensure m_pSelectedButton doesn't go wild.
+	int Target = -1;
+	if(m_pSelectedButton != nullptr)
+		Target = std::distance(m_vTouchButtons.data(), m_pSelectedButton);
+	CTouchButton NewButton(this);
+	NewButton.m_pBehavior = std::make_unique<CBindTouchButtonBehavior>("", CButtonLabel::EType::PLAIN, "");
+	// So the vector's elements might be moved. If moved all button's m_VisibilityCached will be set to false. This should be prevented.
+	std::vector<bool> vCachedVisibilities;
+	vCachedVisibilities.reserve(m_vTouchButtons.size());
+	for(const auto &Button : m_vTouchButtons)
+	{
+		vCachedVisibilities.emplace_back(Button.m_VisibilityCached);
+	}
+	for(unsigned Iterator = 0; Iterator < vCachedVisibilities.size(); Iterator++)
+	{
+		m_vTouchButtons[Iterator].m_VisibilityCached = vCachedVisibilities[Iterator];
+	}
+	m_vTouchButtons.push_back(std::move(NewButton));
+	if(Target != -1)
+		m_pSelectedButton = &m_vTouchButtons[Target];
+	return &m_vTouchButtons.back();
+}
+
+void CTouchControls::DeleteSelectedButton()
+{
+	if(m_pSelectedButton != nullptr)
+	{
+		auto DeleteIt = m_vTouchButtons.begin() + (m_pSelectedButton - m_vTouchButtons.data());
+		m_vTouchButtons.erase(DeleteIt);
+	}
+	ResetButtonPointers();
+	m_UnsavedChanges = false;
+}
+
+bool CTouchControls::IsRectOverlapping(CUnitRect MyRect) const
+{
+	for(const auto &TouchButton : m_vTouchButtons)
+	{
+		if(m_pSelectedButton == &TouchButton)
+			continue;
+		bool IsVisible = std::all_of(TouchButton.m_vVisibilities.begin(), TouchButton.m_vVisibilities.end(), [&](const auto &Visibility) {
+			return Visibility.m_Parity == m_aVirtualVisibilities[(int)Visibility.m_Type];
+		});
+		if(IsVisible && MyRect.IsOverlap(TouchButton.m_UnitRect))
+			return true;
+	}
+	return false;
+}
+
+CTouchControls::CUnitRect CTouchControls::UpdatePosition(CUnitRect MyRect, bool Ignore)
+{
+	std::vector<CUnitRect> vVisibleButtonRects;
+	for(const auto &TouchButton : m_vTouchButtons)
+	{
+		if(m_pSelectedButton == &TouchButton && !Ignore)
+			continue;
+		bool IsVisible = std::all_of(TouchButton.m_vVisibilities.begin(), TouchButton.m_vVisibilities.end(), [&](const auto &Visibility) {
+			return Visibility.m_Parity == m_aVirtualVisibilities[(int)Visibility.m_Type];
+		});
+		if(IsVisible)
+			vVisibleButtonRects.emplace_back(TouchButton.m_UnitRect);
+	}
+	return FindPositionXY(vVisibleButtonRects, MyRect);
+}
+
+void CTouchControls::ResetButtonPointers()
+{
+	m_pSelectedButton = nullptr;
+	m_pSampleButton = nullptr;
+	m_ShownRect = std::nullopt;
+}
+
+// After sending the type, the popup should be reset immediately.
+CTouchControls::CPopupParam CTouchControls::RequiredPopup()
+{
+	CPopupParam ReturnPopup = m_PopupParam;
+	// Reset type so it won't be called for multiple times.
+	m_PopupParam.m_PopupType = EPopupType::NUM_POPUPS;
+	return ReturnPopup;
+}
+
+// Return true if any issue is not finished.
+bool CTouchControls::AnyIssueNotResolved() const
+{
+	return std::any_of(m_aIssueParam.begin(), m_aIssueParam.end(), [](const auto &Issue) {
+		return !Issue.m_Resolved;
+	});
+}
+
+std::array<CTouchControls::CIssueParam, (unsigned)CTouchControls::EIssueType::NUM_ISSUES> CTouchControls::Issues()
+{
+	std::array<CIssueParam, (unsigned)EIssueType::NUM_ISSUES> aUnresolvedIssues;
+	for(int Issue = 0; Issue < (int)EIssueType::NUM_ISSUES; Issue++)
+	{
+		aUnresolvedIssues[Issue] = m_aIssueParam[Issue];
+		m_aIssueParam[Issue].m_Resolved = true;
+	}
+	return aUnresolvedIssues;
+}
+
+// Make it look like the button, only have bind behavior. This is only used on m_pSampleButton.
+void CTouchControls::UpdateSampleButton(const CTouchButton &SrcButton)
+{
+	dbg_assert(m_pSampleButton != nullptr, "Sample button not created");
+	m_pSampleButton->m_UnitRect = SrcButton.m_UnitRect;
+	m_pSampleButton->m_Shape = SrcButton.m_Shape;
+	m_pSampleButton->m_vVisibilities = SrcButton.m_vVisibilities;
+	CButtonLabel Label = SrcButton.m_pBehavior->GetLabel();
+	m_pSampleButton->m_pBehavior = std::make_unique<CBindTouchButtonBehavior>(Label.m_pLabel, Label.m_Type, "");
+	m_pSampleButton->UpdatePointers();
+	m_pSampleButton->UpdateScreenFromUnitRect();
+}
+
+std::vector<CTouchControls::CTouchButton *> CTouchControls::GetButtonsEditor()
+{
+	std::vector<CTouchButton *> vpButtons;
+	vpButtons.reserve(m_vTouchButtons.size());
+	for(auto &TouchButton : m_vTouchButtons)
+	{
+		TouchButton.UpdateVisibilityEditor();
+		vpButtons.emplace_back(&TouchButton);
+	}
+	return vpButtons;
+}
+
+float CTouchControls::CUnitRect::Distance(const CUnitRect &Other) const
+{
+	vec2 Delta;
+	Delta.x = Other.m_X + Other.m_W / 2.0f - m_X - m_W / 2.0f;
+	Delta.y = Other.m_Y + Other.m_H / 2.0f - m_Y - m_H / 2.0f;
+	return length(Delta / BUTTON_SIZE_SCALE);
 }


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
Supports editing touch controls ingame. General features:
1. Edit everything that can be changed by editing touch_controls.json
2. Move & zoom buttons on screen directly
3. Automatically avoid selected button being overlapped
4. Preview button layout under different visibilities
5. Browse & search for buttons by label, command or position

Other edits:
Use `m_JoystickCount` to support multi joysticks on screen so `swap-action` can act correctly

Previews:
![Screenshot_2025-08-30-18-27-37-097_org ddnet clienu](https://github.com/user-attachments/assets/435014af-31a3-47b4-aa07-339f852b2152)
![Screenshot_2025-08-30-18-27-54-531_org ddnet clienu](https://github.com/user-attachments/assets/d32e5e09-8b9b-48fa-b62c-8a42104bdf31)
![Screenshot_2025-08-30-18-28-08-491_org ddnet clienu](https://github.com/user-attachments/assets/8936e8e8-382e-4a8b-8015-974301e7744d)
![Screenshot_2025-08-30-18-28-17-323_org ddnet clienu](https://github.com/user-attachments/assets/f65705d8-7d5c-49b2-bcc0-089eabbc0e45)


<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)