### PR TITLE
Refactor: build render pipeline for maplayers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2382,6 +2382,8 @@ if(CLIENT)
     components/players.h
     components/race_demo.cpp
     components/race_demo.h
+    components/render_layer.cpp
+    components/render_layer.h
     components/scoreboard.cpp
     components/scoreboard.h
     components/skins.cpp

--- a/src/game/client/components/background.cpp
+++ b/src/game/client/components/background.cpp
@@ -34,11 +34,6 @@ CBackgroundEngineMap *CBackground::CreateBGMap()
 	return new CBackgroundEngineMap;
 }
 
-const char *CBackground::LoadingTitle() const
-{
-	return Localize("Loading background map");
-}
-
 void CBackground::OnInit()
 {
 	m_pBackgroundMap = CreateBGMap();

--- a/src/game/client/components/background.h
+++ b/src/game/client/components/background.h
@@ -32,8 +32,6 @@ protected:
 
 	virtual CBackgroundEngineMap *CreateBGMap();
 
-	const char *LoadingTitle() const override;
-
 public:
 	CBackground(int MapType = CMapLayers::TYPE_BACKGROUND_FORCE, bool OnlineOnly = true);
 	virtual ~CBackground();

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -1,21 +1,6 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#include <engine/demo.h>
-#include <engine/graphics.h>
-#include <engine/keys.h>
-#include <engine/serverbrowser.h>
-#include <engine/shared/config.h>
-#include <engine/storage.h>
-
 #include <game/client/gameclient.h>
-#include <game/client/render.h>
-
-#include <game/layers.h>
-#include <game/mapitems.h>
-#include <game/mapitems_ex.h>
-
-#include <game/client/components/camera.h>
-#include <game/client/components/mapimages.h>
 #include <game/localization.h>
 
 #include "maplayers.h"
@@ -25,6 +10,54 @@
 using namespace std::chrono_literals;
 
 const int LAYER_DEFAULT_TILESET = -1;
+
+void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, IMap *pMap, CMapBasedEnvelopePointAccess *pEnvelopePoints, IClient *pClient, CGameClient *pGameClient, bool OnlineOnly)
+{
+	int EnvStart, EnvNum;
+	pMap->GetType(MAPITEMTYPE_ENVELOPE, &EnvStart, &EnvNum);
+	if(Env < 0 || Env >= EnvNum)
+		return;
+
+	const CMapItemEnvelope *pItem = (CMapItemEnvelope *)pMap->GetItem(EnvStart + Env);
+	if(pItem->m_Channels <= 0)
+		return;
+	Channels = minimum<size_t>(Channels, pItem->m_Channels, CEnvPoint::MAX_CHANNELS);
+
+	pEnvelopePoints->SetPointsRange(pItem->m_StartPoint, pItem->m_NumPoints);
+	if(pEnvelopePoints->NumPoints() == 0)
+		return;
+
+	static std::chrono::nanoseconds s_Time{0};
+	static auto s_LastLocalTime = time_get_nanoseconds();
+	if(OnlineOnly && (pItem->m_Version < 2 || pItem->m_Synchronized))
+	{
+		if(pGameClient->m_Snap.m_pGameInfoObj)
+		{
+			// get the lerp of the current tick and prev
+			const auto TickToNanoSeconds = std::chrono::nanoseconds(1s) / (int64_t)pClient->GameTickSpeed();
+			const int MinTick = pClient->PrevGameTick(g_Config.m_ClDummy) - pGameClient->m_Snap.m_pGameInfoObj->m_RoundStartTick;
+			const int CurTick = pClient->GameTick(g_Config.m_ClDummy) - pGameClient->m_Snap.m_pGameInfoObj->m_RoundStartTick;
+			s_Time = std::chrono::nanoseconds((int64_t)(mix<double>(
+									    0,
+									    (CurTick - MinTick),
+									    (double)pClient->IntraGameTick(g_Config.m_ClDummy)) *
+								    TickToNanoSeconds.count())) +
+				 MinTick * TickToNanoSeconds;
+		}
+	}
+	else
+	{
+		const auto CurTime = time_get_nanoseconds();
+		s_Time += CurTime - s_LastLocalTime;
+		s_LastLocalTime = CurTime;
+	}
+	CRenderTools::RenderEvalEnvelope(pEnvelopePoints, s_Time + std::chrono::nanoseconds(std::chrono::milliseconds(TimeOffsetMillis)), Result, Channels);
+}
+
+void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels)
+{
+	EnvelopeEval(TimeOffsetMillis, Env, Result, Channels, this->m_pLayers->Map(), this->m_pEnvelopePoints.get(), this->Client(), this->m_pClient, this->m_OnlineOnly);
+}
 
 CMapLayers::CMapLayers(int Type, bool OnlineOnly)
 {
@@ -43,326 +76,15 @@ CCamera *CMapLayers::GetCurCamera()
 	return &m_pClient->m_Camera;
 }
 
