### PR TITLE
Support live playback of demos while they are being recorded

### DIFF
--- a/src/engine/demo.h
+++ b/src/engine/demo.h
@@ -65,6 +65,8 @@ public:
 	{
 	public:
 		bool m_Paused;
+		bool m_LiveDemo;
+		bool m_LivePlayback;
 		float m_Speed;
 
 		int m_FirstTick;

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -567,21 +567,45 @@ CDemoPlayer::EReadChunkHeaderResult CDemoPlayer::ReadChunkHeader(int *pType, int
 	return CHUNKHEADER_SUCCESS;
 }
 
-bool CDemoPlayer::ScanFile()
+CDemoPlayer::EScanFileResult CDemoPlayer::ScanFile()
 {
 	const int64_t StartPos = io_tell(m_File);
-	m_vKeyFrames.clear();
 	if(StartPos < 0)
-		return false;
+	{
+		return EScanFileResult::ERROR_UNRECOVERABLE;
+	}
+
+	const auto &ResetToStartPosition = [&](EScanFileResult Result) -> EScanFileResult {
+		if(io_seek(m_File, StartPos, IOSEEK_START) != 0)
+		{
+			m_vKeyFrames.clear();
+			return EScanFileResult::ERROR_UNRECOVERABLE;
+		}
+		return Result;
+	};
 
 	int ChunkTick = -1;
+	if(!m_vKeyFrames.empty())
+	{
+		if(io_seek(m_File, m_vKeyFrames.back().m_Filepos, IOSEEK_START) != 0)
+		{
+			return ResetToStartPosition(EScanFileResult::ERROR_RECOVERABLE);
+		}
+		int ChunkType, ChunkSize;
+		const EReadChunkHeaderResult Result = ReadChunkHeader(&ChunkType, &ChunkSize, &ChunkTick);
+		if(Result != CHUNKHEADER_SUCCESS ||
+			(ChunkSize > 0 && io_skip(m_File, ChunkSize) != 0))
+		{
+			return ResetToStartPosition(EScanFileResult::ERROR_RECOVERABLE);
+		}
+	}
+
 	while(true)
 	{
 		const int64_t CurrentPos = io_tell(m_File);
 		if(CurrentPos < 0)
 		{
-			m_vKeyFrames.clear();
-			return false;
+			return ResetToStartPosition(EScanFileResult::ERROR_RECOVERABLE);
 		}
 
 		int ChunkType, ChunkSize;
@@ -592,8 +616,7 @@ bool CDemoPlayer::ScanFile()
 		}
 		else if(Result == CHUNKHEADER_ERROR)
 		{
-			m_vKeyFrames.clear();
-			return false;
+			return ResetToStartPosition(EScanFileResult::ERROR_RECOVERABLE);
 		}
 
 		if(ChunkType & CHUNKTYPEFLAG_TICKMARKER)
@@ -602,28 +625,23 @@ bool CDemoPlayer::ScanFile()
 			{
 				m_vKeyFrames.emplace_back(CurrentPos, ChunkTick);
 			}
-
 			if(m_Info.m_Info.m_FirstTick == -1)
+			{
 				m_Info.m_Info.m_FirstTick = ChunkTick;
+			}
 			m_Info.m_Info.m_LastTick = ChunkTick;
 		}
 		else if(ChunkSize)
 		{
 			if(io_skip(m_File, ChunkSize) != 0)
 			{
-				m_vKeyFrames.clear();
-				return false;
+				return ResetToStartPosition(EScanFileResult::ERROR_RECOVERABLE);
 			}
 		}
 	}
 
-	if(io_seek(m_File, StartPos, IOSEEK_START) != 0)
-	{
-		m_vKeyFrames.clear();
-		return false;
-	}
 	// Cannot start playback without at least one keyframe
-	return !m_vKeyFrames.empty();
+	return ResetToStartPosition(m_vKeyFrames.empty() ? EScanFileResult::ERROR_UNRECOVERABLE : EScanFileResult::SUCCESS);
 }
 
 void CDemoPlayer::DoTick()
@@ -839,12 +857,13 @@ int CDemoPlayer::Load(class IStorage *pStorage, class IConsole *pConsole, const 
 		}
 	}
 
-	// scan the file for interesting points
-	if(!ScanFile())
+	// Scan the file for interesting points
+	if(ScanFile() == EScanFileResult::ERROR_UNRECOVERABLE)
 	{
 		Stop("Error scanning demo file");
 		return -1;
 	}
+	m_Info.m_LiveStateUpdating = true;
 
 	// reset slice markers
 	g_Config.m_ClDemoSliceBegin = -1;
@@ -957,6 +976,10 @@ void CDemoPlayer::Play()
 	set_new_tick();
 	m_Info.m_CurrentTime = m_Info.m_PreviousTick * time_freq() / SERVER_TICK_SPEED;
 	m_Info.m_LastUpdate = Time();
