### PR TITLE
Move editor `FindNextFree*Number` functions to layers' classes, remove unnecessary `virtual` of editor layer functions

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -9396,10 +9396,10 @@ void CEditor::AdjustBrushSpecialTiles(bool UseNextFree, int Adjust)
 
 		if(pLayerTiles->m_HasTele)
 		{
-			int NextFreeTeleNumber = FindNextFreeTeleNumber();
-			int NextFreeCPNumber = FindNextFreeTeleNumber(true);
-
+			int NextFreeTeleNumber = m_Map.m_pTeleLayer->FindNextFreeNumber(false);
+			int NextFreeCPNumber = m_Map.m_pTeleLayer->FindNextFreeNumber(true);
 			std::shared_ptr<CLayerTele> pTeleLayer = std::static_pointer_cast<CLayerTele>(pLayer);
+
 			for(int y = 0; y < pTeleLayer->m_Height; y++)
 			{
 				for(int x = 0; x < pTeleLayer->m_Width; x++)
@@ -9448,9 +9448,9 @@ void CEditor::AdjustBrushSpecialTiles(bool UseNextFree, int Adjust)
 		}
 		else if(pLayerTiles->m_HasSwitch)
 		{
-			int NextFreeNumber = FindNextFreeSwitchNumber();
-
+			int NextFreeNumber = m_Map.m_pSwitchLayer->FindNextFreeNumber();
 			std::shared_ptr<CLayerSwitch> pSwitchLayer = std::static_pointer_cast<CLayerSwitch>(pLayer);
+
 			for(int y = 0; y < pSwitchLayer->m_Height; y++)
 			{
 				for(int x = 0; x < pSwitchLayer->m_Width; x++)
@@ -9493,49 +9493,6 @@ void CEditor::AdjustBrushSpecialTiles(bool UseNextFree, int Adjust)
 			}
 		}
 	}
-}
-
-int CEditor::FindNextFreeSwitchNumber()
-{
-	int Number = -1;
-
-	for(int i = 1; i <= 255; i++)
-	{
-		if(!m_Map.m_pSwitchLayer->ContainsElementWithId(i))
-		{
-			Number = i;
-			break;
-		}
-	}
-	return Number;
-}
-
-int CEditor::FindNextFreeTeleNumber(bool Checkpoint)
-{
-	int Number = -1;
-	for(int i = 1; i <= 255; i++)
-	{
-		if(!m_Map.m_pTeleLayer->ContainsElementWithId(i, Checkpoint))
-		{
-			Number = i;
-			break;
-		}
-	}
-	return Number;
-}
-
-int CEditor::FindNextFreeTuneNumber()
-{
-	int Number = -1;
-	for(int i = 1; i <= 255; i++)
-	{
-		if(!m_Map.m_pTuneLayer->ContainsElementWithId(i))
-		{
-			Number = i;
-			break;
-		}
-	}
-	return Number;
 }
 
 IEditor *CreateEditor() { return new CEditor; }

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1201,9 +1201,6 @@ public:
 	unsigned char m_ViewSwitch;
 
 	void AdjustBrushSpecialTiles(bool UseNextFree, int Adjust = 0);
-	int FindNextFreeSwitchNumber();
-	int FindNextFreeTeleNumber(bool Checkpoint = false);
-	int FindNextFreeTuneNumber();
 
 	// Undo/Redo
 	CEditorHistory m_EditorHistory;

--- a/src/game/editor/mapitems/layer_switch.cpp
+++ b/src/game/editor/mapitems/layer_switch.cpp
@@ -323,7 +323,7 @@ void CLayerSwitch::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUI
 	FlagModified(sx, sy, w, h);
 }
 
