### PR TITLE
Sound refactoring and additions

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -384,9 +384,9 @@ MACRO_CONFIG_INT(SndRate, snd_rate, 48000, 5512, 384000, CFGFLAG_SAVE | CFGFLAG_
 MACRO_CONFIG_INT(SndEnable, snd_enable, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Sound enable")
 MACRO_CONFIG_INT(SndMusic, snd_enable_music, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Play background music")
 MACRO_CONFIG_INT(SndVolume, snd_volume, 30, 0, 100, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Sound volume")
-MACRO_CONFIG_INT(SndChatSoundVolume, snd_chat_volume, 30, 0, 100, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Chat sound volume")
-MACRO_CONFIG_INT(SndGameSoundVolume, snd_game_volume, 30, 0, 100, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Game sound volume")
-MACRO_CONFIG_INT(SndMapSoundVolume, snd_ambient_volume, 30, 0, 100, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Map Sound sound volume")
+MACRO_CONFIG_INT(SndChatVolume, snd_chat_volume, 30, 0, 100, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Chat sound volume")
+MACRO_CONFIG_INT(SndGameVolume, snd_game_volume, 30, 0, 100, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Game sound volume")
+MACRO_CONFIG_INT(SndMapVolume, snd_ambient_volume, 30, 0, 100, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Map Sound sound volume")
 MACRO_CONFIG_INT(SndBackgroundMusicVolume, snd_background_music_volume, 30, 0, 100, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Background music sound volume")
 
 MACRO_CONFIG_INT(SndNonactiveMute, snd_nonactive_mute, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Mute sounds when window is not active")

--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -143,7 +143,7 @@ void CEffects::SmokeTrail(vec2 Pos, vec2 Vel, float Alpha, float TimePassed)
 	m_pClient->m_Particles.Add(CParticles::GROUP_PROJECTILE_TRAIL, &p, TimePassed);
 }
 
-void CEffects::SkidTrail(vec2 Pos, vec2 Vel, float Alpha)
+void CEffects::SkidTrail(vec2 Pos, vec2 Vel, int Direction, float Alpha)
 {
 	if(!m_Add100hz)
 		return;
@@ -151,8 +151,8 @@ void CEffects::SkidTrail(vec2 Pos, vec2 Vel, float Alpha)
 	CParticle p;
 	p.SetDefault();
 	p.m_Spr = SPRITE_PART_SMOKE;
-	p.m_Pos = Pos;
-	p.m_Vel = Vel + random_direction() * 50.0f;
+	p.m_Pos = Pos + vec2(-Direction * 6.0f, 12.0f);
+	p.m_Vel = vec2(-Direction * 100.0f * length(Vel), -50.0f) + random_direction() * 50.0f;
 	p.m_LifeSpan = random_float(0.5f, 1.0f);
 	p.m_StartSize = random_float(24.0f, 36.0f);
 	p.m_EndSize = 0;

--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -28,13 +28,13 @@ void CEffects::AirJump(vec2 Pos, float Alpha)
 	p.SetDefault();
 	p.m_Spr = SPRITE_PART_AIRJUMP;
 	p.m_Pos = Pos + vec2(-6.0f, 16.0f);
-	p.m_Vel = vec2(0, -200);
+	p.m_Vel = vec2(0.0f, -200.0f);
 	p.m_LifeSpan = 0.5f;
 	p.m_StartSize = 48.0f;
-	p.m_EndSize = 0;
+	p.m_EndSize = 0.0f;
 	p.m_Rot = random_angle();
-	p.m_Rotspeed = pi * 2;
-	p.m_Gravity = 500;
+	p.m_Rotspeed = pi * 2.0f;
+	p.m_Gravity = 500.0f;
 	p.m_Friction = 0.7f;
 	p.m_FlowAffected = 0.0f;
 	p.m_Color.a = Alpha;
@@ -62,13 +62,13 @@ void CEffects::PowerupShine(vec2 Pos, vec2 Size, float Alpha)
 	p.SetDefault();
 	p.m_Spr = SPRITE_PART_SLICE;
 	p.m_Pos = Pos + vec2(random_float(-0.5f, 0.5f), random_float(-0.5f, 0.5f)) * Size;
-	p.m_Vel = vec2(0, 0);
+	p.m_Vel = vec2(0.0f, 0.0f);
 	p.m_LifeSpan = 0.5f;
 	p.m_StartSize = 16.0f;
-	p.m_EndSize = 0;
+	p.m_EndSize = 0.0f;
 	p.m_Rot = random_angle();
-	p.m_Rotspeed = pi * 2;
-	p.m_Gravity = 500;
+	p.m_Rotspeed = pi * 2.0f;
+	p.m_Gravity = 500.0f;
 	p.m_Friction = 0.9f;
 	p.m_FlowAffected = 0.0f;
 	p.m_Color.a = Alpha;
@@ -85,7 +85,7 @@ void CEffects::FreezingFlakes(vec2 Pos, vec2 Size, float Alpha)
 	p.SetDefault();
 	p.m_Spr = SPRITE_PART_SNOWFLAKE;
 	p.m_Pos = Pos + vec2(random_float(-0.5f, 0.5f), random_float(-0.5f, 0.5f)) * Size;
-	p.m_Vel = vec2(0, 0);
+	p.m_Vel = vec2(0.0f, 0.0f);
 	p.m_LifeSpan = 1.5f;
 	p.m_StartSize = random_float(0.5f, 1.5f) * 16.0f;
 	p.m_EndSize = p.m_StartSize * 0.5f;
@@ -112,7 +112,7 @@ void CEffects::SparkleTrail(vec2 Pos, float Alpha)
 	p.SetDefault();
 	p.m_Spr = SPRITE_PART_SPARKLE;
 	p.m_Pos = Pos + random_direction() * random_float(40.0f);
-	p.m_Vel = vec2(0, 0);
+	p.m_Vel = vec2(0.0f, 0.0f);
 	p.m_LifeSpan = 0.5f;
 	p.m_StartSize = 0.0f;
 	p.m_EndSize = random_float(20.0f, 30.0f);
@@ -135,7 +135,7 @@ void CEffects::SmokeTrail(vec2 Pos, vec2 Vel, float Alpha, float TimePassed)
 	p.m_Vel = Vel + random_direction() * 50.0f;
 	p.m_LifeSpan = random_float(0.5f, 1.0f);
 	p.m_StartSize = random_float(12.0f, 20.0f);
-	p.m_EndSize = 0;
+	p.m_EndSize = 0.0f;
 	p.m_Friction = 0.7f;
 	p.m_Gravity = random_float(-500.0f);
 	p.m_Color.a = Alpha;
@@ -154,7 +154,7 @@ void CEffects::SkidTrail(vec2 Pos, vec2 Vel, int Direction, float Alpha)
 		p.m_Vel = vec2(-Direction * 100.0f * length(Vel), -50.0f) + random_direction() * 50.0f;
 		p.m_LifeSpan = random_float(0.5f, 1.0f);
 		p.m_StartSize = random_float(24.0f, 36.0f);
-		p.m_EndSize = 0;
+		p.m_EndSize = 0.0f;
 		p.m_Friction = 0.7f;
 		p.m_Gravity = random_float(-500.0f);
 		p.m_Color = ColorRGBA(0.75f, 0.75f, 0.75f, Alpha);
@@ -183,7 +183,7 @@ void CEffects::BulletTrail(vec2 Pos, float Alpha, float TimePassed)
 	p.m_Pos = Pos;
 	p.m_LifeSpan = random_float(0.25f, 0.5f);
 	p.m_StartSize = 8.0f;
-	p.m_EndSize = 0;
+	p.m_EndSize = 0.0f;
 	p.m_Friction = 0.7f;
 	p.m_Color.a *= Alpha;
 	p.m_StartAlpha = Alpha;
@@ -201,7 +201,7 @@ void CEffects::PlayerSpawn(vec2 Pos, float Alpha)
 		p.m_Vel = random_direction() * (std::pow(random_float(), 3) * 600.0f);
 		p.m_LifeSpan = random_float(0.3f, 0.6f);
 		p.m_StartSize = random_float(64.0f, 96.0f);
-		p.m_EndSize = 0;
+		p.m_EndSize = 0.0f;
 		p.m_Rot = random_angle();
 		p.m_Rotspeed = random_float();
 		p.m_Gravity = random_float(-400.0f);
@@ -259,7 +259,7 @@ void CEffects::PlayerDeath(vec2 Pos, int ClientId, float Alpha)
 		p.m_Vel = random_direction() * (random_float(0.1f, 1.1f) * 900.0f);
 		p.m_LifeSpan = random_float(0.3f, 0.6f);
 		p.m_StartSize = random_float(24.0f, 40.0f);
-		p.m_EndSize = 0;
+		p.m_EndSize = 0.0f;
 		p.m_Rot = random_angle();
 		p.m_Rotspeed = random_float(-0.5f, 0.5f) * pi;
 		p.m_Gravity = 800.0f;
@@ -292,7 +292,7 @@ void CEffects::Confetti(vec2 Pos, float Alpha)
 		p.m_Vel = direction(-0.5f * pi + random_float(-0.2f, 0.2f)) * random_float(0.01f, 1.0f) * 2000.0f;
 		p.m_LifeSpan = random_float(1.0f, 1.2f);
 		p.m_StartSize = random_float(12.0f, 24.0f);
-		p.m_EndSize = 0;
+		p.m_EndSize = 0.0f;
 		p.m_Rot = random_angle();
 		p.m_Rotspeed = random_float(-0.5f, 0.5f) * pi;
 		p.m_Gravity = -700.0f;
@@ -313,7 +313,7 @@ void CEffects::Confetti(vec2 Pos, float Alpha)
 		p.m_Vel = direction(-0.5f * pi + random_float(-0.8f, 0.8f)) * random_float(0.01f, 1.0f) * 1500.0f;
 		p.m_LifeSpan = random_float(0.8f, 1.0f);
 		p.m_StartSize = random_float(12.0f, 24.0f);
-		p.m_EndSize = 0;
+		p.m_EndSize = 0.0f;
 		p.m_Rot = random_angle();
 		p.m_Rotspeed = random_float(-0.5f, 0.5f) * pi;
 		p.m_Gravity = -700.0f;
@@ -334,8 +334,8 @@ void CEffects::Explosion(vec2 Pos, float Alpha)
 			if(x == 0 && y == 0)
 				continue;
 
-			float a = 1 - (length(vec2(x, y)) / length(vec2(8, 8)));
-			m_pClient->m_Flow.Add(Pos + vec2(x, y) * 16, normalize(vec2(x, y)) * 5000.0f * a, 10.0f);
+			float a = 1 - (length(vec2(x, y)) / length(vec2(8.0f, 8.0f)));
+			m_pClient->m_Flow.Add(Pos + vec2(x, y) * 16.0f, normalize(vec2(x, y)) * 5000.0f * a, 10.0f);
 		}
 
 	// add the explosion
@@ -345,7 +345,7 @@ void CEffects::Explosion(vec2 Pos, float Alpha)
 	p.m_Pos = Pos;
 	p.m_LifeSpan = 0.4f;
 	p.m_StartSize = 150.0f;
-	p.m_EndSize = 0;
+	p.m_EndSize = 0.0f;
 	p.m_Rot = random_angle();
 	p.m_Color.a = Alpha;
 	p.m_StartAlpha = Alpha;
@@ -358,8 +358,8 @@ void CEffects::Explosion(vec2 Pos, float Alpha)
 		const vec2 DistanceToTopLeft = Pos - vec2(round_truncate(Pos.x / 32), round_truncate(Pos.y / 32)) * 32;
 
 		vec2 CheckOffset;
-		CheckOffset.x = (DistanceToTopLeft.x > 16 ? 32 : -1);
-		CheckOffset.y = (DistanceToTopLeft.y > 16 ? 32 : -1);
+		CheckOffset.x = (DistanceToTopLeft.x > 16.0f ? 32.0f : -1.0f);
+		CheckOffset.y = (DistanceToTopLeft.y > 16.0f ? 32.0f : -1.0f);
 		CheckOffset -= DistanceToTopLeft;
 
 		for(vec2 Mask : {vec2(1.0f, 0.0f), vec2(0.0f, 1.0f), vec2(1.0f, 1.0f)})
@@ -382,7 +382,7 @@ void CEffects::Explosion(vec2 Pos, float Alpha)
 		p.m_Vel = random_direction() * (random_float(1.0f, 1.2f) * 1000.0f);
 		p.m_LifeSpan = random_float(0.5f, 0.9f);
 		p.m_StartSize = random_float(32.0f, 40.0f);
-		p.m_EndSize = 0;
+		p.m_EndSize = 0.0f;
 		p.m_Gravity = random_float(-800.0f);
 		p.m_Friction = 0.4f;
 		p.m_Color = mix(vec4(0.75f, 0.75f, 0.75f, 1.0f), vec4(0.5f, 0.5f, 0.5f, 1.0f), random_float());
@@ -401,7 +401,7 @@ void CEffects::HammerHit(vec2 Pos, float Alpha)
 	p.m_Pos = Pos;
 	p.m_LifeSpan = 0.3f;
 	p.m_StartSize = 120.0f;
-	p.m_EndSize = 0;
+	p.m_EndSize = 0.0f;
 	p.m_Rot = random_angle();
 	p.m_Color.a = Alpha;
 	p.m_StartAlpha = Alpha;

--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -403,34 +403,30 @@ void CEffects::HammerHit(vec2 Pos, float Alpha)
 
 void CEffects::OnRender()
 {
-	static int64_t s_LastUpdate100hz = 0;
-	static int64_t s_LastUpdate50hz = 0;
-	static int64_t s_LastUpdate5hz = 0;
-
 	float Speed = 1.0f;
 	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
 		Speed = DemoPlayer()->BaseInfo()->m_Speed;
 
-	if(time() - s_LastUpdate100hz > time_freq() / (100 * Speed))
+	if(time() - m_LastUpdate100hz > time_freq() / (100 * Speed))
 	{
 		m_Add100hz = true;
-		s_LastUpdate100hz = time();
+		m_LastUpdate100hz = time();
 	}
 	else
 		m_Add100hz = false;
 
-	if(time() - s_LastUpdate50hz > time_freq() / (50 * Speed))
+	if(time() - m_LastUpdate50hz > time_freq() / (50 * Speed))
 	{
 		m_Add50hz = true;
-		s_LastUpdate50hz = time();
+		m_LastUpdate50hz = time();
 	}
 	else
 		m_Add50hz = false;
 
-	if(time() - s_LastUpdate5hz > time_freq() / (5 * Speed))
+	if(time() - m_LastUpdate5hz > time_freq() / (5 * Speed))
 	{
 		m_Add5hz = true;
-		s_LastUpdate5hz = time();
+		m_LastUpdate5hz = time();
 	}
 	else
 		m_Add5hz = false;

--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -145,22 +145,31 @@ void CEffects::SmokeTrail(vec2 Pos, vec2 Vel, float Alpha, float TimePassed)
 
 void CEffects::SkidTrail(vec2 Pos, vec2 Vel, int Direction, float Alpha)
 {
-	if(!m_Add100hz)
-		return;
-
-	CParticle p;
-	p.SetDefault();
-	p.m_Spr = SPRITE_PART_SMOKE;
-	p.m_Pos = Pos + vec2(-Direction * 6.0f, 12.0f);
-	p.m_Vel = vec2(-Direction * 100.0f * length(Vel), -50.0f) + random_direction() * 50.0f;
-	p.m_LifeSpan = random_float(0.5f, 1.0f);
-	p.m_StartSize = random_float(24.0f, 36.0f);
-	p.m_EndSize = 0;
-	p.m_Friction = 0.7f;
-	p.m_Gravity = random_float(-500.0f);
-	p.m_Color = ColorRGBA(0.75f, 0.75f, 0.75f, Alpha);
-	p.m_StartAlpha = Alpha;
-	m_pClient->m_Particles.Add(CParticles::GROUP_GENERAL, &p);
+	if(m_Add100hz)
+	{
+		CParticle p;
+		p.SetDefault();
+		p.m_Spr = SPRITE_PART_SMOKE;
+		p.m_Pos = Pos + vec2(-Direction * 6.0f, 12.0f);
+		p.m_Vel = vec2(-Direction * 100.0f * length(Vel), -50.0f) + random_direction() * 50.0f;
+		p.m_LifeSpan = random_float(0.5f, 1.0f);
+		p.m_StartSize = random_float(24.0f, 36.0f);
+		p.m_EndSize = 0;
+		p.m_Friction = 0.7f;
+		p.m_Gravity = random_float(-500.0f);
+		p.m_Color = ColorRGBA(0.75f, 0.75f, 0.75f, Alpha);
+		p.m_StartAlpha = Alpha;
+		m_pClient->m_Particles.Add(CParticles::GROUP_GENERAL, &p);
+	}
+	if(g_Config.m_SndGame)
+	{
+		int64_t Now = time();
+		if(Now - m_SkidSoundTimer > time_freq() / 10)
+		{
+			m_SkidSoundTimer = Now;
+			m_pClient->m_Sounds.PlayAt(CSounds::CHN_WORLD, SOUND_PLAYER_SKID, 1.0f, Pos);
+		}
+	}
 }
 
 void CEffects::BulletTrail(vec2 Pos, float Alpha, float TimePassed)

--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -407,29 +407,15 @@ void CEffects::OnRender()
 	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
 		Speed = DemoPlayer()->BaseInfo()->m_Speed;
 
-	if(time() - m_LastUpdate100hz > time_freq() / (100 * Speed))
-	{
-		m_Add100hz = true;
-		m_LastUpdate100hz = time();
-	}
-	else
-		m_Add100hz = false;
-
-	if(time() - m_LastUpdate50hz > time_freq() / (50 * Speed))
-	{
-		m_Add50hz = true;
-		m_LastUpdate50hz = time();
-	}
-	else
-		m_Add50hz = false;
-
-	if(time() - m_LastUpdate5hz > time_freq() / (5 * Speed))
-	{
-		m_Add5hz = true;
-		m_LastUpdate5hz = time();
-	}
-	else
-		m_Add5hz = false;
+	const int64_t Now = time();
+	auto FUpdateClock = [&](bool &Add, int64_t &LastUpdate, int Frequency) {
+		Add = Now - LastUpdate > time_freq() / ((float)Frequency * Speed);
+		if(Add)
+			LastUpdate = Now;
+	};
+	FUpdateClock(m_Add5hz, m_LastUpdate5hz, 5);
+	FUpdateClock(m_Add50hz, m_LastUpdate50hz, 50);
+	FUpdateClock(m_Add100hz, m_LastUpdate100hz, 100);
 
 	if(m_Add50hz)
 		m_pClient->m_Flow.Update();

--- a/src/game/client/components/effects.h
+++ b/src/game/client/components/effects.h
@@ -19,6 +19,8 @@ private:
 	bool m_Add100hz;
 	int64_t m_LastUpdate100hz = 0;
 
+	int64_t m_SkidSoundTimer = 0;
+
 public:
 	CEffects();
 	virtual int Sizeof() const override { return sizeof(*this); }

--- a/src/game/client/components/effects.h
+++ b/src/game/client/components/effects.h
@@ -9,9 +9,15 @@
 
 class CEffects : public CComponent
 {
+private:
 	bool m_Add5hz;
+	int64_t m_LastUpdate5hz = 0;
+
 	bool m_Add50hz;
+	int64_t m_LastUpdate50hz = 0;
+
 	bool m_Add100hz;
+	int64_t m_LastUpdate100hz = 0;
 
 public:
 	CEffects();

--- a/src/game/client/components/effects.h
+++ b/src/game/client/components/effects.h
@@ -27,7 +27,7 @@ public:
 
 	void BulletTrail(vec2 Pos, float Alpha, float TimePassed);
 	void SmokeTrail(vec2 Pos, vec2 Vel, float Alpha, float TimePassed);
-	void SkidTrail(vec2 Pos, vec2 Vel, float Alpha);
+	void SkidTrail(vec2 Pos, vec2 Vel, int Direction, float Alpha);
 	void Explosion(vec2 Pos, float Alpha);
 	void HammerHit(vec2 Pos, float Alpha);
 	void AirJump(vec2 Pos, float Alpha);

--- a/src/game/client/components/effects.h
+++ b/src/game/client/components/effects.h
@@ -19,19 +19,19 @@ public:
 
 	virtual void OnRender() override;
 
-	void BulletTrail(vec2 Pos, float Alpha = 1.f, float TimePassed = 0.f);
-	void SmokeTrail(vec2 Pos, vec2 Vel, float Alpha = 1.f, float TimePassed = 0.f);
-	void SkidTrail(vec2 Pos, vec2 Vel, float Alpha = 1.0f);
-	void Explosion(vec2 Pos, float Alpha = 1.0f);
-	void HammerHit(vec2 Pos, float Alpha = 1.0f);
-	void AirJump(vec2 Pos, float Alpha = 1.0f);
-	void DamageIndicator(vec2 Pos, vec2 Dir, float Alpha = 1.0f);
-	void PlayerSpawn(vec2 Pos, float Alpha = 1.0f);
-	void PlayerDeath(vec2 Pos, int ClientId, float Alpha = 1.0f);
-	void PowerupShine(vec2 Pos, vec2 Size, float Alpha = 1.0f);
-	void FreezingFlakes(vec2 Pos, vec2 Size, float Alpha = 1.0f);
-	void SparkleTrail(vec2 Pos, float Alpha = 1.0f);
-	void Confetti(vec2 Pos, float Alpha = 1.0f);
+	void BulletTrail(vec2 Pos, float Alpha, float TimePassed);
+	void SmokeTrail(vec2 Pos, vec2 Vel, float Alpha, float TimePassed);
+	void SkidTrail(vec2 Pos, vec2 Vel, float Alpha);
+	void Explosion(vec2 Pos, float Alpha);
+	void HammerHit(vec2 Pos, float Alpha);
+	void AirJump(vec2 Pos, float Alpha);
+	void DamageIndicator(vec2 Pos, vec2 Dir, float Alpha);
+	void PlayerSpawn(vec2 Pos, float Alpha);
+	void PlayerDeath(vec2 Pos, int ClientId, float Alpha);
+	void PowerupShine(vec2 Pos, vec2 Size, float Alpha);
+	void FreezingFlakes(vec2 Pos, vec2 Size, float Alpha);
+	void SparkleTrail(vec2 Pos, float Alpha);
+	void Confetti(vec2 Pos, float Alpha);
 
 	void Update();
 };

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -103,7 +103,7 @@ void CItems::RenderProjectile(const CProjectileData *pCurrent, int ItemId)
 	// don't check for validity of the projectile for the current weapon here, so particle effects are rendered for mod compatibility
 	if(CurWeapon == WEAPON_GRENADE)
 	{
-		m_pClient->m_Effects.SmokeTrail(Pos, Vel * -1, Alpha);
+		m_pClient->m_Effects.SmokeTrail(Pos, Vel * -1, Alpha, 0.0f);
 		static float s_Time = 0.0f;
 		static float s_LastLocalTime = LocalTime();
 
@@ -124,7 +124,7 @@ void CItems::RenderProjectile(const CProjectileData *pCurrent, int ItemId)
 	}
 	else
 	{
-		m_pClient->m_Effects.BulletTrail(Pos, Alpha);
+		m_pClient->m_Effects.BulletTrail(Pos, Alpha, 0.0f);
 
 		if(length(Vel) > 0.00001f)
 			Graphics()->QuadsSetRotation(angle(Vel));

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -354,7 +354,7 @@ void CMenus::DoLaserPreview(const CUIRect *pRect, const ColorHSLA LaserOutlineCo
 		TeeRenderInfo.m_ColorBody = ColorRGBA(1, 1, 1);
 		TeeRenderInfo.m_ColorFeet = ColorRGBA(1, 1, 1);
 		RenderTools()->RenderTee(CAnimState::GetIdle(), &TeeRenderInfo, EMOTE_PAIN, vec2(1, 0), From);
-		GameClient()->m_Effects.FreezingFlakes(From, vec2(32, 32));
+		GameClient()->m_Effects.FreezingFlakes(From, vec2(32, 32), 1.0f);
 		break;
 	}
 	default:

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1819,21 +1819,21 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 	{
 		MainView.HSplitTop(5.0f, nullptr, &MainView);
 		MainView.HSplitTop(20.0f, &Button, &MainView);
-		Ui()->DoScrollbarOption(&g_Config.m_SndGameSoundVolume, &g_Config.m_SndGameSoundVolume, &Button, Localize("Game sound volume"), 0, 100, &CUi::ms_LogarithmicScrollbarScale, 0u, "%");
+		Ui()->DoScrollbarOption(&g_Config.m_SndGameVolume, &g_Config.m_SndGameVolume, &Button, Localize("Game sound volume"), 0, 100, &CUi::ms_LogarithmicScrollbarScale, 0u, "%");
 	}
 
 	// volume slider gui sounds
 	{
 		MainView.HSplitTop(5.0f, nullptr, &MainView);
 		MainView.HSplitTop(20.0f, &Button, &MainView);
-		Ui()->DoScrollbarOption(&g_Config.m_SndChatSoundVolume, &g_Config.m_SndChatSoundVolume, &Button, Localize("Chat sound volume"), 0, 100, &CUi::ms_LogarithmicScrollbarScale, 0u, "%");
+		Ui()->DoScrollbarOption(&g_Config.m_SndChatVolume, &g_Config.m_SndChatVolume, &Button, Localize("Chat sound volume"), 0, 100, &CUi::ms_LogarithmicScrollbarScale, 0u, "%");
 	}
 
 	// volume slider map sounds
 	{
 		MainView.HSplitTop(5.0f, nullptr, &MainView);
 		MainView.HSplitTop(20.0f, &Button, &MainView);
-		Ui()->DoScrollbarOption(&g_Config.m_SndMapSoundVolume, &g_Config.m_SndMapSoundVolume, &Button, Localize("Map sound volume"), 0, 100, &CUi::ms_LogarithmicScrollbarScale, 0u, "%");
+		Ui()->DoScrollbarOption(&g_Config.m_SndMapVolume, &g_Config.m_SndMapVolume, &Button, Localize("Map sound volume"), 0, 100, &CUi::ms_LogarithmicScrollbarScale, 0u, "%");
 	}
 
 	// volume slider background music

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -537,10 +537,7 @@ void CPlayers::RenderPlayer(
 			m_SkidSoundTime = time();
 		}
 
-		m_pClient->m_Effects.SkidTrail(
-			Position + vec2(-Player.m_Direction * 6, 12),
-			vec2(-Player.m_Direction * 100 * length(Vel), -50),
-			Alpha);
+		m_pClient->m_Effects.SkidTrail(Position, Vel, Player.m_Direction, Alpha);
 	}
 
 	// draw gun

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -529,16 +529,7 @@ void CPlayers::RenderPlayer(
 
 	// do skidding
 	if(!InAir && WantOtherDir && length(Vel * 50) > 500.0f)
-	{
-		if(time() - m_SkidSoundTime > time_freq() / 10)
-		{
-			if(g_Config.m_SndGame)
-				m_pClient->m_Sounds.PlayAt(CSounds::CHN_WORLD, SOUND_PLAYER_SKID, 1.0f, Position);
-			m_SkidSoundTime = time();
-		}
-
 		m_pClient->m_Effects.SkidTrail(Position, Vel, Player.m_Direction, Alpha);
-	}
 
 	// draw gun
 	if(Player.m_Weapon >= 0)

--- a/src/game/client/components/players.h
+++ b/src/game/client/components/players.h
@@ -37,8 +37,6 @@ class CPlayers : public CComponent
 	int m_WeaponEmoteQuadContainerIndex;
 	int m_aWeaponSpriteMuzzleQuadContainerIndex[NUM_WEAPONS];
 
-	int64_t m_SkidSoundTime = 0;
-
 public:
 	float GetPlayerTargetAngle(
 		const CNetObj_Character *pPrevChar,

--- a/src/game/client/components/sounds.cpp
+++ b/src/game/client/components/sounds.cpp
@@ -45,14 +45,14 @@ void CSoundLoading::Run()
 
 void CSounds::UpdateChannels()
 {
-	const float NewGuiSoundVolume = g_Config.m_SndChatSoundVolume / 100.0f;
+	const float NewGuiSoundVolume = g_Config.m_SndChatVolume / 100.0f;
 	if(NewGuiSoundVolume != m_GuiSoundVolume)
 	{
 		m_GuiSoundVolume = NewGuiSoundVolume;
 		Sound()->SetChannel(CSounds::CHN_GUI, m_GuiSoundVolume, 0.0f);
 	}
 
-	const float NewGameSoundVolume = g_Config.m_SndGameSoundVolume / 100.0f;
+	const float NewGameSoundVolume = g_Config.m_SndGameVolume / 100.0f;
 	if(NewGameSoundVolume != m_GameSoundVolume)
 	{
 		m_GameSoundVolume = NewGameSoundVolume;
@@ -60,7 +60,7 @@ void CSounds::UpdateChannels()
 		Sound()->SetChannel(CSounds::CHN_GLOBAL, m_GameSoundVolume, 0.0f);
 	}
 
-	const float NewMapSoundVolume = g_Config.m_SndMapSoundVolume / 100.0f;
+	const float NewMapSoundVolume = g_Config.m_SndMapVolume / 100.0f;
 	if(NewMapSoundVolume != m_MapSoundVolume)
 	{
 		m_MapSoundVolume = NewMapSoundVolume;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2243,7 +2243,7 @@ void CGameClient::OnNewSnapshot()
 					for(int j = 0; j < Amount; j++)
 					{
 						float Angle = mix(Min, Max, (j + 1) / (float)(Amount + 2));
-						m_Effects.DamageIndicator(Pos, direction(Angle));
+						m_Effects.DamageIndicator(Pos, direction(Angle), 1.0f);
 					}
 				}
 			}


### PR DESCRIPTION
~~`snd_game_volume_others` has been added which is meant to control the volume of players in other teams~~

~~Unfortunatley, as per #10301, only skid sounds have all information to do this, this is why it hasn't been added to UI yet~~

See commits

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
