### PR TITLE
Refactor: Optimize maplayers

### DIFF
--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -125,11 +125,11 @@ class CMapLayers : public CComponent
 		bool m_IsTextured;
 	};
 	std::vector<SQuadLayerVisuals *> m_vpQuadLayerVisuals;
+	std::vector<std::vector<int>> m_vvLayerCount;
+	int m_GameGroup;
 
 	virtual CCamera *GetCurCamera();
 	virtual const char *LoadingTitle() const;
-
-	void LayersOfGroupCount(CMapItemGroup *pGroup, int &TileLayerCount, int &QuadLayerCount, bool &PassedGameLayer);
 
 public:
 	enum


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

There are multiple ways that maplayers can be optimized, this PR implements 2 obvious ways:
- pre-calculate Tilelayer and Quadlayer indices
- calculate start and end indices for foreground and background (foreground benefits most)
- optimize `RenderTileLayer`, because it's a hot path for rendering

## Results:
### Vulkan:

|           |   #frames old |   FT old avg. (µs) |   FT old min (µs) |   FT old max (µs) |   #frames new |   FT new avg. (µs) |   FT new min (µs) |   FT new max (µs) |   Improvement avg. (%) |   Improvement min (%) |   Improvement max (%) |
|:----------|--------------:|-------------------:|------------------:|------------------:|--------------:|-------------------:|------------------:|------------------:|-----------------------:|----------------------:|----------------------:|
| dm1       |         36795 |            1630.25 |               115 |             16737 |         39217 |            1529.49 |               184 |             10520 |                6.18064 |             -60       |               37.1452 |
| kingsleap |         17718 |            3386.21 |              2548 |             13209 |         18565 |            3231.75 |              2608 |              9773 |                4.56148 |              -2.35479 |               26.0126 |

Blue line is 19.1, orange is this PR:

![KingsLeapVulkan](https://github.com/user-attachments/assets/22f188da-619b-4ae1-87e6-c423af0b00b7)

You can clearly see the blue line above the orange one, meaning higher frametimes for 19.1. The stats also show **an improvement of frametimes by 5%**.

I expect other backends with tilelayer buffering to behave similar.

### OpenGL 1.0.0:

|           |   #frames old |   FT old avg. (µs) |   FT old min (µs) |   FT old max (µs) |   #frames new |   FT new avg. (µs) |   FT new min (µs) |   FT new max (µs) |   Improvement avg. (%) |   Improvement min (%) |   Improvement max (%) |
|:----------|--------------:|-------------------:|------------------:|------------------:|--------------:|-------------------:|------------------:|------------------:|-----------------------:|----------------------:|----------------------:|
| dm1       |         39338 |            1524.8  |               852 |             12841 |         39166 |            1531.51 |               882 |             10789 |              -0.439952 |              -3.52113 |               15.9801 |
| kingsleap |         12714 |            4719.13 |              3764 |             10851 |         12557 |            4778.3  |              3714 |             15083 |              -1.25388  |               1.32837 |              -39.001  |

Blue line is 19.1, orange is this PR:

![KingsLeapOpenGL](https://github.com/user-attachments/assets/25f5652e-e001-4574-8766-aadb040649f6)

I must say, I can't get any good stats for OpenGL, it's **really noisy**. This is also against my expectations, I would have expected more FPS, but this test is not conclusive.

## Method:

### Data collection:

I created a 1 minute demo for the maps `dm1` and `KingsLeap`. I decided for the second map, because it contains a lot of tilelayers, quads, animations and it's mine. 

Afterwards I switched between maps and backends and collected data. For the data collection I opened and stopped the demo, put the time to 0:00, typed `exec benchmark.cfg` into the console:

`benchmark.cfg`:
```cfg
toggle_local_console
demo_play
benchmark_quit 60 benchmark.txt
```

This automatically closes the console (which affects FPS), starts the demo (which creates overhead), and then starts the benchark for 60 seconds.

### Analysis:

I analysed the data with python, I'll put the jupyter notebook into the attachment

### Computer Setup:

This is my laptop, I might add more stats of a different machine if requested:

CPU: 11th Gen Intel(R) Core(TM) i5-1145G7 @ 2.60GHz
RAM: 16GB
Graphics: Intel(R) Xe Graphics (TGL GT2)

## Github

closes #10004

## Attachments

- [x] Jupyter notebook
- [x] Demos
- [x] My collected data

[BenchmarkData.zip](https://github.com/user-attachments/files/19791843/BenchmarkData.zip) 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
