### PR TITLE
Ensure demo playback starts at time 00:00, fix unsmooth server demo recording on empty servers, various refactoring

### DIFF
--- a/src/engine/demo.h
+++ b/src/engine/demo.h
@@ -17,8 +17,9 @@ enum
 
 static const unsigned char gs_aHeaderMarker[7] = {'T', 'W', 'D', 'E', 'M', 'O', 0};
 
-constexpr int g_DemoSpeeds = 22;
-extern const double g_aSpeeds[g_DemoSpeeds];
+static constexpr double DEMO_SPEEDS[] = {0.1, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0, 16.0, 20.0, 24.0, 28.0, 32.0, 40.0, 48.0, 56.0, 64.0};
+static constexpr int DEMO_SPEED_INDEX_DEFAULT = 4;
+static_assert(DEMO_SPEEDS[DEMO_SPEED_INDEX_DEFAULT] == 1.0);
 
 typedef bool (*DEMOFUNC_FILTER)(const void *pData, int DataSize, void *pUser);
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3244,7 +3244,6 @@ int CServer::Run()
 				}
 			}
 
-			// wait for incoming data
 			if(NonActive)
 			{
 				if(Config()->m_SvReloadWhenEmpty == 1)
@@ -3257,7 +3256,17 @@ int CServer::Run()
 					m_MapReload = true;
 					m_ReloadedWhenEmpty = true;
 				}
+			}
+			else
+			{
+				m_ReloadedWhenEmpty = false;
+			}
 
+			// wait for incoming data
+			if(NonActive &&
+				!m_aDemoRecorder[RECORDER_MANUAL].IsRecording() &&
+				!m_aDemoRecorder[RECORDER_AUTO].IsRecording())
+			{
 				if(Config()->m_SvShutdownWhenEmpty)
 					m_RunServer = STOPPING;
 				else
@@ -3265,8 +3274,6 @@ int CServer::Run()
 			}
 			else
 			{
-				m_ReloadedWhenEmpty = false;
-
 				set_new_tick();
 				t = time_get();
 				int x = (TickStartTime(m_CurrentGameTick + 1) - t) * 1000000 / time_freq() + 1;

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -633,14 +633,7 @@ void CDemoPlayer::DoTick()
 	m_Info.m_Info.m_CurrentTick = m_Info.m_NextTick;
 	int ChunkTick = m_Info.m_Info.m_CurrentTick;
 
-	int64_t Freq = time_freq();
-	int64_t CurtickStart = m_Info.m_Info.m_CurrentTick * Freq / SERVER_TICK_SPEED;
-	int64_t PrevtickStart = m_Info.m_PreviousTick * Freq / SERVER_TICK_SPEED;
-	m_Info.m_IntraTick = (m_Info.m_CurrentTime - PrevtickStart) / (float)(CurtickStart - PrevtickStart);
-	m_Info.m_IntraTickSincePrev = (m_Info.m_CurrentTime - PrevtickStart) / (float)(Freq / SERVER_TICK_SPEED);
-	m_Info.m_TickTime = (m_Info.m_CurrentTime - PrevtickStart) / (float)Freq;
-	if(m_UpdateIntraTimesFunc)
-		m_UpdateIntraTimesFunc();
+	UpdateTimes();
 
 	bool GotSnapshot = false;
 	while(true)
@@ -1072,18 +1065,24 @@ int CDemoPlayer::Update(bool RealTime)
 		}
 	}
 
-	// update intratick
-	{
-		int64_t CurtickStart = m_Info.m_Info.m_CurrentTick * Freq / SERVER_TICK_SPEED;
-		int64_t PrevtickStart = m_Info.m_PreviousTick * Freq / SERVER_TICK_SPEED;
-		m_Info.m_IntraTick = (m_Info.m_CurrentTime - PrevtickStart) / (float)(CurtickStart - PrevtickStart);
-		m_Info.m_IntraTickSincePrev = (m_Info.m_CurrentTime - PrevtickStart) / (float)(Freq / SERVER_TICK_SPEED);
-		m_Info.m_TickTime = (m_Info.m_CurrentTime - PrevtickStart) / (float)Freq;
-		if(m_UpdateIntraTimesFunc)
-			m_UpdateIntraTimesFunc();
-	}
+	UpdateTimes();
 
 	return 0;
