### PR TITLE
Add weapon tele prediction when 1 exit

### DIFF
--- a/src/game/client/prediction/entities/laser.cpp
+++ b/src/game/client/prediction/entities/laser.cpp
@@ -20,6 +20,8 @@ CLaser::CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEner
 	m_Dir = Direction;
 	m_Bounces = 0;
 	m_EvalTick = 0;
+	m_TelePos = vec2(0, 0);
+	m_WasTele = false;
 	m_Type = Type;
 	m_ZeroEnergyBounceInLastTick = false;
 	m_TuneZone = GameWorld()->m_WorldConfig.m_UseTuneZones ? Collision()->IsTune(Collision()->GetMapIndex(m_Pos)) : 0;
@@ -33,7 +35,7 @@ bool CLaser::HitCharacter(vec2 From, vec2 To)
 	vec2 At;
 	CCharacter *pOwnerChar = GameWorld()->GetCharacterById(m_Owner);
 	CCharacter *pHit;
-	bool DontHitSelf = (g_Config.m_SvOldLaser || !GameWorld()->m_WorldConfig.m_IsDDRace) || (m_Bounces == 0);
+	bool DontHitSelf = (g_Config.m_SvOldLaser || !GameWorld()->m_WorldConfig.m_IsDDRace) || (m_Bounces == 0 && !m_WasTele);
 
 	if(pOwnerChar ? (!pOwnerChar->LaserHitDisabled() && m_Type == WEAPON_LASER) || (!pOwnerChar->ShotgunHitDisabled() && m_Type == WEAPON_SHOTGUN) : g_Config.m_SvHit)
 		pHit = GameWorld()->IntersectCharacter(m_Pos, To, 0.f, At, DontHitSelf ? pOwnerChar : nullptr, m_Owner);
@@ -102,9 +104,18 @@ void CLaser::DoBounce()
 	vec2 Coltile;
 
 	int Res;
+	int TeleNumber;
+
+	if(m_WasTele)
+	{
+		m_PrevPos = m_TelePos;
+		m_Pos = m_TelePos;
+		m_TelePos = vec2(0, 0);
+	}
+
 	vec2 To = m_Pos + m_Dir * m_Energy;
 
-	Res = Collision()->IntersectLineTeleWeapon(m_Pos, To, &Coltile, &To);
+	Res = Collision()->IntersectLineTeleWeapon(m_Pos, To, &Coltile, &To, &TeleNumber);
 
 	if(Res)
 	{
@@ -143,7 +154,16 @@ void CLaser::DoBounce()
 			}
 			m_ZeroEnergyBounceInLastTick = Distance == 0.0f;
 
-			m_Bounces++;
+			if(Res == TILE_TELEINWEAPON && Collision()->TeleOuts(TeleNumber - 1).size() == 1)
+			{
+				m_TelePos = Collision()->TeleOuts(TeleNumber - 1)[0];
+				m_WasTele = true;
+			}
+			else
+			{
+				m_Bounces++;
+				m_WasTele = false;
+			}
 
 			int BounceNum = GetTuning(m_TuneZone)->m_LaserBounceNum;
 

--- a/src/game/client/prediction/entities/laser.h
+++ b/src/game/client/prediction/entities/laser.h
@@ -30,6 +30,8 @@ protected:
 private:
 	vec2 m_From;
 	vec2 m_Dir;
+	vec2 m_TelePos;
+	bool m_WasTele;
 	float m_Energy;
 	int m_Bounces;
 	int m_EvalTick;

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -146,6 +146,19 @@ void CProjectile::Tick()
 		}
 		m_MarkedForDestroy = true;
 	}
+
+	// predict if the projectile goes through the weapon teleport, only when there's 1 exit, because the out tele is random
+	int Index = Collision()->GetIndex(PrevPos, CurPos);
+	int TeleNumber;
+	if(g_Config.m_SvOldTeleportWeapons)
+		TeleNumber = Collision()->IsTeleport(Index);
+	else
+		TeleNumber = Collision()->IsTeleportWeapon(Index);
+	if(TeleNumber && Collision()->TeleOuts(TeleNumber - 1).size() == 1)
+	{
+		m_Pos = Collision()->TeleOuts(TeleNumber - 1)[0];
+		m_StartTick = GameWorld()->GameTick();
+	}
 }
 
 // DDRace

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -41,12 +41,12 @@ bool CLaser::HitCharacter(vec2 From, vec2 To)
 	vec2 At;
 	CCharacter *pOwnerChar = GameServer()->GetPlayerChar(m_Owner);
 	CCharacter *pHit;
-	bool pDontHitSelf = g_Config.m_SvOldLaser || (m_Bounces == 0 && !m_WasTele);
+	bool DontHitSelf = g_Config.m_SvOldLaser || (m_Bounces == 0 && !m_WasTele);
 
 	if(pOwnerChar ? (!pOwnerChar->LaserHitDisabled() && m_Type == WEAPON_LASER) || (!pOwnerChar->ShotgunHitDisabled() && m_Type == WEAPON_SHOTGUN) : g_Config.m_SvHit)
-		pHit = GameWorld()->IntersectCharacter(m_Pos, To, 0.f, At, pDontHitSelf ? pOwnerChar : nullptr, m_Owner);
+		pHit = GameWorld()->IntersectCharacter(m_Pos, To, 0.f, At, DontHitSelf ? pOwnerChar : nullptr, m_Owner);
 	else
