### PR TITLE
Improve skin handling performance

### DIFF
--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -351,19 +351,15 @@ void CGhost::OnRender()
 		if(Player.m_Weapon == WEAPON_NINJA && g_Config.m_ClShowNinja)
 		{
 			// change the skin for the ghost to the ninja
-			const auto *pSkin = m_pClient->m_Skins.FindOrNullptr("x_ninja");
-			if(pSkin != nullptr)
+			GhostNinjaRenderInfo = Ghost.m_pManagedTeeRenderInfo->TeeRenderInfo();
+			GhostNinjaRenderInfo.ApplySkin(GameClient()->m_Players.NinjaTeeRenderInfo()->TeeRenderInfo());
+			GhostNinjaRenderInfo.m_CustomColoredSkin = m_pClient->IsTeamPlay();
+			if(!GhostNinjaRenderInfo.m_CustomColoredSkin)
 			{
-				GhostNinjaRenderInfo = Ghost.m_pManagedTeeRenderInfo->TeeRenderInfo();
-				GhostNinjaRenderInfo.Apply(pSkin);
-				GhostNinjaRenderInfo.m_CustomColoredSkin = m_pClient->IsTeamPlay();
-				if(!GhostNinjaRenderInfo.m_CustomColoredSkin)
-				{
-					GhostNinjaRenderInfo.m_ColorBody = ColorRGBA(1, 1, 1);
-					GhostNinjaRenderInfo.m_ColorFeet = ColorRGBA(1, 1, 1);
-				}
-				pRenderInfo = &GhostNinjaRenderInfo;
+				GhostNinjaRenderInfo.m_ColorBody = ColorRGBA(1, 1, 1);
+				GhostNinjaRenderInfo.m_ColorFeet = ColorRGBA(1, 1, 1);
 			}
+			pRenderInfo = &GhostNinjaRenderInfo;
 		}
 
 		m_pClient->m_Players.RenderHook(&Prev, &Player, pRenderInfo, -2, IntraTick);

--- a/src/game/client/components/players.h
+++ b/src/game/client/components/players.h
@@ -37,6 +37,12 @@ class CPlayers : public CComponent
 	int m_WeaponEmoteQuadContainerIndex;
 	int m_aWeaponSpriteMuzzleQuadContainerIndex[NUM_WEAPONS];
 
+	void CreateNinjaTeeRenderInfo();
+	void CreateSpectatorTeeRenderInfo();
+
+	std::shared_ptr<CManagedTeeRenderInfo> m_pNinjaTeeRenderInfo;
+	std::shared_ptr<CManagedTeeRenderInfo> m_pSpectatorTeeRenderInfo;
+
 public:
 	float GetPlayerTargetAngle(
 		const CNetObj_Character *pPrevChar,
@@ -47,6 +53,9 @@ public:
 	virtual int Sizeof() const override { return sizeof(*this); }
 	virtual void OnInit() override;
 	virtual void OnRender() override;
+
+	const std::shared_ptr<CManagedTeeRenderInfo> &NinjaTeeRenderInfo() const { return m_pNinjaTeeRenderInfo; }
+	const std::shared_ptr<CManagedTeeRenderInfo> &SpectatorTeeRenderInfo() const { return m_pSpectatorTeeRenderInfo; }
 };
 
 #endif

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -109,7 +109,7 @@ public:
 		};
 
 		CSkinContainer(CSkinContainer &&Other) = default;
-		CSkinContainer(CSkins *pSkins, const char *pName, EType Type, int StorageType);
+		CSkinContainer(CSkins *pSkins, const char *pName, const char *pNormalizedName, EType Type, int StorageType);
 		~CSkinContainer();
 
 		bool operator<(const CSkinContainer &Other) const;
@@ -255,10 +255,17 @@ public:
 
 	void RandomizeSkin(int Dummy);
 
-	static bool IsVanillaSkin(const char *pName);
 	static bool IsSpecialSkin(const char *pName);
 
 private:
+	static bool IsVanillaSkinNormalized(const char *pNormalizedName);
+	static bool IsSpecialSkinNormalized(const char *pNormalizedName);
+
+	/**
+	 * Names of all vanilla and special skins.
+	 *
+	 * The names have to be in lower case for efficient comparison.
+	 */
 	constexpr static const char *VANILLA_SKINS[] = {"bluekitty", "bluestripe", "brownbear",
 		"cammo", "cammostripes", "coala", "default", "limekitty",
 		"pinky", "redbopp", "redstripe", "saddo", "toptri",

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -99,6 +99,14 @@ public:
 		m_SkinMetrics = pSkin->m_Metrics;
 	}
 
+	void ApplySkin(const CTeeRenderInfo &TeeRenderInfo)
+	{
+		m_OriginalRenderSkin = TeeRenderInfo.m_OriginalRenderSkin;
+		m_ColorableRenderSkin = TeeRenderInfo.m_ColorableRenderSkin;
+		m_BloodColor = TeeRenderInfo.m_BloodColor;
+		m_SkinMetrics = TeeRenderInfo.m_SkinMetrics;
+	}
+
 	void ApplyColors(bool CustomColoredSkin, int ColorBody, int ColorFeet)
 	{
 		m_CustomColoredSkin = CustomColoredSkin;


### PR DESCRIPTION
Avoid normalizing skin names multiple times when retrieving skin containers.

Avoid unnecessarily checking for vanilla and special skins when retrieving existing skin containers.

Use `CManagedTeeRenderInfo` for the `x_spec` and `x_ninja` skins to cache these skins and avoid retrieving them each time that a player with them is being rendered.

Closes #10337.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
