### PR TITLE
Add error handling for checking points on first launch

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -297,6 +297,13 @@ public:
 	virtual void DemoSliceEnd() = 0;
 	virtual void DemoSlice(const char *pDstPath, CLIENTFUNC_FILTER pfnFilter, void *pUser) = 0;
 
+	enum class EInfoState
+	{
+		LOADING,
+		SUCCESS,
+		ERROR,
+	};
+	virtual EInfoState InfoState() const = 0;
 	virtual void RequestDDNetInfo() = 0;
 	virtual bool EditorHasUnsavedData() const = 0;
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2429,7 +2429,10 @@ void CClient::LoadDDNetInfo()
 	const json_value *pDDNetInfo = m_ServerBrowser.LoadDDNetInfo();
 
 	if(!pDDNetInfo)
+	{
+		m_InfoState = EInfoState::ERROR;
 		return;
+	}
 
 	const json_value &DDNetInfo = *pDDNetInfo;
 	const json_value &CurrentVersion = DDNetInfo["version"];
@@ -2503,6 +2506,7 @@ void CClient::LoadDDNetInfo()
 	}
 	const json_value &WarnPngliteIncompatibleImages = DDNetInfo["warn-pnglite-incompatible-images"];
 	Graphics()->WarnPngliteIncompatibleImages(WarnPngliteIncompatibleImages.type == json_boolean && (bool)WarnPngliteIncompatibleImages);
+	m_InfoState = EInfoState::SUCCESS;
 }
 
 int CClient::ConnectNetTypes() const
@@ -2893,6 +2897,7 @@ void CClient::Update()
 			if(m_ServerBrowser.DDNetInfoSha256() == m_pDDNetInfoTask->ResultSha256())
 			{
 				log_debug("client/info", "DDNet info already up-to-date");
+				m_InfoState = EInfoState::SUCCESS;
 			}
 			else
 			{
@@ -2905,6 +2910,7 @@ void CClient::Update()
 		else if(m_pDDNetInfoTask->State() == EHttpState::ERROR || m_pDDNetInfoTask->State() == EHttpState::ABORTED)
 		{
 			ResetDDNetInfoTask();
+			m_InfoState = EInfoState::ERROR;
 		}
 	}
 
@@ -5068,6 +5074,7 @@ void CClient::RequestDDNetInfo()
 	// Use ipv4 so we can know the ingame ip addresses of players before they join game servers
 	m_pDDNetInfoTask->IpResolve(IPRESOLVE::V4);
 	Http()->Run(m_pDDNetInfoTask);
+	m_InfoState = EInfoState::LOADING;
 }
 
 int CClient::GetPredictionTime()

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -163,6 +163,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	SHA256_DIGEST m_MapDetailsSha256 = SHA256_ZEROED;
 	char m_aMapDetailsUrl[256] = "";
 
+	EInfoState m_InfoState = EInfoState::ERROR;
 	std::shared_ptr<CHttpRequest> m_pDDNetInfoTask = nullptr;
 
 	// time
@@ -380,6 +381,7 @@ public:
 	void ResetMapDownload(bool ResetActive);
 	void FinishMapDownload();
 
+	EInfoState InfoState() const override { return m_InfoState; }
 	void RequestDDNetInfo() override;
 	void ResetDDNetInfoTask();
 	void LoadDDNetInfo();

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1316,15 +1316,11 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 	else if(m_Popup == POPUP_POINTS)
 	{
 		pTitle = Localize("Existing Player");
-		if(Client()->Points() > 50)
+		if(Client()->InfoState() == IClient::EInfoState::SUCCESS && Client()->Points() > 50)
 		{
 			str_format(aBuf, sizeof(aBuf), Localize("Your nickname '%s' is already used (%d points). Do you still want to use it?"), Client()->PlayerName(), Client()->Points());
 			pExtraText = aBuf;
 			TopAlign = true;
-		}
-		else if(Client()->Points() >= 0)
-		{
-			m_Popup = POPUP_NONE;
 		}
 		else
 		{
@@ -1803,24 +1799,43 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 	}
 	else if(m_Popup == POPUP_POINTS)
 	{
-		CUIRect Yes, No;
+		Box.HSplitBottom(20.0f, &Box, nullptr);
+		Box.HSplitBottom(24.0f, &Box, &Part);
+		Part.VMargin(120.0f, &Part);
 
-		Box.HSplitBottom(20.f, &Box, &Part);
-		Box.HSplitBottom(24.f, &Box, &Part);
-		Part.VMargin(80.0f, &Part);
+		if(Client()->InfoState() == IClient::EInfoState::SUCCESS && Client()->Points() > 50)
+		{
+			CUIRect Yes, No;
+			Part.VSplitMid(&No, &Yes, 40.0f);
+			static CButtonContainer s_ButtonNo;
+			if(DoButton_Menu(&s_ButtonNo, Localize("No"), 0, &No) ||
+				Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
+			{
+				m_Popup = POPUP_FIRST_LAUNCH;
+			}
 
-		Part.VSplitMid(&No, &Yes);
-
-		Yes.VMargin(20.0f, &Yes);
-		No.VMargin(20.0f, &No);
-
-		static CButtonContainer s_ButtonNo;
-		if(DoButton_Menu(&s_ButtonNo, Localize("No"), 0, &No) || Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
-			m_Popup = POPUP_FIRST_LAUNCH;
-
-		static CButtonContainer s_ButtonYes;
-		if(DoButton_Menu(&s_ButtonYes, Localize("Yes"), 0, &Yes) || Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER))
-			m_Popup = POPUP_NONE;
+			static CButtonContainer s_ButtonYes;
+			if(DoButton_Menu(&s_ButtonYes, Localize("Yes"), 0, &Yes) ||
+				Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER))
+			{
+				m_Popup = POPUP_NONE;
+			}
+		}
+		else
+		{
+			static CButtonContainer s_Button;
+			if(DoButton_Menu(&s_Button, Localize("Cancel"), 0, &Part) ||
+				Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE) ||
+				Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER) ||
+				Client()->InfoState() == IClient::EInfoState::SUCCESS)
+			{
+				m_Popup = POPUP_NONE;
+			}
+			if(Client()->InfoState() == IClient::EInfoState::ERROR)
+			{
+				PopupMessage(Localize("Error checking player name"), Localize("Could not check for existing player with your name. Check your internet connection."), Localize("Ok"));
+			}
+		}
 	}
 	else if(m_Popup == POPUP_WARNING)
 	{


### PR DESCRIPTION
Show error message if the points for the initially chosen player name could not be determined, e.g. because no internet connection is available. Previously, the popup did not indicate errors and incorrectly showed yes and no buttons also while the points are being checked, now a cancel button is shown instead.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
