### PR TITLE
Add client-configurable kill protection time cl_kill_protection

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -609,4 +609,8 @@ Messages = [
 	NetMessageEx("Sv_MapSoundGlobal", "map-sound-global@netmsg.ddnet.org", [
 		NetIntAny("m_SoundId"),
 	]),
+
+	NetMessageEx("Cl_KillProtection", "killprotection@netmsg.ddnet.org", [
+		NetIntRange("m_Time", -1, 9999),
+	]),
 ]

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -666,7 +666,8 @@ MACRO_CONFIG_INT(SvSpamMuteDuration, sv_spam_mute_duration, 60, 0, 3600, CFGFLAG
 
 MACRO_CONFIG_INT(SvShutdownWhenEmpty, sv_shutdown_when_empty, 0, 0, 1, CFGFLAG_SERVER, "Shutdown server as soon as no one is on it anymore")
 MACRO_CONFIG_INT(SvReloadWhenEmpty, sv_reload_when_empty, 0, 0, 2, CFGFLAG_SERVER, "Reload map when server is empty (1 = reload once, 2 = reload every time server gets empty)")
-MACRO_CONFIG_INT(SvKillProtection, sv_kill_protection, 20, 0, 9999, CFGFLAG_SERVER, "0 - Disable, 1-9999 minutes")
+MACRO_CONFIG_INT(ClKillProtection, cl_kill_protection, -1, -1, 9999, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Minutes after kill protection is engaged (-1 = use server's default, 0 = disabled)")
+MACRO_CONFIG_INT(SvKillProtection, sv_kill_protection, 20, 0, 9999, CFGFLAG_SERVER, "Default kill protection time in minutes")
 MACRO_CONFIG_INT(SvSoloServer, sv_solo_server, 0, 0, 1, CFGFLAG_SERVER | CFGFLAG_GAME, "Set server to solo mode (no player interactions, has to be set before loading the map)")
 MACRO_CONFIG_STR(SvClientSuggestion, sv_client_suggestion, 128, "Get DDNet client from DDNet.org to use all features on DDNet!", CFGFLAG_SERVER, "Broadcast to display to players without DDNet client")
 MACRO_CONFIG_STR(SvClientSuggestionOld, sv_client_suggestion_old, 128, "Your DDNet client is old, update it on DDNet.org!", CFGFLAG_SERVER, "Broadcast to display to players with an old version of DDNet client")

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -669,6 +669,7 @@ void CGameClient::OnReset()
 
 	std::fill(std::begin(m_aDDRaceMsgSent), std::end(m_aDDRaceMsgSent), false);
 	std::fill(std::begin(m_aShowOthers), std::end(m_aShowOthers), SHOW_OTHERS_NOT_SET);
+	std::fill(std::begin(m_aKillProtection), std::end(m_aKillProtection), KILL_PROTECTION_NOT_SET);
 	std::fill(std::begin(m_aLastUpdateTick), std::end(m_aLastUpdateTick), 0);
 
 	m_PredictedDummyId = -1;
@@ -904,6 +905,7 @@ void CGameClient::OnDummyDisconnect()
 	m_aLocalIds[1] = -1;
 	m_aDDRaceMsgSent[1] = false;
 	m_aShowOthers[1] = SHOW_OTHERS_NOT_SET;
+	m_aKillProtection[1] = KILL_PROTECTION_NOT_SET;
 	m_aLastNewPredictedTick[1] = -1;
 	m_PredictedDummyId = -1;
 }
@@ -2109,6 +2111,15 @@ void CGameClient::OnNewSnapshot()
 
 		// update state
 		m_aShowOthers[g_Config.m_ClDummy] = g_Config.m_ClShowOthers;
+	}
+
+	if(m_aKillProtection[g_Config.m_ClDummy] == KILL_PROTECTION_NOT_SET || m_aKillProtection[g_Config.m_ClDummy] != g_Config.m_ClKillProtection)
+	{
+		CNetMsg_Cl_KillProtection Msg;
+		Msg.m_Time = g_Config.m_ClKillProtection;
+		Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
+
+		m_aKillProtection[g_Config.m_ClDummy] = g_Config.m_ClKillProtection;
 	}
 
 	float ShowDistanceZoom = m_Camera.m_Zoom;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -857,6 +857,7 @@ private:
 
 	bool m_aDDRaceMsgSent[NUM_DUMMIES];
 	int m_aShowOthers[NUM_DUMMIES];
+	int m_aKillProtection[NUM_DUMMIES];
 
 	std::vector<std::shared_ptr<CManagedTeeRenderInfo>> m_vpManagedTeeRenderInfos;
 	void UpdateManagedTeeRenderInfos();

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -132,6 +132,11 @@ enum
 	SHOW_OTHERS_ONLY_TEAM = 2 // show players that are in solo and are in the same team
 };
 
+enum
+{
+	KILL_PROTECTION_NOT_SET = -2
+};
+
 struct SSwitchers
 {
 	bool m_aStatus[NUM_DDRACE_TEAMS];

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -2443,7 +2443,7 @@ void CGameContext::ConProtectedKill(IConsole::IResult *pResult, void *pUserData)
 		return;
 
 	int CurrTime = (pSelf->Server()->Tick() - pChr->m_StartTime) / pSelf->Server()->TickSpeed();
-	if(g_Config.m_SvKillProtection != 0 && CurrTime >= (60 * g_Config.m_SvKillProtection) && pChr->m_DDRaceState == DDRACE_STARTED)
+	if(pPlayer->m_KillProtection != 0 && CurrTime >= (60 * pPlayer->m_KillProtection) && pChr->m_DDRaceState == DDRACE_STARTED)
 	{
 		pPlayer->KillCharacter(WEAPON_SELF);
 	}

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -309,6 +309,7 @@ public:
 	void OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int ClientId);
 	void OnEmoticonNetMessage(const CNetMsg_Cl_Emoticon *pMsg, int ClientId);
 	void OnKillNetMessage(const CNetMsg_Cl_Kill *pMsg, int ClientId);
+	void OnKillProtectionNetMessage(const CNetMsg_Cl_KillProtection *pMsg, int ClientId);
 	void OnStartInfoNetMessage(const CNetMsg_Cl_StartInfo *pMsg, int ClientId);
 
 	bool OnClientDataPersist(int ClientId, void *pData) override;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -111,6 +111,7 @@ void CPlayer::Reset()
 	m_Last_Team = 0;
 	m_ShowOthers = g_Config.m_SvShowOthersDefault;
 	m_ShowAll = g_Config.m_SvShowAllDefault;
+	m_KillProtection = g_Config.m_SvKillProtection;
 	m_ShowDistance = vec2(1200, 800);
 	m_SpecTeam = false;
 	m_NinjaJetpack = false;

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -177,6 +177,7 @@ public:
 	int64_t m_Last_Team;
 	int m_ShowOthers;
 	bool m_ShowAll;
+	int m_KillProtection;
 	vec2 m_ShowDistance;
 	bool m_SpecTeam;
 	bool m_NinjaJetpack;


### PR DESCRIPTION
Implements the idea from #10001
Each player will have their own kill protection timer.


> I like that reasoning. However, we'd have to find a way to make it work with shared kill protection across a team.

For teams, each player still has their own timer, but I can make it so the lowest time from the entire team is used if needed. However, that might be confusing


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
