### PR TITLE
Fix mirrored speeders

### DIFF
--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -801,25 +801,30 @@ int CCollision::MoverSpeed(int x, int y, vec2 *pSpeed) const
 	switch(m_pTiles[Ny * m_Width + Nx].m_Flags)
 	{
 	case ROTATION_0:
-		Target.x = 0.0f;
-		Target.y = -4.0f;
+	case TILEFLAG_YFLIP ^ ROTATION_180:
+		Target = vec2(0.0f, -4.0f);
 		break;
+
 	case ROTATION_90:
-		Target.x = 4.0f;
-		Target.y = 0.0f;
+	case TILEFLAG_YFLIP ^ ROTATION_270:
+		Target = vec2(4.0f, 0.0f);
 		break;
+
 	case ROTATION_180:
-		Target.x = 0.0f;
-		Target.y = 4.0f;
+	case TILEFLAG_YFLIP ^ ROTATION_0:
+		Target = vec2(0.0f, 4.0f);
 		break;
+
 	case ROTATION_270:
-		Target.x = -4.0f;
-		Target.y = 0.0f;
+	case TILEFLAG_YFLIP ^ ROTATION_90:
+		Target = vec2(-4.0f, 0.0f);
 		break;
+
 	default:
 		Target = vec2(0.0f, 0.0f);
 		break;
 	}
+
 	if(Index == TILE_CP_F)
 	{
 		Target *= 4.0f;


### PR DESCRIPTION
I've run a script to check if this change breaks any maps. A mirrored speeder with an entity on top was found only on
`Journey Man 2` at position (1027, 128), The shield is now moving slightly between speeders instead of standing still, but it doesn't affect gameplay
![image](https://github.com/user-attachments/assets/2ec1fb76-a13e-4b45-a4c0-a0b1f0fdba7c)




## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
