### PR TITLE
Dynamic skin loading and unloading, improve skin list UI

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3786,6 +3786,24 @@ bool str_tofloat(const char *str, float *out)
 	return true;
 }
 
+void str_utf8_tolower(const char *input, char *output, size_t size)
+{
+	size_t out_pos = 0;
+	while(*input)
+	{
+		const int code = str_utf8_tolower_codepoint(str_utf8_decode(&input));
+		char encoded_code[4];
+		const int code_size = str_utf8_encode(encoded_code, code);
+		if(out_pos + code_size + 1 > size) // +1 for null termination
+		{
+			break;
+		}
+		mem_copy(&output[out_pos], encoded_code, code_size);
+		out_pos += code_size;
+	}
+	output[out_pos] = '\0';
+}
+
 int str_utf8_comp_nocase(const char *a, const char *b)
 {
 	int code_a;

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3793,8 +3793,8 @@ int str_utf8_comp_nocase(const char *a, const char *b)
 
 	while(*a && *b)
 	{
-		code_a = str_utf8_tolower(str_utf8_decode(&a));
-		code_b = str_utf8_tolower(str_utf8_decode(&b));
+		code_a = str_utf8_tolower_codepoint(str_utf8_decode(&a));
+		code_b = str_utf8_tolower_codepoint(str_utf8_decode(&b));
 
 		if(code_a != code_b)
 			return code_a - code_b;
@@ -3813,8 +3813,8 @@ int str_utf8_comp_nocase_num(const char *a, const char *b, int num)
 
 	while(*a && *b)
 	{
-		code_a = str_utf8_tolower(str_utf8_decode(&a));
-		code_b = str_utf8_tolower(str_utf8_decode(&b));
+		code_a = str_utf8_tolower_codepoint(str_utf8_decode(&a));
+		code_b = str_utf8_tolower_codepoint(str_utf8_decode(&b));
 
 		if(code_a != code_b)
 			return code_a - code_b;
@@ -3834,7 +3834,7 @@ const char *str_utf8_find_nocase(const char *haystack, const char *needle, const
 		const char *b = needle;
 		const char *a_next = a;
 		const char *b_next = b;
-		while(*a && *b && str_utf8_tolower(str_utf8_decode(&a_next)) == str_utf8_tolower(str_utf8_decode(&b_next)))
+		while(*a && *b && str_utf8_tolower_codepoint(str_utf8_decode(&a_next)) == str_utf8_tolower_codepoint(str_utf8_decode(&b_next)))
 		{
 			a = a_next;
 			b = b_next;

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2263,17 +2263,16 @@ int str_utf8_to_skeleton(const char *str, int *buf, int buf_len);
 */
 int str_utf8_comp_confusable(const char *str1, const char *str2);
 
-/*
-	Function: str_utf8_tolower
-		Converts the given Unicode codepoint to lowercase (locale insensitive).
-
-	Parameters:
-		code - Unicode codepoint to convert.
-
-	Returns:
-		Lowercase codepoint
-*/
-int str_utf8_tolower(int code);
+/**
+ * Converts the given Unicode codepoint to lowercase (locale insensitive).
+ *
+ * @ingroup Strings
+ *
+ * @param code Unicode codepoint to convert.
+ *
+ * @return Lowercase codepoint.
+ */
+int str_utf8_tolower_codepoint(int code);
 
 /*
 	Function: str_utf8_comp_nocase

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2274,6 +2274,21 @@ int str_utf8_comp_confusable(const char *str1, const char *str2);
  */
 int str_utf8_tolower_codepoint(int code);
 
+/**
+ * Converts the given UTF-8 string to lowercase (locale insensitive).
+ *
+ * @ingroup Strings
+ *
+ * @param str String to convert to lowercase.
+ * @param output Buffer that will receive the lowercase string.
+ * @param size Size of the output buffer.
+ *
+ * @remark The strings are treated as zero-terminated strings.
+ * @remark This function does not work in-place as converting a UTF-8 string to
+ *         lowercase may increase its length.
+ */
+void str_utf8_tolower(const char *input, char *output, size_t size);
+
 /*
 	Function: str_utf8_comp_nocase
 		Compares two utf8 strings case insensitively.

--- a/src/base/unicode/tolower.cpp
+++ b/src/base/unicode/tolower.cpp
@@ -9,7 +9,7 @@ static int compul(const void *a, const void *b)
 	return ul_a->upper - ul_b->upper;
 }
 
-int str_utf8_tolower(int code)
+int str_utf8_tolower_codepoint(int code)
 {
 	struct UPPER_LOWER key;
 	struct UPPER_LOWER *res;

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -282,7 +282,7 @@ void CCommandProcessor_SDL_GL::HandleError()
 	case GFX_ERROR_TYPE_OUT_OF_MEMORY_BUFFER:
 		[[fallthrough]];
 	case GFX_ERROR_TYPE_OUT_OF_MEMORY_STAGING:
-		m_Error.m_vErrors.emplace_back(SGfxErrorContainer::SError{true, Localizable("Out of VRAM. Try removing custom assets (skins, entities, etc.), especially those with high resolution.", "Graphics error")});
+		m_Error.m_vErrors.emplace_back(SGfxErrorContainer::SError{true, Localizable("Out of VRAM. Try setting 'cl_skins_loaded_max' to a lower value or remove custom assets (skins, entities, etc.), especially those with high resolution.", "Graphics error")});
 		break;
 	case GFX_ERROR_TYPE_RENDER_RECORDING:
 		m_Error.m_vErrors.emplace_back(SGfxErrorContainer::SError{true, Localizable("An error during command recording occurred. Try to update your GPU drivers.", "Graphics error")});

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4746,7 +4746,7 @@ int main(int argc, const char **argv)
 	});
 
 	// create the components
-	IEngine *pEngine = CreateEngine(GAME_NAME, pFutureConsoleLogger, 2 * std::thread::hardware_concurrency() + 2);
+	IEngine *pEngine = CreateEngine(GAME_NAME, pFutureConsoleLogger);
 	pKernel->RegisterInterface(pEngine, false);
 	CleanerFunctions.emplace([pEngine]() {
 		// Engine has to be destroyed before the graphics so that skin download thread can finish

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -24,7 +24,7 @@ public:
 	virtual void SetAdditionalLogger(std::shared_ptr<ILogger> &&pLogger) = 0;
 };
 
-extern IEngine *CreateEngine(const char *pAppname, std::shared_ptr<CFutureLogger> pFutureLogger, int Jobs);
-extern IEngine *CreateTestEngine(const char *pAppname, int Jobs);
+extern IEngine *CreateEngine(const char *pAppname, std::shared_ptr<CFutureLogger> pFutureLogger);
+extern IEngine *CreateTestEngine(const char *pAppname);
 
 #endif

--- a/src/engine/server/main.cpp
+++ b/src/engine/server/main.cpp
@@ -113,7 +113,7 @@ int main(int argc, const char **argv)
 	pKernel->RegisterInterface(pServer);
 
 	// create the components
-	IEngine *pEngine = CreateEngine(GAME_NAME, pFutureConsoleLogger, 2 * std::thread::hardware_concurrency() + 2);
+	IEngine *pEngine = CreateEngine(GAME_NAME, pFutureConsoleLogger);
 	pKernel->RegisterInterface(pEngine);
 
 	IStorage *pStorage = CreateStorage(IStorage::EInitializationType::SERVER, argc, argv);

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -140,11 +140,19 @@ MACRO_CONFIG_INT(ClMapDownloadLowSpeedLimit, cl_map_download_low_speed_limit, 40
 MACRO_CONFIG_INT(ClMapDownloadLowSpeedTime, cl_map_download_low_speed_time, 3, 0, 100000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "HTTP map downloads: Set low speed limit time period (0 to disable)")
 
 MACRO_CONFIG_STR(ClLanguagefile, cl_languagefile, 255, "", CFGFLAG_CLIENT | CFGFLAG_SAVE, "What language file to use")
+
+// skin loading
+#if defined(CONF_ARCH_IA32)
+MACRO_CONFIG_INT(ClSkinsLoadedMax, cl_skins_loaded_max, 256, 256, 8192, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Maximum number of skins that can be loaded at the same time")
+#else
+MACRO_CONFIG_INT(ClSkinsLoadedMax, cl_skins_loaded_max, 512, 256, 8192, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Maximum number of skins that can be loaded at the same time")
+#endif
 MACRO_CONFIG_STR(ClSkinDownloadUrl, cl_skin_download_url, 100, "https://skins.ddnet.org/skin/", CFGFLAG_CLIENT | CFGFLAG_SAVE, "URL used to download skins")
 MACRO_CONFIG_STR(ClSkinCommunityDownloadUrl, cl_skin_community_download_url, 100, "https://skins.ddnet.org/skin/community/", CFGFLAG_CLIENT | CFGFLAG_SAVE, "URL used to download community skins")
 MACRO_CONFIG_INT(ClVanillaSkinsOnly, cl_vanilla_skins_only, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Only show skins available in Vanilla Teeworlds")
 MACRO_CONFIG_INT(ClDownloadSkins, cl_download_skins, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Download skins from cl_skin_download_url on-the-fly")
 MACRO_CONFIG_INT(ClDownloadCommunitySkins, cl_download_community_skins, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Allow to download skins created by the community. Uses cl_skin_community_download_url instead of cl_skin_download_url for the download")
+
 MACRO_CONFIG_INT(ClAutoStatboardScreenshot, cl_auto_statboard_screenshot, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Automatically take game over statboard screenshot")
 MACRO_CONFIG_INT(ClAutoStatboardScreenshotMax, cl_auto_statboard_screenshot_max, 10, 0, 1000, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Maximum number of automatically created statboard screenshots (0 = no limit)")
 

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -11,6 +11,8 @@
 #include <engine/shared/network.h>
 #include <engine/storage.h>
 
+#include <thread>
+
 class CEngine : public IEngine
 {
 	IConsole *m_pConsole;
@@ -46,7 +48,7 @@ class CEngine : public IEngine
 	}
 
 public:
-	CEngine(bool Test, const char *pAppname, std::shared_ptr<CFutureLogger> pFutureLogger, int Jobs) :
+	CEngine(bool Test, const char *pAppname, std::shared_ptr<CFutureLogger> pFutureLogger) :
 		m_pFutureLogger(std::move(pFutureLogger))
 	{
 		str_copy(m_aAppName, pAppname);
@@ -66,7 +68,7 @@ public:
 			CNetBase::Init();
 		}
 
-		m_JobPool.Init(Jobs);
+		m_JobPool.Init(std::max(4, (int)std::thread::hardware_concurrency()) - 2);
 
 		m_Logging = false;
 	}
@@ -103,5 +105,5 @@ public:
 	}
 };
 
-IEngine *CreateEngine(const char *pAppname, std::shared_ptr<CFutureLogger> pFutureLogger, int Jobs) { return new CEngine(false, pAppname, std::move(pFutureLogger), Jobs); }
-IEngine *CreateTestEngine(const char *pAppname, int Jobs) { return new CEngine(true, pAppname, nullptr, Jobs); }
+IEngine *CreateEngine(const char *pAppname, std::shared_ptr<CFutureLogger> pFutureLogger) { return new CEngine(false, pAppname, std::move(pFutureLogger)); }
+IEngine *CreateTestEngine(const char *pAppname) { return new CEngine(true, pAppname, nullptr); }

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -52,13 +52,13 @@ public:
 		str_copy(m_aAppName, pAppname);
 		if(!Test)
 		{
-			dbg_msg("engine", "running on %s-%s-%s", CONF_FAMILY_STRING, CONF_PLATFORM_STRING, CONF_ARCH_STRING);
-			dbg_msg("engine", "arch is %s", CONF_ARCH_ENDIAN_STRING);
+			log_info("engine", "running on %s-%s-%s", CONF_FAMILY_STRING, CONF_PLATFORM_STRING, CONF_ARCH_STRING);
+			log_info("engine", "arch is %s", CONF_ARCH_ENDIAN_STRING);
 
 			char aVersionStr[128];
 			if(os_version_str(aVersionStr, sizeof(aVersionStr)))
 			{
-				dbg_msg("engine", "operating system version: %s", aVersionStr);
+				log_info("engine", "operating system version: %s", aVersionStr);
 			}
 
 			// init the network
@@ -89,8 +89,6 @@ public:
 
 	void AddJob(std::shared_ptr<IJob> pJob) override
 	{
-		if(g_Config.m_Debug)
-			dbg_msg("engine", "job added");
 		m_JobPool.Add(std::move(pJob));
 	}
 

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -82,6 +82,7 @@ MAYBE_UNUSED static const char *FONT_ICON_SQUARE_MINUS = "\xEF\x85\x86";
 MAYBE_UNUSED static const char *FONT_ICON_SQUARE_PLUS = "\xEF\x83\xBE";
 MAYBE_UNUSED static const char *FONT_ICON_SORT_UP = "\xEF\x83\x9E";
 MAYBE_UNUSED static const char *FONT_ICON_SORT_DOWN = "\xEF\x83\x9D";
+MAYBE_UNUSED static const char *FONT_ICON_TRIANGLE_EXCLAMATION = "\xEF\x81\xB1";
 
 MAYBE_UNUSED static const char *FONT_ICON_HOUSE = "\xEF\x80\x95";
 MAYBE_UNUSED static const char *FONT_ICON_NEWSPAPER = "\xEF\x87\xAA";

--- a/src/game/client/component.h
+++ b/src/game/client/component.h
@@ -170,6 +170,12 @@ public:
 	 */
 	virtual void OnWindowResize() {}
 	/**
+	 * Called when the component should get updated.
+	 *
+	 * The update order depends on the component insertion order.
+	 */
+	virtual void OnUpdate(){};
+	/**
 	 * Called when the component should get rendered.
 	 *
 	 * The render order depends on the component insertion order.

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -18,9 +18,147 @@
 #include <game/generated/client_data.h>
 #include <game/localization.h>
 
-#include <chrono>
-
 using namespace std::chrono_literals;
+
+CSkins::CAbstractSkinLoadJob::CAbstractSkinLoadJob(CSkins *pSkins, const char *pName) :
+	m_pSkins(pSkins)
+{
+	str_copy(m_aName, pName);
+	Abortable(true);
+}
+
+CSkins::CAbstractSkinLoadJob::~CAbstractSkinLoadJob()
+{
+	m_Data.m_Info.Free();
+	m_Data.m_InfoGrayscale.Free();
+}
+
+CSkins::CSkinLoadJob::CSkinLoadJob(CSkins *pSkins, const char *pName, int StorageType) :
+	CAbstractSkinLoadJob(pSkins, pName),
+	m_StorageType(StorageType)
+{
+}
+
+CSkins::CSkinContainer::CSkinContainer(CSkins *pSkins, const char *pName, EType Type, int StorageType) :
+	m_pSkins(pSkins),
+	m_Type(Type),
+	m_StorageType(StorageType)
+{
+	str_copy(m_aName, pName);
+	str_utf8_tolower(m_aName, m_aNormalizedName, sizeof(m_aNormalizedName));
+	m_Vanilla = IsVanillaSkin(m_aName);
+	m_Special = IsSpecialSkin(m_aName);
+	m_AlwaysLoaded = m_Vanilla; // Vanilla skins are loaded immediately and not unloaded
+}
+
+CSkins::CSkinContainer::~CSkinContainer()
+{
+	if(m_pLoadJob)
+	{
+		m_pLoadJob->Abort();
+	}
+}
+
+bool CSkins::CSkinContainer::operator<(const CSkinContainer &Other) const
+{
+	return str_comp(m_aNormalizedName, Other.m_aNormalizedName) < 0;
+}
+
+static constexpr std::chrono::nanoseconds MIN_REQUESTED_TIME_FOR_PENDING = 250ms;
+static constexpr std::chrono::nanoseconds MAX_REQUESTED_TIME_FOR_PENDING = 500ms;
+static constexpr std::chrono::nanoseconds MIN_UNLOAD_TIME_PENDING = 1s;
+static constexpr std::chrono::nanoseconds MIN_UNLOAD_TIME_LOADED = 2s;
+static_assert(MIN_REQUESTED_TIME_FOR_PENDING < MAX_REQUESTED_TIME_FOR_PENDING);
+static_assert(MIN_REQUESTED_TIME_FOR_PENDING < MIN_UNLOAD_TIME_PENDING, "Unloading pending skins must take longer than adding more pending skins");
+
+void CSkins::CSkinContainer::RequestLoad()
+{
+	if(m_AlwaysLoaded)
+	{
+		return;
+	}
+
+	// Delay loading skins a bit after the load has been requested to avoid loading a lot of skins
+	// when quickly scrolling through lists or if a player with a new skin quickly joins and leaves.
+	if(m_State == EState::UNLOADED)
+	{
+		const std::chrono::nanoseconds Now = time_get_nanoseconds();
+		if(!m_FirstLoadRequest.has_value() ||
+			!m_LastLoadRequest.has_value() ||
+			Now - m_LastLoadRequest.value() > MAX_REQUESTED_TIME_FOR_PENDING)
+		{
+			m_FirstLoadRequest = Now;
+			m_LastLoadRequest = m_FirstLoadRequest;
+		}
+		else if(Now - m_FirstLoadRequest.value() > MIN_REQUESTED_TIME_FOR_PENDING)
+		{
+			m_State = EState::PENDING;
+		}
+	}
+	else if(m_State == EState::PENDING ||
+		m_State == EState::LOADING ||
+		m_State == EState::LOADED)
+	{
+		m_LastLoadRequest = time_get_nanoseconds();
+	}
+
+	if(m_State == EState::PENDING ||
+		m_State == EState::LOADED)
+	{
+		if(m_UsageEntryIterator.has_value())
+		{
+			m_pSkins->m_SkinsUsageList.erase(m_UsageEntryIterator.value());
+		}
+		m_pSkins->m_SkinsUsageList.emplace_front(NormalizedName());
+		m_UsageEntryIterator = m_pSkins->m_SkinsUsageList.begin();
+	}
+}
+
+CSkins::CSkinContainer::EState CSkins::CSkinContainer::DetermineInitialState() const
+{
+	if(m_AlwaysLoaded)
+	{
+		// Load immediately if it should always be loaded
+		return EState::PENDING;
+	}
+	else if((g_Config.m_ClVanillaSkinsOnly && !m_Vanilla) ||
+		(m_Type == EType::DOWNLOAD && !g_Config.m_ClDownloadSkins))
+	{
+		// Fail immediately if it shouldn't be loaded
+		return EState::NOT_FOUND;
+	}
+	else
+	{
+		return EState::UNLOADED;
+	}
+}
+
+void CSkins::CSkinContainer::SetState(EState State)
+{
+	m_State = State;
+
+	if(m_State == EState::PENDING ||
+		m_State == EState::LOADING ||
+		m_State == EState::LOADED)
+	{
+		RequestLoad();
+	}
+	else
+	{
+		m_FirstLoadRequest = std::nullopt;
+		m_LastLoadRequest = std::nullopt;
+	}
+
+	if(m_State != EState::PENDING &&
+		m_State != EState::LOADED &&
+		m_UsageEntryIterator.has_value())
+	{
+		m_pSkins->m_SkinsUsageList.erase(m_UsageEntryIterator.value());
+		m_UsageEntryIterator = std::nullopt;
+	}
+
+	m_pSkins->m_SkinList.ForceRefresh();
+}
 
 bool CSkins::CSkinListEntry::operator<(const CSkins::CSkinListEntry &Other) const
 {
@@ -32,7 +170,12 @@ bool CSkins::CSkinListEntry::operator<(const CSkins::CSkinListEntry &Other) cons
 	{
 		return false;
 	}
-	return str_comp_nocase(m_pSkin->GetName(), Other.m_pSkin->GetName()) < 0;
+	return str_comp(m_pSkinContainer->NormalizedName(), Other.m_pSkinContainer->NormalizedName()) < 0;
+}
+
+void CSkins::CSkinListEntry::RequestLoad()
+{
+	m_pSkinContainer->RequestLoad();
 }
 
 CSkins::CSkins() :
@@ -57,12 +200,14 @@ CSkins::CSkins() :
 
 bool CSkins::IsVanillaSkin(const char *pName)
 {
-	return std::any_of(std::begin(VANILLA_SKINS), std::end(VANILLA_SKINS), [pName](const char *pVanillaSkin) { return str_comp(pName, pVanillaSkin) == 0; });
+	return std::any_of(std::begin(VANILLA_SKINS), std::end(VANILLA_SKINS), [pName](const char *pVanillaSkin) {
+		return str_utf8_comp_nocase(pName, pVanillaSkin) == 0;
+	});
 }
 
 bool CSkins::IsSpecialSkin(const char *pName)
 {
-	return str_startswith(pName, "x_") != nullptr;
+	return str_utf8_find_nocase(pName, "x_") == pName;
 }
 
 class CSkinScanUser
@@ -72,17 +217,21 @@ public:
 	CSkins::TSkinLoadedCallback m_SkinLoadedCallback;
 };
 
-int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
+int CSkins::SkinScan(const char *pName, int IsDir, int StorageType, void *pUser)
 {
 	auto *pUserReal = static_cast<CSkinScanUser *>(pUser);
 	CSkins *pSelf = pUserReal->m_pThis;
 
 	if(IsDir)
+	{
 		return 0;
+	}
 
 	const char *pSuffix = str_endswith(pName, ".png");
 	if(pSuffix == nullptr)
+	{
 		return 0;
+	}
 
 	char aSkinName[IO_MAX_PATH_LENGTH];
 	str_truncate(aSkinName, sizeof(aSkinName), pName, pSuffix - pName);
@@ -93,12 +242,15 @@ int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 		return 0;
 	}
 
-	if(g_Config.m_ClVanillaSkinsOnly && !IsVanillaSkin(aSkinName))
+	CSkinContainer SkinContainer(pSelf, aSkinName, CSkinContainer::EType::LOCAL, StorageType);
+	auto &&pSkinContainer = std::make_unique<CSkinContainer>(std::move(SkinContainer));
+	const auto &[SkinIt, Inserted] = pSelf->m_Skins.insert({pSkinContainer->NormalizedName(), std::move(pSkinContainer)});
+	if(!Inserted)
+	{
 		return 0;
+	}
 
-	char aPath[IO_MAX_PATH_LENGTH];
-	str_format(aPath, sizeof(aPath), "skins/%s", pName);
-	pSelf->LoadSkin(aSkinName, aPath, DirType);
+	SkinIt->second->SetState(SkinIt->second->DetermineInitialState());
 	pUserReal->m_SkinLoadedCallback();
 	return 0;
 }
@@ -138,75 +290,52 @@ static void CheckMetrics(CSkin::CSkinMetricVariable &Metrics, const uint8_t *pIm
 	Metrics.m_MaxHeight = CheckHeight;
 }
 
-const CSkin *CSkins::LoadSkin(const char *pName, const char *pPath, int DirType)
+bool CSkins::LoadSkinData(const char *pName, CSkinLoadData &Data) const
 {
-	CImageInfo Info;
-	if(!Graphics()->LoadPng(Info, pPath, DirType))
-	{
-		log_error("skins", "Failed to load skin PNG: %s", pName);
-		return nullptr;
-	}
-	const CSkin *pSkin = LoadSkin(pName, Info);
-	Info.Free();
-	return pSkin;
-}
-
-const CSkin *CSkins::LoadSkin(const char *pName, CImageInfo &Info)
-{
-	if(!Graphics()->CheckImageDivisibility(pName, Info, g_pData->m_aSprites[SPRITE_TEE_BODY].m_pSet->m_Gridx, g_pData->m_aSprites[SPRITE_TEE_BODY].m_pSet->m_Gridy, true))
+	if(!Graphics()->CheckImageDivisibility(pName, Data.m_Info, g_pData->m_aSprites[SPRITE_TEE_BODY].m_pSet->m_Gridx, g_pData->m_aSprites[SPRITE_TEE_BODY].m_pSet->m_Gridy, true))
 	{
 		log_error("skins", "Skin failed image divisibility: %s", pName);
-		return nullptr;
+		Data.m_Info.Free();
+		return false;
 	}
-	if(!Graphics()->IsImageFormatRgba(pName, Info))
+	if(!Graphics()->IsImageFormatRgba(pName, Data.m_Info))
 	{
 		log_error("skins", "Skin format is not RGBA: %s", pName);
-		return nullptr;
+		Data.m_Info.Free();
+		return false;
 	}
-	const size_t BodyWidth = g_pData->m_aSprites[SPRITE_TEE_BODY].m_W * (Info.m_Width / g_pData->m_aSprites[SPRITE_TEE_BODY].m_pSet->m_Gridx);
-	const size_t BodyHeight = g_pData->m_aSprites[SPRITE_TEE_BODY].m_H * (Info.m_Height / g_pData->m_aSprites[SPRITE_TEE_BODY].m_pSet->m_Gridy);
-	if(BodyWidth > Info.m_Width || BodyHeight > Info.m_Height)
+	const size_t BodyWidth = g_pData->m_aSprites[SPRITE_TEE_BODY].m_W * (Data.m_Info.m_Width / g_pData->m_aSprites[SPRITE_TEE_BODY].m_pSet->m_Gridx);
+	const size_t BodyHeight = g_pData->m_aSprites[SPRITE_TEE_BODY].m_H * (Data.m_Info.m_Height / g_pData->m_aSprites[SPRITE_TEE_BODY].m_pSet->m_Gridy);
+	if(BodyWidth > Data.m_Info.m_Width || BodyHeight > Data.m_Info.m_Height)
 	{
-		log_error("skins", "Skin size unsupported (w=%" PRIzu ", h=%" PRIzu "): %s", Info.m_Width, Info.m_Height, pName);
-		return nullptr;
+		log_error("skins", "Skin size unsupported (w=%" PRIzu ", h=%" PRIzu "): %s", Data.m_Info.m_Width, Data.m_Info.m_Height, pName);
+		Data.m_Info.Free();
+		return false;
 	}
 
-	CSkin Skin{pName};
-	Skin.m_OriginalSkin.m_Body = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_BODY]);
-	Skin.m_OriginalSkin.m_BodyOutline = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_BODY_OUTLINE]);
-	Skin.m_OriginalSkin.m_Feet = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_FOOT]);
-	Skin.m_OriginalSkin.m_FeetOutline = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_FOOT_OUTLINE]);
-	Skin.m_OriginalSkin.m_Hands = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_HAND]);
-	Skin.m_OriginalSkin.m_HandsOutline = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_HAND_OUTLINE]);
-
-	for(int i = 0; i < 6; ++i)
-	{
-		Skin.m_OriginalSkin.m_aEyes[i] = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_EYE_NORMAL + i]);
-	}
-
-	int FeetGridPixelsWidth = (Info.m_Width / g_pData->m_aSprites[SPRITE_TEE_FOOT].m_pSet->m_Gridx);
-	int FeetGridPixelsHeight = (Info.m_Height / g_pData->m_aSprites[SPRITE_TEE_FOOT].m_pSet->m_Gridy);
+	int FeetGridPixelsWidth = Data.m_Info.m_Width / g_pData->m_aSprites[SPRITE_TEE_FOOT].m_pSet->m_Gridx;
+	int FeetGridPixelsHeight = Data.m_Info.m_Height / g_pData->m_aSprites[SPRITE_TEE_FOOT].m_pSet->m_Gridy;
 	int FeetWidth = g_pData->m_aSprites[SPRITE_TEE_FOOT].m_W * FeetGridPixelsWidth;
 	int FeetHeight = g_pData->m_aSprites[SPRITE_TEE_FOOT].m_H * FeetGridPixelsHeight;
 	int FeetOffsetX = g_pData->m_aSprites[SPRITE_TEE_FOOT].m_X * FeetGridPixelsWidth;
 	int FeetOffsetY = g_pData->m_aSprites[SPRITE_TEE_FOOT].m_Y * FeetGridPixelsHeight;
 
-	int FeetOutlineGridPixelsWidth = (Info.m_Width / g_pData->m_aSprites[SPRITE_TEE_FOOT_OUTLINE].m_pSet->m_Gridx);
-	int FeetOutlineGridPixelsHeight = (Info.m_Height / g_pData->m_aSprites[SPRITE_TEE_FOOT_OUTLINE].m_pSet->m_Gridy);
+	int FeetOutlineGridPixelsWidth = Data.m_Info.m_Width / g_pData->m_aSprites[SPRITE_TEE_FOOT_OUTLINE].m_pSet->m_Gridx;
+	int FeetOutlineGridPixelsHeight = Data.m_Info.m_Height / g_pData->m_aSprites[SPRITE_TEE_FOOT_OUTLINE].m_pSet->m_Gridy;
 	int FeetOutlineWidth = g_pData->m_aSprites[SPRITE_TEE_FOOT_OUTLINE].m_W * FeetOutlineGridPixelsWidth;
 	int FeetOutlineHeight = g_pData->m_aSprites[SPRITE_TEE_FOOT_OUTLINE].m_H * FeetOutlineGridPixelsHeight;
 	int FeetOutlineOffsetX = g_pData->m_aSprites[SPRITE_TEE_FOOT_OUTLINE].m_X * FeetOutlineGridPixelsWidth;
 	int FeetOutlineOffsetY = g_pData->m_aSprites[SPRITE_TEE_FOOT_OUTLINE].m_Y * FeetOutlineGridPixelsHeight;
 
-	int BodyOutlineGridPixelsWidth = (Info.m_Width / g_pData->m_aSprites[SPRITE_TEE_BODY_OUTLINE].m_pSet->m_Gridx);
-	int BodyOutlineGridPixelsHeight = (Info.m_Height / g_pData->m_aSprites[SPRITE_TEE_BODY_OUTLINE].m_pSet->m_Gridy);
+	int BodyOutlineGridPixelsWidth = Data.m_Info.m_Width / g_pData->m_aSprites[SPRITE_TEE_BODY_OUTLINE].m_pSet->m_Gridx;
+	int BodyOutlineGridPixelsHeight = Data.m_Info.m_Height / g_pData->m_aSprites[SPRITE_TEE_BODY_OUTLINE].m_pSet->m_Gridy;
 	int BodyOutlineWidth = g_pData->m_aSprites[SPRITE_TEE_BODY_OUTLINE].m_W * BodyOutlineGridPixelsWidth;
 	int BodyOutlineHeight = g_pData->m_aSprites[SPRITE_TEE_BODY_OUTLINE].m_H * BodyOutlineGridPixelsHeight;
 	int BodyOutlineOffsetX = g_pData->m_aSprites[SPRITE_TEE_BODY_OUTLINE].m_X * BodyOutlineGridPixelsWidth;
 	int BodyOutlineOffsetY = g_pData->m_aSprites[SPRITE_TEE_BODY_OUTLINE].m_Y * BodyOutlineGridPixelsHeight;
 
-	const size_t PixelStep = Info.PixelSize();
-	const size_t Pitch = Info.m_Width * PixelStep;
+	const size_t PixelStep = Data.m_Info.PixelSize();
+	const size_t Pitch = Data.m_Info.m_Width * PixelStep;
 
 	// dig out blood color
 	{
@@ -216,24 +345,25 @@ const CSkin *CSkins::LoadSkin(const char *pName, CImageInfo &Info)
 			for(size_t x = 0; x < BodyWidth; x++)
 			{
 				const size_t Offset = y * Pitch + x * PixelStep;
-				if(Info.m_pData[Offset + 3] > 128)
+				if(Data.m_Info.m_pData[Offset + 3] > 128)
 				{
 					for(size_t c = 0; c < 3; c++)
 					{
-						aColors[c] += Info.m_pData[Offset + c];
+						aColors[c] += Data.m_Info.m_pData[Offset + c];
 					}
 				}
 			}
 		}
-		Skin.m_BloodColor = ColorRGBA(normalize(vec3(aColors[0], aColors[1], aColors[2])));
+		Data.m_BloodColor = ColorRGBA(normalize(vec3(aColors[0], aColors[1], aColors[2])));
 	}
 
-	CheckMetrics(Skin.m_Metrics.m_Body, Info.m_pData, Pitch, 0, 0, BodyWidth, BodyHeight);
-	CheckMetrics(Skin.m_Metrics.m_Body, Info.m_pData, Pitch, BodyOutlineOffsetX, BodyOutlineOffsetY, BodyOutlineWidth, BodyOutlineHeight);
-	CheckMetrics(Skin.m_Metrics.m_Feet, Info.m_pData, Pitch, FeetOffsetX, FeetOffsetY, FeetWidth, FeetHeight);
-	CheckMetrics(Skin.m_Metrics.m_Feet, Info.m_pData, Pitch, FeetOutlineOffsetX, FeetOutlineOffsetY, FeetOutlineWidth, FeetOutlineHeight);
+	CheckMetrics(Data.m_Metrics.m_Body, Data.m_Info.m_pData, Pitch, 0, 0, BodyWidth, BodyHeight);
+	CheckMetrics(Data.m_Metrics.m_Body, Data.m_Info.m_pData, Pitch, BodyOutlineOffsetX, BodyOutlineOffsetY, BodyOutlineWidth, BodyOutlineHeight);
+	CheckMetrics(Data.m_Metrics.m_Feet, Data.m_Info.m_pData, Pitch, FeetOffsetX, FeetOffsetY, FeetWidth, FeetHeight);
+	CheckMetrics(Data.m_Metrics.m_Feet, Data.m_Info.m_pData, Pitch, FeetOutlineOffsetX, FeetOutlineOffsetY, FeetOutlineWidth, FeetOutlineHeight);
 
-	ConvertToGrayscale(Info);
+	Data.m_InfoGrayscale = Data.m_Info.DeepCopy();
+	ConvertToGrayscale(Data.m_InfoGrayscale);
 
 	int aFreq[256] = {0};
 	uint8_t OrgWeight = 1;
@@ -245,9 +375,9 @@ const CSkin *CSkins::LoadSkin(const char *pName, CImageInfo &Info)
 		for(size_t x = 0; x < BodyWidth; x++)
 		{
 			const size_t Offset = y * Pitch + x * PixelStep;
-			if(Info.m_pData[Offset + 3] > 128)
+			if(Data.m_InfoGrayscale.m_pData[Offset + 3] > 128)
 			{
-				aFreq[Info.m_pData[Offset]]++;
+				aFreq[Data.m_InfoGrayscale.m_pData[Offset]]++;
 			}
 		}
 	}
@@ -266,7 +396,7 @@ const CSkin *CSkins::LoadSkin(const char *pName, CImageInfo &Info)
 		for(size_t x = 0; x < BodyWidth; x++)
 		{
 			const size_t Offset = y * Pitch + x * PixelStep;
-			uint8_t v = Info.m_pData[Offset];
+			uint8_t v = Data.m_InfoGrayscale.m_pData[Offset];
 			if(v <= OrgWeight)
 			{
 				v = (uint8_t)((v / (float)OrgWeight) * NewWeight);
@@ -275,35 +405,82 @@ const CSkin *CSkins::LoadSkin(const char *pName, CImageInfo &Info)
 			{
 				v = (uint8_t)(((v - OrgWeight) / (float)(255 - OrgWeight)) * (255 - NewWeight) + NewWeight);
 			}
-			Info.m_pData[Offset] = v;
-			Info.m_pData[Offset + 1] = v;
-			Info.m_pData[Offset + 2] = v;
+			Data.m_InfoGrayscale.m_pData[Offset] = v;
+			Data.m_InfoGrayscale.m_pData[Offset + 1] = v;
+			Data.m_InfoGrayscale.m_pData[Offset + 2] = v;
 		}
 	}
 
-	Skin.m_ColorableSkin.m_Body = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_BODY]);
-	Skin.m_ColorableSkin.m_BodyOutline = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_BODY_OUTLINE]);
-	Skin.m_ColorableSkin.m_Feet = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_FOOT]);
-	Skin.m_ColorableSkin.m_FeetOutline = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_FOOT_OUTLINE]);
-	Skin.m_ColorableSkin.m_Hands = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_HAND]);
-	Skin.m_ColorableSkin.m_HandsOutline = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_HAND_OUTLINE]);
+	return true;
+}
 
-	for(int i = 0; i < 6; ++i)
+void CSkins::LoadSkinFinish(CSkinContainer *pSkinContainer, const CSkinLoadData &Data)
+{
+	CSkin Skin{pSkinContainer->Name()};
+
+	Skin.m_OriginalSkin.m_Body = Graphics()->LoadSpriteTexture(Data.m_Info, &g_pData->m_aSprites[SPRITE_TEE_BODY]);
+	Skin.m_OriginalSkin.m_BodyOutline = Graphics()->LoadSpriteTexture(Data.m_Info, &g_pData->m_aSprites[SPRITE_TEE_BODY_OUTLINE]);
+	Skin.m_OriginalSkin.m_Feet = Graphics()->LoadSpriteTexture(Data.m_Info, &g_pData->m_aSprites[SPRITE_TEE_FOOT]);
+	Skin.m_OriginalSkin.m_FeetOutline = Graphics()->LoadSpriteTexture(Data.m_Info, &g_pData->m_aSprites[SPRITE_TEE_FOOT_OUTLINE]);
+	Skin.m_OriginalSkin.m_Hands = Graphics()->LoadSpriteTexture(Data.m_Info, &g_pData->m_aSprites[SPRITE_TEE_HAND]);
+	Skin.m_OriginalSkin.m_HandsOutline = Graphics()->LoadSpriteTexture(Data.m_Info, &g_pData->m_aSprites[SPRITE_TEE_HAND_OUTLINE]);
+	for(size_t i = 0; i < std::size(Skin.m_OriginalSkin.m_aEyes); ++i)
 	{
-		Skin.m_ColorableSkin.m_aEyes[i] = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_EYE_NORMAL + i]);
+		Skin.m_OriginalSkin.m_aEyes[i] = Graphics()->LoadSpriteTexture(Data.m_Info, &g_pData->m_aSprites[SPRITE_TEE_EYE_NORMAL + i]);
 	}
+
+	Skin.m_ColorableSkin.m_Body = Graphics()->LoadSpriteTexture(Data.m_InfoGrayscale, &g_pData->m_aSprites[SPRITE_TEE_BODY]);
+	Skin.m_ColorableSkin.m_BodyOutline = Graphics()->LoadSpriteTexture(Data.m_InfoGrayscale, &g_pData->m_aSprites[SPRITE_TEE_BODY_OUTLINE]);
+	Skin.m_ColorableSkin.m_Feet = Graphics()->LoadSpriteTexture(Data.m_InfoGrayscale, &g_pData->m_aSprites[SPRITE_TEE_FOOT]);
+	Skin.m_ColorableSkin.m_FeetOutline = Graphics()->LoadSpriteTexture(Data.m_InfoGrayscale, &g_pData->m_aSprites[SPRITE_TEE_FOOT_OUTLINE]);
+	Skin.m_ColorableSkin.m_Hands = Graphics()->LoadSpriteTexture(Data.m_InfoGrayscale, &g_pData->m_aSprites[SPRITE_TEE_HAND]);
+	Skin.m_ColorableSkin.m_HandsOutline = Graphics()->LoadSpriteTexture(Data.m_InfoGrayscale, &g_pData->m_aSprites[SPRITE_TEE_HAND_OUTLINE]);
+	for(size_t i = 0; i < std::size(Skin.m_ColorableSkin.m_aEyes); ++i)
+	{
+		Skin.m_ColorableSkin.m_aEyes[i] = Graphics()->LoadSpriteTexture(Data.m_InfoGrayscale, &g_pData->m_aSprites[SPRITE_TEE_EYE_NORMAL + i]);
+	}
+
+	Skin.m_Metrics = Data.m_Metrics;
+	Skin.m_BloodColor = Data.m_BloodColor;
 
 	if(g_Config.m_Debug)
 	{
 		log_trace("skins", "Loaded skin '%s'", Skin.GetName());
 	}
 
-	auto &&pSkin = std::make_unique<CSkin>(std::move(Skin));
-	const auto SkinInsertIt = m_Skins.insert({pSkin->GetName(), std::move(pSkin)});
+	auto SkinIt = m_Skins.find(pSkinContainer->NormalizedName());
+	dbg_assert(SkinIt != m_Skins.end(), "LoadSkinFinish on skin '%s' which is not in m_Skins", pSkinContainer->NormalizedName());
+	SkinIt->second->m_pSkin = std::make_unique<CSkin>(std::move(Skin));
+	pSkinContainer->SetState(CSkinContainer::EState::LOADED);
+}
 
-	m_LastRefreshTime = time_get_nanoseconds();
-
-	return SkinInsertIt.first->second.get();
+void CSkins::LoadSkinDirect(const char *pName)
+{
+	auto &&pSkinContainer = std::make_unique<CSkinContainer>(this, pName, CSkinContainer::EType::LOCAL, IStorage::TYPE_ALL);
+	const auto &[SkinIt, Inserted] = m_Skins.insert({pSkinContainer->NormalizedName(), std::move(pSkinContainer)});
+	if(!Inserted)
+	{
+		return;
+	}
+	char aPath[IO_MAX_PATH_LENGTH];
+	str_format(aPath, sizeof(aPath), "skins/%s.png", pName);
+	CSkinLoadData DefaultSkinData;
+	SkinIt->second->SetState(CSkinContainer::EState::LOADING);
+	if(!Graphics()->LoadPng(DefaultSkinData.m_Info, aPath, SkinIt->second->StorageType()))
+	{
+		log_error("skins", "Failed to load PNG of skin '%s' from '%s'", pName, aPath);
+		SkinIt->second->SetState(CSkinContainer::EState::ERROR);
+	}
+	else if(LoadSkinData(pName, DefaultSkinData))
+	{
+		LoadSkinFinish(SkinIt->second.get(), DefaultSkinData);
+	}
+	else
+	{
+		SkinIt->second->SetState(CSkinContainer::EState::ERROR);
+	}
+	DefaultSkinData.m_Info.Free();
+	DefaultSkinData.m_InfoGrayscale.Free();
 }
 
 void CSkins::OnConsoleInit()
@@ -311,6 +488,9 @@ void CSkins::OnConsoleInit()
 	ConfigManager()->RegisterCallback(CSkins::ConfigSaveCallback, this);
 	Console()->Register("add_favorite_skin", "s[skin_name]", CFGFLAG_CLIENT, ConAddFavoriteSkin, this, "Add a skin as a favorite");
 	Console()->Register("remove_favorite_skin", "s[skin_name]", CFGFLAG_CLIENT, ConRemFavoriteSkin, this, "Remove a skin from the favorites");
+
+	Console()->Chain("player_skin", ConchainRefreshSkinList, this);
+	Console()->Chain("dummy_skin", ConchainRefreshSkinList, this);
 }
 
 void CSkins::OnInit()
@@ -333,25 +513,145 @@ void CSkins::OnInit()
 
 void CSkins::OnShutdown()
 {
-	m_LoadingSkins.clear();
+	for(auto &[_, pSkinContainer] : m_Skins)
+	{
+		if(pSkinContainer->m_pLoadJob)
+		{
+			pSkinContainer->m_pLoadJob->Abort();
+		}
+	}
+	m_Skins.clear();
 }
 
-void CSkins::OnRender()
+void CSkins::OnUpdate()
 {
+	// Only update skins periodically to reduce FPS impact
 	const std::chrono::nanoseconds StartTime = time_get_nanoseconds();
-	for(auto &[_, pLoadingSkin] : m_LoadingSkins)
+	const std::chrono::nanoseconds MaxTime = std::chrono::microseconds(maximum(round_to_int(Client()->RenderFrameTime() / 8.0f), 25));
+	if(m_ContainerUpdateTime.has_value() && StartTime - m_ContainerUpdateTime.value() < MaxTime)
 	{
-		if(!pLoadingSkin->m_pDownloadJob || !pLoadingSkin->m_pDownloadJob->Done())
+		return;
+	}
+	m_ContainerUpdateTime = StartTime;
+
+	// Update loaded state of managed skins which are not retrieved with the FindImpl function
+	GameClient()->CollectManagedTeeRenderInfos([&](const char *pSkinName) {
+		// This will update the loaded state of the container
+		dbg_assert(FindContainerOrNullptr(pSkinName) != nullptr, "No skin container found for managed tee render info: %s", pSkinName);
+	});
+	// Keep player and dummy skin loaded
+	FindContainerOrNullptr(g_Config.m_ClPlayerSkin);
+	FindContainerOrNullptr(g_Config.m_ClDummySkin);
+
+	CSkinLoadingStats Stats = LoadingStats();
+	UpdateUnloadSkins(Stats);
+	UpdateStartLoading(Stats);
+	UpdateFinishLoading(Stats, StartTime, MaxTime);
+}
+
+void CSkins::UpdateUnloadSkins(CSkinLoadingStats &Stats)
+{
+	if(Stats.m_NumPending + Stats.m_NumLoaded + Stats.m_NumLoading <= (size_t)g_Config.m_ClSkinsLoadedMax)
+	{
+		return;
+	}
+
+	const std::chrono::nanoseconds UnloadStart = time_get_nanoseconds();
+	size_t NumToUnload = std::min<size_t>(Stats.m_NumPending + Stats.m_NumLoaded + Stats.m_NumLoading - (size_t)g_Config.m_ClSkinsLoadedMax, 16);
+	const size_t MaxSkipped = m_SkinsUsageList.size() / 8;
+	size_t NumSkipped = 0;
+	for(auto It = m_SkinsUsageList.rbegin(); It != m_SkinsUsageList.rend() && NumToUnload != 0 && NumSkipped < MaxSkipped; ++It)
+	{
+		auto SkinIt = m_Skins.find(*It);
+		dbg_assert(SkinIt != m_Skins.end(), "m_SkinsUsageList contains skin not in m_Skins");
+		auto &pSkinContainer = SkinIt->second;
+		dbg_assert(!pSkinContainer->m_AlwaysLoaded, "m_SkinsUsageList contains skins with m_AlwaysLoaded");
+		if(pSkinContainer->m_State != CSkinContainer::EState::PENDING &&
+			pSkinContainer->m_State != CSkinContainer::EState::LOADED)
+		{
+			dbg_assert(pSkinContainer->m_State == CSkinContainer::EState::LOADING, "m_SkinsUsageList contains skin which is not PENDING, LOADING or LOADED");
+			NumSkipped++;
+			continue;
+		}
+		const std::chrono::nanoseconds TimeUnused = UnloadStart - pSkinContainer->m_LastLoadRequest.value();
+		if(TimeUnused < (pSkinContainer->m_State == CSkinContainer::EState::LOADED ? MIN_UNLOAD_TIME_LOADED : MIN_UNLOAD_TIME_PENDING))
+		{
+			NumSkipped++;
+			continue;
+		}
+		if(pSkinContainer->m_State == CSkinContainer::EState::LOADED)
+		{
+			pSkinContainer->m_pSkin->m_OriginalSkin.Unload(Graphics());
+			pSkinContainer->m_pSkin->m_ColorableSkin.Unload(Graphics());
+			pSkinContainer->m_pSkin = nullptr;
+			Stats.m_NumLoaded--;
+		}
+		else
+		{
+			Stats.m_NumPending--;
+		}
+		Stats.m_NumUnloaded++;
+		pSkinContainer->SetState(CSkinContainer::EState::UNLOADED);
+		NumToUnload--;
+	}
+}
+
+void CSkins::UpdateStartLoading(CSkinLoadingStats &Stats)
+{
+	for(auto &[_, pSkinContainer] : m_Skins)
+	{
+		if(Stats.m_NumPending == 0 || Stats.m_NumLoading + Stats.m_NumLoaded >= (size_t)g_Config.m_ClSkinsLoadedMax)
+		{
+			break;
+		}
+		if(pSkinContainer->m_State != CSkinContainer::EState::PENDING)
 		{
 			continue;
 		}
-
-		if(pLoadingSkin->m_pDownloadJob->State() == IJob::STATE_DONE && pLoadingSkin->m_pDownloadJob->ImageInfo().m_pData)
+		switch(pSkinContainer->Type())
 		{
-			LoadSkin(pLoadingSkin->Name(), pLoadingSkin->m_pDownloadJob->ImageInfo());
-			GameClient()->OnSkinUpdate(pLoadingSkin->Name());
-			pLoadingSkin->m_pDownloadJob = nullptr;
-			if(time_get_nanoseconds() - StartTime >= 250us)
+		case CSkinContainer::EType::LOCAL:
+			pSkinContainer->m_pLoadJob = std::make_shared<CSkinLoadJob>(this, pSkinContainer->Name(), pSkinContainer->StorageType());
+			break;
+		case CSkinContainer::EType::DOWNLOAD:
+			pSkinContainer->m_pLoadJob = std::make_shared<CSkinDownloadJob>(this, pSkinContainer->Name());
+			break;
+		default:
+			dbg_assert(false, "pSkinContainer->Type() invalid");
+			dbg_break();
+		}
+		Engine()->AddJob(pSkinContainer->m_pLoadJob);
+		pSkinContainer->SetState(CSkinContainer::EState::LOADING);
+		Stats.m_NumPending--;
+		Stats.m_NumLoading++;
+	}
+}
+
+void CSkins::UpdateFinishLoading(CSkinLoadingStats &Stats, std::chrono::nanoseconds StartTime, std::chrono::nanoseconds MaxTime)
+{
+	for(auto &[_, pSkinContainer] : m_Skins)
+	{
+		if(Stats.m_NumLoading == 0)
+		{
+			break;
+		}
+		if(pSkinContainer->m_State != CSkinContainer::EState::LOADING)
+		{
+			continue;
+		}
+		dbg_assert(pSkinContainer->m_pLoadJob != nullptr, "Skin container in loading state must have a load job");
+		if(!pSkinContainer->m_pLoadJob->Done())
+		{
+			continue;
+		}
+		Stats.m_NumLoading--;
+		if(pSkinContainer->m_pLoadJob->State() == IJob::STATE_DONE && pSkinContainer->m_pLoadJob->m_Data.m_Info.m_pData)
+		{
+			LoadSkinFinish(pSkinContainer.get(), pSkinContainer->m_pLoadJob->m_Data);
+			GameClient()->OnSkinUpdate(pSkinContainer->Name());
+			pSkinContainer->m_pLoadJob = nullptr;
+			Stats.m_NumLoaded++;
+			if(time_get_nanoseconds() - StartTime >= MaxTime)
 			{
 				// Avoid using too much frame time for loading skins
 				break;
@@ -359,60 +659,125 @@ void CSkins::OnRender()
 		}
 		else
 		{
-			pLoadingSkin->m_pDownloadJob = nullptr;
+			if(pSkinContainer->m_pLoadJob->State() == IJob::STATE_DONE && pSkinContainer->m_pLoadJob->m_NotFound)
+			{
+				pSkinContainer->SetState(CSkinContainer::EState::NOT_FOUND);
+				Stats.m_NumNotFound++;
+			}
+			else
+			{
+				pSkinContainer->SetState(CSkinContainer::EState::ERROR);
+				Stats.m_NumError++;
+			}
+			pSkinContainer->m_pLoadJob = nullptr;
 		}
 	}
 }
 
 void CSkins::Refresh(TSkinLoadedCallback &&SkinLoadedCallback)
 {
-	m_LoadingSkins.clear();
-
-	for(const auto &[_, pSkin] : m_Skins)
+	for(auto &[_, pSkinContainer] : m_Skins)
 	{
-		pSkin->m_OriginalSkin.Unload(Graphics());
-		pSkin->m_ColorableSkin.Unload(Graphics());
+		if(pSkinContainer->m_pLoadJob)
+		{
+			pSkinContainer->m_pLoadJob->Abort();
+		}
+		if(pSkinContainer->m_pSkin)
+		{
+			pSkinContainer->m_pSkin->m_OriginalSkin.Unload(Graphics());
+			pSkinContainer->m_pSkin->m_ColorableSkin.Unload(Graphics());
+		}
 	}
 	m_Skins.clear();
+	m_SkinsUsageList.clear();
+
+	LoadSkinDirect("default");
+	SkinLoadedCallback();
 
 	CSkinScanUser SkinScanUser;
 	SkinScanUser.m_pThis = this;
 	SkinScanUser.m_SkinLoadedCallback = SkinLoadedCallback;
 	Storage()->ListDirectory(IStorage::TYPE_ALL, "skins", SkinScan, &SkinScanUser);
-
-	m_LastRefreshTime = time_get_nanoseconds();
 }
 
-const std::vector<CSkins::CSkinListEntry> &CSkins::SkinList()
+CSkins::CSkinLoadingStats CSkins::LoadingStats() const
 {
-	if(m_SkinListLastRefreshTime.has_value() && m_SkinListLastRefreshTime.value() == m_LastRefreshTime)
+	CSkinLoadingStats Stats;
+	for(const auto &[_, pSkinContainer] : m_Skins)
 	{
-		return m_vSkinList;
+		switch(pSkinContainer->m_State)
+		{
+		case CSkinContainer::EState::UNLOADED:
+			Stats.m_NumUnloaded++;
+			break;
+		case CSkinContainer::EState::PENDING:
+			Stats.m_NumPending++;
+			break;
+		case CSkinContainer::EState::LOADING:
+			Stats.m_NumLoading++;
+			break;
+		case CSkinContainer::EState::LOADED:
+			Stats.m_NumLoaded++;
+			break;
+		case CSkinContainer::EState::ERROR:
+			Stats.m_NumError++;
+			break;
+		case CSkinContainer::EState::NOT_FOUND:
+			Stats.m_NumNotFound++;
+			break;
+		}
+	}
+	return Stats;
+}
+
+CSkins::CSkinList &CSkins::SkinList()
+{
+	if(!m_SkinList.m_NeedsUpdate)
+	{
+		return m_SkinList;
 	}
 
-	m_vSkinList.clear();
-	for(const auto &[_, pSkin] : m_Skins)
+	m_SkinList.m_vSkins.clear();
+	m_SkinList.m_UnfilteredCount = 0;
+	for(const auto &[_, pSkinContainer] : m_Skins)
 	{
-		if(g_Config.m_ClSkinFilterString[0] != '\0' && !str_utf8_find_nocase(pSkin->GetName(), g_Config.m_ClSkinFilterString))
+		if(pSkinContainer->IsSpecial())
 		{
 			continue;
 		}
 
-		if(IsSpecialSkin(pSkin->GetName()))
+		const bool SelectedMain = str_utf8_comp_nocase(pSkinContainer->Name(), g_Config.m_ClPlayerSkin) == 0;
+		const bool SelectedDummy = str_utf8_comp_nocase(pSkinContainer->Name(), g_Config.m_ClDummySkin) == 0;
+
+		// Don't include skins in the list that couldn't be found in the database except the current player
+		// and dummy skins to avoid showing a lot of not-found entries while the user is typing a skin name.
+		if(pSkinContainer->m_State == CSkinContainer::EState::NOT_FOUND &&
+			!pSkinContainer->IsSpecial() &&
+			!SelectedMain &&
+			!SelectedDummy)
 		{
 			continue;
 		}
+		m_SkinList.m_UnfilteredCount++;
 
-		m_vSkinList.emplace_back(pSkin.get(), IsFavorite(pSkin->GetName()));
+		std::optional<std::pair<int, int>> NameMatch;
+		if(g_Config.m_ClSkinFilterString[0] != '\0')
+		{
+			const char *pNameMatchEnd;
+			const char *pNameMatchStart = str_utf8_find_nocase(pSkinContainer->Name(), g_Config.m_ClSkinFilterString, &pNameMatchEnd);
+			if(pNameMatchStart == nullptr)
+			{
+				continue;
+			}
+			NameMatch = std::make_pair<int, int>(pNameMatchStart - pSkinContainer->Name(), pNameMatchEnd - pNameMatchStart);
+		}
+
+		m_SkinList.m_vSkins.emplace_back(pSkinContainer.get(), IsFavorite(pSkinContainer->Name()), SelectedMain, SelectedDummy, NameMatch);
 	}
 
-	std::sort(m_vSkinList.begin(), m_vSkinList.end());
-	return m_vSkinList;
-}
-
-void CSkins::ForceRefreshSkinList()
-{
-	m_SkinListLastRefreshTime = std::nullopt;
+	std::sort(m_SkinList.m_vSkins.begin(), m_SkinList.m_vSkins.end());
+	m_SkinList.m_NeedsUpdate = false;
+	return m_SkinList;
 }
 
 const CSkin *CSkins::Find(const char *pName)
@@ -429,15 +794,27 @@ const CSkin *CSkins::Find(const char *pName)
 	return pSkin;
 }
 
-const CSkin *CSkins::FindOrNullptr(const char *pName, bool IgnorePrefix)
+const CSkins::CSkinContainer *CSkins::FindContainerOrNullptr(const char *pName)
 {
-	if(g_Config.m_ClVanillaSkinsOnly && !IsVanillaSkin(pName))
+	if(!CSkin::IsValidName(pName))
 	{
 		return nullptr;
 	}
+	CSkinContainer SkinContainer(this, pName, CSkinContainer::EType::DOWNLOAD, IStorage::TYPE_SAVE);
+	auto &&pSkinContainer = std::make_unique<CSkinContainer>(std::move(SkinContainer));
+	const auto &[SkinIt, Inserted] = m_Skins.insert({pSkinContainer->NormalizedName(), std::move(pSkinContainer)});
+	if(Inserted)
+	{
+		SkinIt->second->SetState(SkinIt->second->DetermineInitialState());
+	}
+	SkinIt->second->RequestLoad();
+	return SkinIt->second.get();
+}
 
+const CSkin *CSkins::FindOrNullptr(const char *pName, bool IgnorePrefix)
+{
 	const char *pSkinPrefix = m_aEventSkinPrefix[0] != '\0' ? m_aEventSkinPrefix : g_Config.m_ClSkinPrefix;
-	if(!IgnorePrefix && pSkinPrefix[0] != '\0')
+	if(!g_Config.m_ClVanillaSkinsOnly && !IgnorePrefix && pSkinPrefix[0] != '\0')
 	{
 		char aNameWithPrefix[2 * MAX_SKIN_LENGTH + 2]; // Larger than skin name length to allow IsValidName to check if it's too long
 		str_format(aNameWithPrefix, sizeof(aNameWithPrefix), "%s_%s", pSkinPrefix, pName);
@@ -454,38 +831,12 @@ const CSkin *CSkins::FindOrNullptr(const char *pName, bool IgnorePrefix)
 
 const CSkin *CSkins::FindImpl(const char *pName)
 {
-	auto SkinIt = m_Skins.find(pName);
-	if(SkinIt != m_Skins.end())
-	{
-		return SkinIt->second.get();
-	}
-
-	if(!g_Config.m_ClDownloadSkins)
+	const CSkinContainer *pSkinContainer = FindContainerOrNullptr(pName);
+	if(pSkinContainer == nullptr || pSkinContainer->m_State != CSkinContainer::EState::LOADED)
 	{
 		return nullptr;
 	}
-
-	if(str_comp(pName, "default") == 0)
-	{
-		return nullptr;
-	}
-
-	if(!CSkin::IsValidName(pName))
-	{
-		return nullptr;
-	}
-
-	if(m_LoadingSkins.find(pName) != m_LoadingSkins.end())
-	{
-		return nullptr;
-	}
-
-	CLoadingSkin LoadingSkin(pName);
-	LoadingSkin.m_pDownloadJob = std::make_shared<CSkinDownloadJob>(this, pName);
-	Engine()->AddJob(LoadingSkin.m_pDownloadJob);
-	auto &&pLoadingSkin = std::make_unique<CLoadingSkin>(std::move(LoadingSkin));
-	m_LoadingSkins.insert({pLoadingSkin->Name(), std::move(pLoadingSkin)});
-	return nullptr;
+	return pSkinContainer->m_pSkin.get();
 }
 
 void CSkins::AddFavorite(const char *pName)
@@ -497,26 +848,32 @@ void CSkins::AddFavorite(const char *pName)
 		return;
 	}
 
-	const auto &[_, Inserted] = m_Favorites.emplace(pName);
+	char aNormalizedName[NORMALIZED_SKIN_NAME_LENGTH];
+	str_utf8_tolower(pName, aNormalizedName, sizeof(aNormalizedName));
+	const auto &[_, Inserted] = m_Favorites.emplace(aNormalizedName);
 	if(Inserted)
 	{
-		m_SkinListLastRefreshTime = std::nullopt;
+		m_SkinList.ForceRefresh();
 	}
 }
 
 void CSkins::RemoveFavorite(const char *pName)
 {
-	const auto FavoriteIt = m_Favorites.find(pName);
+	char aNormalizedName[NORMALIZED_SKIN_NAME_LENGTH];
+	str_utf8_tolower(pName, aNormalizedName, sizeof(aNormalizedName));
+	const auto FavoriteIt = m_Favorites.find(aNormalizedName);
 	if(FavoriteIt != m_Favorites.end())
 	{
 		m_Favorites.erase(FavoriteIt);
-		m_SkinListLastRefreshTime = std::nullopt;
+		m_SkinList.ForceRefresh();
 	}
 }
 
 bool CSkins::IsFavorite(const char *pName) const
 {
-	return m_Favorites.find(pName) != m_Favorites.end();
+	char aNormalizedName[NORMALIZED_SKIN_NAME_LENGTH];
+	str_utf8_tolower(pName, aNormalizedName, sizeof(aNormalizedName));
+	return m_Favorites.find(aNormalizedName) != m_Favorites.end();
 }
 
 void CSkins::RandomizeSkin(int Dummy)
@@ -545,43 +902,59 @@ void CSkins::RandomizeSkin(int Dummy)
 		*pColorFeet = Feet.Pack(false);
 	}
 
-	std::vector<const CSkin *> vpConsideredSkins;
-	for(const auto &[_, pSkin] : m_Skins)
+	std::vector<const CSkinContainer *> vpConsideredSkins;
+	for(const auto &[_, pSkinContainer] : m_Skins)
 	{
-		if(IsSpecialSkin(pSkin->GetName()))
+		if(pSkinContainer->m_State == CSkinContainer::EState::ERROR ||
+			pSkinContainer->m_State == CSkinContainer::EState::NOT_FOUND ||
+			pSkinContainer->IsSpecial())
+		{
 			continue;
-		vpConsideredSkins.push_back(pSkin.get());
+		}
+		vpConsideredSkins.push_back(pSkinContainer.get());
 	}
-	const CSkin *pRandomSkin;
+	const char *pRandomSkin;
 	if(vpConsideredSkins.empty())
 	{
-		pRandomSkin = Find("default");
+		pRandomSkin = "default";
 	}
 	else
 	{
-		pRandomSkin = vpConsideredSkins[rand() % vpConsideredSkins.size()];
+		pRandomSkin = vpConsideredSkins[rand() % vpConsideredSkins.size()]->Name();
 	}
 
 	char *pSkinName = Dummy ? g_Config.m_ClDummySkin : g_Config.m_ClPlayerSkin;
 	const size_t SkinNameSize = Dummy ? sizeof(g_Config.m_ClDummySkin) : sizeof(g_Config.m_ClPlayerSkin);
-	str_copy(pSkinName, pRandomSkin->GetName(), SkinNameSize);
+	str_copy(pSkinName, pRandomSkin, SkinNameSize);
+	m_SkinList.ForceRefresh();
+}
+
+void CSkins::CSkinLoadJob::Run()
+{
+	char aPath[IO_MAX_PATH_LENGTH];
+	str_format(aPath, sizeof(aPath), "skins/%s.png", m_aName);
+	if(m_pSkins->Graphics()->LoadPng(m_Data.m_Info, aPath, m_StorageType))
+	{
+		if(State() == IJob::STATE_ABORTED)
+		{
+			return;
+		}
+		m_pSkins->LoadSkinData(m_aName, m_Data);
+	}
+	else
+	{
+		log_error("skins", "Failed to load PNG of skin '%s' from '%s'", m_aName, aPath);
+	}
 }
 
 CSkins::CSkinDownloadJob::CSkinDownloadJob(CSkins *pSkins, const char *pName) :
-	m_pSkins(pSkins)
+	CAbstractSkinLoadJob(pSkins, pName)
 {
-	str_copy(m_aName, pName);
-	Abortable(true);
-}
-
-CSkins::CSkinDownloadJob::~CSkinDownloadJob()
-{
-	m_ImageInfo.Free();
 }
 
 bool CSkins::CSkinDownloadJob::Abort()
 {
-	if(!IJob::Abort())
+	if(!CAbstractSkinLoadJob::Abort())
 	{
 		return false;
 	}
@@ -616,6 +989,7 @@ void CSkins::CSkinDownloadJob::Run()
 	pGet->MaxResponseSize(MaxResponseSize);
 	pGet->ValidateBeforeOverwrite(true);
 	pGet->LogProgress(HTTPLOG::NONE);
+	pGet->FailOnErrorStatus(false);
 	{
 		const CLockScope LockScope(m_Lock);
 		m_pGetRequest = pGet;
@@ -628,9 +1002,15 @@ void CSkins::CSkinDownloadJob::Run()
 		unsigned PngSize;
 		if(m_pSkins->Storage()->ReadFile(aPathReal, IStorage::TYPE_SAVE, &pPngData, &PngSize))
 		{
-			m_pSkins->Graphics()->LoadPng(m_ImageInfo, (uint8_t *)pPngData, PngSize, aPathReal);
+			if(m_pSkins->Graphics()->LoadPng(m_Data.m_Info, static_cast<uint8_t *>(pPngData), PngSize, aPathReal))
+			{
+				if(State() == IJob::STATE_ABORTED)
+				{
+					return;
+				}
+				m_pSkins->LoadSkinData(m_aName, m_Data);
+			}
 			free(pPngData);
-			pPngData = nullptr;
 		}
 	}
 
@@ -641,11 +1021,12 @@ void CSkins::CSkinDownloadJob::Run()
 	}
 	if(pGet->State() != EHttpState::DONE || State() == IJob::STATE_ABORTED || pGet->StatusCode() >= 400)
 	{
+		m_NotFound = pGet->State() == EHttpState::DONE && pGet->StatusCode() == 404; // 404 Not Found
 		return;
 	}
 	if(pGet->StatusCode() == 304) // 304 Not Modified
 	{
-		bool Success = m_ImageInfo.m_pData != nullptr;
+		bool Success = m_Data.m_Info.m_pData != nullptr;
 		pGet->OnValidation(Success);
 		if(Success)
 		{
@@ -659,6 +1040,7 @@ void CSkins::CSkinDownloadJob::Run()
 		pGet->ValidateBeforeOverwrite(true);
 		pGet->SkipByFileTime(false);
 		pGet->LogProgress(HTTPLOG::NONE);
+		pGet->FailOnErrorStatus(false);
 		{
 			const CLockScope LockScope(m_Lock);
 			m_pGetRequest = pGet;
@@ -669,8 +1051,9 @@ void CSkins::CSkinDownloadJob::Run()
 			const CLockScope LockScope(m_Lock);
 			m_pGetRequest = nullptr;
 		}
-		if(pGet->State() != EHttpState::DONE || State() == IJob::STATE_ABORTED)
+		if(pGet->State() != EHttpState::DONE || State() == IJob::STATE_ABORTED || pGet->StatusCode() >= 400)
 		{
+			m_NotFound = pGet->State() == EHttpState::DONE && pGet->StatusCode() == 404; // 404 Not Found
 			return;
 		}
 	}
@@ -679,42 +1062,22 @@ void CSkins::CSkinDownloadJob::Run()
 	size_t ResultSize;
 	pGet->Result(&pResult, &ResultSize);
 
-	m_ImageInfo.Free();
-	bool Success = m_pSkins->Graphics()->LoadPng(m_ImageInfo, pResult, ResultSize, aUrl);
+	m_Data.m_Info.Free();
+	m_Data.m_InfoGrayscale.Free();
+	const bool Success = m_pSkins->Graphics()->LoadPng(m_Data.m_Info, pResult, ResultSize, aUrl);
+	if(Success)
+	{
+		if(State() == IJob::STATE_ABORTED)
+		{
+			return;
+		}
+		m_pSkins->LoadSkinData(m_aName, m_Data);
+	}
+	else
+	{
+		log_error("skins", "Failed to load PNG of skin '%s' downloaded from '%s' (size %" PRIzu ")", m_aName, aUrl, ResultSize);
+	}
 	pGet->OnValidation(Success);
-	if(!Success)
-	{
-		log_error("skins", "Failed to load PNG of skin '%s' downloaded from '%s' (%d)", m_aName, aUrl, (int)ResultSize);
-		return;
-	}
-}
-
-CSkins::CLoadingSkin::CLoadingSkin(const char *pName)
-{
-	str_copy(m_aName, pName);
-}
-
-CSkins::CLoadingSkin::~CLoadingSkin()
-{
-	if(m_pDownloadJob)
-	{
-		m_pDownloadJob->Abort();
-	}
-}
-
-bool CSkins::CLoadingSkin::operator<(const CLoadingSkin &Other) const
-{
-	return str_comp(m_aName, Other.m_aName) < 0;
-}
-
-bool CSkins::CLoadingSkin::operator<(const char *pOther) const
-{
-	return str_comp(m_aName, pOther) < 0;
-}
-
-bool CSkins::CLoadingSkin::operator==(const char *pOther) const
-{
-	return !str_comp(m_aName, pOther);
 }
 
 void CSkins::ConAddFavoriteSkin(IConsole::IResult *pResult, void *pUserData)
@@ -742,5 +1105,15 @@ void CSkins::OnConfigSave(IConfigManager *pConfigManager)
 		char aBuffer[32 + MAX_SKIN_LENGTH];
 		str_format(aBuffer, sizeof(aBuffer), "add_favorite_skin \"%s\"", Favorite.c_str());
 		pConfigManager->WriteLine(aBuffer);
+	}
+}
+
+void CSkins::ConchainRefreshSkinList(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
+{
+	CSkins *pThis = static_cast<CSkins *>(pUserData);
+	pfnCallback(pResult, pCallbackUserData);
+	if(pResult->NumArguments())
+	{
+		pThis->m_SkinList.ForceRefresh();
 	}
 }

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -12,33 +12,223 @@
 #include <game/client/skin.h>
 
 #include <chrono>
+#include <list>
 #include <optional>
 #include <set>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
 
 class CHttpRequest;
 
 class CSkins : public CComponent
 {
+private:
+	/**
+	 * Maximum length of normalized skin names. Normalization may increase the length.
+	 */
+	static constexpr size_t NORMALIZED_SKIN_NAME_LENGTH = 2 * MAX_SKIN_LENGTH;
+
+	/**
+	 * The data of a skin that can be loaded in a separate thread.
+	 */
+	class CSkinLoadData
+	{
+	public:
+		CImageInfo m_Info;
+		CImageInfo m_InfoGrayscale;
+		CSkin::CSkinMetrics m_Metrics;
+		ColorRGBA m_BloodColor;
+	};
+
+	/**
+	 * An abstract job to load a skin from a source determined by the derived class.
+	 */
+	class CAbstractSkinLoadJob : public IJob
+	{
+	public:
+		CAbstractSkinLoadJob(CSkins *pSkins, const char *pName);
+		virtual ~CAbstractSkinLoadJob();
+
+		CSkinLoadData m_Data;
+		bool m_NotFound = false;
+
+	protected:
+		CSkins *m_pSkins;
+		char m_aName[MAX_SKIN_LENGTH];
+	};
+
 public:
+	/**
+	 * Container for a skin, its loading state, job and various meta data.
+	 */
+	class CSkinContainer
+	{
+		friend class CSkins;
+
+	public:
+		enum class EType
+		{
+			/**
+			 * Skin should be loaded locally (from skins folder).
+			 */
+			LOCAL,
+			/**
+			 * Skin should be downloaded (or loaded from downloadedskins).
+			 */
+			DOWNLOAD,
+		};
+
+		enum class EState
+		{
+			/**
+			 * Skin is unloaded and loading is not desired.
+			 */
+			UNLOADED,
+			/**
+			 * Skin is unloaded and should be loaded when a slot is free. Skin will enter @link LOADING @endlink
+			 * state when maximum number of loaded skins is not exceeded.
+			 */
+			PENDING,
+			/**
+			 * Skin is currently loading, iff @link m_pLoadJob @endlink is set.
+			 */
+			LOADING,
+			/**
+			 * Skin is loaded, iff @link m_pSkin @endlink is set.
+			 */
+			LOADED,
+			/**
+			 * Skin failed to be loaded due to an unexpected error.
+			 */
+			ERROR,
+			/**
+			 * Skin failed to be downloaded because it could not be found.
+			 */
+			NOT_FOUND,
+		};
+
+		CSkinContainer(CSkinContainer &&Other) = default;
+		CSkinContainer(CSkins *pSkins, const char *pName, EType Type, int StorageType);
+		~CSkinContainer();
+
+		bool operator<(const CSkinContainer &Other) const;
+		CSkinContainer &operator=(CSkinContainer &&Other) = default;
+
+		const char *Name() const { return m_aName; }
+		const char *NormalizedName() const { return m_aNormalizedName; }
+		EType Type() const { return m_Type; }
+		int StorageType() const { return m_StorageType; }
+		bool IsVanilla() const { return m_Vanilla; }
+		bool IsSpecial() const { return m_Special; }
+		bool IsAlwaysLoaded() const { return m_AlwaysLoaded; }
+		EState State() const { return m_State; }
+		const std::unique_ptr<CSkin> &Skin() const { return m_pSkin; }
+
+		/**
+		 * Request that this skin should be loaded and should stay loaded.
+		 */
+		void RequestLoad();
+
+	private:
+		CSkins *m_pSkins;
+		char m_aName[MAX_SKIN_LENGTH];
+		char m_aNormalizedName[NORMALIZED_SKIN_NAME_LENGTH];
+		EType m_Type;
+		int m_StorageType;
+		bool m_Vanilla;
+		bool m_Special;
+		bool m_AlwaysLoaded;
+
+		EState m_State = EState::UNLOADED;
+		std::unique_ptr<CSkin> m_pSkin = nullptr;
+		std::shared_ptr<CAbstractSkinLoadJob> m_pLoadJob = nullptr;
+
+		/**
+		 * The time when loading of this skin was first requested.
+		 */
+		std::optional<std::chrono::nanoseconds> m_FirstLoadRequest;
+		/**
+		 * The time when loading of this skin was most recently requested.
+		 */
+		std::optional<std::chrono::nanoseconds> m_LastLoadRequest;
+		/**
+		 * Iterator into @link CSkins::m_SkinsUsageList @endlink for this skin container.
+		 */
+		std::optional<std::list<std::string_view>::iterator> m_UsageEntryIterator;
+
+		EState DetermineInitialState() const;
+		void SetState(EState State);
+	};
+
+	/**
+	 * Represents a skin being displayed in a list in the UI.
+	 */
 	class CSkinListEntry
 	{
 	public:
-		const CSkin *m_pSkin;
-		bool m_Favorite;
-
 		CSkinListEntry() :
-			m_pSkin(nullptr),
+			m_pSkinContainer(nullptr),
 			m_Favorite(false) {}
-		CSkinListEntry(const CSkin *pSkin, bool Favorite) :
-			m_pSkin(pSkin),
-			m_Favorite(Favorite) {}
+		CSkinListEntry(CSkinContainer *pSkinContainer, bool Favorite, bool SelectedMain, bool SelectedDummy, std::optional<std::pair<int, int>> NameMatch) :
+			m_pSkinContainer(pSkinContainer),
+			m_Favorite(Favorite),
+			m_SelectedMain(SelectedMain),
+			m_SelectedDummy(SelectedDummy),
+			m_NameMatch(NameMatch) {}
 
 		bool operator<(const CSkinListEntry &Other) const;
 
-		const void *ListItemId() const { return &m_pSkin; }
-		const void *FavoriteButtonId() const { return &m_Favorite; }
+		const CSkinContainer *SkinContainer() const { return m_pSkinContainer; }
+		bool IsFavorite() const { return m_Favorite; }
+		bool IsSelectedMain() const { return m_SelectedMain; }
+		bool IsSelectedDummy() const { return m_SelectedDummy; }
+		const std::optional<std::pair<int, int>> &NameMatch() const { return m_NameMatch; }
+
+		const void *ListItemId() const { return &m_ListItemId; }
+		const void *FavoriteButtonId() const { return &m_FavoriteButtonId; }
+		const void *ErrorTooltipId() const { return &m_ErrorTooltipId; }
+
+		/**
+		 * Request that this skin should be loaded and should stay loaded.
+		 */
+		void RequestLoad();
+
+	private:
+		CSkinContainer *m_pSkinContainer;
+		bool m_Favorite;
+		bool m_SelectedMain;
+		bool m_SelectedDummy;
+		std::optional<std::pair<int, int>> m_NameMatch;
+		char m_ListItemId;
+		char m_FavoriteButtonId;
+		char m_ErrorTooltipId;
+	};
+
+	class CSkinList
+	{
+		friend class CSkins;
+
+	public:
+		std::vector<CSkinListEntry> &Skins() { return m_vSkins; }
+		int UnfilteredCount() const { return m_UnfilteredCount; }
+		void ForceRefresh() { m_NeedsUpdate = true; }
+
+	private:
+		std::vector<CSkinListEntry> m_vSkins;
+		int m_UnfilteredCount;
+		bool m_NeedsUpdate = true;
+	};
+
+	class CSkinLoadingStats
+	{
+	public:
+		size_t m_NumUnloaded = 0;
+		size_t m_NumPending = 0;
+		size_t m_NumLoading = 0;
+		size_t m_NumLoaded = 0;
+		size_t m_NumError = 0;
+		size_t m_NumNotFound = 0;
 	};
 
 	CSkins();
@@ -49,14 +239,13 @@ public:
 	void OnConsoleInit() override;
 	void OnInit() override;
 	void OnShutdown() override;
-	void OnRender() override;
+	void OnUpdate() override;
 
 	void Refresh(TSkinLoadedCallback &&SkinLoadedCallback);
-	std::chrono::nanoseconds LastRefreshTime() const { return m_LastRefreshTime; }
+	CSkinLoadingStats LoadingStats() const;
+	CSkinList &SkinList();
 
-	const std::vector<CSkinListEntry> &SkinList();
-	void ForceRefreshSkinList();
-
+	const CSkinContainer *FindContainerOrNullptr(const char *pName);
 	const CSkin *FindOrNullptr(const char *pName, bool IgnorePrefix = false);
 	const CSkin *Find(const char *pName);
 
@@ -75,69 +264,61 @@ private:
 		"pinky", "redbopp", "redstripe", "saddo", "toptri",
 		"twinbop", "twintri", "warpaint", "x_ninja", "x_spec"};
 
-	class CSkinDownloadJob : public IJob
+	class CSkinLoadJob : public CAbstractSkinLoadJob
+	{
+	public:
+		CSkinLoadJob(CSkins *pSkins, const char *pName, int StorageType);
+
+	protected:
+		void Run() override;
+
+	private:
+		int m_StorageType;
+	};
+
+	class CSkinDownloadJob : public CAbstractSkinLoadJob
 	{
 	public:
 		CSkinDownloadJob(CSkins *pSkins, const char *pName);
-		~CSkinDownloadJob();
 
 		bool Abort() override REQUIRES(!m_Lock);
-
-		CImageInfo &ImageInfo() { return m_ImageInfo; }
 
 	protected:
 		void Run() override REQUIRES(!m_Lock);
 
 	private:
-		CSkins *m_pSkins;
-		char m_aName[MAX_SKIN_LENGTH];
 		CLock m_Lock;
-		std::shared_ptr<CHttpRequest> m_pGetRequest;
-		CImageInfo m_ImageInfo;
+		std::shared_ptr<CHttpRequest> m_pGetRequest GUARDED_BY(m_Lock);
 	};
 
-	class CLoadingSkin
-	{
-	private:
-		char m_aName[MAX_SKIN_LENGTH];
+	std::unordered_map<std::string_view, std::unique_ptr<CSkinContainer>> m_Skins;
+	std::optional<std::chrono::nanoseconds> m_ContainerUpdateTime;
+	/**
+	 * Sorted from most recently to least recently used. Must be kept synchronized with the skin containers.
+	 * Only contains pending and loaded skins as only these are unloaded.
+	 */
+	std::list<std::string_view> m_SkinsUsageList;
 
-	public:
-		std::shared_ptr<CSkinDownloadJob> m_pDownloadJob = nullptr;
-
-		CLoadingSkin(CLoadingSkin &&Other) = default;
-		CLoadingSkin(const char *pName);
-		~CLoadingSkin();
-
-		bool operator<(const CLoadingSkin &Other) const;
-		bool operator<(const char *pOther) const;
-		bool operator==(const char *pOther) const;
-
-		CLoadingSkin &operator=(CLoadingSkin &&Other) = default;
-
-		const char *Name() const { return m_aName; }
-	};
-
-	std::unordered_map<std::string_view, std::unique_ptr<CSkin>> m_Skins;
-
-	std::unordered_map<std::string_view, std::unique_ptr<CLoadingSkin>> m_LoadingSkins;
-	std::chrono::nanoseconds m_LastRefreshTime;
-
-	std::vector<CSkinListEntry> m_vSkinList;
-	std::optional<std::chrono::nanoseconds> m_SkinListLastRefreshTime;
-
+	CSkinList m_SkinList;
 	std::set<std::string> m_Favorites;
 
 	CSkin m_PlaceholderSkin;
 	char m_aEventSkinPrefix[MAX_SKIN_LENGTH];
 
-	const CSkin *LoadSkin(const char *pName, const char *pPath, int DirType);
-	const CSkin *LoadSkin(const char *pName, CImageInfo &Info);
+	bool LoadSkinData(const char *pName, CSkinLoadData &Data) const;
+	void LoadSkinFinish(CSkinContainer *pSkinContainer, const CSkinLoadData &Data);
+	void LoadSkinDirect(const char *pName);
 	const CSkin *FindImpl(const char *pName);
-	static int SkinScan(const char *pName, int IsDir, int DirType, void *pUser);
+	static int SkinScan(const char *pName, int IsDir, int StorageType, void *pUser);
+
+	void UpdateUnloadSkins(CSkinLoadingStats &Stats);
+	void UpdateStartLoading(CSkinLoadingStats &Stats);
+	void UpdateFinishLoading(CSkinLoadingStats &Stats, std::chrono::nanoseconds StartTime, std::chrono::nanoseconds MaxTime);
 
 	static void ConAddFavoriteSkin(IConsole::IResult *pResult, void *pUserData);
 	static void ConRemFavoriteSkin(IConsole::IResult *pResult, void *pUserData);
 	static void ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData);
 	void OnConfigSave(IConfigManager *pConfigManager);
+	static void ConchainRefreshSkinList(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 };
 #endif

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -487,6 +487,11 @@ void CGameClient::OnUpdate()
 		m_Controls.m_aMousePosOnAction[g_Config.m_ClDummy] = m_Controls.m_aMousePos[g_Config.m_ClDummy];
 		m_Binds.m_MouseOnAction = false;
 	}
+
+	for(auto &pComponent : m_vpAll)
+	{
+		pComponent->OnUpdate();
+	}
 }
 
 void CGameClient::OnDummySwap()

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1633,7 +1633,7 @@ void CGameClient::OnNewSnapshot()
 					pClient->m_Country = pInfo->m_Country;
 
 					IntsToStr(&pInfo->m_Skin0, 6, pClient->m_aSkinName, std::size(pClient->m_aSkinName));
-					if(pClient->m_aSkinName[0] == '\0' ||
+					if(!CSkin::IsValidName(pClient->m_aSkinName) ||
 						(!m_GameInfo.m_AllowXSkins && CSkins::IsSpecialSkin(pClient->m_aSkinName)))
 					{
 						str_copy(pClient->m_aSkinName, "default");
@@ -4221,7 +4221,7 @@ void CGameClient::OnSkinUpdate(const char *pSkinName)
 	for(std::shared_ptr<CManagedTeeRenderInfo> &pManagedTeeRenderInfo : m_vpManagedTeeRenderInfos)
 	{
 		if(!(pManagedTeeRenderInfo->SkinDescriptor().m_Flags & CSkinDescriptor::FLAG_SIX) ||
-			str_comp(pManagedTeeRenderInfo->SkinDescriptor().m_aSkinName, pSkinName) != 0)
+			str_utf8_comp_nocase(pManagedTeeRenderInfo->SkinDescriptor().m_aSkinName, pSkinName) != 0)
 		{
 			continue;
 		}
@@ -4254,6 +4254,14 @@ void CGameClient::UpdateManagedTeeRenderInfos()
 			break;
 		}
 		m_vpManagedTeeRenderInfos.erase(UnusedInfo);
+	}
+}
+
+void CGameClient::CollectManagedTeeRenderInfos(const std::function<void(const char *pSkinName)> &ActiveSkinAcceptor)
+{
+	for(const std::shared_ptr<CManagedTeeRenderInfo> &pManagedTeeRenderInfo : m_vpManagedTeeRenderInfos)
+	{
+		ActiveSkinAcceptor(pManagedTeeRenderInfo->m_SkinDescriptor.m_aSkinName);
 	}
 }
 

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -602,6 +602,7 @@ public:
 	void OnSkinUpdate(const char *pSkinName);
 	std::shared_ptr<CManagedTeeRenderInfo> CreateManagedTeeRenderInfo(const CTeeRenderInfo &TeeRenderInfo, const CSkinDescriptor &SkinDescriptor);
 	std::shared_ptr<CManagedTeeRenderInfo> CreateManagedTeeRenderInfo(const CClientData &Client);
