### PR TITLE
Fix multi-view zoom

### DIFF
--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -154,7 +154,8 @@ void CCamera::UpdateCamera()
 	else if(!IsSpectatingPlayer && CurrentZoom != m_UserZoomTarget)
 	{
 		// stop spectating player
-		ChangeZoom(m_UserZoomTarget, GameClient()->m_MultiViewActivated ? g_Config.m_ClMultiViewZoomSmoothness : g_Config.m_ClSmoothZoomTime, false);
+		if(!GameClient()->m_MultiViewActivated)
+			ChangeZoom(m_UserZoomTarget, g_Config.m_ClSmoothZoomTime, false);
 		m_AutoSpecCameraZooming = false;
 
 		ZoomChanged = true;


### PR DESCRIPTION
Fixes multi-view not zooming at all, both in game and demo. The if is executed only when stopping spectating player, or zooming in multiview, in which `m_UserZoomTarget` was overwriting the correct zoom.


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
