### PR TITLE
Add option to show/hide touch controls while rendering demo

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -292,6 +292,7 @@ MACRO_CONFIG_INT(SvPracticeByDefault, sv_practice_by_default, 0, 0, 1, CFGFLAG_S
 
 MACRO_CONFIG_INT(ClVideoPauseWithDemo, cl_video_pausewithdemo, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Pause video rendering when demo playing pause")
 MACRO_CONFIG_INT(ClVideoShowhud, cl_video_showhud, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame HUD when rendering video")
+MACRO_CONFIG_INT(ClVideoTouchControls, cl_video_touch_controls, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame touch controls when rendering video")
 MACRO_CONFIG_INT(ClVideoShowChat, cl_video_showchat, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show chat when rendering video")
 MACRO_CONFIG_INT(ClVideoSndEnable, cl_video_sound_enable, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Use sound when rendering video")
 MACRO_CONFIG_INT(ClVideoShowHookCollOther, cl_video_show_hook_coll_other, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show other players' hook collision lines when rendering video")

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1614,7 +1614,7 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		Box.VMargin(60.0f, &Box);
 		Box.HMargin(20.0f, &Box);
 		Box.HSplitBottom(24.0f, &Box, &Row);
-		Box.HSplitBottom(40.0f, &Box, nullptr);
+		Box.HSplitBottom(30.0f, &Box, nullptr);
 		Row.VMargin(40.0f, &Row);
 		Row.VSplitMid(&Abort, &Ok, 40.0f);
 
@@ -1655,20 +1655,24 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 			}
 		}
 
-		CUIRect ShowChatCheckbox, UseSoundsCheckbox;
+		CUIRect ShowTouchControlsCheckbox, UseSoundsCheckbox, ShowChatCheckbox, ShowHudButton;
 		Box.HSplitBottom(20.0f, &Box, &Row);
 		Box.HSplitBottom(10.0f, &Box, nullptr);
-		Row.VSplitMid(&ShowChatCheckbox, &UseSoundsCheckbox, 20.0f);
+		Row.VSplitMid(nullptr, &ShowTouchControlsCheckbox, 20.0f);
+		Box.HSplitBottom(20.0f, &Box, &Row);
+		Box.HSplitBottom(10.0f, &Box, nullptr);
+		Row.VSplitMid(&UseSoundsCheckbox, &ShowChatCheckbox, 20.0f);
+		Box.HSplitBottom(20.0f, &Box, &Row);
+		Row.VSplitMid(&Row, &ShowHudButton, 20.0f);
 
-		if(DoButton_CheckBox(&g_Config.m_ClVideoShowChat, Localize("Show chat"), g_Config.m_ClVideoShowChat, &ShowChatCheckbox))
-			g_Config.m_ClVideoShowChat ^= 1;
+		if(DoButton_CheckBox(&g_Config.m_ClVideoTouchControls, Localize("Show touch controls"), g_Config.m_ClVideoTouchControls, &ShowTouchControlsCheckbox))
+			g_Config.m_ClVideoTouchControls ^= 1;
 
 		if(DoButton_CheckBox(&g_Config.m_ClVideoSndEnable, Localize("Use sounds"), g_Config.m_ClVideoSndEnable, &UseSoundsCheckbox))
 			g_Config.m_ClVideoSndEnable ^= 1;
 
-		CUIRect ShowHudButton;
-		Box.HSplitBottom(20.0f, &Box, &Row);
-		Row.VSplitMid(&Row, &ShowHudButton, 20.0f);
+		if(DoButton_CheckBox(&g_Config.m_ClVideoShowChat, Localize("Show chat"), g_Config.m_ClVideoShowChat, &ShowChatCheckbox))
+			g_Config.m_ClVideoShowChat ^= 1;
 
 		if(DoButton_CheckBox(&g_Config.m_ClVideoShowhud, Localize("Show ingame HUD"), g_Config.m_ClVideoShowhud, &ShowHudButton))
 			g_Config.m_ClVideoShowhud ^= 1;

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -43,11 +43,11 @@ void CMenus::RenderGame(CUIRect MainView)
 {
 	CUIRect Button, ButtonBars, ButtonBar, ButtonBar2;
 	bool ShowDDRaceButtons = MainView.w > 855.0f;
-	MainView.HSplitTop(45.0f + (g_Config.m_ClTouchControls ? 35.0f : 0.0f), &ButtonBars, &MainView);
+	MainView.HSplitTop(45.0f + (GameClient()->m_TouchControls.IsActive() ? 35.0f : 0.0f), &ButtonBars, &MainView);
 	ButtonBars.Draw(ms_ColorTabbarActive, IGraphics::CORNER_B, 10.0f);
 	ButtonBars.Margin(10.0f, &ButtonBars);
 	ButtonBars.HSplitTop(25.0f, &ButtonBar, &ButtonBars);
-	if(g_Config.m_ClTouchControls)
+	if(GameClient()->m_TouchControls.IsActive())
 	{
 		ButtonBars.HSplitTop(10.0f, nullptr, &ButtonBars);
 		ButtonBars.HSplitTop(25.0f, &ButtonBar2, &ButtonBars);
@@ -231,7 +231,7 @@ void CMenus::RenderGame(CUIRect MainView)
 		GameClient()->m_Tooltips.DoToolTip(&s_AutoCameraButton, &Button, m_pClient->m_Camera.AutoSpecCameraTooltip());
 	}
 
-	if(g_Config.m_ClTouchControls)
+	if(GameClient()->m_TouchControls.IsActive())
 	{
 		ButtonBar2.VSplitLeft(200.0f, &Button, &ButtonBar2);
 		static char s_TouchControlsEditCheckbox;
@@ -1588,7 +1588,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 void CMenus::RenderIngameHint()
 {
 	// With touch controls enabled there is a Close button in the menu and usually no Escape key available.
-	if(g_Config.m_ClTouchControls)
+	if(GameClient()->m_TouchControls.IsActive())
 		return;
 
 	float Width = 300 * Graphics()->ScreenAspect();

--- a/src/game/client/components/touch_controls.cpp
+++ b/src/game/client/components/touch_controls.cpp
@@ -721,9 +721,7 @@ void CTouchControls::OnWindowResize()
 
 bool CTouchControls::OnTouchState(const std::vector<IInput::CTouchFingerState> &vTouchFingerStates)
 {
-	if(!g_Config.m_ClTouchControls)
-		return false;
-	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+	if(!IsActive())
 		return false;
 	if(GameClient()->m_Chat.IsActive() ||
 		GameClient()->m_GameConsole.IsActive() ||
@@ -741,9 +739,7 @@ bool CTouchControls::OnTouchState(const std::vector<IInput::CTouchFingerState> &
 
 void CTouchControls::OnRender()
 {
-	if(!g_Config.m_ClTouchControls)
-		return;
-	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+	if(!IsActive())
 		return;
 	if(GameClient()->m_Chat.IsActive() ||
 		GameClient()->m_Emoticon.IsActive() ||
@@ -756,6 +752,21 @@ void CTouchControls::OnRender()
 	Graphics()->MapScreen(0.0f, 0.0f, ScreenSize.x, ScreenSize.y);
 
 	RenderButtons();
+}
+
+bool CTouchControls::IsActive() const
+{
+	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+	{
+		return false;
+	}
+#if defined(CONF_VIDEORECORDER)
+	if(IVideo::Current())
+	{
+		return g_Config.m_ClVideoTouchControls;
+	}
+#endif
+	return g_Config.m_ClTouchControls;
 }
 
 bool CTouchControls::LoadConfigurationFromFile(int StorageType)

--- a/src/game/client/components/touch_controls.h
+++ b/src/game/client/components/touch_controls.h
@@ -44,6 +44,7 @@ public:
 	void OnWindowResize() override;
 	bool OnTouchState(const std::vector<IInput::CTouchFingerState> &vTouchFingerStates) override;
 	void OnRender() override;
+	bool IsActive() const;
 
 	bool LoadConfigurationFromFile(int StorageType);
 	bool LoadConfigurationFromClipboard();


### PR DESCRIPTION
Add `cl_video_touch_controls` option which overrides whether the touch controls are shown while rendering a demo, to more easily hide/show all touch controls while rendering a demo instead of having to manually disable and enable `cl_touch_controls`.

Add checkbox to demo rendering popup to toggle `cl_video_touch_controls`.

This is preparation for adding demo rendering support on Android. Though this change already affects other platforms potentially using touch controls.

Screenshots:
- Before: 
![screenshot_2025-05-02_15-44-41](https://github.com/user-attachments/assets/49006119-9a65-4c5e-94b9-4b6af8ad1d0c)
- After: 
![screenshot_2025-05-02_15-44-22](https://github.com/user-attachments/assets/facc47f8-de60-4085-80a0-36ae398c7ece)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
