### PR TITLE
Prevent direct touch when active touch button becomes invisible

### DIFF
--- a/src/game/client/components/touch_controls.h
+++ b/src/game/client/components/touch_controls.h
@@ -524,6 +524,12 @@ private:
 	CActionState m_aDirectTouchActionStates[NUM_ACTIONS];
 
 	/**
+	 * These fingers were activating buttons that became invisible and were therefore deactivated. The fingers
+	 * are stored until they are released so they do not activate direct touch input or touch buttons anymore.
+	 */
+	std::vector<IInput::CTouchFinger> m_vStaleFingers;
+
+	/**
 	 * A pointer to the action joystick, if any exists in the current configuration, or `nullptr` if none.
 	 * This is set by @link CJoystickActionTouchButtonBehavior @endlink when it is initialized and always
 	 * cleared before loading a new touch button configuration.


### PR DESCRIPTION
Previously, when a command executed by a touch button caused a touch button to become invisible, the direct touch input was incorrectly activated by the still pressed finger of the invisible button. For example, when touching a bind behavior button with command `dummy_disconnect` and visibility `dummy-connected`, the button would become invisible due to the dummy being disconnected, but the direct touch action, e.g. fire, would incorrectly be activated as well. This is prevented by storing the touch fingers of touch buttons that became invisible until the fingers are released.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
