### PR TITLE
Store the StrongWeakId of the local player and use the stored data when the snap unavailable

### DIFF
--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -710,16 +710,38 @@ void CNamePlates::RenderNamePlateGame(vec2 Position, const CNetObj_PlayerInfo *p
 		const int SelectedId = Following ? GameClient()->m_Snap.m_SpecInfo.m_SpectatorId : GameClient()->m_Snap.m_LocalClientId;
 		const CGameClient::CSnapState::CCharacterInfo &Selected = GameClient()->m_Snap.m_aCharacters[SelectedId];
 		const CGameClient::CSnapState::CCharacterInfo &Other = GameClient()->m_Snap.m_aCharacters[pPlayerInfo->m_ClientId];
-		if(Selected.m_HasExtendedData && Other.m_HasExtendedData)
+
+		const bool ShouldShowIndicator = Other.m_HasExtendedData && (GameClient()->m_Snap.m_pLocalInfo && (GameClient()->m_Snap.m_pLocalInfo->m_Team != TEAM_SPECTATORS || Following));
+
+		if(ShouldShowIndicator)
 		{
 			Data.m_HookStrongWeakId = Other.m_ExtendedData.m_StrongWeakId;
 			Data.m_ShowHookStrongWeakId = g_Config.m_Debug || g_Config.m_ClNamePlatesStrong == 2;
-			if(SelectedId == pPlayerInfo->m_ClientId)
-				Data.m_ShowHookStrongWeak = Data.m_ShowHookStrongWeakId;
-			else
+
+			// Get selected player's StrongWeakId from snap data or saved local data
+			int SelectedStrongWeakId = 0;
+			bool HasSelectedId = false;
+
+			if(Selected.m_HasExtendedData)
 			{
-				Data.m_HookStrongWeakState = Selected.m_ExtendedData.m_StrongWeakId > Other.m_ExtendedData.m_StrongWeakId ? EHookStrongWeakState::STRONG : EHookStrongWeakState::WEAK;
-				Data.m_ShowHookStrongWeak = g_Config.m_Debug || g_Config.m_ClNamePlatesStrong > 0;
+				SelectedStrongWeakId = Selected.m_ExtendedData.m_StrongWeakId;
+				HasSelectedId = true;
+			}
+			else if(!Following && GameClient()->LocalStrongWeakId(g_Config.m_ClDummy) != -1)
+			{
+				SelectedStrongWeakId = GameClient()->LocalStrongWeakId(g_Config.m_ClDummy);
+				HasSelectedId = true;
+			}
+
+			if(HasSelectedId)
+			{
+				if(SelectedId == pPlayerInfo->m_ClientId)
+					Data.m_ShowHookStrongWeak = Data.m_ShowHookStrongWeakId;
+				else
+				{
+					Data.m_HookStrongWeakState = SelectedStrongWeakId > Other.m_ExtendedData.m_StrongWeakId ? EHookStrongWeakState::STRONG : EHookStrongWeakState::WEAK;
+					Data.m_ShowHookStrongWeak = g_Config.m_Debug || g_Config.m_ClNamePlatesStrong > 0;
+				}
 			}
 		}
 	}

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -618,6 +618,7 @@ void CGameClient::OnReset()
 	m_LastFlagCarrierBlue = -4;
 
 	std::fill(std::begin(m_aCheckInfo), std::end(m_aCheckInfo), -1);
+	std::fill(std::begin(m_aLocalStrongWeakId), std::end(m_aLocalStrongWeakId), -1);
 
 	// m_aDDNetVersionStr is initialized once in OnInit
 
@@ -1748,6 +1749,14 @@ void CGameClient::OnNewSnapshot()
 					if(pCharacterData->m_JumpedTotal != -1)
 					{
 						m_Snap.m_aCharacters[Item.m_Id].m_HasExtendedDisplayInfo = true;
+					}
+
+					// Store local player's StrongWeakId for when snap data is unavailable
+					auto *it = std::find(std::begin(m_aLocalIds), std::end(m_aLocalIds), Item.m_Id);
+					if(it != std::end(m_aLocalIds))
+					{
+						int Dummy = it - std::begin(m_aLocalIds);
+						m_aLocalStrongWeakId[Dummy] = pCharacterData->m_StrongWeakId;
 					}
 					CClientData *pClient = &m_aClients[Item.m_Id];
 					// Collision

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -251,6 +251,9 @@ private:
 	bool m_GamePaused = false;
 	int m_PrevLocalId = -1;
 
+	// Preserved for spectating when snap data unavailable
+	int m_aLocalStrongWeakId[NUM_DUMMIES];
+
 public:
 	IKernel *Kernel() { return IInterface::Kernel(); }
 	IEngine *Engine() const { return m_pEngine; }
@@ -292,6 +295,7 @@ public:
 		return m_NetObjHandler.NumObjCorrections();
 	}
 	const char *NetobjCorrectedOn() { return m_NetObjHandler.CorrectedObjOn(); }
+	int LocalStrongWeakId(int Dummy) const { return m_aLocalStrongWeakId[Dummy]; }
 
 	bool m_SuppressEvents;
 	bool m_NewTick;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
fix #10229 
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
