### PR TITLE
Make mutes of websockets addresses consistent with bans

### DIFF
--- a/src/game/server/mutes.cpp
+++ b/src/game/server/mutes.cpp
@@ -7,6 +7,10 @@
 
 static NETADDR KeyAddress(NETADDR Addr)
 {
+	if(Addr.type == NETTYPE_WEBSOCKET_IPV4)
+	{
+		Addr.type = NETTYPE_IPV4;
+	}
 	Addr.port = 0;
 	return Addr;
 }


### PR DESCRIPTION
Websocket IPv4 addresses are considered identical to regular IPv4 addresses for checking bans and mutes.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
