### PR TITLE
Add tests for `time_*` functions, increase test coverage of various functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3014,6 +3014,7 @@ if((GTEST_FOUND OR DOWNLOAD_GTEST) AND SERVER)
     test.cpp
     test.h
     thread.cpp
+    time.cpp
     timestamp.cpp
     unix.cpp
     uuid.cpp

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2880,6 +2880,7 @@ int str_format_v(char *buffer, int buffer_size, const char *format, va_list args
 	return str_utf8_fix_truncation(buffer);
 }
 
+#if !defined(CONF_DEBUG)
 int str_format_int(char *buffer, size_t buffer_size, int value)
 {
 	buffer[0] = '\0'; // Fix false positive clang-analyzer-core.UndefinedBinaryOperatorResult when using result
@@ -2887,6 +2888,7 @@ int str_format_int(char *buffer, size_t buffer_size, int value)
 	result.ptr[0] = '\0';
 	return result.ptr - buffer;
 }
+#endif
 
 #undef str_format
 int str_format(char *buffer, int buffer_size, const char *format, ...)

--- a/src/test/fs.cpp
+++ b/src/test/fs.cpp
@@ -60,6 +60,14 @@ TEST(Filesystem, SplitFileExtension)
 	EXPECT_STREQ(aExt, "");
 }
 
+TEST(Filesystem, StoragePath)
+{
+	char aStoragePath[IO_MAX_PATH_LENGTH];
+	ASSERT_FALSE(fs_storage_path("TestAppName", aStoragePath, sizeof(aStoragePath)));
+	EXPECT_FALSE(fs_is_relative_path(aStoragePath));
+	EXPECT_TRUE(str_endswith_nocase(aStoragePath, "/TestAppName"));
+}
+
 TEST(Filesystem, CreateCloseDelete)
 {
 	CTestInfo Info;

--- a/src/test/fs.cpp
+++ b/src/test/fs.cpp
@@ -43,8 +43,20 @@ TEST(Filesystem, SplitFileExtension)
 	EXPECT_STREQ(aName, "no_dot");
 	EXPECT_STREQ(aExt, "");
 
+	fs_split_file_extension("no_dot", aName, sizeof(aName)); // extension parameter is optional
+	EXPECT_STREQ(aName, "no_dot");
+
+	fs_split_file_extension("no_dot", nullptr, 0, aExt, sizeof(aExt)); // name parameter is optional
+	EXPECT_STREQ(aExt, "");
+
 	fs_split_file_extension(".dot_first", aName, sizeof(aName), aExt, sizeof(aExt));
 	EXPECT_STREQ(aName, ".dot_first");
+	EXPECT_STREQ(aExt, "");
+
+	fs_split_file_extension(".dot_first", aName, sizeof(aName)); // extension parameter is optional
+	EXPECT_STREQ(aName, ".dot_first");
+
+	fs_split_file_extension(".dot_first", nullptr, 0, aExt, sizeof(aExt)); // name parameter is optional
 	EXPECT_STREQ(aExt, "");
 }
 

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -4,6 +4,8 @@
 
 #include <game/gamecore.h>
 
+#include <limits>
+
 typedef void (*TStringArgumentFunction)(char *pStr);
 template<TStringArgumentFunction Func>
 static void TestInplace(const char *pInput, const char *pOutput)
@@ -667,6 +669,17 @@ TEST(Str, Format)
 	EXPECT_STREQ(aBuf, "9: ");
 	EXPECT_EQ(str_format(aBuf, 4, "%d: ", 99), 3);
 	EXPECT_STREQ(aBuf, "99:");
+}
+
+TEST(Str, FormatNumber)
+{
+	char aBuf[16];
+	EXPECT_EQ(str_format(aBuf, sizeof(aBuf), "%d", 0), 1);
+	EXPECT_STREQ(aBuf, "0");
+	EXPECT_EQ(str_format(aBuf, sizeof(aBuf), "%d", std::numeric_limits<int>::min()), 11);
+	EXPECT_STREQ(aBuf, "-2147483648");
+	EXPECT_EQ(str_format(aBuf, sizeof(aBuf), "%d", std::numeric_limits<int>::max()), 10);
+	EXPECT_STREQ(aBuf, "2147483647");
 }
 
 TEST(Str, FormatTruncate)

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -573,6 +573,13 @@ TEST(Str, Base64)
 	EXPECT_STREQ(aBuf, "YXN1cmUu");
 	StrBase64Str(aBuf, sizeof(aBuf), "sure.");
 	EXPECT_STREQ(aBuf, "c3VyZS4=");
