### PR TITLE
Fix color constexpr constructor

### DIFF
--- a/src/base/color.h
+++ b/src/base/color.h
@@ -61,36 +61,24 @@ public:
 	{
 	}
 
-	constexpr color4_base(const vec4 &v4)
+	constexpr color4_base(const vec4 &v4) :
+		x(v4.x), y(v4.y), z(v4.z), a(v4.w)
 	{
-		x = v4.x;
-		y = v4.y;
-		z = v4.z;
-		a = v4.w;
 	}
 
-	constexpr color4_base(const vec3 &v3)
+	constexpr color4_base(const vec3 &v3) :
+		x(v3.x), y(v3.y), z(v3.z), a(1.0f)
 	{
-		x = v3.x;
-		y = v3.y;
-		z = v3.z;
-		a = 1.0f;
 	}
 
-	constexpr color4_base(float nx, float ny, float nz, float na)
+	constexpr color4_base(float nx, float ny, float nz, float na) :
+		x(nx), y(ny), z(nz), a(na)
 	{
-		x = nx;
-		y = ny;
-		z = nz;
-		a = na;
 	}
 
-	constexpr color4_base(float nx, float ny, float nz)
+	constexpr color4_base(float nx, float ny, float nz) :
+		x(nx), y(ny), z(nz), a(1.0f)
 	{
-		x = nx;
-		y = ny;
-		z = nz;
-		a = 1.0f;
 	}
 
 	constexpr color4_base(unsigned col, bool alpha = false)

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -80,8 +80,8 @@
 
 using namespace std::chrono_literals;
 
-static const ColorRGBA gs_ClientNetworkPrintColor{0.7f, 1, 0.7f, 1.0f};
-static const ColorRGBA gs_ClientNetworkErrPrintColor{1.0f, 0.25f, 0.25f, 1.0f};
+static constexpr ColorRGBA gs_ClientNetworkPrintColor{0.7f, 1, 0.7f, 1.0f};
+static constexpr ColorRGBA gs_ClientNetworkErrPrintColor{1.0f, 0.25f, 0.25f, 1.0f};
 
 CClient::CClient() :
 	m_DemoPlayer(&m_SnapshotDelta, true, [&]() { UpdateDemoIntraTimers(); }),

--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -9,7 +9,7 @@
 
 #include <memory>
 
-static const ColorRGBA gs_ConsoleDefaultColor(1, 1, 1, 1);
+static constexpr ColorRGBA gs_ConsoleDefaultColor(1, 1, 1, 1);
 
 enum LEVEL : char;
 struct CChecksumData;

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -27,7 +27,7 @@ static const unsigned char gs_OldVersion = 3;
 static const unsigned char gs_Sha256Version = 6;
 static const unsigned char gs_VersionTickCompression = 5; // demo files with this version or higher will use `CHUNKTICKFLAG_TICK_COMPRESSED`
 
