### PR TITLE
Correctly align damage indicator

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -278,7 +278,7 @@ void CGameContext::CreateDamageInd(vec2 Pos, float Angle, int Amount, CClientMas
 	float e = a + pi / 3;
 	for(int i = 0; i < Amount; i++)
 	{
-		float f = mix(s, e, (i + 1) / (float)(Amount + 2));
+		float f = mix(s, e, (i + 1) / (float)(Amount + 1));
 		CNetEvent_DamageInd *pEvent = m_Events.Create<CNetEvent_DamageInd>(Mask);
 		if(pEvent)
 		{


### PR DESCRIPTION
Non lopsided damage indicators
Was surprisingly easier to "fix" than I thought

### Before:
![BeforeGun](https://github.com/user-attachments/assets/46bf563f-7a43-4e8a-97fe-689373814c0d) ![Before](https://github.com/user-attachments/assets/415813d4-37ea-48a2-ab01-990a0233ecac)
### After:
![AfterGun](https://github.com/user-attachments/assets/74825ca7-088b-48d8-b994-5a981b6f764e) ![After](https://github.com/user-attachments/assets/7b8f6ed7-887b-4506-9f6e-bf088a5735cb)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
