### PR TITLE
Fix: move render loading into each layer

### DIFF
--- a/src/game/client/components/render_layer.cpp
+++ b/src/game/client/components/render_layer.cpp
@@ -183,6 +183,13 @@ void CRenderLayer::UseTexture(IGraphics::CTextureHandle TextureHandle) const
 		m_pGraphics->TextureClear();
 }
 
+void CRenderLayer::RenderLoading() const
+{
+	const char *pLoadingTitle = Localize("Loading map");
+	const char *pLoadingMessage = Localize("Uploading map data to GPU");
+	m_pGameClient->m_Menus.RenderLoading(pLoadingTitle, pLoadingMessage, 0);
+}
+
 /**************
  * Tile Layer *
  **************/
@@ -712,6 +719,7 @@ void CRenderLayerTile::UploadTileData(std::optional<CTileLayerVisuals> &VisualsO
 		// and finally inform the backend how many indices are required
 		m_pGraphics->IndicesNumRequiredNotify(vTmpTiles.size() * 6);
 	}
+	RenderLoading();
 }
 
 int CRenderLayerTile::GetDataIndex(unsigned int &TileSize) const
@@ -943,6 +951,7 @@ void CRenderLayerQuads::Init()
 		// and finally inform the backend how many indices are required
 		m_pGraphics->IndicesNumRequiredNotify(m_pLayerQuads->m_NumQuads * 6);
 	}
+	RenderLoading();
 }
 
 void CRenderLayerQuads::Render(const CRenderLayerParams &Params)

--- a/src/game/client/components/render_layer.h
+++ b/src/game/client/components/render_layer.h
@@ -61,6 +61,7 @@ protected:
 
 	void UseTexture(IGraphics::CTextureHandle TextureHandle) const;
 	virtual IGraphics::CTextureHandle GetTexture() const = 0;
+	void RenderLoading() const;
 
 	class IGraphics *m_pGraphics = nullptr;
 	class IMap *m_pMap = nullptr;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

After the pipeline merge the rendering initialization didn't swap after gpu uploads anymore. This PR reintroduces this.

@Jupeyy can you double check if this is right?

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
