### PR TITLE
Switch back to Makefiles for Emscripten in README again

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ You can then manually merge this directory with the one in the ddnet source dire
 
 Run `rustup target add wasm32-unknown-emscripten` to install the WASM target for compiling Rust.
 
-Then run `emcmake cmake .. -G "Ninja" -DVIDEORECORDER=OFF -DVULKAN=OFF -DSERVER=OFF -DTOOLS=OFF -DPREFER_BUNDLED_LIBS=ON` in your build directory to configure followed by `cmake --build . -j8` to build.
+Then run `emcmake cmake .. -G "Unix Makefiles" -DVIDEORECORDER=OFF -DVULKAN=OFF -DSERVER=OFF -DTOOLS=OFF -DPREFER_BUNDLED_LIBS=ON` in your build directory to configure followed by `cmake --build . -j8` to build. Note that using the Ninja build system with Emscripten is not currently possible due to [CMake issue 16395](https://gitlab.kitware.com/cmake/cmake/-/issues/16395).
 
 To test the compiled code locally, just use `emrun --browser firefox DDNet.html`
 


### PR DESCRIPTION
Due to https://gitlab.kitware.com/cmake/cmake/-/issues/16395 the CMake Ninja generator will incorrectly escape dollar signs which breaks the required build option `-s DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=[\\$autoResumeAudioContext,\\$dynCall]` specified in `Emscripten.toolchain`.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