+}
+
+void CDemoPlayer::UpdateTimes()
+{
+	const int64_t Freq = time_freq();
+	const int64_t CurrentTickStart = m_Info.m_Info.m_CurrentTick * Freq / SERVER_TICK_SPEED;
+	const int64_t PreviousTickStart = m_Info.m_PreviousTick * Freq / SERVER_TICK_SPEED;
+	m_Info.m_IntraTick = (m_Info.m_CurrentTime - PreviousTickStart) / (float)(CurrentTickStart - PreviousTickStart);
+	m_Info.m_IntraTickSincePrev = (m_Info.m_CurrentTime - PreviousTickStart) / (float)(Freq / SERVER_TICK_SPEED);
+	m_Info.m_TickTime = (m_Info.m_CurrentTime - PreviousTickStart) / (float)Freq;
+
+	if(m_UpdateIntraTimesFunc)
+	{
+		m_UpdateIntraTimesFunc();
+	}
 }
 
 void CDemoPlayer::Stop(const char *pErrorMessage)

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -623,7 +623,8 @@ bool CDemoPlayer::ScanFile()
 		m_vKeyFrames.clear();
 		return false;
 	}
-	return true;
+	// Cannot start playback without at least one keyframe
+	return !m_vKeyFrames.empty();
 }
 
 void CDemoPlayer::DoTick()

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -17,7 +17,6 @@
 #include "network.h"
 #include "snapshot.h"
 
-const double g_aSpeeds[g_DemoSpeeds] = {0.1, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0, 16.0, 20.0, 24.0, 28.0, 32.0, 40.0, 48.0, 56.0, 64.0};
 const CUuid SHA256_EXTENSION =
 	{{0x6b, 0xe6, 0xda, 0x4a, 0xce, 0xbd, 0x38, 0x0c,
 		0x9b, 0x5b, 0x12, 0x89, 0xc8, 0x42, 0xd7, 0x80}};
@@ -487,7 +486,7 @@ CDemoPlayer::~CDemoPlayer()
 void CDemoPlayer::Construct(class CSnapshotDelta *pSnapshotDelta, bool UseVideo)
 {
 	m_File = nullptr;
-	m_SpeedIndex = 4;
+	m_SpeedIndex = DEMO_SPEED_INDEX_DEFAULT;
 
 	m_pSnapshotDelta = pSnapshotDelta;
 	m_LastSnapshotDataSize = -1;
@@ -811,7 +810,7 @@ int CDemoPlayer::Load(class IStorage *pStorage, class IConsole *pConsole, const 
 	m_Info.m_Info.m_CurrentTick = -1;
 	m_Info.m_PreviousTick = -1;
 	m_Info.m_Info.m_Speed = 1;
-	m_SpeedIndex = 4;
+	m_SpeedIndex = DEMO_SPEED_INDEX_DEFAULT;
 	m_LastSnapshotDataSize = -1;
 
 	if(!GetDemoInfo(pStorage, m_pConsole, pFilename, StorageType, &m_Info.m_Header, &m_Info.m_TimelineMarkers, &m_MapInfo, &m_File, m_aErrorMessage, sizeof(m_aErrorMessage)))
@@ -1040,14 +1039,14 @@ void CDemoPlayer::SetSpeed(float Speed)
 
 void CDemoPlayer::SetSpeedIndex(int SpeedIndex)
 {
-	dbg_assert(SpeedIndex >= 0 && SpeedIndex < g_DemoSpeeds, "invalid SpeedIndex");
+	dbg_assert(SpeedIndex >= 0 && SpeedIndex < (int)std::size(DEMO_SPEEDS), "invalid SpeedIndex");
 	m_SpeedIndex = SpeedIndex;
-	SetSpeed(g_aSpeeds[m_SpeedIndex]);
+	SetSpeed(DEMO_SPEEDS[m_SpeedIndex]);
 }
 
 void CDemoPlayer::AdjustSpeedIndex(int Offset)
 {
-	SetSpeedIndex(clamp(m_SpeedIndex + Offset, 0, (int)(std::size(g_aSpeeds) - 1)));
+	SetSpeedIndex(clamp(m_SpeedIndex + Offset, 0, (int)(std::size(DEMO_SPEEDS) - 1)));
 }
 
 int CDemoPlayer::Update(bool RealTime)

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -937,16 +937,27 @@ int64_t CDemoPlayer::Time()
 #endif
 }
 
-int CDemoPlayer::Play()
+void CDemoPlayer::Play()
 {
-	// fill in previous and next tick
-	while(m_Info.m_PreviousTick == -1 && IsPlaying())
+	// Fill in previous and next tick
+	while(m_Info.m_PreviousTick == -1)
+	{
 		DoTick();
+		if(!IsPlaying())
+		{
+			// Empty demo or error playing tick
+			return;
+		}
+	}
 
-	// set start info
+	// Initialize playback time. Using `set_new_tick` is essential so that `Time`
+	// returns the updated time, otherwise the delta between `m_LastUpdate` and
+	// the value that `Time` returns when called in the `Update` function can be
+	// very large depending on the time required to load the demo, which causes
+	// demo playback to start later. This ensures it always starts at 00:00.
+	set_new_tick();
 	m_Info.m_CurrentTime = m_Info.m_PreviousTick * time_freq() / SERVER_TICK_SPEED;
 	m_Info.m_LastUpdate = Time();
-	return 0;
 }
 
 int CDemoPlayer::SeekPercent(float Percent)

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -71,8 +71,9 @@ public:
 		virtual void OnDemoPlayerMessage(void *pData, int Size) = 0;
 	};
 
