### PR TITLE
Fix crash when sorting in editor load

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -721,7 +721,7 @@ public:
 			return true;
 		if(str_comp(pRhs->m_aFilename, "..") == 0)
 			return false;
-		if(pLhs->m_IsLink || pRhs->m_IsLink)
+		if(pLhs->m_IsLink != pRhs->m_IsLink)
 			return pLhs->m_IsLink;
 		if(pLhs->m_IsDir != pRhs->m_IsDir)
 			return pLhs->m_IsDir;
@@ -734,7 +734,7 @@ public:
 			return true;
 		if(str_comp(pRhs->m_aFilename, "..") == 0)
 			return false;
-		if(pLhs->m_IsLink || pRhs->m_IsLink)
+		if(pLhs->m_IsLink != pRhs->m_IsLink)
 			return pLhs->m_IsLink;
 		if(pLhs->m_IsDir != pRhs->m_IsDir)
 			return pLhs->m_IsDir;


### PR DESCRIPTION
Fixes invalid comparator crash when sorting by `Time modified` in editor's `Load` map

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
