### PR TITLE
DDNet 19.3

### DIFF
--- a/data/languages/arabic.txt
+++ b/data/languages/arabic.txt
@@ -1146,9 +1146,6 @@ Restarting. Please wait…
 Loading skin files
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -1218,6 +1215,10 @@ Multi-View
 == 
 
 [Spectating]
+Following %d: %s
+== 
+
+[Spectating]
 Following %s
 == 
 
@@ -1229,6 +1230,9 @@ Team %d
 == 
 
 Some map images could not be loaded. Check the local console for details.
+== 
+
+Loading map
 == 
 
 Uploading map data to GPU
@@ -1298,6 +1302,15 @@ Join Tutorial Server
 == 
 
 Skip Tutorial
+== 
+
+Cancel
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Unable to save the skin with a reserved name
@@ -1431,11 +1444,11 @@ Go back the specified duration
 == 
 
 [Demo player duration]
-%d min.
+%s min.
 == 
 
 [Demo player duration]
-%d sec.
+%s sec.
 == 
 
 Change the skip duration
@@ -1784,9 +1797,6 @@ Reset controls
 == 
 
 Are you sure that you want to reset the controls to their defaults?
-== 
-
-Cancel
 == 
 
 Windowed

--- a/data/languages/azerbaijani.txt
+++ b/data/languages/azerbaijani.txt
@@ -2008,9 +2008,6 @@ Active: Hook
 "%s" is not compatible with pnglite and cannot be loaded by old DDNet versions:
 == "%s" pnglite ilə uyğun gəlmir və köhnə DDnet versiyaları tərəfindən yüklənə bilmir.
 
-Loading background map
-== Fon xəritəsi yüklənir
-
 [Spectating Camera Mode Icon]
 AUTO
 == AVTOMATİK
@@ -2121,7 +2118,20 @@ Out of VRAM. Try setting 'cl_skins_loaded_max' to a lower value or remove custom
 No demo with this filename exists
 == 
 
+[Spectating]
+Following %d: %s
+== 
+
+Loading map
+== 
+
 This name cannot be used for files and folders
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Map size

--- a/data/languages/belarusian.txt
+++ b/data/languages/belarusian.txt
@@ -1847,9 +1847,6 @@ No demo with this filename exists
 Some fonts could not be loaded. Check the local console for details.
 == Некаторыя шрыфты не атрымалася загрузіць. Для атрымання дэталей праверце лакальную кансоль.
 
-Loading background map
-== Загрузка фонавай карты
-
 Auto-sync player camera
 == Аўтасінхранізацыя з камерай гульца
 
@@ -2180,7 +2177,20 @@ Active: Hook
 Out of VRAM. Try setting 'cl_skins_loaded_max' to a lower value or remove custom assets (skins, entities, etc.), especially those with high resolution.
 == 
 
+[Spectating]
+Following %d: %s
+== 
+
+Loading map
+== 
+
 This name cannot be used for files and folders
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 This skin name cannot be used.

--- a/data/languages/bosnian.txt
+++ b/data/languages/bosnian.txt
@@ -1006,9 +1006,6 @@ Restarting. Please wait…
 Loading skin files
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -1081,6 +1078,10 @@ Multi-View
 == 
 
 [Spectating]
+Following %d: %s
+== 
+
+[Spectating]
 Following %s
 == 
 
@@ -1092,6 +1093,9 @@ Team %d
 == 
 
 Some map images could not be loaded. Check the local console for details.
+== 
+
+Loading map
 == 
 
 Uploading map data to GPU
@@ -1176,6 +1180,15 @@ Join Tutorial Server
 == 
 
 Skip Tutorial
+== 
+
+Cancel
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Unable to save the skin with a reserved name
@@ -1324,11 +1337,11 @@ Go back the specified duration
 == 
 
 [Demo player duration]
-%d min.
+%s min.
 == 
 
 [Demo player duration]
-%d sec.
+%s sec.
 == 
 
 Change the skip duration
@@ -1707,9 +1720,6 @@ Reset controls
 == 
 
 Are you sure that you want to reset the controls to their defaults?
-== 
-
-Cancel
 == 
 
 Windowed

--- a/data/languages/brazilian_portuguese.txt
+++ b/data/languages/brazilian_portuguese.txt
@@ -2203,13 +2203,13 @@ Dragger Inner Color
 
 [Spectating]
 Following %d: %s
-== 
+== Seguindo %d: %s
 
 Loading map
-== 
+== Carregando mapa
 
 Error checking player name
-== 
+== Erro ao verificar nome de jogador
 
 Could not check for existing player with your name. Check your internet connection.
-== 
+== Não foi possível verificar se há um jogador com o seu nome. Verifique sua conexão de internet. 

--- a/data/languages/brazilian_portuguese.txt
+++ b/data/languages/brazilian_portuguese.txt
@@ -2008,9 +2008,6 @@ Active: Hook
 "%s" is not compatible with pnglite and cannot be loaded by old DDNet versions:
 == "%s" não é compatível com pnglite e não pode ser carregado por versões antigas do DDNet:
 
-Loading background map
-== Carregando mapa de fundo
-
 [Spectating Camera Mode Icon]
 AUTO
 == AUTO
@@ -2203,3 +2200,16 @@ Dragger Outline Color
 
 Dragger Inner Color
 == Cor interna do dragger
+
+[Spectating]
+Following %d: %s
+== 
+
+Loading map
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
+== 

--- a/data/languages/bulgarian.txt
+++ b/data/languages/bulgarian.txt
@@ -625,9 +625,6 @@ Loading skin files
 Search
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -703,6 +700,10 @@ Multi-View
 == 
 
 [Spectating]
+Following %d: %s
+== 
+
+[Spectating]
 Following %s
 == 
 
@@ -720,6 +721,9 @@ Team %d
 == 
 
 Some map images could not be loaded. Check the local console for details.
+== 
+
+Loading map
 == 
 
 Uploading map data to GPU
@@ -849,6 +853,15 @@ Show DDNet map finishes in server browser
 == 
 
 transmits your player name to info.ddnet.org
+== 
+
+Cancel
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Unable to save the skin with a reserved name
@@ -1015,11 +1028,11 @@ Go back the specified duration
 == 
 
 [Demo player duration]
-%d min.
+%s min.
 == 
 
 [Demo player duration]
-%d sec.
+%s sec.
 == 
 
 Change the skip duration
@@ -1527,9 +1540,6 @@ Reset controls
 == 
 
 Are you sure that you want to reset the controls to their defaults?
-== 
-
-Cancel
 == 
 
 Windowed

--- a/data/languages/catalan.txt
+++ b/data/languages/catalan.txt
@@ -1247,9 +1247,6 @@ Restarting. Please wait…
 Loading skin files
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -1319,6 +1316,10 @@ Multi-View
 == 
 
 [Spectating]
+Following %d: %s
+== 
+
+[Spectating]
 Following %s
 == 
 
@@ -1330,6 +1331,9 @@ Team %d
 == 
 
 Some map images could not be loaded. Check the local console for details.
