### PR TITLE
Improvements to recoloring of skins

### DIFF
--- a/src/engine/gfx/image_manipulation.cpp
+++ b/src/engine/gfx/image_manipulation.cpp
@@ -76,10 +76,14 @@ void ConvertToGrayscale(const CImageInfo &Image)
 	const size_t Step = Image.PixelSize();
 	for(size_t i = 0; i < Image.m_Width * Image.m_Height; ++i)
 	{
-		const int Average = (Image.m_pData[i * Step] + Image.m_pData[i * Step + 1] + Image.m_pData[i * Step + 2]) / 3;
-		Image.m_pData[i * Step] = Average;
-		Image.m_pData[i * Step + 1] = Average;
-		Image.m_pData[i * Step + 2] = Average;
+		const uint8_t R = Image.m_pData[i * Step];
+		const uint8_t G = Image.m_pData[i * Step + 1];
+		const uint8_t B = Image.m_pData[i * Step + 2];
+		const uint8_t Luma = (uint8_t)(0.2126f * R + 0.7152f * G + 0.0722f * B);
+
+		Image.m_pData[i * Step] = Luma;
+		Image.m_pData[i * Step + 1] = Luma;
+		Image.m_pData[i * Step + 2] = Luma;
 	}
 }
 

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -236,10 +236,10 @@ const CSkin *CSkins::LoadSkin(const char *pName, CImageInfo &Info)
 	ConvertToGrayscale(Info);
 
 	int aFreq[256] = {0};
-	int OrgWeight = 0;
-	int NewWeight = 192;
+	uint8_t OrgWeight = 1;
+	uint8_t NewWeight = 192;
 
-	// find most common frequency
+	// find most common non-zero frequency
 	for(size_t y = 0; y < BodyHeight; y++)
 	{
 		for(size_t x = 0; x < BodyWidth; x++)
@@ -261,29 +261,19 @@ const CSkin *CSkins::LoadSkin(const char *pName, CImageInfo &Info)
 	}
 
 	// reorder
-	int InvOrgWeight = 255 - OrgWeight;
-	int InvNewWeight = 255 - NewWeight;
 	for(size_t y = 0; y < BodyHeight; y++)
 	{
 		for(size_t x = 0; x < BodyWidth; x++)
 		{
 			const size_t Offset = y * Pitch + x * PixelStep;
-			int v = Info.m_pData[Offset];
-			if(v <= OrgWeight && OrgWeight == 0)
+			uint8_t v = Info.m_pData[Offset];
+			if(v <= OrgWeight)
 			{
-				v = 0;
-			}
-			else if(v <= OrgWeight)
-			{
-				v = (int)(((v / (float)OrgWeight) * NewWeight));
-			}
-			else if(InvOrgWeight == 0)
-			{
-				v = NewWeight;
+				v = (uint8_t)((v / (float)OrgWeight) * NewWeight);
 			}
 			else
 			{
-				v = (int)(((v - OrgWeight) / (float)InvOrgWeight) * InvNewWeight + NewWeight);
+				v = (uint8_t)(((v - OrgWeight) / (float)(255 - OrgWeight)) * (255 - NewWeight) + NewWeight);
 			}
 			Info.m_pData[Offset] = v;
 			Info.m_pData[Offset + 1] = v;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
The first change fixes #9545. The second change is to use luma when converting images to grayscale, which preserves the perceived brightness of colors and results in more natural looking gray shades. This affects mainly skins, but also some minor assets that use the grayscale function as well.
![color_avg_luma](https://github.com/user-attachments/assets/96e6a664-f399-479c-8c2a-ab21ec93ca95)

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
