### PR TITLE
Name plate fixes

### DIFF
--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -190,7 +190,6 @@ public:
 		CNamePlatePartIcon(This)
 	{
 		m_Texture = g_pData->m_aImages[IMAGE_ARROW].m_Id;
-		m_ShiftOnInvis = true;
 		m_Direction = Dir;
 		switch(m_Direction)
 		{
@@ -209,10 +208,11 @@ public:
 	{
 		if(!Data.m_ShowDirection)
 		{
-			m_Size = vec2(0.0f, 0.0f);
+			m_ShiftOnInvis = false;
 			m_Visible = false;
 			return;
 		}
+		m_ShiftOnInvis = true; // Only shift (horizontally) the other parts if directions as a whole is visible
 		m_Size = vec2(Data.m_FontSizeDirection, Data.m_FontSizeDirection);
 		m_Padding.y = m_Size.y / 2.0f;
 		switch(m_Direction)
@@ -378,7 +378,7 @@ protected:
 			m_Sprite = SPRITE_HOOK_STRONG;
 			m_Color = color_cast<ColorRGBA>(ColorHSLA(6401973));
 			break;
-		case CNamePlateData::HOOKSTRONGWEAK_UNKNOWN:
+		case CNamePlateData::HOOKSTRONGWEAK_NEUTRAL:
 			m_Sprite = SPRITE_HOOK_ICON;
 			m_Color = ColorRGBA(1.0f, 1.0f, 1.0f);
 			break;
@@ -412,19 +412,12 @@ protected:
 		m_Visible = Data.m_ShowHookStrongWeakId;
 		if(!m_Visible)
 			return false;
-		m_Color.a = Data.m_Color.a;
-		return m_FontSize != Data.m_FontSizeHookStrongWeak || m_StrongWeakId != Data.m_HookStrongWeakId;
-	}
-	void UpdateText(CGameClient &This, const CNamePlateData &Data) override
-	{
-		m_FontSize = Data.m_FontSizeHookStrongWeak;
-		m_StrongWeakId = Data.m_HookStrongWeakId;
 		switch(Data.m_HookStrongWeak)
 		{
 		case CNamePlateData::HOOKSTRONGWEAK_STRONG:
 			m_Color = color_cast<ColorRGBA>(ColorHSLA(6401973));
 			break;
-		case CNamePlateData::HOOKSTRONGWEAK_UNKNOWN:
+		case CNamePlateData::HOOKSTRONGWEAK_NEUTRAL:
 			m_Color = ColorRGBA(1.0f, 1.0f, 1.0f);
 			break;
 		case CNamePlateData::HOOKSTRONGWEAK_WEAK:
@@ -432,6 +425,12 @@ protected:
 			break;
 		}
 		m_Color.a = Data.m_Color.a;
+		return m_FontSize != Data.m_FontSizeHookStrongWeak || m_StrongWeakId != Data.m_HookStrongWeakId;
+	}
+	void UpdateText(CGameClient &This, const CNamePlateData &Data) override
+	{
+		m_FontSize = Data.m_FontSizeHookStrongWeak;
+		m_StrongWeakId = Data.m_HookStrongWeakId;
 		str_format(m_aText, sizeof(m_aText), "%d", m_StrongWeakId);
 		CTextCursor Cursor;
 		This.TextRender()->SetCursor(&Cursor, 0.0f, 0.0f, m_FontSize, TEXTFLAG_RENDER);
@@ -704,7 +703,7 @@ void CNamePlates::RenderNamePlateGame(vec2 Position, const CNetObj_PlayerInfo *p
 	}
 
 	Data.m_ShowHookStrongWeak = false;
-	Data.m_HookStrongWeak = CNamePlateData::HOOKSTRONGWEAK_UNKNOWN;
+	Data.m_HookStrongWeak = CNamePlateData::HOOKSTRONGWEAK_NEUTRAL;
 	Data.m_ShowHookStrongWeakId = false;
 	Data.m_HookStrongWeakId = 0;
 
@@ -779,7 +778,7 @@ void CNamePlates::RenderNamePlatePreview(vec2 Position, int Dummy)
 	Data.m_ShowHookStrongWeakId = g_Config.m_ClNamePlatesStrong == 2;
 	if(Dummy == g_Config.m_ClDummy)
 	{
-		Data.m_HookStrongWeak = CNamePlateData::HOOKSTRONGWEAK_UNKNOWN;
+		Data.m_HookStrongWeak = CNamePlateData::HOOKSTRONGWEAK_NEUTRAL;
 		Data.m_ShowHookStrongWeak = Data.m_ShowHookStrongWeakId;
 	}
 	else

--- a/src/game/client/components/nameplates.h
+++ b/src/game/client/components/nameplates.h
@@ -34,7 +34,7 @@ public:
 	enum
 	{
 		HOOKSTRONGWEAK_WEAK,
-		HOOKSTRONGWEAK_UNKNOWN,
+		HOOKSTRONGWEAK_NEUTRAL,
 		HOOKSTRONGWEAK_STRONG
 	} m_HookStrongWeak;
 	bool m_ShowHookStrongWeakId;


### PR DESCRIPTION
* Fix directions adding padding when invsibible after being visible (great explanation), closes #9986 
* Fix color not updating on strong weak id, supercedes #9936 (thanks @Hoco4ekc)
* Rename `HOOKSTRONGWEAK_UNKNOWN` TO `HOOKSTRONGWEAK_NEUTRAL`

To reproduce:

```
connect 45.141.57.22:8300 # any server with strong/weak
cl_show_direction 3 # or have yours previously enabled
dummy_connect
cl_show_direction 0
```

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/079b4cd1-3113-41a4-804b-425478247aa0) | ![image](https://github.com/user-attachments/assets/9fbbe921-be82-405b-9c89-2e504791f327) |

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