+== 
+
+Loading map
 == 
 
 Uploading map data to GPU
@@ -1390,6 +1394,15 @@ Videos directory
 == 
 
 Video was saved to '%s'
+== 
+
+Cancel
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Unable to save the skin with a reserved name
@@ -1493,11 +1506,11 @@ Go back the specified duration
 == 
 
 [Demo player duration]
-%d min.
+%s min.
 == 
 
 [Demo player duration]
-%d sec.
+%s sec.
 == 
 
 Change the skip duration
@@ -1834,9 +1847,6 @@ Reset controls
 == 
 
 Are you sure that you want to reset the controls to their defaults?
-== 
-
-Cancel
 == 
 
 Allows maps to render with more detail

--- a/data/languages/chuvash.txt
+++ b/data/languages/chuvash.txt
@@ -628,9 +628,6 @@ Loading skin files
 Search
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -706,6 +703,10 @@ Multi-View
 == 
 
 [Spectating]
+Following %d: %s
+== 
+
+[Spectating]
 Following %s
 == 
 
@@ -723,6 +724,9 @@ Team %d
 == 
 
 Some map images could not be loaded. Check the local console for details.
+== 
+
+Loading map
 == 
 
 Uploading map data to GPU
@@ -852,6 +856,15 @@ Show DDNet map finishes in server browser
 == 
 
 transmits your player name to info.ddnet.org
+== 
+
+Cancel
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Unable to save the skin with a reserved name
@@ -1018,11 +1031,11 @@ Go back the specified duration
 == 
 
 [Demo player duration]
-%d min.
+%s min.
 == 
 
 [Demo player duration]
-%d sec.
+%s sec.
 == 
 
 Change the skip duration
@@ -1527,9 +1540,6 @@ Reset controls
 == 
 
 Are you sure that you want to reset the controls to their defaults?
-== 
-
-Cancel
 == 
 
 Windowed

--- a/data/languages/czech.txt
+++ b/data/languages/czech.txt
@@ -1920,9 +1920,6 @@ No demo with this filename exists
 Some fonts could not be loaded. Check the local console for details.
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -1949,11 +1946,24 @@ Active
 Loading maps…
 == 
 
+[Spectating]
+Following %d: %s
+== 
+
 [Spectating Camera Mode Icon]
 AUTO
 == 
 
+Loading map
+== 
+
 This name cannot be used for files and folders
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Online friends (%d)

--- a/data/languages/danish.txt
+++ b/data/languages/danish.txt
@@ -1143,9 +1143,6 @@ Restarting. Please wait…
 Loading skin files
 == Indlæser skinfiler
 
-Loading background map
-== Indlæser baggrundsbane
-
 Auto-sync player camera
 == Auto-sync spiller kamera
 
@@ -2123,7 +2120,20 @@ Out of VRAM. Try setting 'cl_skins_loaded_max' to a lower value or remove custom
 No demo with this filename exists
 == 
 
+[Spectating]
+Following %d: %s
+== 
+
+Loading map
+== 
+
 This name cannot be used for files and folders
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Map size

--- a/data/languages/dutch.txt
+++ b/data/languages/dutch.txt
@@ -1266,9 +1266,6 @@ Restarting. Please wait…
 Loading skin files
 == Skin-bestanden laden
 
-Loading background map
-== Achtergrondmap laden
-
 Searching
 == Zoeken
 
@@ -2123,7 +2120,20 @@ Out of VRAM. Try setting 'cl_skins_loaded_max' to a lower value or remove custom
 No demo with this filename exists
 == 
 
+[Spectating]
+Following %d: %s
+== 
+
+Loading map
+== 
+
 This name cannot be used for files and folders
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Map size

--- a/data/languages/esperanto.txt
+++ b/data/languages/esperanto.txt
@@ -647,9 +647,6 @@ Restarting. Please wait…
 Loading skin files
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -722,6 +719,10 @@ Multi-View
 == 
 
 [Spectating]
+Following %d: %s
+== 
+
+[Spectating]
 Following %s
 == 
 
@@ -739,6 +740,9 @@ Team %d
 == 
 
 Some map images could not be loaded. Check the local console for details.
+== 
+
+Loading map
 == 
 
 Uploading map data to GPU
@@ -841,6 +845,15 @@ Show DDNet map finishes in server browser
 == 
 
 transmits your player name to info.ddnet.org
+== 
+
+Cancel
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Unable to save the skin with a reserved name
@@ -983,11 +996,11 @@ Go back the specified duration
 == 
 
 [Demo player duration]
-%d min.
+%s min.
 == 
 
 [Demo player duration]
-%d sec.
+%s sec.
 == 
 
 Change the skip duration
@@ -1552,9 +1565,6 @@ Reset controls
 == 
 
 Are you sure that you want to reset the controls to their defaults?
-== 
-
-Cancel
 == 
 
 Voting

--- a/data/languages/estonian.txt
+++ b/data/languages/estonian.txt
@@ -1848,9 +1848,6 @@ No demo with this filename exists
 Some fonts could not be loaded. Check the local console for details.
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -1877,8 +1874,15 @@ Active
 Loading maps…
 == 
 
+[Spectating]
+Following %d: %s
+== 
+
 [Spectating Camera Mode Icon]
 AUTO
+== 
+
+Loading map
 == 
 
 Save skin
@@ -1888,6 +1892,12 @@ Are you sure you want to save your skin? If a skin with this name already exists
 == 
 
 This name cannot be used for files and folders
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Unable to save the skin with a reserved name

--- a/data/languages/finnish.txt
+++ b/data/languages/finnish.txt
@@ -1809,9 +1809,6 @@ No demo with this filename exists
 Some fonts could not be loaded. Check the local console for details.
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -1839,11 +1836,18 @@ Loading maps…
 == 
 
 [Spectating]
+Following %d: %s
+== 
+
+[Spectating]
 Following %s
 == 
 
 [Spectating Camera Mode Icon]
 AUTO
+== 
+
+Loading map
 == 
 
 Save skin
@@ -1853,6 +1857,12 @@ Are you sure you want to save your skin? If a skin with this name already exists
 == 
 
 This name cannot be used for files and folders
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Unable to save the skin with a reserved name

--- a/data/languages/french.txt
+++ b/data/languages/french.txt
@@ -2021,9 +2021,6 @@ No demo with this filename exists
 "%s" is not compatible with pnglite and cannot be loaded by old DDNet versions:
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -2050,11 +2047,24 @@ Active
 Loading maps…
 == 
 
+[Spectating]
+Following %d: %s
+== 
+
 [Spectating Camera Mode Icon]
 AUTO
 == 
 
+Loading map
+== 
+
 This name cannot be used for files and folders
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Toggle auto camera

--- a/data/languages/galician.txt
+++ b/data/languages/galician.txt
@@ -1575,9 +1575,6 @@ Quitting. Please wait…
 Restarting. Please wait…
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -1638,6 +1635,10 @@ Multi-View
 == 
 
 [Spectating]
