### PR TITLE
CTeeRenderInfo refactor

### DIFF
--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -380,7 +380,6 @@ void CGhost::UpdateTeeRenderInfo(CGhostItem &Ghost)
 
 	CTeeRenderInfo TeeRenderInfo;
 	TeeRenderInfo.ApplyColors(Ghost.m_Skin.m_UseCustomColor, Ghost.m_Skin.m_ColorBody, Ghost.m_Skin.m_ColorFeet);
-	TeeRenderInfo.m_Size = 64.0f;
 
 	Ghost.m_pManagedTeeRenderInfo = GameClient()->CreateManagedTeeRenderInfo(TeeRenderInfo, SkinDescriptor);
 }

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -338,7 +338,6 @@ void CMenus::DoLaserPreview(const CUIRect *pRect, const ColorHSLA LaserOutlineCo
 		CTeeRenderInfo TeeRenderInfo;
 		TeeRenderInfo.Apply(m_pClient->m_Skins.Find(g_Config.m_ClPlayerSkin));
 		TeeRenderInfo.ApplyColors(g_Config.m_ClPlayerUseCustomColor, g_Config.m_ClPlayerColorBody, g_Config.m_ClPlayerColorFeet);
-		TeeRenderInfo.m_Size = 64.0f;
 		RenderTools()->RenderTee(CAnimState::GetIdle(), &TeeRenderInfo, EMOTE_NORMAL, vec2(-1, 0), Pos);
 		break;
 	}
@@ -350,7 +349,6 @@ void CMenus::DoLaserPreview(const CUIRect *pRect, const ColorHSLA LaserOutlineCo
 		else
 			TeeRenderInfo.Apply(m_pClient->m_Skins.Find(g_Config.m_ClPlayerSkin));
 		TeeRenderInfo.m_TeeRenderFlags = TEE_EFFECT_FROZEN;
-		TeeRenderInfo.m_Size = 64.0f;
 		TeeRenderInfo.m_ColorBody = ColorRGBA(1, 1, 1);
 		TeeRenderInfo.m_ColorFeet = ColorRGBA(1, 1, 1);
 		RenderTools()->RenderTee(CAnimState::GetIdle(), &TeeRenderInfo, EMOTE_PAIN, vec2(1, 0), From);

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -794,7 +794,6 @@ void CNamePlates::RenderNamePlatePreview(vec2 Position, int Dummy)
 		TeeRenderInfo.Apply(m_pClient->m_Skins.Find(g_Config.m_ClDummySkin));
 		TeeRenderInfo.ApplyColors(g_Config.m_ClDummyUseCustomColor, g_Config.m_ClDummyColorBody, g_Config.m_ClDummyColorFeet);
 	}
-	TeeRenderInfo.m_Size = 64.0f;
 
 	CNamePlate NamePlate(*GameClient(), Data);
 	Position.y += NamePlate.Size().y / 2.0f;

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -366,8 +366,6 @@ void CPlayers::RenderHook(
 	if(ClientId == -2) // ghost
 		Alpha = g_Config.m_ClRaceGhostAlpha / 100.0f;
 
-	RenderInfo.m_Size = 64.0f;
-
 	vec2 Position;
 	if(in_range(ClientId, MAX_CLIENTS - 1))
 		Position = m_pClient->m_aClients[ClientId].m_RenderPos;
@@ -428,11 +426,8 @@ void CPlayers::RenderPlayer(
 	int ClientId,
 	float Intra)
 {
-	CNetObj_Character Prev;
-	CNetObj_Character Player;
-	Prev = *pPrevChar;
-	Player = *pPlayerChar;
-
+	const CNetObj_Character &Prev = *pPrevChar;
+	const CNetObj_Character &Player = *pPlayerChar;
 	CTeeRenderInfo RenderInfo = *pRenderInfo;
 
 	bool Local = m_pClient->m_Snap.m_LocalClientId == ClientId;
@@ -440,9 +435,6 @@ void CPlayers::RenderPlayer(
 	float Alpha = (OtherTeam || ClientId < 0) ? g_Config.m_ClShowOthersAlpha / 100.0f : 1.0f;
 	if(ClientId == -2) // ghost
 		Alpha = g_Config.m_ClRaceGhostAlpha / 100.0f;
-
-	// set size
-	RenderInfo.m_Size = 64.0f;
 
 	float IntraTick = Intra;
 	if(ClientId >= 0)
@@ -846,6 +838,9 @@ void CPlayers::OnRender()
 			}
 		}
 	}
+	CTeeRenderInfo RenderInfoSpec;
+	RenderInfoSpec.Apply(m_pClient->m_Skins.Find("x_spec"));
+	const int LocalClientId = m_pClient->m_Snap.m_LocalClientId;
 
 	// get screen edges to avoid rendering offscreen
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2722,7 +2722,7 @@ void CGameClient::CClientData::Reset()
 		m_pSkinInfo->SetRefreshCallback(nullptr);
 		m_pSkinInfo = nullptr;
 	}
-	m_RenderInfo.Reset();
+	m_RenderInfo = CTeeRenderInfo();
 
 	m_Angle = 0.0f;
 	m_Active = false;

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -70,22 +70,9 @@ class CTeeRenderInfo
 public:
 	CTeeRenderInfo()
 	{
-		Reset();
-	}
-
-	void Reset()
-	{
 		m_OriginalRenderSkin.Reset();
 		m_ColorableRenderSkin.Reset();
 		m_SkinMetrics.Reset();
-		m_CustomColoredSkin = false;
-		m_BloodColor = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
-		m_ColorBody = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
-		m_ColorFeet = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
-		m_Size = 1.0f;
-		m_GotAirJump = true;
-		m_TeeRenderFlags = 0;
-		m_FeetFlipped = false;
 
 		for(auto &Sixup : m_aSixup)
 			Sixup.Reset();
@@ -127,15 +114,14 @@ public:
 
 	CSkin::CSkinMetrics m_SkinMetrics;
 
-	bool m_CustomColoredSkin;
-	ColorRGBA m_BloodColor;
-
-	ColorRGBA m_ColorBody;
-	ColorRGBA m_ColorFeet;
-	float m_Size;
-	bool m_GotAirJump;
-	int m_TeeRenderFlags;
-	bool m_FeetFlipped;
+	bool m_CustomColoredSkin = false;
+	ColorRGBA m_BloodColor = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+	ColorRGBA m_ColorBody = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+	ColorRGBA m_ColorFeet = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+	float m_Size = 64.0f;
+	bool m_GotAirJump = true;
+	int m_TeeRenderFlags = 0;
+	bool m_FeetFlipped = false;
 
 	bool Valid() const
 	{


### PR DESCRIPTION
minor CTeeRenderInfo refactor
* Set default size to 64.0f, and remove redundant sets
* Remove .Reset(), move everything to constructor
* Move variable inits to class instead of constructor (as per contributing guidelines)

and
* Clean up variables in render player

Also a question:
Should all Reset()'s be removed?

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
