### PR TITLE
More precise interval for demo l/r

### DIFF
--- a/data/languages/azerbaijani.txt
+++ b/data/languages/azerbaijani.txt
@@ -1604,12 +1604,12 @@ Go back the specified duration
 == Verilən zaman qədər geri qayıt
 
 [Demo player duration]
-%d min.
-== %d dəq.
+%s min.
+== %s dəq.
 
 [Demo player duration]
-%d sec.
-== %d san.
+%s sec.
+== %s san.
 
 Change the skip duration
 == Keçiləcək zamanı dəyişdir

--- a/data/languages/belarusian.txt
+++ b/data/languages/belarusian.txt
@@ -1573,12 +1573,12 @@ Go back the specified duration
 == Назад на выбраную працягласць
 
 [Demo player duration]
-%d min.
-== %d хв.
+%s min.
+== %s хв.
 
 [Demo player duration]
-%d sec.
-== %d сек.
+%s sec.
+== %s сек.
 
 Change the skip duration
 == Змяніць працягласць пропуску

--- a/data/languages/brazilian_portuguese.txt
+++ b/data/languages/brazilian_portuguese.txt
@@ -1604,12 +1604,12 @@ Go back the specified duration
 == Voltar na duração especificada
 
 [Demo player duration]
-%d min.
-== %d min.
+%s min.
+== %s min.
 
 [Demo player duration]
-%d sec.
-== %d seg.
+%s sec.
+== %s seg.
 
 Change the skip duration
 == Alterar a duração de pulo

--- a/data/languages/czech.txt
+++ b/data/languages/czech.txt
@@ -1334,12 +1334,12 @@ Go back the specified duration
 == Vrátit se o zadanou dobu
 
 [Demo player duration]
-%d min.
-== %d min.
+%s min.
+== %s min.
 
 [Demo player duration]
-%d sec.
-== %d sec.
+%s sec.
+== %s sec.
 
 Change the skip duration
 == Změnit dobu přeskočení

--- a/data/languages/danish.txt
+++ b/data/languages/danish.txt
@@ -1422,12 +1422,12 @@ Go back the specified duration
 == Gå tilbage til den angivne varighed
 
 [Demo player duration]
-%d min.
-== %d min.
+%s min.
+== %s min.
 
 [Demo player duration]
-%d sec.
-== %d sec.
+%s sec.
+== %s sec.
 
 Change the skip duration
 == Skift overspringstiden

--- a/data/languages/dutch.txt
+++ b/data/languages/dutch.txt
@@ -1480,12 +1480,12 @@ Go back the specified duration
 == Ga terug met de opgegeven duur
 
 [Demo player duration]
-%d min.
-== %d min.
+%s min.
+== %s min.
 
 [Demo player duration]
-%d sec.
-== %d sec.
+%s sec.
+== %s sec.
 
 Change the skip duration
 == Wijzig de skipduur

--- a/data/languages/estonian.txt
+++ b/data/languages/estonian.txt
@@ -1287,12 +1287,12 @@ Go back the specified duration
 == Mine tagasi määratud kestus
 
 [Demo player duration]
-%d min.
-== %d min.
+%s min.
+== %s min.
 
 [Demo player duration]
-%d sec.
-== %d sek.
+%s sec.
+== %s sek.
 
 Change the skip duration
 == Muuda vahelejätmise kestust

--- a/data/languages/finnish.txt
+++ b/data/languages/finnish.txt
@@ -1290,12 +1290,12 @@ Go back the specified duration
 == Mene annetun ajan taaksepäin
 
 [Demo player duration]
-%d min.
-== %d min.
+%s min.
+== %s min.
 
 [Demo player duration]
-%d sec.
-== %d sek.
+%s sec.
+== %s sek.
 
 Change the skip duration
 == Vaihda hyppyajan kesto

--- a/data/languages/french.txt
+++ b/data/languages/french.txt
@@ -1657,12 +1657,12 @@ Go back the specified duration
 == Saut arrière de la durée spécifiée
 
 [Demo player duration]
-%d min.
-== %d min.
+%s min.
+== %s min.
 
 [Demo player duration]
-%d sec.
-== %d sec.
+%s sec.
+== %s sec.
 
 Change the skip duration
 == Modifier la durée du saut