+Following %d: %s
+== 
+
+[Spectating]
 Following %s
 == 
 
@@ -1646,6 +1647,9 @@ AUTO
 == 
 
 Some map images could not be loaded. Check the local console for details.
+== 
+
+Loading map
 == 
 
 Some map sounds could not be loaded. Check the local console for details.
@@ -1702,6 +1706,12 @@ Videos directory
 Video was saved to '%s'
 == 
 
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
+== 
+
 Unable to save the skin with a reserved name
 == 
 
@@ -1745,11 +1755,11 @@ Go back the specified duration
 == 
 
 [Demo player duration]
-%d min.
+%s min.
 == 
 
 [Demo player duration]
-%d sec.
+%s sec.
 == 
 
 Change the skip duration

--- a/data/languages/german.txt
+++ b/data/languages/german.txt
@@ -2005,9 +2005,6 @@ Active: Hook
 Preview 'Hook collisions' being pressed
 == Vorschau für 'Hakenkollisionen' gedrückt
 
-Loading background map
-== Hintergrund-Karte laden
-
 [Spectating Camera Mode Icon]
 AUTO
 == AUTO
@@ -2203,3 +2200,16 @@ Dragger Outline Color
 
 Dragger Inner Color
 == Dragger-Innenfarbe
+
+[Spectating]
+Following %d: %s
+== Folge %d: %s
+
+Loading map
+== Karte laden
+
+Error checking player name
+== Fehler beim Prüfen des Spielernamens
+
+Could not check for existing player with your name. Check your internet connection.
+== Konnte nicht prüfen ob ein Spieler mit deinem Namen existiert. Prüfe deine Internetverbindung.

--- a/data/languages/greek.txt
+++ b/data/languages/greek.txt
@@ -634,9 +634,6 @@ Loading skin files
 Search
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -709,6 +706,10 @@ Multi-View
 == 
 
 [Spectating]
+Following %d: %s
+== 
+
+[Spectating]
 Following %s
 == 
 
@@ -726,6 +727,9 @@ Team %d
 == 
 
 Some map images could not be loaded. Check the local console for details.
+== 
+
+Loading map
 == 
 
 Uploading map data to GPU
@@ -855,6 +859,15 @@ Show DDNet map finishes in server browser
 == 
 
 transmits your player name to info.ddnet.org
+== 
+
+Cancel
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Unable to save the skin with a reserved name
@@ -1021,11 +1034,11 @@ Go back the specified duration
 == 
 
 [Demo player duration]
-%d min.
+%s min.
 == 
 
 [Demo player duration]
-%d sec.
+%s sec.
 == 
 
 Change the skip duration
@@ -1530,9 +1543,6 @@ Reset controls
 == 
 
 Are you sure that you want to reset the controls to their defaults?
-== 
-
-Cancel
 == 
 
 Windowed

--- a/data/languages/hungarian.txt
+++ b/data/languages/hungarian.txt
@@ -1559,9 +1559,6 @@ Quitting. Please wait…
 Restarting. Please wait…
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -1622,6 +1619,10 @@ Multi-View
 == 
 
 [Spectating]
+Following %d: %s
+== 
+
+[Spectating]
 Following %s
 == 
 
@@ -1630,6 +1631,9 @@ AUTO
 == 
 
 Some map images could not be loaded. Check the local console for details.
+== 
+
+Loading map
 == 
 
 Some map sounds could not be loaded. Check the local console for details.
@@ -1684,6 +1688,12 @@ Videos directory
 == 
 
 Video was saved to '%s'
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Unable to save the skin with a reserved name
@@ -1748,11 +1758,11 @@ Go back the specified duration
 == 
 
 [Demo player duration]
-%d min.
+%s min.
 == 
 
 [Demo player duration]
-%d sec.
+%s sec.
 == 
 
 Change the skip duration

--- a/data/languages/italian.txt
+++ b/data/languages/italian.txt
@@ -1420,9 +1420,6 @@ Why are you slowmo replaying to read this?
 Loading skin files
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -1480,6 +1477,10 @@ Loading maps…
 == 
 
 [Spectating]
+Following %d: %s
+== 
+
+[Spectating]
 Following %s
 == 
 
@@ -1488,6 +1489,9 @@ AUTO
 == 
 
 Some map images could not be loaded. Check the local console for details.
+== 
+
+Loading map
 == 
 
 Some map sounds could not be loaded. Check the local console for details.
@@ -1527,6 +1531,12 @@ Videos directory
 == 
 
 Video was saved to '%s'
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Unable to save the skin with a reserved name
@@ -1612,11 +1622,11 @@ Go back the specified duration
 == 
 
 [Demo player duration]
-%d min.
+%s min.
 == 
 
 [Demo player duration]
-%d sec.
+%s sec.
 == 
 
 Change the skip duration

--- a/data/languages/japanese.txt
+++ b/data/languages/japanese.txt
@@ -1187,9 +1187,6 @@ Restarting. Please wait…
 Loading skin files
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -1259,6 +1256,10 @@ Multi-View
 == 
 
 [Spectating]
+Following %d: %s
+== 
+
+[Spectating]
 Following %s
 == 
 
@@ -1270,6 +1271,9 @@ Team %d
 == 
 
 Some map images could not be loaded. Check the local console for details.
+== 
+
+Loading map
 == 
 
 Uploading map data to GPU
@@ -1336,6 +1340,15 @@ Join Tutorial Server
 == 
 
 Skip Tutorial
+== 
+
+Cancel
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Unable to save the skin with a reserved name
@@ -1463,11 +1476,11 @@ Go back the specified duration
 == 
 
 [Demo player duration]
-%d min.
+%s min.
 == 
 
 [Demo player duration]
-%d sec.
+%s sec.
 == 
 
 Change the skip duration
@@ -1810,9 +1823,6 @@ Reset controls
 == 
 
 Are you sure that you want to reset the controls to their defaults?
-== 
-
-Cancel
 == 
 
 Windowed fullscreen

--- a/data/languages/korean.txt
+++ b/data/languages/korean.txt
@@ -1517,9 +1517,6 @@ Quitting. Please wait…
 Restarting. Please wait…
 == 재시작 중입니다. 잠시만 기다려 주십시오…
 
-Loading background map
-== 배경 맵 로딩 중
-
 Searching
 == 검색
 
@@ -2126,7 +2123,20 @@ Out of VRAM. Try setting 'cl_skins_loaded_max' to a lower value or remove custom
 No demo with this filename exists
 == 
 
+[Spectating]
+Following %d: %s
+== 
+
+Loading map
+== 
+
 This name cannot be used for files and folders
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Map size

--- a/data/languages/kyrgyz.txt
+++ b/data/languages/kyrgyz.txt
@@ -632,9 +632,6 @@ Loading skin files
 Search
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -707,6 +704,10 @@ Multi-View
 == 
 
 [Spectating]
+Following %d: %s
+== 
+
+[Spectating]
 Following %s
 == 
 
