### PR TITLE
Refactor: Add group render-layer

### DIFF
--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -89,7 +89,9 @@ void CMapLayers::OnMapLoad()
 	for(int g = 0; g < m_pLayers->NumGroups(); g++)
 	{
 		CMapItemGroup *pGroup = m_pLayers->GetGroup(g);
-		if(!pGroup)
+		std::unique_ptr<CRenderLayer> pRenderLayerGroup = std::make_unique<CRenderLayerGroup>(g, pGroup);
+		pRenderLayerGroup->OnInit(Graphics(), m_pLayers->Map(), RenderTools(), m_pImages, m_pEnvelopePoints, Client(), m_pClient, m_OnlineOnly);
+		if(!pRenderLayerGroup->IsValid())
 		{
 			dbg_msg("maplayers", "error group was null, group number = %d, total groups = %d", g, m_pLayers->NumGroups());
 			dbg_msg("maplayers", "this is here to prevent a crash but the source of this is unknown, please report this for it to get fixed");
@@ -113,6 +115,9 @@ void CMapLayers::OnMapLoad()
 				if(!PassedGameLayer)
 					continue;
 			}
+
+			if(pRenderLayerGroup)
+				m_vRenderLayers.push_back(std::move(pRenderLayerGroup));
 
 			std::unique_ptr<CRenderLayer> pRenderLayer;
 
@@ -212,22 +217,13 @@ void CMapLayers::OnRender()
 	Params.EntityOverlayVal = m_Type == TYPE_FULL_DESIGN ? 0 : g_Config.m_ClOverlayEntities;
 	Params.m_RenderType = m_Type;
 	Params.m_Center = GetCurCamera()->m_Center;
+	Params.m_Zoom = GetCurCamera()->m_Zoom;
 
-	auto DisableClip = [&]() {
-		if(!g_Config.m_GfxNoclip || Params.m_RenderType == CMapLayers::TYPE_FULL_DESIGN)
-			Graphics()->ClipDisable();
-	};
-
-	int CurrentGroup = -1;
 	bool DoRenderGroup = true;
 	for(auto &&pRenderLayer : m_vRenderLayers)
 	{
-		if(CurrentGroup != pRenderLayer->GetGroup())
-		{
-			DisableClip(); // disable clip of previous group
-			CurrentGroup = pRenderLayer->GetGroup();
-			DoRenderGroup = RenderGroup(Params, CurrentGroup);
-		}
+		if(pRenderLayer->IsGroup())
+			DoRenderGroup = pRenderLayer->DoRender(Params);
 
 		if(!DoRenderGroup)
 			continue;
@@ -235,7 +231,8 @@ void CMapLayers::OnRender()
 		pRenderLayer->Render(Params);
 	}
 
-	DisableClip();
+	// Reset clip from last group
+	Graphics()->ClipDisable();
 
 	// don't reset screen on background
 	if(m_Type != TYPE_BACKGROUND && m_Type != TYPE_BACKGROUND_FORCE)
@@ -243,10 +240,10 @@ void CMapLayers::OnRender()
 		// reset the screen like it was before
 		Graphics()->MapScreen(Screen.x, Screen.y, Screen.w, Screen.h);
 	}
-	// apply game group again
 	else
 	{
-		RenderTools()->MapScreenToGroup(Params.m_Center.x, Params.m_Center.y, m_pLayers->GameGroup(), GetCurCamera()->m_Zoom);
+		// reset the screen to the default interface
+		RenderTools()->MapScreenToInterface(Params.m_Center.x, Params.m_Center.y, Params.m_Zoom);
 	}
 }
 
@@ -265,38 +262,4 @@ int CMapLayers::GetLayerType(const CMapItemLayer *pLayer) const
 	else if(pLayer == (CMapItemLayer *)m_pLayers->TuneLayer())
 		return LAYER_TUNE;
 	return LAYER_DEFAULT_TILESET;
