### PR TITLE
Show error message when saving files with invalid filename

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1571,7 +1571,11 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 			if(!m_vpFilteredDemos[m_DemolistSelectedIndex]->m_IsDir && !str_endswith(aBufNew, ".demo"))
 				str_append(aBufNew, ".demo");
 
-			if(Storage()->FileExists(aBufNew, m_vpFilteredDemos[m_DemolistSelectedIndex]->m_StorageType))
+			if(!str_valid_filename(m_DemoRenameInput.GetString()))
+			{
+				PopupMessage(Localize("Error"), Localize("This name cannot be used for files and folders"), Localize("Ok"), POPUP_RENAME_DEMO);
+			}
+			else if(Storage()->FileExists(aBufNew, m_vpFilteredDemos[m_DemolistSelectedIndex]->m_StorageType))
 			{
 				PopupMessage(Localize("Error"), Localize("A demo with this name already exists"), Localize("Ok"), POPUP_RENAME_DEMO);
 			}
@@ -1630,7 +1634,12 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 			str_format(aVideoPath, sizeof(aVideoPath), "videos/%s", m_DemoRenderInput.GetString());
 			if(!str_endswith(aVideoPath, ".mp4"))
 				str_append(aVideoPath, ".mp4");
-			if(Storage()->FolderExists(aVideoPath, IStorage::TYPE_SAVE))
+
+			if(!str_valid_filename(m_DemoRenderInput.GetString()))
+			{
+				PopupMessage(Localize("Error"), Localize("This name cannot be used for files and folders"), Localize("Ok"), POPUP_RENDER_DEMO);
+			}
+			else if(Storage()->FolderExists(aVideoPath, IStorage::TYPE_SAVE))
 			{
 				PopupMessage(Localize("Error"), Localize("A folder with this name already exists"), Localize("Ok"), POPUP_RENDER_DEMO);
 			}
@@ -1847,20 +1856,22 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		static CButtonContainer s_ButtonYes;
 		if(DoButton_Menu(&s_ButtonYes, Localize("Yes"), m_SkinNameInput.IsEmpty() ? 1 : 0, &Yes) || Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER))
 		{
-			if(m_SkinNameInput.GetLength())
+			if(!str_valid_filename(m_SkinNameInput.GetString()))
 			{
-				if(m_SkinNameInput.GetString()[0] != 'x' && m_SkinNameInput.GetString()[1] != '_')
-				{
-					if(m_pClient->m_Skins7.SaveSkinfile(m_SkinNameInput.GetString(), m_Dummy))
-					{
-						m_Popup = POPUP_NONE;
-						m_SkinList7LastRefreshTime = std::nullopt;
-					}
-					else
-						PopupMessage(Localize("Error"), Localize("Unable to save the skin"), Localize("Ok"), POPUP_SAVE_SKIN);
-				}
-				else
-					PopupMessage(Localize("Error"), Localize("Unable to save the skin with a reserved name"), Localize("Ok"), POPUP_SAVE_SKIN);
+				PopupMessage(Localize("Error"), Localize("This name cannot be used for files and folders"), Localize("Ok"), POPUP_SAVE_SKIN);
+			}
+			else if(CSkins7::IsSpecialSkin(m_SkinNameInput.GetString()))
+			{
+				PopupMessage(Localize("Error"), Localize("Unable to save the skin with a reserved name"), Localize("Ok"), POPUP_SAVE_SKIN);
+			}
+			else if(!m_pClient->m_Skins7.SaveSkinfile(m_SkinNameInput.GetString(), m_Dummy))
+			{
+				PopupMessage(Localize("Error"), Localize("Unable to save the skin"), Localize("Ok"), POPUP_SAVE_SKIN);
+			}
+			else
+			{
+				m_Popup = POPUP_NONE;
+				m_SkinList7LastRefreshTime = std::nullopt;
 			}
 		}
 

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -847,13 +847,19 @@ void CMenus::RenderDemoPlayerSliceSavePopup(CUIRect MainView)
 			m_DemoSliceInput.Set(aNameWithoutExt);
 		}
 