-const char *CMapLayers::LoadingTitle() const
-{
-	return GameClient()->DemoPlayer()->IsPlaying() ? Localize("Preparing demo playback") : Localize("Connected");
-}
-
-void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, void *pUser)
-{
-	CMapLayers *pThis = (CMapLayers *)pUser;
-
-	int EnvStart, EnvNum;
-	pThis->m_pLayers->Map()->GetType(MAPITEMTYPE_ENVELOPE, &EnvStart, &EnvNum);
-	if(Env < 0 || Env >= EnvNum)
-		return;
-
-	const CMapItemEnvelope *pItem = (CMapItemEnvelope *)pThis->m_pLayers->Map()->GetItem(EnvStart + Env);
-	if(pItem->m_Channels <= 0)
-		return;
-	Channels = minimum<size_t>(Channels, pItem->m_Channels, CEnvPoint::MAX_CHANNELS);
-
-	pThis->m_pEnvelopePoints->SetPointsRange(pItem->m_StartPoint, pItem->m_NumPoints);
-	if(pThis->m_pEnvelopePoints->NumPoints() == 0)
-		return;
-
-	static std::chrono::nanoseconds s_Time{0};
-	static auto s_LastLocalTime = time_get_nanoseconds();
-	if(pThis->m_OnlineOnly && (pItem->m_Version < 2 || pItem->m_Synchronized))
-	{
-		if(pThis->m_pClient->m_Snap.m_pGameInfoObj)
-		{
-			// get the lerp of the current tick and prev
-			const auto TickToNanoSeconds = std::chrono::nanoseconds(1s) / (int64_t)pThis->Client()->GameTickSpeed();
-			const int MinTick = pThis->Client()->PrevGameTick(g_Config.m_ClDummy) - pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick;
-			const int CurTick = pThis->Client()->GameTick(g_Config.m_ClDummy) - pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick;
-			s_Time = std::chrono::nanoseconds((int64_t)(mix<double>(
-									    0,
-									    (CurTick - MinTick),
-									    (double)pThis->Client()->IntraGameTick(g_Config.m_ClDummy)) *
-								    TickToNanoSeconds.count())) +
-				 MinTick * TickToNanoSeconds;
-		}
-	}
-	else
-	{
-		const auto CurTime = time_get_nanoseconds();
-		s_Time += CurTime - s_LastLocalTime;
-		s_LastLocalTime = CurTime;
-	}
-	CRenderTools::RenderEvalEnvelope(pThis->m_pEnvelopePoints.get(), s_Time + std::chrono::nanoseconds(std::chrono::milliseconds(TimeOffsetMillis)), Result, Channels);
-}
-
-static void FillTmpTile(SGraphicTile *pTmpTile, SGraphicTileTexureCoords *pTmpTex, unsigned char Flags, unsigned char Index, int x, int y, const ivec2 &Offset, int Scale)
-{
-	if(pTmpTex)
-	{
-		unsigned char x0 = 0;
-		unsigned char y0 = 0;
-		unsigned char x1 = x0 + 1;
-		unsigned char y1 = y0;
-		unsigned char x2 = x0 + 1;
-		unsigned char y2 = y0 + 1;
-		unsigned char x3 = x0;
-		unsigned char y3 = y0 + 1;
-
-		if(Flags & TILEFLAG_XFLIP)
-		{
-			x0 = x2;
-			x1 = x3;
-			x2 = x3;
-			x3 = x0;
-		}
-
-		if(Flags & TILEFLAG_YFLIP)
-		{
-			y0 = y3;
-			y2 = y1;
-			y3 = y1;
-			y1 = y0;
-		}
-
-		if(Flags & TILEFLAG_ROTATE)
-		{
-			unsigned char Tmp = x0;
-			x0 = x3;
-			x3 = x2;
-			x2 = x1;
-			x1 = Tmp;
-			Tmp = y0;
-			y0 = y3;
-			y3 = y2;
-			y2 = y1;
-			y1 = Tmp;
-		}
-
-		pTmpTex->m_TexCoordTopLeft.x = x0;
-		pTmpTex->m_TexCoordTopLeft.y = y0;
-		pTmpTex->m_TexCoordBottomLeft.x = x3;
-		pTmpTex->m_TexCoordBottomLeft.y = y3;
-		pTmpTex->m_TexCoordTopRight.x = x1;
-		pTmpTex->m_TexCoordTopRight.y = y1;
-		pTmpTex->m_TexCoordBottomRight.x = x2;
-		pTmpTex->m_TexCoordBottomRight.y = y2;
-
-		pTmpTex->m_TexCoordTopLeft.z = Index;
-		pTmpTex->m_TexCoordBottomLeft.z = Index;
-		pTmpTex->m_TexCoordTopRight.z = Index;
-		pTmpTex->m_TexCoordBottomRight.z = Index;
-
-		bool HasRotation = (Flags & TILEFLAG_ROTATE) != 0;
-		pTmpTex->m_TexCoordTopLeft.w = HasRotation;
-		pTmpTex->m_TexCoordBottomLeft.w = HasRotation;
-		pTmpTex->m_TexCoordTopRight.w = HasRotation;
-		pTmpTex->m_TexCoordBottomRight.w = HasRotation;
-	}
-
-	pTmpTile->m_TopLeft.x = x * Scale + Offset.x;
-	pTmpTile->m_TopLeft.y = y * Scale + Offset.y;
-	pTmpTile->m_BottomLeft.x = x * Scale + Offset.x;
-	pTmpTile->m_BottomLeft.y = y * Scale + Scale + Offset.y;
-	pTmpTile->m_TopRight.x = x * Scale + Scale + Offset.x;
-	pTmpTile->m_TopRight.y = y * Scale + Offset.y;
-	pTmpTile->m_BottomRight.x = x * Scale + Scale + Offset.x;
-	pTmpTile->m_BottomRight.y = y * Scale + Scale + Offset.y;
-}
-
-static void FillTmpTileSpeedup(SGraphicTile *pTmpTile, SGraphicTileTexureCoords *pTmpTex, unsigned char Flags, int x, int y, const ivec2 &Offset, int Scale, short AngleRotate)
-{
-	int Angle = AngleRotate % 360;
-	FillTmpTile(pTmpTile, pTmpTex, Angle >= 270 ? ROTATION_270 : (Angle >= 180 ? ROTATION_180 : (Angle >= 90 ? ROTATION_90 : 0)), AngleRotate % 90, x, y, Offset, Scale);
-}
-
-bool CMapLayers::STileLayerVisuals::Init(unsigned int Width, unsigned int Height)
-{
-	m_Width = Width;
-	m_Height = Height;
-	if(Width == 0 || Height == 0)
-		return false;
-	if constexpr(sizeof(unsigned int) >= sizeof(ptrdiff_t))
-		if(Width >= std::numeric_limits<std::ptrdiff_t>::max() || Height >= std::numeric_limits<std::ptrdiff_t>::max())
-			return false;
-
-	m_pTilesOfLayer = new CMapLayers::STileLayerVisuals::STileVisual[Height * Width];
-
-	m_vBorderTop.resize(Width);
-	m_vBorderBottom.resize(Width);
-
-	m_vBorderLeft.resize(Height);
-	m_vBorderRight.resize(Height);
-	return true;
-}
-
-CMapLayers::STileLayerVisuals::~STileLayerVisuals()
-{
-	delete[] m_pTilesOfLayer;
-
-	m_pTilesOfLayer = nullptr;
-}
-
-static bool AddTile(std::vector<SGraphicTile> &vTmpTiles, std::vector<SGraphicTileTexureCoords> &vTmpTileTexCoords, unsigned char Index, unsigned char Flags, int x, int y, bool DoTextureCoords, bool FillSpeedup = false, int AngleRotate = -1, const ivec2 &Offset = ivec2{0, 0}, int Scale = 32)
-{
-	if(Index)
-	{
-		vTmpTiles.emplace_back();
-		SGraphicTile &Tile = vTmpTiles.back();
-		SGraphicTileTexureCoords *pTileTex = nullptr;
-		if(DoTextureCoords)
-		{
-			vTmpTileTexCoords.emplace_back();
-			SGraphicTileTexureCoords &TileTex = vTmpTileTexCoords.back();
-			pTileTex = &TileTex;
-		}
-		if(FillSpeedup)
-			FillTmpTileSpeedup(&Tile, pTileTex, Flags, x, y, Offset, Scale, AngleRotate);
-		else
-			FillTmpTile(&Tile, pTileTex, Flags, Index, x, y, Offset, Scale);
-
-		return true;
-	}
-	return false;
-}
-
-struct STmpQuadVertexTextured
-{
-	float m_X, m_Y, m_CenterX, m_CenterY;
-	unsigned char m_R, m_G, m_B, m_A;
-	float m_U, m_V;
-};
-
-struct STmpQuadVertex
-{
-	float m_X, m_Y, m_CenterX, m_CenterY;
-	unsigned char m_R, m_G, m_B, m_A;
-};
-
-struct STmpQuad
-{
-	STmpQuadVertex m_aVertices[4];
-};
-
-struct STmpQuadTextured
-{
-	STmpQuadVertexTextured m_aVertices[4];
-};
-
-void mem_copy_special(void *pDest, void *pSource, size_t Size, size_t Count, size_t Steps)
-{
-	size_t CurStep = 0;
-	for(size_t i = 0; i < Count; ++i)
-	{
-		mem_copy(((char *)pDest) + CurStep + i * Size, ((char *)pSource) + i * Size, Size);
-		CurStep += Steps;
-	}
-}
-
-CMapLayers::~CMapLayers()
-{
-	// clear everything and destroy all buffers
-	if(!m_vpTileLayerVisuals.empty())
-	{
-		int s = m_vpTileLayerVisuals.size();
-		for(int i = 0; i < s; ++i)
-		{
-			delete m_vpTileLayerVisuals[i];
-		}
-	}
-	if(!m_vpQuadLayerVisuals.empty())
-	{
-		int s = m_vpQuadLayerVisuals.size();
-		for(int i = 0; i < s; ++i)
-		{
-			delete m_vpQuadLayerVisuals[i];
-		}
-	}
-}
-
 void CMapLayers::OnMapLoad()
 {
-	m_pEnvelopePoints = std::make_unique<CMapBasedEnvelopePointAccess>(m_pLayers->Map());
-
-	if(!Graphics()->IsTileBufferingEnabled() && !Graphics()->IsQuadBufferingEnabled())
-	{
-		// Find game group
-		for(int g = 0; g < m_pLayers->NumGroups(); g++)
-		{
-			CMapItemGroup *pGroup = m_pLayers->GetGroup(g);
-			if(!pGroup)
-			{
-				dbg_msg("maplayers", "error group was null, group number = %d, total groups = %d", g, m_pLayers->NumGroups());
-				dbg_msg("maplayers", "this is here to prevent a crash but the source of this is unknown, please report this for it to get fixed");
-				dbg_msg("maplayers", "we need mapname and crc and the map that caused this if possible, and anymore info you think is relevant");
-				continue;
-			}
-
-			for(int l = 0; l < pGroup->m_NumLayers; l++)
-			{
-				CMapItemLayer *pLayer = m_pLayers->GetLayer(pGroup->m_StartLayer + l);
-				int LayerType = GetLayerType(pLayer);
-				if(LayerType == LAYER_GAME)
-				{
-					m_GameGroup = g;
-					return;
-				}
-			}
-		}
-		dbg_msg("maplayers", "failed to find game group, total groups = %d", m_pLayers->NumGroups());
-		return;
-	}
-
-	const char *pLoadingTitle = LoadingTitle();
-	const char *pLoadingMessage = Localize("Uploading map data to GPU");
-	auto &&RenderLoading = [&]() {
-		GameClient()->m_Menus.RenderLoading(pLoadingTitle, pLoadingMessage, 0);
-	};
-
-	// clear everything and destroy all buffers
-	if(!m_vpTileLayerVisuals.empty())
-	{
-		int s = m_vpTileLayerVisuals.size();
-		for(int i = 0; i < s; ++i)
-		{
-			Graphics()->DeleteBufferContainer(m_vpTileLayerVisuals[i]->m_BufferContainerIndex, true);
-			delete m_vpTileLayerVisuals[i];
-		}
-		m_vpTileLayerVisuals.clear();
-	}
-	if(!m_vpQuadLayerVisuals.empty())
-	{
-		int s = m_vpQuadLayerVisuals.size();
-		for(int i = 0; i < s; ++i)
-		{
-			Graphics()->DeleteBufferContainer(m_vpQuadLayerVisuals[i]->m_BufferContainerIndex, true);
-			delete m_vpQuadLayerVisuals[i];
-		}
-		m_vpQuadLayerVisuals.clear();
-
-		RenderLoading();
-	}
-
+	m_pEnvelopePoints = std::make_shared<CMapBasedEnvelopePointAccess>(m_pLayers->Map());
 	bool PassedGameLayer = false;
-	// prepare all visuals for all tile layers
-	std::vector<SGraphicTile> vtmpTiles;
-	std::vector<SGraphicTileTexureCoords> vtmpTileTexCoords;
-	std::vector<SGraphicTile> vtmpBorderTopTiles;
-	std::vector<SGraphicTileTexureCoords> vtmpBorderTopTilesTexCoords;
-	std::vector<SGraphicTile> vtmpBorderLeftTiles;
-	std::vector<SGraphicTileTexureCoords> vtmpBorderLeftTilesTexCoords;
-	std::vector<SGraphicTile> vtmpBorderRightTiles;
-	std::vector<SGraphicTileTexureCoords> vtmpBorderRightTilesTexCoords;
-	std::vector<SGraphicTile> vtmpBorderBottomTiles;
-	std::vector<SGraphicTileTexureCoords> vtmpBorderBottomTilesTexCoords;
-	std::vector<SGraphicTile> vtmpBorderCorners;
-	std::vector<SGraphicTileTexureCoords> vtmpBorderCornersTexCoords;
+	m_vRenderLayers.clear();
 
-	std::vector<STmpQuad> vtmpQuads;
-	std::vector<STmpQuadTextured> vtmpQuadsTextured;
-
-	m_vvLayerCount.clear();
-	m_vvLayerCount.resize(m_pLayers->NumGroups());
-
-	int TileLayerCounter = 0;
-	int QuadLayerCounter = 0;
+	const char *pLoadingTitle = Localize("Loading map");
+	const char *pLoadingMessage = Localize("Uploading map data to GPU");
+	m_pClient->m_Menus.RenderLoading(pLoadingTitle, pLoadingMessage, 0);
 
 	for(int g = 0; g < m_pLayers->NumGroups(); g++)
 	{
@@ -375,24 +97,16 @@ void CMapLayers::OnMapLoad()
 			continue;
 		}
 
-		std::vector<int> vLayerCounter(pGroup->m_NumLayers, 0);
-
 		for(int l = 0; l < pGroup->m_NumLayers; l++)
 		{
 			CMapItemLayer *pLayer = m_pLayers->GetLayer(pGroup->m_StartLayer + l);
 			int LayerType = GetLayerType(pLayer);
 			PassedGameLayer |= LayerType == LAYER_GAME;
-			bool IsEntityLayer = LayerType != LAYER_DEFAULT_TILESET;
-			if(LayerType == LAYER_GAME)
-				m_GameGroup = g;
 
-			if(m_Type <= TYPE_BACKGROUND_FORCE)
+			if(m_Type == TYPE_BACKGROUND_FORCE || m_Type == TYPE_BACKGROUND)
 			{
 				if(PassedGameLayer)
-				{
-					m_vvLayerCount[g] = vLayerCounter;
 					return;
-				}
 			}
 			else if(m_Type == TYPE_FOREGROUND)
 			{
@@ -400,699 +114,90 @@ void CMapLayers::OnMapLoad()
 					continue;
 			}
 
-			if(pLayer->m_Type == LAYERTYPE_TILES && Graphics()->IsTileBufferingEnabled())
+			std::unique_ptr<CRenderLayer> pRenderLayer;
+
+			if(pLayer->m_Type == LAYERTYPE_TILES)
 			{
-				CMapItemLayerTilemap *pTMap = (CMapItemLayerTilemap *)pLayer;
-				const bool DoTextureCoords = IsEntityLayer || (pTMap->m_Image >= 0 && pTMap->m_Image < m_pImages->Num());
+				CMapItemLayerTilemap *pTileLayer = (CMapItemLayerTilemap *)pLayer;
 
-				void *pTiles;
-				int TileLayerAndOverlayCount = GetTileLayerAndOverlayCount(pTMap, LayerType, &pTiles);
-
-				if(TileLayerAndOverlayCount)
+				switch(LayerType)
 				{
-					TileLayerCounter += TileLayerAndOverlayCount;
-					vLayerCounter[l] = TileLayerCounter;
-
-					int CurOverlay = 0;
-					while(CurOverlay < TileLayerAndOverlayCount)
-					{
-						// We can later just count the tile layers to get the idx in the vector
-						m_vpTileLayerVisuals.push_back(new STileLayerVisuals());
-						STileLayerVisuals &Visuals = *m_vpTileLayerVisuals.back();
-						if(!Visuals.Init(pTMap->m_Width, pTMap->m_Height))
-						{
-							++CurOverlay;
-							continue;
-						}
-						Visuals.m_IsTextured = DoTextureCoords;
-
-						vtmpTiles.clear();
-						vtmpTileTexCoords.clear();
-
-						vtmpBorderTopTiles.clear();
-						vtmpBorderLeftTiles.clear();
-						vtmpBorderRightTiles.clear();
-						vtmpBorderBottomTiles.clear();
-						vtmpBorderCorners.clear();
-						vtmpBorderTopTilesTexCoords.clear();
-						vtmpBorderLeftTilesTexCoords.clear();
-						vtmpBorderRightTilesTexCoords.clear();
-						vtmpBorderBottomTilesTexCoords.clear();
-						vtmpBorderCornersTexCoords.clear();
-
-						if(!DoTextureCoords)
-						{
-							vtmpTiles.reserve((size_t)pTMap->m_Width * pTMap->m_Height);
-							vtmpBorderTopTiles.reserve((size_t)pTMap->m_Width);
-							vtmpBorderBottomTiles.reserve((size_t)pTMap->m_Width);
-							vtmpBorderLeftTiles.reserve((size_t)pTMap->m_Height);
-							vtmpBorderRightTiles.reserve((size_t)pTMap->m_Height);
-							vtmpBorderCorners.reserve((size_t)4);
-						}
-						else
-						{
-							vtmpTileTexCoords.reserve((size_t)pTMap->m_Width * pTMap->m_Height);
-							vtmpBorderTopTilesTexCoords.reserve((size_t)pTMap->m_Width);
-							vtmpBorderBottomTilesTexCoords.reserve((size_t)pTMap->m_Width);
-							vtmpBorderLeftTilesTexCoords.reserve((size_t)pTMap->m_Height);
-							vtmpBorderRightTilesTexCoords.reserve((size_t)pTMap->m_Height);
-							vtmpBorderCornersTexCoords.reserve((size_t)4);
-						}
-
-						int x = 0;
-						int y = 0;
-						for(y = 0; y < pTMap->m_Height; ++y)
-						{
-							for(x = 0; x < pTMap->m_Width; ++x)
-							{
-								unsigned char Index = 0;
-								unsigned char Flags = 0;
-								int AngleRotate = -1;
-
-								if(!IsEntityLayer || LayerType == LAYER_GAME || LayerType == LAYER_FRONT)
-								{
-									Index = ((CTile *)pTiles)[y * pTMap->m_Width + x].m_Index;
-									Flags = ((CTile *)pTiles)[y * pTMap->m_Width + x].m_Flags;
-								}
-								else if(LayerType == LAYER_SWITCH)
-								{
-									Flags = 0;
-									Index = ((CSwitchTile *)pTiles)[y * pTMap->m_Width + x].m_Type;
-									if(CurOverlay == 0)
-									{
-										Flags = ((CSwitchTile *)pTiles)[y * pTMap->m_Width + x].m_Flags;
-										if(Index == TILE_SWITCHTIMEDOPEN)
-											Index = 8;
-									}
-									else if(CurOverlay == 1)
-										Index = ((CSwitchTile *)pTiles)[y * pTMap->m_Width + x].m_Number;
-									else if(CurOverlay == 2)
-										Index = ((CSwitchTile *)pTiles)[y * pTMap->m_Width + x].m_Delay;
-								}
-								else if(LayerType == LAYER_TELE)
-								{
-									Index = ((CTeleTile *)pTiles)[y * pTMap->m_Width + x].m_Type;
-									Flags = 0;
-									if(CurOverlay == 1)
-									{
-										if(IsTeleTileNumberUsedAny(Index))
-											Index = ((CTeleTile *)pTiles)[y * pTMap->m_Width + x].m_Number;
-										else
-											Index = 0;
-									}
-								}
-								else if(LayerType == LAYER_SPEEDUP)
-								{
-									Index = ((CSpeedupTile *)pTiles)[y * pTMap->m_Width + x].m_Type;
-									unsigned char Force = ((CSpeedupTile *)pTiles)[y * pTMap->m_Width + x].m_Force;
-									unsigned char MaxSpeed = ((CSpeedupTile *)pTiles)[y * pTMap->m_Width + x].m_MaxSpeed;
-									Flags = 0;
-									AngleRotate = ((CSpeedupTile *)pTiles)[y * pTMap->m_Width + x].m_Angle;
-									if((Force == 0 && Index == TILE_SPEED_BOOST_OLD) || (Force == 0 && MaxSpeed == 0 && Index == TILE_SPEED_BOOST) || !IsValidSpeedupTile(Index))
-										Index = 0;
-									else if(CurOverlay == 1)
-										Index = Force;
-									else if(CurOverlay == 2)
-										Index = MaxSpeed;
-								}
-								else if(LayerType == LAYER_TUNE)
-								{
-									Index = ((CTuneTile *)pTiles)[y * pTMap->m_Width + x].m_Type;
-									Flags = 0;
-								}
-
-								// the amount of tiles handled before this tile
-								int TilesHandledCount = vtmpTiles.size();
-								Visuals.m_pTilesOfLayer[y * pTMap->m_Width + x].SetIndexBufferByteOffset((offset_ptr32)(TilesHandledCount));
-
-								bool AddAsSpeedup = false;
-								if(LayerType == LAYER_SPEEDUP && CurOverlay == 0)
-									AddAsSpeedup = true;
-
-								if(AddTile(vtmpTiles, vtmpTileTexCoords, Index, Flags, x, y, DoTextureCoords, AddAsSpeedup, AngleRotate))
-									Visuals.m_pTilesOfLayer[y * pTMap->m_Width + x].Draw(true);
-
-								// do the border tiles
-								if(x == 0)
-								{
-									if(y == 0)
-									{
-										Visuals.m_BorderTopLeft.SetIndexBufferByteOffset((offset_ptr32)(vtmpBorderCorners.size()));
-										if(AddTile(vtmpBorderCorners, vtmpBorderCornersTexCoords, Index, Flags, 0, 0, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{-32, -32}))
-											Visuals.m_BorderTopLeft.Draw(true);
-									}
-									else if(y == pTMap->m_Height - 1)
-									{
-										Visuals.m_BorderBottomLeft.SetIndexBufferByteOffset((offset_ptr32)(vtmpBorderCorners.size()));
-										if(AddTile(vtmpBorderCorners, vtmpBorderCornersTexCoords, Index, Flags, 0, 0, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{-32, 0}))
-											Visuals.m_BorderBottomLeft.Draw(true);
-									}
-									Visuals.m_vBorderLeft[y].SetIndexBufferByteOffset((offset_ptr32)(vtmpBorderLeftTiles.size()));
-									if(AddTile(vtmpBorderLeftTiles, vtmpBorderLeftTilesTexCoords, Index, Flags, 0, y, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{-32, 0}))
-										Visuals.m_vBorderLeft[y].Draw(true);
-								}
-								else if(x == pTMap->m_Width - 1)
-								{
-									if(y == 0)
-									{
-										Visuals.m_BorderTopRight.SetIndexBufferByteOffset((offset_ptr32)(vtmpBorderCorners.size()));
-										if(AddTile(vtmpBorderCorners, vtmpBorderCornersTexCoords, Index, Flags, 0, 0, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{0, -32}))
-											Visuals.m_BorderTopRight.Draw(true);
-									}
-									else if(y == pTMap->m_Height - 1)
-									{
-										Visuals.m_BorderBottomRight.SetIndexBufferByteOffset((offset_ptr32)(vtmpBorderCorners.size()));
-										if(AddTile(vtmpBorderCorners, vtmpBorderCornersTexCoords, Index, Flags, 0, 0, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{0, 0}))
-											Visuals.m_BorderBottomRight.Draw(true);
-									}
-									Visuals.m_vBorderRight[y].SetIndexBufferByteOffset((offset_ptr32)(vtmpBorderRightTiles.size()));
-									if(AddTile(vtmpBorderRightTiles, vtmpBorderRightTilesTexCoords, Index, Flags, 0, y, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{0, 0}))
-										Visuals.m_vBorderRight[y].Draw(true);
-								}
-								if(y == 0)
-								{
-									Visuals.m_vBorderTop[x].SetIndexBufferByteOffset((offset_ptr32)(vtmpBorderTopTiles.size()));
-									if(AddTile(vtmpBorderTopTiles, vtmpBorderTopTilesTexCoords, Index, Flags, x, 0, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{0, -32}))
-										Visuals.m_vBorderTop[x].Draw(true);
-								}
-								else if(y == pTMap->m_Height - 1)
-								{
-									Visuals.m_vBorderBottom[x].SetIndexBufferByteOffset((offset_ptr32)(vtmpBorderBottomTiles.size()));
-									if(AddTile(vtmpBorderBottomTiles, vtmpBorderBottomTilesTexCoords, Index, Flags, x, 0, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{0, 0}))
-										Visuals.m_vBorderBottom[x].Draw(true);
-								}
-							}
-						}
-
-						// append one kill tile to the gamelayer
-						if(LayerType == LAYER_GAME)
-						{
-							Visuals.m_BorderKillTile.SetIndexBufferByteOffset((offset_ptr32)(vtmpTiles.size()));
-							if(AddTile(vtmpTiles, vtmpTileTexCoords, TILE_DEATH, 0, 0, 0, DoTextureCoords))
-								Visuals.m_BorderKillTile.Draw(true);
-						}
-
-						// add the border corners, then the borders and fix their byte offsets
-						int TilesHandledCount = vtmpTiles.size();
-						Visuals.m_BorderTopLeft.AddIndexBufferByteOffset(TilesHandledCount);
-						Visuals.m_BorderTopRight.AddIndexBufferByteOffset(TilesHandledCount);
-						Visuals.m_BorderBottomLeft.AddIndexBufferByteOffset(TilesHandledCount);
-						Visuals.m_BorderBottomRight.AddIndexBufferByteOffset(TilesHandledCount);
-						// add the Corners to the tiles
-						vtmpTiles.insert(vtmpTiles.end(), vtmpBorderCorners.begin(), vtmpBorderCorners.end());
-						vtmpTileTexCoords.insert(vtmpTileTexCoords.end(), vtmpBorderCornersTexCoords.begin(), vtmpBorderCornersTexCoords.end());
-
-						// now the borders
-						TilesHandledCount = vtmpTiles.size();
-						if(pTMap->m_Width > 0)
-						{
-							for(int i = 0; i < pTMap->m_Width; ++i)
-							{
-								Visuals.m_vBorderTop[i].AddIndexBufferByteOffset(TilesHandledCount);
-							}
-						}
-						vtmpTiles.insert(vtmpTiles.end(), vtmpBorderTopTiles.begin(), vtmpBorderTopTiles.end());
-						vtmpTileTexCoords.insert(vtmpTileTexCoords.end(), vtmpBorderTopTilesTexCoords.begin(), vtmpBorderTopTilesTexCoords.end());
-
-						TilesHandledCount = vtmpTiles.size();
-						if(pTMap->m_Width > 0)
-						{
-							for(int i = 0; i < pTMap->m_Width; ++i)
-							{
-								Visuals.m_vBorderBottom[i].AddIndexBufferByteOffset(TilesHandledCount);
-							}
-						}
-						vtmpTiles.insert(vtmpTiles.end(), vtmpBorderBottomTiles.begin(), vtmpBorderBottomTiles.end());
-						vtmpTileTexCoords.insert(vtmpTileTexCoords.end(), vtmpBorderBottomTilesTexCoords.begin(), vtmpBorderBottomTilesTexCoords.end());
-
-						TilesHandledCount = vtmpTiles.size();
-						if(pTMap->m_Height > 0)
-						{
-							for(int i = 0; i < pTMap->m_Height; ++i)
-							{
-								Visuals.m_vBorderLeft[i].AddIndexBufferByteOffset(TilesHandledCount);
-							}
-						}
-						vtmpTiles.insert(vtmpTiles.end(), vtmpBorderLeftTiles.begin(), vtmpBorderLeftTiles.end());
-						vtmpTileTexCoords.insert(vtmpTileTexCoords.end(), vtmpBorderLeftTilesTexCoords.begin(), vtmpBorderLeftTilesTexCoords.end());
-
-						TilesHandledCount = vtmpTiles.size();
-						if(pTMap->m_Height > 0)
-						{
-							for(int i = 0; i < pTMap->m_Height; ++i)
-							{
-								Visuals.m_vBorderRight[i].AddIndexBufferByteOffset(TilesHandledCount);
-							}
-						}
-						vtmpTiles.insert(vtmpTiles.end(), vtmpBorderRightTiles.begin(), vtmpBorderRightTiles.end());
-						vtmpTileTexCoords.insert(vtmpTileTexCoords.end(), vtmpBorderRightTilesTexCoords.begin(), vtmpBorderRightTilesTexCoords.end());
-
-						// setup params
-						float *pTmpTiles = vtmpTiles.empty() ? nullptr : (float *)vtmpTiles.data();
-						unsigned char *pTmpTileTexCoords = vtmpTileTexCoords.empty() ? nullptr : (unsigned char *)vtmpTileTexCoords.data();
-
-						Visuals.m_BufferContainerIndex = -1;
-						size_t UploadDataSize = vtmpTileTexCoords.size() * sizeof(SGraphicTileTexureCoords) + vtmpTiles.size() * sizeof(SGraphicTile);
-						if(UploadDataSize > 0)
-						{
-							char *pUploadData = (char *)malloc(sizeof(char) * UploadDataSize);
-
-							mem_copy_special(pUploadData, pTmpTiles, sizeof(vec2), vtmpTiles.size() * 4, (DoTextureCoords ? sizeof(ubvec4) : 0));
-							if(DoTextureCoords)
-							{
-								mem_copy_special(pUploadData + sizeof(vec2), pTmpTileTexCoords, sizeof(ubvec4), vtmpTiles.size() * 4, sizeof(vec2));
-							}
-
-							// first create the buffer object
-							int BufferObjectIndex = Graphics()->CreateBufferObject(UploadDataSize, pUploadData, 0, true);
-
-							// then create the buffer container
-							SBufferContainerInfo ContainerInfo;
-							ContainerInfo.m_Stride = (DoTextureCoords ? (sizeof(float) * 2 + sizeof(ubvec4)) : 0);
-							ContainerInfo.m_VertBufferBindingIndex = BufferObjectIndex;
-							ContainerInfo.m_vAttributes.emplace_back();
-							SBufferContainerInfo::SAttribute *pAttr = &ContainerInfo.m_vAttributes.back();
-							pAttr->m_DataTypeCount = 2;
-							pAttr->m_Type = GRAPHICS_TYPE_FLOAT;
-							pAttr->m_Normalized = false;
-							pAttr->m_pOffset = nullptr;
-							pAttr->m_FuncType = 0;
-							if(DoTextureCoords)
-							{
-								ContainerInfo.m_vAttributes.emplace_back();
-								pAttr = &ContainerInfo.m_vAttributes.back();
-								pAttr->m_DataTypeCount = 4;
-								pAttr->m_Type = GRAPHICS_TYPE_UNSIGNED_BYTE;
-								pAttr->m_Normalized = false;
-								pAttr->m_pOffset = (void *)(sizeof(vec2));
-								pAttr->m_FuncType = 1;
-							}
-
-							Visuals.m_BufferContainerIndex = Graphics()->CreateBufferContainer(&ContainerInfo);
-							// and finally inform the backend how many indices are required
-							Graphics()->IndicesNumRequiredNotify(vtmpTiles.size() * 6);
-
-							RenderLoading();
-						}
-
-						++CurOverlay;
-					}
+				case LAYER_DEFAULT_TILESET:
+					pRenderLayer = std::make_unique<CRenderLayerTile>(
+						g, l,
+						pLayer->m_Flags,
+						pTileLayer);
+					break;
+				case LAYER_GAME:
+					pRenderLayer = std::make_unique<CRenderLayerEntityGame>(
+						g, l,
+						pLayer->m_Flags,
+						pTileLayer);
+					break;
+				case LAYER_FRONT:
+					pRenderLayer = std::make_unique<CRenderLayerEntityFront>(
+						g, l,
+						pLayer->m_Flags,
+						pTileLayer);
+					break;
+				case LAYER_TELE:
+					pRenderLayer = std::make_unique<CRenderLayerEntityTele>(
+						g, l,
+						pLayer->m_Flags,
+						pTileLayer);
+					break;
+				case LAYER_SPEEDUP:
+					pRenderLayer = std::make_unique<CRenderLayerEntitySpeedup>(
+						g, l,
+						pLayer->m_Flags,
+						pTileLayer);
+					break;
+				case LAYER_SWITCH:
+					pRenderLayer = std::make_unique<CRenderLayerEntitySwitch>(
+						g, l,
+						pLayer->m_Flags,
+						pTileLayer);
+					break;
+				case LAYER_TUNE:
+					pRenderLayer = std::make_unique<CRenderLayerEntityTune>(
+						g, l,
+						pLayer->m_Flags,
+						pTileLayer);
+					break;
+				default:
+					dbg_assert(false, "Unknown LayerType %d", LayerType);
+					break;
 				}
 			}
-			else if(pLayer->m_Type == LAYERTYPE_QUADS && Graphics()->IsQuadBufferingEnabled())
+			else if(pLayer->m_Type == LAYERTYPE_QUADS)
 			{
-				++QuadLayerCounter;
-				vLayerCounter[l] = QuadLayerCounter;
-
 				CMapItemLayerQuads *pQLayer = (CMapItemLayerQuads *)pLayer;
 
-				m_vpQuadLayerVisuals.push_back(new SQuadLayerVisuals());
-				SQuadLayerVisuals *pQLayerVisuals = m_vpQuadLayerVisuals.back();
-
-				const bool Textured = pQLayer->m_Image >= 0 && pQLayer->m_Image < m_pImages->Num();
-
-				vtmpQuads.clear();
-				vtmpQuadsTextured.clear();
-
-				if(Textured)
-					vtmpQuadsTextured.resize(pQLayer->m_NumQuads);
+				IGraphics::CTextureHandle TextureHandle;
+				if(pQLayer->m_Image >= 0 && pQLayer->m_Image < m_pImages->Num())
+					TextureHandle = m_pImages->Get(pQLayer->m_Image);
 				else
-					vtmpQuads.resize(pQLayer->m_NumQuads);
+					TextureHandle.Invalidate();
 
-				CQuad *pQuads = (CQuad *)m_pLayers->Map()->GetDataSwapped(pQLayer->m_Data);
-				for(int i = 0; i < pQLayer->m_NumQuads; ++i)
+				pRenderLayer = std::make_unique<CRenderLayerQuads>(
+					g, l,
+					TextureHandle,
+					pLayer->m_Flags,
+					pQLayer);
+			}
+
+			// just ignore invalid layers from rendering
+			if(pRenderLayer)
+			{
+				pRenderLayer->OnInit(Graphics(), m_pLayers->Map(), RenderTools(), m_pImages, m_pEnvelopePoints, Client(), m_pClient, m_OnlineOnly);
+				if(pRenderLayer->IsValid())
 				{
-					CQuad *pQuad = &pQuads[i];
-					for(int j = 0; j < 4; ++j)
-					{
-						int QuadIdX = j;
-						if(j == 2)
-							QuadIdX = 3;
-						else if(j == 3)
-							QuadIdX = 2;
-						if(!Textured)
-						{
-							// ignore the conversion for the position coordinates
-							vtmpQuads[i].m_aVertices[j].m_X = (pQuad->m_aPoints[QuadIdX].x);
-							vtmpQuads[i].m_aVertices[j].m_Y = (pQuad->m_aPoints[QuadIdX].y);
-							vtmpQuads[i].m_aVertices[j].m_CenterX = (pQuad->m_aPoints[4].x);
-							vtmpQuads[i].m_aVertices[j].m_CenterY = (pQuad->m_aPoints[4].y);
-							vtmpQuads[i].m_aVertices[j].m_R = (unsigned char)pQuad->m_aColors[QuadIdX].r;
-							vtmpQuads[i].m_aVertices[j].m_G = (unsigned char)pQuad->m_aColors[QuadIdX].g;
-							vtmpQuads[i].m_aVertices[j].m_B = (unsigned char)pQuad->m_aColors[QuadIdX].b;
-							vtmpQuads[i].m_aVertices[j].m_A = (unsigned char)pQuad->m_aColors[QuadIdX].a;
-						}
-						else
-						{
-							// ignore the conversion for the position coordinates
-							vtmpQuadsTextured[i].m_aVertices[j].m_X = (pQuad->m_aPoints[QuadIdX].x);
-							vtmpQuadsTextured[i].m_aVertices[j].m_Y = (pQuad->m_aPoints[QuadIdX].y);
-							vtmpQuadsTextured[i].m_aVertices[j].m_CenterX = (pQuad->m_aPoints[4].x);
-							vtmpQuadsTextured[i].m_aVertices[j].m_CenterY = (pQuad->m_aPoints[4].y);
-							vtmpQuadsTextured[i].m_aVertices[j].m_U = fx2f(pQuad->m_aTexcoords[QuadIdX].x);
-							vtmpQuadsTextured[i].m_aVertices[j].m_V = fx2f(pQuad->m_aTexcoords[QuadIdX].y);
-							vtmpQuadsTextured[i].m_aVertices[j].m_R = (unsigned char)pQuad->m_aColors[QuadIdX].r;
-							vtmpQuadsTextured[i].m_aVertices[j].m_G = (unsigned char)pQuad->m_aColors[QuadIdX].g;
-							vtmpQuadsTextured[i].m_aVertices[j].m_B = (unsigned char)pQuad->m_aColors[QuadIdX].b;
-							vtmpQuadsTextured[i].m_aVertices[j].m_A = (unsigned char)pQuad->m_aColors[QuadIdX].a;
-						}
-					}
-				}
-
-				size_t UploadDataSize = 0;
-				if(Textured)
-					UploadDataSize = vtmpQuadsTextured.size() * sizeof(STmpQuadTextured);
-				else
-					UploadDataSize = vtmpQuads.size() * sizeof(STmpQuad);
-
-				if(UploadDataSize > 0)
-				{
-					void *pUploadData = nullptr;
-					if(Textured)
-						pUploadData = vtmpQuadsTextured.data();
-					else
-						pUploadData = vtmpQuads.data();
-					// create the buffer object
-					int BufferObjectIndex = Graphics()->CreateBufferObject(UploadDataSize, pUploadData, 0);
-					// then create the buffer container
-					SBufferContainerInfo ContainerInfo;
-					ContainerInfo.m_Stride = (Textured ? (sizeof(STmpQuadTextured) / 4) : (sizeof(STmpQuad) / 4));
-					ContainerInfo.m_VertBufferBindingIndex = BufferObjectIndex;
-					ContainerInfo.m_vAttributes.emplace_back();
-					SBufferContainerInfo::SAttribute *pAttr = &ContainerInfo.m_vAttributes.back();
-					pAttr->m_DataTypeCount = 4;
-					pAttr->m_Type = GRAPHICS_TYPE_FLOAT;
-					pAttr->m_Normalized = false;
-					pAttr->m_pOffset = nullptr;
-					pAttr->m_FuncType = 0;
-					ContainerInfo.m_vAttributes.emplace_back();
-					pAttr = &ContainerInfo.m_vAttributes.back();
-					pAttr->m_DataTypeCount = 4;
-					pAttr->m_Type = GRAPHICS_TYPE_UNSIGNED_BYTE;
-					pAttr->m_Normalized = true;
-					pAttr->m_pOffset = (void *)(sizeof(float) * 4);
-					pAttr->m_FuncType = 0;
-					if(Textured)
-					{
-						ContainerInfo.m_vAttributes.emplace_back();
-						pAttr = &ContainerInfo.m_vAttributes.back();
-						pAttr->m_DataTypeCount = 2;
-						pAttr->m_Type = GRAPHICS_TYPE_FLOAT;
-						pAttr->m_Normalized = false;
-						pAttr->m_pOffset = (void *)(sizeof(float) * 4 + sizeof(unsigned char) * 4);
-						pAttr->m_FuncType = 0;
-					}
-
-					pQLayerVisuals->m_BufferContainerIndex = Graphics()->CreateBufferContainer(&ContainerInfo);
-					// and finally inform the backend how many indices are required
-					Graphics()->IndicesNumRequiredNotify(pQLayer->m_NumQuads * 6);
-
-					RenderLoading();
+					pRenderLayer->Init();
+					m_vRenderLayers.push_back(std::move(pRenderLayer));
 				}
 			}
 		}
-		m_vvLayerCount[g] = vLayerCounter;
 	}
