### PR TITLE
Remove unnecessary and incorrect definition of `__USE_GNU`

### DIFF
--- a/src/base/system.h
+++ b/src/base/system.h
@@ -11,10 +11,6 @@
 #include "detect.h"
 #include "types.h"
 
-#ifndef __USE_GNU
-#define __USE_GNU
-#endif
-
 #include <chrono>
 #include <cinttypes>
 #include <cstdarg>


### PR DESCRIPTION
Introduced by 9febf58. According to https://stackoverflow.com/a/7297011 the macro `__USE_GNU` should never be defined in user code but instead `_GNU_SOURCE` should be defined to enable desired features. However, neither definition are required for compilation anymore.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