+	void CollectManagedTeeRenderInfos(const std::function<void(const char *pSkinName)> &ActiveSkinAcceptor);
 
 	void RenderShutdownMessage() override;
 

--- a/src/test/gameworld.cpp
+++ b/src/test/gameworld.cpp
@@ -55,7 +55,7 @@ public:
 		m_pKernel = std::unique_ptr<IKernel>(IKernel::Create());
 		m_pKernel->RegisterInterface(m_pServer);
 
-		IEngine *pEngine = CreateTestEngine(GAME_NAME, 1);
+		IEngine *pEngine = CreateTestEngine(GAME_NAME);
 		m_pKernel->RegisterInterface(pEngine);
 
 		m_TestInfo.m_DeleteTestStorageFilesOnSuccess = true;

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -195,13 +195,16 @@ TEST(Str, Utf8ToSkeleton)
 	EXPECT_EQ(aBuf[5], 'u');
 }
 
-TEST(Str, Utf8ToLower)
+TEST(Str, Utf8ToLowerCodepoint)
 {
-	EXPECT_TRUE(str_utf8_tolower('A') == 'a');
-	EXPECT_TRUE(str_utf8_tolower('z') == 'z');
-	EXPECT_TRUE(str_utf8_tolower(192) == 224); // À -> à
-	EXPECT_TRUE(str_utf8_tolower(7882) == 7883); // Ị -> ị
+	EXPECT_TRUE(str_utf8_tolower_codepoint('A') == 'a');
+	EXPECT_TRUE(str_utf8_tolower_codepoint('z') == 'z');
+	EXPECT_TRUE(str_utf8_tolower_codepoint(192) == 224); // À -> à
+	EXPECT_TRUE(str_utf8_tolower_codepoint(7882) == 7883); // Ị -> ị
+}
 
