### PR TITLE
Enable FrozenLastTick only if prediction supported

### DIFF
--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1111,7 +1111,8 @@ bool CCharacter::UnFreeze()
 		m_FreezeTime = 0;
 		m_Core.m_FreezeStart = 0;
 		m_Core.m_FreezeEnd = m_Core.m_DeepFrozen ? -1 : 0;
-		m_FrozenLastTick = true;
+		if(GameWorld()->m_WorldConfig.m_PredictDDRace)
+			m_FrozenLastTick = true;
 		return true;
 	}
 	return false;


### PR DESCRIPTION
In the code, m_FrozenLastTick flag is always will be enabled when the character is unfrozen, and it is disabled only if m_PredictDDRace is enabled. Therefore, if m_PredictDDRace disabled, the client assumes that it is always the last tick of the freeze and endlessly displays the repeated hammer hit or gun shot on fire hold.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
