### PR TITLE
Minor storage.cpp refactor

### DIFF
--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -68,38 +68,49 @@ public:
 		bool Success = true;
 		if(InitializationType == EInitializationType::CLIENT)
 		{
-			Success &= CreateFolder("screenshots", TYPE_SAVE);
-			Success &= CreateFolder("screenshots/auto", TYPE_SAVE);
-			Success &= CreateFolder("screenshots/auto/stats", TYPE_SAVE);
-			Success &= CreateFolder("maps", TYPE_SAVE);
-			Success &= CreateFolder("maps/auto", TYPE_SAVE);
-			Success &= CreateFolder("mapres", TYPE_SAVE);
-			Success &= CreateFolder("downloadedmaps", TYPE_SAVE);
-			Success &= CreateFolder("skins", TYPE_SAVE);
-			Success &= CreateFolder("skins7", TYPE_SAVE);
-			Success &= CreateFolder("downloadedskins", TYPE_SAVE);
-			Success &= CreateFolder("themes", TYPE_SAVE);
-			Success &= CreateFolder("communityicons", TYPE_SAVE);
-			Success &= CreateFolder("assets", TYPE_SAVE);
-			Success &= CreateFolder("assets/emoticons", TYPE_SAVE);
-			Success &= CreateFolder("assets/entities", TYPE_SAVE);
-			Success &= CreateFolder("assets/game", TYPE_SAVE);
-			Success &= CreateFolder("assets/particles", TYPE_SAVE);
-			Success &= CreateFolder("assets/hud", TYPE_SAVE);
-			Success &= CreateFolder("assets/extras", TYPE_SAVE);
+			static constexpr const char *CLIENT_DIRS[] = {
+				"assets",
+				"assets/emoticons",
+				"assets/entities",
+				"assets/extras",
+				"assets/game",
+				"assets/hud",
+				"assets/particles",
+				"audio",
+				"communityicons",
+				"downloadedmaps",
+				"downloadedskins",
+				"mapres",
+				"maps",
+				"maps/auto",
+				"screenshots",
+				"screenshots/auto",
+				"screenshots/auto/stats",
+				"skins",
+				"skins7",
+				"themes",
 #if defined(CONF_VIDEORECORDER)
-			Success &= CreateFolder("videos", TYPE_SAVE);
+				"videos"
 #endif
+			};
+
+			for(const char *pDir : CLIENT_DIRS)
+				Success &= CreateFolder(pDir, TYPE_SAVE);
 		}
-		Success &= CreateFolder("dumps", TYPE_SAVE);
-		Success &= CreateFolder("demos", TYPE_SAVE);
-		Success &= CreateFolder("demos/auto", TYPE_SAVE);
-		Success &= CreateFolder("demos/auto/race", TYPE_SAVE);
-		Success &= CreateFolder("demos/auto/server", TYPE_SAVE);
-		Success &= CreateFolder("demos/replays", TYPE_SAVE);
-		Success &= CreateFolder("editor", TYPE_SAVE);
-		Success &= CreateFolder("ghosts", TYPE_SAVE);
-		Success &= CreateFolder("teehistorian", TYPE_SAVE);
+
+		static constexpr const char *COMMON_DIRS[] = {
+			"dumps",
+			"demos",
+			"demos/auto",
+			"demos/auto/race",
+			"demos/auto/server",
+			"demos/replays",
+			"editor",
+			"ghosts",
+			"teehistorian"};
+
+		for(const char *pDir : COMMON_DIRS)
+			Success &= CreateFolder(pDir, TYPE_SAVE);
 
 		if(!Success)
 		{
@@ -465,7 +476,7 @@ public:
 		}
 	}
 
-	const char *GetPath(int Type, const char *pDir, char *pBuffer, unsigned BufferSize)
+	const char *GetPath(int Type, const char *pDir, char *pBuffer, unsigned BufferSize) const
 	{
 		if(Type == TYPE_ABSOLUTE)
 		{
@@ -478,7 +489,7 @@ public:
 		return pBuffer;
 	}
 
-	void TranslateType(int &Type, const char *pPath)
+	void TranslateType(int &Type, const char *pPath) const
 	{
 		if(Type == TYPE_SAVE_OR_ABSOLUTE)
 			Type = fs_is_relative_path(pPath) ? TYPE_SAVE : TYPE_ABSOLUTE;
@@ -507,7 +518,7 @@ public:
 
 		if(str_startswith(pFilename, "mapres/../skins/"))
 		{
-			pFilename = pFilename + 10; // just start from skins/
+			pFilename = pFilename + str_length("mapres/../");
 		}
 		if(pFilename[0] == '/' || pFilename[0] == '\\' || str_find(pFilename, "../") != nullptr || str_find(pFilename, "..\\") != nullptr
 #ifdef CONF_FAMILY_WINDOWS
@@ -544,7 +555,7 @@ public:
 	}
 
 	template<typename F>
-	bool GenericExists(const char *pFilename, int Type, F &&CheckFunction)
+	bool GenericExists(const char *pFilename, int Type, F &&CheckFunction) const
 	{
 		TranslateType(Type, pFilename);
 


### PR DESCRIPTION
Adds an empty `audio` folder to `%appdata%/DDNet`, because people that were adding their custom sounds had to create the folder themselves, which was confusing and seemed very unintended

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