--- a/data/languages/german.txt
+++ b/data/languages/german.txt
@@ -1604,12 +1604,12 @@ Go back the specified duration
 == Gesetzte Dauer zurück
 
 [Demo player duration]
-%d min.
-== %d Min.
+%s min.
+== %s Min.
 
 [Demo player duration]
-%d sec.
-== %d Sek.
+%s sec.
+== %s Sek.
 
 Change the skip duration
 == Überspring-Dauer ändern

--- a/data/languages/korean.txt
+++ b/data/languages/korean.txt
@@ -1591,12 +1591,12 @@ Friends
 == 친구
 
 [Demo player duration]
-%d min.
-== %d 분
+%s min.
+== %s 분
 
 [Demo player duration]
-%d sec.
-== %d 초
+%s sec.
+== %s 초
 
 Folder Link
 == 폴더 주소

--- a/data/languages/persian.txt
+++ b/data/languages/persian.txt
@@ -1667,12 +1667,12 @@ Go back the specified duration
 == ﺪﯿﻧﺍﺩﺮﮔﺮﺑ ﺐﻘﻋ ﻪﺑ ﺍﺭ ﻩﺪﺷ ﺺﺨﺸﻣ ﻥﺎﻣﺯ ﺕﺪﻣ
 
 [Demo player duration]
-%d min.
-== ﻪﻘﯿﻗﺩ %d
+%s min.
+== ﻪﻘﯿﻗﺩ %s
 
 [Demo player duration]
-%d sec.
-== ﻪﯿﻧﺎﺛ %d
+%s sec.
+== ﻪﯿﻧﺎﺛ %s
 
 Change the skip duration
 == ﻩﺪﺷ ﭗﯿﻜﺳﺍ ﻥﺎﻣﺯ ﺕﺪﻣ ﺮﯿﯿﻐﺗ

--- a/data/languages/polish.txt
+++ b/data/languages/polish.txt
@@ -1399,12 +1399,12 @@ Go back the specified duration
 == Cofnij o określony czas
 
 [Demo player duration]
-%d min.
-== %d min.
+%s min.
+== %s min.
 
 [Demo player duration]
-%d sec.
-== %d sek.
+%s sec.
+== %s sek.
 
 Change the skip duration
 == Zmień długość pominięcia

--- a/data/languages/portuguese.txt
+++ b/data/languages/portuguese.txt
@@ -1225,12 +1225,12 @@ Go back the specified duration
 == Retroceder a duração especificada
 
 [Demo player duration]
-%d min.
-== %d min.
+%s min.
+== %s min.
 
 [Demo player duration]
-%d sec.
-== %d seg.
+%s sec.
+== %s seg.
 
 Change the skip duration
 == Mudar a duração de salto

--- a/data/languages/romanian.txt
+++ b/data/languages/romanian.txt
@@ -971,12 +971,12 @@ Go back the specified duration
 == Mergi înapoi cu durata specificată
 
 [Demo player duration]
-%d min.
-== %d min.
+%s min.
+== %s min.
 
 [Demo player duration]
-%d sec.
-== %d sec.
+%s sec.
+== %s sec.
 
 Change the skip duration
 == Schimbă durata de sărire

--- a/data/languages/russian.txt
+++ b/data/languages/russian.txt
@@ -1607,12 +1607,12 @@ Go back the specified duration
 == Отмотать назад на заданное время 
 
 [Demo player duration]
-%d min.
-== %d мин.
+%s min.
+== %s мин.
 
 [Demo player duration]
-%d sec.
-== %d сек.
+%s sec.
+== %s сек.
 
 Change the skip duration
 == Изменить продолжительность шага

--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -1640,12 +1640,12 @@ Go back the specified duration
 == 快退指定时长
 
 [Demo player duration]
-%d min.
-== %d 分
+%s min.
+== %s 分
 
 [Demo player duration]
-%d sec.
-== %d 秒
+%s sec.
+== %s 秒
 
 Change the skip duration
 == 变更指定时长

--- a/data/languages/slovak.txt
+++ b/data/languages/slovak.txt
@@ -916,12 +916,12 @@ Go back the specified duration
 == Vrátiť sa o zadanú dobu
 
 [Demo player duration]
-%d min.
-== %d min.
+%s min.
+== %s min.
 
 [Demo player duration]
