### PR TITLE
Limit dyncam offset for auto-sync camera

### DIFF
--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -257,7 +257,13 @@ void CCamera::UpdateCamera()
 		}
 
 		float OffsetAmount = maximum(l - CurrentDeadzone, 0.0f) * (CurrentFollowFactor / 100.0f);
-		m_DyncamTargetCameraOffset = normalize(TargetPos) * OffsetAmount;
+
+		if(IsSpectatingPlayer)
+		{
+			OffsetAmount = minimum(OffsetAmount, 350.0f * m_Zoom);
+		}
+
+		m_DyncamTargetCameraOffset = normalize_pre_length(TargetPos, l) * OffsetAmount;
 	}
 
 	m_LastTargetPos = TargetPos;


### PR DESCRIPTION
Clamping the dyncam when auto-sync is enabled so tees stay on screen.

Fix the camera glitching out when a client/server send weird cursor position while having dyncam on.
(The glitch currently is known to show up when spectating taterclient with improve precision and dyncam on)

The offset limit is arbitrarily selected by eyeballing the tees position.

Video shows a modded server sending `Target * 1000.0f`. (top left regular player, bottom right spectator)

https://github.com/user-attachments/assets/6d0576af-6397-4daf-8ed0-eaa4f667639f

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
