### PR TITLE
make grabber color customizable

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -598,6 +598,9 @@ MACRO_CONFIG_COL(ClLaserDoorInnerColor, cl_laser_door_inner_color, 7701379, CFGF
 MACRO_CONFIG_COL(ClLaserDoorOutlineColor, cl_laser_door_outline_color, 7667473, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Laser outline color for doors")
 MACRO_CONFIG_COL(ClLaserFreezeInnerColor, cl_laser_freeze_inner_color, 12001153, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Laser inner color for freezes")
 MACRO_CONFIG_COL(ClLaserFreezeOutlineColor, cl_laser_freeze_outline_color, 11613223, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Laser outline color for freezes")
+MACRO_CONFIG_COL(ClLaserGrabberInnerColor, cl_laser_grabber_inner_color, 65437, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Laser inner color for grabbers")
+MACRO_CONFIG_COL(ClLaserGrabberOutlineColor, cl_laser_grabber_outline_color, 57618, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Laser outline color for grabbers")
+
 MACRO_CONFIG_COL(ClKillMessageNormalColor, cl_kill_message_normal_color, 255, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_COLALPHA, "Kill message normal color")
 MACRO_CONFIG_COL(ClKillMessageHighlightColor, cl_kill_message_highlight_color, 255, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_COLALPHA, "Kill message highlight color")
 

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -254,7 +254,6 @@ void CItems::RenderLaser(const CLaserData *pCurrent, bool IsPredicted)
 		ColorOut = g_Config.m_ClLaserShotgunOutlineColor;
 		ColorIn = g_Config.m_ClLaserShotgunInnerColor;
 		break;
-	case LASERTYPE_DRAGGER:
 	case LASERTYPE_DOOR:
 		ColorOut = g_Config.m_ClLaserDoorOutlineColor;
 		ColorIn = g_Config.m_ClLaserDoorInnerColor;
@@ -262,6 +261,10 @@ void CItems::RenderLaser(const CLaserData *pCurrent, bool IsPredicted)
 	case LASERTYPE_FREEZE:
 		ColorOut = g_Config.m_ClLaserFreezeOutlineColor;
 		ColorIn = g_Config.m_ClLaserFreezeInnerColor;
+		break;
+	case LASERTYPE_DRAGGER:
+		ColorOut = g_Config.m_ClLaserGrabberOutlineColor;
+		ColorIn = g_Config.m_ClLaserGrabberInnerColor;
 		break;
 	case LASERTYPE_GUN:
 	case LASERTYPE_PLASMA:

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -27,6 +27,7 @@
 
 #include <engine/client/updater.h>
 
+#include <game/client/animstate.h>
 #include <game/client/components/binds.h>
 #include <game/client/components/console.h>
 #include <game/client/components/menu_background.h>
@@ -304,7 +305,7 @@ int CMenus::DoButton_CheckBox_Common(const void *pId, const char *pText, const c
 void CMenus::DoLaserPreview(const CUIRect *pRect, const ColorHSLA LaserOutlineColor, const ColorHSLA LaserInnerColor, const int LaserType)
 {
 	CUIRect Section = *pRect;
-	vec2 From = vec2(Section.x + 50.0f, Section.y + Section.h / 2.0f);
+	vec2 From = vec2(Section.x + 30.0f, Section.y + Section.h / 2.0f);
 	vec2 Pos = vec2(Section.x + Section.w - 10.0f, Section.y + Section.h / 2.0f);
 
 	const ColorRGBA OuterColor = color_cast<ColorRGBA>(ColorHSLA(LaserOutlineColor));
@@ -332,6 +333,30 @@ void CMenus::DoLaserPreview(const CUIRect *pRect, const ColorHSLA LaserOutlineCo
 		RenderTools()->DrawSprite(Section.x + 30.0f, Section.y + Section.h / 2.0f, 60.0f);
 		Graphics()->QuadsEnd();
 		break;
+	case LASERTYPE_DRAGGER:
+	{
+		CTeeRenderInfo TeeRenderInfo;
+		TeeRenderInfo.Apply(m_pClient->m_Skins.Find(g_Config.m_ClPlayerSkin));
+		TeeRenderInfo.ApplyColors(g_Config.m_ClPlayerUseCustomColor, g_Config.m_ClPlayerColorBody, g_Config.m_ClPlayerColorFeet);
+		TeeRenderInfo.m_Size = 64.0f;
+		RenderTools()->RenderTee(CAnimState::GetIdle(), &TeeRenderInfo, EMOTE_NORMAL, vec2(1, 0), From);
+		break;
+	}
+	case LASERTYPE_FREEZE:
+	{
+		CTeeRenderInfo TeeRenderInfo;
+		if(g_Config.m_ClShowNinja)
+			TeeRenderInfo.Apply(m_pClient->m_Skins.Find("x_ninja"));
+		else
+			TeeRenderInfo.Apply(m_pClient->m_Skins.Find(g_Config.m_ClPlayerSkin));
+		TeeRenderInfo.m_TeeRenderFlags = TEE_EFFECT_FROZEN;
+		TeeRenderInfo.m_Size = 64.0f;
+		TeeRenderInfo.m_ColorBody = ColorRGBA(1, 1, 1);
+		TeeRenderInfo.m_ColorFeet = ColorRGBA(1, 1, 1);
+		RenderTools()->RenderTee(CAnimState::GetIdle(), &TeeRenderInfo, EMOTE_PAIN, vec2(1, 0), From);
+		GameClient()->m_Effects.FreezingFlakes(From, vec2(32, 32));
+		break;
+	}
 	default:
 		GameClient()->m_Items.RenderLaser(From, From, OuterColor, InnerColor, 4.0f, TicksHead, LaserType);
 	}

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2996,12 +2996,14 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 		LeftView.HSplitTop(MarginSmall, nullptr, &LeftView);
 
 		// General entity laser settings
-		static CButtonContainer s_LaserDoorOutResetId, s_LaserDoorInResetId, s_LaserFreezeOutResetId, s_LaserFreezeInResetId;
+		static CButtonContainer s_LaserDoorOutResetId, s_LaserDoorInResetId, s_LaserFreezeOutResetId, s_LaserFreezeInResetId, s_LaserGrabberOutResetId, s_LaserGrabberInResetId;
 
 		ColorHSLA LaserDoorOutlineColor = DoLine_ColorPicker(&s_LaserDoorOutResetId, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &LeftView, Localize("Door Laser Outline Color"), &g_Config.m_ClLaserDoorOutlineColor, ColorRGBA(0.0f, 0.131372f, 0.096078f, 1.0f), false);
 		ColorHSLA LaserDoorInnerColor = DoLine_ColorPicker(&s_LaserDoorInResetId, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &LeftView, Localize("Door Laser Inner Color"), &g_Config.m_ClLaserDoorInnerColor, ColorRGBA(0.262745f, 0.760784f, 0.639215f, 1.0f), false);
 		ColorHSLA LaserFreezeOutlineColor = DoLine_ColorPicker(&s_LaserFreezeOutResetId, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &LeftView, Localize("Freeze Laser Outline Color"), &g_Config.m_ClLaserFreezeOutlineColor, ColorRGBA(0.131372f, 0.123529f, 0.182352f, 1.0f), false);
 		ColorHSLA LaserFreezeInnerColor = DoLine_ColorPicker(&s_LaserFreezeInResetId, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &LeftView, Localize("Freeze Laser Inner Color"), &g_Config.m_ClLaserFreezeInnerColor, ColorRGBA(0.482352f, 0.443137f, 0.564705f, 1.0f), false);
+		ColorHSLA LaserGrabberOutlineColor = DoLine_ColorPicker(&s_LaserGrabberOutResetId, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &LeftView, Localize("Grabber Outline Color"), &g_Config.m_ClLaserGrabberOutlineColor, ColorRGBA(0.1640625f, 0.015625f, 0.015625f, 1.0f), false);
+		ColorHSLA LaserGrabberInnerColor = DoLine_ColorPicker(&s_LaserGrabberInResetId, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &LeftView, Localize("Grabber Inner Color"), &g_Config.m_ClLaserGrabberInnerColor, ColorRGBA(1.f, 0.23046875f, 0.23046875f, 1.0f), false);
 
 		static CButtonContainer s_AllToRifleResetId, s_AllToDefaultResetId;
 
@@ -3015,6 +3017,8 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 			g_Config.m_ClLaserDoorInnerColor = g_Config.m_ClLaserRifleInnerColor;
 			g_Config.m_ClLaserFreezeOutlineColor = g_Config.m_ClLaserRifleOutlineColor;
 			g_Config.m_ClLaserFreezeInnerColor = g_Config.m_ClLaserRifleInnerColor;
+			g_Config.m_ClLaserGrabberOutlineColor = g_Config.m_ClLaserRifleOutlineColor;
+			g_Config.m_ClLaserGrabberInnerColor = g_Config.m_ClLaserRifleInnerColor;
 		}
 
 		// values taken from the CL commands
@@ -3030,6 +3034,8 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 			g_Config.m_ClLaserDoorInnerColor = 7701379;
 			g_Config.m_ClLaserFreezeOutlineColor = 11613223;
 			g_Config.m_ClLaserFreezeInnerColor = 12001153;
+			g_Config.m_ClLaserGrabberOutlineColor = 54807;
+			g_Config.m_ClLaserGrabberInnerColor = 65437;
 		}
 
 		// ***** Laser Preview ***** //
@@ -3037,7 +3043,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 			TEXTALIGN_ML, &RightView, HeadlineHeight);
 		RightView.HSplitTop(MarginSmall, nullptr, &RightView);
 
-		const float LaserPreviewHeight = 50.0f;
+		const float LaserPreviewHeight = 60.0f;
 		CUIRect LaserPreview;
 		RightView.HSplitTop(LaserPreviewHeight, &LaserPreview, &RightView);
 		RightView.HSplitTop(2 * MarginSmall, nullptr, &RightView);
@@ -3053,7 +3059,11 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		RightView.HSplitTop(LaserPreviewHeight, &LaserPreview, &RightView);
 		RightView.HSplitTop(2 * MarginSmall, nullptr, &RightView);
-		DoLaserPreview(&LaserPreview, LaserFreezeOutlineColor, LaserFreezeInnerColor, LASERTYPE_DOOR);
+		DoLaserPreview(&LaserPreview, LaserFreezeOutlineColor, LaserFreezeInnerColor, LASERTYPE_FREEZE);
+
+		RightView.HSplitTop(LaserPreviewHeight, &LaserPreview, &RightView);
+		RightView.HSplitTop(2 * MarginSmall, nullptr, &RightView);
+		DoLaserPreview(&LaserPreview, LaserGrabberOutlineColor, LaserGrabberInnerColor, LASERTYPE_DRAGGER);
 	}
 }
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Use a custom color for grabbers as well, make them different from doors. Previously doors and grabbers shared the same color.
Requested by @SollyBunny

Also reworks the settings page laser a bit

Screenshots:
![screenshot_2025-03-30_23-45-52](https://github.com/user-attachments/assets/9e9e33c5-3194-4393-8819-c0b0e2b537d1)
![screenshot_2025-03-29_22-33-17](https://github.com/user-attachments/assets/b6239a67-ede7-41c3-8135-99548f45fb82)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