-bool CLayerSwitch::ContainsElementWithId(int Id)
+bool CLayerSwitch::ContainsElementWithId(int Id) const
 {
 	for(int y = 0; y < m_Height; ++y)
 	{

--- a/src/game/editor/mapitems/layer_switch.cpp
+++ b/src/game/editor/mapitems/layer_switch.cpp
@@ -323,6 +323,18 @@ void CLayerSwitch::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUI
 	FlagModified(sx, sy, w, h);
 }
 
+int CLayerSwitch::FindNextFreeNumber() const
+{
+	for(int i = 1; i <= 255; i++)
+	{
+		if(!ContainsElementWithId(i))
+		{
+			return i;
+		}
+	}
+	return -1;
+}
+
 bool CLayerSwitch::ContainsElementWithId(int Id) const
 {
 	for(int y = 0; y < m_Height; ++y)

--- a/src/game/editor/mapitems/layer_switch.h
+++ b/src/game/editor/mapitems/layer_switch.h
@@ -35,6 +35,7 @@ public:
 	void BrushFlipY() override;
 	void BrushRotate(float Amount) override;
 	void FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRect Rect) override;
+	int FindNextFreeNumber() const;
 	bool ContainsElementWithId(int Id) const;
 	void GetPos(int Number, int Offset, ivec2 &SwitchPos);
 

--- a/src/game/editor/mapitems/layer_switch.h
+++ b/src/game/editor/mapitems/layer_switch.h
@@ -35,8 +35,8 @@ public:
 	void BrushFlipY() override;
 	void BrushRotate(float Amount) override;
 	void FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRect Rect) override;
-	virtual bool ContainsElementWithId(int Id);
-	virtual void GetPos(int Number, int Offset, ivec2 &SwitchPos);
+	bool ContainsElementWithId(int Id) const;
+	void GetPos(int Number, int Offset, ivec2 &SwitchPos);
 
 	int m_GotoSwitchOffset;
 	ivec2 m_GotoSwitchLastPos;

--- a/src/game/editor/mapitems/layer_tele.cpp
+++ b/src/game/editor/mapitems/layer_tele.cpp
@@ -303,7 +303,7 @@ void CLayerTele::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRe
 	FlagModified(sx, sy, w, h);
 }
 
-bool CLayerTele::ContainsElementWithId(int Id, bool Checkpoint)
+bool CLayerTele::ContainsElementWithId(int Id, bool Checkpoint) const
 {
 	for(int y = 0; y < m_Height; ++y)
 	{

--- a/src/game/editor/mapitems/layer_tele.cpp
+++ b/src/game/editor/mapitems/layer_tele.cpp
@@ -303,6 +303,18 @@ void CLayerTele::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRe
 	FlagModified(sx, sy, w, h);
 }
 
+int CLayerTele::FindNextFreeNumber(bool Checkpoint) const
+{
+	for(int i = 1; i <= 255; i++)
+	{
+		if(!ContainsElementWithId(i, Checkpoint))
+		{
+			return i;
+		}
+	}
+	return -1;
+}
+
 bool CLayerTele::ContainsElementWithId(int Id, bool Checkpoint) const
 {
 	for(int y = 0; y < m_Height; ++y)

--- a/src/game/editor/mapitems/layer_tele.h
+++ b/src/game/editor/mapitems/layer_tele.h
@@ -33,8 +33,8 @@ public:
 	void BrushFlipY() override;
 	void BrushRotate(float Amount) override;
 	void FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRect Rect) override;
-	virtual bool ContainsElementWithId(int Id, bool Checkpoint);
-	virtual void GetPos(int Number, int Offset, int &TeleX, int &TeleY);
+	bool ContainsElementWithId(int Id, bool Checkpoint) const;
+	void GetPos(int Number, int Offset, int &TeleX, int &TeleY);
 
 	int m_GotoTeleOffset;
 	ivec2 m_GotoTeleLastPos;

--- a/src/game/editor/mapitems/layer_tele.h
+++ b/src/game/editor/mapitems/layer_tele.h
@@ -33,6 +33,7 @@ public:
 	void BrushFlipY() override;
 	void BrushRotate(float Amount) override;
 	void FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRect Rect) override;
+	int FindNextFreeNumber(bool Checkpoint) const;
 	bool ContainsElementWithId(int Id, bool Checkpoint) const;
 	void GetPos(int Number, int Offset, int &TeleX, int &TeleY);
 

--- a/src/game/editor/mapitems/layer_tune.cpp
+++ b/src/game/editor/mapitems/layer_tune.cpp
@@ -279,6 +279,18 @@ void CLayerTune::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRe
 	FlagModified(sx, sy, w, h);
 }
 
+int CLayerTune::FindNextFreeNumber() const
+{
+	for(int i = 1; i <= 255; i++)
+	{
+		if(!ContainsElementWithId(i))
+		{
+			return i;
+		}
+	}
+	return -1;
+}
+
 bool CLayerTune::ContainsElementWithId(int Id) const
 {
 	for(int y = 0; y < m_Height; ++y)

--- a/src/game/editor/mapitems/layer_tune.cpp
+++ b/src/game/editor/mapitems/layer_tune.cpp
@@ -279,7 +279,7 @@ void CLayerTune::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRe
 	FlagModified(sx, sy, w, h);
 }
 
