### PR TITLE
Delete unused `data` files on Android when unpacking assets

### DIFF
--- a/src/android/android_main.cpp
+++ b/src/android/android_main.cpp
@@ -218,6 +218,25 @@ const char *InitAndroid()
 		}
 	}
 
+	for(size_t i = 1; i < vIntegritySaveLines.size(); ++i)
+	{
+		const CIntegrityFileLine &IntegritySaveLine = vIntegritySaveLines[i];
+
+		// Check if the asset was deleted since the last unpacking
+		const bool LineFound = std::any_of(vIntegrityLines.begin(), vIntegrityLines.end(), [&](const CIntegrityFileLine &Line) {
+			return str_comp(Line.m_aFilename, IntegritySaveLine.m_aFilename) == 0;
+		});
+		if(LineFound)
+		{
+			continue;
+		}
+
+		if(fs_remove(IntegritySaveLine.m_aFilename) != 0)
+		{
+			log_warn("android", "Failed to delete unused asset '%s'", IntegritySaveLine.m_aFilename);
+		}
+	}
+
 	// The integrity file will be unpacked every time when launching,
 	// so we can simply rename it to update the saved integrity file.
 	if((fs_is_file(INTEGRITY_INDEX_SAVE) && fs_remove(INTEGRITY_INDEX_SAVE) != 0) || fs_rename(INTEGRITY_INDEX, INTEGRITY_INDEX_SAVE) != 0)


### PR DESCRIPTION
When unpacking the assets from the APK, also delete unused files from the `data` directory instead of only adding new files.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
