### PR TITLE
map_diff: Fix misleading 'flags' in the diff output

### DIFF
--- a/src/tools/map_diff.cpp
+++ b/src/tools/map_diff.cpp
@@ -25,21 +25,21 @@ bool Process(IStorage *pStorage, const char **pMapNames)
 		}
 	}
 
-	int aStart[2], aNum[2];
+	int aStart[2], aLayersNum[2];
 	for(int i = 0; i < 2; ++i)
-		aMaps[i].GetType(MAPITEMTYPE_LAYER, &aStart[i], &aNum[i]);
+		aMaps[i].GetType(MAPITEMTYPE_LAYER, &aStart[i], &aLayersNum[i]);
 
 	// ensure basic layout
-	if(aNum[0] != aNum[1])
+	if(aLayersNum[0] != aLayersNum[1])
 	{
 		dbg_msg("map_diff", "different layer numbers:");
 		for(int i = 0; i < 2; ++i)
-			dbg_msg("map_diff", "  \"%s\": %d layers", pMapNames[i], aNum[i]);
+			dbg_msg("map_diff", "  \"%s\": %d layers", pMapNames[i], aLayersNum[i]);
 		return false;
 	}
 
 	// preload data
-	for(int j = 0; j < aNum[0]; ++j)
+	for(int j = 0; j < aLayersNum[0]; ++j)
 	{
 		for(int i = 0; i < 2; ++i)
 		{
@@ -50,7 +50,7 @@ bool Process(IStorage *pStorage, const char **pMapNames)
 	}
 
 	// compare
-	for(int j = 0; j < aNum[0]; ++j)
+	for(int j = 0; j < aLayersNum[0]; ++j)
 	{
 		CMapItemLayer *apItem[2];
 		for(int i = 0; i < 2; ++i)
@@ -86,7 +86,7 @@ bool Process(IStorage *pStorage, const char **pMapNames)
 				int Pos = y * apTilemap[0]->m_Width + x;
 				if(apTile[0][Pos].m_Index != apTile[1][Pos].m_Index || apTile[0][Pos].m_Flags != apTile[1][Pos].m_Flags)
 				{
-					dbg_msg("map_diff", "[%d:%s] %dx%d: (index: %d, flags: %d) != (index: %d, flags: %d)", aNum[0], aaName[0], x, y, apTile[0][Pos].m_Index, apTile[0][Pos].m_Flags, apTile[1][Pos].m_Index, apTile[1][Pos].m_Flags);
+					dbg_msg("map_diff", "[%d:%s] %dx%d: (index: %d, flags: %d) != (index: %d, flags: %d)", aLayersNum[0], aaName[0], x, y, apTile[0][Pos].m_Index, apTile[0][Pos].m_Flags, apTile[1][Pos].m_Index, apTile[1][Pos].m_Flags);
 				}
 			}
 		}

--- a/src/tools/map_diff.cpp
+++ b/src/tools/map_diff.cpp
@@ -13,14 +13,14 @@ bool Process(IStorage *pStorage, const char **pMapNames)
 	{
 		if(!aMaps[i].Open(pStorage, pMapNames[i], IStorage::TYPE_ABSOLUTE))
 		{
-			dbg_msg("map_compare", "error opening map '%s'", pMapNames[i]);
+			dbg_msg("map_diff", "error opening map '%s'", pMapNames[i]);
 			return false;
 		}
 
 		const CMapItemVersion *pVersion = static_cast<CMapItemVersion *>(aMaps[i].FindItem(MAPITEMTYPE_VERSION, 0));
 		if(pVersion == nullptr || pVersion->m_Version != 1)
 		{
-			dbg_msg("map_compare", "unsupported map version '%s'", pMapNames[i]);
+			dbg_msg("map_diff", "unsupported map version '%s'", pMapNames[i]);
 			return false;
 		}
 	}
@@ -32,9 +32,9 @@ bool Process(IStorage *pStorage, const char **pMapNames)
 	// ensure basic layout
 	if(aNum[0] != aNum[1])
 	{
-		dbg_msg("map_compare", "different layer numbers:");
+		dbg_msg("map_diff", "different layer numbers:");
 		for(int i = 0; i < 2; ++i)
-			dbg_msg("map_compare", "  \"%s\": %d layers", pMapNames[i], aNum[i]);
+			dbg_msg("map_diff", "  \"%s\": %d layers", pMapNames[i], aNum[i]);
 		return false;
 	}
 
@@ -70,9 +70,9 @@ bool Process(IStorage *pStorage, const char **pMapNames)
 
 		if(str_comp(aaName[0], aaName[1]) != 0 || apTilemap[0]->m_Width != apTilemap[1]->m_Width || apTilemap[0]->m_Height != apTilemap[1]->m_Height)
 		{
-			dbg_msg("map_compare", "different tile layers:");
+			dbg_msg("map_diff", "different tile layers:");
 			for(int i = 0; i < 2; ++i)
-				dbg_msg("map_compare", "  \"%s\" (%dx%d)", aaName[i], apTilemap[i]->m_Width, apTilemap[i]->m_Height);
+				dbg_msg("map_diff", "  \"%s\" (%dx%d)", aaName[i], apTilemap[i]->m_Width, apTilemap[i]->m_Height);
 			return false;
 		}
 		CTile *apTile[2];
@@ -86,7 +86,7 @@ bool Process(IStorage *pStorage, const char **pMapNames)
 				int Pos = y * apTilemap[0]->m_Width + x;
 				if(apTile[0][Pos].m_Index != apTile[1][Pos].m_Index || apTile[0][Pos].m_Flags != apTile[1][Pos].m_Flags)
 				{
-					dbg_msg("map_compare", "[%d:%s] %dx%d: (index: %d, flags: %d) != (index: %d, flags: %d)", aNum[0], aaName[0], x, y, apTile[0][Pos].m_Index, apTile[0][Pos].m_Flags, apTile[1][Pos].m_Index, apTile[0][Pos].m_Flags);
+					dbg_msg("map_diff", "[%d:%s] %dx%d: (index: %d, flags: %d) != (index: %d, flags: %d)", aNum[0], aaName[0], x, y, apTile[0][Pos].m_Index, apTile[0][Pos].m_Flags, apTile[1][Pos].m_Index, apTile[0][Pos].m_Flags);
 				}
 			}
 		}

--- a/src/tools/map_diff.cpp
+++ b/src/tools/map_diff.cpp
@@ -86,7 +86,7 @@ bool Process(IStorage *pStorage, const char **pMapNames)
 				int Pos = y * apTilemap[0]->m_Width + x;
 				if(apTile[0][Pos].m_Index != apTile[1][Pos].m_Index || apTile[0][Pos].m_Flags != apTile[1][Pos].m_Flags)
 				{
-					dbg_msg("map_diff", "[%d:%s] %dx%d: (index: %d, flags: %d) != (index: %d, flags: %d)", aNum[0], aaName[0], x, y, apTile[0][Pos].m_Index, apTile[0][Pos].m_Flags, apTile[1][Pos].m_Index, apTile[0][Pos].m_Flags);
+					dbg_msg("map_diff", "[%d:%s] %dx%d: (index: %d, flags: %d) != (index: %d, flags: %d)", aNum[0], aaName[0], x, y, apTile[0][Pos].m_Index, apTile[0][Pos].m_Flags, apTile[1][Pos].m_Index, apTile[1][Pos].m_Flags);
 				}
 			}
 		}


### PR DESCRIPTION
The tool printed `apTile[0][Pos].m_Flags` twice. It should use `apTile[1]` for the counterpart Flags value.

The fix is in commit 3246b54. The other two commits are optional.

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