+
+	StrBase64Str(aBuf, 4, "pleasure.");
+	EXPECT_STREQ(aBuf, "cGx");
+	StrBase64Str(aBuf, 5, "pleasure.");
+	EXPECT_STREQ(aBuf, "cGxl");
+	StrBase64Str(aBuf, 6, "pleasure.");
+	EXPECT_STREQ(aBuf, "cGxlY");
 }
 
 TEST(Str, Base64Decode)
@@ -601,6 +608,9 @@ TEST(Str, Base64Decode)
 	str_copy(aOut, "XXXXXXXXXXXXXXXX", sizeof(aOut));
 	EXPECT_EQ(str_base64_decode(aOut, sizeof(aOut), "////"), 3);
 	EXPECT_STREQ(aOut, "\xff\xff\xffXXXXXXXXXXXXX");
+	str_copy(aOut, "XXXXXXXXXXXXXXXX", sizeof(aOut));
+	EXPECT_EQ(str_base64_decode(aOut, sizeof(aOut), "CQk+"), 3);
+	EXPECT_STREQ(aOut, "		>XXXXXXXXXXXXX");
 }
 
 TEST(Str, Base64DecodeError)
@@ -616,10 +626,17 @@ TEST(Str, Base64DecodeError)
 	EXPECT_LT(str_base64_decode(aBuf, sizeof(aBuf), "AAA=AAAA"), 0);
 	// Invalid characters.
 	EXPECT_LT(str_base64_decode(aBuf, sizeof(aBuf), "----"), 0);
+	EXPECT_LT(str_base64_decode(aBuf, sizeof(aBuf), "A---"), 0);
+	EXPECT_LT(str_base64_decode(aBuf, sizeof(aBuf), "AA--"), 0);
+	EXPECT_LT(str_base64_decode(aBuf, sizeof(aBuf), "AAA-"), 0);
 	EXPECT_LT(str_base64_decode(aBuf, sizeof(aBuf), "AAAA "), 0);
 	EXPECT_LT(str_base64_decode(aBuf, sizeof(aBuf), "AAA "), 0);
 	// Invalid padding values.
 	EXPECT_LT(str_base64_decode(aBuf, sizeof(aBuf), "//=="), 0);
+	// Wrong output buffer size.
+	EXPECT_LT(str_base64_decode(aBuf, 2, "cGxlYXN1cmUu"), 0);
+	EXPECT_LT(str_base64_decode(aBuf, 3, "cGxlYXN1cmUu"), 0);
+	EXPECT_LT(str_base64_decode(aBuf, 4, "cGxlYXN1cmUu"), 0);
 }
 
 TEST(Str, Tokenize)

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -717,6 +717,14 @@ TEST(Str, TrimWords)
 	EXPECT_STREQ(str_trim_words(pStr3, 3), "dddd");
 	EXPECT_STREQ(str_trim_words(pStr3, 4), "");
 	EXPECT_STREQ(str_trim_words(pStr3, 100), "");
+	const char *pStr4 = "";
+	EXPECT_STREQ(str_trim_words(pStr4, 0), "");
+	EXPECT_STREQ(str_trim_words(pStr4, 1), "");
+	EXPECT_STREQ(str_trim_words(pStr4, 2), "");
+	const char *pStr5 = "     ";
+	EXPECT_STREQ(str_trim_words(pStr5, 0), "");
+	EXPECT_STREQ(str_trim_words(pStr5, 1), "");
+	EXPECT_STREQ(str_trim_words(pStr5, 2), "");
 }
 
 TEST(Str, CopyNum)

--- a/src/test/time.cpp
+++ b/src/test/time.cpp
@@ -1,0 +1,29 @@
+#include <gtest/gtest.h>
+
+#include <base/system.h>
+
+#include <thread>
+
+TEST(Time, Timestamp)
+{
+	(void)time_timestamp();
+}
+
+TEST(Time, HourOfTheDay)
+{
+	const int Hour = time_houroftheday();
+	EXPECT_TRUE(Hour >= 0 && Hour <= 23);
+}
+
+TEST(Time, Season)
+{
+	(void)time_season();
+}
+
+TEST(Time, Nanoseconds)
+{
+	const std::chrono::nanoseconds Time1 = time_get_nanoseconds();
+	std::this_thread::sleep_for(std::chrono::microseconds(1));
+	const std::chrono::nanoseconds Time2 = time_get_nanoseconds();
+	EXPECT_LT(Time1, Time2);
+}


### PR DESCRIPTION


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