-%d sec.
-== %d sec.
+%s sec.
+== %s sec.
 
 Change the skip duration
 == Zmeniť dobu preskočenia

--- a/data/languages/spanish.txt
+++ b/data/languages/spanish.txt
@@ -1606,12 +1606,12 @@ Go back the specified duration
 == Retroceder el tiempo especificado
 
 [Demo player duration]
-%d min.
-== %d min.
+%s min.
+== %s min.
 
 [Demo player duration]
-%d sec.
-== %d seg.
+%s sec.
+== %s seg.
 
 Change the skip duration
 == Cambiar duración del salto

--- a/data/languages/swedish.txt
+++ b/data/languages/swedish.txt
@@ -1607,12 +1607,12 @@ Go back the specified duration
 == Gå tillbaka den angivna tiden
 
 [Demo player duration]
-%d min.
-== %d min.
+%s min.
+== %s min.
 
 [Demo player duration]
-%d sec.
-== %d sek.
+%s sec.
+== %s sek.
 
 Change the skip duration
 == Ändra tiden för framspolning

--- a/data/languages/traditional_chinese.txt
+++ b/data/languages/traditional_chinese.txt
@@ -1640,12 +1640,12 @@ Go back the specified duration
 == 倒轉指定時長
 
 [Demo player duration]
-%d min.
-== %d 分
+%s min.
+== %s 分
 
 [Demo player duration]
-%d sec.
-== %d 秒
+%s sec.
+== %s 秒
 
 Change the skip duration
 == 變更指定時長

--- a/data/languages/turkish.txt
+++ b/data/languages/turkish.txt
@@ -1604,12 +1604,12 @@ Go back the specified duration
 == Belirtilen süre kadar geri git
 
 [Demo player duration]
-%d min.
-== %d dk.
+%s min.
+== %s dk.
 
 [Demo player duration]
-%d sec.
-== %d sn.
+%s sec.
+== %s sn.
 
 Change the skip duration
 == Atlanacak süreyi değiştir

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -8,8 +8,8 @@
 == %.2f МіБ
 
 [Demo player duration]
-%d min.
-== %dхв
+%s min.
+== %sхв
 
 %d new mentions
 == Нових згадок: %d
@@ -31,8 +31,8 @@
 == Гравці: %d
 
 [Demo player duration]
-%d sec.
-== %dс
+%s sec.
+== %sс
 
 %d/%d KiB (%.1f KiB/s)
 == %d/%d КіБ (%.1f КіБ/с)

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -469,7 +469,8 @@ protected:
 	vec2 m_DemoControlsPositionOffset = vec2(0.0f, 0.0f);
 	float m_LastPauseChange = -1.0f;
 	float m_LastSpeedChange = -1.0f;
-	int m_SkipDurationIndex = 1;
+	static constexpr int DEFAULT_SKIP_DURATION_INDEX = 3;
+	int m_SkipDurationIndex = DEFAULT_SKIP_DURATION_INDEX;
 	static bool DemoFilterChat(const void *pData, int Size, void *pUser);
 	bool FetchHeader(CDemoItem &Item);
 	void FetchAllHeaders();

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -469,6 +469,7 @@ protected:
 	vec2 m_DemoControlsPositionOffset = vec2(0.0f, 0.0f);
 	float m_LastPauseChange = -1.0f;
 	float m_LastSpeedChange = -1.0f;
+	int m_SkipDurationIndex = 1;
 	static bool DemoFilterChat(const void *pData, int Size, void *pUser);
 	bool FetchHeader(CDemoItem &Item);
 	void FetchAllHeaders();

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -150,12 +150,16 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		return 1.0f;
 	};
 
-	static const int s_aSkipDurationsSeconds[] = {1, 5, 10, 30, 60, 5 * 60, 10 * 60};
+	static constexpr float SKIP_DURATIONS_SECONDS[] = {0.1f, 0.5f, 1.0f, 5.0f, 10.0f, 30.0f, 60.0f, 5.0f * 60.0f, 10.0f * 60.0f};
+	static constexpr const char *SKIP_DURATIONS_STRINGS[] = {"0.1", "0.5", "1", "5", "10", "30", "60", "5", "10"};
+	static_assert(SKIP_DURATIONS_SECONDS[DEFAULT_SKIP_DURATION_INDEX] == 5.0f);
+	static_assert(std::size(SKIP_DURATIONS_SECONDS) == std::size(SKIP_DURATIONS_STRINGS));
+
 	const int DemoLengthSeconds = TotalTicks / Client()->GameTickSpeed();
 	int NumDurationLabels = 0;
