### PR TITLE
Fix rare map rendering crash

### DIFF
--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -817,6 +817,8 @@ void CMapLayers::OnMapLoad()
 
 void CMapLayers::RenderTileLayer(int LayerIndex, const ColorRGBA &Color)
 {
+	if(LayerIndex < 0)
+		return;
 	STileLayerVisuals &Visuals = *m_vpTileLayerVisuals[LayerIndex];
 	if(Visuals.m_BufferContainerIndex == -1)
 		return; // no visuals were created


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

On some old demos the client crashes upon opening them because the map has a negative LayerIndex in `void CMapLayers::RenderTileLayer(int LayerIndex, const ColorRGBA &Color)`.
It seems like this bug was recently introduced. This might even be some higher level issue but just returning if LayerIndex < 0 works.

Here is a download link to one of those demos: https://files.catbox.moe/hr88xv.demo since github won't allow me to upload .demo files. In this case LayerIndex holds the value -3 before crashing.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
