### PR TITLE
Add version info to client and server executable on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2556,8 +2556,12 @@ if(CLIENT)
   endif()
 
   if(TARGET_OS STREQUAL "windows")
+    set(VERSION_EXECUTABLE "${CLIENT_EXECUTABLE}")
+    set(VERSION_COMPANY "${CLIENT_EXECUTABLE} Team")
+    configure_file("other/versioninfo/versioninfo.rc.in" "client.versioninfo.rc")
     configure_file("other/manifest/client.manifest.in" "client.manifest")
     set(CLIENT_ICON "other/icons/DDNet.rc")
+    set(CLIENT_VERSIONINFO "${CMAKE_CURRENT_BINARY_DIR}/client.versioninfo.rc")
     if(NOT MINGW)
       set(CLIENT_MANIFEST "${CMAKE_CURRENT_BINARY_DIR}/client.manifest")
     else()
@@ -2566,6 +2570,7 @@ if(CLIENT)
     endif()
   else()
     set(CLIENT_ICON)
+    set(CLIENT_VERSIONINFO)
     set(CLIENT_MANIFEST)
   endif()
 
@@ -2574,6 +2579,7 @@ if(CLIENT)
     add_library(game-client SHARED
       ${CLIENT_SRC}
       ${CLIENT_ICON}
+      ${CLIENT_VERSIONINFO}
       ${CLIENT_MANIFEST}
       ${DEPS_CLIENT}
       $<TARGET_OBJECTS:engine-gfx>
@@ -2585,6 +2591,7 @@ if(CLIENT)
     add_executable(game-client WIN32
       ${CLIENT_SRC}
       ${CLIENT_ICON}
+      ${CLIENT_VERSIONINFO}
       ${CLIENT_MANIFEST}
       ${DEPS_CLIENT}
       $<TARGET_OBJECTS:engine-gfx>
@@ -2758,9 +2765,14 @@ if(SERVER)
   )
   set(SERVER_SRC ${ENGINE_SERVER_WITHOUT_MAIN} ${GAME_SERVER} ${GAME_GENERATED_SERVER})
   if(TARGET_OS STREQUAL "windows")
+    set(VERSION_EXECUTABLE "${SERVER_EXECUTABLE}")
+    set(VERSION_COMPANY "${CLIENT_EXECUTABLE} Team")
+    configure_file("other/versioninfo/versioninfo.rc.in" "server.versioninfo.rc")
     set(SERVER_ICON "other/icons/DDNet-Server.rc")
+    set(SERVER_VERSIONINFO "${CMAKE_CURRENT_BINARY_DIR}/server.versioninfo.rc")
   else()
     set(SERVER_ICON)
+    set(SERVER_VERSIONINFO)
   endif()
 
   # Antibot
@@ -2801,6 +2813,7 @@ if(SERVER)
       $<TARGET_OBJECTS:game-server-without-main>
       "${PROJECT_SOURCE_DIR}/src/engine/server/main.cpp"
       ${SERVER_ICON}
+      ${SERVER_VERSIONINFO}
       $<TARGET_OBJECTS:engine-shared>
       $<TARGET_OBJECTS:game-shared>
       $<TARGET_OBJECTS:rust-bridge-shared>
@@ -2810,6 +2823,7 @@ if(SERVER)
       ${DEPS}
       "${PROJECT_SOURCE_DIR}/src/engine/server/main.cpp"
       ${SERVER_ICON}
+      ${SERVER_VERSIONINFO}
       $<TARGET_OBJECTS:game-server-without-main>
       $<TARGET_OBJECTS:engine-shared>
       $<TARGET_OBJECTS:game-shared>

--- a/other/versioninfo/versioninfo.rc.in
+++ b/other/versioninfo/versioninfo.rc.in
@@ -1,0 +1,38 @@
+#include <winver.h>
+#include <ntdef.h>
+
+#if CONF_DEBUG
+#define VER_DEBUG VS_FF_DEBUG
+#else
+#define VER_DEBUG 0
+#endif
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION       ${VERSION_MAJOR},${VERSION_MINOR},${VERSION_PATCH},0
+PRODUCTVERSION    ${VERSION_MAJOR},${VERSION_MINOR},${VERSION_PATCH},0
+FILEFLAGSMASK     VS_FFI_FILEFLAGSMASK
+FILEFLAGS         VER_DEBUG
+FILEOS            VOS__WINDOWS32
+FILETYPE          VFT_APP
+FILESUBTYPE       VFT2_UNKNOWN
+BEGIN
+	BLOCK "StringFileInfo"
+	BEGIN
+		BLOCK "040904B0"
+		BEGIN
+		VALUE "Comments",         "${VERSION_EXECUTABLE}\0"
+		VALUE "CompanyName",      "${VERSION_COMPANY}\0"
+		VALUE "FileDescription",  "${VERSION_EXECUTABLE}\0"
+		VALUE "FileVersion",      "${VERSION}\0"
+		VALUE "InternalName",     "${VERSION_EXECUTABLE}\0"
+		VALUE "LegalCopyright",   "Copyright (C) ${VERSION_COMPANY}\0"
+		VALUE "OriginalFilename", "${VERSION_EXECUTABLE}.exe\0"
+		VALUE "ProductName",      "${VERSION_EXECUTABLE}\0"
+		VALUE "ProductVersion",   "${VERSION}\0"
+		END
+	END
+	BLOCK "VarFileInfo"
+	BEGIN
+		VALUE "Translation", 0x0409, 1200
+	END
+END


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource for details about the format.

Closes #6203.

Screenshots:
- Settings app: 
![settings](https://github.com/user-attachments/assets/f19f4655-0838-469c-a57b-c1df6be06fef)
- Client properties:
![client](https://github.com/user-attachments/assets/e88eeea2-7513-462b-97d9-e123d9b911a7)
- Server properties:
![server](https://github.com/user-attachments/assets/17b7dfe5-cf74-458f-88f3-0813df9a3e3a)

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