+	if(m_Info.m_LiveStateUpdating && m_Info.m_LastScan <= 0)
+	{
+		m_Info.m_LastScan = m_Info.m_LastUpdate;
+	}
 }
 
 int CDemoPlayer::SeekPercent(float Percent)
@@ -1001,7 +1024,20 @@ int CDemoPlayer::SetPos(int WantedTick)
 	if(!m_File)
 		return -1;
 
-	WantedTick = std::clamp(WantedTick, m_Info.m_Info.m_FirstTick, m_Info.m_Info.m_LastTick);
+	int LastSeekableTick = m_Info.m_Info.m_LastTick;
+	if(m_Info.m_Info.m_LiveDemo)
+	{
+		// Make sure we don't seek all the way until the end in a live demo because the chunk data may not be fully written.
+		LastSeekableTick -= 2 * SERVER_TICK_SPEED;
+	}
+	if(LastSeekableTick < m_Info.m_Info.m_FirstTick)
+	{
+		WantedTick = m_Info.m_Info.m_FirstTick;
+	}
+	else
+	{
+		WantedTick = std::clamp(WantedTick, m_Info.m_Info.m_FirstTick, LastSeekableTick);
+	}
 	const int KeyFrameWantedTick = WantedTick - 5; // -5 because we have to have a current tick and previous tick when we do the playback
 	const float Percent = (KeyFrameWantedTick - m_Info.m_Info.m_FirstTick) / (float)(m_Info.m_Info.m_LastTick - m_Info.m_Info.m_FirstTick);
 
@@ -1024,8 +1060,14 @@ int CDemoPlayer::SetPos(int WantedTick)
 	m_Info.m_PreviousTick = -1;
 
 	// playback everything until we hit our tick
-	while(m_Info.m_NextTick < WantedTick && IsPlaying())
+	while(m_Info.m_NextTick < WantedTick)
+	{
 		DoTick();
+		if(!IsPlaying())
+		{
+			return -1;
+		}
+	}
 
 	Play();
 
@@ -1049,36 +1091,119 @@ void CDemoPlayer::AdjustSpeedIndex(int Offset)
 	SetSpeedIndex(std::clamp(m_SpeedIndex + Offset, 0, (int)(std::size(DEMO_SPEEDS) - 1)));
 }
 
