### PR TITLE
Fix server browser being refreshed multiple times on client start

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -897,8 +897,7 @@ void CMenus::OnInit()
 	{
 		m_ShowStart = false;
 	}
-
-	SetMenuPage(g_Config.m_UiPage);
+	m_MenuPage = g_Config.m_UiPage;
 
 	m_RefreshButton.Init(Ui(), -1);
 	m_ConnectButton.Init(Ui(), -1);


### PR DESCRIPTION
The server browser is always refreshed on client start when the menus are first rendered. The additional use of the `SetMenuPage` function to initialize the menu page was causing the server browser to be refreshed unnecessarily.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
