### PR TITLE
Fix duplicate IP addresses in server connection strings

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -685,6 +685,7 @@ void CServerBrowser::QueueRequest(CServerEntry *pEntry)
 
 void ServerBrowserFormatAddresses(char *pBuffer, int BufferSize, NETADDR *pAddrs, int NumAddrs)
 {
+	pBuffer[0] = '\0';
 	for(int i = 0; i < NumAddrs; i++)
 	{
 		if(i != 0)


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
0a3354f introduced a bug in ServerBrowserFormatAddresses The buffer handling wasn't initialized with an empty string first before switching from manual buffer to str_append, resulting in duplicate IPs when connecting to servers that existed on both IPv4 and IPv6 addresses.

before↓
![image](https://github.com/user-attachments/assets/8b5841e9-a197-45ad-bf43-c4a1222217c7)

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
