### PR TITLE
Optimize quad rendering by grouping quads

### DIFF
--- a/cmake/BuildVulkanShaders.cmake
+++ b/cmake/BuildVulkanShaders.cmake
@@ -146,14 +146,14 @@ if(NOT FOUND_MATCHING_SHA256_FILE)
   generate_shader_file("" "" "${PROJECT_SOURCE_DIR}/data/shader/vulkan/quad.frag" "data/shader/vulkan/quad.frag.spv")
   generate_shader_file("" "" "${PROJECT_SOURCE_DIR}/data/shader/vulkan/quad.vert" "data/shader/vulkan/quad.vert.spv")
   
-  generate_shader_file("-DTW_PUSH_CONST" "" "${PROJECT_SOURCE_DIR}/data/shader/vulkan/quad.frag" "data/shader/vulkan/quad_push.frag.spv")
-  generate_shader_file("-DTW_PUSH_CONST" "" "${PROJECT_SOURCE_DIR}/data/shader/vulkan/quad.vert" "data/shader/vulkan/quad_push.vert.spv")
+  generate_shader_file("-DTW_QUAD_GROUPED" "" "${PROJECT_SOURCE_DIR}/data/shader/vulkan/quad.frag" "data/shader/vulkan/quad_grouped.frag.spv")
+  generate_shader_file("-DTW_QUAD_GROUPED" "" "${PROJECT_SOURCE_DIR}/data/shader/vulkan/quad.vert" "data/shader/vulkan/quad_grouped.vert.spv")
   
   generate_shader_file("-DTW_QUAD_TEXTURED" "" "${PROJECT_SOURCE_DIR}/data/shader/vulkan/quad.frag" "data/shader/vulkan/quad_textured.frag.spv")
   generate_shader_file("-DTW_QUAD_TEXTURED" "" "${PROJECT_SOURCE_DIR}/data/shader/vulkan/quad.vert" "data/shader/vulkan/quad_textured.vert.spv")
   
-  generate_shader_file("-DTW_QUAD_TEXTURED" "-DTW_PUSH_CONST" "${PROJECT_SOURCE_DIR}/data/shader/vulkan/quad.frag" "data/shader/vulkan/quad_push_textured.frag.spv")
-  generate_shader_file("-DTW_QUAD_TEXTURED" "-DTW_PUSH_CONST" "${PROJECT_SOURCE_DIR}/data/shader/vulkan/quad.vert" "data/shader/vulkan/quad_push_textured.vert.spv")
+  generate_shader_file("-DTW_QUAD_TEXTURED" "-DTW_QUAD_GROUPED" "${PROJECT_SOURCE_DIR}/data/shader/vulkan/quad.frag" "data/shader/vulkan/quad_grouped_textured.frag.spv")
+  generate_shader_file("-DTW_QUAD_TEXTURED" "-DTW_QUAD_GROUPED" "${PROJECT_SOURCE_DIR}/data/shader/vulkan/quad.vert" "data/shader/vulkan/quad_grouped_textured.vert.spv")
 
   execute_process(${GLSLANG_VALIDATOR_COMMAND_LIST} RESULT_VARIABLE STATUS)
   if(STATUS AND NOT STATUS EQUAL 0)

--- a/data/shader/quad.frag
+++ b/data/shader/quad.frag
@@ -2,10 +2,18 @@
 uniform sampler2D gTextureSampler;
 #endif
 
+#ifndef TW_QUAD_GROUPED
 uniform vec4 gVertColors[TW_MAX_QUADS];
+#else
+uniform vec4 gVertColors[1];
+#endif
 
 noperspective in vec4 QuadColor;
+#ifndef TW_QUAD_GROUPED
 flat in int QuadIndex;
+#else
+#define QuadIndex 0
+#endif
 #ifdef TW_QUAD_TEXTURED
 noperspective in vec2 TexCoord;
 #endif

--- a/data/shader/quad.vert
+++ b/data/shader/quad.vert
@@ -6,13 +6,18 @@ layout (location = 2) in vec2 inVertexTexCoord;
 
 uniform mat4x2 gPos;
 
