### PR TITLE
Fix envelop performance by caching the envelop point access.

### DIFF
--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -3,8 +3,10 @@
 #ifndef GAME_CLIENT_COMPONENTS_MAPLAYERS_H
 #define GAME_CLIENT_COMPONENTS_MAPLAYERS_H
 #include <game/client/component.h>
+#include <game/client/render.h>
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 #define INDEX_BUFFER_GROUP_WIDTH 12
@@ -31,6 +33,7 @@ class CMapLayers : public CComponent
 
 	CLayers *m_pLayers;
 	CMapImages *m_pImages;
+	std::unique_ptr<CMapBasedEnvelopePointAccess> m_pEnvelopePoints;
 
 	int m_Type;
 	bool m_OnlineOnly;


### PR DESCRIPTION
Since we saw major performance degradation between DDNet 17.4.x and all versions afterwards on the map TeeTown, I checked with a profiler and it seems the `GetItem` which does a linear search to find items inside a map, is the bottleneck. 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