-}
-
-void CMapLayers::RenderTileLayer(int LayerIndex, const ColorRGBA &Color)
-{
-	STileLayerVisuals &Visuals = *m_vpTileLayerVisuals[LayerIndex];
-	if(Visuals.m_BufferContainerIndex == -1)
-		return; // no visuals were created
-
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
-
-	int ScreenRectY0 = std::floor(ScreenY0 / 32);
-	int ScreenRectX0 = std::floor(ScreenX0 / 32);
-	int ScreenRectY1 = std::ceil(ScreenY1 / 32);
-	int ScreenRectX1 = std::ceil(ScreenX1 / 32);
-
-	if(ScreenRectX1 > 0 && ScreenRectY1 > 0 && ScreenRectX0 < (int)Visuals.m_Width && ScreenRectY0 < (int)Visuals.m_Height)
-	{
-		// create the indice buffers we want to draw -- reuse them
-		static std::vector<char *> s_vpIndexOffsets;
-		static std::vector<unsigned int> s_vDrawCounts;
-
-		int X0 = std::max(ScreenRectX0, 0);
-		int X1 = std::min(ScreenRectX1, (int)Visuals.m_Width);
-		if(X0 <= X1)
-		{
-			int Y0 = std::max(ScreenRectY0, 0);
-			int Y1 = std::min(ScreenRectY1, (int)Visuals.m_Height);
-
-			s_vpIndexOffsets.clear();
-			s_vDrawCounts.clear();
-
-			unsigned long long Reserve = absolute(Y1 - Y0) + 1;
-			s_vpIndexOffsets.reserve(Reserve);
-			s_vDrawCounts.reserve(Reserve);
-
-			for(int y = Y0; y < Y1; ++y)
-			{
-				int XR = X1 - 1;
-
-				dbg_assert(Visuals.m_pTilesOfLayer[y * Visuals.m_Width + XR].IndexBufferByteOffset() >= Visuals.m_pTilesOfLayer[y * Visuals.m_Width + X0].IndexBufferByteOffset(), "Tile count wrong.");
-
-				unsigned int NumVertices = ((Visuals.m_pTilesOfLayer[y * Visuals.m_Width + XR].IndexBufferByteOffset() - Visuals.m_pTilesOfLayer[y * Visuals.m_Width + X0].IndexBufferByteOffset()) / sizeof(unsigned int)) + (Visuals.m_pTilesOfLayer[y * Visuals.m_Width + XR].DoDraw() ? 6lu : 0lu);
-
-				if(NumVertices)
-				{
-					s_vpIndexOffsets.push_back((offset_ptr_size)Visuals.m_pTilesOfLayer[y * Visuals.m_Width + X0].IndexBufferByteOffset());
-					s_vDrawCounts.push_back(NumVertices);
-				}
-			}
-
-			int DrawCount = s_vpIndexOffsets.size();
-			if(DrawCount != 0)
-			{
-				Graphics()->RenderTileLayer(Visuals.m_BufferContainerIndex, Color, s_vpIndexOffsets.data(), s_vDrawCounts.data(), DrawCount);
-			}
-		}
-	}
-
-	if(ScreenRectX1 > (int)Visuals.m_Width || ScreenRectY1 > (int)Visuals.m_Height || ScreenRectX0 < 0 || ScreenRectY0 < 0)
-	{
-		RenderTileBorder(LayerIndex, Color, ScreenRectX0, ScreenRectY0, ScreenRectX1, ScreenRectY1);
-	}
-}
-
-void CMapLayers::RenderTileBorder(int LayerIndex, const ColorRGBA &Color, int BorderX0, int BorderY0, int BorderX1, int BorderY1)
-{
-	STileLayerVisuals &Visuals = *m_vpTileLayerVisuals[LayerIndex];
-
-	int Y0 = std::max(0, BorderY0);
-	int X0 = std::max(0, BorderX0);
-	int Y1 = std::min((int)Visuals.m_Height, BorderY1);
-	int X1 = std::min((int)Visuals.m_Width, BorderX1);
-
-	// corners
-	auto DrawCorner = [this, &Visuals, Color](vec2 Offset, vec2 Scale, STileLayerVisuals::STileVisual &Visual) {
-		Offset *= 32.0f;
-		Graphics()->RenderBorderTiles(Visuals.m_BufferContainerIndex, Color, (offset_ptr_size)Visual.IndexBufferByteOffset(), Offset, Scale, 1);
-	};
-
-	if(BorderX0 < 0)
-	{
-		// Draw corners on left side
-		if(BorderY0 < 0 && Visuals.m_BorderTopLeft.DoDraw())
-		{
-			DrawCorner(
-				vec2(0, 0),
-				vec2(std::abs(BorderX0), std::abs(BorderY0)),
-				Visuals.m_BorderTopLeft);
-		}
-		if(BorderY1 > (int)Visuals.m_Height && Visuals.m_BorderBottomLeft.DoDraw())
-		{
-			DrawCorner(
-				vec2(0, Visuals.m_Height),
-				vec2(std::abs(BorderX0), BorderY1 - Visuals.m_Height),
-				Visuals.m_BorderBottomLeft);
-		}
-	}
-	if(BorderX1 > (int)Visuals.m_Width)
-	{
-		// Draw corners on right side
-		if(BorderY0 < 0 && Visuals.m_BorderTopRight.DoDraw())
-		{
-			DrawCorner(
-				vec2(Visuals.m_Width, 0),
-				vec2(BorderX1 - Visuals.m_Width, std::abs(BorderY0)),
-				Visuals.m_BorderTopRight);
-		}
-		if(BorderY1 > (int)Visuals.m_Height && Visuals.m_BorderBottomRight.DoDraw())
-		{
-			DrawCorner(
-				vec2(Visuals.m_Width, Visuals.m_Height),
-				vec2(BorderX1 - Visuals.m_Width, BorderY1 - Visuals.m_Height),
-				Visuals.m_BorderBottomRight);
-		}
-	}
-
-	// borders
-	auto DrawBorder = [this, &Visuals, Color](vec2 Offset, vec2 Scale, STileLayerVisuals::STileVisual &StartVisual, STileLayerVisuals::STileVisual &EndVisual) {
-		unsigned int DrawNum = ((EndVisual.IndexBufferByteOffset() - StartVisual.IndexBufferByteOffset()) / (sizeof(unsigned int) * 6)) + (EndVisual.DoDraw() ? 1lu : 0lu);
-		offset_ptr_size pOffset = (offset_ptr_size)StartVisual.IndexBufferByteOffset();
-		Offset *= 32.0f;
-		Graphics()->RenderBorderTiles(Visuals.m_BufferContainerIndex, Color, pOffset, Offset, Scale, DrawNum);
-	};
-
-	if(Y0 < (int)Visuals.m_Height && Y1 > 0)
-	{
-		if(BorderX1 > (int)Visuals.m_Width)
-		{
-			// Draw right border
-			DrawBorder(
-				vec2(Visuals.m_Width, 0),
-				vec2(BorderX1 - Visuals.m_Width, 1.f),
-				Visuals.m_vBorderRight[Y0], Visuals.m_vBorderRight[Y1 - 1]);
-		}
-		if(BorderX0 < 0)
-		{
-			// Draw left border
-			DrawBorder(
-				vec2(0, 0),
-				vec2(std::abs(BorderX0), 1),
-				Visuals.m_vBorderLeft[Y0], Visuals.m_vBorderLeft[Y1 - 1]);
-		}
-	}
-
-	if(X0 < (int)Visuals.m_Width && X1 > 0)
-	{
-		if(BorderY0 < 0)
-		{
-			// Draw top border
-			DrawBorder(
-				vec2(0, 0),
-				vec2(1, std::abs(BorderY0)),
-				Visuals.m_vBorderTop[X0], Visuals.m_vBorderTop[X1 - 1]);
-		}
-		if(BorderY1 > (int)Visuals.m_Height)
-		{
-			// Draw bottom border
-			DrawBorder(
-				vec2(0, Visuals.m_Height),
-				vec2(1, BorderY1 - Visuals.m_Height),
-				Visuals.m_vBorderBottom[X0], Visuals.m_vBorderBottom[X1 - 1]);
-		}
-	}
-}
-
-void CMapLayers::RenderKillTileBorder(int LayerIndex, const ColorRGBA &Color)
-{
-	STileLayerVisuals &Visuals = *m_vpTileLayerVisuals[LayerIndex];
-	if(Visuals.m_BufferContainerIndex == -1)
-		return; // no visuals were created
-
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
-
-	int BorderY0 = std::floor(ScreenY0 / 32);
-	int BorderX0 = std::floor(ScreenX0 / 32);
-	int BorderY1 = std::ceil(ScreenY1 / 32);
-	int BorderX1 = std::ceil(ScreenX1 / 32);
-
-	const int BorderDist = 201;
-
-	if(BorderX0 >= -BorderDist && BorderY0 >= -BorderDist && BorderX1 <= (int)Visuals.m_Width + BorderDist && BorderY1 <= (int)Visuals.m_Height + BorderDist)
-		return;
-	if(!Visuals.m_BorderKillTile.DoDraw())
-		return;
-
-	BorderX0 = std::clamp(BorderX0, -300, (int)Visuals.m_Width + 299);
-	BorderY0 = std::clamp(BorderY0, -300, (int)Visuals.m_Height + 299);
-	BorderX1 = std::clamp(BorderX1, -300, (int)Visuals.m_Width + 299);
-	BorderY1 = std::clamp(BorderY1, -300, (int)Visuals.m_Height + 299);
-
-	auto DrawKillBorder = [Color, this, LayerIndex](vec2 Offset, vec2 Scale) {
-		offset_ptr_size pOffset = (offset_ptr_size)m_vpTileLayerVisuals[LayerIndex]->m_BorderKillTile.IndexBufferByteOffset();
-		Offset *= 32.0f;
-		Graphics()->RenderBorderTiles(m_vpTileLayerVisuals[LayerIndex]->m_BufferContainerIndex, Color, pOffset, Offset, Scale, 1);
-	};
-
-	// Draw left kill tile border
-	if(BorderX0 < -BorderDist)
-	{
-		DrawKillBorder(
-			vec2(BorderX0, BorderY0),
-			vec2(-BorderDist - BorderX0, BorderY1 - BorderY0));
-	}
-	// Draw top kill tile border
-	if(BorderY0 < -BorderDist)
-	{
-		DrawKillBorder(
-			vec2(std::max(BorderX0, -BorderDist), BorderY0),
-			vec2(std::min(BorderX1, (int)Visuals.m_Width + BorderDist) - std::max(BorderX0, -BorderDist), -BorderDist - BorderY0));
-	}
-	// Draw right kill tile border
-	if(BorderX1 > (int)Visuals.m_Width + BorderDist)
-	{
-		DrawKillBorder(
-			vec2(Visuals.m_Width + BorderDist, BorderY0),
-			vec2(BorderX1 - (Visuals.m_Width + BorderDist), BorderY1 - BorderY0));
-	}
-	// Draw bottom kill tile border
-	if(BorderY1 > (int)Visuals.m_Height + BorderDist)
-	{
-		DrawKillBorder(
-			vec2(std::max(BorderX0, -BorderDist), Visuals.m_Height + BorderDist),
-			vec2(std::min(BorderX1, (int)Visuals.m_Width + BorderDist) - std::max(BorderX0, -BorderDist), BorderY1 - (Visuals.m_Height + BorderDist)));
-	}
-}
-
-void CMapLayers::RenderQuadLayer(int LayerIndex, CMapItemLayerQuads *pQuadLayer, bool Force)
-{
-	SQuadLayerVisuals &Visuals = *m_vpQuadLayerVisuals[LayerIndex];
-	if(Visuals.m_BufferContainerIndex == -1)
-		return; // no visuals were created
-
-	if(!Force && (!g_Config.m_ClShowQuads || g_Config.m_ClOverlayEntities == 100))
-		return;
-
-	CQuad *pQuads = (CQuad *)m_pLayers->Map()->GetDataSwapped(pQuadLayer->m_Data);
-
-	static std::vector<SQuadRenderInfo> s_vQuadRenderInfo;
-
-	s_vQuadRenderInfo.resize(pQuadLayer->m_NumQuads);
-	size_t QuadsRenderCount = 0;
-	size_t CurQuadOffset = 0;
-	for(int i = 0; i < pQuadLayer->m_NumQuads; ++i)
-	{
-		CQuad *pQuad = &pQuads[i];
-
-		ColorRGBA Color = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
-		EnvelopeEval(pQuad->m_ColorEnvOffset, pQuad->m_ColorEnv, Color, 4, this);
-
-		const bool IsFullyTransparent = Color.a <= 0.0f;
-		const bool NeedsFlush = QuadsRenderCount == gs_GraphicsMaxQuadsRenderCount || IsFullyTransparent;
-
-		if(NeedsFlush)
-		{
-			// render quads of the current offset directly(cancel batching)
-			Graphics()->RenderQuadLayer(Visuals.m_BufferContainerIndex, s_vQuadRenderInfo.data(), QuadsRenderCount, CurQuadOffset);
-			QuadsRenderCount = 0;
-			CurQuadOffset = i;
-			if(IsFullyTransparent)
-			{
-				// since this quad is ignored, the offset is the next quad
-				++CurQuadOffset;
-			}
-		}
-
-		if(!IsFullyTransparent)
-		{
-			ColorRGBA Position = ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f);
-			EnvelopeEval(pQuad->m_PosEnvOffset, pQuad->m_PosEnv, Position, 3, this);
-
-			SQuadRenderInfo &QInfo = s_vQuadRenderInfo[QuadsRenderCount++];
-			QInfo.m_Color = Color;
-			QInfo.m_Offsets.x = Position.r;
-			QInfo.m_Offsets.y = Position.g;
-			QInfo.m_Rotation = Position.b / 180.0f * pi;
-		}
-	}
-	Graphics()->RenderQuadLayer(Visuals.m_BufferContainerIndex, s_vQuadRenderInfo.data(), QuadsRenderCount, CurQuadOffset);
 }
 
 void CMapLayers::OnRender()
@@ -1103,168 +208,41 @@ void CMapLayers::OnRender()
 	CUIRect Screen;
 	Graphics()->GetScreen(&Screen.x, &Screen.y, &Screen.w, &Screen.h);
 
-	vec2 Center = GetCurCamera()->m_Center;
+	CRenderLayerParams Params;
+	Params.EntityOverlayVal = m_Type == TYPE_FULL_DESIGN ? 0 : g_Config.m_ClOverlayEntities;
+	Params.m_RenderType = m_Type;
+	Params.m_Center = GetCurCamera()->m_Center;
 
