### PR TITLE
Add more tests for IO and filesystem functions

### DIFF
--- a/src/test/fs.cpp
+++ b/src/test/fs.cpp
@@ -52,10 +52,13 @@ TEST(Filesystem, CreateCloseDelete)
 {
 	CTestInfo Info;
 
+	EXPECT_FALSE(fs_is_file(Info.m_aFilename));
 	IOHANDLE File = io_open(Info.m_aFilename, IOFLAG_WRITE);
 	ASSERT_TRUE(File);
 	EXPECT_FALSE(io_close(File));
+	EXPECT_TRUE(fs_is_file(Info.m_aFilename));
 	EXPECT_FALSE(fs_remove(Info.m_aFilename));
+	EXPECT_FALSE(fs_is_file(Info.m_aFilename));
 }
 
 TEST(Filesystem, CreateDeleteDirectory)
@@ -64,16 +67,21 @@ TEST(Filesystem, CreateDeleteDirectory)
 	char aFilename[IO_MAX_PATH_LENGTH];
 	str_format(aFilename, sizeof(aFilename), "%s/test.txt", Info.m_aFilename);
 
+	EXPECT_FALSE(fs_is_dir(Info.m_aFilename));
 	EXPECT_FALSE(fs_makedir(Info.m_aFilename));
+	EXPECT_TRUE(fs_is_dir(Info.m_aFilename));
+
 	IOHANDLE File = io_open(aFilename, IOFLAG_WRITE);
 	ASSERT_TRUE(File);
 	EXPECT_FALSE(io_close(File));
 
 	// Directory removal fails if there are any files left in the directory.
 	EXPECT_TRUE(fs_removedir(Info.m_aFilename));
+	EXPECT_TRUE(fs_is_dir(Info.m_aFilename));
 
 	EXPECT_FALSE(fs_remove(aFilename));
 	EXPECT_FALSE(fs_removedir(Info.m_aFilename));
+	EXPECT_FALSE(fs_is_dir(Info.m_aFilename));
 }
 
 TEST(Filesystem, CantDeleteDirectoryWithRemove)
@@ -92,4 +100,180 @@ TEST(Filesystem, CantDeleteFileWithRemoveDirectory)
 	EXPECT_FALSE(io_close(File));
 	EXPECT_TRUE(fs_removedir(Info.m_aFilename)); // Cannot remove file with directory removal function.
 	EXPECT_FALSE(fs_remove(Info.m_aFilename));
