### PR TITLE
Move console color parsing to color.cpp

### DIFF
--- a/src/base/color.cpp
+++ b/src/base/color.cpp
@@ -46,3 +46,45 @@ std::optional<T> color_parse(const char *pStr)
 }
 
 template std::optional<ColorRGBA> color_parse<ColorRGBA>(const char *);
+
+template<typename T>
+std::optional<T> color_parse_console(const char *pStr, float DarkestLighting)
+{
+	if(str_isallnum(pStr) || ((pStr[0] == '-' || pStr[0] == '+') && str_isallnum(pStr + 1))) // Teeworlds Color (Packed HSL)
+	{
+		unsigned long Value = str_toulong_base(pStr, 10);
+		if(Value == std::numeric_limits<unsigned long>::max())
+			return std::nullopt;
+		return ColorHSLA(Value, true).UnclampLighting(DarkestLighting);
+	}
+	else if(*pStr == '$') // Hex RGB/RGBA
+	{
+		auto ParsedColor = color_parse<ColorRGBA>(pStr + 1);
+		if(ParsedColor)
+			return color_cast<ColorHSLA>(ParsedColor.value());
+		else
+			return std::nullopt;
+	}
+	else if(!str_comp_nocase(pStr, "red"))
+		return ColorHSLA(0.0f / 6.0f, 1.0f, 0.5f);
+	else if(!str_comp_nocase(pStr, "yellow"))
+		return ColorHSLA(1.0f / 6.0f, 1.0f, 0.5f);
+	else if(!str_comp_nocase(pStr, "green"))
+		return ColorHSLA(2.0f / 6.0f, 1.0f, 0.5f);
+	else if(!str_comp_nocase(pStr, "cyan"))
+		return ColorHSLA(3.0f / 6.0f, 1.0f, 0.5f);
+	else if(!str_comp_nocase(pStr, "blue"))
+		return ColorHSLA(4.0f / 6.0f, 1.0f, 0.5f);
+	else if(!str_comp_nocase(pStr, "magenta"))
+		return ColorHSLA(5.0f / 6.0f, 1.0f, 0.5f);
+	else if(!str_comp_nocase(pStr, "white"))
+		return ColorHSLA(0.0f, 0.0f, 1.0f);
+	else if(!str_comp_nocase(pStr, "gray"))
+		return ColorHSLA(0.0f, 0.0f, 0.5f);
+	else if(!str_comp_nocase(pStr, "black"))
+		return ColorHSLA(0.0f, 0.0f, 0.0f);
+
+	return std::nullopt;
+}
+
+template std::optional<ColorHSLA> color_parse_console<ColorHSLA>(const char *, float);

--- a/src/base/color.h
+++ b/src/base/color.h
@@ -301,4 +301,7 @@ constexpr T color_invert(const T &col)
 template<typename T>
 std::optional<T> color_parse(const char *pStr);
 
+template<typename T>
+std::optional<T> color_parse_console(const char *pStr, float DarkestLighting);
+
 #endif

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -78,43 +78,7 @@ std::optional<ColorHSLA> CConsole::CResult::GetColor(unsigned Index, float Darke
 {
 	if(Index >= m_NumArgs)
 		return std::nullopt;
-
-	const char *pStr = m_apArgs[Index];
-	if(str_isallnum(pStr) || ((pStr[0] == '-' || pStr[0] == '+') && str_isallnum(pStr + 1))) // Teeworlds Color (Packed HSL)
-	{
-		unsigned long Value = str_toulong_base(pStr, 10);
-		if(Value == std::numeric_limits<unsigned long>::max())
-			return std::nullopt;
-		return ColorHSLA(Value, true).UnclampLighting(DarkestLighting);
-	}
-	else if(*pStr == '$') // Hex RGB/RGBA
-	{
-		auto ParsedColor = color_parse<ColorRGBA>(pStr + 1);
-		if(ParsedColor)
-			return color_cast<ColorHSLA>(ParsedColor.value());
-		else
-			return std::nullopt;
-	}
-	else if(!str_comp_nocase(pStr, "red"))
-		return ColorHSLA(0.0f / 6.0f, 1, .5f);
-	else if(!str_comp_nocase(pStr, "yellow"))
-		return ColorHSLA(1.0f / 6.0f, 1, .5f);
-	else if(!str_comp_nocase(pStr, "green"))
-		return ColorHSLA(2.0f / 6.0f, 1, .5f);
-	else if(!str_comp_nocase(pStr, "cyan"))
-		return ColorHSLA(3.0f / 6.0f, 1, .5f);
-	else if(!str_comp_nocase(pStr, "blue"))
-		return ColorHSLA(4.0f / 6.0f, 1, .5f);
-	else if(!str_comp_nocase(pStr, "magenta"))
-		return ColorHSLA(5.0f / 6.0f, 1, .5f);
-	else if(!str_comp_nocase(pStr, "white"))
-		return ColorHSLA(0, 0, 1);
-	else if(!str_comp_nocase(pStr, "gray"))
-		return ColorHSLA(0, 0, .5f);
-	else if(!str_comp_nocase(pStr, "black"))
-		return ColorHSLA(0, 0, 0);
-
-	return std::nullopt;
+	return color_parse_console(m_apArgs[Index], DarkestLighting);
 }
 
 const IConsole::CCommandInfo *CConsole::CCommand::NextCommandInfo(int AccessLevel, int FlagMask) const


### PR DESCRIPTION
I want to use the function somewhere else, and duplicating it is ew

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