-	// Hide Entities in full design mode
-	int EntityOverlayVal = m_Type == TYPE_FULL_DESIGN ? 0 : g_Config.m_ClOverlayEntities;
-	bool OnlyShowEntities = EntityOverlayVal == 100;
-
-	bool PassedGameLayer = false;
-	int StartGroup = m_Type == TYPE_FOREGROUND ? m_GameGroup : 0;
-	int EndGroup = (m_Type == TYPE_BACKGROUND || m_Type == TYPE_BACKGROUND_FORCE) ? std::min(m_GameGroup + 1, m_pLayers->NumGroups()) : m_pLayers->NumGroups();
-
-	for(int g = StartGroup; g < EndGroup; g++)
-	{
-		CMapItemGroup *pGroup = m_pLayers->GetGroup(g);
-
-		if(!pGroup)
-		{
-			dbg_msg("maplayers", "error group was null, group number = %d, total groups = %d", g, m_pLayers->NumGroups());
-			dbg_msg("maplayers", "this is here to prevent a crash but the source of this is unknown, please report this for it to get fixed");
-			dbg_msg("maplayers", "we need mapname and crc and the map that caused this if possible, and anymore info you think is relevant");
-			continue;
-		}
-
-		if((!g_Config.m_GfxNoclip || m_Type == TYPE_FULL_DESIGN) && pGroup->m_Version >= 2 && pGroup->m_UseClipping)
-		{
-			// set clipping
-			float aPoints[4];
-			RenderTools()->MapScreenToGroup(Center.x, Center.y, m_pLayers->GameGroup(), GetCurCamera()->m_Zoom);
-			Graphics()->GetScreen(&aPoints[0], &aPoints[1], &aPoints[2], &aPoints[3]);
-			float x0 = (pGroup->m_ClipX - aPoints[0]) / (aPoints[2] - aPoints[0]);
-			float y0 = (pGroup->m_ClipY - aPoints[1]) / (aPoints[3] - aPoints[1]);
-			float x1 = ((pGroup->m_ClipX + pGroup->m_ClipW) - aPoints[0]) / (aPoints[2] - aPoints[0]);
-			float y1 = ((pGroup->m_ClipY + pGroup->m_ClipH) - aPoints[1]) / (aPoints[3] - aPoints[1]);
-
-			if(x1 < 0.0f || x0 > 1.0f || y1 < 0.0f || y0 > 1.0f)
-				continue;
-
-			Graphics()->ClipEnable((int)(x0 * Graphics()->ScreenWidth()), (int)(y0 * Graphics()->ScreenHeight()),
-				(int)((x1 - x0) * Graphics()->ScreenWidth()), (int)((y1 - y0) * Graphics()->ScreenHeight()));
-		}
-
-		RenderTools()->MapScreenToGroup(Center.x, Center.y, pGroup, GetCurCamera()->m_Zoom);
-
-		for(int l = 0; l < pGroup->m_NumLayers; l++)
-		{
-			CMapItemLayer *pLayer = m_pLayers->GetLayer(pGroup->m_StartLayer + l);
-			int LayerType = GetLayerType(pLayer);
-			PassedGameLayer |= LayerType == LAYER_GAME;
-			bool IsEntityLayer = LayerType != LAYER_DEFAULT_TILESET;
-
-			// stop rendering if we render background but reach the foreground
-			if(PassedGameLayer && (m_Type == TYPE_BACKGROUND || m_Type == TYPE_BACKGROUND_FORCE))
-				return;
-
-			// skip rendering if we render foreground but are in background
-			if(!PassedGameLayer && m_Type == TYPE_FOREGROUND)
-				continue;
-
-			// skip rendering if we render background force, but deactivated tile layer and want to render a tilelayer
-			if(pLayer->m_Type == LAYERTYPE_TILES && !g_Config.m_ClBackgroundShowTilesLayers && m_Type == TYPE_BACKGROUND_FORCE)
-				continue;
-
-			// skip rendering if we render background but encounter an entity, e.g. speed layer infront of game layer or similar
-			if(m_Type == TYPE_BACKGROUND_FORCE && IsEntityLayer)
-				continue;
-
-			// skip rendering entities if we want to render everything in it's full glory
-			if(m_Type == TYPE_FULL_DESIGN && IsEntityLayer)
-				continue;
-
-			// skip rendering anything but entities if we only want to render entities
-			if(!IsEntityLayer && OnlyShowEntities && m_Type != TYPE_BACKGROUND_FORCE)
-				continue;
-
-			// skip rendering of entities if don't want them
-			if(IsEntityLayer && !EntityOverlayVal)
-				continue;
-
-			// skip rendering if detail layers if not wanted
-			if(pLayer->m_Flags & LAYERFLAG_DETAIL && !g_Config.m_GfxHighDetail && m_Type != TYPE_FULL_DESIGN && LayerType != LAYER_GAME) // detail but no details
-				continue;
-
-			if(pLayer->m_Type == LAYERTYPE_TILES)
-			{
-				ColorRGBA Color;
-				int TextureId = -1;
-				CMapItemLayerTilemap *pLayerTilemap = (CMapItemLayerTilemap *)pLayer;
-				if(!IsEntityLayer)
-				{
-					if(pLayerTilemap->m_Image >= 0 && pLayerTilemap->m_Image < m_pImages->Num())
-						TextureId = pLayerTilemap->m_Image;
-
-					Color = ColorRGBA(pLayerTilemap->m_Color.r / 255.0f, pLayerTilemap->m_Color.g / 255.0f, pLayerTilemap->m_Color.b / 255.0f, pLayerTilemap->m_Color.a / 255.0f);
-					if(EntityOverlayVal && m_Type != TYPE_BACKGROUND_FORCE)
-						Color.a *= (100 - EntityOverlayVal) / 100.0f;
-
-					ColorRGBA ColorEnv = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
-					EnvelopeEval(pLayerTilemap->m_ColorEnvOffset, pLayerTilemap->m_ColorEnv, ColorEnv, 4, this);
-					Color = Color.Multiply(ColorEnv);
-				}
-				else
-				{
-					Color = ColorRGBA(1.0f, 1.0f, 1.0f, EntityOverlayVal / 100.0f);
-				}
-
-				if(!Graphics()->IsTileBufferingEnabled())
-				{
-					void *pTilesData = nullptr;
-					GetTileLayerAndOverlayCount(pLayerTilemap, LayerType, &pTilesData);
-					RenderTilelayerNoTileBuffer(TextureId, LayerType, pTilesData, pLayerTilemap, Color);
-				}
-				else
-				{
-					RenderTilelayerWithTileBuffer(TextureId, LayerType, m_vvLayerCount[g][l], Color);
-				}
-			}
-			else if(pLayer->m_Type == LAYERTYPE_QUADS)
-			{
-				CMapItemLayerQuads *pLayerQuads = (CMapItemLayerQuads *)pLayer;
-				if(pLayerQuads->m_Image >= 0 && pLayerQuads->m_Image < m_pImages->Num())
-					Graphics()->TextureSet(m_pImages->Get(pLayerQuads->m_Image));
-				else
-					Graphics()->TextureClear();
-
-				CQuad *pQuads = (CQuad *)m_pLayers->Map()->GetDataSwapped(pLayerQuads->m_Data);
-				if(m_Type == TYPE_BACKGROUND_FORCE || m_Type == TYPE_FULL_DESIGN)
-				{
-					if(g_Config.m_ClShowQuads || m_Type == TYPE_FULL_DESIGN)
-					{
-						if(!Graphics()->IsQuadBufferingEnabled())
-						{
-							Graphics()->BlendNormal();
-							RenderTools()->ForceRenderQuads(pQuads, pLayerQuads->m_NumQuads, LAYERRENDERFLAG_TRANSPARENT, EnvelopeEval, this, 1.f);
-						}
-						else
-						{
-							RenderQuadLayer(m_vvLayerCount[g][l] - 1, pLayerQuads, true);
-						}
-					}
-				}
-				else
-				{
-					if(!Graphics()->IsQuadBufferingEnabled())
-					{
-						Graphics()->BlendNormal();
-						RenderTools()->RenderQuads(pQuads, pLayerQuads->m_NumQuads, LAYERRENDERFLAG_TRANSPARENT, EnvelopeEval, this);
-					}
-					else
-					{
-						RenderQuadLayer(m_vvLayerCount[g][l] - 1, pLayerQuads, false);
-					}
-				}
-			}
-		}
-		if(!g_Config.m_GfxNoclip || m_Type == TYPE_FULL_DESIGN)
+	auto DisableClip = [&]() {
+		if(!g_Config.m_GfxNoclip || Params.m_RenderType == CMapLayers::TYPE_FULL_DESIGN)
 			Graphics()->ClipDisable();
+	};
+
+	int CurrentGroup = -1;
+	bool DoRenderGroup = true;
+	for(auto &&pRenderLayer : m_vRenderLayers)
+	{
+		if(CurrentGroup != pRenderLayer->GetGroup())
+		{
+			DisableClip(); // disable clip of previous group
+			CurrentGroup = pRenderLayer->GetGroup();
+			DoRenderGroup = RenderGroup(Params, CurrentGroup);
+		}
+
+		if(!DoRenderGroup)
+			continue;
+
+		pRenderLayer->Render(Params);
 	}
 
-	if(!g_Config.m_GfxNoclip || m_Type == TYPE_FULL_DESIGN)
-		Graphics()->ClipDisable();
+	DisableClip();
 
-	// reset the screen like it was before
-	Graphics()->MapScreen(Screen.x, Screen.y, Screen.w, Screen.h);
+	// don't reset screen on background
+	if(m_Type != TYPE_BACKGROUND && m_Type != TYPE_BACKGROUND_FORCE)
+	{
+		// reset the screen like it was before
+		Graphics()->MapScreen(Screen.x, Screen.y, Screen.w, Screen.h);
+	}
 }
 
 int CMapLayers::GetLayerType(const CMapItemLayer *pLayer) const
@@ -1284,229 +262,36 @@ int CMapLayers::GetLayerType(const CMapItemLayer *pLayer) const
 	return LAYER_DEFAULT_TILESET;
 }
 
-int CMapLayers::GetTileLayerAndOverlayCount(const CMapItemLayerTilemap *pLayerTilemap, int LayerType, void **ppTiles) const
+bool CMapLayers::RenderGroup(const CRenderLayerParams &Params, int GroupId)
 {
-	int DataIndex;
-	unsigned int TileSize;
-	int OverlayCount;
-	switch(LayerType)
+	CMapItemGroup *pGroup = m_pLayers->GetGroup(GroupId);
+
+	if(!pGroup)
 	{
-	case LAYER_FRONT:
-		DataIndex = pLayerTilemap->m_Front;
-		TileSize = sizeof(CTile);
-		OverlayCount = 0;
-		break;
-	case LAYER_SWITCH:
-		DataIndex = pLayerTilemap->m_Switch;
-		TileSize = sizeof(CSwitchTile);
-		OverlayCount = 2;
-		break;
-	case LAYER_TELE:
-		DataIndex = pLayerTilemap->m_Tele;
-		TileSize = sizeof(CTeleTile);
-		OverlayCount = 1;
-		break;
-	case LAYER_SPEEDUP:
-		DataIndex = pLayerTilemap->m_Speedup;
-		TileSize = sizeof(CSpeedupTile);
-		OverlayCount = 2;
-		break;
-	case LAYER_TUNE:
-		DataIndex = pLayerTilemap->m_Tune;
-		TileSize = sizeof(CTuneTile);
-		OverlayCount = 0;
-		break;
-	case LAYER_GAME:
-	default:
-		DataIndex = pLayerTilemap->m_Data;
-		TileSize = sizeof(CTile);
-		OverlayCount = 0;
-		break;
+		dbg_msg("maplayers", "error group was null, group number = %d, total groups = %d", GroupId, m_pLayers->NumGroups());
+		dbg_msg("maplayers", "this is here to prevent a crash but the source of this is unknown, please report this for it to get fixed");
+		dbg_msg("maplayers", "we need mapname and crc and the map that caused this if possible, and anymore info you think is relevant");
+		return false;
 	}
 
-	void *pTiles = m_pLayers->Map()->GetData(DataIndex);
-	int Size = m_pLayers->Map()->GetDataSize(DataIndex);
-
-	if(!pTiles || Size < pLayerTilemap->m_Width * pLayerTilemap->m_Height * (int)TileSize)
-		return 0;
-
-	if(ppTiles)
-		*ppTiles = pTiles;
-
-	return OverlayCount + 1; // always add 1 tilelayer
-}
-
-void CMapLayers::RenderTilelayerWithTileBuffer(int ImageIndex, int LayerType, int TileLayerCounter, const ColorRGBA &Color)
-{
-	switch(LayerType)
+	if((!g_Config.m_GfxNoclip || Params.m_RenderType == CMapLayers::TYPE_FULL_DESIGN) && pGroup->m_Version >= 2 && pGroup->m_UseClipping)
 	{
-	case LAYER_GAME:
-		Graphics()->TextureSet(m_pImages->GetEntities(MAP_IMAGE_ENTITY_LAYER_TYPE_ALL_EXCEPT_SWITCH));
-		Graphics()->BlendNormal();
-		RenderKillTileBorder(TileLayerCounter - 1, Color.Multiply(GetDeathBorderColor()));
-		RenderTileLayer(TileLayerCounter - 1, Color);
-		break;
+		// set clipping
+		float aPoints[4];
+		RenderTools()->MapScreenToGroup(Params.m_Center.x, Params.m_Center.y, m_pLayers->GameGroup(), GetCurCamera()->m_Zoom);
+		Graphics()->GetScreen(&aPoints[0], &aPoints[1], &aPoints[2], &aPoints[3]);
+		float x0 = (pGroup->m_ClipX - aPoints[0]) / (aPoints[2] - aPoints[0]);
+		float y0 = (pGroup->m_ClipY - aPoints[1]) / (aPoints[3] - aPoints[1]);
+		float x1 = ((pGroup->m_ClipX + pGroup->m_ClipW) - aPoints[0]) / (aPoints[2] - aPoints[0]);
+		float y1 = ((pGroup->m_ClipY + pGroup->m_ClipH) - aPoints[1]) / (aPoints[3] - aPoints[1]);
 
-	case LAYER_TELE:
-		Graphics()->TextureSet(m_pImages->GetEntities(MAP_IMAGE_ENTITY_LAYER_TYPE_ALL_EXCEPT_SWITCH));
-		Graphics()->BlendNormal();
-		RenderTileLayer(TileLayerCounter - 2, Color);
-		if(g_Config.m_ClTextEntities)
-		{
-			Graphics()->TextureSet(m_pImages->GetOverlayCenter());
-			RenderTileLayer(TileLayerCounter - 1, Color);
-		}
-		break;
+		if(x1 < 0.0f || x0 > 1.0f || y1 < 0.0f || y0 > 1.0f)
+			return false;
 
-	case LAYER_SPEEDUP:
-		// draw arrow -- clamp to the edge of the arrow image
-		Graphics()->WrapClamp();
-		Graphics()->TextureSet(m_pImages->GetSpeedupArrow());
-		RenderTileLayer(TileLayerCounter - 3, Color);
-		Graphics()->WrapNormal();
-
-		if(g_Config.m_ClTextEntities)
-		{
-			Graphics()->TextureSet(m_pImages->GetOverlayBottom());
-			RenderTileLayer(TileLayerCounter - 2, Color);
-			Graphics()->TextureSet(m_pImages->GetOverlayTop());
-			RenderTileLayer(TileLayerCounter - 1, Color);
-		}
-		break;
-
-	case LAYER_SWITCH:
-		Graphics()->TextureSet(m_pImages->GetEntities(MAP_IMAGE_ENTITY_LAYER_TYPE_SWITCH));
-		Graphics()->BlendNormal();
-		RenderTileLayer(TileLayerCounter - 3, Color);
-		if(g_Config.m_ClTextEntities)
-		{
-			Graphics()->TextureSet(m_pImages->GetOverlayTop());
-			RenderTileLayer(TileLayerCounter - 2, Color);
-			Graphics()->TextureSet(m_pImages->GetOverlayBottom());
-			RenderTileLayer(TileLayerCounter - 1, Color);
-		}
-		break;
-
-	case LAYER_FRONT:
-	case LAYER_TUNE:
-		Graphics()->TextureSet(m_pImages->GetEntities(MAP_IMAGE_ENTITY_LAYER_TYPE_ALL_EXCEPT_SWITCH));
-		Graphics()->BlendNormal();
-		RenderTileLayer(TileLayerCounter - 1, Color);
-		break;
-
-	case LAYER_DEFAULT_TILESET:
-		if(ImageIndex != -1)
-			Graphics()->TextureSet(m_pImages->Get(ImageIndex));
-		else
-			Graphics()->TextureClear();
-		Graphics()->BlendNormal();
-		RenderTileLayer(TileLayerCounter - 1, Color);
-		break;
-
-	default:
-		dbg_assert(false, "Unknown LayerType %d", LayerType);
+		Graphics()->ClipEnable((int)(x0 * Graphics()->ScreenWidth()), (int)(y0 * Graphics()->ScreenHeight()),
+			(int)((x1 - x0) * Graphics()->ScreenWidth()), (int)((y1 - y0) * Graphics()->ScreenHeight()));
 	}
-}
 
-void CMapLayers::RenderTilelayerNoTileBuffer(int ImageIndex, int LayerType, void *pTilesData, CMapItemLayerTilemap *pLayerTilemap, const ColorRGBA &Color)
-{
-	int OverlayRenderFlags = g_Config.m_ClTextEntities ? OVERLAYRENDERFLAG_TEXT : 0;
-
-	switch(LayerType)
-	{
-	case LAYER_GAME:
-	{
-		Graphics()->TextureSet(m_pImages->GetEntities(MAP_IMAGE_ENTITY_LAYER_TYPE_ALL_EXCEPT_SWITCH));
-		CTile *pGameTiles = (CTile *)pTilesData;
-		Graphics()->BlendNone();
-		RenderTools()->RenderTilemap(pGameTiles, pLayerTilemap->m_Width, pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_OPAQUE);
-		Graphics()->BlendNormal();
-		RenderTools()->RenderTileRectangle(-201, -201, pLayerTilemap->m_Width + 402, pLayerTilemap->m_Height + 402,
-			TILE_AIR, TILE_DEATH, // display air inside, death outside
-			32.0f, Color.Multiply(GetDeathBorderColor()), TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_TRANSPARENT);
-
-		RenderTools()->RenderTilemap(pGameTiles, pLayerTilemap->m_Width, pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_TRANSPARENT);
-	}
-	break;
-
-	case LAYER_TELE:
-	{
-		Graphics()->TextureSet(m_pImages->GetEntities(MAP_IMAGE_ENTITY_LAYER_TYPE_ALL_EXCEPT_SWITCH));
-		CTeleTile *pTeleTiles = (CTeleTile *)pTilesData;
-		Graphics()->BlendNone();
-		RenderTools()->RenderTelemap(pTeleTiles, pLayerTilemap->m_Width, pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_OPAQUE);
-		Graphics()->BlendNormal();
-		RenderTools()->RenderTelemap(pTeleTiles, pLayerTilemap->m_Width, pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_TRANSPARENT);
-		RenderTools()->RenderTeleOverlay(pTeleTiles, pLayerTilemap->m_Width, pLayerTilemap->m_Height, 32.0f, OverlayRenderFlags, Color.a);
-	}
-	break;
-
-	case LAYER_SPEEDUP:
-	{
-		Graphics()->TextureSet(m_pImages->GetEntities(MAP_IMAGE_ENTITY_LAYER_TYPE_ALL_EXCEPT_SWITCH));
-		CSpeedupTile *pSpeedupTiles = (CSpeedupTile *)pTilesData;
-		RenderTools()->RenderSpeedupOverlay(pSpeedupTiles, pLayerTilemap->m_Width, pLayerTilemap->m_Height, 32.0f, OverlayRenderFlags, Color.a);
-	}
-	break;
-
-	case LAYER_SWITCH:
-	{
-		Graphics()->TextureSet(m_pImages->GetEntities(MAP_IMAGE_ENTITY_LAYER_TYPE_SWITCH));
-		CSwitchTile *pSwitchTiles = (CSwitchTile *)pTilesData;
-		Graphics()->BlendNone();
-		RenderTools()->RenderSwitchmap(pSwitchTiles, pLayerTilemap->m_Width, pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_OPAQUE);
-		Graphics()->BlendNormal();
-		RenderTools()->RenderSwitchmap(pSwitchTiles, pLayerTilemap->m_Width, pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_TRANSPARENT);
-		RenderTools()->RenderSwitchOverlay(pSwitchTiles, pLayerTilemap->m_Width, pLayerTilemap->m_Height, 32.0f, OverlayRenderFlags, Color.a);
-	}
-	break;
-
-	case LAYER_TUNE:
-	{
-		Graphics()->TextureSet(m_pImages->GetEntities(MAP_IMAGE_ENTITY_LAYER_TYPE_ALL_EXCEPT_SWITCH));
-		CTuneTile *pTuneTiles = (CTuneTile *)pTilesData;
-		Graphics()->BlendNone();
-		RenderTools()->RenderTunemap(pTuneTiles, pLayerTilemap->m_Width, pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_OPAQUE);
-		Graphics()->BlendNormal();
-		RenderTools()->RenderTunemap(pTuneTiles, pLayerTilemap->m_Width, pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_TRANSPARENT);
-	}
-	break;
-
-	case LAYER_FRONT:
-	{
-		Graphics()->TextureSet(m_pImages->GetEntities(MAP_IMAGE_ENTITY_LAYER_TYPE_ALL_EXCEPT_SWITCH));
-		CTile *pTiles = (CTile *)pTilesData;
-		Graphics()->BlendNone();
-		RenderTools()->RenderTilemap(pTiles, pLayerTilemap->m_Width, pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_OPAQUE);
-		Graphics()->BlendNormal();
-		RenderTools()->RenderTilemap(pTiles, pLayerTilemap->m_Width, pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_TRANSPARENT);
-	}
-	break;
-
-	case LAYER_DEFAULT_TILESET:
-	{
-		if(ImageIndex != -1)
-			Graphics()->TextureSet(m_pImages->Get(ImageIndex));
-		else
-			Graphics()->TextureClear();
-		CTile *pTiles = (CTile *)pTilesData;
-		Graphics()->BlendNone();
-		RenderTools()->RenderTilemap(pTiles, pLayerTilemap->m_Width, pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_OPAQUE);
-		Graphics()->BlendNormal();
-		RenderTools()->RenderTilemap(pTiles, pLayerTilemap->m_Width, pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_TRANSPARENT);
-	}
-	break;
-
-	default:
-		dbg_assert(false, "Unknown LayerType %d", LayerType);
-	}
-}
-
-ColorRGBA CMapLayers::GetDeathBorderColor() const
-{
-	// draw kill tiles outside the entity clipping rectangle
-	// slow blinking to hint that it's not a part of the map
-	float Seconds = time_get() / (float)time_freq();
-	float Alpha = 0.3f + 0.35f * (1.f + std::sin(2.f * pi * Seconds / 3.f));
-	return ColorRGBA(1.f, 1.f, 1.f, Alpha);
+	RenderTools()->MapScreenToGroup(Params.m_Center.x, Params.m_Center.y, pGroup, GetCurCamera()->m_Zoom);
+	return true;
 }

--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -5,17 +5,10 @@
 #include <game/client/component.h>
 #include <game/client/render.h>
 
+#include "render_layer.h"
 #include <cstdint>
 #include <memory>
 #include <vector>
-
-#define INDEX_BUFFER_GROUP_WIDTH 12
-#define INDEX_BUFFER_GROUP_HEIGHT 9
-#define INDEX_BORDER_BUFFER_GROUP_SIZE 20
-
-typedef char *offset_ptr_size;
-typedef uintptr_t offset_ptr;
-typedef unsigned int offset_ptr32;
 
 class CCamera;
 class CLayers;