+TEST(Str, Utf8CompNocase)
+{
 	EXPECT_TRUE(str_utf8_comp_nocase("ÖlÜ", "ölü") == 0);
 	EXPECT_TRUE(str_utf8_comp_nocase("ÜlÖ", "ölü") > 0); // ü > ö
 	EXPECT_TRUE(str_utf8_comp_nocase("ÖlÜ", "ölüa") < 0); // NULL < a

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -203,6 +203,51 @@ TEST(Str, Utf8ToLowerCodepoint)
 	EXPECT_TRUE(str_utf8_tolower_codepoint(7882) == 7883); // Ị -> ị
 }
 
+template<size_t BufferSize = 128>
+static void TestStrUtf8ToLower(const char *pInput, const char *pOutput)
+{
+	char aBuf[BufferSize];
+	str_utf8_tolower(pInput, aBuf, sizeof(aBuf));
+	EXPECT_STREQ(aBuf, pOutput);
+}
+
+TEST(Str, Utf8ToLower)
+{
+	// See https://stackoverflow.com/a/18689585
+	TestStrUtf8ToLower<>("", "");
+	TestStrUtf8ToLower<>("a", "a");
+	TestStrUtf8ToLower<>("A", "a");
+	TestStrUtf8ToLower<>("z", "z");
+	TestStrUtf8ToLower<>("Z", "z");
+	TestStrUtf8ToLower<>("ABC", "abc");
+	TestStrUtf8ToLower<>("ÖÜÄẞ", "öüäß");
+	TestStrUtf8ToLower<>("Iİ", "ii");
+	TestStrUtf8ToLower<>("Ϊ", "ϊ");
+	TestStrUtf8ToLower<>("Į", "į");
+	TestStrUtf8ToLower<>("Җ", "җ");
+	TestStrUtf8ToLower<>("Ѹ", "ѹ");
+	TestStrUtf8ToLower<>("Ǆ", "ǆ");
+	TestStrUtf8ToLower<>("ⒹⒹＮＥＴ", "ⓓⓓｎｅｔ");
+	TestStrUtf8ToLower<>("Ⱥ", "ⱥ"); // lower case uses more bytes than upper case
+
+	TestStrUtf8ToLower<1>("ABC", "");
+	TestStrUtf8ToLower<2>("ABC", "a");
+	TestStrUtf8ToLower<3>("ABC", "ab");
+	TestStrUtf8ToLower<4>("ABC", "abc");
+
+	TestStrUtf8ToLower<1>("ȺȺȺ", "");
+	TestStrUtf8ToLower<2>("ȺȺȺ", "");
+	TestStrUtf8ToLower<3>("ȺȺȺ", "");
+	TestStrUtf8ToLower<4>("ȺȺȺ", "ⱥ");
+	TestStrUtf8ToLower<5>("ȺȺȺ", "ⱥ");
+	TestStrUtf8ToLower<6>("ȺȺȺ", "ⱥ");
+	TestStrUtf8ToLower<7>("ȺȺȺ", "ⱥⱥ");
+	TestStrUtf8ToLower<8>("ȺȺȺ", "ⱥⱥ");
+	TestStrUtf8ToLower<9>("ȺȺȺ", "ⱥⱥ");
+	TestStrUtf8ToLower<10>("ȺȺȺ", "ⱥⱥⱥ");
+	TestStrUtf8ToLower<11>("ȺȺȺ", "ⱥⱥⱥ");
+}
+
 TEST(Str, Utf8CompNocase)
 {
 	EXPECT_TRUE(str_utf8_comp_nocase("ÖlÜ", "ölü") == 0);


### PR DESCRIPTION
https://github.com/user-attachments/assets/75699008-1bc1-48e2-a410-de00ff476f4e

Skin Loading and Unloading
--------------------------

Instead of loading all skins from the `skins` folder immediately, only scan the folder to determine which skins are available and lazily load skins when they are being used. Skins not present in the `skins` folder are loaded from `downloadedskins` or downloaded.

Load all skin data (image data, image data in grayscale, metrics, blood color) is background jobs, so in the main thread we only need to upload the skin data to the GPU and add the skin to the map.

Start background jobs to load vanilla skins (including special skins) immediately so this base set of skins is available directly. All other skins are only loaded on demand.

Load the `default` skin specifically on the main thread to ensure that it is immediately available as a placeholder for skins which are not loaded yet.

Add the config variable `cl_skins_loaded_max` to specify the maximum number of skins that can be loaded at the same time. This defaults to 256 skins on 32 bit and 512 skins on 64 bit.

Unload the least recently used skins when trying to load more skins than the maximum. This is implemented using a basic LRU cache with an `std::list`, which is much more efficient then searching through the map of all skins when there are many skins (e.g. with the entire skin database).

Skin List UI Improvements
-------------------------

Show progress indicator for skins that are loading.

![image](https://github.com/user-attachments/assets/abd10379-599d-4a53-a460-81cddaa4ab60)

Show error icon with tooltip for skins that failed to be loaded due to a file/download error.

![image](https://github.com/user-attachments/assets/0327c1ec-74c1-4d8d-b06e-993f2937c8f8)

Show error icon with tooltip when entering an invalid or special skin name.

![image](https://github.com/user-attachments/assets/69cbe2d0-55c6-41db-a033-f927a2ef78da)

Show question mark icon with tooltip for skins that could not be found locally or in the skin database.

![image](https://github.com/user-attachments/assets/d9ac9d8a-5f57-42d7-bf53-186aefcc77b4)

Show error message and button to reset the filter when the skin filter does not match any available skin.

![image](https://github.com/user-attachments/assets/f48e9854-ee53-440c-86b7-d4ef49597d81)

Increase the scrolling speed so 2 rows of skins are scrolled with the mouse wheel to make the scrolling speed more consistent with other lists.

Cache information about the skin list to avoid duplicate calculations and improve the performance of skin list rendering.

Show how many skins are in which state when `debug` is enabled.

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
