### PR TITLE
Consistently order favorite skins in config file

### DIFF
--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -13,9 +13,9 @@
 
 #include <chrono>
 #include <optional>
+#include <set>
 #include <string_view>
 #include <unordered_map>
-#include <unordered_set>
 
 class CHttpRequest;
 
@@ -125,7 +125,7 @@ private:
 	std::vector<CSkinListEntry> m_vSkinList;
 	std::optional<std::chrono::nanoseconds> m_SkinListLastRefreshTime;
 
-	std::unordered_set<std::string> m_Favorites;
+	std::set<std::string> m_Favorites;
 
 	CSkin m_PlaceholderSkin;
 	char m_aEventSkinPrefix[MAX_SKIN_LENGTH];


### PR DESCRIPTION
Fix favorite skins being ordered randomly in the config file due to use of `std::unordered_set`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