-		pHit = GameWorld()->IntersectCharacter(m_Pos, To, 0.f, At, pDontHitSelf ? pOwnerChar : nullptr, m_Owner, pOwnerChar);
+		pHit = GameWorld()->IntersectCharacter(m_Pos, To, 0.f, At, DontHitSelf ? pOwnerChar : nullptr, m_Owner, pOwnerChar);
 
 	if(!pHit || (pHit == pOwnerChar && g_Config.m_SvOldLaser) || (pHit != pOwnerChar && pOwnerChar ? (pOwnerChar->LaserHitDisabled() && m_Type == WEAPON_LASER) || (pOwnerChar->ShotgunHitDisabled() && m_Type == WEAPON_SHOTGUN) : !g_Config.m_SvHit))
 		return false;
@@ -111,7 +111,7 @@ void CLaser::DoBounce()
 	vec2 Coltile;
 
 	int Res;
-	int z;
+	int TeleNumber;
 
 	if(m_WasTele)
 	{
@@ -122,7 +122,7 @@ void CLaser::DoBounce()
 
 	vec2 To = m_Pos + m_Dir * m_Energy;
 
-	Res = GameServer()->Collision()->IntersectLineTeleWeapon(m_Pos, To, &Coltile, &To, &z);
+	Res = GameServer()->Collision()->IntersectLineTeleWeapon(m_Pos, To, &Coltile, &To, &TeleNumber);
 
 	if(Res)
 	{
@@ -165,10 +165,10 @@ void CLaser::DoBounce()
 			}
 			m_ZeroEnergyBounceInLastTick = Distance == 0.0f;
 
-			if(Res == TILE_TELEINWEAPON && !GameServer()->Collision()->TeleOuts(z - 1).empty())
+			if(Res == TILE_TELEINWEAPON && !GameServer()->Collision()->TeleOuts(TeleNumber - 1).empty())
 			{
-				int TeleOut = GameServer()->m_World.m_Core.RandomOr0(GameServer()->Collision()->TeleOuts(z - 1).size());
-				m_TelePos = GameServer()->Collision()->TeleOuts(z - 1)[TeleOut];
+				int TeleOut = GameServer()->m_World.m_Core.RandomOr0(GameServer()->Collision()->TeleOuts(TeleNumber - 1).size());
+				m_TelePos = GameServer()->Collision()->TeleOuts(TeleNumber - 1)[TeleOut];
 				m_WasTele = true;
 			}
 			else
@@ -205,13 +205,13 @@ void CLaser::DoBounce()
 		bool Found = false;
 
 		// Check if the laser hits a player.
-		bool pDontHitSelf = g_Config.m_SvOldLaser || (m_Bounces == 0 && !m_WasTele);
+		bool DontHitSelf = g_Config.m_SvOldLaser || (m_Bounces == 0 && !m_WasTele);
 		vec2 At;
 		CCharacter *pHit;
 		if(pOwnerChar ? (!pOwnerChar->LaserHitDisabled() && m_Type == WEAPON_LASER) : g_Config.m_SvHit)
-			pHit = GameServer()->m_World.IntersectCharacter(m_Pos, To, 0.f, At, pDontHitSelf ? pOwnerChar : nullptr, m_Owner);
+			pHit = GameServer()->m_World.IntersectCharacter(m_Pos, To, 0.f, At, DontHitSelf ? pOwnerChar : nullptr, m_Owner);
 		else
-			pHit = GameServer()->m_World.IntersectCharacter(m_Pos, To, 0.f, At, pDontHitSelf ? pOwnerChar : nullptr, m_Owner, pOwnerChar);
+			pHit = GameServer()->m_World.IntersectCharacter(m_Pos, To, 0.f, At, DontHitSelf ? pOwnerChar : nullptr, m_Owner, pOwnerChar);
 
 		if(pHit)
 			Found = GetNearestAirPosPlayer(pHit->m_Pos, &PossiblePos);

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -274,16 +274,16 @@ void CProjectile::Tick()
 		return;
 	}
 
-	int x = GameServer()->Collision()->GetIndex(PrevPos, CurPos);
-	int z;
+	int Index = GameServer()->Collision()->GetIndex(PrevPos, CurPos);
+	int TeleNumber;
 	if(g_Config.m_SvOldTeleportWeapons)
-		z = GameServer()->Collision()->IsTeleport(x);
+		TeleNumber = GameServer()->Collision()->IsTeleport(Index);
 	else
-		z = GameServer()->Collision()->IsTeleportWeapon(x);
-	if(z && !GameServer()->Collision()->TeleOuts(z - 1).empty())
+		TeleNumber = GameServer()->Collision()->IsTeleportWeapon(Index);
+	if(TeleNumber && !GameServer()->Collision()->TeleOuts(TeleNumber - 1).empty())
 	{
-		int TeleOut = GameServer()->m_World.m_Core.RandomOr0(GameServer()->Collision()->TeleOuts(z - 1).size());
-		m_Pos = GameServer()->Collision()->TeleOuts(z - 1)[TeleOut];
+		int TeleOut = GameServer()->m_World.m_Core.RandomOr0(GameServer()->Collision()->TeleOuts(TeleNumber - 1).size());
+		m_Pos = GameServer()->Collision()->TeleOuts(TeleNumber - 1)[TeleOut];
 		m_StartTick = Server()->Tick();
 	}
 }


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/d097cbcc-0aba-4f84-9bce-2c270aeb0aee



After:

https://github.com/user-attachments/assets/4206e256-c479-44cc-bf7e-d7f3e2d666bf



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
