### PR TITLE
Fix wrong sixup value in antibot

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1138,11 +1138,10 @@ int CServer::NewClientCallback(int ClientId, void *pUser, bool Sixup)
 	pThis->m_aClients[ClientId].m_DDNetVersionSettled = false;
 	mem_zero(&pThis->m_aClients[ClientId].m_Addr, sizeof(NETADDR));
 	pThis->m_aClients[ClientId].Reset();
+	pThis->m_aClients[ClientId].m_Sixup = Sixup;
 
 	pThis->GameServer()->TeehistorianRecordPlayerJoin(ClientId, Sixup);
 	pThis->Antibot()->OnEngineClientJoin(ClientId);
-
-	pThis->m_aClients[ClientId].m_Sixup = Sixup;
 
 #if defined(CONF_FAMILY_UNIX)
 	pThis->SendConnLoggingCommand(OPEN_SESSION, pThis->ClientAddr(ClientId));


### PR DESCRIPTION
Closed #10219

It now correctly sets sixup to true at all times not one tick delayed.

```
2025-05-30 14:13:13 I antibot: null antibot initialized
2025-05-30 14:13:14 I server: version 19.3 on linux amd64
2025-05-30 14:13:14 I server: git revision hash: 6d9a08fedf20321a
2025-05-30 14:13:14 I server: Loaded 0 announcements
2025-05-30 14:13:14 I server: Found 527 maps for maplist
2025-05-30 14:13:15 I server: FillAntibot Sixup = 1
2025-05-30 14:13:15 I antibot: join srvsixup=1 
2025-05-30 14:13:15 I server: FillAntibot Sixup = 1
2025-05-30 14:13:15 I server: FillAntibot Sixup = 1
2025-05-30 14:13:15 I server: FillAntibot Sixup = 1
2025-05-30 14:13:15 I server: FillAntibot Sixup = 1
2025-05-30 14:13:15 I server: FillAntibot Sixup = 1
```

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
