### PR TITLE
Avoid global static variables for `CRenderTools` sprite scale

### DIFF
--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -89,9 +89,6 @@ bool CSkinDescriptor::CSixup::operator==(const CSixup &Other) const
 	       m_XmasHat == Other.m_XmasHat;
 }
 
-static float gs_SpriteWScale;
-static float gs_SpriteHScale;
-
 void CRenderTools::Init(IGraphics *pGraphics, ITextRender *pTextRender)
 {
 	m_pGraphics = pGraphics;
@@ -130,7 +127,7 @@ void CRenderTools::Init(IGraphics *pGraphics, ITextRender *pTextRender)
 	Graphics()->QuadContainerUpload(m_TeeQuadContainerIndex);
 }
 
-void CRenderTools::SelectSprite(const CDataSprite *pSprite, int Flags) const
+void CRenderTools::SelectSprite(const CDataSprite *pSprite, int Flags)
 {
 	int x = pSprite->m_X;
 	int y = pSprite->m_Y;
@@ -139,7 +136,7 @@ void CRenderTools::SelectSprite(const CDataSprite *pSprite, int Flags) const
 	int cx = pSprite->m_pSet->m_Gridx;
 	int cy = pSprite->m_pSet->m_Gridy;
 
-	GetSpriteScaleImpl(w, h, gs_SpriteWScale, gs_SpriteHScale);
+	GetSpriteScaleImpl(w, h, m_SpriteScale.x, m_SpriteScale.y);
 
 	float x1 = x / (float)cx + 0.5f / (float)(cx * 32);
 	float x2 = (x + w) / (float)cx - 0.5f / (float)(cx * 32);
@@ -155,13 +152,13 @@ void CRenderTools::SelectSprite(const CDataSprite *pSprite, int Flags) const
 	Graphics()->QuadsSetSubset(x1, y1, x2, y2);
 }
 
-void CRenderTools::SelectSprite(int Id, int Flags) const
+void CRenderTools::SelectSprite(int Id, int Flags)
 {
 	dbg_assert(Id >= 0 && Id < g_pData->m_NumSprites, "Id invalid");
 	SelectSprite(&g_pData->m_aSprites[Id], Flags);
 }
 
-void CRenderTools::SelectSprite7(int Id, int Flags) const
+void CRenderTools::SelectSprite7(int Id, int Flags)
 {
 	dbg_assert(Id >= 0 && Id < client_data7::g_pData->m_NumSprites, "Id invalid");
 	SelectSprite(&client_data7::g_pData->m_aSprites[Id], Flags);
@@ -188,7 +185,7 @@ void CRenderTools::GetSpriteScaleImpl(int Width, int Height, float &ScaleX, floa
 
 void CRenderTools::DrawSprite(float x, float y, float Size) const
 {
-	IGraphics::CQuadItem QuadItem(x, y, Size * gs_SpriteWScale, Size * gs_SpriteHScale);
+	IGraphics::CQuadItem QuadItem(x, y, Size * m_SpriteScale.x, Size * m_SpriteScale.y);
 	Graphics()->QuadsDraw(&QuadItem, 1);
 }
 
@@ -210,7 +207,7 @@ void CRenderTools::RenderCursor(vec2 Center, float Size) const
 	Graphics()->WrapNormal();
 }
 
-void CRenderTools::RenderIcon(int ImageId, int SpriteId, const CUIRect *pRect, const ColorRGBA *pColor) const
+void CRenderTools::RenderIcon(int ImageId, int SpriteId, const CUIRect *pRect, const ColorRGBA *pColor)
 {
 	Graphics()->TextureSet(g_pData->m_aImages[ImageId].m_Id);
 	Graphics()->QuadsBegin();
@@ -340,7 +337,7 @@ void CRenderTools::GetRenderTeeOffsetToRenderedTee(const CAnimState *pAnim, cons
 	TeeOffsetToMid.y = -MidOfRendered;
 }
 
-void CRenderTools::RenderTee(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha) const
+void CRenderTools::RenderTee(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha)
 {
 	if(pInfo->m_aSixup[g_Config.m_ClDummy].PartTexture(protocol7::SKINPART_BODY).IsValid())
 		RenderTee7(pAnim, pInfo, Emote, Dir, Pos, Alpha);
@@ -351,7 +348,7 @@ void CRenderTools::RenderTee(const CAnimState *pAnim, const CTeeRenderInfo *pInf
 	Graphics()->QuadsSetRotation(0);
 }
 
-void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha) const
+void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha)
 {
 	vec2 Direction = Dir;
 	vec2 Position = Pos;

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -255,13 +255,15 @@ class CRenderTools
 
 	int m_TeeQuadContainerIndex;
 
+	vec2 m_SpriteScale = vec2(-1.0f, -1.0f);
+
 	static void GetRenderTeeBodyScale(float BaseSize, float &BodyScale);
 	static void GetRenderTeeFeetScale(float BaseSize, float &FeetScaleWidth, float &FeetScaleHeight);
 
-	void SelectSprite(const CDataSprite *pSprite, int Flags) const;
+	void SelectSprite(const CDataSprite *pSprite, int Flags);
 
 	void RenderTee6(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha = 1.0f) const;
-	void RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha = 1.0f) const;
+	void RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha = 1.0f);
 
 public:
 	class IGraphics *Graphics() const { return m_pGraphics; }
