### PR TITLE
Fix sound preview assertion on closing editor after loading map

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -8697,6 +8697,8 @@ void CEditor::Reset(bool CreateDefault)
 	for(CEditorComponent &Component : m_vComponents)
 		Component.OnReset();
 
+	m_ToolbarPreviewSound = -1;
+
 	// create default layers
 	if(CreateDefault)
 	{


### PR DESCRIPTION
Closes #10351.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
