### PR TITLE
Logout the current connection when timeout is used

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -4314,16 +4314,21 @@ int *CServer::GetIdMap(int ClientId)
 
 bool CServer::SetTimedOut(int ClientId, int OrigId)
 {
-	if(!m_NetServer.SetTimedOut(ClientId, OrigId))
+	if(!m_NetServer.CanSetTimedOut(ClientId, OrigId))
 	{
 		return false;
 	}
-	m_aClients[ClientId].m_Sixup = m_aClients[OrigId].m_Sixup;
 
+	// The login was on the current conn, logout should also be on the current conn
 	if(m_aClients[OrigId].m_Authed != AUTHED_NO)
 	{
-		LogoutClient(ClientId, "Timeout Protection");
+		LogoutClient(OrigId, "Timeout Protection");
 	}
+
+	m_NetServer.SetTimedOut(ClientId, OrigId);
+
+	m_aClients[ClientId].m_Sixup = m_aClients[OrigId].m_Sixup;
+
 	DelClientCallback(OrigId, "Timeout Protection used", this);
 	m_aClients[ClientId].m_Authed = AUTHED_NO;
 	m_aClients[ClientId].m_Flags = m_aClients[OrigId].m_Flags;

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -466,7 +466,8 @@ public:
 
 	//
 	void SetMaxClientsPerIp(int Max);
-	bool SetTimedOut(int ClientId, int OrigId);
+	bool CanSetTimedOut(int ClientId, int OrigId);
+	void SetTimedOut(int ClientId, int OrigId);
 	void SetTimeoutProtected(int ClientId);
 
 	int ResetErrorString(int ClientId);

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -773,14 +773,15 @@ void CNetServer::SetMaxClientsPerIp(int Max)
 	m_MaxClientsPerIp = Max;
 }
 
-bool CNetServer::SetTimedOut(int ClientId, int OrigId)
+bool CNetServer::CanSetTimedOut(int ClientId, int OrigId)
 {
-	if(m_aSlots[ClientId].m_Connection.State() != NET_CONNSTATE_ERROR)
-		return false;
+	return m_aSlots[ClientId].m_Connection.State() == NET_CONNSTATE_ERROR;
+}
 
+void CNetServer::SetTimedOut(int ClientId, int OrigId)
+{
 	m_aSlots[ClientId].m_Connection.SetTimedOut(ClientAddr(OrigId), m_aSlots[OrigId].m_Connection.SeqSequence(), m_aSlots[OrigId].m_Connection.AckSequence(), m_aSlots[OrigId].m_Connection.SecurityToken(), m_aSlots[OrigId].m_Connection.ResendBuffer(), m_aSlots[OrigId].m_Connection.m_Sixup);
 	m_aSlots[OrigId].m_Connection.Reset();
-	return true;
 }
 
 void CNetServer::SetTimeoutProtected(int ClientId)


### PR DESCRIPTION
This mostly ensures there won't be AuthLogout items in teehistorian for client ids that haven't logged in.

Also explains the initial confusion around #3490

@Zwelf && @heinrich5991 should this come with a teehistorian minor bump too?

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
