### PR TITLE
fix Rust build under multi-config generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -899,7 +899,10 @@ if(NOT CMAKE_OSX_ARCHITECTURES AND (DEFINED CMAKE_RUST_COMPILER_TARGET OR RUST_N
 endif()
 set(CARGO_BUILD_DIR_DEBUG "${CARGO_BUILD_DIR}debug")
 set(CARGO_BUILD_DIR_RELEASE "${CARGO_BUILD_DIR}release")
-if(GENERATOR_IS_MULTI_CONFIG)
+
+# We can't check this directly; it is a cmake property, not a variable
+get_cmake_property(MULTI_CONFIG_BUILD GENERATOR_IS_MULTI_CONFIG)
+if(MULTI_CONFIG_BUILD)
   if(CMAKE_VERSION VERSION_LESS 3.20)
     message(SEND_ERROR "Multi-config generators only supported from CMake 3.20 and up")
   else()


### PR DESCRIPTION
Using the "Ninja Multi-Config" CMake generator, the Rust component of the build would previously fail with an error like 
```
ninja: error: 'debug/libddnet_engine_shared.a', needed by 'Debug/DDNet.exe', missing and no known rule to make it
```
Subsequently, the entire build would fail.

I went in and added a few `message()` calls to find out what build directory it was trying to use, and as it turns out, multi-config generators were not being detected properly. Apparently the mechanism to check this is not a traditional CMake variable, but a property which has to be explicitly queried and then placed into a variable.
https://discourse.cmake.org/t/generator-is-multi-config-doesnt-get-set-in-vs-code-with-ninja-multi-config-generator/7372

The docs for this look really similar to those for normal variables.
https://cmake.org/cmake/help/latest/prop_gbl/GENERATOR_IS_MULTI_CONFIG.html#generator-is-multi-config
> "prop_gbl"


I speculate this would've broken certain Visual Studio configurations, but I didn't test