### PR TITLE
Add preview of selected game tile in editor tile popup

### DIFF
--- a/src/game/editor/enums.h
+++ b/src/game/editor/enums.h
@@ -1,7 +1,7 @@
 #ifndef GAME_EDITOR_ENUMS_H
 #define GAME_EDITOR_ENUMS_H
 
-constexpr const char *g_apGametileOpNames[] = {
+constexpr const char *g_apGameTileOpNames[] = {
 	"Air",
 	"Hookable",
 	"Death",
@@ -31,6 +31,8 @@ enum class EGameTileOp
 	RED_CHECK_TELE,
 	LIVE_FREEZE,
 	LIVE_UNFREEZE,
+
+	NONE = -1,
 };
 
 constexpr const char *g_apAutoMapReferenceNames[] = {

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -799,6 +799,7 @@ void CLayerTiles::FillGameTiles(EGameTileOp Fill)
 	{
 		std::shared_ptr<CLayerGroup> pGroup = m_pEditor->m_Map.m_vpGroups[m_pEditor->m_SelectedGroup];
 		m_FillGameTile = Result;
+		m_SelectedGameTileOp = Fill;
 		const int OffsetX = -pGroup->m_OffsetX / 32;
 		const int OffsetY = -pGroup->m_OffsetY / 32;
 
@@ -845,7 +846,7 @@ void CLayerTiles::FillGameTiles(EGameTileOp Fill)
 
 			vpActions.push_back(std::make_shared<CEditorBrushDrawAction>(m_pEditor, GameGroupIndex));
 			char aDisplay[256];
-			str_format(aDisplay, sizeof(aDisplay), "Construct '%s' game tiles (x%d)", g_apGametileOpNames[(int)Fill], Changes);
+			str_format(aDisplay, sizeof(aDisplay), "Construct '%s' game tiles (x%d)", g_apGameTileOpNames[(int)Fill], Changes);
 			m_pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionBulk>(m_pEditor, vpActions, aDisplay, true));
 		}
 		else
@@ -969,7 +970,12 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 	{
 		pToolBox->HSplitBottom(12.0f, pToolBox, &Button);
 		static int s_GameTilesButton = 0;
-		if(m_pEditor->DoButton_Editor(&s_GameTilesButton, "Game tiles", 0, &Button, BUTTONFLAG_LEFT, "Construct game tiles from this layer."))
+		char aBuf[128];
+		if(m_SelectedGameTileOp == EGameTileOp::NONE || m_SelectedGameTileOp == EGameTileOp::AIR)
+			str_copy(aBuf, "Game tiles", sizeof(aBuf));
+		else
+			str_format(aBuf, sizeof(aBuf), "Game tiles: %s", g_apGameTileOpNames[(size_t)m_SelectedGameTileOp]);
+		if(m_pEditor->DoButton_Editor(&s_GameTilesButton, aBuf, 0, &Button, BUTTONFLAG_LEFT, "Construct game tiles from this layer."))
 			m_pEditor->PopupSelectGametileOpInvoke(m_pEditor->Ui()->MouseX(), m_pEditor->Ui()->MouseY());
 		const int Selected = m_pEditor->PopupSelectGameTileOpResult();
 		FillGameTiles((EGameTileOp)Selected);

--- a/src/game/editor/mapitems/layer_tiles.h
+++ b/src/game/editor/mapitems/layer_tiles.h
@@ -177,6 +177,7 @@ public:
 
 	int m_FillGameTile = -1;
 	bool m_LiveGameTiles = false;
+	EGameTileOp m_SelectedGameTileOp = EGameTileOp::NONE;
 	int m_AutoMapperConfig;
 	int m_AutoMapperReference;
 	int m_Seed;


### PR DESCRIPTION
Previously, when using live game tiles, it was impossible to tell which tile is selected before placing it. This became confusing and difficult to remember, especially since different layers could have different game tiles selected

![image](https://github.com/user-attachments/assets/f72158bc-e72b-4939-a25e-02a039a7214e)
![image](https://github.com/user-attachments/assets/12bfb7e7-42c1-43ee-a47f-a8791e88e0b3)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
