### PR TITLE
Fix 0.7 server info too large with many player and long names

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2307,7 +2307,7 @@ void CServer::CacheServerInfo(CCache *pCache, int Type, bool SendClients)
 #undef ADD_INT
 }
 
-void CServer::CacheServerInfoSixup(CCache *pCache, bool SendClients)
+void CServer::CacheServerInfoSixup(CCache *pCache, bool SendClients, int MaxConsideredClients)
 {
 	pCache->Clear();
 
@@ -2316,22 +2316,35 @@ void CServer::CacheServerInfoSixup(CCache *pCache, bool SendClients)
 
 	// Could be moved to a separate function and cached
 	// count the players
-	int PlayerCount = 0, ClientCount = 0;
+	int PlayerCount = 0, ClientCount = 0, ClientCountAll = 0;
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		if(m_aClients[i].IncludedInServerInfo())
 		{
-			if(GameServer()->IsClientPlayer(i))
-				PlayerCount++;
+			ClientCountAll++;
+			if(i < MaxConsideredClients)
+			{
+				if(GameServer()->IsClientPlayer(i))
+					PlayerCount++;
 
-			ClientCount++;
+				ClientCount++;
+			}
 		}
 	}
 
 	char aVersion[32];
 	str_format(aVersion, sizeof(aVersion), "0.7↔%s", GameServer()->Version());
 	Packer.AddString(aVersion, 32);
-	Packer.AddString(Config()->m_SvName, 64);
+	if(!SendClients || ClientCountAll == ClientCount)
+	{
+		Packer.AddString(Config()->m_SvName, 64);
+	}
+	else
+	{
+		char aName[64];
+		str_format(aName, sizeof(aName), "%s [%d/%d]", Config()->m_SvName, ClientCountAll, m_NetServer.MaxClients() - Config()->m_SvReservedSlots);
+		Packer.AddString(aName, 64);
+	}
 	Packer.AddString(Config()->m_SvHostname, 128);
 	Packer.AddString(GetMapName(), 32);
 
@@ -2353,7 +2366,7 @@ void CServer::CacheServerInfoSixup(CCache *pCache, bool SendClients)
 
 	if(SendClients)
 	{
-		for(int i = 0; i < MAX_CLIENTS; i++)
+		for(int i = 0; i < MaxConsideredClients; i++)
 		{
 			if(m_aClients[i].IncludedInServerInfo())
 			{
@@ -2362,6 +2375,23 @@ void CServer::CacheServerInfoSixup(CCache *pCache, bool SendClients)
 				Packer.AddInt(m_aClients[i].m_Country); // client country (ISO 3166-1 numeric)
 				Packer.AddInt(m_aClients[i].m_Score.value_or(-1)); // client score
 				Packer.AddInt(GameServer()->IsClientPlayer(i) ? 0 : 1); // flag spectator=1, bot=2 (player=0)
+
+				const int MaxPacketSize = NET_MAX_PAYLOAD - 128;
+				if(MaxConsideredClients == MAX_CLIENTS)
+				{
+					if(Packer.Size() > MaxPacketSize - 32) // -32 because repacking will increase the length of the name
+					{
+						// Server info is too large for a packet. Only include as many clients as fit.
+						// We need to ensure that the client counts match, otherwise the 0.7 client
+						// will ignore the info, so we repack but only consider the first i clients.
+						CacheServerInfoSixup(pCache, true, i);
+						return;
+					}
+				}
+				else
+				{
+					dbg_assert(Packer.Size() <= MaxPacketSize, "Max packet size exceeded while repacking");
+				}
 			}
 		}
 	}
@@ -2574,7 +2604,7 @@ void CServer::UpdateServerInfo(bool Resend)
 			CacheServerInfo(&m_aServerInfoCache[i * 2 + j], i, j);
 
 	for(int i = 0; i < 2; i++)
-		CacheServerInfoSixup(&m_aSixupServerInfoCache[i], i);
+		CacheServerInfoSixup(&m_aSixupServerInfoCache[i], i, MAX_CLIENTS);
 
 	if(Resend)
 	{

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -402,7 +402,7 @@ public:
 
 	void ExpireServerInfo() override;
 	void CacheServerInfo(CCache *pCache, int Type, bool SendClients);
-	void CacheServerInfoSixup(CCache *pCache, bool SendClients);
+	void CacheServerInfoSixup(CCache *pCache, bool SendClients, int MaxConsideredClients);
 	void SendServerInfo(const NETADDR *pAddr, int Token, int Type, bool SendClients);
 	void GetServerInfoSixup(CPacker *pPacker, int Token, bool SendClients);
 	bool RateLimitServerInfoConnless();


### PR DESCRIPTION
Fixes server crashing when the 0.7 server info is requested containing more than 38 players with names and clans of maximum length.

Only pack as many clients into the 0.7 server info as will fit into a packet. The client count in the server info must be equal to the included number of client entries, so the entire server info is repacked with a reduced number of clients to ensure that 0.7 clients will still accept it. The real number of players is appended to the server name like for the existing `SERVERINFO_VANILLA` when not all clients could be included.

Closes #10064. Supersedes #10065.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