@@ -30,109 +23,22 @@ class CMapLayers : public CComponent
 {
 	friend class CBackground;
 	friend class CMenuBackground;
+	friend class CRenderLayer;
+	friend class CRenderLayerTile;
+	friend class CRenderLayerQuads;
+	friend class CRenderLayerEntityGame;
+	friend class CRenderLayerEntityFront;
+	friend class CRenderLayerEntityTele;
+	friend class CRenderLayerEntitySpeedup;
+	friend class CRenderLayerEntitySwitch;
+	friend class CRenderLayerEntityTune;
 
 	CLayers *m_pLayers;
 	CMapImages *m_pImages;
-	std::unique_ptr<CMapBasedEnvelopePointAccess> m_pEnvelopePoints;
+	std::shared_ptr<CMapBasedEnvelopePointAccess> m_pEnvelopePoints;
 
 	int m_Type;
 	bool m_OnlineOnly;
-
-	struct STileLayerVisuals
-	{
-		STileLayerVisuals() :
-			m_pTilesOfLayer(nullptr)
-		{
-			m_Width = 0;
-			m_Height = 0;
-			m_BufferContainerIndex = -1;
-			m_IsTextured = false;
-		}
-
-		bool Init(unsigned int Width, unsigned int Height);
-
-		~STileLayerVisuals();
-
-		struct STileVisual
-		{
-			STileVisual() :
-				m_IndexBufferByteOffset(0) {}
-
-		private:
-			offset_ptr32 m_IndexBufferByteOffset;
-
-		public:
-			bool DoDraw()
-			{
-				return (m_IndexBufferByteOffset & 0x10000000) != 0;
-			}
-
-			void Draw(bool SetDraw)
-			{
-				m_IndexBufferByteOffset = (SetDraw ? 0x10000000 : (offset_ptr32)0) | (m_IndexBufferByteOffset & 0xEFFFFFFF);
-			}
-
-			offset_ptr IndexBufferByteOffset()
-			{
-				return ((offset_ptr)(m_IndexBufferByteOffset & 0xEFFFFFFF) * 6 * sizeof(uint32_t));
-			}
-
-			void SetIndexBufferByteOffset(offset_ptr32 IndexBufferByteOff)
-			{
-				m_IndexBufferByteOffset = IndexBufferByteOff | (m_IndexBufferByteOffset & 0x10000000);
-			}
-
-			void AddIndexBufferByteOffset(offset_ptr32 IndexBufferByteOff)
-			{
-				m_IndexBufferByteOffset = ((m_IndexBufferByteOffset & 0xEFFFFFFF) + IndexBufferByteOff) | (m_IndexBufferByteOffset & 0x10000000);
-			}
-		};
-		STileVisual *m_pTilesOfLayer;
-
-		STileVisual m_BorderTopLeft;
-		STileVisual m_BorderTopRight;
-		STileVisual m_BorderBottomRight;
-		STileVisual m_BorderBottomLeft;
-
-		STileVisual m_BorderKillTile; //end of map kill tile -- game layer only
-
-		std::vector<STileVisual> m_vBorderTop;
-		std::vector<STileVisual> m_vBorderLeft;
-		std::vector<STileVisual> m_vBorderRight;
-		std::vector<STileVisual> m_vBorderBottom;
-
-		unsigned int m_Width;
-		unsigned int m_Height;
-		int m_BufferContainerIndex;
-		bool m_IsTextured;
-	};
-	std::vector<STileLayerVisuals *> m_vpTileLayerVisuals;
-
-	struct SQuadLayerVisuals
-	{
-		SQuadLayerVisuals() :
-			m_QuadNum(0), m_pQuadsOfLayer(nullptr), m_BufferContainerIndex(-1), m_IsTextured(false) {}
-
-		struct SQuadVisual
-		{
-			SQuadVisual() :
-				m_IndexBufferByteOffset(0) {}
-
-			offset_ptr m_IndexBufferByteOffset;
-		};
-
-		int m_QuadNum;
-		SQuadVisual *m_pQuadsOfLayer;
-
-		int m_BufferContainerIndex;
-		bool m_IsTextured;
-	};
-	std::vector<SQuadLayerVisuals *> m_vpQuadLayerVisuals;
-	std::vector<std::vector<int>> m_vvLayerCount;
-	int m_GameGroup;
-
-	virtual CCamera *GetCurCamera();
-	virtual const char *LoadingTitle() const;
 
 public:
 	enum
@@ -144,27 +50,21 @@ public:
 		TYPE_ALL = -1,
 	};
 
+	static void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, IMap *pMap, CMapBasedEnvelopePointAccess *pEnvelopePoints, IClient *pClient, CGameClient *pGameClient, bool OnlineOnly);
+	void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels);
+
 	CMapLayers(int Type, bool OnlineOnly = true);
-	virtual ~CMapLayers();
 	virtual int Sizeof() const override { return sizeof(*this); }
 	virtual void OnInit() override;
 	virtual void OnRender() override;
 	virtual void OnMapLoad() override;
 
-	static void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, void *pUser);
+	virtual CCamera *GetCurCamera();
 
 private:
-	void RenderTileLayer(int LayerIndex, const ColorRGBA &Color);
-	void RenderTileBorder(int LayerIndex, const ColorRGBA &Color, int BorderX0, int BorderY0, int BorderX1, int BorderY1);
-	void RenderKillTileBorder(int LayerIndex, const ColorRGBA &Color);
-	void RenderQuadLayer(int LayerIndex, CMapItemLayerQuads *pQuadLayer, bool ForceRender = false);
-
+	std::vector<std::unique_ptr<CRenderLayer>> m_vRenderLayers;
 	int GetLayerType(const CMapItemLayer *pLayer) const;
-	int GetTileLayerAndOverlayCount(const CMapItemLayerTilemap *pLayerTilemap, int LayerType, void **ppTiles = nullptr) const;
-
-	void RenderTilelayerNoTileBuffer(int ImageIndex, int LayerType, void *pTilesData, CMapItemLayerTilemap *pLayerTilemap, const ColorRGBA &Color);
-	void RenderTilelayerWithTileBuffer(int ImageIndex, int LayerType, int TileLayerCounter, const ColorRGBA &Color);
-	ColorRGBA GetDeathBorderColor() const;
+	bool RenderGroup(const CRenderLayerParams &Params, int GroupId);
 };
 
 #endif

--- a/src/game/client/components/mapsounds.cpp
+++ b/src/game/client/components/mapsounds.cpp
@@ -195,7 +195,7 @@ void CMapSounds::OnRender()
 			continue;
 
 		ColorRGBA Position = ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f);
-		CMapLayers::EnvelopeEval(Source.m_pSource->m_PosEnvOffset, Source.m_pSource->m_PosEnv, Position, 2, &m_pClient->m_MapLayersBackground);
+		GameClient()->m_MapLayersBackground.EnvelopeEval(Source.m_pSource->m_PosEnvOffset, Source.m_pSource->m_PosEnv, Position, 2);
 
 		float x = fx2f(Source.m_pSource->m_Position.x) + Position.r;
 		float y = fx2f(Source.m_pSource->m_Position.y) + Position.g;
@@ -209,7 +209,7 @@ void CMapSounds::OnRender()
 		Sound()->SetVoicePosition(Source.m_Voice, vec2(x, y));
 
 		ColorRGBA Volume = ColorRGBA(1.0f, 0.0f, 0.0f, 0.0f);
-		CMapLayers::EnvelopeEval(Source.m_pSource->m_SoundEnvOffset, Source.m_pSource->m_SoundEnv, Volume, 1, &m_pClient->m_MapLayersBackground);
+		GameClient()->m_MapLayersBackground.EnvelopeEval(Source.m_pSource->m_SoundEnvOffset, Source.m_pSource->m_SoundEnv, Volume, 1);
 		if(Volume.r < 1.0f)
 		{
 			Sound()->SetVoiceVolume(Source.m_Voice, Volume.r);

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -362,11 +362,6 @@ CCamera *CMenuBackground::GetCurCamera()
 	return &m_Camera;
 }
 