-	struct CPlaybackInfo
+	class CPlaybackInfo
 	{
+	public:
 		CDemoHeader m_Header;
 		CTimelineMarkers m_TimelineMarkers;
 
@@ -95,12 +96,13 @@ private:
 	TUpdateIntraTimesFunc m_UpdateIntraTimesFunc;
 
 	// Playback
-	struct SKeyFrame
+	class CKeyFrame
 	{
+	public:
 		int64_t m_Filepos;
 		int m_Tick;
 
-		SKeyFrame(int64_t Filepos, int Tick) :
+		CKeyFrame(int64_t Filepos, int Tick) :
 			m_Filepos(Filepos), m_Tick(Tick)
 		{
 		}
@@ -111,7 +113,7 @@ private:
 	int64_t m_MapOffset;
 	char m_aFilename[IO_MAX_PATH_LENGTH];
 	char m_aErrorMessage[256];
-	std::vector<SKeyFrame> m_vKeyFrames;
+	std::vector<CKeyFrame> m_vKeyFrames;
 	CMapInfo m_MapInfo;
 	int m_SpeedIndex;
 

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -162,7 +162,7 @@ public:
 	int Load(class IStorage *pStorage, class IConsole *pConsole, const char *pFilename, int StorageType);
 	unsigned char *GetMapData(class IStorage *pStorage);
 	bool ExtractMap(class IStorage *pStorage);
-	int Play();
+	void Play();
 	void Pause() override;
 	void Unpause() override;
 	void Stop(const char *pErrorMessage = "");

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -143,6 +143,7 @@ private:
 	EReadChunkHeaderResult ReadChunkHeader(int *pType, int *pSize, int *pTick);
 	void DoTick();
 	bool ScanFile();
+	void UpdateTimes();
 
 	int64_t Time();
 	bool m_Sixup;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1679,7 +1679,7 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		Row.VSplitLeft(5.0f, nullptr, &Row);
 		static CButtonContainer s_SlowDownButton;
 		if(DoButton_FontIcon(&s_SlowDownButton, FONT_ICON_BACKWARD, 0, &SlowDownButton, BUTTONFLAG_LEFT))
-			m_Speed = clamp(m_Speed - 1, 0, (int)(g_DemoSpeeds - 1));
+			m_Speed = clamp(m_Speed - 1, 0, (int)(std::size(DEMO_SPEEDS) - 1));
 
 		// paused
 		CUIRect PausedButton;
@@ -1695,12 +1695,12 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		Row.VSplitLeft(8.0f, nullptr, &Row);
 		static CButtonContainer s_FastForwardButton;
 		if(DoButton_FontIcon(&s_FastForwardButton, FONT_ICON_FORWARD, 0, &FastForwardButton, BUTTONFLAG_LEFT))
-			m_Speed = clamp(m_Speed + 1, 0, (int)(g_DemoSpeeds - 1));
+			m_Speed = clamp(m_Speed + 1, 0, (int)(std::size(DEMO_SPEEDS) - 1));
 
 		// speed meter
 		char aBuffer[128];
 		const char *pPaused = m_StartPaused ? Localize("(paused)") : "";
-		str_format(aBuffer, sizeof(aBuffer), "%s: ×%g %s", Localize("Speed"), g_aSpeeds[m_Speed], pPaused);
+		str_format(aBuffer, sizeof(aBuffer), "%s: ×%g %s", Localize("Speed"), DEMO_SPEEDS[m_Speed], pPaused);
 		Ui()->DoLabel(&Row, aBuffer, 12.8f, TEXTALIGN_ML);
 		Box.HSplitBottom(16.0f, &Box, nullptr);
 		Box.HSplitBottom(24.0f, &Box, &Row);
@@ -2093,7 +2093,7 @@ void CMenus::PopupConfirmDemoReplaceVideo()
 	char aVideoName[IO_MAX_PATH_LENGTH];
 	str_copy(aVideoName, m_DemoRenderInput.GetString());
 	const char *pError = Client()->DemoPlayer_Render(aBuf, m_DemolistStorageType, aVideoName, m_Speed, m_StartPaused);
-	m_Speed = 4;
+	m_Speed = DEMO_SPEED_INDEX_DEFAULT;
 	m_StartPaused = false;
 	m_LastPauseChange = -1.0f;
 	m_LastSpeedChange = -1.0f;

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -374,13 +374,8 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 
 	// do seekbar
 	{
-		const float Rounding = 5.0f;
-
-		static int s_SeekBarId = 0;
-		void *pId = &s_SeekBarId;
-		char aBuffer[128];
-
 		// draw seek bar
+		const float Rounding = 5.0f;
 		SeekBar.Draw(ColorRGBA(0, 0, 0, 0.5f), IGraphics::CORNER_ALL, Rounding);
 
 		// draw filled bar
@@ -445,13 +440,15 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		str_time((int64_t)CurrentTick / Client()->GameTickSpeed() * 100, TIME_HOURS, aCurrentTime, sizeof(aCurrentTime));
 		char aTotalTime[32];
 		str_time((int64_t)TotalTicks / Client()->GameTickSpeed() * 100, TIME_HOURS, aTotalTime, sizeof(aTotalTime));
-		str_format(aBuffer, sizeof(aBuffer), "%s / %s", aCurrentTime, aTotalTime);
-		Ui()->DoLabel(&SeekBar, aBuffer, SeekBar.h * 0.70f, TEXTALIGN_MC);
+		char aSeekBarLabel[128];
+		str_format(aSeekBarLabel, sizeof(aSeekBarLabel), "%s / %s", aCurrentTime, aTotalTime);
+		Ui()->DoLabel(&SeekBar, aSeekBarLabel, SeekBar.h * 0.70f, TEXTALIGN_MC);
 
 		// do the logic
 		const bool Inside = Ui()->MouseInside(&SeekBar);
 
-		if(Ui()->CheckActiveItem(pId))
+		static char s_SeekBarId;
+		if(Ui()->CheckActiveItem(&s_SeekBarId))
 		{
 			if(!Ui()->MouseButton(0))
 				Ui()->SetActiveItem(nullptr);
@@ -478,23 +475,23 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 				}
 			}
 		}
-		else if(Ui()->HotItem() == pId)
+		else if(Ui()->HotItem() == &s_SeekBarId)
 		{
 			if(Ui()->MouseButton(0))
 			{
-				Ui()->SetActiveItem(pId);
+				Ui()->SetActiveItem(&s_SeekBarId);
 			}
 		}
 
 		if(Inside && !Ui()->MouseButton(0))
-			Ui()->SetHotItem(pId);
+			Ui()->SetHotItem(&s_SeekBarId);
 
-		if(Ui()->HotItem() == pId)
+		if(Ui()->HotItem() == &s_SeekBarId)
 		{
 			const int HoveredTick = (int)(clamp((Ui()->MouseX() - SeekBar.x - Rounding) / (SeekBar.w - 2 * Rounding), 0.0f, 1.0f) * TotalTicks);
 			static char s_aHoveredTime[32];
 			str_time((int64_t)HoveredTick / Client()->GameTickSpeed() * 100, TIME_HOURS, s_aHoveredTime, sizeof(s_aHoveredTime));
-			GameClient()->m_Tooltips.DoToolTip(pId, &SeekBar, s_aHoveredTime);
+			GameClient()->m_Tooltips.DoToolTip(&s_SeekBarId, &SeekBar, s_aHoveredTime);
 		}
 	}
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -579,21 +579,21 @@ void CGameClient::OnConnected()
 		pComponent->OnReset();
 	}
 
