### PR TITLE
 Fix CCamera::SetView clamping y pos with map width instead of map height

### DIFF
--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -501,7 +501,7 @@ void CCamera::SetView(ivec2 Pos, bool Relative)
 
 	m_ForceFreeviewPos = vec2(
 		clamp(UntestedViewPos.x, 200.0f, Collision()->GetWidth() * 32 - 200.0f),
-		clamp(UntestedViewPos.y, 200.0f, Collision()->GetWidth() * 32 - 200.0f));
+		clamp(UntestedViewPos.y, 200.0f, Collision()->GetHeight() * 32 - 200.0f));
 }
 
 void CCamera::GotoSwitch(int Number, int Offset)
@@ -589,8 +589,8 @@ void CCamera::GotoTele(int Number, int Offset)
 					MatchPos = m_GotoTeleLastPos;
 					break;
 				}
-					FullRound = true;
-				}
+				FullRound = true;
+			}
 		} while(distance(m_GotoTeleLastPos, MatchPos) < 10.0f);
 	}
 

--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -589,11 +589,8 @@ void CCamera::GotoTele(int Number, int Offset)
 					MatchPos = m_GotoTeleLastPos;
 					break;
 				}
-				else
-				{
 					FullRound = true;
 				}
-			}
 		} while(distance(m_GotoTeleLastPos, MatchPos) < 10.0f);
 	}
 


### PR DESCRIPTION
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
