### PR TITLE
Show demo play/speed HUD for `demo_play`/`demo_speed` commands

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -928,6 +928,9 @@ void CMenus::OnInit()
 	Console()->Chain("cl_asset_hud", ConchainAssetHud, this);
 	Console()->Chain("cl_asset_extras", ConchainAssetExtras, this);
 
+	Console()->Chain("demo_play", ConchainDemoPlay, this);
+	Console()->Chain("demo_speed", ConchainDemoSpeed, this);
+
 	m_TextureBlob = Graphics()->LoadTexture("blob.png", IStorage::TYPE_ALL);
 
 	// setup load amount

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -482,6 +482,8 @@ protected:
 	void RenderDemoBrowserButtons(CUIRect ButtonsView, bool WasListboxItemActivated);
 	void PopupConfirmDeleteDemo();
 	void PopupConfirmDeleteFolder();
+	static void ConchainDemoPlay(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+	static void ConchainDemoSpeed(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
 	// found in menus_start.cpp
 	void RenderStartMenu(CUIRect MainView);

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -1650,3 +1650,20 @@ void CMenus::PopupConfirmDeleteFolder()
 		PopupMessage(Localize("Error"), aError, Localize("Ok"));
 	}
 }
+
+void CMenus::ConchainDemoPlay(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
+{
+	CMenus *pThis = static_cast<CMenus *>(pUserData);
+	pThis->m_LastPauseChange = pThis->Client()->GlobalTime();
+	pfnCallback(pResult, pCallbackUserData);
+}
+
+void CMenus::ConchainDemoSpeed(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
+{
+	CMenus *pThis = static_cast<CMenus *>(pUserData);
+	if(pResult->NumArguments() == 1)
+	{
+		pThis->m_LastSpeedChange = pThis->Client()->GlobalTime();
+	}
+	pfnCallback(pResult, pCallbackUserData);
+}


### PR DESCRIPTION
Also show the play/pause and speed HUD when using the `demo_play` and `demo_speed` commands instead of only when using the hard-coded space and arrow hotkeys.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
