### PR TITLE
Only process 'leftclick-to-spectate' when 'BUG_DDRACE_INPUT' flag is set

### DIFF
--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -171,7 +171,7 @@ bool CSpectator::OnInput(const IInput::CEvent &Event)
 		return true;
 	}
 
-	if(g_Config.m_ClSpectatorMouseclicks)
+	if(g_Config.m_ClSpectatorMouseclicks && m_pClient->m_GameInfo.m_BugDDRaceInput)
 	{
 		if(m_pClient->m_Snap.m_SpecInfo.m_Active && !IsActive() && !GameClient()->m_MultiViewActivated &&
 			!Ui()->IsPopupOpen() && !m_pClient->m_GameConsole.IsActive() && !m_pClient->m_Menus.IsActive())


### PR DESCRIPTION


<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