@@ -724,6 +725,9 @@ Team %d
 == 
 
 Some map images could not be loaded. Check the local console for details.
+== 
+
+Loading map
 == 
 
 Uploading map data to GPU
@@ -853,6 +857,15 @@ Show DDNet map finishes in server browser
 == 
 
 transmits your player name to info.ddnet.org
+== 
+
+Cancel
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Unable to save the skin with a reserved name
@@ -1019,11 +1032,11 @@ Go back the specified duration
 == 
 
 [Demo player duration]
-%d min.
+%s min.
 == 
 
 [Demo player duration]
-%d sec.
+%s sec.
 == 
 
 Change the skip duration
@@ -1528,9 +1541,6 @@ Reset controls
 == 
 
 Are you sure that you want to reset the controls to their defaults?
-== 
-
-Cancel
 == 
 
 Windowed

--- a/data/languages/norwegian.txt
+++ b/data/languages/norwegian.txt
@@ -1154,9 +1154,6 @@ Restarting. Please wait…
 Loading skin files
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -1226,6 +1223,10 @@ Multi-View
 == 
 
 [Spectating]
+Following %d: %s
+== 
+
+[Spectating]
 Following %s
 == 
 
@@ -1237,6 +1238,9 @@ Team %d
 == 
 
 Some map images could not be loaded. Check the local console for details.
+== 
+
+Loading map
 == 
 
 Uploading map data to GPU
@@ -1303,6 +1307,15 @@ Join Tutorial Server
 == 
 
 Skip Tutorial
+== 
+
+Cancel
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Unable to save the skin with a reserved name
@@ -1436,11 +1449,11 @@ Go back the specified duration
 == 
 
 [Demo player duration]
-%d min.
+%s min.
 == 
 
 [Demo player duration]
-%d sec.
+%s sec.
 == 
 
 Change the skip duration
@@ -1789,9 +1802,6 @@ Reset controls
 == 
 
 Are you sure that you want to reset the controls to their defaults?
-== 
-
-Cancel
 == 
 
 Windowed

--- a/data/languages/persian.txt
+++ b/data/languages/persian.txt
@@ -1903,9 +1903,6 @@ The width of texture %s is not divisible by %d, or the height is not divisible b
 Some fonts could not be loaded. Check the local console for details.
 == .ﺪﯿﻨﻛ ﯽﺳﺭﺮﺑ ﺍﺭ ﯽﻠﺤﻣ ﻝﻮﺴﻨﻛ ،ﺮﺘﺸﯿﺑ ﺕﺎﯿﺋﺰﺟ ىﺍﺮﺑ .ﺪﻧﺪﺸﻧ ىﺭﺍﺬﮔﺭﺎﺑ ﺎﻫﺖﻧﻮﻓ ﯽﺧﺮﺑ
 
-Loading background map
-== ﻪﻨﯿﻣﺯﺲﭘ ﻪﺸﻘﻧ ىﺭﺍﺬﮔﺭﺎﺑ ﻝﺎﺣ ﺭﺩ
-
 [Spectating Camera Mode Icon]
 AUTO
 == ﺭﺎﻛﺩﻮﺧ
@@ -2069,7 +2066,20 @@ Active
 Loading maps…
 == 
 
+[Spectating]
+Following %d: %s
+== 
+
+Loading map
+== 
+
 This name cannot be used for files and folders
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Map size

--- a/data/languages/polish.txt
+++ b/data/languages/polish.txt
@@ -1909,9 +1909,6 @@ https://wiki.ddnet.org/wiki/Mapping
 Some fonts could not be loaded. Check the local console for details.
 == Nie można załadować niektórych czcionek. Sprawdź konsolę, aby uzyskać szczegóły.
 
-Loading background map
-== Ładowanie tła mapy
-
 [Spectating Camera Mode Icon]
 AUTO
 == AUTO
@@ -2205,3 +2202,16 @@ Dragger Outline Color
 
 Dragger Inner Color
 == Kolor zewnętrzny draggera
+
+[Spectating]
+Following %d: %s
+== 
+
+Loading map
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
+== 

--- a/data/languages/portuguese.txt
+++ b/data/languages/portuguese.txt
@@ -942,9 +942,6 @@ Restarting. Please wait…
 Loading skin files
 == A carregar os ficheiros de skin
 
-Loading background map
-== A carregar o mapa de fundo
-
 Searching
 == A pesquisar
 
@@ -2070,7 +2067,20 @@ Active
 Loading maps…
 == 
 
+[Spectating]
+Following %d: %s
+== 
+
+Loading map
+== 
+
 This name cannot be used for files and folders
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Map size

--- a/data/languages/romanian.txt
+++ b/data/languages/romanian.txt
@@ -2010,9 +2010,6 @@ https://wiki.ddnet.org/wiki/Mapping
 "%s" is not compatible with pnglite and cannot be loaded by old DDNet versions:
 == "%s" nu este compatibilă cu pnglite și nu poate fi încărcată de versiunile vechi DDNet:
 
-Loading background map
-== Se încarcă harta de fundal
-
 [Spectating Camera Mode Icon]
 AUTO
 == AUTO
@@ -2182,7 +2179,20 @@ AntiPing: prediction margin
 Out of VRAM. Try setting 'cl_skins_loaded_max' to a lower value or remove custom assets (skins, entities, etc.), especially those with high resolution.
 == 
 
+[Spectating]
+Following %d: %s
+== 
+
+Loading map
+== 
+
 This name cannot be used for files and folders
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 This skin name cannot be used.

--- a/data/languages/russian.txt
+++ b/data/languages/russian.txt
@@ -2008,9 +2008,6 @@ Active: Hook
 "%s" is not compatible with pnglite and cannot be loaded by old DDNet versions:
 == "%s" не совместим с pnglite и не может быть загружен старыми версиями DDNet:
 
-Loading background map
-== Загрузка карты фона
-
 Auto-sync player camera
 == Автоматически синхронизировать камеру игрока
 
@@ -2203,3 +2200,16 @@ Dragger Outline Color
 
 Dragger Inner Color
 == Цвет драггера
+
+[Spectating]
+Following %d: %s
+== 
+
+Loading map
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
+== 

--- a/data/languages/serbian.txt
+++ b/data/languages/serbian.txt
@@ -1643,9 +1643,6 @@ Loading demo file from storage
 Some fonts could not be loaded. Check the local console for details.
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -1703,6 +1700,10 @@ Loading maps…
 == 
 
 [Spectating]
+Following %d: %s
+== 
+
+[Spectating]
 Following %s
 == 
 
@@ -1711,6 +1712,9 @@ AUTO
 == 
 
 Some map images could not be loaded. Check the local console for details.
+== 
+
+Loading map
 == 
 
 Some map sounds could not be loaded. Check the local console for details.
@@ -1750,6 +1754,12 @@ Videos directory
 == 
 
 Video was saved to '%s'
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Unable to save the skin with a reserved name
@@ -1792,11 +1802,11 @@ Go back the specified duration
 == 
 
 [Demo player duration]
