### PR TITLE
Fix Emscripten CMake configuration due to `--preload-file`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3529,6 +3529,10 @@ foreach(target ${TARGETS})
   if(ENABLE_IPO)
     set_property(TARGET ${target} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
   endif()
+  if(TARGET_OS STREQUAL "emscripten")
+    # Preload data directory into the filesystem
+    target_link_options(${target} PRIVATE --preload-file data)
+  endif()
 endforeach()
 
 foreach(target ${TARGETS_LINK})

--- a/cmake/toolchains/Emscripten.toolchain
+++ b/cmake/toolchains/Emscripten.toolchain
@@ -3,8 +3,6 @@ set(WASM_ENGINE_FLAGS "")
 set(WASM_ENGINE_FLAGS "-s LLD_REPORT_UNDEFINED -s USE_PTHREADS=1")
 # needed for loading files in a c-like style
 set(WASM_ENGINE_FLAGS "${WASM_ENGINE_FLAGS} -s FILESYSTEM=1 -s FORCE_FILESYSTEM=1")
-# load data directory to the filesystem
-set(WASM_ENGINE_FLAGS "${WASM_ENGINE_FLAGS} --preload-file data")
 # remove some annoyance for now, TODO
 set(WASM_ENGINE_FLAGS "${WASM_ENGINE_FLAGS} --allow-multiple-definition -Wl,--shared-memory,--no-check-features")
 # TODO


### PR DESCRIPTION
Specify `--preload-file data` linker flag to preload data directory into the filesystem in the `CMakeLists.txt` file as an additional target link option instead of specifying it in the `Emscripten.toolchain` file, as the latter caused the CMake configuration steps to fail due to the `data` folder being missing during this phase:

```
error: data does not exist
em++: error: '/emsdk/upstream/emscripten/tools/file_packager cmTC_83f35.data --from-emcc --preload data' failed (returned 1)
```

This was causing the CMake configuration phase to take longer, but building seemed to work anyway because it eventually falls back to some working defaults.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
