### PR TITLE
Improve network clipped to use radius + border

### DIFF
--- a/src/game/server/entity.cpp
+++ b/src/game/server/entity.cpp
@@ -92,12 +92,16 @@ bool NetworkClipped(const CGameContext *pGameServer, int SnappingClient, vec2 Ch
 	if(SnappingClient == SERVER_DEMO_CLIENT || pGameServer->m_apPlayers[SnappingClient]->m_ShowAll)
 		return false;
 
+	// Border of 10 blocks outside of view range
+	float Border = 32.f * 10.f;
+
 	float dx = pGameServer->m_apPlayers[SnappingClient]->m_ViewPos.x - CheckPos.x;
-	if(absolute(dx) > pGameServer->m_apPlayers[SnappingClient]->m_ShowDistance.x)
+	if(absolute(dx) > pGameServer->m_apPlayers[SnappingClient]->m_ShowDistance.x / 2.f + Border)
 		return true;
 
 	float dy = pGameServer->m_apPlayers[SnappingClient]->m_ViewPos.y - CheckPos.y;
-	return absolute(dy) > pGameServer->m_apPlayers[SnappingClient]->m_ShowDistance.y;
+	// Divide by 2 to get the radius.
+	return absolute(dy) > pGameServer->m_apPlayers[SnappingClient]->m_ShowDistance.y / 2.f + Border;
 }
 
 bool NetworkClippedLine(const CGameContext *pGameServer, int SnappingClient, vec2 StartPos, vec2 EndPos)


### PR DESCRIPTION
Taken from https://github.com/ddnet/ddnet/pull/9274/files/f49c3467760d610f6388b0b5a1f7ee04b8a74572#diff-b11d1429ae1c076f07f2072d988dc7b78e30a8ab55badc01b889cb914510b300 as a separate PR (see comments)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
