### PR TITLE
Refactor `net_socket_read_wait` function

### DIFF
--- a/src/base/system.h
+++ b/src/base/system.h
@@ -989,11 +989,16 @@ std::string net_error_message();
 int net_would_block();
 
 /**
- * @todo document
+ * Waits for a socket to have data available to receive up the specified timeout duration.
  *
  * @ingroup Network-General
+ *
+ * @param sock Socket to wait on.
+ * @param nanoseconds Timeout duration to wait.
+ *
+ * @return `1` if data was received within the timeout duration, `0` otherwise.
  */
-int net_socket_read_wait(NETSOCKET sock, int time);
+int net_socket_read_wait(NETSOCKET sock, std::chrono::nanoseconds nanoseconds);
 
 /**
  * @defgroup Network-UDP
@@ -2901,8 +2906,6 @@ void crashdump_init_if_available(const char *log_file_path);
  * @return Current value of the timer in nanoseconds.
  */
 std::chrono::nanoseconds time_get_nanoseconds();
-
-int net_socket_read_wait(NETSOCKET sock, std::chrono::nanoseconds nanoseconds);
 
 /**
  * Fixes the command line arguments to be encoded in UTF-8 on all systems.

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3333,7 +3333,7 @@ void CClient::Run()
 			SleepTimeInNanoSeconds = (std::chrono::nanoseconds(1s) / (int64_t)g_Config.m_ClRefreshRate) - (Now - LastTime);
 			auto SleepTimeInNanoSecondsInner = SleepTimeInNanoSeconds;
 			auto NowInner = Now;
-			while((SleepTimeInNanoSecondsInner / std::chrono::nanoseconds(1us).count()) > 0ns)
+			while(std::chrono::duration_cast<std::chrono::microseconds>(SleepTimeInNanoSecondsInner) > 0us)
 			{
 				net_socket_read_wait(m_aNetClient[CONN_MAIN].m_Socket, SleepTimeInNanoSecondsInner);
 				auto NowInnerCalc = time_get_nanoseconds();

--- a/src/test/net.cpp
+++ b/src/test/net.cpp
@@ -2,6 +2,10 @@
 
 #include <base/system.h>
 
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 TEST(Net, Ipv4AndIpv6Work)
 {
 	NETADDR Bindaddr = {};
@@ -31,7 +35,7 @@ TEST(Net, Ipv4AndIpv6Work)
 
 	EXPECT_EQ(net_udp_send(Socket2, &TargetV4, "abc", 3), 3);
 
-	EXPECT_EQ(net_socket_read_wait(Socket1, 10000000), 1);
+	EXPECT_EQ(net_socket_read_wait(Socket1, 10s), 1);
 	ASSERT_EQ(net_udp_recv(Socket1, &Addr, &pData), 3);
 	Addr.port = 0;
 	EXPECT_EQ(Addr, LocalhostV4);
@@ -39,7 +43,7 @@ TEST(Net, Ipv4AndIpv6Work)
 
 	EXPECT_EQ(net_udp_send(Socket2, &TargetV6, "def", 3), 3);
 
-	EXPECT_EQ(net_socket_read_wait(Socket1, 10000000), 1);
+	EXPECT_EQ(net_socket_read_wait(Socket1, 10s), 1);
 	ASSERT_EQ(net_udp_recv(Socket1, &Addr, &pData), 3);
 	Addr.port = 0;
 	EXPECT_EQ(Addr, LocalhostV6);

--- a/src/tools/stun.cpp
+++ b/src/tools/stun.cpp
@@ -2,6 +2,10 @@
 #include <base/system.h>
 #include <engine/shared/stun.h>
 
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 int main(int argc, const char **argv)
 {
 	CCmdlineFix CmdlineFix(&argc, &argv);
@@ -49,7 +53,7 @@ int main(int argc, const char **argv)
 	unsigned char *pResponse;
 	while(true)
 	{
-		if(!net_socket_read_wait(Socket, 1000000))
+		if(!net_socket_read_wait(Socket, 1s))
 		{
 			log_error("stun", "no udp message received from server until timeout");
 			return 3;


### PR DESCRIPTION
Remove the function overload accepting the milliseconds as an `int` and instead only use `std::chrono` types and conversions.

Do not allow waiting for sockets indefinitely when time argument is negative, as this functionality is never used and may lead to issues on some systems. Waiting indefinitely should be avoided with the Emscripten client as it blocks the browser's main thread. It should also be avoided on Windows as it may lead to undefined behavior in the presence of asynchronous procedure calls.

Add doxygen documentation.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