-%d min.
+%s min.
 == 
 
 [Demo player duration]
-%d sec.
+%s sec.
 == 
 
 Change the skip duration

--- a/data/languages/serbian_cyrillic.txt
+++ b/data/languages/serbian_cyrillic.txt
@@ -1438,9 +1438,6 @@ Quitting. Please wait…
 Restarting. Please wait…
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -1501,6 +1498,10 @@ Multi-View
 == 
 
 [Spectating]
+Following %d: %s
+== 
+
+[Spectating]
 Following %s
 == 
 
@@ -1509,6 +1510,9 @@ AUTO
 == 
 
 Some map images could not be loaded. Check the local console for details.
+== 
+
+Loading map
 == 
 
 Some map sounds could not be loaded. Check the local console for details.
@@ -1566,6 +1570,15 @@ Videos directory
 == 
 
 Video was saved to '%s'
+== 
+
+Cancel
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Unable to save the skin with a reserved name
@@ -1648,11 +1661,11 @@ Go back the specified duration
 == 
 
 [Demo player duration]
-%d min.
+%s min.
 == 
 
 [Demo player duration]
-%d sec.
+%s sec.
 == 
 
 Change the skip duration
@@ -1936,9 +1949,6 @@ Reset controls
 == 
 
 Are you sure that you want to reset the controls to their defaults?
-== 
-
-Cancel
 == 
 
 Show FPS

--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -2133,7 +2133,7 @@ Renders your frame rate in the top right
 
 [Translation credits: Add your own name here when you update translations]
 English translation by the DDNet Team
-== 简体中文翻译由以下人员贡献：MK124, CarolVlCznYu, MC_TYH, Yangfl, Eki, Night_L, TsFreddie, Dan_cao, Momo, cheeser0613, By, Bamcane, Pioooooo, 豆腐渣, XCWQW1
+== 简体中文翻译由以下人员贡献：MK124, CarolVlCznYu, MC_TYH, Yangfl, Eki, Night_L, TsFreddie, Dan_cao, Momo, cheeser0613, By, Bamcane, Pioooooo, 豆腐渣, XCWQW1, Zerol Acqua
 
 Show spectator cursor
 == 显示旁观者光标
@@ -2209,13 +2209,13 @@ Dragger Inner Color
 
 [Spectating]
 Following %d: %s
-== 
+== 正在旁观 %d: %s
 
 Loading map
-== 
+== 加载地图
 
 Error checking player name
-== 
+== 检查玩家名称时出错
 
 Could not check for existing player with your name. Check your internet connection.
-== 
+== 无法验证是否已存在相同名称的玩家。请检查你的网络连接。

--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -2023,9 +2023,6 @@ Active: Hook
 "%s" is not compatible with pnglite and cannot be loaded by old DDNet versions:
 == "%s" 与 pnglite 不兼容，无法被旧版本 DDNet 加载
 
-Loading background map
-== 加载背景地图
-
 [Spectating Camera Mode Icon]
 AUTO
 == 自动
@@ -2209,3 +2206,16 @@ Dragger Outline Color
 
 Dragger Inner Color
 == 光索实心颜色
+
+[Spectating]
+Following %d: %s
+== 
+
+Loading map
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
+== 

--- a/data/languages/slovak.txt
+++ b/data/languages/slovak.txt
@@ -1920,9 +1920,6 @@ No demo with this filename exists
 Some fonts could not be loaded. Check the local console for details.
 == 
 
-Loading background map
-== 
-
 Auto-sync player camera
 == 
 
@@ -1949,11 +1946,24 @@ Active
 Loading maps…
 == 
 
+[Spectating]
+Following %d: %s
+== 
+
 [Spectating Camera Mode Icon]
 AUTO
 == 
 
+Loading map
+== 
+
 This name cannot be used for files and folders
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 Online friends (%d)

--- a/data/languages/spanish.txt
+++ b/data/languages/spanish.txt
@@ -2010,9 +2010,6 @@ Active: Hook
 "%s" is not compatible with pnglite and cannot be loaded by old DDNet versions:
 == "%s" no es compatible con pnglite y no puede ser cargado por versiones de DDNet antiguas:
 
-Loading background map
-== Cargando el mapa de fondo
-
 [Spectating Camera Mode Icon]
 AUTO
 == AUTO
@@ -2205,3 +2202,16 @@ Dragger Outline Color
 
 Dragger Inner Color
 == Color interno del arrastrador
+
+[Spectating]
+Following %d: %s
+== 
+
+Loading map
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
+== 

--- a/data/languages/swedish.txt
+++ b/data/languages/swedish.txt
@@ -2008,9 +2008,6 @@ Active: Hook
 "%s" is not compatible with pnglite and cannot be loaded by old DDNet versions:
 == "%s" är inte en kompatibel med pnglite och kan inte laddas in av äldre versioner av DDNet:
 
-Loading background map
-== Laddar bakgrundsmap
-
 [Spectating Camera Mode Icon]
 AUTO
 == AUTO
@@ -2180,7 +2177,20 @@ AntiPing: prediction margin
 Out of VRAM. Try setting 'cl_skins_loaded_max' to a lower value or remove custom assets (skins, entities, etc.), especially those with high resolution.
 == 
 
+[Spectating]
+Following %d: %s
+== 
+
+Loading map
+== 
+
 This name cannot be used for files and folders
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
 == 
 
 This skin name cannot be used.

--- a/data/languages/traditional_chinese.txt
+++ b/data/languages/traditional_chinese.txt
@@ -2023,9 +2023,6 @@ Active: Hook
 "%s" is not compatible with pnglite and cannot be loaded by old DDNet versions:
 == "%s" 與 pnglite 不兼容，無法被舊版本 DDNet 加載
 
-Loading background map
-== 加載背景地圖
-
 [Spectating Camera Mode Icon]
 AUTO
 == 自動
@@ -2209,3 +2206,16 @@ Dragger Outline Color
 
 Dragger Inner Color
 == 光索實心顏色
+
+[Spectating]
+Following %d: %s
+== 
+
+Loading map
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
+== 

--- a/data/languages/turkish.txt
+++ b/data/languages/turkish.txt
@@ -2008,9 +2008,6 @@ Active: Hook
 "%s" is not compatible with pnglite and cannot be loaded by old DDNet versions:
 == "%s" pnglite ile uyumlu değil ve eski DDnet versiyonları tarafından yüklenemiyor:
 
-Loading background map
-== Arkaplan haritası yükleniyor
-
 [Spectating Camera Mode Icon]
 AUTO
 == OTOMATİK
@@ -2203,3 +2200,16 @@ Dragger Inner Color
 
 AntiPing: prediction margin
 == AntiPing: tahmin marjı
+
+[Spectating]
+Following %d: %s
+== 
+
+Loading map
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
+== 

--- a/data/languages/turkish.txt
+++ b/data/languages/turkish.txt
@@ -2203,13 +2203,13 @@ AntiPing: prediction margin
 
 [Spectating]
 Following %d: %s
