### PR TITLE
Add teleport prediction when 1 exit

### DIFF
--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -749,6 +749,10 @@ void CCharacter::HandleTiles(int Index)
 		return;
 	}
 
+	int TeleCheckpoint = Collision()->IsTeleCheckpoint(MapIndex);
+	if(TeleCheckpoint)
+		m_TeleCheckpoint = TeleCheckpoint;
+
 	// handle switch tiles
 	if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHOPEN && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
 	{
@@ -965,6 +969,103 @@ void CCharacter::HandleTiles(int Index)
 	{
 		m_LastRefillJumps = false;
 	}
+
+	int TeleNumber = Collision()->IsTeleport(MapIndex);
+	if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons && TeleNumber && !Collision()->TeleOuts(TeleNumber - 1).empty())
+	{
+		if(m_Core.m_Super || m_Core.m_Invincible)
+			return;
+		if(Collision()->TeleOuts(TeleNumber - 1).size() == 1)
+		{
+			m_Core.m_Pos = Collision()->TeleOuts(TeleNumber - 1)[0];
+			if(!g_Config.m_SvTeleportHoldHook)
+			{
+				ResetHook();
+			}
+			if(g_Config.m_SvTeleportLoseWeapons)
+				ResetPickups();
+		}
+		return;
+	}
+	int EvilTeleNumber = Collision()->IsEvilTeleport(MapIndex);
+	if(EvilTeleNumber && !Collision()->TeleOuts(EvilTeleNumber - 1).empty())
+	{
+		if(m_Core.m_Super || m_Core.m_Invincible)
+			return;
+		if(Collision()->TeleOuts(EvilTeleNumber - 1).size() == 1)
+		{
+			m_Core.m_Pos = Collision()->TeleOuts(EvilTeleNumber - 1)[0];
+			if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons)
+			{
+				m_Core.m_Vel = vec2(0, 0);
+
+				if(!g_Config.m_SvTeleportHoldHook)
+				{
+					ResetHook();
+					GameWorld()->ReleaseHooked(GetCid());
+				}
+				if(g_Config.m_SvTeleportLoseWeapons)
+				{
+					ResetPickups();
+				}
+			}
+		}
+		return;
+	}
+	if(Collision()->IsCheckEvilTeleport(MapIndex))
+	{
+		if(m_Core.m_Super || m_Core.m_Invincible)
+			return;
+		// first check if there is a TeleCheckOut for the current recorded checkpoint, if not check previous checkpoints
+		for(int k = m_TeleCheckpoint - 1; k >= 0; k--)
+		{
+			if(Collision()->TeleCheckOuts(k).size() == 1)
+			{
+				m_Core.m_Pos = Collision()->TeleCheckOuts(k)[0];
+				m_Core.m_Vel = vec2(0, 0);
+
+				if(!g_Config.m_SvTeleportHoldHook)
+				{
+					ResetHook();
+					GameWorld()->ReleaseHooked(GetCid());
+				}
+
+				return;
+			}
+			if(!Collision()->TeleCheckOuts(k).empty())
+			{
+				return;
+			}
+		}
+		// if no checkpointout have been found (or if there no recorded checkpoint), teleport to start
+		return;
+	}
+	if(Collision()->IsCheckTeleport(MapIndex))
+	{
+		if(m_Core.m_Super || m_Core.m_Invincible)
+			return;
+		// first check if there is a TeleCheckOut for the current recorded checkpoint, if not check previous checkpoints
+		for(int k = m_TeleCheckpoint - 1; k >= 0; k--)
+		{
+			if(Collision()->TeleCheckOuts(k).size() == 1)
+			{
+				m_Core.m_Pos = Collision()->TeleCheckOuts(k)[0];
+
+				if(!g_Config.m_SvTeleportHoldHook)
+				{
+					ResetHook();
+				}
+
+				return;
+			}
+			if(!Collision()->TeleCheckOuts(k).empty())
+			{
+				return;
+			}
+		}
+		// if no checkpointout have been found (or if there no recorded checkpoint), teleport to start
+		return;
+	}
 }
 
 void CCharacter::HandleTuneLayer()
@@ -1144,6 +1245,16 @@ void CCharacter::GiveAllWeapons()
 	for(int i = WEAPON_GUN; i < NUM_WEAPONS - 1; i++)
 	{
 		GiveWeapon(i);
+	}
+}
+
+void CCharacter::ResetPickups()
+{
+	for(int i = WEAPON_SHOTGUN; i < NUM_WEAPONS - 1; i++)
+	{
+		m_Core.m_aWeapons[i].m_Got = false;
+		if(m_Core.m_ActiveWeapon == i)
+			m_Core.m_ActiveWeapon = WEAPON_GUN;
 	}
 }
 

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -68,6 +68,7 @@ public:
 	bool Freeze();
 	bool UnFreeze();
 	void GiveAllWeapons();
+	void ResetPickups();
 	int Team();
 	bool CanCollide(int ClientId) override;
 	bool SameTeam(int ClientId);

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1935,13 +1935,13 @@ void CCharacter::HandleTiles(int Index)
 		m_LastBonus = false;
 	}
 
-	int z = Collision()->IsTeleport(MapIndex);
-	if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons && z && !Collision()->TeleOuts(z - 1).empty())
+	int TeleNumber = Collision()->IsTeleport(MapIndex);
+	if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons && TeleNumber && !Collision()->TeleOuts(TeleNumber - 1).empty())
 	{
 		if(m_Core.m_Super || m_Core.m_Invincible)
 			return;
-		int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleOuts(z - 1).size());
-		m_Core.m_Pos = Collision()->TeleOuts(z - 1)[TeleOut];
+		int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleOuts(TeleNumber - 1).size());
+		m_Core.m_Pos = Collision()->TeleOuts(TeleNumber - 1)[TeleOut];
 		if(!g_Config.m_SvTeleportHoldHook)
 		{
 			ResetHook();
@@ -1950,13 +1950,13 @@ void CCharacter::HandleTiles(int Index)
 			ResetPickups();
 		return;
 	}
-	int evilz = Collision()->IsEvilTeleport(MapIndex);
-	if(evilz && !Collision()->TeleOuts(evilz - 1).empty())
+	int EvilTeleNumber = Collision()->IsEvilTeleport(MapIndex);
+	if(EvilTeleNumber && !Collision()->TeleOuts(EvilTeleNumber - 1).empty())
 	{
 		if(m_Core.m_Super || m_Core.m_Invincible)
 			return;
-		int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleOuts(evilz - 1).size());
-		m_Core.m_Pos = Collision()->TeleOuts(evilz - 1)[TeleOut];
+		int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleOuts(EvilTeleNumber - 1).size());
+		m_Core.m_Pos = Collision()->TeleOuts(EvilTeleNumber - 1)[TeleOut];
 		if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons)
 		{
 			m_Core.m_Vel = vec2(0, 0);


### PR DESCRIPTION
#237

The client can't predict the random tele out, that's why only 1 exit
Thanks to this, the game feels much more responsive, especially with high ping

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
