### PR TITLE
Revert "Store StrongWeakId and uses when snap unavailable"

### DIFF
--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -712,38 +712,16 @@ void CNamePlates::RenderNamePlateGame(vec2 Position, const CNetObj_PlayerInfo *p
 		const int SelectedId = Following ? GameClient()->m_Snap.m_SpecInfo.m_SpectatorId : GameClient()->m_Snap.m_LocalClientId;
 		const CGameClient::CSnapState::CCharacterInfo &Selected = GameClient()->m_Snap.m_aCharacters[SelectedId];
 		const CGameClient::CSnapState::CCharacterInfo &Other = GameClient()->m_Snap.m_aCharacters[pPlayerInfo->m_ClientId];
-
-		const bool ShouldShowIndicator = Other.m_HasExtendedData && (GameClient()->m_Snap.m_pLocalInfo && (GameClient()->m_Snap.m_pLocalInfo->m_Team != TEAM_SPECTATORS || Following));
-
-		if(ShouldShowIndicator)
+		if(Selected.m_HasExtendedData && Other.m_HasExtendedData)
 		{
 			Data.m_HookStrongWeakId = Other.m_ExtendedData.m_StrongWeakId;
 			Data.m_ShowHookStrongWeakId = g_Config.m_Debug || g_Config.m_ClNamePlatesStrong == 2;
-
-			// Get selected player's StrongWeakId from snap data or saved local data
-			int SelectedStrongWeakId = 0;
-			bool HasSelectedId = false;
-
-			if(Selected.m_HasExtendedData)
+			if(SelectedId == pPlayerInfo->m_ClientId)
+				Data.m_ShowHookStrongWeak = Data.m_ShowHookStrongWeakId;
+			else
 			{
-				SelectedStrongWeakId = Selected.m_ExtendedData.m_StrongWeakId;
-				HasSelectedId = true;
-			}
-			else if(!Following && GameClient()->LocalStrongWeakId(g_Config.m_ClDummy) != -1)
-			{
-				SelectedStrongWeakId = GameClient()->LocalStrongWeakId(g_Config.m_ClDummy);
-				HasSelectedId = true;
-			}
-
-			if(HasSelectedId)
-			{
-				if(SelectedId == pPlayerInfo->m_ClientId)
-					Data.m_ShowHookStrongWeak = Data.m_ShowHookStrongWeakId;
-				else
-				{
-					Data.m_HookStrongWeakState = SelectedStrongWeakId > Other.m_ExtendedData.m_StrongWeakId ? EHookStrongWeakState::STRONG : EHookStrongWeakState::WEAK;
-					Data.m_ShowHookStrongWeak = g_Config.m_Debug || g_Config.m_ClNamePlatesStrong > 0;
-				}
+				Data.m_HookStrongWeakState = Selected.m_ExtendedData.m_StrongWeakId > Other.m_ExtendedData.m_StrongWeakId ? EHookStrongWeakState::STRONG : EHookStrongWeakState::WEAK;
+				Data.m_ShowHookStrongWeak = g_Config.m_Debug || g_Config.m_ClNamePlatesStrong > 0;
 			}
 		}
 	}

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -618,7 +618,6 @@ void CGameClient::OnReset()
 	m_LastFlagCarrierBlue = -4;
 
 	std::fill(std::begin(m_aCheckInfo), std::end(m_aCheckInfo), -1);
-	std::fill(std::begin(m_aLocalStrongWeakId), std::end(m_aLocalStrongWeakId), -1);
 
 	// m_aDDNetVersionStr is initialized once in OnInit
 
@@ -1749,14 +1748,6 @@ void CGameClient::OnNewSnapshot()
 					if(pCharacterData->m_JumpedTotal != -1)
 					{
 						m_Snap.m_aCharacters[Item.m_Id].m_HasExtendedDisplayInfo = true;
-					}
-
-					// Store local player's StrongWeakId for when snap data is unavailable
-					auto *it = std::find(std::begin(m_aLocalIds), std::end(m_aLocalIds), Item.m_Id);
-					if(it != std::end(m_aLocalIds))
-					{
-						int Dummy = it - std::begin(m_aLocalIds);
-						m_aLocalStrongWeakId[Dummy] = pCharacterData->m_StrongWeakId;
 					}
 					CClientData *pClient = &m_aClients[Item.m_Id];
 					// Collision

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1119,18 +1119,6 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 		// reset character prediction
 		if(!(m_GameWorld.m_WorldConfig.m_IsFNG && pMsg->m_Weapon == WEAPON_LASER))
 		{
-			// update saved strong/weak ids if our character isn't on screen
-			for(int DummyId = 0; DummyId < NUM_DUMMIES; DummyId++)
-			{
-				if(m_aLocalIds[DummyId] == -1)
-					continue;
-
-				if(pMsg->m_Victim == m_aLocalIds[DummyId])
-					m_aLocalStrongWeakId[DummyId] = 0;
-				else if(m_CharOrder.HasStrongAgainst(m_aLocalIds[DummyId], pMsg->m_Victim))
-					m_aLocalStrongWeakId[DummyId]++;
-			}
-
 			m_CharOrder.GiveWeak(pMsg->m_Victim);
 			if(CCharacter *pChar = m_GameWorld.GetCharacterById(pMsg->m_Victim))
 				pChar->ResetPrediction();
@@ -1172,18 +1160,6 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 		{
 			if(m_Teams.Team(i) == pMsg->m_Team)
 			{
-				// update saved strong/weak ids if our character isn't on screen
-				for(int DummyId = 0; DummyId < NUM_DUMMIES; DummyId++)
-				{
-					if(m_aLocalIds[DummyId] == -1)
-						continue;
-
-					if(i == m_aLocalIds[DummyId])
-						m_aLocalStrongWeakId[DummyId] = 0;
-					else if(m_CharOrder.HasStrongAgainst(m_aLocalIds[DummyId], i))
-						m_aLocalStrongWeakId[DummyId]++;
-				}
-
 				if(CCharacter *pChar = m_GameWorld.GetCharacterById(i))
 				{
 					pChar->ResetPrediction();

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -251,9 +251,6 @@ private:
 	bool m_GamePaused = false;
 	int m_PrevLocalId = -1;
 
-	// Preserved for spectating when snap data unavailable
-	int m_aLocalStrongWeakId[NUM_DUMMIES];
-
 public:
 	IKernel *Kernel() { return IInterface::Kernel(); }
 	IEngine *Engine() const { return m_pEngine; }
@@ -295,7 +292,6 @@ public:
 		return m_NetObjHandler.NumObjCorrections();
 	}
 	const char *NetobjCorrectedOn() { return m_NetObjHandler.CorrectedObjOn(); }
-	int LocalStrongWeakId(int Dummy) const { return m_aLocalStrongWeakId[Dummy]; }
 
 	bool m_SuppressEvents;
 	bool m_NewTick;

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -147,7 +147,7 @@ public:
 			m_Ids.push_back(c);
 		}
 	}
-	bool HasStrongAgainst(int From, int To) const
+	bool HasStrongAgainst(int From, int To)
 	{
 		for(int i : m_Ids)
 		{


### PR DESCRIPTION
This reverts commit d83bb21cd5d8ffb31d293ac2a929c19fbac6c77c.

It was not a proper fix as explained in https://github.com/ddnet/ddnet/pull/10281#issuecomment-2958490610 and it seems to cause more issues (#10361).

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