-bool CLayerTune::ContainsElementWithId(int Id)
+bool CLayerTune::ContainsElementWithId(int Id) const
 {
 	for(int y = 0; y < m_Height; ++y)
 	{

--- a/src/game/editor/mapitems/layer_tune.h
+++ b/src/game/editor/mapitems/layer_tune.h
@@ -32,8 +32,8 @@ public:
 	void BrushFlipY() override;
 	void BrushRotate(float Amount) override;
 	void FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRect Rect) override;
-	virtual bool ContainsElementWithId(int Id);
-	virtual void GetPos(int Number, int Offset, ivec2 &Pos);
+	bool ContainsElementWithId(int Id) const;
+	void GetPos(int Number, int Offset, ivec2 &Pos);
 
 	int m_GotoTuneOffset;
 	ivec2 m_GotoTuneLastPos;

--- a/src/game/editor/mapitems/layer_tune.h
+++ b/src/game/editor/mapitems/layer_tune.h
@@ -32,6 +32,7 @@ public:
 	void BrushFlipY() override;
 	void BrushRotate(float Amount) override;
 	void FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRect Rect) override;
+	int FindNextFreeNumber() const;
 	bool ContainsElementWithId(int Id) const;
 	void GetPos(int Number, int Offset, ivec2 &Pos);
 

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -2669,7 +2669,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupTele(void *pContext, CUIRect View, b
 		if(pEditor->DoButton_Editor(&s_NextFreeTelePid, "F", 0, &FindFreeTeleSlot, BUTTONFLAG_LEFT, "[Ctrl+F] Find next free tele number.") ||
 			(Active && pEditor->Input()->ModifierIsPressed() && pEditor->Input()->KeyPress(KEY_F)))
 		{
-			int TeleNumber = pEditor->FindNextFreeTeleNumber();
+			int TeleNumber = pEditor->m_Map.m_pTeleLayer->FindNextFreeNumber(false);
 			if(TeleNumber != -1)
 			{
 				pEditor->m_TeleNumber = TeleNumber;
@@ -2681,7 +2681,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupTele(void *pContext, CUIRect View, b
 		if(pEditor->DoButton_Editor(&s_NextFreeCheckpointPid, "F", 0, &FindFreeCheckpointSlot, BUTTONFLAG_LEFT, "[Ctrl+F] Find next free checkpoint number.") ||
 			(Active && pEditor->Input()->ModifierIsPressed() && pEditor->Input()->KeyPress(KEY_F)))
 		{
-			int CheckpointNumber = pEditor->FindNextFreeTeleNumber(true);
+			int CheckpointNumber = pEditor->m_Map.m_pTeleLayer->FindNextFreeNumber(true);
 			if(CheckpointNumber != -1)
 			{
 				pEditor->m_TeleCheckpointNumber = CheckpointNumber;
@@ -2831,7 +2831,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSwitch(void *pContext, CUIRect View,
 		if(pEditor->DoButton_Editor(&s_EmptySlotPid, "F", 0, &FindEmptySlot, BUTTONFLAG_LEFT, "[Ctrl+F] Find empty slot.") ||
 			(Active && pEditor->Input()->ModifierIsPressed() && pEditor->Input()->KeyPress(KEY_F)))
 		{
-			int Number = pEditor->FindNextFreeSwitchNumber();
+			int Number = pEditor->m_Map.m_pSwitchLayer->FindNextFreeNumber();
 			if(Number != -1)
 				pEditor->m_SwitchNum = Number;
 		}
@@ -2931,7 +2931,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupTune(void *pContext, CUIRect View, b
 		if(pEditor->DoButton_Editor(&s_EmptySlotPid, "F", 0, &FindEmptySlot, BUTTONFLAG_LEFT, "[Ctrl+F] Find unused zone.") ||
 			(Active && pEditor->Input()->ModifierIsPressed() && pEditor->Input()->KeyPress(KEY_F)))
 		{
-			int Number = pEditor->FindNextFreeTuneNumber();
+			int Number = pEditor->m_Map.m_pTuneLayer->FindNextFreeNumber();
 			if(Number != -1)
 				pEditor->m_TuningNum = Number;
 		}


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
