### PR TITLE
Revert "Add teleport prediction when 1 exit"

### DIFF
--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -749,10 +749,6 @@ void CCharacter::HandleTiles(int Index)
 		return;
 	}
 
-	int TeleCheckpoint = Collision()->IsTeleCheckpoint(MapIndex);
-	if(TeleCheckpoint)
-		m_TeleCheckpoint = TeleCheckpoint;
-
 	// handle switch tiles
 	if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHOPEN && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
 	{
@@ -969,103 +965,6 @@ void CCharacter::HandleTiles(int Index)
 	{
 		m_LastRefillJumps = false;
 	}
-
-	int TeleNumber = Collision()->IsTeleport(MapIndex);
-	if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons && TeleNumber && !Collision()->TeleOuts(TeleNumber - 1).empty())
-	{
-		if(m_Core.m_Super || m_Core.m_Invincible)
-			return;
-		if(Collision()->TeleOuts(TeleNumber - 1).size() == 1)
-		{
-			m_Core.m_Pos = Collision()->TeleOuts(TeleNumber - 1)[0];
-			if(!g_Config.m_SvTeleportHoldHook)
-			{
-				ResetHook();
-			}
-			if(g_Config.m_SvTeleportLoseWeapons)
-				ResetPickups();
-		}
-		return;
-	}
-	int EvilTeleNumber = Collision()->IsEvilTeleport(MapIndex);
-	if(EvilTeleNumber && !Collision()->TeleOuts(EvilTeleNumber - 1).empty())
-	{
-		if(m_Core.m_Super || m_Core.m_Invincible)
-			return;
-		if(Collision()->TeleOuts(EvilTeleNumber - 1).size() == 1)
-		{
-			m_Core.m_Pos = Collision()->TeleOuts(EvilTeleNumber - 1)[0];
-			if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons)
-			{
-				m_Core.m_Vel = vec2(0, 0);
-
-				if(!g_Config.m_SvTeleportHoldHook)
-				{
-					ResetHook();
-					GameWorld()->ReleaseHooked(GetCid());
-				}
-				if(g_Config.m_SvTeleportLoseWeapons)
-				{
-					ResetPickups();
-				}
-			}
-		}
-		return;
-	}
-	if(Collision()->IsCheckEvilTeleport(MapIndex))
-	{
-		if(m_Core.m_Super || m_Core.m_Invincible)
-			return;
-		// first check if there is a TeleCheckOut for the current recorded checkpoint, if not check previous checkpoints
-		for(int k = m_TeleCheckpoint - 1; k >= 0; k--)
-		{
-			if(Collision()->TeleCheckOuts(k).size() == 1)
-			{
-				m_Core.m_Pos = Collision()->TeleCheckOuts(k)[0];
-				m_Core.m_Vel = vec2(0, 0);
-
-				if(!g_Config.m_SvTeleportHoldHook)
-				{
-					ResetHook();
-					GameWorld()->ReleaseHooked(GetCid());
-				}
-
-				return;
-			}
-			if(!Collision()->TeleCheckOuts(k).empty())
-			{
-				return;
-			}
-		}
-		// if no checkpointout have been found (or if there no recorded checkpoint), teleport to start
-		return;
-	}
-	if(Collision()->IsCheckTeleport(MapIndex))
-	{
-		if(m_Core.m_Super || m_Core.m_Invincible)
-			return;
-		// first check if there is a TeleCheckOut for the current recorded checkpoint, if not check previous checkpoints
-		for(int k = m_TeleCheckpoint - 1; k >= 0; k--)
-		{
-			if(Collision()->TeleCheckOuts(k).size() == 1)
-			{
-				m_Core.m_Pos = Collision()->TeleCheckOuts(k)[0];
-
-				if(!g_Config.m_SvTeleportHoldHook)
-				{
-					ResetHook();
-				}
-
-				return;
-			}
-			if(!Collision()->TeleCheckOuts(k).empty())
-			{
-				return;
-			}
-		}
-		// if no checkpointout have been found (or if there no recorded checkpoint), teleport to start
-		return;
-	}
 }
 
 void CCharacter::HandleTuneLayer()
@@ -1245,16 +1144,6 @@ void CCharacter::GiveAllWeapons()
 	for(int i = WEAPON_GUN; i < NUM_WEAPONS - 1; i++)
 	{
 		GiveWeapon(i);
-	}
-}
-
-void CCharacter::ResetPickups()
-{
-	for(int i = WEAPON_SHOTGUN; i < NUM_WEAPONS - 1; i++)
-	{
-		m_Core.m_aWeapons[i].m_Got = false;
-		if(m_Core.m_ActiveWeapon == i)
-			m_Core.m_ActiveWeapon = WEAPON_GUN;
 	}
 }
 

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -69,7 +69,6 @@ public:
 	bool Freeze();
 	bool UnFreeze();
 	void GiveAllWeapons();
-	void ResetPickups();
 	int Team();
 	bool CanCollide(int ClientId) override;
 	bool SameTeam(int ClientId);

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1935,13 +1935,13 @@ void CCharacter::HandleTiles(int Index)
 		m_LastBonus = false;
 	}
 
-	int TeleNumber = Collision()->IsTeleport(MapIndex);
-	if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons && TeleNumber && !Collision()->TeleOuts(TeleNumber - 1).empty())
+	int z = Collision()->IsTeleport(MapIndex);
+	if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons && z && !Collision()->TeleOuts(z - 1).empty())
 	{
 		if(m_Core.m_Super || m_Core.m_Invincible)
 			return;
-		int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleOuts(TeleNumber - 1).size());
-		m_Core.m_Pos = Collision()->TeleOuts(TeleNumber - 1)[TeleOut];
+		int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleOuts(z - 1).size());
+		m_Core.m_Pos = Collision()->TeleOuts(z - 1)[TeleOut];
 		if(!g_Config.m_SvTeleportHoldHook)
 		{
 			ResetHook();
@@ -1950,13 +1950,13 @@ void CCharacter::HandleTiles(int Index)
 			ResetPickups();
 		return;
 	}
-	int EvilTeleNumber = Collision()->IsEvilTeleport(MapIndex);
-	if(EvilTeleNumber && !Collision()->TeleOuts(EvilTeleNumber - 1).empty())
+	int evilz = Collision()->IsEvilTeleport(MapIndex);
+	if(evilz && !Collision()->TeleOuts(evilz - 1).empty())
 	{
 		if(m_Core.m_Super || m_Core.m_Invincible)
 			return;
-		int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleOuts(EvilTeleNumber - 1).size());
-		m_Core.m_Pos = Collision()->TeleOuts(EvilTeleNumber - 1)[TeleOut];
+		int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleOuts(evilz - 1).size());
+		m_Core.m_Pos = Collision()->TeleOuts(evilz - 1)[TeleOut];
 		if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons)
 		{
 			m_Core.m_Vel = vec2(0, 0);


### PR DESCRIPTION
Reverts ddnet/ddnet#10254

1. #10275
2. We own this code, nobody can tell me we have to introduce inconsistent behavior for 1 tele exit, vs many tele exits.

The reverted PR has no linked issue that `accepted` that we merge inconsistent behavior.
Either we are consequent about this or we leave it be.