### PR TITLE
Call `ClampMousePos` on render instead of on cursor move

### DIFF
--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -320,6 +320,8 @@ void CControls::OnRender()
 	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 		return;
 
+	ClampMousePos();
+
 	if(g_Config.m_ClAutoswitchWeaponsOutOfAmmo && !GameClient()->m_GameInfo.m_UnlimitedAmmo && m_pClient->m_Snap.m_pLocalCharacter)
 	{
 		// Keep track of ammo count, we know weapon ammo only when we switch to that weapon, this is tracked on server and protocol does not track that
@@ -400,7 +402,6 @@ bool CControls::OnCursorMove(float x, float y, IInput::ECursorType CursorType)
 		Factor *= m_pClient->m_Camera.m_Zoom;
 
 	m_aMousePos[g_Config.m_ClDummy] += vec2(x, y) * Factor;
-	ClampMousePos();
 	return true;
 }
 


### PR DESCRIPTION
This fixes a bug where it was possible to see outside the possible range with dyncam. 

Closes #3696

Fix taken from 0.7: https://github.com/teeworlds/teeworlds/commit/055685406afc7b726f0126f0efc96bc6302da7b6


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
