### PR TITLE
Tests: Fix temp files cleanup

### DIFF
--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -62,7 +62,7 @@ public:
 		{
 			return m_IsDirectory < Other.m_IsDirectory;
 		}
-		return str_comp(m_aData, Other.m_aData) < 0;
+		return str_comp(m_aData, Other.m_aData) > 0;
 	}
 };
 

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -150,3 +150,32 @@ int main(int argc, const char **argv)
 	secure_random_uninit();
 	return Result;
 }
+
+TEST(TestInfo, Sort)
+{
+	std::vector<CTestInfoPath> vEntries;
+	vEntries.resize(3);
+
+	const char aBasePath[] = "test_dir";
+	const char aSubPath[] = "test_dir/subdir";
+	const char aFilePath[] = "test_dir/subdir/file.txt";
+
+	vEntries[0].m_IsDirectory = true;
+	str_copy(vEntries[0].m_aData, aBasePath);
+
+	vEntries[1].m_IsDirectory = true;
+	str_copy(vEntries[1].m_aData, aSubPath);
+
+	vEntries[2].m_IsDirectory = false;
+	str_copy(vEntries[2].m_aData, aFilePath);
+
+	// Sorts directories after files.
+	std::sort(vEntries.begin(), vEntries.end());
+
+	EXPECT_FALSE(vEntries[0].m_IsDirectory);
+	EXPECT_EQ(str_comp(vEntries[0].m_aData, aFilePath), 0);
+	EXPECT_TRUE(vEntries[1].m_IsDirectory);
+	EXPECT_EQ(str_comp(vEntries[1].m_aData, aSubPath), 0);
+	EXPECT_TRUE(vEntries[2].m_IsDirectory);
+	EXPECT_EQ(str_comp(vEntries[2].m_aData, aBasePath), 0);
+}


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
Before those changes `TestDeleteTestStorageFiles()` failed to remove a subdir with a file because it tried to remove parent dir before the subdir (due to a bug in `CTestInfoPath` comparison operator).

Added a simple test to validate the issue and the fix (the test fails without the change in `CTestInfoPath`).

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
