### PR TITLE
Allow removing nonexistent files/folders, improve error handling

### DIFF
--- a/src/android/android_main.cpp
+++ b/src/android/android_main.cpp
@@ -239,7 +239,7 @@ const char *InitAndroid()
 
 	// The integrity file will be unpacked every time when launching,
 	// so we can simply rename it to update the saved integrity file.
-	if((fs_is_file(INTEGRITY_INDEX_SAVE) && fs_remove(INTEGRITY_INDEX_SAVE) != 0) || fs_rename(INTEGRITY_INDEX, INTEGRITY_INDEX_SAVE) != 0)
+	if(fs_remove(INTEGRITY_INDEX_SAVE) != 0 || fs_rename(INTEGRITY_INDEX, INTEGRITY_INDEX_SAVE) != 0)
 	{
 		return "Failed to update the saved integrity index file.";
 	}

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2363,8 +2363,7 @@ void CClient::FinishMapDownload()
 	SHA256_DIGEST *pSha256 = m_MapdownloadSha256Present ? &m_MapdownloadSha256 : nullptr;
 
 	bool FileSuccess = true;
-	if(Storage()->FileExists(m_aMapdownloadFilename, IStorage::TYPE_SAVE))
-		FileSuccess &= Storage()->RemoveFile(m_aMapdownloadFilename, IStorage::TYPE_SAVE);
+	FileSuccess &= Storage()->RemoveFile(m_aMapdownloadFilename, IStorage::TYPE_SAVE);
 	FileSuccess &= Storage()->RenameFile(m_aMapdownloadFilenameTemp, m_aMapdownloadFilename, IStorage::TYPE_SAVE);
 	if(!FileSuccess)
 	{

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -793,12 +793,7 @@ public:
 		char aBuffer[IO_MAX_PATH_LENGTH];
 		GetPath(Type, pFilename, aBuffer, sizeof(aBuffer));
 
-		bool Success = !fs_remove(aBuffer);
-		if(!Success)
-		{
-			log_error("storage", "failed to remove file: %s", aBuffer);
-		}
-		return Success;
+		return fs_remove(aBuffer) == 0;
 	}
 
 	bool RemoveFolder(const char *pFilename, int Type) override
@@ -808,12 +803,7 @@ public:
 		char aBuffer[IO_MAX_PATH_LENGTH];
 		GetPath(Type, pFilename, aBuffer, sizeof(aBuffer));
 
-		bool Success = !fs_removedir(aBuffer);
-		if(!Success)
-		{
-			log_error("storage", "failed to remove folder: %s", aBuffer);
-		}
-		return Success;
+		return fs_removedir(aBuffer) == 0;
 	}
 
 	bool RemoveBinaryFile(const char *pFilename) override
@@ -821,12 +811,7 @@ public:
 		char aBuffer[IO_MAX_PATH_LENGTH];
 		GetBinaryPath(pFilename, aBuffer, sizeof(aBuffer));
 
-		bool Success = !fs_remove(aBuffer);
-		if(!Success)
-		{
-			log_error("storage", "failed to remove binary file: %s", aBuffer);
-		}
-		return Success;
+		return fs_remove(aBuffer) == 0;
 	}
 
 	bool RenameFile(const char *pOldFilename, const char *pNewFilename, int Type) override
@@ -838,12 +823,7 @@ public:
 		GetPath(Type, pOldFilename, aOldBuffer, sizeof(aOldBuffer));
 		GetPath(Type, pNewFilename, aNewBuffer, sizeof(aNewBuffer));
 
-		bool Success = !fs_rename(aOldBuffer, aNewBuffer);
-		if(!Success)
-		{
-			log_error("storage", "failed to rename file: %s -> %s", aOldBuffer, aNewBuffer);
-		}
-		return Success;
+		return fs_rename(aOldBuffer, aNewBuffer) == 0;
 	}
 
 	bool RenameBinaryFile(const char *pOldFilename, const char *pNewFilename) override
@@ -859,12 +839,7 @@ public:
 			return false;
 		}
 
-		bool Success = !fs_rename(aOldBuffer, aNewBuffer);
-		if(!Success)
-		{
-			log_error("storage", "failed to rename binary file: %s -> %s", aOldBuffer, aNewBuffer);
-		}
-		return Success;
+		return fs_rename(aOldBuffer, aNewBuffer) == 0;
 	}
 
 	bool CreateFolder(const char *pFoldername, int Type) override
@@ -874,12 +849,7 @@ public:
 		char aBuffer[IO_MAX_PATH_LENGTH];
 		GetPath(Type, pFoldername, aBuffer, sizeof(aBuffer));
 
-		bool Success = !fs_makedir(aBuffer);
-		if(!Success)
-		{
-			log_error("storage", "failed to create folder: %s", aBuffer);
-		}
-		return Success;
+		return fs_makedir(aBuffer) == 0;
 	}
 
 	void GetCompletePath(int Type, const char *pDir, char *pBuffer, unsigned BufferSize) override

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -8999,7 +8999,7 @@ void CEditor::HandleWriterFinishJobs()
 	m_WriterFinishJobs.pop_front();
 
 	char aBuf[2 * IO_MAX_PATH_LENGTH + 128];
-	if(Storage()->FileExists(pJob->GetRealFileName(), IStorage::TYPE_SAVE) && !Storage()->RemoveFile(pJob->GetRealFileName(), IStorage::TYPE_SAVE))
+	if(!Storage()->RemoveFile(pJob->GetRealFileName(), IStorage::TYPE_SAVE))
 	{
 		str_format(aBuf, sizeof(aBuf), "Saving failed: Could not remove old map file '%s'.", pJob->GetRealFileName());
 		ShowFileDialogError("%s", aBuf);

--- a/src/test/fs.cpp
+++ b/src/test/fs.cpp
@@ -102,6 +102,22 @@ TEST(Filesystem, CantDeleteFileWithRemoveDirectory)
 	EXPECT_FALSE(fs_remove(Info.m_aFilename));
 }
 
+TEST(Filesystem, DeleteNonexistentFile)
+{
+	CTestInfo Info;
+
+	EXPECT_FALSE(fs_is_file(Info.m_aFilename));
+	EXPECT_FALSE(fs_remove(Info.m_aFilename)); // Can delete a file that does not exist.
+}
+
+TEST(Filesystem, DeleteNonexistentDirectory)
+{
+	CTestInfo Info;
+
+	EXPECT_FALSE(fs_is_dir(Info.m_aFilename));
+	EXPECT_FALSE(fs_removedir(Info.m_aFilename)); // Can delete a folder that does not exist.
+}
+
 TEST(Filesystem, DeleteOpenFile)
 {
 	CTestInfo Info;


### PR DESCRIPTION
Change `fs_remove` and `fs_removedir` functions to succeed also when the file or folder to be removed does not exist in the first place, to avoid checking separately whether the file or folder exists.

Add more detailed OS-specific error messages for filesystem functions and remove less detailed error messages from storage wrapper functions.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