@@ -269,8 +271,8 @@ public:
 
 	void Init(class IGraphics *pGraphics, class ITextRender *pTextRender);
 
-	void SelectSprite(int Id, int Flags = 0) const;
-	void SelectSprite7(int Id, int Flags = 0) const;
+	void SelectSprite(int Id, int Flags = 0);
+	void SelectSprite7(int Id, int Flags = 0);
 
 	void GetSpriteScale(const CDataSprite *pSprite, float &ScaleX, float &ScaleY) const;
 	void GetSpriteScale(int Id, float &ScaleX, float &ScaleY) const;
@@ -279,7 +281,7 @@ public:
 	void DrawSprite(float x, float y, float Size) const;
 	void DrawSprite(float x, float y, float ScaledWidth, float ScaledHeight) const;
 	void RenderCursor(vec2 Center, float Size) const;
-	void RenderIcon(int ImageId, int SpriteId, const CUIRect *pRect, const ColorRGBA *pColor = nullptr) const;
+	void RenderIcon(int ImageId, int SpriteId, const CUIRect *pRect, const ColorRGBA *pColor = nullptr);
 	int QuadContainerAddSprite(int QuadContainerIndex, float x, float y, float Size) const;
 	int QuadContainerAddSprite(int QuadContainerIndex, float Size) const;
 	int QuadContainerAddSprite(int QuadContainerIndex, float Width, float Height) const;
@@ -293,7 +295,7 @@ public:
 	// returns the offset to use, to render the tee with @see RenderTee exactly in the mid
 	static void GetRenderTeeOffsetToRenderedTee(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, vec2 &TeeOffsetToMid);
 	// object render methods
-	void RenderTee(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha = 1.0f) const;
+	void RenderTee(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha = 1.0f);
 
 	// map render methods (render_map.cpp)
 	static void RenderEvalEnvelope(const IEnvelopePointAccess *pPoints, std::chrono::nanoseconds TimeNanos, ColorRGBA &Result, size_t Channels);
@@ -317,7 +319,7 @@ public:
 	// DDRace
 
 	void RenderTeleOverlay(CTeleTile *pTele, int w, int h, float Scale, int OverlayRenderFlags, float Alpha = 1.0f) const;
-	void RenderSpeedupOverlay(CSpeedupTile *pSpeedup, int w, int h, float Scale, int OverlayRenderFlags, float Alpha = 1.0f) const;
+	void RenderSpeedupOverlay(CSpeedupTile *pSpeedup, int w, int h, float Scale, int OverlayRenderFlags, float Alpha = 1.0f);
 	void RenderSwitchOverlay(CSwitchTile *pSwitch, int w, int h, float Scale, int OverlayRenderFlags, float Alpha = 1.0f) const;
 	void RenderTuneOverlay(CTuneTile *pTune, int w, int h, float Scale, int OverlayRenderFlags, float Alpha = 1.0f) const;
 	void RenderTelemap(CTeleTile *pTele, int w, int h, float Scale, ColorRGBA Color, int RenderFlags) const;

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -779,7 +779,7 @@ void CRenderTools::RenderTeleOverlay(CTeleTile *pTele, int w, int h, float Scale
 	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 }
 
-void CRenderTools::RenderSpeedupOverlay(CSpeedupTile *pSpeedup, int w, int h, float Scale, int OverlayRenderFlag, float Alpha) const
+void CRenderTools::RenderSpeedupOverlay(CSpeedupTile *pSpeedup, int w, int h, float Scale, int OverlayRenderFlag, float Alpha)
 {
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
 	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);


### PR DESCRIPTION
Some `CRenderTools` functions are not `const` anymore because they modify this member variable by calling the `SelectSprite`/`SelectSprite7` function.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