-}
-
-bool CMapLayers::RenderGroup(const CRenderLayerParams &Params, int GroupId)
-{
-	CMapItemGroup *pGroup = m_pLayers->GetGroup(GroupId);
-
-	if(!pGroup)
-	{
-		dbg_msg("maplayers", "error group was null, group number = %d, total groups = %d", GroupId, m_pLayers->NumGroups());
-		dbg_msg("maplayers", "this is here to prevent a crash but the source of this is unknown, please report this for it to get fixed");
-		dbg_msg("maplayers", "we need mapname and crc and the map that caused this if possible, and anymore info you think is relevant");
-		return false;
-	}
-
-	if((!g_Config.m_GfxNoclip || Params.m_RenderType == CMapLayers::TYPE_FULL_DESIGN) && pGroup->m_Version >= 2 && pGroup->m_UseClipping)
-	{
-		// set clipping
-		float aPoints[4];
-		RenderTools()->MapScreenToGroup(Params.m_Center.x, Params.m_Center.y, m_pLayers->GameGroup(), GetCurCamera()->m_Zoom);
-		Graphics()->GetScreen(&aPoints[0], &aPoints[1], &aPoints[2], &aPoints[3]);
-		float x0 = (pGroup->m_ClipX - aPoints[0]) / (aPoints[2] - aPoints[0]);
-		float y0 = (pGroup->m_ClipY - aPoints[1]) / (aPoints[3] - aPoints[1]);
-		float x1 = ((pGroup->m_ClipX + pGroup->m_ClipW) - aPoints[0]) / (aPoints[2] - aPoints[0]);
-		float y1 = ((pGroup->m_ClipY + pGroup->m_ClipH) - aPoints[1]) / (aPoints[3] - aPoints[1]);
-
-		if(x1 < 0.0f || x0 > 1.0f || y1 < 0.0f || y0 > 1.0f)
-			return false;
-
-		Graphics()->ClipEnable((int)(x0 * Graphics()->ScreenWidth()), (int)(y0 * Graphics()->ScreenHeight()),
-			(int)((x1 - x0) * Graphics()->ScreenWidth()), (int)((y1 - y0) * Graphics()->ScreenHeight()));
-	}
-
-	RenderTools()->MapScreenToGroup(Params.m_Center.x, Params.m_Center.y, pGroup, GetCurCamera()->m_Zoom);
-	return true;
 }

--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -64,7 +64,6 @@ public:
 private:
 	std::vector<std::unique_ptr<CRenderLayer>> m_vRenderLayers;
 	int GetLayerType(const CMapItemLayer *pLayer) const;
-	bool RenderGroup(const CRenderLayerParams &Params, int GroupId);
 };
 
 #endif

--- a/src/game/client/components/render_layer.cpp
+++ b/src/game/client/components/render_layer.cpp
@@ -191,6 +191,44 @@ void CRenderLayer::RenderLoading() const
 }
 
 /**************
+ * Group *
+ **************/
+
+CRenderLayerGroup::CRenderLayerGroup(int GroupId, CMapItemGroup *pGroup) :
+	CRenderLayer(GroupId, 0, 0), m_pGroup(pGroup) {}
+
+bool CRenderLayerGroup::DoRender(const CRenderLayerParams &Params) const
+{
+	if(!g_Config.m_GfxNoclip || Params.m_RenderType == CMapLayers::TYPE_FULL_DESIGN)
+	{
+		m_pGraphics->ClipDisable();
+		if(m_pGroup->m_Version >= 2 && m_pGroup->m_UseClipping)
+		{
+			// set clipping
+			float aPoints[4];
+			m_pRenderTools->MapScreenToInterface(Params.m_Center.x, Params.m_Center.y, Params.m_Zoom);
+			m_pGraphics->GetScreen(&aPoints[0], &aPoints[1], &aPoints[2], &aPoints[3]);
+			float x0 = (m_pGroup->m_ClipX - aPoints[0]) / (aPoints[2] - aPoints[0]);
+			float y0 = (m_pGroup->m_ClipY - aPoints[1]) / (aPoints[3] - aPoints[1]);
+			float x1 = ((m_pGroup->m_ClipX + m_pGroup->m_ClipW) - aPoints[0]) / (aPoints[2] - aPoints[0]);
+			float y1 = ((m_pGroup->m_ClipY + m_pGroup->m_ClipH) - aPoints[1]) / (aPoints[3] - aPoints[1]);
+
+			if(x1 < 0.0f || x0 > 1.0f || y1 < 0.0f || y0 > 1.0f)
+				return false;
+
+			m_pGraphics->ClipEnable((int)(x0 * m_pGraphics->ScreenWidth()), (int)(y0 * m_pGraphics->ScreenHeight()),
+				(int)((x1 - x0) * m_pGraphics->ScreenWidth()), (int)((y1 - y0) * m_pGraphics->ScreenHeight()));
+		}
+	}
+	return true;
+}
+
+void CRenderLayerGroup::Render(const CRenderLayerParams &Params)
+{
+	m_pRenderTools->MapScreenToGroup(Params.m_Center.x, Params.m_Center.y, m_pGroup, Params.m_Zoom);
+}
+
+/**************
  * Tile Layer *
  **************/
 