-== 
+== İzleniyor %d: %s
 
 Loading map
-== 
+== Harita yükleniyor
 
 Error checking player name
-== 
+== Oyuncu adı kontrol edilirken hata
 
 Could not check for existing player with your name. Check your internet connection.
-== 
+== Adınıza sahip mevcut oyuncu olup olmadığı kontrol edilemedi. İnternet bağlantınızı kontrol edin.

--- a/data/languages/turkish.txt
+++ b/data/languages/turkish.txt
@@ -596,7 +596,7 @@ Downloading %s:
 == İndiriliyor %s:
 
 Update failed! Check log…
-== Güncelleme sırasında hata oluştu!
+== Güncelleme sırasında hata oluştu…
 
 DDNet Client updated!
 == DDNet İstemcisi güncellendi!
@@ -2209,7 +2209,7 @@ Loading map
 == Harita yükleniyor
 
 Error checking player name
-== Oyuncu adı kontrol edilirken hata
+== Oyuncu adı kontrol edilirken hata oluştu
 
 Could not check for existing player with your name. Check your internet connection.
 == Adınıza sahip mevcut oyuncu olup olmadığı kontrol edilemedi. İnternet bağlantınızı kontrol edin.

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -1024,9 +1024,6 @@ Loading…
 Loading assets
 == Завантаження текстур
 
-Loading background map
-== Завантаження мапи-тла
-
 Loading commands…
 == Завантаження команд…
 
@@ -2203,3 +2200,16 @@ Dragger Inner Color
 
 AntiPing: prediction margin
 == AntiPing: допуск передбачення
+
+[Spectating]
+Following %d: %s
+== 
+
+Loading map
+== 
+
+Error checking player name
+== 
+
+Could not check for existing player with your name. Check your internet connection.
+== 

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -2203,13 +2203,13 @@ AntiPing: prediction margin
 
 [Spectating]
 Following %d: %s
-== 
+== Спостерігає за %d: %s
 
 Loading map
-== 
+== Завантаження мапи
 
 Error checking player name
-== 
+== Помилка перевірки імені гравця
 
 Could not check for existing player with your name. Check your internet connection.
-== 
+== Не вдалося перевірити, чи існує гравець із таким іменем. Перевірте з'єднання з інтернетом.

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -124,7 +124,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	};
 
 	static constexpr float SKIP_DURATIONS_SECONDS[] = {0.1f, 0.5f, 1.0f, 5.0f, 10.0f, 30.0f, 60.0f, 5.0f * 60.0f, 10.0f * 60.0f};
-	static constexpr const char *SKIP_DURATIONS_STRINGS[] = {"0.1", "0.5", "1", "5", "10", "30", "60", "5", "10"};
+	static constexpr const char *SKIP_DURATIONS_STRINGS[] = {"0.1", "0.5", "1", "5", "10", "30", "1", "5", "10"};
 	static_assert(SKIP_DURATIONS_SECONDS[DEFAULT_SKIP_DURATION_INDEX] == 5.0f);
 	static_assert(std::size(SKIP_DURATIONS_SECONDS) == std::size(SKIP_DURATIONS_STRINGS));
 

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -712,38 +712,16 @@ void CNamePlates::RenderNamePlateGame(vec2 Position, const CNetObj_PlayerInfo *p
 		const int SelectedId = Following ? GameClient()->m_Snap.m_SpecInfo.m_SpectatorId : GameClient()->m_Snap.m_LocalClientId;
 		const CGameClient::CSnapState::CCharacterInfo &Selected = GameClient()->m_Snap.m_aCharacters[SelectedId];
 		const CGameClient::CSnapState::CCharacterInfo &Other = GameClient()->m_Snap.m_aCharacters[pPlayerInfo->m_ClientId];
-
-		const bool ShouldShowIndicator = Other.m_HasExtendedData && (GameClient()->m_Snap.m_pLocalInfo && (GameClient()->m_Snap.m_pLocalInfo->m_Team != TEAM_SPECTATORS || Following));
-
-		if(ShouldShowIndicator)
+		if(Selected.m_HasExtendedData && Other.m_HasExtendedData)
 		{
 			Data.m_HookStrongWeakId = Other.m_ExtendedData.m_StrongWeakId;
 			Data.m_ShowHookStrongWeakId = g_Config.m_Debug || g_Config.m_ClNamePlatesStrong == 2;
-
-			// Get selected player's StrongWeakId from snap data or saved local data
-			int SelectedStrongWeakId = 0;
-			bool HasSelectedId = false;
-
-			if(Selected.m_HasExtendedData)
+			if(SelectedId == pPlayerInfo->m_ClientId)
+				Data.m_ShowHookStrongWeak = Data.m_ShowHookStrongWeakId;
+			else
 			{
-				SelectedStrongWeakId = Selected.m_ExtendedData.m_StrongWeakId;
-				HasSelectedId = true;
-			}
-			else if(!Following && GameClient()->LocalStrongWeakId(g_Config.m_ClDummy) != -1)
-			{
-				SelectedStrongWeakId = GameClient()->LocalStrongWeakId(g_Config.m_ClDummy);
-				HasSelectedId = true;
-			}
-
-			if(HasSelectedId)
-			{
-				if(SelectedId == pPlayerInfo->m_ClientId)
-					Data.m_ShowHookStrongWeak = Data.m_ShowHookStrongWeakId;
-				else
-				{
-					Data.m_HookStrongWeakState = SelectedStrongWeakId > Other.m_ExtendedData.m_StrongWeakId ? EHookStrongWeakState::STRONG : EHookStrongWeakState::WEAK;
-					Data.m_ShowHookStrongWeak = g_Config.m_Debug || g_Config.m_ClNamePlatesStrong > 0;
-				}
+				Data.m_HookStrongWeakState = Selected.m_ExtendedData.m_StrongWeakId > Other.m_ExtendedData.m_StrongWeakId ? EHookStrongWeakState::STRONG : EHookStrongWeakState::WEAK;
+				Data.m_ShowHookStrongWeak = g_Config.m_Debug || g_Config.m_ClNamePlatesStrong > 0;
 			}
 		}
 	}

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -618,7 +618,6 @@ void CGameClient::OnReset()
 	m_LastFlagCarrierBlue = -4;
 
 	std::fill(std::begin(m_aCheckInfo), std::end(m_aCheckInfo), -1);
-	std::fill(std::begin(m_aLocalStrongWeakId), std::end(m_aLocalStrongWeakId), -1);
 
 	// m_aDDNetVersionStr is initialized once in OnInit
 