-const char *CMenuBackground::LoadingTitle() const
-{
-	return Localize("Loading background map");
-}
-
 void CMenuBackground::ChangePosition(int PositionNumber)
 {
 	if(PositionNumber != m_CurrentPosition)

--- a/src/game/client/components/menu_background.h
+++ b/src/game/client/components/menu_background.h
@@ -113,7 +113,6 @@ public:
 	bool IsLoading() const { return m_Loading; }
 
 	class CCamera *GetCurCamera() override;
-	const char *LoadingTitle() const override;
 
 	void ChangePosition(int PositionNumber);
 

--- a/src/game/client/components/render_layer.cpp
+++ b/src/game/client/components/render_layer.cpp
@@ -1,0 +1,1268 @@
+#include "render_layer.h"
+#include "maplayers.h"
+
+#include <engine/graphics.h>
+#include <engine/shared/config.h>
+#include <engine/storage.h>
+
+#include <game/client/gameclient.h>
+#include <game/layers.h>
+#include <game/localization.h>
+#include <game/mapitems.h>
+
+#include <chrono>
+
+/************************
+ * Render Buffer Helper *
+ ************************/
+static void FillTmpTile(SGraphicTile *pTmpTile, SGraphicTileTexureCoords *pTmpTex, unsigned char Flags, unsigned char Index, int x, int y, const ivec2 &Offset, int Scale)
+{
+	if(pTmpTex)
+	{
+		unsigned char aTexX[]{0, 1, 1, 0};
+		unsigned char aTexY[]{0, 0, 1, 1};
+
+		if(Flags & TILEFLAG_XFLIP)
+			std::rotate(std::begin(aTexX), std::begin(aTexX) + 2, std::end(aTexX));
+
+		if(Flags & TILEFLAG_YFLIP)
+			std::rotate(std::begin(aTexY), std::begin(aTexY) + 2, std::end(aTexY));
+
+		if(Flags & TILEFLAG_ROTATE)
+		{
+			std::rotate(std::begin(aTexX), std::begin(aTexX) + 3, std::end(aTexX));
+			std::rotate(std::begin(aTexY), std::begin(aTexY) + 3, std::end(aTexY));
+		}
+
+		pTmpTex->m_TexCoordTopLeft.x = aTexX[0];
+		pTmpTex->m_TexCoordTopLeft.y = aTexY[0];
+		pTmpTex->m_TexCoordBottomLeft.x = aTexX[3];
+		pTmpTex->m_TexCoordBottomLeft.y = aTexY[3];
+		pTmpTex->m_TexCoordTopRight.x = aTexX[1];
+		pTmpTex->m_TexCoordTopRight.y = aTexY[1];
+		pTmpTex->m_TexCoordBottomRight.x = aTexX[2];
+		pTmpTex->m_TexCoordBottomRight.y = aTexY[2];
+
+		pTmpTex->m_TexCoordTopLeft.z = Index;
+		pTmpTex->m_TexCoordBottomLeft.z = Index;
+		pTmpTex->m_TexCoordTopRight.z = Index;
+		pTmpTex->m_TexCoordBottomRight.z = Index;
+
+		bool HasRotation = (Flags & TILEFLAG_ROTATE) != 0;
+		pTmpTex->m_TexCoordTopLeft.w = HasRotation;
+		pTmpTex->m_TexCoordBottomLeft.w = HasRotation;
+		pTmpTex->m_TexCoordTopRight.w = HasRotation;
+		pTmpTex->m_TexCoordBottomRight.w = HasRotation;
+	}
+
+	vec2 TopLeft(x * Scale + Offset.x, y * Scale + Offset.y);
+	vec2 BottomRight(x * Scale + Scale + Offset.x, y * Scale + Scale + Offset.y);
+	pTmpTile->m_TopLeft = TopLeft;
+	pTmpTile->m_BottomLeft.x = TopLeft.x;
+	pTmpTile->m_BottomLeft.y = BottomRight.y;
+	pTmpTile->m_TopRight.x = BottomRight.x;
+	pTmpTile->m_TopRight.y = TopLeft.y;
+	pTmpTile->m_BottomRight = BottomRight;
+}
+
+static void FillTmpTileSpeedup(SGraphicTile *pTmpTile, SGraphicTileTexureCoords *pTmpTex, unsigned char Flags, int x, int y, const ivec2 &Offset, int Scale, short AngleRotate)
+{
+	int Angle = AngleRotate % 360;
+	FillTmpTile(pTmpTile, pTmpTex, Angle >= 270 ? ROTATION_270 : (Angle >= 180 ? ROTATION_180 : (Angle >= 90 ? ROTATION_90 : 0)), AngleRotate % 90, x, y, Offset, Scale);
+}
+
+static bool AddTile(std::vector<SGraphicTile> &vTmpTiles, std::vector<SGraphicTileTexureCoords> &vTmpTileTexCoords, unsigned char Index, unsigned char Flags, int x, int y, bool DoTextureCoords, bool FillSpeedup = false, int AngleRotate = -1, const ivec2 &Offset = ivec2{0, 0}, int Scale = 32)
+{
+	if(Index <= 0)
+		return false;
+
+	vTmpTiles.emplace_back();
+	SGraphicTile &Tile = vTmpTiles.back();
+	SGraphicTileTexureCoords *pTileTex = nullptr;
+	if(DoTextureCoords)
+	{
+		vTmpTileTexCoords.emplace_back();
+		SGraphicTileTexureCoords &TileTex = vTmpTileTexCoords.back();
+		pTileTex = &TileTex;
+	}
+	if(FillSpeedup)
+		FillTmpTileSpeedup(&Tile, pTileTex, Flags, x, y, Offset, Scale, AngleRotate);
+	else
+		FillTmpTile(&Tile, pTileTex, Flags, Index, x, y, Offset, Scale);
+
+	return true;
+}
+
+class CTmpQuadVertexTextured
+{
+public:
+	float m_X, m_Y, m_CenterX, m_CenterY;
+	unsigned char m_R, m_G, m_B, m_A;
+	float m_U, m_V;
+};
+
+class CTmpQuadVertex
+{
+public:
+	float m_X, m_Y, m_CenterX, m_CenterY;
+	unsigned char m_R, m_G, m_B, m_A;
+};
+
+class CTmpQuad
+{
+public:
+	CTmpQuadVertex m_aVertices[4];
+};
+
+class CTmpQuadTextured
+{
+public:
+	CTmpQuadVertexTextured m_aVertices[4];
+};
+
+static void mem_copy_special(void *pDest, void *pSource, size_t Size, size_t Count, size_t Steps)
+{
+	size_t CurStep = 0;
+	for(size_t i = 0; i < Count; ++i)
+	{
+		mem_copy(((char *)pDest) + CurStep + i * Size, ((char *)pSource) + i * Size, Size);
+		CurStep += Steps;
+	}
+}
+
+void CRenderLayer::EnvelopeEvalRenderLayer(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, void *pUser)
+{
+	CRenderLayer *pRenderLayer = (CRenderLayer *)pUser;
+	CMapLayers::EnvelopeEval(TimeOffsetMillis, Env, Result, Channels, pRenderLayer->m_pMap, pRenderLayer->m_pEnvelopePoints.get(), pRenderLayer->m_pClient, pRenderLayer->m_pGameClient, pRenderLayer->m_OnlineOnly);
+}
+
+bool CRenderLayerTile::CTileLayerVisuals::Init(unsigned int Width, unsigned int Height)
+{
+	m_Width = Width;
+	m_Height = Height;
+	if(Width == 0 || Height == 0)
+		return false;
+	if constexpr(sizeof(unsigned int) >= sizeof(ptrdiff_t))
+		if(Width >= std::numeric_limits<std::ptrdiff_t>::max() || Height >= std::numeric_limits<std::ptrdiff_t>::max())
+			return false;
+
+	m_vTilesOfLayer.resize((size_t)Height * (size_t)Width);
+
+	m_vBorderTop.resize(Width);
+	m_vBorderBottom.resize(Width);
+
+	m_vBorderLeft.resize(Height);
+	m_vBorderRight.resize(Height);
+	return true;
+}
+
+/*************
+* Base Layer *
+**************/
+
+CRenderLayer::CRenderLayer(int GroupId, int LayerId, int Flags) :
+	m_GroupId(GroupId), m_LayerId(LayerId), m_Flags(Flags) {}
+
+void CRenderLayer::OnInit(IGraphics *pGraphics, IMap *pMap, CRenderTools *pRenderTools, CMapImages *pMapImages, std::shared_ptr<CMapBasedEnvelopePointAccess> &pEvelopePoints, IClient *pClient, CGameClient *pGameClient, bool OnlineOnly)
+{
+	m_pGraphics = pGraphics;
+	m_pMap = pMap;
+	m_pRenderTools = pRenderTools;
+	m_pMapImages = pMapImages;
+	m_pClient = pClient;
+	m_pGameClient = pGameClient;
+	m_pEnvelopePoints = pEvelopePoints;
+	m_OnlineOnly = OnlineOnly;
+}
+
+void CRenderLayer::UseTexture(IGraphics::CTextureHandle TextureHandle) const
+{
+	if(TextureHandle.IsValid())
+		m_pGraphics->TextureSet(TextureHandle);
+	else
+		m_pGraphics->TextureClear();
+}
+
+/**************
+ * Tile Layer *
+ **************/
+
+CRenderLayerTile::CRenderLayerTile(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap) :
+	CRenderLayer(GroupId, LayerId, Flags)
+{
+	m_pLayerTilemap = pLayerTilemap;
+	m_Color = ColorRGBA(m_pLayerTilemap->m_Color.r / 255.0f, m_pLayerTilemap->m_Color.g / 255.0f, m_pLayerTilemap->m_Color.b / 255.0f, pLayerTilemap->m_Color.a / 255.0f);
+}
+
+void CRenderLayerTile::RenderTileLayer(const ColorRGBA &Color, CTileLayerVisuals *pTileLayerVisuals)
+{
+	CTileLayerVisuals &Visuals = pTileLayerVisuals ? *pTileLayerVisuals : m_VisualTiles.value();
+	if(Visuals.m_BufferContainerIndex == -1)
+		return; // no visuals were created
+
+	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
+	m_pGraphics->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+
+	int ScreenRectY0 = std::floor(ScreenY0 / 32);
+	int ScreenRectX0 = std::floor(ScreenX0 / 32);
+	int ScreenRectY1 = std::ceil(ScreenY1 / 32);
+	int ScreenRectX1 = std::ceil(ScreenX1 / 32);
+
+	if(ScreenRectX1 > 0 && ScreenRectY1 > 0 && ScreenRectX0 < (int)Visuals.m_Width && ScreenRectY0 < (int)Visuals.m_Height)
+	{
+		// create the indice buffers we want to draw -- reuse them
+		std::vector<char *> vpIndexOffsets;
+		std::vector<unsigned int> vDrawCounts;
+
+		int X0 = std::max(ScreenRectX0, 0);
+		int X1 = std::min(ScreenRectX1, (int)Visuals.m_Width);
+		if(X0 <= X1)
+		{
+			int Y0 = std::max(ScreenRectY0, 0);
+			int Y1 = std::min(ScreenRectY1, (int)Visuals.m_Height);
+
+			unsigned long long Reserve = absolute(Y1 - Y0) + 1;
+			vpIndexOffsets.reserve(Reserve);
+			vDrawCounts.reserve(Reserve);
+
+			for(int y = Y0; y < Y1; ++y)
+			{
+				int XR = X1 - 1;
+
+				dbg_assert(Visuals.m_vTilesOfLayer[y * Visuals.m_Width + XR].IndexBufferByteOffset() >= Visuals.m_vTilesOfLayer[y * Visuals.m_Width + X0].IndexBufferByteOffset(), "Tile count wrong.");
+
+				unsigned int NumVertices = ((Visuals.m_vTilesOfLayer[y * Visuals.m_Width + XR].IndexBufferByteOffset() - Visuals.m_vTilesOfLayer[y * Visuals.m_Width + X0].IndexBufferByteOffset()) / sizeof(unsigned int)) + (Visuals.m_vTilesOfLayer[y * Visuals.m_Width + XR].DoDraw() ? 6lu : 0lu);
+
+				if(NumVertices)
+				{
+					vpIndexOffsets.push_back((offset_ptr_size)Visuals.m_vTilesOfLayer[y * Visuals.m_Width + X0].IndexBufferByteOffset());
+					vDrawCounts.push_back(NumVertices);
+				}
+			}
+
+			int DrawCount = vpIndexOffsets.size();
+			if(DrawCount != 0)
+			{
+				m_pGraphics->RenderTileLayer(Visuals.m_BufferContainerIndex, Color, vpIndexOffsets.data(), vDrawCounts.data(), DrawCount);
+			}
+		}
+	}
+
+	if(ScreenRectX1 > (int)Visuals.m_Width || ScreenRectY1 > (int)Visuals.m_Height || ScreenRectX0 < 0 || ScreenRectY0 < 0)
+	{
+		RenderTileBorder(Color, ScreenRectX0, ScreenRectY0, ScreenRectX1, ScreenRectY1);
+	}
+}
+
+void CRenderLayerTile::RenderTileBorder(const ColorRGBA &Color, int BorderX0, int BorderY0, int BorderX1, int BorderY1)
+{
+	CTileLayerVisuals &Visuals = m_VisualTiles.value();
+
+	int Y0 = std::max(0, BorderY0);
+	int X0 = std::max(0, BorderX0);
+	int Y1 = std::min((int)Visuals.m_Height, BorderY1);
+	int X1 = std::min((int)Visuals.m_Width, BorderX1);
+
+	// corners
+	auto DrawCorner = [&](vec2 Offset, vec2 Scale, CTileLayerVisuals::CTileVisual &Visual) {
+		Offset *= 32.0f;
+		m_pGraphics->RenderBorderTiles(Visuals.m_BufferContainerIndex, Color, (offset_ptr_size)Visual.IndexBufferByteOffset(), Offset, Scale, 1);
+	};
+
+	if(BorderX0 < 0)
+	{
+		// Draw corners on left side
+		if(BorderY0 < 0 && Visuals.m_BorderTopLeft.DoDraw())
+		{
+			DrawCorner(
+				vec2(0, 0),
+				vec2(std::abs(BorderX0), std::abs(BorderY0)),
+				Visuals.m_BorderTopLeft);
+		}
+		if(BorderY1 > (int)Visuals.m_Height && Visuals.m_BorderBottomLeft.DoDraw())
+		{
+			DrawCorner(
+				vec2(0, Visuals.m_Height),
+				vec2(std::abs(BorderX0), BorderY1 - Visuals.m_Height),
+				Visuals.m_BorderBottomLeft);
+		}
+	}
+	if(BorderX1 > (int)Visuals.m_Width)
+	{
+		// Draw corners on right side
+		if(BorderY0 < 0 && Visuals.m_BorderTopRight.DoDraw())
+		{
+			DrawCorner(
+				vec2(Visuals.m_Width, 0),
+				vec2(BorderX1 - Visuals.m_Width, std::abs(BorderY0)),
+				Visuals.m_BorderTopRight);
+		}
+		if(BorderY1 > (int)Visuals.m_Height && Visuals.m_BorderBottomRight.DoDraw())
+		{
+			DrawCorner(
+				vec2(Visuals.m_Width, Visuals.m_Height),
+				vec2(BorderX1 - Visuals.m_Width, BorderY1 - Visuals.m_Height),
+				Visuals.m_BorderBottomRight);
+		}
+	}
+
+	// borders
+	auto DrawBorder = [&](vec2 Offset, vec2 Scale, CTileLayerVisuals::CTileVisual &StartVisual, CTileLayerVisuals::CTileVisual &EndVisual) {
+		unsigned int DrawNum = ((EndVisual.IndexBufferByteOffset() - StartVisual.IndexBufferByteOffset()) / (sizeof(unsigned int) * 6)) + (EndVisual.DoDraw() ? 1lu : 0lu);
+		offset_ptr_size pOffset = (offset_ptr_size)StartVisual.IndexBufferByteOffset();
+		Offset *= 32.0f;
+		m_pGraphics->RenderBorderTiles(Visuals.m_BufferContainerIndex, Color, pOffset, Offset, Scale, DrawNum);
+	};
+
+	if(Y0 < (int)Visuals.m_Height && Y1 > 0)
+	{
+		if(BorderX1 > (int)Visuals.m_Width)
+		{
+			// Draw right border
+			DrawBorder(
+				vec2(Visuals.m_Width, 0),
+				vec2(BorderX1 - Visuals.m_Width, 1.f),
+				Visuals.m_vBorderRight[Y0], Visuals.m_vBorderRight[Y1 - 1]);
+		}
+		if(BorderX0 < 0)
+		{
+			// Draw left border
+			DrawBorder(
+				vec2(0, 0),
+				vec2(std::abs(BorderX0), 1),
+				Visuals.m_vBorderLeft[Y0], Visuals.m_vBorderLeft[Y1 - 1]);
+		}
+	}
+
+	if(X0 < (int)Visuals.m_Width && X1 > 0)
+	{
+		if(BorderY0 < 0)
+		{
+			// Draw top border
+			DrawBorder(
+				vec2(0, 0),
+				vec2(1, std::abs(BorderY0)),
+				Visuals.m_vBorderTop[X0], Visuals.m_vBorderTop[X1 - 1]);
+		}
+		if(BorderY1 > (int)Visuals.m_Height)
+		{
+			// Draw bottom border
+			DrawBorder(
+				vec2(0, Visuals.m_Height),
+				vec2(1, BorderY1 - Visuals.m_Height),
+				Visuals.m_vBorderBottom[X0], Visuals.m_vBorderBottom[X1 - 1]);
+		}
+	}
+}
+
+void CRenderLayerTile::RenderKillTileBorder(const ColorRGBA &Color)
+{
+	CTileLayerVisuals &Visuals = m_VisualTiles.value();
+	if(Visuals.m_BufferContainerIndex == -1)
+		return; // no visuals were created
+
+	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
+	m_pGraphics->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+
+	int BorderY0 = std::floor(ScreenY0 / 32);
+	int BorderX0 = std::floor(ScreenX0 / 32);
+	int BorderY1 = std::ceil(ScreenY1 / 32);
+	int BorderX1 = std::ceil(ScreenX1 / 32);
+
+	if(BorderX0 >= -BorderRenderDistance && BorderY0 >= -BorderRenderDistance && BorderX1 <= (int)Visuals.m_Width + BorderRenderDistance && BorderY1 <= (int)Visuals.m_Height + BorderRenderDistance)
+		return;
+	if(!Visuals.m_BorderKillTile.DoDraw())
+		return;
+
+	BorderX0 = std::clamp(BorderX0, -300, (int)Visuals.m_Width + 299);
+	BorderY0 = std::clamp(BorderY0, -300, (int)Visuals.m_Height + 299);
+	BorderX1 = std::clamp(BorderX1, -300, (int)Visuals.m_Width + 299);
+	BorderY1 = std::clamp(BorderY1, -300, (int)Visuals.m_Height + 299);
+
+	auto DrawKillBorder = [&](vec2 Offset, vec2 Scale) {
+		offset_ptr_size pOffset = (offset_ptr_size)Visuals.m_BorderKillTile.IndexBufferByteOffset();
+		Offset *= 32.0f;
+		m_pGraphics->RenderBorderTiles(Visuals.m_BufferContainerIndex, Color, pOffset, Offset, Scale, 1);
+	};
+
+	// Draw left kill tile border
+	if(BorderX0 < -BorderRenderDistance)
+	{
+		DrawKillBorder(
+			vec2(BorderX0, BorderY0),
+			vec2(-BorderRenderDistance - BorderX0, BorderY1 - BorderY0));
+	}
+	// Draw top kill tile border
+	if(BorderY0 < -BorderRenderDistance)
+	{
+		DrawKillBorder(
+			vec2(std::max(BorderX0, -BorderRenderDistance), BorderY0),
+			vec2(std::min(BorderX1, (int)Visuals.m_Width + BorderRenderDistance) - std::max(BorderX0, -BorderRenderDistance), -BorderRenderDistance - BorderY0));
+	}
+	// Draw right kill tile border
+	if(BorderX1 > (int)Visuals.m_Width + BorderRenderDistance)
+	{
+		DrawKillBorder(
+			vec2(Visuals.m_Width + BorderRenderDistance, BorderY0),
+			vec2(BorderX1 - (Visuals.m_Width + BorderRenderDistance), BorderY1 - BorderY0));
+	}
+	// Draw bottom kill tile border
+	if(BorderY1 > (int)Visuals.m_Height + BorderRenderDistance)
+	{
+		DrawKillBorder(
+			vec2(std::max(BorderX0, -BorderRenderDistance), Visuals.m_Height + BorderRenderDistance),
+			vec2(std::min(BorderX1, (int)Visuals.m_Width + BorderRenderDistance) - std::max(BorderX0, -BorderRenderDistance), BorderY1 - (Visuals.m_Height + BorderRenderDistance)));
+	}
+}
+
+ColorRGBA CRenderLayerTile::GetRenderColor(const CRenderLayerParams &Params) const
+{
+	ColorRGBA Color = m_Color;
+	if(Params.EntityOverlayVal && Params.m_RenderType != CMapLayers::TYPE_BACKGROUND_FORCE)
+		Color.a *= (100 - Params.EntityOverlayVal) / 100.0f;
+
+	ColorRGBA ColorEnv = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+	CMapLayers::EnvelopeEval(m_pLayerTilemap->m_ColorEnvOffset, m_pLayerTilemap->m_ColorEnv, ColorEnv, 4, m_pMap, m_pEnvelopePoints.get(), m_pClient, m_pGameClient, m_OnlineOnly);
+	Color = Color.Multiply(ColorEnv);
+	return Color;
+}
+
+void CRenderLayerTile::Render(const CRenderLayerParams &Params)
+{
+	if(!DoRender(Params))
+		return;
+
+	UseTexture(GetTexture());
+	ColorRGBA Color = GetRenderColor(Params);
+	if(m_pGraphics->IsTileBufferingEnabled())
+	{
+		RenderTileLayerWithTileBuffer(Color);
+	}
+	else
+	{
+		RenderTileLayerNoTileBuffer(Color);
+	}
+}
+
+bool CRenderLayerTile::DoRender(const CRenderLayerParams &Params) const
+{
+	// skip rendering if we render background force, but deactivated tile layer and want to render a tilelayer
+	if(!g_Config.m_ClBackgroundShowTilesLayers && Params.m_RenderType == CMapLayers::TYPE_BACKGROUND_FORCE)
+		return false;
+
+	// skip rendering anything but entities if we only want to render entities
+	if(Params.EntityOverlayVal == 100 && Params.m_RenderType != CMapLayers::TYPE_BACKGROUND_FORCE)
+		return false;
+
+	// skip rendering if detail layers if not wanted
+	if(m_Flags & LAYERFLAG_DETAIL && !g_Config.m_GfxHighDetail && Params.m_RenderType != CMapLayers::TYPE_FULL_DESIGN) // detail but no details
+		return false;
+	return true;
+}
+
+void CRenderLayerTile::RenderTileLayerWithTileBuffer(const ColorRGBA &Color)
+{
+	m_pGraphics->BlendNormal();
+	RenderTileLayer(Color);
+}
+
+void CRenderLayerTile::RenderTileLayerNoTileBuffer(const ColorRGBA &Color)
+{
+	CTile *pTiles = GetData<CTile>();
+	m_pGraphics->BlendNone();
+	m_pRenderTools->RenderTilemap(pTiles, m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_OPAQUE);
+	m_pGraphics->BlendNormal();
+	m_pRenderTools->RenderTilemap(pTiles, m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_TRANSPARENT);
+}
+
+void CRenderLayerTile::Init()
+{
+	if(m_pLayerTilemap->m_Image >= 0 && m_pLayerTilemap->m_Image < m_pMapImages->Num())
+		m_TextureHandle = m_pMapImages->Get(m_pLayerTilemap->m_Image);
+	else
+		m_TextureHandle.Invalidate();
+	UploadTileData(m_VisualTiles, 0, false);
+}
+
+void CRenderLayerTile::UploadTileData(std::optional<CTileLayerVisuals> &VisualsOptional, int CurOverlay, bool AddAsSpeedup, bool IsGameLayer)
+{
+	if(!m_pGraphics->IsTileBufferingEnabled())
+		return;
+
+	// prepare all visuals for all tile layers
+	std::vector<SGraphicTile> vTmpTiles;
+	std::vector<SGraphicTileTexureCoords> vTmpTileTexCoords;
+	std::vector<SGraphicTile> vTmpBorderTopTiles;
+	std::vector<SGraphicTileTexureCoords> vTmpBorderTopTilesTexCoords;
+	std::vector<SGraphicTile> vTmpBorderLeftTiles;
+	std::vector<SGraphicTileTexureCoords> vTmpBorderLeftTilesTexCoords;
+	std::vector<SGraphicTile> vTmpBorderRightTiles;
+	std::vector<SGraphicTileTexureCoords> vTmpBorderRightTilesTexCoords;
+	std::vector<SGraphicTile> vTmpBorderBottomTiles;
+	std::vector<SGraphicTileTexureCoords> vTmpBorderBottomTilesTexCoords;
+	std::vector<SGraphicTile> vTmpBorderCorners;
+	std::vector<SGraphicTileTexureCoords> vTmpBorderCornersTexCoords;
+
+	const bool DoTextureCoords = GetTexture().IsValid();
+
+	// create the visual and set it in the optional, afterwards get it
+	CTileLayerVisuals v;
+	VisualsOptional = v;
+	CTileLayerVisuals &Visuals = VisualsOptional.value();
+
+	if(!Visuals.Init(m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height))
+		return;
+
+	Visuals.m_IsTextured = DoTextureCoords;
+
+	if(!DoTextureCoords)
+	{
+		vTmpTiles.reserve((size_t)m_pLayerTilemap->m_Width * m_pLayerTilemap->m_Height);
+		vTmpBorderTopTiles.reserve((size_t)m_pLayerTilemap->m_Width);
+		vTmpBorderBottomTiles.reserve((size_t)m_pLayerTilemap->m_Width);
+		vTmpBorderLeftTiles.reserve((size_t)m_pLayerTilemap->m_Height);
+		vTmpBorderRightTiles.reserve((size_t)m_pLayerTilemap->m_Height);
+		vTmpBorderCorners.reserve((size_t)4);
+	}
+	else
+	{
+		vTmpTileTexCoords.reserve((size_t)m_pLayerTilemap->m_Width * m_pLayerTilemap->m_Height);
+		vTmpBorderTopTilesTexCoords.reserve((size_t)m_pLayerTilemap->m_Width);
+		vTmpBorderBottomTilesTexCoords.reserve((size_t)m_pLayerTilemap->m_Width);
+		vTmpBorderLeftTilesTexCoords.reserve((size_t)m_pLayerTilemap->m_Height);
+		vTmpBorderRightTilesTexCoords.reserve((size_t)m_pLayerTilemap->m_Height);
+		vTmpBorderCornersTexCoords.reserve((size_t)4);
+	}
+
+	int x = 0;
+	int y = 0;
+	for(y = 0; y < m_pLayerTilemap->m_Height; ++y)
+	{
+		for(x = 0; x < m_pLayerTilemap->m_Width; ++x)
+		{
+			unsigned char Index = 0;
+			unsigned char Flags = 0;
+			int AngleRotate = -1;
+			GetTileData(&Index, &Flags, &AngleRotate, x, y, CurOverlay);
+
+			// the amount of tiles handled before this tile
+			int TilesHandledCount = vTmpTiles.size();
+			Visuals.m_vTilesOfLayer[y * m_pLayerTilemap->m_Width + x].SetIndexBufferByteOffset((offset_ptr32)(TilesHandledCount));
+
+			if(AddTile(vTmpTiles, vTmpTileTexCoords, Index, Flags, x, y, DoTextureCoords, AddAsSpeedup, AngleRotate))
+				Visuals.m_vTilesOfLayer[y * m_pLayerTilemap->m_Width + x].Draw(true);
+
+			// do the border tiles
+			if(x == 0)
+			{
+				if(y == 0)
+				{
+					Visuals.m_BorderTopLeft.SetIndexBufferByteOffset((offset_ptr32)(vTmpBorderCorners.size()));
+					if(AddTile(vTmpBorderCorners, vTmpBorderCornersTexCoords, Index, Flags, 0, 0, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{-32, -32}))
+						Visuals.m_BorderTopLeft.Draw(true);
+				}
+				else if(y == m_pLayerTilemap->m_Height - 1)
+				{
+					Visuals.m_BorderBottomLeft.SetIndexBufferByteOffset((offset_ptr32)(vTmpBorderCorners.size()));
+					if(AddTile(vTmpBorderCorners, vTmpBorderCornersTexCoords, Index, Flags, 0, 0, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{-32, 0}))
+						Visuals.m_BorderBottomLeft.Draw(true);
+				}
+				Visuals.m_vBorderLeft[y].SetIndexBufferByteOffset((offset_ptr32)(vTmpBorderLeftTiles.size()));
+				if(AddTile(vTmpBorderLeftTiles, vTmpBorderLeftTilesTexCoords, Index, Flags, 0, y, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{-32, 0}))
+					Visuals.m_vBorderLeft[y].Draw(true);
+			}
+			else if(x == m_pLayerTilemap->m_Width - 1)
+			{
+				if(y == 0)
+				{
+					Visuals.m_BorderTopRight.SetIndexBufferByteOffset((offset_ptr32)(vTmpBorderCorners.size()));
+					if(AddTile(vTmpBorderCorners, vTmpBorderCornersTexCoords, Index, Flags, 0, 0, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{0, -32}))
+						Visuals.m_BorderTopRight.Draw(true);
+				}
+				else if(y == m_pLayerTilemap->m_Height - 1)
+				{
+					Visuals.m_BorderBottomRight.SetIndexBufferByteOffset((offset_ptr32)(vTmpBorderCorners.size()));
+					if(AddTile(vTmpBorderCorners, vTmpBorderCornersTexCoords, Index, Flags, 0, 0, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{0, 0}))
+						Visuals.m_BorderBottomRight.Draw(true);
+				}
+				Visuals.m_vBorderRight[y].SetIndexBufferByteOffset((offset_ptr32)(vTmpBorderRightTiles.size()));
+				if(AddTile(vTmpBorderRightTiles, vTmpBorderRightTilesTexCoords, Index, Flags, 0, y, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{0, 0}))
+					Visuals.m_vBorderRight[y].Draw(true);
+			}
+			if(y == 0)
+			{
+				Visuals.m_vBorderTop[x].SetIndexBufferByteOffset((offset_ptr32)(vTmpBorderTopTiles.size()));
+				if(AddTile(vTmpBorderTopTiles, vTmpBorderTopTilesTexCoords, Index, Flags, x, 0, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{0, -32}))
+					Visuals.m_vBorderTop[x].Draw(true);
+			}
+			else if(y == m_pLayerTilemap->m_Height - 1)
+			{
+				Visuals.m_vBorderBottom[x].SetIndexBufferByteOffset((offset_ptr32)(vTmpBorderBottomTiles.size()));
+				if(AddTile(vTmpBorderBottomTiles, vTmpBorderBottomTilesTexCoords, Index, Flags, x, 0, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{0, 0}))
+					Visuals.m_vBorderBottom[x].Draw(true);
+			}
+		}
+	}
+
+	// append one kill tile to the gamelayer
+	if(IsGameLayer)
+	{
+		Visuals.m_BorderKillTile.SetIndexBufferByteOffset((offset_ptr32)(vTmpTiles.size()));
+		if(AddTile(vTmpTiles, vTmpTileTexCoords, TILE_DEATH, 0, 0, 0, DoTextureCoords))
+			Visuals.m_BorderKillTile.Draw(true);
+	}
+
+	// add the border corners, then the borders and fix their byte offsets
+	int TilesHandledCount = vTmpTiles.size();
+	Visuals.m_BorderTopLeft.AddIndexBufferByteOffset(TilesHandledCount);
+	Visuals.m_BorderTopRight.AddIndexBufferByteOffset(TilesHandledCount);
+	Visuals.m_BorderBottomLeft.AddIndexBufferByteOffset(TilesHandledCount);
+	Visuals.m_BorderBottomRight.AddIndexBufferByteOffset(TilesHandledCount);
+	// add the Corners to the tiles
+	vTmpTiles.insert(vTmpTiles.end(), vTmpBorderCorners.begin(), vTmpBorderCorners.end());
+	vTmpTileTexCoords.insert(vTmpTileTexCoords.end(), vTmpBorderCornersTexCoords.begin(), vTmpBorderCornersTexCoords.end());
+
+	// now the borders
+	TilesHandledCount = vTmpTiles.size();
+	if(m_pLayerTilemap->m_Width > 0)
+	{
+		for(int i = 0; i < m_pLayerTilemap->m_Width; ++i)
+		{
+			Visuals.m_vBorderTop[i].AddIndexBufferByteOffset(TilesHandledCount);
+		}
+	}
+	vTmpTiles.insert(vTmpTiles.end(), vTmpBorderTopTiles.begin(), vTmpBorderTopTiles.end());
+	vTmpTileTexCoords.insert(vTmpTileTexCoords.end(), vTmpBorderTopTilesTexCoords.begin(), vTmpBorderTopTilesTexCoords.end());
+
+	TilesHandledCount = vTmpTiles.size();
+	if(m_pLayerTilemap->m_Width > 0)
+	{
+		for(int i = 0; i < m_pLayerTilemap->m_Width; ++i)
+		{
+			Visuals.m_vBorderBottom[i].AddIndexBufferByteOffset(TilesHandledCount);
+		}
+	}
+	vTmpTiles.insert(vTmpTiles.end(), vTmpBorderBottomTiles.begin(), vTmpBorderBottomTiles.end());
+	vTmpTileTexCoords.insert(vTmpTileTexCoords.end(), vTmpBorderBottomTilesTexCoords.begin(), vTmpBorderBottomTilesTexCoords.end());
+
+	TilesHandledCount = vTmpTiles.size();
+	if(m_pLayerTilemap->m_Height > 0)
+	{
+		for(int i = 0; i < m_pLayerTilemap->m_Height; ++i)
+		{
+			Visuals.m_vBorderLeft[i].AddIndexBufferByteOffset(TilesHandledCount);
+		}
+	}
+	vTmpTiles.insert(vTmpTiles.end(), vTmpBorderLeftTiles.begin(), vTmpBorderLeftTiles.end());
+	vTmpTileTexCoords.insert(vTmpTileTexCoords.end(), vTmpBorderLeftTilesTexCoords.begin(), vTmpBorderLeftTilesTexCoords.end());
+
+	TilesHandledCount = vTmpTiles.size();
+	if(m_pLayerTilemap->m_Height > 0)
+	{
+		for(int i = 0; i < m_pLayerTilemap->m_Height; ++i)
+		{
+			Visuals.m_vBorderRight[i].AddIndexBufferByteOffset(TilesHandledCount);
+		}
+	}
+	vTmpTiles.insert(vTmpTiles.end(), vTmpBorderRightTiles.begin(), vTmpBorderRightTiles.end());
+	vTmpTileTexCoords.insert(vTmpTileTexCoords.end(), vTmpBorderRightTilesTexCoords.begin(), vTmpBorderRightTilesTexCoords.end());
+
+	// setup params
+	float *pTmpTiles = vTmpTiles.empty() ? nullptr : (float *)vTmpTiles.data();
+	unsigned char *pTmpTileTexCoords = vTmpTileTexCoords.empty() ? nullptr : (unsigned char *)vTmpTileTexCoords.data();
+
+	Visuals.m_BufferContainerIndex = -1;
+	size_t UploadDataSize = vTmpTileTexCoords.size() * sizeof(SGraphicTileTexureCoords) + vTmpTiles.size() * sizeof(SGraphicTile);
+	if(UploadDataSize > 0)
+	{
+		char *pUploadData = (char *)malloc(sizeof(char) * UploadDataSize);
+
+		mem_copy_special(pUploadData, pTmpTiles, sizeof(vec2), vTmpTiles.size() * 4, (DoTextureCoords ? sizeof(ubvec4) : 0));
+		if(DoTextureCoords)
+		{
+			mem_copy_special(pUploadData + sizeof(vec2), pTmpTileTexCoords, sizeof(ubvec4), vTmpTiles.size() * 4, sizeof(vec2));
+		}
+
+		// first create the buffer object
+		int BufferObjectIndex = m_pGraphics->CreateBufferObject(UploadDataSize, pUploadData, 0, true);
+
+		// then create the buffer container
+		SBufferContainerInfo ContainerInfo;
+		ContainerInfo.m_Stride = (DoTextureCoords ? (sizeof(float) * 2 + sizeof(ubvec4)) : 0);
+		ContainerInfo.m_VertBufferBindingIndex = BufferObjectIndex;
+		ContainerInfo.m_vAttributes.emplace_back();
+		SBufferContainerInfo::SAttribute *pAttr = &ContainerInfo.m_vAttributes.back();
+		pAttr->m_DataTypeCount = 2;
+		pAttr->m_Type = GRAPHICS_TYPE_FLOAT;
+		pAttr->m_Normalized = false;
+		pAttr->m_pOffset = nullptr;
+		pAttr->m_FuncType = 0;
+		if(DoTextureCoords)
+		{
+			ContainerInfo.m_vAttributes.emplace_back();
+			pAttr = &ContainerInfo.m_vAttributes.back();
+			pAttr->m_DataTypeCount = 4;
+			pAttr->m_Type = GRAPHICS_TYPE_UNSIGNED_BYTE;
+			pAttr->m_Normalized = false;
+			pAttr->m_pOffset = (void *)(sizeof(vec2));
+			pAttr->m_FuncType = 1;
+		}
+
+		Visuals.m_BufferContainerIndex = m_pGraphics->CreateBufferContainer(&ContainerInfo);
+		// and finally inform the backend how many indices are required
+		m_pGraphics->IndicesNumRequiredNotify(vTmpTiles.size() * 6);
+	}
+}
+
+int CRenderLayerTile::GetDataIndex(unsigned int &TileSize) const
+{
+	TileSize = sizeof(CTile);
+	return m_pLayerTilemap->m_Data;
+}
+
+void *CRenderLayerTile::GetRawData() const
+{
+	unsigned int TileSize;
+	unsigned int DataIndex = GetDataIndex(TileSize);
+	void *pTiles = m_pMap->GetData(DataIndex);
+	int Size = m_pMap->GetDataSize(DataIndex);
+
+	if(!pTiles || Size < m_pLayerTilemap->m_Width * m_pLayerTilemap->m_Height * (int)TileSize)
+		return nullptr;
+
+	return pTiles;
+}
+
+template<class T>
+T *CRenderLayerTile::GetData() const
+{
+	return (T *)GetRawData();
+}
+
+void CRenderLayerTile::GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const
+{
+	CTile *pTiles = GetData<CTile>();
+	*pIndex = pTiles[y * m_pLayerTilemap->m_Width + x].m_Index;
+	*pFlags = pTiles[y * m_pLayerTilemap->m_Width + x].m_Flags;
+}
+
+/**************
+ * Quad Layer *
+ **************/
+
+CRenderLayerQuads::CRenderLayerQuads(int GroupId, int LayerId, IGraphics::CTextureHandle TextureHandle, int Flags, CMapItemLayerQuads *pLayerQuads) :
+	CRenderLayer(GroupId, LayerId, Flags)
+{
+	m_pLayerQuads = pLayerQuads;
+	m_ContainsEnvelopes = false;
+}
+
+void CRenderLayerQuads::RenderQuadLayer(bool Force)
+{
+	CQuadLayerVisuals &Visuals = m_VisualQuad.value();
+	if(Visuals.m_BufferContainerIndex == -1)
+		return; // no visuals were created
+
+	if(!Force && (!g_Config.m_ClShowQuads || g_Config.m_ClOverlayEntities == 100))
+		return;
+
+	CQuad *pQuads = (CQuad *)m_pMap->GetDataSwapped(m_pLayerQuads->m_Data);
+
+	size_t QuadsRenderCount = 0;
+	size_t CurQuadOffset = 0;
+	if(m_ContainsEnvelopes)
+	{
+		for(int i = 0; i < m_pLayerQuads->m_NumQuads; ++i)
+		{
+			CQuad *pQuad = &pQuads[i];
+
+			ColorRGBA Color = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+			CMapLayers::EnvelopeEval(pQuad->m_ColorEnvOffset, pQuad->m_ColorEnv, Color, 4, m_pMap, m_pEnvelopePoints.get(), m_pClient, m_pGameClient, m_OnlineOnly);
+
+			const bool IsFullyTransparent = Color.a <= 0.0f;
+			const bool NeedsFlush = QuadsRenderCount == gs_GraphicsMaxQuadsRenderCount || IsFullyTransparent;
+
+			if(NeedsFlush)
+			{
+				// render quads of the current offset directly(cancel batching)
+				m_pGraphics->RenderQuadLayer(Visuals.m_BufferContainerIndex, m_vQuadRenderInfo.data(), QuadsRenderCount, CurQuadOffset);
+				QuadsRenderCount = 0;
+				CurQuadOffset = i;
+				if(IsFullyTransparent)
+				{
+					// since this quad is ignored, the offset is the next quad
+					++CurQuadOffset;
+				}
+			}
+
+			if(!IsFullyTransparent)
+			{
+				ColorRGBA Position = ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f);
+				CMapLayers::EnvelopeEval(pQuad->m_PosEnvOffset, pQuad->m_PosEnv, Position, 3, m_pMap, m_pEnvelopePoints.get(), m_pClient, m_pGameClient, m_OnlineOnly);
+
+				SQuadRenderInfo &QInfo = m_vQuadRenderInfo[QuadsRenderCount++];
+				QInfo.m_Color = Color;
+				QInfo.m_Offsets.x = Position.r;
+				QInfo.m_Offsets.y = Position.g;
+				QInfo.m_Rotation = Position.b / 180.0f * pi;
+			}
+		}
+		m_pGraphics->RenderQuadLayer(Visuals.m_BufferContainerIndex, m_vQuadRenderInfo.data(), QuadsRenderCount, CurQuadOffset);
+	}
+	else
+	{
+		for(CurQuadOffset = 0; CurQuadOffset < (size_t)m_pLayerQuads->m_NumQuads; CurQuadOffset += gs_GraphicsMaxQuadsRenderCount)
+		{
+			QuadsRenderCount = std::min((size_t)m_pLayerQuads->m_NumQuads - CurQuadOffset, gs_GraphicsMaxQuadsRenderCount);
+			m_pGraphics->RenderQuadLayer(Visuals.m_BufferContainerIndex, m_vQuadRenderInfo.data(), QuadsRenderCount, CurQuadOffset);
+		}
+	}
+}
+
+void CRenderLayerQuads::Init()
+{
+	if(m_pLayerQuads->m_Image >= 0 && m_pLayerQuads->m_Image < m_pMapImages->Num())
+		m_TextureHandle = m_pMapImages->Get(m_pLayerQuads->m_Image);
+	else
+		m_TextureHandle.Invalidate();
+
+	if(!m_pGraphics->IsQuadBufferingEnabled())
+		return;
+
+	std::vector<CTmpQuad> vTmpQuads;
+	std::vector<CTmpQuadTextured> vTmpQuadsTextured;
+	CQuadLayerVisuals v;
+	m_VisualQuad = v;
+	CQuadLayerVisuals *pQLayerVisuals = &(m_VisualQuad.value());
+
+	const bool Textured = m_pLayerQuads->m_Image >= 0 && m_pLayerQuads->m_Image < m_pMapImages->Num();
+
+	if(Textured)
+		vTmpQuadsTextured.resize(m_pLayerQuads->m_NumQuads);
+	else
+		vTmpQuads.resize(m_pLayerQuads->m_NumQuads);
+
+	m_vQuadRenderInfo.resize(m_pLayerQuads->m_NumQuads);
+	CQuad *pQuads = (CQuad *)m_pMap->GetDataSwapped(m_pLayerQuads->m_Data);
+
+	for(int i = 0; i < m_pLayerQuads->m_NumQuads; ++i)
+	{
+		CQuad *pQuad = &pQuads[i];
+
+		if(pQuads[i].m_ColorEnv >= 0 || pQuads[i].m_PosEnv >= 0)
+			m_ContainsEnvelopes = true;
+
+		// init for envelopeless quad layers
+		SQuadRenderInfo &QInfo = m_vQuadRenderInfo[i];
+		QInfo.m_Color = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+		QInfo.m_Offsets.x = 0;
+		QInfo.m_Offsets.y = 0;
+		QInfo.m_Rotation = 0;
+
+		for(int j = 0; j < 4; ++j)
+		{
+			int QuadIdX = j;
+			if(j == 2)
+				QuadIdX = 3;
+			else if(j == 3)
+				QuadIdX = 2;
+			if(!Textured)
+			{
+				// ignore the conversion for the position coordinates
+				vTmpQuads[i].m_aVertices[j].m_X = (pQuad->m_aPoints[QuadIdX].x);
+				vTmpQuads[i].m_aVertices[j].m_Y = (pQuad->m_aPoints[QuadIdX].y);
+				vTmpQuads[i].m_aVertices[j].m_CenterX = (pQuad->m_aPoints[4].x);
+				vTmpQuads[i].m_aVertices[j].m_CenterY = (pQuad->m_aPoints[4].y);
+				vTmpQuads[i].m_aVertices[j].m_R = (unsigned char)pQuad->m_aColors[QuadIdX].r;
+				vTmpQuads[i].m_aVertices[j].m_G = (unsigned char)pQuad->m_aColors[QuadIdX].g;
+				vTmpQuads[i].m_aVertices[j].m_B = (unsigned char)pQuad->m_aColors[QuadIdX].b;
+				vTmpQuads[i].m_aVertices[j].m_A = (unsigned char)pQuad->m_aColors[QuadIdX].a;
+			}
+			else
+			{
+				// ignore the conversion for the position coordinates
+				vTmpQuadsTextured[i].m_aVertices[j].m_X = (pQuad->m_aPoints[QuadIdX].x);
+				vTmpQuadsTextured[i].m_aVertices[j].m_Y = (pQuad->m_aPoints[QuadIdX].y);
+				vTmpQuadsTextured[i].m_aVertices[j].m_CenterX = (pQuad->m_aPoints[4].x);
+				vTmpQuadsTextured[i].m_aVertices[j].m_CenterY = (pQuad->m_aPoints[4].y);
+				vTmpQuadsTextured[i].m_aVertices[j].m_U = fx2f(pQuad->m_aTexcoords[QuadIdX].x);
+				vTmpQuadsTextured[i].m_aVertices[j].m_V = fx2f(pQuad->m_aTexcoords[QuadIdX].y);
+				vTmpQuadsTextured[i].m_aVertices[j].m_R = (unsigned char)pQuad->m_aColors[QuadIdX].r;
+				vTmpQuadsTextured[i].m_aVertices[j].m_G = (unsigned char)pQuad->m_aColors[QuadIdX].g;
+				vTmpQuadsTextured[i].m_aVertices[j].m_B = (unsigned char)pQuad->m_aColors[QuadIdX].b;
+				vTmpQuadsTextured[i].m_aVertices[j].m_A = (unsigned char)pQuad->m_aColors[QuadIdX].a;
+			}
+		}
+	}
+
+	size_t UploadDataSize = 0;
+	if(Textured)
+		UploadDataSize = vTmpQuadsTextured.size() * sizeof(CTmpQuadTextured);
+	else
+		UploadDataSize = vTmpQuads.size() * sizeof(CTmpQuad);
+
+	if(UploadDataSize > 0)
+	{
+		void *pUploadData = nullptr;
+		if(Textured)
+			pUploadData = vTmpQuadsTextured.data();
+		else
+			pUploadData = vTmpQuads.data();
+		// create the buffer object
+		int BufferObjectIndex = m_pGraphics->CreateBufferObject(UploadDataSize, pUploadData, 0);
+		// then create the buffer container
+		SBufferContainerInfo ContainerInfo;
+		ContainerInfo.m_Stride = (Textured ? (sizeof(CTmpQuadTextured) / 4) : (sizeof(CTmpQuad) / 4));
+		ContainerInfo.m_VertBufferBindingIndex = BufferObjectIndex;
+		ContainerInfo.m_vAttributes.emplace_back();
+		SBufferContainerInfo::SAttribute *pAttr = &ContainerInfo.m_vAttributes.back();
+		pAttr->m_DataTypeCount = 4;
+		pAttr->m_Type = GRAPHICS_TYPE_FLOAT;
+		pAttr->m_Normalized = false;
+		pAttr->m_pOffset = nullptr;
+		pAttr->m_FuncType = 0;
+		ContainerInfo.m_vAttributes.emplace_back();
+		pAttr = &ContainerInfo.m_vAttributes.back();
+		pAttr->m_DataTypeCount = 4;
+		pAttr->m_Type = GRAPHICS_TYPE_UNSIGNED_BYTE;
+		pAttr->m_Normalized = true;
+		pAttr->m_pOffset = (void *)(sizeof(float) * 4);
+		pAttr->m_FuncType = 0;
+		if(Textured)
+		{
+			ContainerInfo.m_vAttributes.emplace_back();
+			pAttr = &ContainerInfo.m_vAttributes.back();
+			pAttr->m_DataTypeCount = 2;
+			pAttr->m_Type = GRAPHICS_TYPE_FLOAT;
+			pAttr->m_Normalized = false;
+			pAttr->m_pOffset = (void *)(sizeof(float) * 4 + sizeof(unsigned char) * 4);
+			pAttr->m_FuncType = 0;
+		}
+
+		pQLayerVisuals->m_BufferContainerIndex = m_pGraphics->CreateBufferContainer(&ContainerInfo);
+		// and finally inform the backend how many indices are required
+		m_pGraphics->IndicesNumRequiredNotify(m_pLayerQuads->m_NumQuads * 6);
+	}
+}
+
+void CRenderLayerQuads::Render(const CRenderLayerParams &Params)
+{
+	UseTexture(GetTexture());
+	CQuad *pQuads = (CQuad *)m_pMap->GetDataSwapped(m_pLayerQuads->m_Data);
+	if(Params.m_RenderType == CMapLayers::TYPE_BACKGROUND_FORCE || Params.m_RenderType == CMapLayers::TYPE_FULL_DESIGN)
+	{
+		if(g_Config.m_ClShowQuads || Params.m_RenderType == CMapLayers::TYPE_FULL_DESIGN)
+		{
+			if(!m_pGraphics->IsQuadBufferingEnabled())
+			{
+				m_pGraphics->BlendNormal();
+				m_pRenderTools->ForceRenderQuads(pQuads, m_pLayerQuads->m_NumQuads, LAYERRENDERFLAG_TRANSPARENT, EnvelopeEvalRenderLayer, this, 1.f);
+			}
+			else
+			{
+				RenderQuadLayer(true);
+			}
+		}
+	}
+	else
+	{
+		if(!m_pGraphics->IsQuadBufferingEnabled())
+		{
+			m_pGraphics->BlendNormal();
+			m_pRenderTools->RenderQuads(pQuads, m_pLayerQuads->m_NumQuads, LAYERRENDERFLAG_TRANSPARENT, EnvelopeEvalRenderLayer, this);
+		}
+		else
+		{
+			RenderQuadLayer(false);
+		}
+	}
+}
+
+bool CRenderLayerQuads::DoRender(const CRenderLayerParams &Params) const
+{
+	// skip rendering anything but entities if we only want to render entities
+	if(Params.EntityOverlayVal == 100 && Params.m_RenderType != CMapLayers::TYPE_BACKGROUND_FORCE)
+		return false;
+
+	// skip rendering if detail layers if not wanted
+	if(m_Flags & LAYERFLAG_DETAIL && !g_Config.m_GfxHighDetail && Params.m_RenderType != CMapLayers::TYPE_FULL_DESIGN) // detail but no details
+		return false;
+	return true;
+}
+
+/****************
+ * Entity Layer *
+ ****************/
+// BASE
+CRenderLayerEntityBase::CRenderLayerEntityBase(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap) :
+	CRenderLayerTile(GroupId, LayerId, Flags, pLayerTilemap) {}
+
+bool CRenderLayerEntityBase::DoRender(const CRenderLayerParams &Params) const
+{
+	// skip rendering if we render background force or full design
+	if(Params.m_RenderType == CMapLayers::TYPE_BACKGROUND_FORCE || Params.m_RenderType == CMapLayers::TYPE_FULL_DESIGN)
+		return false;
+
+	// skip rendering of entities if don't want them
+	if(!Params.EntityOverlayVal)
+		return false;
+
+	return true;
+}
+
+IGraphics::CTextureHandle CRenderLayerEntityBase::GetTexture() const
+{
+	return m_pMapImages->GetEntities(MAP_IMAGE_ENTITY_LAYER_TYPE_ALL_EXCEPT_SWITCH);
+}
+
+// GAME
+CRenderLayerEntityGame::CRenderLayerEntityGame(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap) :
+	CRenderLayerEntityBase(GroupId, LayerId, Flags, pLayerTilemap) {}
+
+void CRenderLayerEntityGame::Init()
+{
+	UploadTileData(m_VisualTiles, 0, false, true);
+}
+
+void CRenderLayerEntityGame::RenderTileLayerWithTileBuffer(const ColorRGBA &Color)
+{
+	m_pGraphics->BlendNormal();
+	RenderKillTileBorder(Color.Multiply(GetDeathBorderColor()));
+	RenderTileLayer(Color);
+}
+
+void CRenderLayerEntityGame::RenderTileLayerNoTileBuffer(const ColorRGBA &Color)
+{
+	CTile *pGameTiles = GetData<CTile>();
+	m_pGraphics->BlendNone();
+	m_pRenderTools->RenderTilemap(pGameTiles, m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_OPAQUE);
+	m_pGraphics->BlendNormal();
+	m_pRenderTools->RenderTileRectangle(-BorderRenderDistance, -BorderRenderDistance, m_pLayerTilemap->m_Width + 2 * BorderRenderDistance, m_pLayerTilemap->m_Height + 2 * BorderRenderDistance,
+		TILE_AIR, TILE_DEATH, // display air inside, death outside
+		32.0f, Color.Multiply(GetDeathBorderColor()), TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_TRANSPARENT);
+
+	m_pRenderTools->RenderTilemap(pGameTiles, m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_TRANSPARENT);
+}
+
+ColorRGBA CRenderLayerEntityGame::GetDeathBorderColor() const
+{
+	// draw kill tiles outside the entity clipping rectangle
+	// slow blinking to hint that it's not a part of the map
+	float Seconds = time_get() / (float)time_freq();
+	float Alpha = 0.3f + 0.35f * (1.f + std::sin(2.f * pi * Seconds / 3.f));
+	return ColorRGBA(1.f, 1.f, 1.f, Alpha);
+}
+
+// FRONT
+CRenderLayerEntityFront::CRenderLayerEntityFront(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap) :
+	CRenderLayerEntityBase(GroupId, LayerId, Flags, pLayerTilemap) {}
+
+int CRenderLayerEntityFront::GetDataIndex(unsigned int &TileSize) const
+{
+	TileSize = sizeof(CTile);
+	return m_pLayerTilemap->m_Front;
+}
+
+// TELE
+CRenderLayerEntityTele::CRenderLayerEntityTele(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap) :
+	CRenderLayerEntityBase(GroupId, LayerId, Flags, pLayerTilemap) {}
+
+int CRenderLayerEntityTele::GetDataIndex(unsigned int &TileSize) const
+{
+	TileSize = sizeof(CTeleTile);
+	return m_pLayerTilemap->m_Tele;
+}
+
+void CRenderLayerEntityTele::Init()
+{
+	UploadTileData(m_VisualTiles, 0, false);
+	UploadTileData(m_VisualTeleNumbers, 1, false);
+}
+
+void CRenderLayerEntityTele::RenderTileLayerWithTileBuffer(const ColorRGBA &Color)
+{
+	m_pGraphics->BlendNormal();
+	RenderTileLayer(Color);
+	if(g_Config.m_ClTextEntities)
+	{
+		m_pGraphics->TextureSet(m_pMapImages->GetOverlayCenter());
+		RenderTileLayer(Color, &m_VisualTeleNumbers.value());
+	}
+}
+
+void CRenderLayerEntityTele::RenderTileLayerNoTileBuffer(const ColorRGBA &Color)
+{
+	CTeleTile *pTeleTiles = GetData<CTeleTile>();
+	m_pGraphics->BlendNone();
+	m_pRenderTools->RenderTelemap(pTeleTiles, m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_OPAQUE);
+	m_pGraphics->BlendNormal();
+	m_pRenderTools->RenderTelemap(pTeleTiles, m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_TRANSPARENT);
+
+	int OverlayRenderFlags = g_Config.m_ClTextEntities ? OVERLAYRENDERFLAG_TEXT : 0;
+	m_pRenderTools->RenderTeleOverlay(pTeleTiles, m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height, 32.0f, OverlayRenderFlags, Color.a);
+}
+
+void CRenderLayerEntityTele::GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const
+{
+	CTeleTile *pTiles = GetData<CTeleTile>();
+	*pIndex = pTiles[y * m_pLayerTilemap->m_Width + x].m_Type;
+	*pFlags = 0;
+	if(CurOverlay == 1)
+	{
+		if(IsTeleTileNumberUsedAny(*pIndex))
+			*pIndex = pTiles[y * m_pLayerTilemap->m_Width + x].m_Number;
+		else
+			*pIndex = 0;
+	}
+}
+
+// SPEEDUP
+CRenderLayerEntitySpeedup::CRenderLayerEntitySpeedup(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap) :
+	CRenderLayerEntityBase(GroupId, LayerId, Flags, pLayerTilemap) {}
+
+IGraphics::CTextureHandle CRenderLayerEntitySpeedup::GetTexture() const
+{
+	return m_pMapImages->GetSpeedupArrow();
+}
+
+int CRenderLayerEntitySpeedup::GetDataIndex(unsigned int &TileSize) const
+{
+	TileSize = sizeof(CSpeedupTile);
+	return m_pLayerTilemap->m_Speedup;
+}
+
+void CRenderLayerEntitySpeedup::Init()
+{
+	UploadTileData(m_VisualTiles, 0, true);
+	UploadTileData(m_VisualForce, 1, false);
+	UploadTileData(m_VisualMaxSpeed, 2, false);
+}
+
+void CRenderLayerEntitySpeedup::GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const
+{
+	CSpeedupTile *pTiles = GetData<CSpeedupTile>();
+	*pIndex = pTiles[y * m_pLayerTilemap->m_Width + x].m_Type;
+	unsigned char Force = pTiles[y * m_pLayerTilemap->m_Width + x].m_Force;
+	unsigned char MaxSpeed = pTiles[y * m_pLayerTilemap->m_Width + x].m_MaxSpeed;
+	*pFlags = 0;
+	*pAngleRotate = pTiles[y * m_pLayerTilemap->m_Width + x].m_Angle;
+	if((Force == 0 && *pIndex == TILE_SPEED_BOOST_OLD) || (Force == 0 && MaxSpeed == 0 && *pIndex == TILE_SPEED_BOOST) || !IsValidSpeedupTile(*pIndex))
+		*pIndex = 0;
+	else if(CurOverlay == 1)
+		*pIndex = Force;
+	else if(CurOverlay == 2)
+		*pIndex = MaxSpeed;
+}
+
+void CRenderLayerEntitySpeedup::RenderTileLayerWithTileBuffer(const ColorRGBA &Color)
+{
+	// draw arrow -- clamp to the edge of the arrow image
+	m_pGraphics->WrapClamp();
+	UseTexture(GetTexture());
+	RenderTileLayer(Color);
+	m_pGraphics->WrapNormal();
+
+	if(g_Config.m_ClTextEntities)
+	{
+		m_pGraphics->TextureSet(m_pMapImages->GetOverlayBottom());
+		RenderTileLayer(Color, &m_VisualForce.value());
+		m_pGraphics->TextureSet(m_pMapImages->GetOverlayTop());
+		RenderTileLayer(Color, &m_VisualMaxSpeed.value());
+	}
+}
+
+void CRenderLayerEntitySpeedup::RenderTileLayerNoTileBuffer(const ColorRGBA &Color)
+{
+	CSpeedupTile *pSpeedupTiles = GetData<CSpeedupTile>();
+	int OverlayRenderFlags = g_Config.m_ClTextEntities ? OVERLAYRENDERFLAG_TEXT : 0;
+	m_pRenderTools->RenderSpeedupOverlay(pSpeedupTiles, m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height, 32.0f, OverlayRenderFlags, Color.a);
+}
+
+// SWITCH
+CRenderLayerEntitySwitch::CRenderLayerEntitySwitch(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap) :
+	CRenderLayerEntityBase(GroupId, LayerId, Flags, pLayerTilemap) {}
+
+IGraphics::CTextureHandle CRenderLayerEntitySwitch::GetTexture() const
+{
+	return m_pMapImages->GetEntities(MAP_IMAGE_ENTITY_LAYER_TYPE_SWITCH);
+}
+
+int CRenderLayerEntitySwitch::GetDataIndex(unsigned int &TileSize) const
+{
+	TileSize = sizeof(CSwitchTile);
+	return m_pLayerTilemap->m_Switch;
+}
+
+void CRenderLayerEntitySwitch::Init()
+{
+	UploadTileData(m_VisualTiles, 0, false);
+	UploadTileData(m_VisualSwitchNumberTop, 1, false);
+	UploadTileData(m_VisualSwitchNumberBottom, 2, false);
+}
+
+void CRenderLayerEntitySwitch::GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const
+{
+	CSwitchTile *pTiles = GetData<CSwitchTile>();
+	*pFlags = 0;
+	*pIndex = pTiles[y * m_pLayerTilemap->m_Width + x].m_Type;
+	if(CurOverlay == 0)
+	{
+		*pFlags = pTiles[y * m_pLayerTilemap->m_Width + x].m_Flags;
+		if(*pIndex == TILE_SWITCHTIMEDOPEN)
+			*pIndex = 8;
+	}
+	else if(CurOverlay == 1)
+		*pIndex = pTiles[y * m_pLayerTilemap->m_Width + x].m_Number;
+	else if(CurOverlay == 2)
+		*pIndex = pTiles[y * m_pLayerTilemap->m_Width + x].m_Delay;
+}
+
+void CRenderLayerEntitySwitch::RenderTileLayerWithTileBuffer(const ColorRGBA &Color)
+{
+	m_pGraphics->BlendNormal();
+	RenderTileLayer(Color);
+	if(g_Config.m_ClTextEntities)
+	{
+		m_pGraphics->TextureSet(m_pMapImages->GetOverlayTop());
+		RenderTileLayer(Color, &m_VisualSwitchNumberTop.value());
+		m_pGraphics->TextureSet(m_pMapImages->GetOverlayBottom());
+		RenderTileLayer(Color, &m_VisualSwitchNumberBottom.value());
+	}
+}
+
+void CRenderLayerEntitySwitch::RenderTileLayerNoTileBuffer(const ColorRGBA &Color)
+{
+	CSwitchTile *pSwitchTiles = GetData<CSwitchTile>();
+	m_pGraphics->BlendNone();
+	m_pRenderTools->RenderSwitchmap(pSwitchTiles, m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_OPAQUE);
+	m_pGraphics->BlendNormal();
+	m_pRenderTools->RenderSwitchmap(pSwitchTiles, m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_TRANSPARENT);
+	int OverlayRenderFlags = g_Config.m_ClTextEntities ? OVERLAYRENDERFLAG_TEXT : 0;
+	m_pRenderTools->RenderSwitchOverlay(pSwitchTiles, m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height, 32.0f, OverlayRenderFlags, Color.a);
+}
+
+// TUNE
+CRenderLayerEntityTune::CRenderLayerEntityTune(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap) :
+	CRenderLayerEntityBase(GroupId, LayerId, Flags, pLayerTilemap) {}
+
+void CRenderLayerEntityTune::GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const
+{
+	CTuneTile *pTiles = GetData<CTuneTile>();
+	*pIndex = pTiles[y * m_pLayerTilemap->m_Width + x].m_Type;
+	*pFlags = 0;
+}
+
+int CRenderLayerEntityTune::GetDataIndex(unsigned int &TileSize) const
+{
+	TileSize = sizeof(CTuneTile);
+	return m_pLayerTilemap->m_Tune;
+}
+
+void CRenderLayerEntityTune::RenderTileLayerNoTileBuffer(const ColorRGBA &Color)
+{
+	CTuneTile *pTuneTiles = GetData<CTuneTile>();
+	m_pGraphics->BlendNone();
+	m_pRenderTools->RenderTunemap(pTuneTiles, m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_OPAQUE);
+	m_pGraphics->BlendNormal();
+	m_pRenderTools->RenderTunemap(pTuneTiles, m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND | LAYERRENDERFLAG_TRANSPARENT);
+}

