### PR TITLE
Ensure datafile reader/writer load/open result is checked

### DIFF
--- a/src/engine/map.h
+++ b/src/engine/map.h
@@ -35,7 +35,7 @@ class IEngineMap : public IMap
 {
 	MACRO_INTERFACE("enginemap")
 public:
-	virtual bool Load(const char *pMapName) = 0;
+	[[nodiscard]] virtual bool Load(const char *pMapName) = 0;
 	virtual void Unload() = 0;
 	virtual bool IsLoaded() const = 0;
 	virtual IOHANDLE File() const = 0;

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -302,7 +302,8 @@ public:
 	// is instantiated.
 	virtual void OnInit(const void *pPersistentData) = 0;
 	virtual void OnConsoleInit() = 0;
-	virtual void OnMapChange(char *pNewMapName, int MapNameSize) = 0;
+	// Returns `true` if map change accepted.
+	[[nodiscard]] virtual bool OnMapChange(char *pNewMapName, int MapNameSize) = 0;
 	// `pPersistentData` may be null if this is the last time `IGameServer`
 	// is destroyed.
 	virtual void OnShutdown(void *pPersistentData) = 0;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2752,10 +2752,14 @@ int CServer::LoadMap(const char *pMapName)
 
 	char aBuf[IO_MAX_PATH_LENGTH];
 	str_format(aBuf, sizeof(aBuf), "maps/%s.map", pMapName);
-	GameServer()->OnMapChange(aBuf, sizeof(aBuf));
-
-	if(!m_pMap->Load(aBuf))
+	if(!GameServer()->OnMapChange(aBuf, sizeof(aBuf)))
+	{
 		return 0;
+	}
+	if(!m_pMap->Load(aBuf))
+	{
+		return 0;
+	}
 
 	// reinit snapshot ids
 	m_IdPool.TimeoutIds();

--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -31,7 +31,7 @@ public:
 	~CDataFileReader();
 	CDataFileReader &operator=(CDataFileReader &&Other);
 
-	bool Open(class IStorage *pStorage, const char *pFilename, int StorageType);
+	[[nodiscard]] bool Open(class IStorage *pStorage, const char *pFilename, int StorageType);
 	void Close();
 	bool IsOpen() const;
 	IOHANDLE File() const;
@@ -125,7 +125,7 @@ public:
 	}
 	~CDataFileWriter();
 
-	bool Open(class IStorage *pStorage, const char *pFilename, int StorageType = IStorage::TYPE_SAVE);
+	[[nodiscard]] bool Open(class IStorage *pStorage, const char *pFilename, int StorageType = IStorage::TYPE_SAVE);
 	int AddItem(int Type, int Id, size_t Size, const void *pData, const CUuid *pUuid = nullptr);
 	int AddData(size_t Size, const void *pData, ECompressionLevel CompressionLevel = COMPRESSION_DEFAULT);
 	int AddDataSwapped(size_t Size, const void *pData);

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -31,7 +31,7 @@ public:
 	void *FindItem(int Type, int Id) override;
 	int NumItems() const override;
 
-	bool Load(const char *pMapName) override;
+	[[nodiscard]] bool Load(const char *pMapName) override;
 	void Unload() override;
 	bool IsLoaded() const override;
 	IOHANDLE File() const override;

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -312,7 +312,7 @@ public:
 	void OnConsoleInit() override;
 	void RegisterDDRaceCommands();
 	void RegisterChatCommands();
-	void OnMapChange(char *pNewMapName, int MapNameSize) override;
+	[[nodiscard]] bool OnMapChange(char *pNewMapName, int MapNameSize) override;
 	void OnShutdown(void *pPersistentData) override;
 
 	void OnTick() override;

--- a/src/test/datafile.cpp
+++ b/src/test/datafile.cpp
@@ -22,7 +22,7 @@ TEST(Datafile, ExtendedType)
 
 	{
 		CDataFileWriter Writer;
-		Writer.Open(pStorage.get(), Info.m_aFilename);
+		ASSERT_TRUE(Writer.Open(pStorage.get(), Info.m_aFilename));
 
 		Writer.AddItem(MAPITEMTYPE_TEST, 0x8000, sizeof(ItemTest), &ItemTest);
 
@@ -31,7 +31,7 @@ TEST(Datafile, ExtendedType)
 
 	{
 		CDataFileReader Reader;
-		Reader.Open(pStorage.get(), Info.m_aFilename, IStorage::TYPE_ALL);
+		ASSERT_TRUE(Reader.Open(pStorage.get(), Info.m_aFilename, IStorage::TYPE_ALL));
 
 		int Start, Num;
 		Reader.GetType(MAPITEMTYPE_TEST, &Start, &Num);
@@ -72,7 +72,7 @@ TEST(Datafile, StringData)
 
 	{
 		CDataFileWriter Writer;
-		Writer.Open(pStorage.get(), Info.m_aFilename);
+		ASSERT_TRUE(Writer.Open(pStorage.get(), Info.m_aFilename));
 
 		EXPECT_EQ(Writer.AddDataString(""), -1); // Empty string is not added
 		EXPECT_EQ(Writer.AddDataString("Abc"), 0);
@@ -88,7 +88,7 @@ TEST(Datafile, StringData)
 
 	{
 		CDataFileReader Reader;
-		Reader.Open(pStorage.get(), Info.m_aFilename, IStorage::TYPE_ALL);
+		ASSERT_TRUE(Reader.Open(pStorage.get(), Info.m_aFilename, IStorage::TYPE_ALL));
 
 		EXPECT_EQ(Reader.GetDataString(-1000), nullptr);
 		EXPECT_STREQ(Reader.GetDataString(-1), "");


### PR DESCRIPTION
Add `[[nodiscard]]` attribute to ensure that the result of the `CDataFileReader::Open`, `CDataFileWriter::Open` and `IEngineMap::Load` functions is checked, as the reader/writer/map is otherwise not usable.

Add error handling to `IGameServer::OnMapChange` function, which now returns `true` if the map change was accepted.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