+}
+
+TEST(Filesystem, DeleteOpenFile)
+{
+	CTestInfo Info;
+
+	IOHANDLE File = io_open(Info.m_aFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(File);
+
+	EXPECT_TRUE(fs_is_file(Info.m_aFilename));
+	EXPECT_FALSE(fs_remove(Info.m_aFilename)); // Can delete a file that has open handle.
+	EXPECT_FALSE(fs_is_file(Info.m_aFilename)); // File should be gone immediately even before the last file handle is closed.
+
+	EXPECT_FALSE(io_close(File));
+}
+
+TEST(Filesystem, DeleteOpenFileMultipleHandles)
+{
+	CTestInfo Info;
+
+	IOHANDLE FileWrite1 = io_open(Info.m_aFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(FileWrite1);
+
+	IOHANDLE FileRead1 = io_open(Info.m_aFilename, IOFLAG_READ);
+	ASSERT_TRUE(FileRead1);
+
+	IOHANDLE FileWrite2 = io_open(Info.m_aFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(FileWrite2);
+
+	IOHANDLE FileRead2 = io_open(Info.m_aFilename, IOFLAG_READ);
+	ASSERT_TRUE(FileRead2);
+
+	EXPECT_TRUE(fs_is_file(Info.m_aFilename));
+	EXPECT_FALSE(fs_remove(Info.m_aFilename)); // Can delete a file that has multiple open handles.
+	EXPECT_FALSE(fs_is_file(Info.m_aFilename)); // File should be gone immediately even before the last file handle is closed.
+
+	EXPECT_FALSE(io_close(FileWrite1));
+	EXPECT_FALSE(io_close(FileRead1));
+	EXPECT_FALSE(io_close(FileWrite2));
+	EXPECT_FALSE(io_close(FileRead2));
+}
+
+TEST(Filesystem, RenameFile)
+{
+	char aNewFilename[IO_MAX_PATH_LENGTH];
+	CTestInfo Info;
+	Info.Filename(aNewFilename, sizeof(aNewFilename), ".renamed");
+
+	IOHANDLE FileWrite = io_open(Info.m_aFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(FileWrite);
+	EXPECT_FALSE(io_close(FileWrite));
+
+	EXPECT_TRUE(fs_is_file(Info.m_aFilename));
+	EXPECT_FALSE(fs_rename(Info.m_aFilename, aNewFilename));
+	EXPECT_FALSE(fs_is_file(Info.m_aFilename));
+	EXPECT_TRUE(fs_is_file(aNewFilename));
+
+	EXPECT_FALSE(fs_remove(aNewFilename));
+}
+
+TEST(Filesystem, RenameFolder)
+{
+	char aNewFilename[IO_MAX_PATH_LENGTH];
+	CTestInfo Info;
+	Info.Filename(aNewFilename, sizeof(aNewFilename), ".renamed");
+
+	EXPECT_FALSE(fs_makedir(Info.m_aFilename));
+
+	EXPECT_TRUE(fs_is_dir(Info.m_aFilename));
+	EXPECT_FALSE(fs_rename(Info.m_aFilename, aNewFilename));
+	EXPECT_FALSE(fs_is_dir(Info.m_aFilename));
+	EXPECT_TRUE(fs_is_dir(aNewFilename));
+
+	EXPECT_FALSE(fs_removedir(aNewFilename));
+}
+
+TEST(Filesystem, RenameOpenFileSource)
+{
+	char aNewFilename[IO_MAX_PATH_LENGTH];
+	CTestInfo Info;
+	Info.Filename(aNewFilename, sizeof(aNewFilename), ".renamed");
+
+	IOHANDLE FileWrite = io_open(Info.m_aFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(FileWrite);
+
+	EXPECT_TRUE(fs_is_file(Info.m_aFilename));
+	EXPECT_FALSE(fs_rename(Info.m_aFilename, aNewFilename)); // Can rename a file that has open handle.
+	EXPECT_FALSE(fs_is_file(Info.m_aFilename)); // Rename should take effect immediately.
+	EXPECT_TRUE(fs_is_file(aNewFilename));
+
+	EXPECT_FALSE(io_close(FileWrite));
+
+	EXPECT_FALSE(fs_remove(aNewFilename));
+}
+
+TEST(Filesystem, RenameOpenFileSourceMultipleHandles)
+{
+	char aNewFilename[IO_MAX_PATH_LENGTH];
+	CTestInfo Info;
+	Info.Filename(aNewFilename, sizeof(aNewFilename), ".renamed");
+
+	IOHANDLE FileWrite1 = io_open(Info.m_aFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(FileWrite1);
+
+	IOHANDLE FileRead1 = io_open(Info.m_aFilename, IOFLAG_READ);
+	ASSERT_TRUE(FileRead1);
+
+	IOHANDLE FileWrite2 = io_open(Info.m_aFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(FileWrite2);
+
+	IOHANDLE FileRead2 = io_open(Info.m_aFilename, IOFLAG_READ);
+	ASSERT_TRUE(FileRead2);
+
+	EXPECT_TRUE(fs_is_file(Info.m_aFilename));
+	EXPECT_FALSE(fs_rename(Info.m_aFilename, aNewFilename)); // Can rename a file that has multiple open handles.
+	EXPECT_FALSE(fs_is_file(Info.m_aFilename)); // Rename should take effect immediately.
+	EXPECT_TRUE(fs_is_file(aNewFilename));
+
+	EXPECT_FALSE(io_close(FileWrite1));
+	EXPECT_FALSE(io_close(FileRead1));
+	EXPECT_FALSE(io_close(FileWrite2));
+	EXPECT_FALSE(io_close(FileRead2));
+
+	EXPECT_FALSE(fs_remove(aNewFilename));
+}
+
+TEST(Filesystem, RenameTargetFileExists)
+{
+	char aNewFilename[IO_MAX_PATH_LENGTH];
+	CTestInfo Info;
+	Info.Filename(aNewFilename, sizeof(aNewFilename), ".renamed");
+
+	IOHANDLE FileWrite1 = io_open(Info.m_aFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(FileWrite1);
+	EXPECT_FALSE(io_close(FileWrite1));
+
+	IOHANDLE FileWrite2 = io_open(aNewFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(FileWrite2);
+	EXPECT_FALSE(io_close(FileWrite2));
+
+	EXPECT_TRUE(fs_is_file(Info.m_aFilename));
+	EXPECT_TRUE(fs_is_file(aNewFilename));
+	EXPECT_FALSE(fs_rename(Info.m_aFilename, aNewFilename)); // Renaming can overwrite the existing target file if it has no open handles.
+	EXPECT_FALSE(fs_is_file(Info.m_aFilename));
+	EXPECT_TRUE(fs_is_file(aNewFilename));
+
+	EXPECT_FALSE(fs_remove(aNewFilename));
+}
+
+TEST(Filesystem, RenameOpenFileDeleteTarget)
+{
+	char aNewFilename[IO_MAX_PATH_LENGTH];
+	CTestInfo Info;
+	Info.Filename(aNewFilename, sizeof(aNewFilename), ".renamed");
+
+	IOHANDLE FileWrite1 = io_open(Info.m_aFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(FileWrite1);
+	EXPECT_FALSE(io_close(FileWrite1));
+
+	IOHANDLE FileWrite2 = io_open(aNewFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(FileWrite2);
+	EXPECT_FALSE(io_close(FileWrite2));
+
+	IOHANDLE FileRead = io_open(aNewFilename, IOFLAG_READ);
+	ASSERT_TRUE(FileRead);
+
+	EXPECT_TRUE(fs_is_file(Info.m_aFilename));
+	EXPECT_TRUE(fs_is_file(aNewFilename));
+	EXPECT_FALSE(fs_remove(aNewFilename)); // Target file must be deleted else rename fails on Windows when target file has open handle.
+	EXPECT_FALSE(fs_rename(Info.m_aFilename, aNewFilename));
+	EXPECT_FALSE(fs_is_file(Info.m_aFilename));
+	EXPECT_TRUE(fs_is_file(aNewFilename));
+
+	EXPECT_FALSE(io_close(FileRead));
+
+	EXPECT_FALSE(fs_remove(aNewFilename));
 }

--- a/src/test/io.cpp
+++ b/src/test/io.cpp
@@ -167,3 +167,27 @@ TEST(Io, WriteTruncatesFile)
 
 	EXPECT_FALSE(fs_remove(Info.m_aFilename));
 }
+
+TEST(Io, OpenFileShared)
+{
+	CTestInfo Info;
+
+	IOHANDLE FileWrite1 = io_open(Info.m_aFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(FileWrite1);
+
+	IOHANDLE FileRead1 = io_open(Info.m_aFilename, IOFLAG_READ);
+	ASSERT_TRUE(FileRead1);
+
+	IOHANDLE FileWrite2 = io_open(Info.m_aFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(FileWrite2);
+
+	IOHANDLE FileRead2 = io_open(Info.m_aFilename, IOFLAG_READ);
+	ASSERT_TRUE(FileRead2);
+
+	EXPECT_FALSE(io_close(FileWrite1));
+	EXPECT_FALSE(io_close(FileRead1));
+	EXPECT_FALSE(io_close(FileWrite2));
+	EXPECT_FALSE(io_close(FileRead2));
+
+	EXPECT_FALSE(fs_remove(Info.m_aFilename));
+}


### PR DESCRIPTION
- Test that opening multiple shared file handles works.
- Test `fs_is_file` and `fs_is_dir` functions.
- Test `fs_remove` and `fs_rename` functions in various cases, in particular using open file handles.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
