### PR TITLE
Fix only show entities

### DIFF
--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -1161,10 +1161,6 @@ void CMapLayers::OnRender()
 			if(m_Type == TYPE_FULL_DESIGN && IsEntityLayer)
 				continue;
 
-			// skip rendering anything but entities if we only want to render entities
-			if(!IsEntityLayer && OnlyShowEntities && m_Type != TYPE_BACKGROUND_FORCE)
-				continue;
-
 			int CurrentTileLayerCount = 0;
 			void *pTilesData = nullptr;
 			if(pLayer->m_Type == LAYERTYPE_TILES)
@@ -1179,6 +1175,10 @@ void CMapLayers::OnRender()
 			{
 				++QuadLayerCounter;
 			}
+
+			// skip rendering anything but entities if we only want to render entities
+			if(!IsEntityLayer && OnlyShowEntities && m_Type != TYPE_BACKGROUND_FORCE)
+				continue;
 
 			// skip rendering of entities if don't want them
 			if(IsEntityLayer && !EntityOverlayVal)


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

closes #10076 

Tilelayers were skipped before counted. This was a tilelayer-counting issue. One of my planned optimizations is doing this in OnMapInit preventing issues like that in the future.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