-	Client()->SetLoadingStateDetail(IClient::LOADING_STATE_DETAIL_GETTING_READY);
-	m_Menus.RenderLoading(pConnectCaption, Localize("Sending initial client info"), 0);
-
-	// send the initial info
-	SendInfo(true);
-	// we should keep this in for now, because otherwise you can't spectate
-	// people at start as the other info 64 packet is only sent after the first
-	// snap
-	Client()->Rcon("crashmeplx");
-
 	ConfigManager()->ResetGameSettings();
 	LoadMapSettings();
 
 	if(Client()->State() != IClient::STATE_DEMOPLAYBACK)
 	{
+		Client()->SetLoadingStateDetail(IClient::LOADING_STATE_DETAIL_GETTING_READY);
+		m_Menus.RenderLoading(pConnectCaption, Localize("Sending initial client info"), 0);
+
+		// send the initial info
+		SendInfo(true);
+		// we should keep this in for now, because otherwise you can't spectate
+		// people at start as the other info 64 packet is only sent after the first
+		// snap
+		Client()->Rcon("crashmeplx");
+
 		if(g_Config.m_ClAutoDemoOnConnect)
 			Client()->DemoRecorder_HandleAutoStart();
 


### PR DESCRIPTION
Separated from #10128. See commit messages.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