-int CDemoPlayer::Update(bool RealTime)
+void CDemoPlayer::Update(bool RealTime)
 {
-	int64_t Now = Time();
-	int64_t Deltatime = Now - m_Info.m_LastUpdate;
+	const int64_t Now = Time();
+	const int64_t Freq = time_freq();
+	const int64_t DeltaTime = Now - m_Info.m_LastUpdate;
 	m_Info.m_LastUpdate = Now;
 
-	if(!IsPlaying())
-		return 0;
+	if(m_Info.m_LiveStateUpdating)
+	{
+		// Determine if demo is live and still being written to, by scanning
+		// file again and checking if more ticks are available than before.
+		if(Now - m_Info.m_LastScan > Freq)
+		{
+			const int PreviousLastTick = m_Info.m_Info.m_LastTick;
+			const EScanFileResult ScanResult = ScanFile();
+			if(ScanResult == EScanFileResult::ERROR_UNRECOVERABLE)
+			{
+				Stop("Unrecoverable error on incrementally scanning demo file to determine live state");
+				return;
+			}
+			else if(ScanResult == EScanFileResult::SUCCESS)
+			{
+				// Live state is known when ScanFile succeeded.
+				m_Info.m_LiveStateUpdating = false;
+			}
+			else
+			{
+				m_Info.m_LiveStateFailedCount++;
+				if(m_Info.m_LiveStateFailedCount >= 15)
+				{
+					// ScanFile keeps failing, which should be unlikely, so this is probably
+					// not a live demo but a regular demo that is truncated at the end.
+					m_Info.m_LiveStateUpdating = false;
+				}
+			}
+			// Check if we got more ticks also when ScanFile failed, because
+			// it could still have found more ticks.
+			if(m_Info.m_Info.m_LastTick > PreviousLastTick)
+			{
+				m_Info.m_Info.m_LiveDemo = true;
+				m_Info.m_LiveStateUpdating = false;
+				m_Info.m_LiveStateUnchangedCount = 0;
+			}
+			m_Info.m_LastScan = Now;
+			// Try again later if ScanFile failed and no more ticks were found.
+		}
+	}
+	else if(m_Info.m_Info.m_LiveDemo)
+	{
+		// Scan live demo at tick frequency to smoothly update total time.
+		if(Now - m_Info.m_LastScan > Freq / SERVER_TICK_SPEED)
+		{
+			const int PreviousLastTick = m_Info.m_Info.m_LastTick;
+			const EScanFileResult ScanResult = ScanFile();
+			if(ScanResult == EScanFileResult::ERROR_UNRECOVERABLE)
+			{
+				Stop("Unrecoverable error on incrementally scanning live demo file");
+				return;
+			}
+			else if(ScanResult == EScanFileResult::SUCCESS &&
+				m_Info.m_Info.m_LastTick == PreviousLastTick)
+			{
+				m_Info.m_LiveStateUnchangedCount++;
+				if(m_Info.m_LiveStateUnchangedCount >= 2 * SERVER_TICK_SPEED)
+				{
+					// Assume demo stopped being live if we scanned the demo
+					// successfully for 2 seconds without reading new ticks.
+					m_Info.m_Info.m_LiveDemo = false;
+				}
+			}
+			else
+			{
+				m_Info.m_LiveStateUnchangedCount = 0;
+			}
+			m_Info.m_LastScan = Now;
+		}
+	}
 
-	const int64_t Freq = time_freq();
+	if(!IsPlaying())
+	{
+		return;
+	}
+
 	if(!m_Info.m_Info.m_Paused)
 	{
-		m_Info.m_CurrentTime += (int64_t)(Deltatime * (double)m_Info.m_Info.m_Speed);
-
-		while(!m_Info.m_Info.m_Paused && IsPlaying())
+		if(m_Info.m_Info.m_LiveDemo &&
+			m_Info.m_Info.m_Speed > 1.0f &&
+			m_Info.m_Info.m_LastTick - m_Info.m_Info.m_CurrentTick <= (DeltaTime * (double)m_Info.m_Info.m_Speed / Freq + 2) * SERVER_TICK_SPEED)
 		{
-			int64_t CurtickStart = m_Info.m_Info.m_CurrentTick * Freq / SERVER_TICK_SPEED;
+			// Reset to default speed if we are fast-forwarding to the end of a live demo,
+			// to prevent playback error due to final demo chunk data still being written.
+			SetSpeedIndex(DEMO_SPEED_INDEX_DEFAULT);
+		}
 
-			// break if we are ready
-			if(RealTime && CurtickStart > m_Info.m_CurrentTime)
+		m_Info.m_CurrentTime += (int64_t)(DeltaTime * (double)m_Info.m_Info.m_Speed);
+
+		// Do more ticks until we reach the current time.
+		while(!m_Info.m_Info.m_Paused)
+		{
+			const int64_t CurrentTickStart = m_Info.m_Info.m_CurrentTick * Freq / SERVER_TICK_SPEED;
+			if(RealTime && CurrentTickStart > m_Info.m_CurrentTime)
+			{
 				break;
-
-			// do one more tick
+			}
 			DoTick();
+			if(!IsPlaying())
+			{
+				return;
+			}
 		}
 	}
 
 	UpdateTimes();
-
-	return 0;
 }
 
 void CDemoPlayer::UpdateTimes()
@@ -1089,6 +1214,7 @@ void CDemoPlayer::UpdateTimes()
 	m_Info.m_IntraTick = (m_Info.m_CurrentTime - PreviousTickStart) / (float)(CurrentTickStart - PreviousTickStart);
 	m_Info.m_IntraTickSincePrev = (m_Info.m_CurrentTime - PreviousTickStart) / (float)(Freq / SERVER_TICK_SPEED);
 	m_Info.m_TickTime = (m_Info.m_CurrentTime - PreviousTickStart) / (float)Freq;
+	m_Info.m_Info.m_LivePlayback = m_Info.m_Info.m_LastTick - m_Info.m_Info.m_CurrentTick < 3 * SERVER_TICK_SPEED;
 
 	if(m_UpdateIntraTimesFunc)
 	{
@@ -1101,6 +1227,7 @@ void CDemoPlayer::Stop(const char *pErrorMessage)
 #if defined(CONF_VIDEORECORDER)
 	if(m_UseVideo && IVideo::Current())
 		IVideo::Current()->Stop();
+	m_WasRecording = false;
 #endif
 
 	if(!m_File)

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -80,6 +80,7 @@ public:
 		IDemoPlayer::CInfo m_Info;
 
 		int64_t m_LastUpdate;
+		int64_t m_LastScan;
 		int64_t m_CurrentTime;
 
 		int m_NextTick;
@@ -88,6 +89,10 @@ public:
 		float m_IntraTick;
 		float m_IntraTickSincePrev;
 		float m_TickTime;
+
+		bool m_LiveStateUpdating;
+		int m_LiveStateFailedCount;
+		int m_LiveStateUnchangedCount;
 	};
 
 private:
