### PR TITLE
Don't allow empty favorite group

### DIFF
--- a/src/engine/client/favorites.cpp
+++ b/src/engine/client/favorites.cpp
@@ -1,3 +1,4 @@
+#include <base/log.h>
 #include <base/system.h>
 #include <engine/favorites.h>
 #include <engine/shared/config.h>
@@ -145,6 +146,11 @@ TRISTATE CFavorites::IsPingAllowed(const NETADDR *pAddrs, int NumAddrs) const
 
 void CFavorites::Add(const NETADDR *pAddrs, int NumAddrs)
 {
+	if(NumAddrs == 0)
+	{
+		log_error("client", "discarding empty favorite group");
+		return;
+	}
 	// First make sure that all the addresses are not registered for some
 	// other favorite.
 	for(int i = 0; i < NumAddrs; i++)


### PR DESCRIPTION
Add check so it doesn't add a dummy favorite server entry that I didn't figure out how to remove in game when using `end_favorite_group` before adding any favorite server.

I don't know what is a favorite group and what it's used for btw...

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