-	for(size_t i = 0; i < std::size(s_aSkipDurationsSeconds); ++i)
+	for(size_t i = 0; i < std::size(SKIP_DURATIONS_SECONDS); ++i)
 	{
-		if(s_aSkipDurationsSeconds[i] >= DemoLengthSeconds)
+		if(SKIP_DURATIONS_SECONDS[i] >= DemoLengthSeconds)
 			break;
 		NumDurationLabels = i + 1;
 	}
@@ -204,7 +208,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			else if(Input()->ShiftIsPressed())
 				m_SkipDurationIndex = maximum(m_SkipDurationIndex - 1, 0);
 			else
-				TimeToSeek = -s_aSkipDurationsSeconds[m_SkipDurationIndex];
+				TimeToSeek = -SKIP_DURATIONS_SECONDS[m_SkipDurationIndex];
 		}
 		else if(Input()->KeyPress(KEY_RIGHT) || Input()->KeyPress(KEY_L))
 		{
@@ -213,7 +217,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			else if(Input()->ShiftIsPressed())
 				m_SkipDurationIndex = minimum(m_SkipDurationIndex + 1, NumDurationLabels - 1);
 			else
-				TimeToSeek = s_aSkipDurationsSeconds[m_SkipDurationIndex];
+				TimeToSeek = SKIP_DURATIONS_SECONDS[m_SkipDurationIndex];
 		}
 
 		// seek to 0-90%
@@ -533,7 +537,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	static CButtonContainer s_TimeBackButton;
 	if(DoButton_FontIcon(&s_TimeBackButton, FONT_ICON_BACKWARD, 0, &Button, BUTTONFLAG_LEFT))
 	{
-		TimeToSeek = -s_aSkipDurationsSeconds[m_SkipDurationIndex];
+		TimeToSeek = -SKIP_DURATIONS_SECONDS[m_SkipDurationIndex];
 	}
 	GameClient()->m_Tooltips.DoToolTip(&s_TimeBackButton, &Button, Localize("Go back the specified duration"));
 
@@ -551,10 +555,10 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		for(int i = 0; i < NumDurationLabels; ++i)
 		{
 			char aBuf[256];
-			if(s_aSkipDurationsSeconds[i] >= 60)
-				str_format(aBuf, sizeof(aBuf), Localize("%d min.", "Demo player duration"), s_aSkipDurationsSeconds[i] / 60);
+			if(SKIP_DURATIONS_SECONDS[i] >= 60)
+				str_format(aBuf, sizeof(aBuf), Localize("%s min.", "Demo player duration"), SKIP_DURATIONS_STRINGS[i]);
 			else
-				str_format(aBuf, sizeof(aBuf), Localize("%d sec.", "Demo player duration"), s_aSkipDurationsSeconds[i]);
+				str_format(aBuf, sizeof(aBuf), Localize("%s sec.", "Demo player duration"), SKIP_DURATIONS_STRINGS[i]);
 			s_vDurationNames[i] = aBuf;
 			s_vpDurationNames[i] = s_vDurationNames[i].c_str();
 		}
@@ -572,7 +576,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	static CButtonContainer s_TimeForwardButton;
 	if(DoButton_FontIcon(&s_TimeForwardButton, FONT_ICON_FORWARD, 0, &Button, BUTTONFLAG_LEFT))
 	{
-		TimeToSeek = s_aSkipDurationsSeconds[m_SkipDurationIndex];
+		TimeToSeek = SKIP_DURATIONS_SECONDS[m_SkipDurationIndex];
 	}
 	GameClient()->m_Tooltips.DoToolTip(&s_TimeForwardButton, &Button, Localize("Go forward the specified duration"));
 

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -150,7 +150,6 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		return 1.0f;
 	};
 
-	static int s_SkipDurationIndex = 1;
 	static const int s_aSkipDurationsSeconds[] = {1, 5, 10, 30, 60, 5 * 60, 10 * 60};
 	const int DemoLengthSeconds = TotalTicks / Client()->GameTickSpeed();
 	int NumDurationLabels = 0;
