### PR TITLE
swap_bind command

### DIFF
--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -18,6 +18,7 @@ class CBinds : public CComponent
 	static void ConBinds(IConsole::IResult *pResult, void *pUserData);
 	static void ConUnbind(IConsole::IResult *pResult, void *pUserData);
 	static void ConUnbindAll(IConsole::IResult *pResult, void *pUserData);
+	static void ConSwapBind(IConsole::IResult *pResult, void *pUserData);
 	class IConsole *GetConsole() const { return Console(); }
 
 	static void ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData);
@@ -65,6 +66,7 @@ public:
 	CBindsSpecial m_SpecialBinds;
 
 	void Bind(int KeyId, const char *pStr, bool FreeOnly = false, int ModifierCombination = MODIFIER_NONE);
+	void SwapBind(int FirstKeyId, int SecondKeyId, int FirstModifierCombination = MODIFIER_NONE, int SecondModifierCombination = MODIFIER_NONE);
 	void SetDefaults();
 	void UnbindAll();
 	const char *Get(int KeyId, int ModifierCombination);

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -117,7 +117,8 @@ static constexpr CArgumentCompletionEntry gs_aArgumentCompletionEntries[] = {
 	{"+toggle", {{EArgumentCompletionType::SETTING, 0}}},
 	{"bind", {{EArgumentCompletionType::KEY, 0}}},
 	{"binds", {{EArgumentCompletionType::KEY, 0}}},
-	{"unbind", {{EArgumentCompletionType::KEY, 0}}}};
+	{"unbind", {{EArgumentCompletionType::KEY, 0}}},
+	{"swap_bind", {{EArgumentCompletionType::KEY, 0}, {EArgumentCompletionType::KEY, 1}}}};
 static constexpr int gs_ArgumentCompletionEntriesBiggestArgumentIndex = [](const auto &aArgumentCompletionEntries) {
 	int BiggestArgumentIndex = -1;
 	for(const auto &Entry : aArgumentCompletionEntries)


### PR DESCRIPTION
Adds `swap_bind s[key] s[key]` from #10261 which was highly desired.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
