### PR TITLE
Minor name plate changes

### DIFF
--- a/src/game/client/components/nameplates.h
+++ b/src/game/client/components/nameplates.h
@@ -1,12 +1,18 @@
 #ifndef GAME_CLIENT_COMPONENTS_NAMEPLATES_H
 #define GAME_CLIENT_COMPONENTS_NAMEPLATES_H
+#include <base/color.h>
 #include <base/vmath.h>
 
 #include <engine/shared/protocol.h>
-#include <engine/textrender.h>
 
 #include <game/client/component.h>
-#include <game/generated/protocol.h>
+
+enum class EHookStrongWeakState
+{
+	WEAK,
+	NEUTRAL,
+	STRONG
+};
 
 class CNamePlateData
 {
@@ -31,12 +37,7 @@ public:
 	bool m_DirRight;
 	float m_FontSizeDirection;
 	bool m_ShowHookStrongWeak;
-	enum
-	{
-		HOOKSTRONGWEAK_WEAK,
-		HOOKSTRONGWEAK_NEUTRAL,
-		HOOKSTRONGWEAK_STRONG
-	} m_HookStrongWeak;
+	EHookStrongWeakState m_HookStrongWeakState;
 	bool m_ShowHookStrongWeakId;
 	int m_HookStrongWeakId;
 	float m_FontSizeHookStrongWeak;


### PR DESCRIPTION
* Remove unused headers in `nameplates.h`
* Use a class enum for hook strong/weak state
* Rename `m_HookStrongWeak` to `m_HookStrongWeakState`
* Remove default `UpdateNeeded` method for text parts (prevent mistakenly updating every frame)
* Use previous name plate size calculation if no update occurs (reduces iteration through name plate parts by 25%)
* Rename local var `Size` to `LineSize` in name plate `Render` and `Update` functions
* Don't update preview name plate twice before render

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
