### PR TITLE
Fix preserved LocalStrongWeakId when player kills

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1119,6 +1119,18 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 		// reset character prediction
 		if(!(m_GameWorld.m_WorldConfig.m_IsFNG && pMsg->m_Weapon == WEAPON_LASER))
 		{
+			// update saved strong/weak ids if our character isn't on screen
+			for(int DummyId = 0; DummyId < NUM_DUMMIES; DummyId++)
+			{
+				if(m_aLocalIds[DummyId] == -1)
+					continue;
+
+				if(pMsg->m_Victim == m_aLocalIds[DummyId])
+					m_aLocalStrongWeakId[DummyId] = 0;
+				else if(m_CharOrder.HasStrongAgainst(m_aLocalIds[DummyId], pMsg->m_Victim))
+					m_aLocalStrongWeakId[DummyId]++;
+			}
+
 			m_CharOrder.GiveWeak(pMsg->m_Victim);
 			if(CCharacter *pChar = m_GameWorld.GetCharacterById(pMsg->m_Victim))
 				pChar->ResetPrediction();
@@ -1160,6 +1172,18 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 		{
 			if(m_Teams.Team(i) == pMsg->m_Team)
 			{
+				// update saved strong/weak ids if our character isn't on screen
+				for(int DummyId = 0; DummyId < NUM_DUMMIES; DummyId++)
+				{
+					if(m_aLocalIds[DummyId] == -1)
+						continue;
+
+					if(i == m_aLocalIds[DummyId])
+						m_aLocalStrongWeakId[DummyId] = 0;
+					else if(m_CharOrder.HasStrongAgainst(m_aLocalIds[DummyId], i))
+						m_aLocalStrongWeakId[DummyId]++;
+				}
+
 				if(CCharacter *pChar = m_GameWorld.GetCharacterById(i))
 				{
 					pChar->ResetPrediction();

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -147,7 +147,7 @@ public:
 			m_Ids.push_back(c);
 		}
 	}
-	bool HasStrongAgainst(int From, int To)
+	bool HasStrongAgainst(int From, int To) const
 	{
 		for(int i : m_Ids)
 		{


### PR DESCRIPTION
Fixes https://github.com/ddnet/ddnet/pull/10281#issuecomment-2945298554

Simply, if a player kills and their StrongWeakId was higher than ours, then we update our Id by 1

However, if a player disconnects instead of being killed, this still causes an incorrect update. I'm not sure if that's fixable. Of course, it goes back to normal once we stop spectating, this whole bug only occurs when we don't see our own character while in spectator mode.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
