### PR TITLE
Fix client crash due to invalid ghost skin data

### DIFF
--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -377,6 +377,10 @@ void CGhost::UpdateTeeRenderInfo(CGhostItem &Ghost)
 	CSkinDescriptor SkinDescriptor;
 	SkinDescriptor.m_Flags = CSkinDescriptor::FLAG_SIX;
 	IntsToStr(Ghost.m_Skin.m_aSkin, std::size(Ghost.m_Skin.m_aSkin), SkinDescriptor.m_aSkinName, std::size(SkinDescriptor.m_aSkinName));
+	if(!CSkin::IsValidName(SkinDescriptor.m_aSkinName))
+	{
+		str_copy(SkinDescriptor.m_aSkinName, "default");
+	}
 
 	CTeeRenderInfo TeeRenderInfo;
 	TeeRenderInfo.ApplyColors(Ghost.m_Skin.m_UseCustomColor, Ghost.m_Skin.m_ColorBody, Ghost.m_Skin.m_ColorFeet);


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
