### PR TITLE
Add default rcon even with auto auth

### DIFF
--- a/src/engine/server/authmanager.cpp
+++ b/src/engine/server/authmanager.cpp
@@ -35,6 +35,11 @@ void CAuthManager::Init()
 		NumDefaultKeys++;
 	if(g_Config.m_SvRconHelperPassword[0])
 		NumDefaultKeys++;
+
+	auto It = std::find_if(m_vKeys.begin(), m_vKeys.end(), [](CKey Key) { return str_comp(Key.m_aIdent, DEFAULT_SAVED_RCON_USER) == 0; });
+	if(It != m_vKeys.end())
+		NumDefaultKeys++;
+
 	if(m_vKeys.size() == NumDefaultKeys && !g_Config.m_SvRconPassword[0])
 	{
 		secure_random_password(g_Config.m_SvRconPassword, sizeof(g_Config.m_SvRconPassword), 6);

--- a/src/engine/shared/config.h
+++ b/src/engine/shared/config.h
@@ -14,6 +14,8 @@
 // include protocol for MAX_CLIENT used in config_variables
 #include <engine/shared/protocol.h>
 
+static constexpr const char *DEFAULT_SAVED_RCON_USER = "local-server";
+
 #define CONFIG_FILE "settings_ddnet.cfg"
 #define AUTOEXEC_FILE "autoexec.cfg"
 #define AUTOEXEC_CLIENT_FILE "autoexec_client.cfg"

--- a/src/game/client/components/local_server.cpp
+++ b/src/game/client/components/local_server.cpp
@@ -8,8 +8,6 @@
 #include <android/android_main.h>
 #endif
 
-static constexpr const char *DEFAULT_SAVED_RCON_USER = "local-server";
-
 void CLocalServer::RunServer(const std::vector<const char *> &vpArguments)
 {
 	secure_random_password(m_aRconPassword, sizeof(m_aRconPassword), 16);


### PR DESCRIPTION
Will generate a default rcon password that is printed in the server console, even when launched with the client
This seemed to be a weekly question on Discord, mainly because the auto-auth feature didn’t always work - https://github.com/ddnet/ddnet/issues/10042

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
