### PR TITLE
Show error message in server browser when no master server found

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -1700,6 +1700,11 @@ bool CServerBrowser::IsGettingServerlist() const
 	return m_pHttp->IsRefreshing();
 }
 
+bool CServerBrowser::IsServerlistError() const
+{
+	return m_pHttp->IsError();
+}
+
 int CServerBrowser::LoadingProgression() const
 {
 	if(m_NumServers == 0)

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -256,6 +256,7 @@ public:
 	void Refresh(int Type, bool Force = false) override;
 	bool IsRefreshing() const override;
 	bool IsGettingServerlist() const override;
+	bool IsServerlistError() const override;
 	int LoadingProgression() const override;
 	void RequestResort() { m_NeedResort = true; }
 

--- a/src/engine/client/serverbrowser_http.cpp
+++ b/src/engine/client/serverbrowser_http.cpp
@@ -307,7 +307,8 @@ public:
 	CServerBrowserHttp(IEngine *pEngine, IHttp *pHttp, const char **ppUrls, int NumUrls, int PreviousBestIndex);
 	~CServerBrowserHttp() override;
 	void Update() override;
-	bool IsRefreshing() override { return m_State != STATE_DONE; }
+	bool IsRefreshing() const override { return m_State != STATE_DONE && m_State != STATE_NO_MASTER; }
+	bool IsError() const override { return m_State == STATE_NO_MASTER; }
 	void Refresh() override;
 	bool GetBestUrl(const char **pBestUrl) const override { return m_pChooseMaster->GetBestUrl(pBestUrl); }
 
@@ -345,6 +346,7 @@ CServerBrowserHttp::CServerBrowserHttp(IEngine *pEngine, IHttp *pHttp, const cha
 	m_pHttp(pHttp),
 	m_pChooseMaster(new CChooseMaster(pEngine, pHttp, Validate, ppUrls, NumUrls, PreviousBestIndex))
 {
+	m_pChooseMaster->Reset();
 	m_pChooseMaster->Refresh();
 }
 

--- a/src/engine/client/serverbrowser_http.h
+++ b/src/engine/client/serverbrowser_http.h
@@ -14,7 +14,8 @@ public:
 
 	virtual void Update() = 0;
 
-	virtual bool IsRefreshing() = 0;
+	virtual bool IsRefreshing() const = 0;
+	virtual bool IsError() const = 0;
 	virtual void Refresh() = 0;
 
 	virtual bool GetBestUrl(const char **pBestUrl) const = 0;

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -324,8 +324,9 @@ public:
 	static constexpr const char *SEARCH_EXCLUDE_TOKEN = ";";
 
 	virtual void Refresh(int Type, bool Force = false) = 0;
-	virtual bool IsGettingServerlist() const = 0;
 	virtual bool IsRefreshing() const = 0;
+	virtual bool IsGettingServerlist() const = 0;
+	virtual bool IsServerlistError() const = 0;
 	virtual int LoadingProgression() const = 0;
 
 	virtual int NumServers() const = 0;

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -243,6 +243,10 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 				str_format(aBuf, sizeof(aBuf), Localize("No local servers found (ports %d-%d)"), IServerBrowser::LAN_PORT_BEGIN, IServerBrowser::LAN_PORT_END);
 				Ui()->DoLabel(&View, aBuf, 16.0f, TEXTALIGN_MC);
 			}
+			else if(ServerBrowser()->IsServerlistError())
+			{
+				Ui()->DoLabel(&View, Localize("Could not get server list from master server"), 16.0f, TEXTALIGN_MC);
+			}
 			else
 			{
 				Ui()->DoLabel(&View, Localize("No servers found"), 16.0f, TEXTALIGN_MC);


### PR DESCRIPTION
Previously, the message `Getting server list from master server` kept being shown also after no master servers could be found. Now, a separate message `Could not get server list from master server` is shown in this case.

The initial state of `CServerBrowserHttp` was also not reset correctly when the class is first created, which incorrectly caused only the message `No servers found` to be shown when no master servers could be found, until the server browser is refreshed manually for the first time.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
