### PR TITLE
Minor improvements to editor automap rule popup

### DIFF
--- a/src/game/editor/auto_map.cpp
+++ b/src/game/editor/auto_map.cpp
@@ -377,11 +377,12 @@ int CAutoMapper::CheckIndexFlag(int Flag, const char *pFlag, bool CheckNone) con
 	return Flag;
 }
 
-const char *CAutoMapper::GetConfigName(int Index)
+const char *CAutoMapper::GetConfigName(int Index) const
 {
 	if(Index < 0 || Index >= (int)m_vConfigs.size())
-		return "";
-
+	{
+		return "(unknown)";
+	}
 	return m_vConfigs[Index].m_aName;
 }
 

--- a/src/game/editor/auto_map.h
+++ b/src/game/editor/auto_map.h
@@ -80,7 +80,7 @@ public:
 	void ProceedLocalized(class CLayerTiles *pLayer, class CLayerTiles *pGameLayer, int ReferenceId, int ConfigId, int Seed = 0, int X = 0, int Y = 0, int Width = -1, int Height = -1);
 	void Proceed(class CLayerTiles *pLayer, class CLayerTiles *pGameLayer, int ReferenceId, int ConfigId, int Seed = 0, int SeedOffsetX = 0, int SeedOffsetY = 0);
 	int ConfigNamesNum() const { return m_vConfigs.size(); }
-	const char *GetConfigName(int Index);
+	const char *GetConfigName(int Index) const;
 
 	bool IsLoaded() const { return m_FileLoaded; }
 

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -2483,6 +2483,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSelectConfigAutoMap(void *pContext, 
 
 	static CListBox s_ListBox;
 	s_ListBox.DoStart(ButtonHeight, pAutoMapper->ConfigNamesNum() + 1, 1, 4, s_AutoMapConfigCurrent + 1, &View, false);
+	s_ListBox.SetScrollbarWidth(15.0f);
 	s_ListBox.DoAutoSpacing(ButtonMargin);
 
 	for(int i = 0; i < pAutoMapper->ConfigNamesNum() + 1; i++)
@@ -2514,9 +2515,9 @@ void CEditor::PopupSelectConfigAutoMapInvoke(int Current, float x, float y)
 	s_AutoMapConfigSelected = -100;
 	s_AutoMapConfigCurrent = Current;
 	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(GetSelectedLayer(0));
-	const int ItemCount = minimum(m_Map.m_vpImages[pLayer->m_Image]->m_AutoMapper.ConfigNamesNum(), 10);
+	const int ItemCount = minimum(m_Map.m_vpImages[pLayer->m_Image]->m_AutoMapper.ConfigNamesNum() + 1, 10); // +1 for None-entry
 	// Width for buttons is 120, 15 is the scrollbar width, 2 is the margin between both.
-	Ui()->DoPopupMenu(&s_PopupSelectConfigAutoMapId, x, y, 120.0f + 15.0f + 2.0f, 26.0f + 14.0f * ItemCount, this, PopupSelectConfigAutoMap);
+	Ui()->DoPopupMenu(&s_PopupSelectConfigAutoMapId, x, y, 120.0f + 15.0f + 2.0f, 10.0f + 12.0f * ItemCount + 2.0f * (ItemCount - 1) + CScrollRegion::HEIGHT_MAGIC_FIX, this, PopupSelectConfigAutoMap);
 }
 
 int CEditor::PopupSelectConfigAutoMapResult()


### PR DESCRIPTION
Show "(unknown)" instead of nothing if a map uses an automapper rule index for which no rule is available locally.

Reduce unnecessary margin at bottom of popup.

Fix popup scrollbar being too wide.

Screenshots:
- Unknown rule:
    - Before: 
![image](https://github.com/user-attachments/assets/15b4005d-3ec9-4e06-9a54-ed553e789f55)
    - After: 
![image](https://github.com/user-attachments/assets/510c3e1f-9599-4336-b718-7a798097ed55)
- Scrollbar and spacing:
   - Before: 
![image](https://github.com/user-attachments/assets/ce17b2b5-eb78-4571-a5a2-bbd2814a8e66)
   - After: 
![image](https://github.com/user-attachments/assets/ad35a8b1-7c49-40ae-b54d-b8371a7414c4)



## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