@@ -144,7 +149,13 @@ private:
 	};
 	EReadChunkHeaderResult ReadChunkHeader(int *pType, int *pSize, int *pTick);
 	void DoTick();
-	bool ScanFile();
+	enum class EScanFileResult
+	{
+		SUCCESS,
+		ERROR_RECOVERABLE,
+		ERROR_UNRECOVERABLE,
+	};
+	EScanFileResult ScanFile();
 	void UpdateTimes();
 
 	int64_t Time();
@@ -179,7 +190,7 @@ public:
 	const char *Filename() const { return m_aFilename; }
 	const char *ErrorMessage() const override { return m_aErrorMessage; }
 
-	int Update(bool RealTime = true);
+	void Update(bool RealTime = true);
 	bool IsSixup() const { return m_Sixup; }
 
 	const CPlaybackInfo *Info() const { return &m_Info; }

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -63,8 +63,13 @@ void CMenus::HandleDemoSeeking(float PositionToSeek, float TimeToSeek)
 		else
 			DemoPlayer()->SeekPercent(PositionToSeek);
 		GameClient()->m_SuppressEvents = false;
-		if(!DemoPlayer()->BaseInfo()->m_Paused && PositionToSeek == 1.0f)
+
+		if(!DemoPlayer()->BaseInfo()->m_Paused &&
+			!DemoPlayer()->BaseInfo()->m_LiveDemo &&
+			PositionToSeek == 1.0f)
+		{
 			DemoPlayer()->Pause();
+		}
 	}
 }
 
@@ -346,6 +351,34 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 				m_DemoControlsPositionOffset.y = std::clamp(m_DemoControlsPositionOffset.y, -DemoControlsOriginal.y, MainView.h - DemoControlsDragRect.h - DemoControlsOriginal.y);
 			}
 		}
+	}
+
+	// Live button
+	if(pInfo->m_LiveDemo)
+	{
+		CUIRect LiveButton;
+		SeekBar.VSplitRight(SeekBar.h, &SeekBar, &LiveButton);
+		SeekBar.VSplitRight(2.0f, &SeekBar, nullptr);
+		TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
+		TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGNMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
+		TextRender()->TextColor(pInfo->m_LivePlayback ? ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f) : ColorRGBA(0.6f, 0.6f, 0.6f, 1.0f));
+		Ui()->DoLabel(&LiveButton, FONT_ICON_CIRCLE, 24.0f, TEXTALIGN_MC);
+		TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
+		TextRender()->SetRenderFlags(0);
+		TextRender()->TextColor(TextRender()->DefaultTextColor());
+		static char s_LiveButtonId;
+		if(Ui()->HotItem() == &s_LiveButtonId)
+		{
+			LiveButton.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), IGraphics::CORNER_ALL, 3.0f);
+		}
+		if(Ui()->DoButtonLogic(&s_LiveButtonId, 0, &LiveButton, BUTTONFLAG_LEFT))
+		{
+			PositionToSeek = 1.0f;
+			DemoPlayer()->SetSpeedIndex(DEMO_SPEED_INDEX_DEFAULT);
+			UpdateLastSpeedChange();
+		}
+		GameClient()->m_Tooltips.DoToolTip(&s_LiveButtonId, &LiveButton,
+			pInfo->m_LivePlayback ? Localize("Live", "Demo playback") : Localize("Go to Live", "Demo playback"));
 	}
 
 	// do seekbar


### PR DESCRIPTION
Check if more ticks are still being written to the demo 1 second after starting playback to detect a live demo. For live demos, each tick incrementally scan for new tickmarkers and keyframes after the last keyframe to properly update the total time while playing the demo. Detect if the demo stopped being recorded by checking if no more tickmarkers have been written within 2 seconds.

Prevent seeking closer than 2 seconds to the end of live demos to avoid demo playback errors due to incomplete reads of the last demo chunk data which may still be written to by a demo recorder. Also reset the demo player speed to the default when fast-forwarding to the end of a live demo to prevent playback errors.

Show a red/grey dot indicator next to the demo seekbar for live demos. The indicator is red to indicate playback being considered live when viewing the last 3 seconds of the live demo. Clicking the live indicator will seek to the most recent viewable time.

![image](https://github.com/user-attachments/assets/e8785cee-23e1-4815-a9d6-0655f5e47033)

![image](https://github.com/user-attachments/assets/3737cec6-55a7-4666-b773-afddbc36d6c5)

Furthermore, support playing truncated demos again when possible instead of failing to open them entirely. Keyframes will now only be read until the truncation occurs. Skipping to the end of a truncated demo may still end playback with an error due to the chunk data being incomplete. A truncated demo file is indistinguishable from a live demo being read in an incomplete state. The detection for live demos is deactivated after 15 seconds if it keeps failing, to avoid unnecessary scanning of files that are likely truncated and not live demos.

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
