### PR TITLE
Add auth level to antibot data

### DIFF
--- a/src/antibot/antibot_data.h
+++ b/src/antibot/antibot_data.h
@@ -5,12 +5,18 @@
 
 enum
 {
-	ANTIBOT_ABI_VERSION = 11,
+	ANTIBOT_ABI_VERSION = 12,
 
 	ANTIBOT_MSGFLAG_NONVITAL = 1,
 	ANTIBOT_MSGFLAG_FLUSH = 2,
 
 	ANTIBOT_MAX_CLIENTS = 128,
+
+	ANTIBOT_AUTHED_NO = 0,
+	ANTIBOT_AUTHED_HELPER = 1,
+	ANTIBOT_AUTHED_MOD = 2,
+	ANTIBOT_AUTHED_ADMIN = 3,
+	ANTIBOT_NUM_AUTHEDS = 4,
 };
 
 struct CAntibotMapData
@@ -27,7 +33,7 @@ struct CAntibotPlayerData
 	bool m_DnsblNone;
 	bool m_DnsblPending;
 	bool m_DnsblBlacklisted;
-	bool m_Authed;
+	int m_AuthLevel;
 };
 
 struct CAntibotInputData

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -35,6 +35,8 @@
 #include <engine/shared/rust_version.h>
 #include <engine/shared/snapshot.h>
 
+#include <antibot/antibot_data.h>
+#include <game/generated/protocol.h>
 #include <game/version.h>
 
 // DDRace
@@ -2458,7 +2460,24 @@ void CServer::FillAntibot(CAntibotRoundData *pData)
 			pPlayer->m_DnsblNone = m_aClients[ClientId].m_DnsblState == CClient::DNSBL_STATE_NONE;
 			pPlayer->m_DnsblPending = m_aClients[ClientId].m_DnsblState == CClient::DNSBL_STATE_PENDING;
 			pPlayer->m_DnsblBlacklisted = m_aClients[ClientId].m_DnsblState == CClient::DNSBL_STATE_BLACKLISTED;
-			pPlayer->m_Authed = m_aClients[ClientId].m_Authed > AUTHED_NO;
+			switch(m_aClients[ClientId].m_Authed)
+			{
+			case AUTHED_NO:
+				pPlayer->m_AuthLevel = ANTIBOT_AUTHED_NO;
+				break;
+			case AUTHED_HELPER:
+				pPlayer->m_AuthLevel = ANTIBOT_AUTHED_HELPER;
+				break;
+			case AUTHED_MOD:
+				pPlayer->m_AuthLevel = ANTIBOT_AUTHED_MOD;
+				break;
+			case AUTHED_ADMIN:
+				pPlayer->m_AuthLevel = ANTIBOT_AUTHED_ADMIN;
+				break;
+			default:
+				dbg_assert(false, "auth level %d not supported by antibot", m_aClients[ClientId].m_Authed);
+				break;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This allows the antibot module to show different levels of antibot details depending on the authed rank.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