-static const ColorRGBA gs_DemoPrintColor{0.75f, 0.7f, 0.7f, 1.0f};
+static constexpr ColorRGBA gs_DemoPrintColor{0.75f, 0.7f, 0.7f, 1.0f};
 
 bool CDemoHeader::Valid() const
 {

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -9,7 +9,7 @@
 #include <game/client/components/console.h>
 #include <game/client/gameclient.h>
 
-static const ColorRGBA gs_BindPrintColor{1.0f, 1.0f, 0.8f, 1.0f};
+static constexpr ColorRGBA gs_BindPrintColor{1.0f, 1.0f, 0.8f, 1.0f};
 
 bool CBinds::CBindsSpecial::OnInput(const IInput::CEvent &Event)
 {

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -178,9 +178,6 @@ static int PossibleKeys(const char *pStr, IInput *pInput, IConsole::FPossibleCal
 	return Index;
 }
 
-const ColorRGBA CGameConsole::ms_SearchHighlightColor = ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f);
-const ColorRGBA CGameConsole::ms_SearchSelectedColor = ColorRGBA(1.0f, 1.0f, 0.0f, 1.0f);
-
 CGameConsole::CInstance::CInstance(int Type)
 {
 	m_pHistoryEntry = nullptr;

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -158,8 +158,8 @@ class CGameConsole : public CComponent
 	bool m_WantsSelectionCopy = false;
 	CUi::CTouchState m_TouchState;
 
-	static const ColorRGBA ms_SearchHighlightColor;
-	static const ColorRGBA ms_SearchSelectedColor;
+	static inline constexpr ColorRGBA ms_SearchHighlightColor = ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f);
+	static inline constexpr ColorRGBA ms_SearchSelectedColor = ColorRGBA(1.0f, 1.0f, 0.0f, 1.0f);
 
 	int PossibleMaps(const char *pStr, IConsole::FPossibleCallback pfnCallback = IConsole::EmptyPossibleCommandCallback, void *pUser = nullptr);
 

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -24,7 +24,7 @@
 
 using namespace FontIcons;
 
-static const ColorRGBA gs_HighlightedTextColor = ColorRGBA(0.4f, 0.4f, 1.0f, 1.0f);
+static constexpr ColorRGBA gs_HighlightedTextColor = ColorRGBA(0.4f, 0.4f, 1.0f, 1.0f);
 
 static ColorRGBA PlayerBackgroundColor(bool Friend, bool Clan, bool Afk, bool Inside)
 {

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -42,7 +42,7 @@ public:
 
 using PartsVector = std::vector<std::unique_ptr<CNamePlatePart>>;
 
-static const ColorRGBA s_OutlineColor = ColorRGBA(0.0f, 0.0f, 0.0f, 0.5f);
+static constexpr ColorRGBA s_OutlineColor = ColorRGBA(0.0f, 0.0f, 0.0f, 0.5f);
 
 class CNamePlatePartText : public CNamePlatePart
 {

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -313,7 +313,7 @@ class CEditor : public IEditor
 	};
 
 	std::shared_ptr<CLayerGroup> m_apSavedBrushes[10];
-	static const ColorRGBA ms_DefaultPropColor;
+	static inline constexpr ColorRGBA ms_DefaultPropColor = ColorRGBA(1, 1, 1, 0.5f);
 
 public:
 	class IInput *Input() const { return m_pInput; }

--- a/src/game/editor/editor_props.cpp
+++ b/src/game/editor/editor_props.cpp
@@ -8,8 +8,6 @@
 
 using namespace FontIcons;
 
-const ColorRGBA CEditor::ms_DefaultPropColor = ColorRGBA(1, 1, 1, 0.5f);
-
 int CEditor::DoProperties(CUIRect *pToolbox, CProperty *pProps, int *pIds, int *pNewVal, const std::vector<ColorRGBA> &vColors)
 {
 	auto Res = DoPropertiesWithState<int>(pToolbox, pProps, pIds, pNewVal, vColors);

--- a/src/game/editor/editor_server_settings.cpp
+++ b/src/game/editor/editor_server_settings.cpp
@@ -1796,12 +1796,6 @@ const char *CMapSettingsBackend::CContext::InputString() const
 	return m_pBackend->Input()->HasComposition() ? m_CompositionStringBuffer.c_str() : m_pLineInput->GetString();
 }
 
-const ColorRGBA CMapSettingsBackend::CContext::ms_ArgumentStringColor = ColorRGBA(84 / 255.0f, 1.0f, 1.0f, 1.0f);
-const ColorRGBA CMapSettingsBackend::CContext::ms_ArgumentNumberColor = ColorRGBA(0.1f, 0.9f, 0.05f, 1.0f);
-const ColorRGBA CMapSettingsBackend::CContext::ms_ArgumentUnknownColor = ColorRGBA(0.6f, 0.6f, 0.6f, 1.0f);
-const ColorRGBA CMapSettingsBackend::CContext::ms_CommentColor = ColorRGBA(0.5f, 0.5f, 0.5f, 1.0f);
-const ColorRGBA CMapSettingsBackend::CContext::ms_ErrorColor = ColorRGBA(240 / 255.0f, 70 / 255.0f, 70 / 255.0f, 1.0f);
-
 void CMapSettingsBackend::CContext::ColorArguments(std::vector<STextColorSplit> &vColorSplits) const
 {
 	// Get argument color based on its type

--- a/src/game/editor/editor_server_settings.h
+++ b/src/game/editor/editor_server_settings.h
@@ -225,11 +225,11 @@ public: // Backend methods
 public: // CContext
 	class CContext
 	{
-		static const ColorRGBA ms_ArgumentStringColor;
-		static const ColorRGBA ms_ArgumentNumberColor;
-		static const ColorRGBA ms_ArgumentUnknownColor;
-		static const ColorRGBA ms_CommentColor;
-		static const ColorRGBA ms_ErrorColor;
+		static inline constexpr ColorRGBA ms_ArgumentStringColor = ColorRGBA(84.0f / 255.0f, 1.0f, 1.0f, 1.0f);
+		static inline constexpr ColorRGBA ms_ArgumentNumberColor = ColorRGBA(0.1f, 0.9f, 0.05f, 1.0f);
+		static inline constexpr ColorRGBA ms_ArgumentUnknownColor = ColorRGBA(0.6f, 0.6f, 0.6f, 1.0f);
+		static inline constexpr ColorRGBA ms_CommentColor = ColorRGBA(0.5f, 0.5f, 0.5f, 1.0f);
+		static inline constexpr ColorRGBA ms_ErrorColor = ColorRGBA(240.0f / 255.0f, 70.0f / 255.0f, 70.0f / 255.0f, 1.0f);
 
 		friend class CMapSettingsBackend;
 


### PR DESCRIPTION
Refactored `color4_base` to use a member initializer list instead of assignments, and changed `const` to `constexpr` where appropriate.
Since ddnet uses C++17, `constexpr` constructors can't have assignment bodies unless all members are trivial, which broke usage in `constexpr` contexts. This can be seen in [#10072](https://github.com/ddnet/ddnet/pull/10072/files#diff-759f13e95473ef7d2ce66a299c2b04f1024e2c55a1c20a5f03ee8c2b92c44239R18-R45) where `ColorRGBA` had to be declared as functions instead of values.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