--- a/src/game/client/components/render_layer.h
+++ b/src/game/client/components/render_layer.h
@@ -1,0 +1,310 @@
+#ifndef GAME_CLIENT_COMPONENTS_RENDER_LAYER_H
+#define GAME_CLIENT_COMPONENTS_RENDER_LAYER_H
+
+#include <cstdint>
+
+using offset_ptr_size = char *;
+using offset_ptr = uintptr_t;
+using offset_ptr32 = unsigned int;
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <base/color.h>
+#include <engine/graphics.h>
+
+#include <game/client/render.h>
+#include <game/mapitems.h>
+#include <game/mapitems_ex.h>
+
+class CMapLayers;
+class CMapItemLayerTilemap;
+class CMapItemLayerQuads;
+class IMap;
+class CMapImages;
+class CRenderTools;
+class IClient;
+class CGameClient;
+
+constexpr int BorderRenderDistance = 201;
+
+class CRenderLayerParams
+{
+public:
+	int m_RenderType;
+	int EntityOverlayVal;
+	vec2 m_Center;
+};
+
+class CRenderLayer
+{
+public:
+	CRenderLayer(int GroupId, int LayerId, int Flags);
+	virtual ~CRenderLayer() = default;
+	void OnInit(IGraphics *pGraphics, IMap *pMap, CRenderTools *pRenderTools, CMapImages *pMapImages, std::shared_ptr<CMapBasedEnvelopePointAccess> &pEvelopePoints, IClient *pClient, CGameClient *pGameClient, bool OnlineOnly);
+
+	virtual void Init() = 0;
+	virtual void Render(const CRenderLayerParams &Params) = 0;
+	virtual bool DoRender(const CRenderLayerParams &Params) const = 0;
+	virtual bool IsValid() const { return true; }
+
+	int GetGroup() const { return m_GroupId; }
+
+protected:
+	static void EnvelopeEvalRenderLayer(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, void *pUser);
+
+	int m_GroupId;
+	int m_LayerId;
+	int m_Flags;
+	bool m_OnlineOnly;
+
+	void UseTexture(IGraphics::CTextureHandle TextureHandle) const;
+	virtual IGraphics::CTextureHandle GetTexture() const = 0;
+
+	class IGraphics *m_pGraphics = nullptr;
+	class IMap *m_pMap = nullptr;
+	class CRenderTools *m_pRenderTools = nullptr;
+	class CMapImages *m_pMapImages = nullptr;
+	class IClient *m_pClient = nullptr;
+	class CGameClient *m_pGameClient = nullptr;
+	std::shared_ptr<CMapBasedEnvelopePointAccess> m_pEnvelopePoints;
+};
+
+class CRenderLayerTile : public CRenderLayer
+{
+public:
+	CRenderLayerTile(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
+	virtual ~CRenderLayerTile() = default;
+	void Render(const CRenderLayerParams &Params) override;
+	bool DoRender(const CRenderLayerParams &Params) const override;
+	void Init() override;
+
+	virtual int GetDataIndex(unsigned int &TileSize) const;
+	bool IsValid() const override { return GetRawData() != nullptr; }
+
+protected:
+	virtual void *GetRawData() const;
+	template<class T>
+	T *GetData() const;
+
+	virtual ColorRGBA GetRenderColor(const CRenderLayerParams &Params) const;
+	virtual void GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const;
+	IGraphics::CTextureHandle GetTexture() const override { return m_TextureHandle; }
+
+private:
+	IGraphics::CTextureHandle m_TextureHandle;
+
+protected:
+	class CTileLayerVisuals
+	{
+	public:
+		CTileLayerVisuals()
+		{
+			m_Width = 0;
+			m_Height = 0;
+			m_BufferContainerIndex = -1;
+			m_IsTextured = false;
+		}
+
+		bool Init(unsigned int Width, unsigned int Height);
+
+		class CTileVisual
+		{
+		public:
+			CTileVisual() :
+				m_IndexBufferByteOffset(0) {}
+
+		private:
+			offset_ptr32 m_IndexBufferByteOffset;
+
+		public:
+			bool DoDraw() const
+			{
+				return (m_IndexBufferByteOffset & 0x10000000) != 0;
+			}
+
+			void Draw(bool SetDraw)
+			{
+				m_IndexBufferByteOffset = (SetDraw ? 0x10000000 : (offset_ptr32)0) | (m_IndexBufferByteOffset & 0xEFFFFFFF);
+			}
+
+			offset_ptr IndexBufferByteOffset() const
+			{
+				return ((offset_ptr)(m_IndexBufferByteOffset & 0xEFFFFFFF) * 6 * sizeof(uint32_t));
+			}
+
+			void SetIndexBufferByteOffset(offset_ptr32 IndexBufferByteOff)
+			{
+				m_IndexBufferByteOffset = IndexBufferByteOff | (m_IndexBufferByteOffset & 0x10000000);
+			}
+
+			void AddIndexBufferByteOffset(offset_ptr32 IndexBufferByteOff)
+			{
+				m_IndexBufferByteOffset = ((m_IndexBufferByteOffset & 0xEFFFFFFF) + IndexBufferByteOff) | (m_IndexBufferByteOffset & 0x10000000);
+			}
+		};
+
+		std::vector<CTileVisual> m_vTilesOfLayer;
+
+		CTileVisual m_BorderTopLeft;
+		CTileVisual m_BorderTopRight;
+		CTileVisual m_BorderBottomRight;
+		CTileVisual m_BorderBottomLeft;
+
+		CTileVisual m_BorderKillTile; // end of map kill tile -- game layer only
+
+		std::vector<CTileVisual> m_vBorderTop;
+		std::vector<CTileVisual> m_vBorderLeft;
+		std::vector<CTileVisual> m_vBorderRight;
+		std::vector<CTileVisual> m_vBorderBottom;
+
+		unsigned int m_Width;
+		unsigned int m_Height;
+		int m_BufferContainerIndex;
+		bool m_IsTextured;
+	};
+
+	void UploadTileData(std::optional<CTileLayerVisuals> &VisualsOptional, int CurOverlay, bool AddAsSpeedup, bool IsGameLayer = false);
+
+	virtual void RenderTileLayerWithTileBuffer(const ColorRGBA &Color);
+	virtual void RenderTileLayerNoTileBuffer(const ColorRGBA &Color);
+
+	void RenderTileLayer(const ColorRGBA &Color, CTileLayerVisuals *pTileLayerVisuals = nullptr);
+	void RenderTileBorder(const ColorRGBA &Color, int BorderX0, int BorderY0, int BorderX1, int BorderY1);
+	void RenderKillTileBorder(const ColorRGBA &Color);
+
+	std::optional<CRenderLayerTile::CTileLayerVisuals> m_VisualTiles;
+	CMapItemLayerTilemap *m_pLayerTilemap;
+	ColorRGBA m_Color;
+};
+
+class CRenderLayerQuads : public CRenderLayer
+{
+public:
+	CRenderLayerQuads(int GroupId, int LayerId, IGraphics::CTextureHandle TextureHandle, int Flags, CMapItemLayerQuads *pLayerQuads);
+	virtual void Init() override;
+	virtual void Render(const CRenderLayerParams &Params) override;
+	virtual bool DoRender(const CRenderLayerParams &Params) const override;
+
+protected:
+	virtual IGraphics::CTextureHandle GetTexture() const override { return m_TextureHandle; }
+
+	class CQuadLayerVisuals
+	{
+	public:
+		CQuadLayerVisuals() :
+			m_QuadNum(0), m_BufferContainerIndex(-1), m_IsTextured(false) {}
+
+		int m_QuadNum;
+		int m_BufferContainerIndex;
+		bool m_IsTextured;
+	};
+	void RenderQuadLayer(bool ForceRender = false);
+
+	std::optional<CRenderLayerQuads::CQuadLayerVisuals> m_VisualQuad;
+	CMapItemLayerQuads *m_pLayerQuads;
+
+	std::vector<SQuadRenderInfo> m_vQuadRenderInfo;
+	bool m_ContainsEnvelopes;
+
+private:
+	IGraphics::CTextureHandle m_TextureHandle;
+};
+
+class CRenderLayerEntityBase : public CRenderLayerTile
+{
+public:
+	CRenderLayerEntityBase(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
+	virtual ~CRenderLayerEntityBase() = default;
+	bool DoRender(const CRenderLayerParams &Params) const override;
+
+protected:
+	ColorRGBA GetRenderColor(const CRenderLayerParams &Params) const override { return ColorRGBA(1.0f, 1.0f, 1.0f, Params.EntityOverlayVal / 100.0f); }
+	IGraphics::CTextureHandle GetTexture() const override;
+};
+
+class CRenderLayerEntityGame final : public CRenderLayerEntityBase
+{
+public:
+	CRenderLayerEntityGame(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
+	void Init() override;
+
+protected:
+	void RenderTileLayerWithTileBuffer(const ColorRGBA &Color) override;
+	void RenderTileLayerNoTileBuffer(const ColorRGBA &Color) override;
+
+private:
+	ColorRGBA GetDeathBorderColor() const;
+};
+
+class CRenderLayerEntityFront final : public CRenderLayerEntityBase
+{
+public:
+	CRenderLayerEntityFront(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
+	int GetDataIndex(unsigned int &TileSize) const override;
+};
+
+class CRenderLayerEntityTele final : public CRenderLayerEntityBase
+{
+public:
+	CRenderLayerEntityTele(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
+	int GetDataIndex(unsigned int &TileSize) const override;
+	void Init() override;
+
+protected:
+	void RenderTileLayerWithTileBuffer(const ColorRGBA &Color) override;
+	void RenderTileLayerNoTileBuffer(const ColorRGBA &Color) override;
+	void GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const override;
+
+private:
+	std::optional<CRenderLayerTile::CTileLayerVisuals> m_VisualTeleNumbers;
+};
+
+class CRenderLayerEntitySpeedup final : public CRenderLayerEntityBase
+{
+public:
+	CRenderLayerEntitySpeedup(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
+	int GetDataIndex(unsigned int &TileSize) const override;
+	void Init() override;
+
+protected:
+	void RenderTileLayerWithTileBuffer(const ColorRGBA &Color) override;
+	void RenderTileLayerNoTileBuffer(const ColorRGBA &Color) override;
+	void GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const override;
+	IGraphics::CTextureHandle GetTexture() const override;
+
+private:
+	std::optional<CRenderLayerTile::CTileLayerVisuals> m_VisualForce;
+	std::optional<CRenderLayerTile::CTileLayerVisuals> m_VisualMaxSpeed;
+};
+
+class CRenderLayerEntitySwitch final : public CRenderLayerEntityBase
+{
+public:
+	CRenderLayerEntitySwitch(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
+	int GetDataIndex(unsigned int &TileSize) const override;
+	void Init() override;
+
+protected:
+	void RenderTileLayerWithTileBuffer(const ColorRGBA &Color) override;
+	void RenderTileLayerNoTileBuffer(const ColorRGBA &Color) override;
+	void GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const override;
+	IGraphics::CTextureHandle GetTexture() const override;
+
+private:
+	std::optional<CRenderLayerTile::CTileLayerVisuals> m_VisualSwitchNumberTop;
+	std::optional<CRenderLayerTile::CTileLayerVisuals> m_VisualSwitchNumberBottom;
+};
+
+class CRenderLayerEntityTune final : public CRenderLayerEntityBase
+{
+public:
+	CRenderLayerEntityTune(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
+	int GetDataIndex(unsigned int &TileSize) const override;
+
+protected:
+	void RenderTileLayerNoTileBuffer(const ColorRGBA &Color) override;
+	void GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const override;
+};
+#endif


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Maplayers is currently doing a layer count for each tilelayer and quadlayer, does a lot of skip checks which are only needed in exceptions and is in not well generalized. This PR introduces objects to handle most of the exceptions and special functions for each layer, reducing most of the switch statements into polymorphism. From some crude testing on dm1, this slightly improves FPS and cleans up the code. The idea is, to create a render-list for a given maplayer type (foreground/background) and just iterating over it in order to render the layers

~~**WIP**!
Current State: Working with all backends, tidy up needed~~

If you have an idea how to split this PR up into smaller chunks, go ahead! I am also unhappy about it's size.

~~Currently contains a bug, where tune layers (and other entity layers) are not rendered correctly~~

Additionally closes #10307

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