+		static CUi::SMessagePopupContext s_MessagePopupContext;
 		char aDemoName[IO_MAX_PATH_LENGTH];
 		DemoPlayer()->GetDemoName(aDemoName, sizeof(aDemoName));
 		if(str_comp(aDemoName, m_DemoSliceInput.GetString()) == 0)
 		{
-			static CUi::SMessagePopupContext s_MessagePopupContext;
 			s_MessagePopupContext.ErrorColor();
 			str_copy(s_MessagePopupContext.m_aMessage, Localize("Please use a different filename"));
+			Ui()->ShowPopupMessage(Ui()->MouseX(), OkButton.y + OkButton.h + 5.0f, &s_MessagePopupContext);
+		}
+		else if(!str_valid_filename(m_DemoSliceInput.GetString()))
+		{
+			s_MessagePopupContext.ErrorColor();
+			str_copy(s_MessagePopupContext.m_aMessage, Localize("This name cannot be used for files and folders"));
 			Ui()->ShowPopupMessage(Ui()->MouseX(), OkButton.y + OkButton.h + 5.0f, &s_MessagePopupContext);
 		}
 		else

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5592,7 +5592,13 @@ void CEditor::RenderFileDialog()
 			if(!str_endswith(m_aFileSaveName, FILETYPE_EXTENSIONS[m_FileDialogFileType]))
 				str_append(m_aFileSaveName, FILETYPE_EXTENSIONS[m_FileDialogFileType]);
 
-			if(m_FileDialogSaveAction && Storage()->FileExists(m_aFileSaveName, StorageType))
+			char aFilename[IO_MAX_PATH_LENGTH];
+			fs_split_file_extension(fs_filename(m_aFileSaveName), aFilename, sizeof(aFilename));
+			if(m_FileDialogSaveAction && !str_valid_filename(aFilename))
+			{
+				ShowFileDialogError("This name cannot be used for files and folders");
+			}
+			else if(m_FileDialogSaveAction && Storage()->FileExists(m_aFileSaveName, StorageType))
 			{
 				if(m_pfnFileDialogFunc == &CallbackSaveMap)
 					m_PopupEventType = POPEVENT_SAVE;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1938,20 +1938,20 @@ CUi::EPopupMenuFunctionResult CEditor::PopupNewFolder(void *pContext, CUIRect Vi
 	static int s_CreateButton = 0;
 	if(pEditor->DoButton_Editor(&s_CreateButton, "Create", 0, &Button, BUTTONFLAG_LEFT, nullptr) || (Active && pEditor->Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
 	{
-		// create the folder
-		if(!pEditor->m_FileDialogNewFolderNameInput.IsEmpty())
+		char aFolderPath[IO_MAX_PATH_LENGTH];
+		str_format(aFolderPath, sizeof(aFolderPath), "%s/%s", pEditor->m_pFileDialogPath, pEditor->m_FileDialogNewFolderNameInput.GetString());
+		if(!str_valid_filename(pEditor->m_FileDialogNewFolderNameInput.GetString()))
 		{
-			char aBuf[IO_MAX_PATH_LENGTH];
-			str_format(aBuf, sizeof(aBuf), "%s/%s", pEditor->m_pFileDialogPath, pEditor->m_FileDialogNewFolderNameInput.GetString());
-			if(pEditor->Storage()->CreateFolder(aBuf, IStorage::TYPE_SAVE))
-			{
-				pEditor->FilelistPopulate(IStorage::TYPE_SAVE);
-				return CUi::POPUP_CLOSE_CURRENT;
-			}
-			else
-			{
-				pEditor->ShowFileDialogError("Failed to create the folder '%s'.", aBuf);
-			}
+			pEditor->ShowFileDialogError("This name cannot be used for files and folders");
+		}
+		else if(!pEditor->Storage()->CreateFolder(aFolderPath, IStorage::TYPE_SAVE))
+		{
+			pEditor->ShowFileDialogError("Failed to create the folder '%s'.", aFolderPath);
+		}
+		else
+		{
+			pEditor->FilelistPopulate(IStorage::TYPE_SAVE);
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 	}
 


### PR DESCRIPTION
Show error message when using an invalid filename in the following dialogs:

- Editor save file dialogs
- Editor new folder dialog
- Slice demo dialog
- Rename demo dialog
- Render demo dialog
- Save 0.7 skin dialog

To prevent invalid filenames from being used in the future.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
