### PR TITLE
Teehistorian: Also record non-changing input

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1399,7 +1399,8 @@ void CGameContext::OnClientPredictedEarlyInput(int ClientId, void *pInput)
 	if(!m_World.m_Paused)
 		m_apPlayers[ClientId]->OnPredictedEarlyInput(pApplyInput);
 
-	if(m_TeeHistorianActive)
+	// For Teehistorian, only record new inputs sent by the client.
+	if(m_TeeHistorianActive && pInput != nullptr)
 	{
 		m_TeeHistorian.RecordPlayerInput(ClientId, m_apPlayers[ClientId]->GetUniqueCid(), pApplyInput);
 	}

--- a/src/game/server/teehistorian.cpp
+++ b/src/game/server/teehistorian.cpp
@@ -24,7 +24,7 @@ private:
 static const char TEEHISTORIAN_NAME[] = "teehistorian@ddnet.tw";
 static const CUuid TEEHISTORIAN_UUID = CalculateUuid(TEEHISTORIAN_NAME);
 static const char TEEHISTORIAN_VERSION[] = "2";
-static const char TEEHISTORIAN_VERSION_MINOR[] = "9";
+static const char TEEHISTORIAN_VERSION_MINOR[] = "10";
 
 #define UUID(id, name) static const CUuid UUID_##id = CalculateUuid(name);
 #include <engine/shared/teehistorian_ex_chunks.h>
@@ -444,10 +444,13 @@ void CTeeHistorian::RecordPlayerInput(int ClientId, uint32_t UniqueClientId, con
 	CNetObj_PlayerInput DiffInput;
 	if(pPrev->m_UniqueClientId == UniqueClientId)
 	{
-		if(mem_comp(&pPrev->m_Input, pInput, sizeof(pPrev->m_Input)) == 0)
-		{
-			return;
-		}
+		// Previously we filtered inputs that matched the previous input.
+		// This caused issues with reproducing the physics.
+		// If the client re-send the previous input and a new input on a tick,
+		// Teehistorian would only record the latter input.
+		//
+		// Note that this means that `INPUT_DIFF` is written with no input difference,
+		// to mark that the client repeated the same input.
 		EnsureTickWritten();
 		Buffer.Reset();
 

--- a/src/test/teehistorian.cpp
+++ b/src/test/teehistorian.cpp
@@ -105,7 +105,7 @@ protected:
 	void Expect(const unsigned char *pOutput, size_t OutputSize)
 	{
 		static CUuid TEEHISTORIAN_UUID = CalculateUuid("teehistorian@ddnet.tw");
-		static const char PREFIX1[] = "{\"comment\":\"teehistorian@ddnet.tw\",\"version\":\"2\",\"version_minor\":\"9\",\"game_uuid\":\"a1eb7182-796e-3b3e-941d-38ca71b2a4a8\",\"server_version\":\"DDNet test\",\"start_time\":\"";
+		static const char PREFIX1[] = "{\"comment\":\"teehistorian@ddnet.tw\",\"version\":\"2\",\"version_minor\":\"10\",\"game_uuid\":\"a1eb7182-796e-3b3e-941d-38ca71b2a4a8\",\"server_version\":\"DDNet test\",\"start_time\":\"";
 		static const char PREFIX2[] = "\",\"server_name\":\"server name\",\"server_port\":\"8303\",\"game_type\":\"game type\",\"map_name\":\"Kobra 3 Solo\",\"map_size\":\"903514\",\"map_sha256\":\"0123456789012345678901234567890123456789012345678901234567890123\",\"map_crc\":\"eceaf25c\",\"prng_description\":\"test-prng:02468ace\",\"config\":{},\"tuning\":{},\"uuids\":[";
 		static const char PREFIX3[] = "]}";
 
@@ -484,7 +484,12 @@ TEST_F(TeeHistorian, Input)
 		0x45,
 		0x00, // ClientId 0
 		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
-		// same unique id, same input -> nothing
+		// same unique id, same input -> InputDiff (diff is zero)
+		// this signals new but unchaged input
+		// Note! previously these inputs were filtered.
+		0x44,
+		0x00, // ClientId 0
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		// same unique id, different input -> InputDiff
 		0x44,
 		0x00, // ClientId 0
@@ -500,7 +505,7 @@ TEST_F(TeeHistorian, Input)
 
 	// new player -> InputNew
 	m_TH.RecordPlayerInput(0, 1, &Input);
-	// same unique id, same input -> nothing
+	// same unique id, same input -> InputDiff (zeroed)
 	m_TH.RecordPlayerInput(0, 1, &Input);
 
 	Input.m_Direction = 0;


### PR DESCRIPTION
Previously, these were skipped.
If multiple inputs were sent on the same tick, this can cause unreproducible teehistorians:

A tee is falling towards the floor and presses jump. It doesn't have dj, so will jump as soon as it reaches the floor.

Scenario 1: Upon touching the ground, the tee sends input to not jump. This new input is recorded by teehistorian, the tee jumps.

Scenario 2: Upon touching the ground, the tee first sends the former input (to jump) again, followed by an input not to jump. The first input is not recorded by Teehistorian, as it is the same as the previous one.
The second input is recorded, as it differs.
However the first input is used for jumping, so the tee will jump.

The teehistorians from scenario 1 and scenario 2 are indistinguishable, even though the tee only jumps in scenario 2.

**I haven't tested the changes yet**, as they are difficult to test and there could be alternative, maybe preferred fixes.
E.g. #8432 would probably also fix this.