### PR TITLE
Add telegun, telegrenade, telelaser prediction

### DIFF
--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -965,6 +965,34 @@ void CCharacter::HandleTiles(int Index)
 	{
 		m_LastRefillJumps = false;
 	}
+
+	// Teleport gun
+	if(((m_TileIndex == TILE_TELE_GUN_ENABLE) || (m_TileFIndex == TILE_TELE_GUN_ENABLE)) && !m_Core.m_HasTelegunGun)
+	{
+		m_Core.m_HasTelegunGun = true;
+	}
+	else if(((m_TileIndex == TILE_TELE_GUN_DISABLE) || (m_TileFIndex == TILE_TELE_GUN_DISABLE)) && m_Core.m_HasTelegunGun)
+	{
+		m_Core.m_HasTelegunGun = false;
+	}
+
+	if(((m_TileIndex == TILE_TELE_GRENADE_ENABLE) || (m_TileFIndex == TILE_TELE_GRENADE_ENABLE)) && !m_Core.m_HasTelegunGrenade)
+	{
+		m_Core.m_HasTelegunGrenade = true;
+	}
+	else if(((m_TileIndex == TILE_TELE_GRENADE_DISABLE) || (m_TileFIndex == TILE_TELE_GRENADE_DISABLE)) && m_Core.m_HasTelegunGrenade)
+	{
+		m_Core.m_HasTelegunGrenade = false;
+	}
+
+	if(((m_TileIndex == TILE_TELE_LASER_ENABLE) || (m_TileFIndex == TILE_TELE_LASER_ENABLE)) && !m_Core.m_HasTelegunLaser)
+	{
+		m_Core.m_HasTelegunLaser = true;
+	}
+	else if(((m_TileIndex == TILE_TELE_LASER_DISABLE) || (m_TileFIndex == TILE_TELE_LASER_DISABLE)) && m_Core.m_HasTelegunLaser)
+	{
+		m_Core.m_HasTelegunLaser = false;
+	}
 }
 
 void CCharacter::HandleTuneLayer()
@@ -1078,6 +1106,16 @@ void CCharacter::DDRacePostCoreTick()
 	else
 	{
 		HandleTiles(CurrentIndex);
+	}
+
+	// teleport gun
+	if(m_TeleGunTeleport)
+	{
+		m_Core.m_Pos = m_TeleGunPos;
+		if(!m_IsBlueTeleGunTeleport)
+			m_Core.m_Vel = vec2(0, 0);
+		m_TeleGunTeleport = false;
+		m_IsBlueTeleGunTeleport = false;
 	}
 }
 
@@ -1197,6 +1235,8 @@ CCharacter::CCharacter(CGameWorld *pGameWorld, int Id, CNetObj_Character *pChar,
 	m_ReloadTimer = 0;
 	m_NumObjectsHit = 0;
 	m_LastRefillJumps = false;
+	m_TeleGunTeleport = false;
+	m_IsBlueTeleGunTeleport = false;
 	m_CanMoveInFreeze = false;
 	m_TeleCheckpoint = 0;
 	m_StrongWeakId = 0;

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -83,6 +83,10 @@ public:
 
 	bool m_LastRefillJumps;
 
+	vec2 m_TeleGunPos;
+	bool m_TeleGunTeleport;
+	bool m_IsBlueTeleGunTeleport;
+
 	// Setters/Getters because i don't want to modify vanilla vars access modifiers
 	int GetLastWeapon() { return m_LastWeapon; }
 	void SetLastWeapon(int LastWeap) { m_LastWeapon = LastWeap; }

--- a/src/game/client/prediction/entities/laser.h
+++ b/src/game/client/prediction/entities/laser.h
@@ -41,6 +41,8 @@ private:
 	vec2 m_PrevPos;
 	int m_Type;
 	int m_TuneZone;
+	bool m_TeleportCancelled;
+	bool m_IsBlueTeleport;
 };
 
 #endif

--- a/src/game/client/prediction/entity.cpp
+++ b/src/game/client/prediction/entity.cpp
@@ -41,3 +41,39 @@ bool CEntity::GameLayerClipped(vec2 CheckPos)
 	return round_to_int(CheckPos.x) / 32 < -200 || round_to_int(CheckPos.x) / 32 > Collision()->GetWidth() + 200 ||
 	       round_to_int(CheckPos.y) / 32 < -200 || round_to_int(CheckPos.y) / 32 > Collision()->GetHeight() + 200;
 }
+
+bool CEntity::GetNearestAirPos(vec2 Pos, vec2 PrevPos, vec2 *pOutPos)
+{
+	for(int k = 0; k < 16 && Collision()->CheckPoint(Pos); k++)
+	{
+		Pos -= normalize(PrevPos - Pos);
+	}
+
+	vec2 PosInBlock = vec2(round_to_int(Pos.x) % 32, round_to_int(Pos.y) % 32);
+	vec2 BlockCenter = vec2(round_to_int(Pos.x), round_to_int(Pos.y)) - PosInBlock + vec2(16.0f, 16.0f);
+
+	*pOutPos = vec2(BlockCenter.x + (PosInBlock.x < 16 ? -2.0f : 1.0f), Pos.y);
+	if(!Collision()->TestBox(*pOutPos, CCharacterCore::PhysicalSizeVec2()))
+		return true;
+
+	*pOutPos = vec2(Pos.x, BlockCenter.y + (PosInBlock.y < 16 ? -2.0f : 1.0f));
+	if(!Collision()->TestBox(*pOutPos, CCharacterCore::PhysicalSizeVec2()))
+		return true;
+
+	*pOutPos = vec2(BlockCenter.x + (PosInBlock.x < 16 ? -2.0f : 1.0f),
+		BlockCenter.y + (PosInBlock.y < 16 ? -2.0f : 1.0f));
+	return !Collision()->TestBox(*pOutPos, CCharacterCore::PhysicalSizeVec2());
+}
+
+bool CEntity::GetNearestAirPosPlayer(vec2 PlayerPos, vec2 *pOutPos)
+{
+	for(int dist = 5; dist >= -1; dist--)
+	{
+		*pOutPos = vec2(PlayerPos.x, PlayerPos.y - dist);
+		if(!Collision()->TestBox(*pOutPos, CCharacterCore::PhysicalSizeVec2()))
+		{
+			return true;
+		}
+	}
+	return false;
+}

--- a/src/game/client/prediction/entity.h
+++ b/src/game/client/prediction/entity.h
@@ -53,6 +53,9 @@ public:
 	int m_Number;
 	int m_Layer;
 
+	bool GetNearestAirPos(vec2 Pos, vec2 PrevPos, vec2 *pOutPos);
+	bool GetNearestAirPosPlayer(vec2 PlayerPos, vec2 *pOutPos);
+
 	int m_SnapTicks;
 	int m_DestroyTick;
 	int m_LastRenderTick;


### PR DESCRIPTION
Predicts telegun tiles and the teleport instantly to feel smoother on high ping.
The build checks will fail, because it's based on #10250

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
