### PR TITLE
Cleanup: Use enum classes for status and protocol in register.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1982,6 +1982,8 @@ set_src(BASE GLOB_RECURSE src/base
   crashdump.cpp
   detect.h
   dynamic.h
+  enum_iterator.h
+  enum_map.h
   hash.cpp
   hash.h
   hash_bundled.cpp

--- a/src/base/enum_iterator.h
+++ b/src/base/enum_iterator.h
@@ -1,0 +1,50 @@
+#ifndef BASE_ENUM_ITERATOR_H
+#define BASE_ENUM_ITERATOR_H
+
+#include <cstddef>
+#include <type_traits>
+
+template<typename Enum, std::size_t Size = static_cast<std::size_t>(Enum::NUM)>
+class CEnumIterator
+{
+	static_assert(std::is_enum_v<Enum>, "EnumMap requires an enum type");
+
+	class CIterator
+	{
+	public:
+		CIterator(std::size_t Index) :
+			m_Index(Index) {}
+
+		CIterator &operator++()
+		{
+			++m_Index;
+			return *this;
+		}
+
+		bool operator!=(const CIterator &other) const
+		{
+			return m_Index != other.m_Index;
+		}
+
+		Enum operator*() const
+		{
+			return static_cast<Enum>(m_Index);
+		}
+
+	private:
+		std::size_t m_Index;
+	};
+
+public:
+	static auto begin()
+	{
+		return CIterator(0);
+	}
+
+	static auto end()
+	{
+		return CIterator(static_cast<std::size_t>(Enum::NUM));
+	}
+};
+
+#endif

--- a/src/base/enum_iterator.h
+++ b/src/base/enum_iterator.h
@@ -7,7 +7,7 @@
 template<typename Enum, std::size_t Size = static_cast<std::size_t>(Enum::NUM)>
 class CEnumIterator
 {
-	static_assert(std::is_enum_v<Enum>, "EnumMap requires an enum type");
+	static_assert(std::is_enum_v<Enum>, "EnumIterator requires an enum type");
 
 	class CIterator
 	{

--- a/src/base/enum_map.h
+++ b/src/base/enum_map.h
@@ -1,0 +1,39 @@
+#ifndef BASE_ENUM_MAP_H
+#define BASE_ENUM_MAP_H
+
+#include <array>
+#include <cstddef>
+#include <type_traits>
+
+template<typename Enum, typename Type, std::size_t Size = static_cast<std::size_t>(Enum::NUM)>
+class CEnumMap
+{
+	static_assert(std::is_enum_v<Enum>, "EnumMap requires an enum type");
+	std::array<Type, Size> m_aData;
+
+public:
+	CEnumMap() = default;
+	CEnumMap(std::array<Type, Size> aData) :
+		m_aData(aData) {}
+	inline constexpr Type &operator[](Enum e) noexcept
+	{
+		return m_aData[static_cast<std::size_t>(e)];
+	}
+
+	inline constexpr Type &operator[](Enum e) const noexcept
+	{
+		return m_aData[static_cast<std::size_t>(e)];
+	}
+
+	inline constexpr void fill(const Type &value)
+	{
+		m_aData.fill(value);
+	}
+
+	auto begin() { return m_aData.begin(); }
+	auto end() { return m_aData.end(); }
+	auto begin() const { return m_aData.begin(); }
+	auto end() const { return m_aData.end(); }
+};
+
+#endif

--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -23,7 +23,7 @@ class CRegister : public IRegister
 		OK,
 		NEED_CHALLENGE,
 		NEED_INFO,
-		ERROR
+		ERROR,
 	};
 
 	enum class EProtocol


### PR DESCRIPTION
Use enum classes for status and protocol in register.cpp

Added two new files in base/ for handling enum classes, may be useful if more things start to use class enums

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
