### PR TITLE
Reveal screen keyboard after selecting text input if closed

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1666,6 +1666,11 @@ void CGraphicsBackend_SDL_GL::NotifyWindow()
 #endif
 }
 
+bool CGraphicsBackend_SDL_GL::IsScreenKeyboardShown()
+{
+	return SDL_IsScreenKeyboardShown(m_pWindow);
+}
+
 void CGraphicsBackend_SDL_GL::WindowDestroyNtf(uint32_t WindowId)
 {
 }

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -260,6 +260,7 @@ public:
 	bool ResizeWindow(int w, int h, int RefreshRate) override;
 	void GetViewportSize(int &w, int &h) override;
 	void NotifyWindow() override;
+	bool IsScreenKeyboardShown() override;
 
 	void WindowDestroyNtf(uint32_t WindowId) override;
 	void WindowCreateNtf(uint32_t WindowId) override;

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -2614,6 +2614,11 @@ void CGraphics_Threaded::GotResized(int w, int h, int RefreshRate)
 	}
 }
 
+bool CGraphics_Threaded::IsScreenKeyboardShown()
+{
+	return m_pBackend->IsScreenKeyboardShown();
+}
+
 void CGraphics_Threaded::AddWindowResizeListener(WINDOW_RESIZE_FUNC pFunc)
 {
 	m_vResizeListeners.emplace_back(pFunc);

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -714,6 +714,7 @@ public:
 	virtual bool ResizeWindow(int w, int h, int RefreshRate) = 0;
 	virtual void GetViewportSize(int &w, int &h) = 0;
 	virtual void NotifyWindow() = 0;
+	virtual bool IsScreenKeyboardShown() = 0;
 
 	virtual void WindowDestroyNtf(uint32_t WindowId) = 0;
 	virtual void WindowCreateNtf(uint32_t WindowId) = 0;
@@ -1199,6 +1200,8 @@ public:
 	void ResizeToScreen() override;
 	void GotResized(int w, int h, int RefreshRate) override;
 	void UpdateViewport(int X, int Y, int W, int H, bool ByResize) override;
+	bool IsScreenKeyboardShown() override;
+
 	void AddWindowResizeListener(WINDOW_RESIZE_FUNC pFunc) override;
 	void AddWindowPropChangeListener(WINDOW_PROPS_CHANGED_FUNC pFunc) override;
 	int GetWindowScreen() override;

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -350,6 +350,17 @@ void CInput::StopTextInput()
 	m_vCandidates.clear();
 }
 
+void CInput::EnsureScreenKeyboardShown()
+{
+	if(!SDL_HasScreenKeyboardSupport() ||
+		Graphics()->IsScreenKeyboardShown())
+	{
+		return;
+	}
+	SDL_StopTextInput();
+	SDL_StartTextInput();
+}
+
 void CInput::ConsumeEvents(std::function<void(const CEvent &Event)> Consumer) const
 {
 	for(const CEvent &Event : m_vInputEvents)

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -150,6 +150,7 @@ public:
 
 	void StartTextInput() override;
 	void StopTextInput() override;
+	void EnsureScreenKeyboardShown() override;
 	const char *GetComposition() const override { return m_CompositionString.c_str(); }
 	bool HasComposition() const override { return !m_CompositionString.empty(); }
 	int GetCompositionCursor() const override { return m_CompositionCursor; }

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -232,6 +232,7 @@ public:
 	virtual void ResizeToScreen() = 0;
 	virtual void GotResized(int w, int h, int RefreshRate) = 0;
 	virtual void UpdateViewport(int X, int Y, int W, int H, bool ByResize) = 0;
+	virtual bool IsScreenKeyboardShown() = 0;
 
 	/**
 	* Listens to a resize event of the canvas, which is usually caused by a window resize.

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -178,6 +178,7 @@ public:
 	// text editing
 	virtual void StartTextInput() = 0;
 	virtual void StopTextInput() = 0;
+	virtual void EnsureScreenKeyboardShown() = 0;
 	virtual const char *GetComposition() const = 0;
 	virtual bool HasComposition() const = 0;
 	virtual int GetCompositionCursor() const = 0;

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -1175,6 +1175,10 @@ void CGameConsole::OnRender()
 			if(pConsole->m_MousePress.y >= pConsole->m_BoundingBox.m_Y && pConsole->m_MousePress.y < pConsole->m_BoundingBox.m_Y + pConsole->m_BoundingBox.m_H)
 			{
 				CLineInput::SMouseSelection *pMouseSelection = pConsole->m_Input.GetMouseSelection();
+				if(pMouseSelection->m_Selecting && !pConsole->m_MouseIsPress && pConsole->m_Input.IsActive())
+				{
+					Input()->EnsureScreenKeyboardShown();
+				}
 				pMouseSelection->m_Selecting = pConsole->m_MouseIsPress;
 				pMouseSelection->m_PressMouse = pConsole->m_MousePress;
 				pMouseSelection->m_ReleaseMouse = pConsole->m_MouseRelease;

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -960,6 +960,10 @@ bool CUi::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize
 		if(!MouseButton(0))
 		{
 			pMouseSelection->m_Selecting = false;
+			if(Active)
+			{
+				Input()->EnsureScreenKeyboardShown();
+			}
 		}
 	}
 	if(ScrollOffset != pMouseSelection->m_Offset.x)


### PR DESCRIPTION
Open the screen keyboard again after it was closed when selecting a text input. Otherwise the console needs to be closed and reopened to reveal the screen keyboard again.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