@@ -1773,14 +1772,6 @@ void CGameClient::OnNewSnapshot()
 					if(pCharacterData->m_JumpedTotal != -1)
 					{
 						m_Snap.m_aCharacters[Item.m_Id].m_HasExtendedDisplayInfo = true;
-					}
-
-					// Store local player's StrongWeakId for when snap data is unavailable
-					auto *it = std::find(std::begin(m_aLocalIds), std::end(m_aLocalIds), Item.m_Id);
-					if(it != std::end(m_aLocalIds))
-					{
-						int Dummy = it - std::begin(m_aLocalIds);
-						m_aLocalStrongWeakId[Dummy] = pCharacterData->m_StrongWeakId;
 					}
 					CClientData *pClient = &m_aClients[Item.m_Id];
 					// Collision

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1118,18 +1118,6 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 		// reset character prediction
 		if(!(m_GameWorld.m_WorldConfig.m_IsFNG && pMsg->m_Weapon == WEAPON_LASER))
 		{
-			// update saved strong/weak ids if our character isn't on screen
-			for(int DummyId = 0; DummyId < NUM_DUMMIES; DummyId++)
-			{
-				if(m_aLocalIds[DummyId] == -1)
-					continue;
-
-				if(pMsg->m_Victim == m_aLocalIds[DummyId])
-					m_aLocalStrongWeakId[DummyId] = 0;
-				else if(m_CharOrder.HasStrongAgainst(m_aLocalIds[DummyId], pMsg->m_Victim))
-					m_aLocalStrongWeakId[DummyId]++;
-			}
-
 			m_CharOrder.GiveWeak(pMsg->m_Victim);
 			if(CCharacter *pChar = m_GameWorld.GetCharacterById(pMsg->m_Victim))
 				pChar->ResetPrediction();
@@ -1171,18 +1159,6 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 		{
 			if(m_Teams.Team(i) == pMsg->m_Team)
 			{
-				// update saved strong/weak ids if our character isn't on screen
-				for(int DummyId = 0; DummyId < NUM_DUMMIES; DummyId++)
-				{
-					if(m_aLocalIds[DummyId] == -1)
-						continue;
-
-					if(i == m_aLocalIds[DummyId])
-						m_aLocalStrongWeakId[DummyId] = 0;
-					else if(m_CharOrder.HasStrongAgainst(m_aLocalIds[DummyId], i))
-						m_aLocalStrongWeakId[DummyId]++;
-				}
-
 				if(CCharacter *pChar = m_GameWorld.GetCharacterById(i))
 				{
 					pChar->ResetPrediction();

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -251,9 +251,6 @@ private:
 	bool m_GamePaused = false;
 	int m_PrevLocalId = -1;
 
-	// Preserved for spectating when snap data unavailable
-	int m_aLocalStrongWeakId[NUM_DUMMIES];
-
 public:
 	IKernel *Kernel() { return IInterface::Kernel(); }
 	IEngine *Engine() const { return m_pEngine; }
@@ -295,7 +292,6 @@ public:
 		return m_NetObjHandler.NumObjCorrections();
 	}
 	const char *NetobjCorrectedOn() { return m_NetObjHandler.CorrectedObjOn(); }
-	int LocalStrongWeakId(int Dummy) const { return m_aLocalStrongWeakId[Dummy]; }
 
 	bool m_SuppressEvents;
 	bool m_NewTick;

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -749,10 +749,6 @@ void CCharacter::HandleTiles(int Index)
 		return;
 	}
 
-	int TeleCheckpoint = Collision()->IsTeleCheckpoint(MapIndex);
-	if(TeleCheckpoint)
-		m_TeleCheckpoint = TeleCheckpoint;
-
 	// handle switch tiles
 	if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHOPEN && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
 	{
@@ -969,103 +965,6 @@ void CCharacter::HandleTiles(int Index)
 	{
 		m_LastRefillJumps = false;
 	}
-
-	int TeleNumber = Collision()->IsTeleport(MapIndex);
-	if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons && TeleNumber && !Collision()->TeleOuts(TeleNumber - 1).empty())
-	{
-		if(m_Core.m_Super || m_Core.m_Invincible)
-			return;
-		if(Collision()->TeleOuts(TeleNumber - 1).size() == 1)
-		{
-			m_Core.m_Pos = Collision()->TeleOuts(TeleNumber - 1)[0];
-			if(!g_Config.m_SvTeleportHoldHook)
-			{
-				ResetHook();
-			}
-			if(g_Config.m_SvTeleportLoseWeapons)
-				ResetPickups();
-		}
-		return;
-	}
-	int EvilTeleNumber = Collision()->IsEvilTeleport(MapIndex);
-	if(EvilTeleNumber && !Collision()->TeleOuts(EvilTeleNumber - 1).empty())
-	{
-		if(m_Core.m_Super || m_Core.m_Invincible)
-			return;
-		if(Collision()->TeleOuts(EvilTeleNumber - 1).size() == 1)
-		{
-			m_Core.m_Pos = Collision()->TeleOuts(EvilTeleNumber - 1)[0];
-			if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons)
-			{
-				m_Core.m_Vel = vec2(0, 0);
-
-				if(!g_Config.m_SvTeleportHoldHook)
-				{
-					ResetHook();
-					GameWorld()->ReleaseHooked(GetCid());
-				}
-				if(g_Config.m_SvTeleportLoseWeapons)
-				{
-					ResetPickups();
-				}
-			}
-		}
-		return;
-	}
-	if(Collision()->IsCheckEvilTeleport(MapIndex))
-	{
-		if(m_Core.m_Super || m_Core.m_Invincible)
-			return;
-		// first check if there is a TeleCheckOut for the current recorded checkpoint, if not check previous checkpoints
-		for(int k = m_TeleCheckpoint - 1; k >= 0; k--)
-		{
-			if(Collision()->TeleCheckOuts(k).size() == 1)
-			{
-				m_Core.m_Pos = Collision()->TeleCheckOuts(k)[0];
-				m_Core.m_Vel = vec2(0, 0);
-
-				if(!g_Config.m_SvTeleportHoldHook)
-				{
-					ResetHook();
-					GameWorld()->ReleaseHooked(GetCid());
-				}
-
-				return;
-			}
-			if(!Collision()->TeleCheckOuts(k).empty())
-			{
-				return;
-			}
-		}
-		// if no checkpointout have been found (or if there no recorded checkpoint), teleport to start
-		return;
-	}
-	if(Collision()->IsCheckTeleport(MapIndex))
-	{
-		if(m_Core.m_Super || m_Core.m_Invincible)
-			return;
-		// first check if there is a TeleCheckOut for the current recorded checkpoint, if not check previous checkpoints
-		for(int k = m_TeleCheckpoint - 1; k >= 0; k--)
-		{
-			if(Collision()->TeleCheckOuts(k).size() == 1)
-			{
-				m_Core.m_Pos = Collision()->TeleCheckOuts(k)[0];
-
-				if(!g_Config.m_SvTeleportHoldHook)
-				{
-					ResetHook();
-				}
-
-				return;
-			}
-			if(!Collision()->TeleCheckOuts(k).empty())
-			{
-				return;
-			}
-		}
-		// if no checkpointout have been found (or if there no recorded checkpoint), teleport to start
-		return;
-	}
 }
 
 void CCharacter::HandleTuneLayer()
