### PR TITLE
Add turret prediction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2416,6 +2416,8 @@ if(CLIENT)
     prediction/entities/laser.h
     prediction/entities/pickup.cpp
     prediction/entities/pickup.h
+    prediction/entities/plasma.cpp
+    prediction/entities/plasma.h
     prediction/entities/projectile.cpp
     prediction/entities/projectile.h
     prediction/entity.cpp

--- a/src/game/client/prediction/entities/plasma.cpp
+++ b/src/game/client/prediction/entities/plasma.cpp
@@ -1,0 +1,130 @@
+/* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
+#include "plasma.h"
+#include "character.h"
+
+#include <game/client/laser_data.h>
+#include <game/collision.h>
+#include <game/mapitems.h>
+
+const float PLASMA_ACCEL = 1.1f;
+
+CPlasma::CPlasma(CGameWorld *pGameWorld, int Id, const CLaserData *pData) :
+	CEntity(pGameWorld, CGameWorld::ENTTYPE_PLASMA)
+{
+	m_Id = Id;
+
+	m_Number = pData->m_SwitchNumber;
+	m_Layer = m_Number > 0 ? LAYER_SWITCH : LAYER_GAME;
+	m_LifeTime = (int)(GameWorld()->GameTickSpeed() * 1.5f);
+
+	m_Explosive = false;
+	m_Freeze = false;
+
+	Read(pData);
+
+	CCharacter *pTarget = GameWorld()->GetCharacterById(m_ForClientId);
+	if(!pTarget)
+	{
+		Reset();
+		return;
+	}
+	m_Core = normalize(pTarget->m_Pos - m_Pos);
+}
+
+bool CPlasma::Match(const CPlasma *pPlasma) const
+{
+	return pPlasma->m_EvalTick == m_EvalTick && pPlasma->m_Number == m_Number &&
+	       pPlasma->m_Explosive == m_Explosive && pPlasma->m_Freeze == m_Freeze && pPlasma->m_ForClientId == m_ForClientId;
+}
+
+void CPlasma::Read(const CLaserData *pData)
+{
+	m_Pos = pData->m_From;
+	m_EvalTick = pData->m_StartTick;
+	m_ForClientId = pData->m_Owner;
+
+	if(0 <= pData->m_Subtype && pData->m_Subtype < NUM_LASERGUNTYPES)
+	{
+		m_Explosive = (pData->m_Subtype & 1);
+		m_Freeze = (pData->m_Subtype & 2);
+	}
+}
+
+void CPlasma::Reset()
+{
+	m_MarkedForDestroy = true;
+}
+
+void CPlasma::Tick()
+{
+	// A plasma bullet has only a limited lifetime
+	if(m_LifeTime == 0)
+	{
+		Reset();
+		return;
+	}
+	CCharacter *pTarget = GameWorld()->GetCharacterById(m_ForClientId);
+	// Without a target, a plasma bullet has no reason to live
+	if(!pTarget)
+	{
+		Reset();
+		return;
+	}
+	m_LifeTime--;
+	Move();
+	HitCharacter(pTarget);
+	// Plasma bullets may explode twice if they would hit both a player and an obstacle in the next move step
+	HitObstacle(pTarget);
+}
+
+void CPlasma::Move()
+{
+	m_Pos += m_Core;
+	m_Core *= PLASMA_ACCEL;
+}
+
+bool CPlasma::HitCharacter(CCharacter *pTarget)
+{
+	vec2 IntersectPos;
+	CCharacter *pHitPlayer = GameWorld()->IntersectCharacter(
+		m_Pos, m_Pos + m_Core, 0.0f, IntersectPos, nullptr, m_ForClientId);
+	if(!pHitPlayer)
+	{
+		return false;
+	}
+
+	// Super player should not be able to stop the plasma bullets
+	if(pHitPlayer->Team() == TEAM_SUPER)
+	{
+		return false;
+	}
+
+	m_Freeze ? pHitPlayer->Freeze() : pHitPlayer->UnFreeze();
+	if(m_Explosive)
+	{
+		// Plasma Turrets are very precise weapons only one tee gets speed from it,
+		// other tees near the explosion remain unaffected
+		GameWorld()->CreateExplosion(
+			m_Pos, m_ForClientId, WEAPON_GRENADE, true, pTarget->Team(), CClientMask().set());
+	}
+	Reset();
+	return true;
+}
+
+bool CPlasma::HitObstacle(CCharacter *pTarget)
+{
+	// Check if the plasma bullet is stopped by a solid block or a laser stopper
+	int HasIntersection = Collision()->IntersectNoLaser(m_Pos, m_Pos + m_Core, nullptr, nullptr);
+	if(HasIntersection)
+	{
+		if(m_Explosive)
+		{
+			// Even in the case of an explosion due to a collision with obstacles, only one player is affected
+			GameWorld()->CreateExplosion(
+				m_Pos, m_ForClientId, WEAPON_GRENADE, true, pTarget->Team(), CClientMask().set());
+		}
+		Reset();
+		return true;
+	}
+	return false;
+}

--- a/src/game/client/prediction/entities/plasma.h
+++ b/src/game/client/prediction/entities/plasma.h
@@ -1,0 +1,32 @@
+/* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
+#ifndef GAME_CLIENT_PREDICTION_ENTITIES_PLASMA_H
+#define GAME_CLIENT_PREDICTION_ENTITIES_PLASMA_H
+
+#include <game/client/prediction/entity.h>
+
+class CLaserData;
+
+class CPlasma : public CEntity
+{
+	vec2 m_Core;
+	bool m_Freeze;
+	bool m_Explosive;
+	int m_ForClientId;
+	int m_EvalTick;
+	int m_LifeTime;
+
+	void Move();
+	bool HitCharacter(CCharacter *pTarget);
+	bool HitObstacle(CCharacter *pTarget);
+
+public:
+	CPlasma(CGameWorld *pGameWorld, int Id, const CLaserData *pData);
+
+	bool Match(const CPlasma *pPlasma) const;
+	void Read(const CLaserData *pData);
+
+	void Reset();
+	void Tick() override;
+};
+
+#endif // GAME_CLIENT_PREDICTION_ENTITIES_PLASMA_H

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -7,6 +7,7 @@
 #include "entities/dragger.h"
 #include "entities/laser.h"
 #include "entities/pickup.h"
+#include "entities/plasma.h"
 #include "entities/projectile.h"
 #include "entity.h"
 #include <engine/shared/config.h>
@@ -561,6 +562,19 @@ void CGameWorld::NetObjAdd(int ObjId, int ObjType, const void *pObjData, const C
 			pEnt->ResetCollision();
 			InsertEntity(pEnt);
 		}
+		else if(Data.m_Type == LASERTYPE_PLASMA)
+		{
+			CPlasma NetPlasma = CPlasma(this, ObjId, &Data);
+			auto *pPlasma = dynamic_cast<CPlasma *>(GetEntity(ObjId, ENTTYPE_PLASMA));
+			if(pPlasma && NetPlasma.Match(pPlasma))
+			{
+				pPlasma->Keep();
+				pPlasma->Read(&Data);
+				return;
+			}
+			CPlasma *pEnt = new CPlasma(NetPlasma);
+			InsertEntity(pEnt);
+		}
 	}
 }
 
@@ -643,6 +657,8 @@ void CGameWorld::CopyWorld(CGameWorld *pFrom)
 				pCopy = new CCharacter(*((CCharacter *)pEnt));
 			else if(Type == ENTTYPE_PICKUP)
 				pCopy = new CPickup(*((CPickup *)pEnt));
+			else if(Type == ENTTYPE_PLASMA)
+				pCopy = new CPlasma(*((CPlasma *)pEnt));
 			if(pCopy)
 			{
 				pCopy->m_pParent = pEnt;
@@ -703,6 +719,14 @@ CEntity *CGameWorld::FindMatch(int ObjId, int ObjType, const void *pObjData)
 		{
 			CDoor *pEnt = (CDoor *)GetEntity(ObjId, ENTTYPE_DOOR);
 			if(pEnt && CDoor(this, ObjId, &Data).Match(pEnt))
+			{
+				return pEnt;
+			}
+		}
+		else if(Data.m_Type == LASERTYPE_PLASMA)
+		{
+			CPlasma *pEnt = (CPlasma *)GetEntity(ObjId, ENTTYPE_PLASMA);
+			if(pEnt && CPlasma(this, ObjId, &Data).Match(pEnt))
 			{
 				return pEnt;
 			}

--- a/src/game/server/entities/plasma.cpp
+++ b/src/game/server/entities/plasma.cpp
@@ -122,7 +122,7 @@ void CPlasma::Snap(int SnappingClient)
 
 	int Subtype = (m_Explosive ? 1 : 0) | (m_Freeze ? 2 : 0);
 	GameServer()->SnapLaserObject(CSnapContext(SnappingClientVersion), GetId(),
-		m_Pos, m_Pos, m_EvalTick, -1, LASERTYPE_PLASMA, Subtype, m_Number);
+		m_Pos, m_Pos, m_EvalTick, m_ForClientId, LASERTYPE_PLASMA, Subtype, m_Number);
 }
 
 void CPlasma::SwapClients(int Client1, int Client2)


### PR DESCRIPTION
Updated the plasma snap to now send the target's ID instead of always sending -1, allowing the client to predict it.


On old servers, where the snap will still be -1 it will simply be not predicted, because -1 is not a valid client id.

https://github.com/user-attachments/assets/641ff445-3ada-4f54-a5d8-1e2b7791c4e4



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
