### PR TITLE
Fix incorrect datafile swaplen handling on big-endian systems

### DIFF
--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -625,7 +625,10 @@ bool CDataFileReader::Open(class IStorage *pStorage, const char *pFilename, int 
 		return false;
 	}
 
-	SwapEndianInPlace(pTmpDataFile->m_pData, pTmpDataFile->m_Header.m_Swaplen);
+	// The swap len also includes the size of the header (without the size offset), but the header was already swapped above.
+	const int64_t DataSwapLen = pTmpDataFile->m_Header.m_Swaplen - (int)(sizeof(Header) - Header.SizeOffset());
+	dbg_assert(DataSwapLen == Size, "Swap len and file size mismatch");
+	SwapEndianInPlace(pTmpDataFile->m_pData, DataSwapLen);
 
 	pTmpDataFile->m_Info.m_pItemTypes = (CDatafileItemType *)pTmpDataFile->m_pData;
 	pTmpDataFile->m_Info.m_pItemOffsets = (int *)&pTmpDataFile->m_Info.m_pItemTypes[pTmpDataFile->m_Header.m_NumItemTypes];


### PR DESCRIPTION
Regression from #9886.

Closes #10218.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [X] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