--- a/src/game/client/components/render_layer.h
+++ b/src/game/client/components/render_layer.h
@@ -35,6 +35,7 @@ public:
 	int m_RenderType;
 	int EntityOverlayVal;
 	vec2 m_Center;
+	float m_Zoom;
 };
 
 class CRenderLayer
@@ -48,6 +49,7 @@ public:
 	virtual void Render(const CRenderLayerParams &Params) = 0;
 	virtual bool DoRender(const CRenderLayerParams &Params) const = 0;
 	virtual bool IsValid() const { return true; }
+	virtual bool IsGroup() const { return false; }
 
 	int GetGroup() const { return m_GroupId; }
 
@@ -70,6 +72,23 @@ protected:
 	class IClient *m_pClient = nullptr;
 	class CGameClient *m_pGameClient = nullptr;
 	std::shared_ptr<CMapBasedEnvelopePointAccess> m_pEnvelopePoints;
+};
+
+class CRenderLayerGroup : public CRenderLayer
+{
+public:
+	CRenderLayerGroup(int GroupId, CMapItemGroup *pGroup);
+	virtual ~CRenderLayerGroup() = default;
+	void Init() override {}
+	void Render(const CRenderLayerParams &Params) override;
+	bool DoRender(const CRenderLayerParams &Params) const override;
+	bool IsValid() const override { return m_pGroup != nullptr; }
+	bool IsGroup() const override { return true; }
+
+protected:
+	IGraphics::CTextureHandle GetTexture() const override { return IGraphics::CTextureHandle(); }
+
+	CMapItemGroup *m_pGroup;
 };
 
 class CRenderLayerTile : public CRenderLayer

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -729,10 +729,10 @@ void CRenderTools::MapScreenToGroup(float CenterX, float CenterY, CMapItemGroup 
 	Graphics()->MapScreen(aPoints[0], aPoints[1], aPoints[2], aPoints[3]);
 }
 
-void CRenderTools::MapScreenToInterface(float CenterX, float CenterY)
+void CRenderTools::MapScreenToInterface(float CenterX, float CenterY, float Zoom)
 {
 	float aPoints[4];
 	MapScreenToWorld(CenterX, CenterY, 100.0f, 100.0f, 100.0f,
-		0, 0, Graphics()->ScreenAspect(), 1.0f, aPoints);
+		0, 0, Graphics()->ScreenAspect(), Zoom, aPoints);
 	Graphics()->MapScreen(aPoints[0], aPoints[1], aPoints[2], aPoints[3]);
 }

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -324,7 +324,7 @@ public:
 	void MapScreenToWorld(float CenterX, float CenterY, float ParallaxX, float ParallaxY,
 		float ParallaxZoom, float OffsetX, float OffsetY, float Aspect, float Zoom, float *pPoints);
 	void MapScreenToGroup(float CenterX, float CenterY, CMapItemGroup *pGroup, float Zoom);
-	void MapScreenToInterface(float CenterX, float CenterY);
+	void MapScreenToInterface(float CenterX, float CenterY, float Zoom = 1.0f);
 
 	// DDRace
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This PR adds introduces group objects to the maplayer render pipeline. This cleans up the rendering even further. It also adds zoom to the parameters preventing possible artifacts with frames/screenshots while zooming in/out and handles the reset to the foreground cleaner. It also decouples all render layers from CMapLayer, which is a step towards a future editor integration.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
