### PR TITLE
Fix 0.7 connect string for servers with multiple addresses

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -689,34 +689,15 @@ void ServerBrowserFormatAddresses(char *pBuffer, int BufferSize, NETADDR *pAddrs
 	{
 		if(i != 0)
 		{
-			if(BufferSize <= 1)
-			{
-				return;
-			}
-			pBuffer[0] = ',';
-			pBuffer[1] = '\0';
-			pBuffer += 1;
-			BufferSize -= 1;
+			str_append(pBuffer, ",", BufferSize);
 		}
-		if(BufferSize <= 1)
-		{
-			return;
-		}
-		char aIpAddr[512];
-		net_addr_str(&pAddrs[i], aIpAddr, sizeof(aIpAddr), true);
 		if(pAddrs[i].type & NETTYPE_TW7)
 		{
-			str_format(
-				pBuffer,
-				BufferSize,
-				"tw-0.7+udp://%s",
-				aIpAddr);
-			return;
+			str_append(pBuffer, "tw-0.7+udp://", BufferSize);
 		}
-		str_copy(pBuffer, aIpAddr, BufferSize);
-		int Length = str_length(pBuffer);
-		pBuffer += Length;
-		BufferSize -= Length;
+		char aIpAddr[NETADDR_MAXSTRSIZE];
+		net_addr_str(&pAddrs[i], aIpAddr, sizeof(aIpAddr), true);
+		str_append(pBuffer, aIpAddr, BufferSize);
 	}
 }
 


### PR DESCRIPTION
Do not return early when encountering first 0.7 address in `ServerBrowserFormatAddresses` function to correctly handle 0.7 servers with multiple addresses (e.g. IPv4 and IPv6).

Use `str_append` function instead of moving the buffer position manually to improve readability.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
