### PR TITLE
Nameplate not major refactoring

### DIFF
--- a/src/game/client/components/nameplates.h
+++ b/src/game/client/components/nameplates.h
@@ -8,7 +8,7 @@
 #include <game/client/component.h>
 #include <game/generated/protocol.h>
 
-class CNamePlateRenderData
+class CNamePlateData
 {
 public:
 	bool m_InGame;
@@ -42,12 +42,11 @@ public:
 	float m_FontSizeHookStrongWeak;
 };
 
-class CNamePlate;
-
 class CNamePlates : public CComponent
 {
 private:
-	CNamePlate *m_pNamePlates;
+	class CNamePlatesData;
+	CNamePlatesData *m_pData;
 
 public:
 	void RenderNamePlateGame(vec2 Position, const CNetObj_PlayerInfo *pPlayerInfo, float Alpha);


### PR DESCRIPTION
Nameplate not major refactoring
* Use RAII
* Use array for nameplates instead of raw ptr
* Use vec2 everywhere instead of X and Y
* Rename CNamePlateData to CNamePlateRenderData
* Few other things

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
