### PR TITLE
Fix menu background theme not rendered when loading demo map

### DIFF
--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -307,9 +307,6 @@ bool CMenuBackground::Render()
 	if(!m_Loaded)
 		return false;
 
-	if(Client()->State() == IClient::STATE_ONLINE || Client()->State() == IClient::STATE_DEMOPLAYBACK)
-		return false;
-
 	m_Camera.m_Zoom = 0.7f;
 
 	float DistToCenter = distance(m_Camera.m_Center, m_RotationCenter);


### PR DESCRIPTION
The `CMenuBackground::Render` function is called in the `CMenus::RenderLoading` function, where it should always cause the background to be rendered, and in the `CMenus::Render` function, where the client state is already checked before, so the client state should be not checked in the `CMenuBackground::Render` function, as this prevented the menu background from being rendered when loading the map for demo playback.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
