### PR TITLE
fix editor from placing invalid speedtiles on erase

### DIFF
--- a/src/game/editor/mapitems/layer_speedup.cpp
+++ b/src/game/editor/mapitems/layer_speedup.cpp
@@ -286,6 +286,8 @@ void CLayerSpeedup::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CU
 				m_pTiles[TgtIndex].m_Index = 0;
 				m_pSpeedupTile[TgtIndex].m_Force = 0;
 				m_pSpeedupTile[TgtIndex].m_Angle = 0;
+				m_pSpeedupTile[TgtIndex].m_MaxSpeed = 0;
+				m_pSpeedupTile[TgtIndex].m_Type = 0;
 
 				if(!Empty)
 					ShowPreventUnusedTilesWarning();
@@ -317,6 +319,8 @@ void CLayerSpeedup::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CU
 					m_pTiles[TgtIndex].m_Index = 0;
 					m_pSpeedupTile[TgtIndex].m_Force = 0;
 					m_pSpeedupTile[TgtIndex].m_Angle = 0;
+					m_pSpeedupTile[TgtIndex].m_MaxSpeed = 0;
+					m_pSpeedupTile[TgtIndex].m_Type = 0;
 				}
 			}
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This PR properly resets speedtiles if erased. This may have caused various issues in the past

closes #10087

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