@@ -160,8 +159,8 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			break;
 		NumDurationLabels = i + 1;
 	}
-	if(NumDurationLabels > 0 && s_SkipDurationIndex >= NumDurationLabels)
-		s_SkipDurationIndex = maximum(0, NumDurationLabels - 1);
+	if(NumDurationLabels > 0 && m_SkipDurationIndex >= NumDurationLabels)
+		m_SkipDurationIndex = maximum(0, NumDurationLabels - 1);
 
 	// handle keyboard shortcuts independent of active menu
 	float PositionToSeek = -1.0f;
@@ -203,18 +202,18 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			if(Input()->ModifierIsPressed())
 				PositionToSeek = FindPreviousMarkerPosition();
 			else if(Input()->ShiftIsPressed())
-				s_SkipDurationIndex = maximum(s_SkipDurationIndex - 1, 0);
+				m_SkipDurationIndex = maximum(m_SkipDurationIndex - 1, 0);
 			else
-				TimeToSeek = -s_aSkipDurationsSeconds[s_SkipDurationIndex];
+				TimeToSeek = -s_aSkipDurationsSeconds[m_SkipDurationIndex];
 		}
 		else if(Input()->KeyPress(KEY_RIGHT) || Input()->KeyPress(KEY_L))
 		{
 			if(Input()->ModifierIsPressed())
 				PositionToSeek = FindNextMarkerPosition();
 			else if(Input()->ShiftIsPressed())
-				s_SkipDurationIndex = minimum(s_SkipDurationIndex + 1, NumDurationLabels - 1);
+				m_SkipDurationIndex = minimum(m_SkipDurationIndex + 1, NumDurationLabels - 1);
 			else
-				TimeToSeek = s_aSkipDurationsSeconds[s_SkipDurationIndex];
+				TimeToSeek = s_aSkipDurationsSeconds[m_SkipDurationIndex];
 		}
 
 		// seek to 0-90%
@@ -534,7 +533,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	static CButtonContainer s_TimeBackButton;
 	if(DoButton_FontIcon(&s_TimeBackButton, FONT_ICON_BACKWARD, 0, &Button, BUTTONFLAG_LEFT))
 	{
-		TimeToSeek = -s_aSkipDurationsSeconds[s_SkipDurationIndex];
+		TimeToSeek = -s_aSkipDurationsSeconds[m_SkipDurationIndex];
 	}
 	GameClient()->m_Tooltips.DoToolTip(&s_TimeBackButton, &Button, Localize("Go back the specified duration"));
 
@@ -563,7 +562,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		static CUi::SDropDownState s_SkipDurationDropDownState;
 		static CScrollRegion s_SkipDurationDropDownScrollRegion;
 		s_SkipDurationDropDownState.m_SelectionPopupContext.m_pScrollRegion = &s_SkipDurationDropDownScrollRegion;
-		s_SkipDurationIndex = Ui()->DoDropDown(&Button, s_SkipDurationIndex, s_vpDurationNames.data(), NumDurationLabels, s_SkipDurationDropDownState);
+		m_SkipDurationIndex = Ui()->DoDropDown(&Button, m_SkipDurationIndex, s_vpDurationNames.data(), NumDurationLabels, s_SkipDurationDropDownState);
 		GameClient()->m_Tooltips.DoToolTip(&s_SkipDurationDropDownState.m_ButtonContainer, &Button, Localize("Change the skip duration"));
 	}
 
@@ -573,7 +572,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	static CButtonContainer s_TimeForwardButton;
 	if(DoButton_FontIcon(&s_TimeForwardButton, FONT_ICON_FORWARD, 0, &Button, BUTTONFLAG_LEFT))
 	{
-		TimeToSeek = s_aSkipDurationsSeconds[s_SkipDurationIndex];
+		TimeToSeek = s_aSkipDurationsSeconds[m_SkipDurationIndex];
 	}
 	GameClient()->m_Tooltips.DoToolTip(&s_TimeForwardButton, &Button, Localize("Go forward the specified duration"));
 


### PR DESCRIPTION
Tick back and forth exists, but that's too short

Translations have been changed to use %s instead of %d, procedurally formating numbers how is shown is bit of a pain

![image](https://github.com/user-attachments/assets/9d3f8d76-18e1-4676-a62b-366600339e9e)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
