### PR TITLE
Make all log levels available to antibot

### DIFF
--- a/src/antibot/antibot_data.h
+++ b/src/antibot/antibot_data.h
@@ -5,12 +5,18 @@
 
 enum
 {
-	ANTIBOT_ABI_VERSION = 11,
+	ANTIBOT_ABI_VERSION = 12,
 
 	ANTIBOT_MSGFLAG_NONVITAL = 1,
 	ANTIBOT_MSGFLAG_FLUSH = 2,
 
 	ANTIBOT_MAX_CLIENTS = 128,
+
+	ANTIBOT_LOG_LEVEL_ERROR = 0,
+	ANTIBOT_LOG_LEVEL_WARN = 1,
+	ANTIBOT_LOG_LEVEL_INFO = 2,
+	ANTIBOT_LOG_LEVEL_DEBUG = 3,
+	ANTIBOT_LOG_LEVEL_TRACE = 4,
 };
 
 struct CAntibotMapData
@@ -101,7 +107,7 @@ struct CAntibotData
 	int64_t m_Now;
 	int64_t m_Freq;
 	void (*m_pfnKick)(int ClientId, const char *pMessage, void *pUser);
-	void (*m_pfnLog)(const char *pMessage, void *pUser);
+	void (*m_pfnLog)(int Level, const char *pMessage, void *pUser);
 	void (*m_pfnReport)(int ClientId, const char *pMessage, void *pUser);
 	void (*m_pfnSend)(int ClientId, const void *pData, int DataSize, int Flags, void *pUser);
 	void (*m_pfnTeehistorian)(const void *pData, int DataSize, void *pUser);

--- a/src/antibot/antibot_null.cpp
+++ b/src/antibot/antibot_null.cpp
@@ -1,5 +1,6 @@
 #define ANTIBOTAPI DYNAMIC_EXPORT
 
+#include <antibot/antibot_data.h>
 #include <antibot/antibot_interface.h>
 
 #include <cstring>
@@ -15,7 +16,7 @@ int AntibotAbiVersion()
 void AntibotInit(CAntibotData *pCallbackData)
 {
 	g_pData = pCallbackData;
-	g_pData->m_pfnLog("null antibot initialized", g_pData->m_pUser);
+	g_pData->m_pfnLog(ANTIBOT_LOG_LEVEL_INFO, "null antibot initialized", g_pData->m_pUser);
 }
 void AntibotRoundStart(CAntibotRoundData *pRoundData){};
 void AntibotRoundEnd(void){};
@@ -25,11 +26,11 @@ void AntibotConsoleCommand(const char *pCommand)
 {
 	if(strcmp(pCommand, "dump") == 0)
 	{
-		g_pData->m_pfnLog("null antibot", g_pData->m_pUser);
+		g_pData->m_pfnLog(ANTIBOT_LOG_LEVEL_INFO, "null antibot", g_pData->m_pUser);
 	}
 	else
 	{
-		g_pData->m_pfnLog("unknown command", g_pData->m_pUser);
+		g_pData->m_pfnLog(ANTIBOT_LOG_LEVEL_INFO, "unknown command", g_pData->m_pUser);
 	}
 }
 void AntibotOnPlayerInit(int /*ClientId*/) {}

--- a/src/engine/server/antibot.cpp
+++ b/src/engine/server/antibot.cpp
@@ -1,7 +1,9 @@
 #include "antibot.h"
 
+#include <antibot/antibot_data.h>
 #include <antibot/antibot_interface.h>
 
+#include <base/log.h>
 #include <base/system.h>
 
 #include <engine/console.h>
@@ -23,21 +25,37 @@ CAntibot::~CAntibot()
 	if(m_Initialized)
 		AntibotDestroy();
 }
+LEVEL CAntibot::AntibotToServerLevel(int Level)
+{
+	switch(Level)
+	{
+	case ANTIBOT_LOG_LEVEL_ERROR:
+		return LEVEL_ERROR;
+	case ANTIBOT_LOG_LEVEL_WARN:
+		return LEVEL_WARN;
+	case ANTIBOT_LOG_LEVEL_INFO:
+		return LEVEL_INFO;
+	case ANTIBOT_LOG_LEVEL_DEBUG:
+		return LEVEL_DEBUG;
+	case ANTIBOT_LOG_LEVEL_TRACE:
+		return LEVEL_TRACE;
+	}
+	return LEVEL_INFO;
+}
 void CAntibot::Kick(int ClientId, const char *pMessage, void *pUser)
 {
 	CAntibot *pAntibot = (CAntibot *)pUser;
 	pAntibot->Server()->Kick(ClientId, pMessage);
 }
-void CAntibot::Log(const char *pMessage, void *pUser)
+void CAntibot::Log(int Level, const char *pMessage, void *pUser)
 {
-	CAntibot *pAntibot = (CAntibot *)pUser;
-	pAntibot->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "antibot", pMessage);
+	log_log(AntibotToServerLevel(Level), "antibot", pMessage);
 }
 void CAntibot::Report(int ClientId, const char *pMessage, void *pUser)
 {
 	char aBuf[256];
 	str_format(aBuf, sizeof(aBuf), "%d: %s", ClientId, pMessage);
-	Log(aBuf, pUser);
+	Log(ANTIBOT_LOG_LEVEL_INFO, aBuf, pUser);
 }
 void CAntibot::Send(int ClientId, const void *pData, int Size, int Flags, void *pUser)
 {

--- a/src/engine/server/antibot.h
+++ b/src/engine/server/antibot.h
@@ -2,6 +2,7 @@
 #define ENGINE_SERVER_ANTIBOT_H
 
 #include <antibot/antibot_data.h>
+#include <base/log.h>
 #include <engine/antibot.h>
 
 class CAntibot : public IEngineAntibot
@@ -18,9 +19,11 @@ class CAntibot : public IEngineAntibot
 	CAntibotRoundData m_RoundData;
 	bool m_Initialized;
 
+	static LEVEL AntibotToServerLevel(int Level);
+
 	void Update();
 	static void Kick(int ClientId, const char *pMessage, void *pUser);
-	static void Log(const char *pMessage, void *pUser);
+	static void Log(int Level, const char *pMessage, void *pUser);
 	static void Report(int ClientId, const char *pMessage, void *pUser);
 	static void Send(int ClientId, const void *pData, int Size, int Flags, void *pUser);
 	static void Teehistorian(const void *pData, int Size, void *pUser);


### PR DESCRIPTION
Follow up to #9916
I closed it thinking it was not needed because I could also directly call into the servers `log_info()`, `log_error()` and so on but that apparently was a odr violation according to clang sanitizers

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