+#ifdef TW_QUAD_GROUPED
+uniform vec2 gOffsets[1];
+uniform float gRotations[1];
+#else
 uniform vec2 gOffsets[TW_MAX_QUADS];
 uniform float gRotations[TW_MAX_QUADS];
-
 uniform int gQuadOffset;
+flat out int QuadIndex;
+#endif
 
 noperspective out vec4 QuadColor;
-flat out int QuadIndex;
+
 #ifdef TW_QUAD_TEXTURED
 noperspective out vec2 TexCoord;
 #endif
@@ -20,9 +25,12 @@ noperspective out vec2 TexCoord;
 void main()
 {
 	vec2 FinalPos = vec2(inVertex.xy);
-	
-	int TmpQuadIndex = int(gl_VertexID / 4) - gQuadOffset;
 
+#ifndef TW_QUAD_GROUPED
+	int TmpQuadIndex = int(gl_VertexID / 4) - gQuadOffset;
+#else
+#define TmpQuadIndex 0
+#endif
 	if(gRotations[TmpQuadIndex] != 0.0)
 	{
 		float X = FinalPos.x - inVertex.z;
@@ -31,13 +39,16 @@ void main()
 		FinalPos.x = X * cos(gRotations[TmpQuadIndex]) - Y * sin(gRotations[TmpQuadIndex]) + inVertex.z;
 		FinalPos.y = X * sin(gRotations[TmpQuadIndex]) + Y * cos(gRotations[TmpQuadIndex]) + inVertex.w;
 	}
-	
 	FinalPos.x = FinalPos.x / 1024.0 + gOffsets[TmpQuadIndex].x;
 	FinalPos.y = FinalPos.y / 1024.0 + gOffsets[TmpQuadIndex].y;
 
+#ifndef TW_QUAD_GROUPED
+	QuadIndex = TmpQuadIndex;
+#endif
+
 	gl_Position = vec4(gPos * vec4(FinalPos, 0.0, 1.0), 0.0, 1.0);
 	QuadColor = inColor;
-	QuadIndex = TmpQuadIndex;
+
 #ifdef TW_QUAD_TEXTURED
 	TexCoord = inVertexTexCoord;
 #endif

--- a/data/shader/vulkan/quad.frag
+++ b/data/shader/vulkan/quad.frag
@@ -17,7 +17,7 @@ struct SQuadUniformEl {
 	float gRotation;
 };
 
-#ifndef TW_PUSH_CONST
+#ifndef TW_QUAD_GROUPED
 #define TW_MAX_QUADS 256
 
 layout (std140, set = UBOSetIndex, binding = 1) uniform SOffBO {
@@ -30,20 +30,19 @@ layout (std140, set = UBOSetIndex, binding = 1) uniform SOffBO {
 
 layout(push_constant) uniform SPosBO {
 	layout(offset = 0) uniform mat4x2 gPos;
-#ifdef TW_PUSH_CONST
+#ifdef TW_QUAD_GROUPED
 	layout(offset = 32) uniform SQuadUniformEl gUniEls[1];
-	layout(offset = 64) uniform int gQuadOffset;
 #else
 	layout(offset = 32) uniform int gQuadOffset;
 #endif
 } gPosBO;
 
 layout (location = 0) noperspective in vec4 QuadColor;
-#ifndef TW_PUSH_CONST
+#ifndef TW_QUAD_GROUPED
 layout (location = 1) flat in int QuadIndex;
 #endif
 #ifdef TW_QUAD_TEXTURED
-#ifndef TW_PUSH_CONST
+#ifndef TW_QUAD_GROUPED
 layout (location = 2) noperspective in vec2 TexCoord;
 #else
 layout (location = 1) noperspective in vec2 TexCoord;

--- a/data/shader/vulkan/quad.vert
+++ b/data/shader/vulkan/quad.vert
@@ -19,7 +19,7 @@ struct SQuadUniformEl {
 	float gRotation;
 };
 
-#ifndef TW_PUSH_CONST
+#ifndef TW_QUAD_GROUPED
 #define TW_MAX_QUADS 256
 
 layout (std140, set = UBOSetIndex, binding = 1) uniform SOffBO {
@@ -32,20 +32,20 @@ layout (std140, set = UBOSetIndex, binding = 1) uniform SOffBO {
 
 layout(push_constant) uniform SPosBO {
 	layout(offset = 0) uniform mat4x2 gPos;
-#ifdef TW_PUSH_CONST
+#ifdef TW_QUAD_GROUPED
 	layout(offset = 32) uniform SQuadUniformEl gUniEls[1];
-	layout(offset = 64) uniform int gQuadOffset;
 #else
 	layout(offset = 32) uniform int gQuadOffset;
 #endif
 } gPosBO;
 
 layout (location = 0) noperspective out vec4 QuadColor;
-#ifndef TW_PUSH_CONST
+#ifndef TW_QUAD_GROUPED
 layout (location = 1) flat out int QuadIndex;
 #endif
+
 #ifdef TW_QUAD_TEXTURED
-#ifndef TW_PUSH_CONST
+#ifndef TW_QUAD_GROUPED
 layout (location = 2) noperspective out vec2 TexCoord;
 #else
 layout (location = 1) noperspective out vec2 TexCoord;
@@ -56,7 +56,7 @@ void main()
 {
 	vec2 FinalPos = vec2(inVertex.xy);
 
-#ifndef TW_PUSH_CONST
+#ifndef TW_QUAD_GROUPED
 	int TmpQuadIndex = int(gl_VertexIndex / 4) - gPosBO.gQuadOffset;
 #endif
 
@@ -74,7 +74,7 @@ void main()
 
 	gl_Position = vec4(gPosBO.gPos * vec4(FinalPos, 0.0, 1.0), 0.0, 1.0);
 	QuadColor = inColor;
-#ifndef TW_PUSH_CONST
+#ifndef TW_QUAD_GROUPED
 	QuadIndex = TmpQuadIndex;
 #endif
 #ifdef TW_QUAD_TEXTURED

--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -1093,7 +1093,8 @@ ERunCommandReturnTypes CCommandProcessorFragment_OpenGL::RunCommand(const CComma
 
 	case CCommandBuffer::CMD_RENDER_TILE_LAYER: Cmd_RenderTileLayer(static_cast<const CCommandBuffer::SCommand_RenderTileLayer *>(pBaseCommand)); break;
 	case CCommandBuffer::CMD_RENDER_BORDER_TILE: Cmd_RenderBorderTile(static_cast<const CCommandBuffer::SCommand_RenderBorderTile *>(pBaseCommand)); break;
-	case CCommandBuffer::CMD_RENDER_QUAD_LAYER: Cmd_RenderQuadLayer(static_cast<const CCommandBuffer::SCommand_RenderQuadLayer *>(pBaseCommand)); break;
+	case CCommandBuffer::CMD_RENDER_QUAD_LAYER: Cmd_RenderQuadLayer(static_cast<const CCommandBuffer::SCommand_RenderQuadLayer *>(pBaseCommand), false); break;
+	case CCommandBuffer::CMD_RENDER_QUAD_LAYER_GROUPED: Cmd_RenderQuadLayer(static_cast<const CCommandBuffer::SCommand_RenderQuadLayer *>(pBaseCommand), true); break;
 	case CCommandBuffer::CMD_RENDER_TEXT: Cmd_RenderText(static_cast<const CCommandBuffer::SCommand_RenderText *>(pBaseCommand)); break;
 	case CCommandBuffer::CMD_RENDER_QUAD_CONTAINER: Cmd_RenderQuadContainer(static_cast<const CCommandBuffer::SCommand_RenderQuadContainer *>(pBaseCommand)); break;
 	case CCommandBuffer::CMD_RENDER_QUAD_CONTAINER_EX: Cmd_RenderQuadContainerEx(static_cast<const CCommandBuffer::SCommand_RenderQuadContainerEx *>(pBaseCommand)); break;

--- a/src/engine/client/backend/opengl/backend_opengl.h
+++ b/src/engine/client/backend/opengl/backend_opengl.h
@@ -115,7 +115,7 @@ protected:
 
 	virtual void Cmd_RenderTileLayer(const CCommandBuffer::SCommand_RenderTileLayer *pCommand) { dbg_assert(false, "Call of unsupported Cmd_RenderTileLayer"); }
 	virtual void Cmd_RenderBorderTile(const CCommandBuffer::SCommand_RenderBorderTile *pCommand) { dbg_assert(false, "Call of unsupported Cmd_RenderBorderTile"); }
-	virtual void Cmd_RenderQuadLayer(const CCommandBuffer::SCommand_RenderQuadLayer *pCommand) { dbg_assert(false, "Call of unsupported Cmd_RenderQuadLayer"); }
+	virtual void Cmd_RenderQuadLayer(const CCommandBuffer::SCommand_RenderQuadLayer *pCommand, bool Grouped) { dbg_assert(false, "Call of unsupported Cmd_RenderQuadLayer"); }
 	virtual void Cmd_RenderText(const CCommandBuffer::SCommand_RenderText *pCommand) { dbg_assert(false, "Call of unsupported Cmd_RenderText"); }
 	virtual void Cmd_RenderQuadContainer(const CCommandBuffer::SCommand_RenderQuadContainer *pCommand) { dbg_assert(false, "Call of unsupported Cmd_RenderQuadContainer"); }
 	virtual void Cmd_RenderQuadContainerEx(const CCommandBuffer::SCommand_RenderQuadContainerEx *pCommand) { dbg_assert(false, "Call of unsupported Cmd_RenderQuadContainerEx"); }

--- a/src/engine/client/backend/opengl/backend_opengl3.h
+++ b/src/engine/client/backend/opengl/backend_opengl3.h
@@ -30,6 +30,8 @@ protected:
 	CGLSLPrimitiveProgram *m_pPrimitiveProgramTextured;
 	CGLSLQuadProgram *m_pQuadProgram;
 	CGLSLQuadProgram *m_pQuadProgramTextured;
+	CGLSLQuadProgram *m_pQuadProgramGrouped;
+	CGLSLQuadProgram *m_pQuadProgramTexturedGrouped;
 	CGLSLTextProgram *m_pTextProgram;
 	CGLSLPrimitiveExProgram *m_pPrimitiveExProgram;
 	CGLSLPrimitiveExProgram *m_pPrimitiveExProgramTextured;
@@ -104,7 +106,7 @@ protected:
 
 	void Cmd_RenderTileLayer(const CCommandBuffer::SCommand_RenderTileLayer *pCommand) override;
 	void Cmd_RenderBorderTile(const CCommandBuffer::SCommand_RenderBorderTile *pCommand) override;
-	void Cmd_RenderQuadLayer(const CCommandBuffer::SCommand_RenderQuadLayer *pCommand) override;
+	void Cmd_RenderQuadLayer(const CCommandBuffer::SCommand_RenderQuadLayer *pCommand, bool Grouped) override;
 	void Cmd_RenderText(const CCommandBuffer::SCommand_RenderText *pCommand) override;
 	void Cmd_RenderQuadContainer(const CCommandBuffer::SCommand_RenderQuadContainer *pCommand) override;
 	void Cmd_RenderQuadContainerEx(const CCommandBuffer::SCommand_RenderQuadContainerEx *pCommand) override;

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -121,6 +121,7 @@ public:
 		CMD_RENDER_TILE_LAYER, // render a tilelayer
 		CMD_RENDER_BORDER_TILE, // render one tile multiple times
 		CMD_RENDER_QUAD_LAYER, // render a quad layer
+		CMD_RENDER_QUAD_LAYER_GROUPED, // render a quad layer in groups meaning they all share the same envelope and offset (which can be none)
 		CMD_RENDER_TEXT, // render text
 		CMD_RENDER_QUAD_CONTAINER, // render a quad buffer container
 		CMD_RENDER_QUAD_CONTAINER_EX, // render a quad buffer container with extended parameters
@@ -391,8 +392,8 @@ public:
 
 	struct SCommand_RenderQuadLayer : public SCommand
 	{
-		SCommand_RenderQuadLayer() :
-			SCommand(CMD_RENDER_QUAD_LAYER) {}
+		SCommand_RenderQuadLayer(bool Grouped) :
+			SCommand(Grouped ? CMD_RENDER_QUAD_LAYER_GROUPED : CMD_RENDER_QUAD_LAYER) {}
 		SState m_State;
 
 		int m_BufferContainerIndex;
@@ -1171,7 +1172,7 @@ public:
 
 	void RenderTileLayer(int BufferContainerIndex, const ColorRGBA &Color, char **pOffsets, unsigned int *pIndicedVertexDrawNum, size_t NumIndicesOffset) override;
 	virtual void RenderBorderTiles(int BufferContainerIndex, const ColorRGBA &Color, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &Scale, uint32_t DrawNum) override;
-	void RenderQuadLayer(int BufferContainerIndex, SQuadRenderInfo *pQuadInfo, size_t QuadNum, int QuadOffset) override;
+	void RenderQuadLayer(int BufferContainerIndex, SQuadRenderInfo *pQuadInfo, size_t QuadNum, int QuadOffset, bool Grouped = false) override;
 	void RenderText(int BufferContainerIndex, int TextQuadNum, int TextureSize, int TextureTextIndex, int TextureTextOutlineIndex, const ColorRGBA &TextColor, const ColorRGBA &TextOutlineColor) override;
 
 	// modern GL functions

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -300,7 +300,7 @@ public:
 	// specific render functions
 	virtual void RenderTileLayer(int BufferContainerIndex, const ColorRGBA &Color, char **pOffsets, unsigned int *pIndicedVertexDrawNum, size_t NumIndicesOffset) = 0;
 	virtual void RenderBorderTiles(int BufferContainerIndex, const ColorRGBA &Color, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &Scale, uint32_t DrawNum) = 0;
-	virtual void RenderQuadLayer(int BufferContainerIndex, SQuadRenderInfo *pQuadInfo, size_t QuadNum, int QuadOffset) = 0;
+	virtual void RenderQuadLayer(int BufferContainerIndex, SQuadRenderInfo *pQuadInfo, size_t QuadNum, int QuadOffset, bool Grouped = false) = 0;
 	virtual void RenderText(int BufferContainerIndex, int TextQuadNum, int TextureSize, int TextureTextIndex, int TextureTextOutlineIndex, const ColorRGBA &TextColor, const ColorRGBA &TextOutlineColor) = 0;
 
 	// opengl 3.3 functions

--- a/src/game/client/components/render_layer.h
+++ b/src/game/client/components/render_layer.h
@@ -185,6 +185,7 @@ class CRenderLayerQuads : public CRenderLayer
 public:
 	CRenderLayerQuads(int GroupId, int LayerId, IGraphics::CTextureHandle TextureHandle, int Flags, CMapItemLayerQuads *pLayerQuads);
 	virtual void Init() override;
+	bool IsValid() const override { return m_pLayerQuads->m_NumQuads > 0; }
 	virtual void Render(const CRenderLayerParams &Params) override;
 	virtual bool DoRender(const CRenderLayerParams &Params) const override;
 
@@ -207,7 +208,16 @@ protected:
 	CMapItemLayerQuads *m_pLayerQuads;
 
 	std::vector<SQuadRenderInfo> m_vQuadRenderInfo;
-	bool m_ContainsEnvelopes;
+
+	bool m_Grouped;
+	class CQuadRenderGroup
+	{
+	public:
+		int m_PosEnv;
+		float m_PosEnvOffset;
+		int m_ColorEnv;
+		float m_ColorEnvOffset;
+	} m_QuadRenderGroup;
 
 private:
 	IGraphics::CTextureHandle m_TextureHandle;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

With the pipeline in place we now after setup, if any quads in a quadlayer are animated or not. If none of them are animated, we can optimize their rendering by pushing their location and color.

This only applies to vulkan and OpenGL 3.3, falls back to default rendering in OpenGL 3 and 1

## Vulkan:
Before ~160 FPS:
![screenshot_2025-06-10_15-14-48](https://github.com/user-attachments/assets/8872a20f-7ee8-4525-9180-cb52b55413d5)

After >1300 FPS (depends on zoom level):
![screenshot_2025-06-11_12-02-48](https://github.com/user-attachments/assets/288d992c-008e-4619-bfbc-4e1e4d680c4a)

## OpenGL 3.3
Before ~36 FPS (no screenshot)

After ~ 1100 FPS:
![screenshot_2025-06-11_16-08-02](https://github.com/user-attachments/assets/452dbcc1-5b9f-45ad-8e2c-a00a55d78c54)


@Jupeyy 

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