@@ -1247,16 +1146,6 @@ void CCharacter::GiveAllWeapons()
 	for(int i = WEAPON_GUN; i < NUM_WEAPONS - 1; i++)
 	{
 		GiveWeapon(i);
-	}
-}
-
-void CCharacter::ResetPickups()
-{
-	for(int i = WEAPON_SHOTGUN; i < NUM_WEAPONS - 1; i++)
-	{
-		m_Core.m_aWeapons[i].m_Got = false;
-		if(m_Core.m_ActiveWeapon == i)
-			m_Core.m_ActiveWeapon = WEAPON_GUN;
 	}
 }
 

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -69,7 +69,6 @@ public:
 	bool Freeze();
 	bool UnFreeze();
 	void GiveAllWeapons();
-	void ResetPickups();
 	int Team();
 	bool CanCollide(int ClientId) override;
 	bool SameTeam(int ClientId);

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1935,13 +1935,13 @@ void CCharacter::HandleTiles(int Index)
 		m_LastBonus = false;
 	}
 
-	int TeleNumber = Collision()->IsTeleport(MapIndex);
-	if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons && TeleNumber && !Collision()->TeleOuts(TeleNumber - 1).empty())
+	int z = Collision()->IsTeleport(MapIndex);
+	if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons && z && !Collision()->TeleOuts(z - 1).empty())
 	{
 		if(m_Core.m_Super || m_Core.m_Invincible)
 			return;
-		int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleOuts(TeleNumber - 1).size());
-		m_Core.m_Pos = Collision()->TeleOuts(TeleNumber - 1)[TeleOut];
+		int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleOuts(z - 1).size());
+		m_Core.m_Pos = Collision()->TeleOuts(z - 1)[TeleOut];
 		if(!g_Config.m_SvTeleportHoldHook)
 		{
 			ResetHook();
@@ -1950,13 +1950,13 @@ void CCharacter::HandleTiles(int Index)
 			ResetPickups();
 		return;
 	}
-	int EvilTeleNumber = Collision()->IsEvilTeleport(MapIndex);
-	if(EvilTeleNumber && !Collision()->TeleOuts(EvilTeleNumber - 1).empty())
+	int evilz = Collision()->IsEvilTeleport(MapIndex);
+	if(evilz && !Collision()->TeleOuts(evilz - 1).empty())
 	{
 		if(m_Core.m_Super || m_Core.m_Invincible)
 			return;
-		int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleOuts(EvilTeleNumber - 1).size());
-		m_Core.m_Pos = Collision()->TeleOuts(EvilTeleNumber - 1)[TeleOut];
+		int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleOuts(evilz - 1).size());
+		m_Core.m_Pos = Collision()->TeleOuts(evilz - 1)[TeleOut];
 		if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons)
 		{
 			m_Core.m_Vel = vec2(0, 0);


### PR DESCRIPTION
DDNet 19.3 is scheduled to release in 7 days, assuming no bad bugs are found. Please test the Release Candidate to prevent problems being only discovered after release. Report bugs in the #bugs channel on DDNet Discord or directly on Github:

- Windows 64bit: https://ddnet.org/downloads/DDNet-19.3-rc3-win64.zip
- Windows ARM: https://ddnet.org/downloads/DDNet-19.3-rc3-win-arm64.zip
- Windows 32bit: https://ddnet.org/downloads/DDNet-19.3-rc3-win32.zip
- Linux x86: https://ddnet.org/downloads/DDNet-19.3-rc3-linux_x86.tar.xz
- Linux x86-64: https://ddnet.org/downloads/DDNet-19.3-rc3-linux_x86_64.tar.xz
- macOS: https://ddnet.org/downloads/DDNet-19.3-rc3-macos.dmg
- Android: https://ddnet.org/downloads/DDNet-19.3-rc3.apk

You can also test the release candidate in Steam by clicking on Settings -> Properties -> Betas and opting into the Release Candidates. This will automatically update you to a new release candidate when it is available, and to the next release when no new candidate is available. So you can always leave this setting enabled to help us test new releases earlier.
![freeze-laser](https://github.com/user-attachments/assets/c29514a3-5e16-402b-adf7-2ae3832c1d50)
![rotate-weapons](https://github.com/user-attachments/assets/57d57244-b4ae-4733-96d5-2142213f79d8)

https://github.com/user-attachments/assets/c01f6b87-3503-4829-962d-a3c89cbfe409

The following changes are included, ideally test their behavior specifically. But just playing as you do normally also helps:
- [Client] **Add turret prediction** [KebsCS]
- [Client] **Freeze-laser visual update and all outlines for laser** [AssassinTee]
- [Client&Server] **Add rotating and flipping of weapons** [KebsCS]
- [Client] Maplayer render pipeline refactoring [AssassinTee]
- [Client] Add laser head prediction [AssassinTee]
- [Client] Fix strong/weak nameplate disappearing [ASKLL-STAR]
- [Client] Predict ninja skin in freeze [KebsCS]
- [Client] Add id to Spectator HUD [SollyBunny]
- [Client] Show demo play/speed HUD for demo_play/demo_speed commands [Robyt3]
- [Client] Allow spec char and normal nameplate at same time [SollyBunny]
- [Client] HUD info cleanup [SollyBunny]
- [Client] Reveal screen keyboard after selecting text input if closed [Robyt3]
- [Client] Improve base network error handling [Robyt3]
- [Client] Fix CCamera::SetView clamping y pos with map width instead of map height [Pioooooo]
- [Client] Fix removing open files on Windows by first renaming to temporary [Robyt3]
- [Client] Add error handling for checking points on first launch [Robyt3]
- [Client] More precise interval for demo l/r [SollyBunny]
- [Client] Fix server browser being refreshed multiple times on client start [Robyt3]
- [Client] Fix wrong hook collision line length in tune zones [KebsCS]
- [Client] Use protocol7 sizes for clan and name to prevent cutoff [SollyBunny]
- [Client] Fix envelop performance by caching the envelop point access [Jupeyy]
- [Client] Increase number of supported joystick buttons to 24 [Robyt3]
- [Client] Prevent direct touch when active touch button becomes invisible [Robyt3]
- [Client] Various fixes to make Emscripten client runnable again [Robyt3]
- [Editor] Fix view in tele popup for checkpoint teleports [KebsCS]
- [Editor] Fix brush not containing all tile data [AssassinTee]
- [Editor] Fix live gametiles with teles [KebsCS]
- [Server] Correctly align damage indicator [qxdFox]
- [Server] Mute and vote mute improvements [Robyt3]
- [Server] Add sv_register_port for NAT [SollyBunny]
- [Server] Distribute tees across all spawn types [ChillerDragon]
- [Server] Websocket networking fixes [Robyt3]
- [Server] Fix sv_shutdown_when_empty not working while recording demo [Robyt3]
- [Server] Fix teamtop5 showing wrong records [Pioooooo]
- [Server] Fix incorrect tune flags [KebsCS]
- [Server] Fix wrong sixup values in antibot [ChillerDragon]