### PR TITLE
Add interact state to fix invisible lasers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2974,6 +2974,8 @@ if(SERVER)
     gamemodes/mod.h
     gameworld.cpp
     gameworld.h
+    interactions.cpp
+    interactions.h
     mutes.cpp
     player.cpp
     player.h

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -5,12 +5,14 @@
 #include "character.h"
 
 #include <engine/shared/config.h>
+#include <engine/shared/protocol.h>
 
 #include <generated/protocol.h>
 
 #include <game/mapitems.h>
 #include <game/server/gamecontext.h>
 #include <game/server/gamemodes/ddnet.h>
+#include <game/server/player.h>
 
 CLaser::CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEnergy, int Owner, int Type) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_LASER, true)
@@ -29,9 +31,11 @@ CLaser::CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEner
 	m_ZeroEnergyBounceInLastTick = false;
 	m_TuneZone = GameServer()->Collision()->IsTune(GameServer()->Collision()->GetMapIndex(m_Pos));
 	CCharacter *pOwnerChar = GameServer()->GetPlayerChar(m_Owner);
-	m_TeamMask = pOwnerChar ? pOwnerChar->TeamMask() : CClientMask();
 	m_BelongsToPracticeTeam = pOwnerChar && pOwnerChar->Teams()->IsPractice(pOwnerChar->Team());
 
+	CPlayer *pOwnerPlayer = (Owner >= 0 && Owner < MAX_CLIENTS) ? GameServer()->m_apPlayers[m_Owner] : nullptr;
+	m_InteractState.Init(GameServer(), Owner, pOwnerPlayer ? pOwnerPlayer->GetUniqueCid() : 0);
+	SyncInteractState();
 	GameWorld()->InsertEntity(this);
 	DoBounce();
 }
@@ -39,6 +43,7 @@ CLaser::CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEner
 bool CLaser::HitCharacter(vec2 From, vec2 To)
 {
 	static const vec2 StackedLaserShotgunBugSpeed = vec2(-2147483648.0f, -2147483648.0f);
+	SyncInteractState();
 	vec2 At;
 	CCharacter *pOwnerChar = GameServer()->GetPlayerChar(m_Owner);
 	CCharacter *pHit;
@@ -49,7 +54,7 @@ bool CLaser::HitCharacter(vec2 From, vec2 To)
 	else
 		pHit = GameWorld()->IntersectCharacter(m_Pos, To, 0.f, At, pDontHitSelf ? pOwnerChar : nullptr, m_Owner, pOwnerChar);
 
-	if(!pHit || (pHit == pOwnerChar && g_Config.m_SvOldLaser) || (pHit != pOwnerChar && pOwnerChar ? (pOwnerChar->LaserHitDisabled() && m_Type == WEAPON_LASER) || (pOwnerChar->ShotgunHitDisabled() && m_Type == WEAPON_SHOTGUN) : !g_Config.m_SvHit))
+	if(!pHit || !m_InteractState.CanHit(pHit->GetPlayer()->GetCid()))
 		return false;
 	m_From = From;
 	m_Pos = At;
@@ -174,7 +179,7 @@ void CLaser::DoBounce()
 			if(m_Bounces > BounceNum)
 				m_Energy = -1;
 
-			GameServer()->CreateSound(m_Pos, SOUND_LASER_BOUNCE, m_TeamMask);
+			GameServer()->CreateSound(m_Pos, SOUND_LASER_BOUNCE, m_InteractState.CanSeeMask());
 		}
 	}
 	else
@@ -254,6 +259,7 @@ void CLaser::Reset()
 
 void CLaser::Tick()
 {
+	SyncInteractState();
 	if((g_Config.m_SvDestroyLasersOnDeath || m_BelongsToPracticeTeam) && m_Owner >= 0)
 	{
 		CCharacter *pOwnerChar = GameServer()->GetPlayerChar(m_Owner);
@@ -277,22 +283,8 @@ void CLaser::Snap(int SnappingClient)
 {
 	if((NetworkClipped(SnappingClient) && NetworkClipped(SnappingClient, m_From)) || !GetId().has_value())
 		return;
-	CCharacter *pOwnerChar = nullptr;
-	if(m_Owner >= 0)
-		pOwnerChar = GameServer()->GetPlayerChar(m_Owner);
-	if(!pOwnerChar)
-		return;
 
-	pOwnerChar = nullptr;
-	CClientMask TeamMask = CClientMask().set();
-
-	if(m_Owner >= 0)
-		pOwnerChar = GameServer()->GetPlayerChar(m_Owner);
-
-	if(pOwnerChar && pOwnerChar->IsAlive())
-		TeamMask = pOwnerChar->TeamMask();
-
-	if(SnappingClient != SERVER_DEMO_CLIENT && !TeamMask.test(SnappingClient))
+	if(SnappingClient != SERVER_DEMO_CLIENT && !m_InteractState.CanSee(SnappingClient))
 		return;
 
 	int SnappingClientVersion = GameServer()->GetClientVersion(SnappingClient);
@@ -305,4 +297,31 @@ void CLaser::Snap(int SnappingClient)
 void CLaser::SwapClients(int Client1, int Client2)
 {
 	m_Owner = m_Owner == Client1 ? Client2 : (m_Owner == Client2 ? Client1 : m_Owner);
+}
+
+void CLaser::SyncInteractState()
+{
+	CPlayer *pOwnerPlayer = (m_Owner >= 0 && m_Owner < MAX_CLIENTS) ? GameServer()->m_apPlayers[m_Owner] : nullptr;
+	CCharacter *pOwnerChar = GameServer()->GetPlayerChar(m_Owner);
+
+	// as long as the owner is connected
+	// refill the state on tick
+	// as soon as the owner disconnects keep that state
+	if(pOwnerPlayer)
+	{
+		bool NoHitOthers = g_Config.m_SvHit;
+		if(pOwnerChar)
+			NoHitOthers = (m_Type == WEAPON_LASER && pOwnerChar->LaserHitDisabled()) || (m_Type == WEAPON_SHOTGUN && pOwnerChar->ShotgunHitDisabled());
+		bool NoHitSelf = g_Config.m_SvOldLaser || (m_Bounces == 0 && !m_WasTele);
+		m_InteractState.FillOwnerConnected(
+			pOwnerChar && pOwnerChar->IsAlive(),
+			pOwnerPlayer ? GameServer()->GetDDRaceTeam(m_Owner) : 0,
+			pOwnerChar && pOwnerChar->Core()->m_Solo,
+			NoHitOthers,
+			NoHitSelf);
+	}
+	else
+	{
+		m_InteractState.FillOwnerDisconnected();
+	}
 }

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -34,7 +34,7 @@ CLaser::CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEner
 	m_BelongsToPracticeTeam = pOwnerChar && pOwnerChar->Teams()->IsPractice(pOwnerChar->Team());
 
 	CPlayer *pOwnerPlayer = (Owner >= 0 && Owner < MAX_CLIENTS) ? GameServer()->m_apPlayers[m_Owner] : nullptr;
-	m_InteractState.Init(GameServer(), Owner, pOwnerPlayer ? pOwnerPlayer->GetUniqueCid() : 0);
+	m_InteractState.Init(Owner, pOwnerPlayer ? pOwnerPlayer->GetUniqueCid() : 0);
 	SyncInteractState();
 	GameWorld()->InsertEntity(this);
 	DoBounce();
@@ -54,7 +54,7 @@ bool CLaser::HitCharacter(vec2 From, vec2 To)
 	else
 		pHit = GameWorld()->IntersectCharacter(m_Pos, To, 0.f, At, pDontHitSelf ? pOwnerChar : nullptr, m_Owner, pOwnerChar);
 
-	if(!pHit || !m_InteractState.CanHit(pHit->GetPlayer()->GetCid()))
+	if(!pHit || !m_InteractState.CanHit(GameServer(), pHit->GetPlayer()->GetCid()))
 		return false;
 	m_From = From;
 	m_Pos = At;
@@ -179,7 +179,7 @@ void CLaser::DoBounce()
 			if(m_Bounces > BounceNum)
 				m_Energy = -1;
 
-			GameServer()->CreateSound(m_Pos, SOUND_LASER_BOUNCE, m_InteractState.CanSeeMask());
+			GameServer()->CreateSound(m_Pos, SOUND_LASER_BOUNCE, m_InteractState.CanSeeMask(GameServer()));
 		}
 	}
 	else
@@ -284,7 +284,7 @@ void CLaser::Snap(int SnappingClient)
 	if((NetworkClipped(SnappingClient) && NetworkClipped(SnappingClient, m_From)) || !GetId().has_value())
 		return;
 
-	if(SnappingClient != SERVER_DEMO_CLIENT && !m_InteractState.CanSee(SnappingClient))
+	if(SnappingClient != SERVER_DEMO_CLIENT && !m_InteractState.CanSee(GameServer(), SnappingClient))
 		return;
 
 	int SnappingClientVersion = GameServer()->GetClientVersion(SnappingClient);

--- a/src/game/server/entities/laser.h
+++ b/src/game/server/entities/laser.h
@@ -4,6 +4,7 @@
 #define GAME_SERVER_ENTITIES_LASER_H
 
 #include <game/server/entity.h>
+#include <game/server/interactions.h>
 
 class CLaser : public CEntity
 {
@@ -31,8 +32,8 @@ private:
 	int m_Bounces;
 	int m_EvalTick;
 	int m_Owner;
-	CClientMask m_TeamMask;
 	bool m_ZeroEnergyBounceInLastTick;
+	CInteractions m_InteractState;
 
 	// DDRace
 
@@ -42,6 +43,7 @@ private:
 	bool m_TeleportCancelled;
 	bool m_IsBlueTeleport;
 	bool m_BelongsToPracticeTeam;
+	void SyncInteractState();
 };
 
 #endif

--- a/src/game/server/interactions.cpp
+++ b/src/game/server/interactions.cpp
@@ -1,0 +1,178 @@
+#include "interactions.h"
+
+#include <engine/shared/protocol.h>
+
+#include <game/server/entities/character.h>
+#include <game/server/gamecontext.h>
+#include <game/server/player.h>
+
+CGameContext *CInteractions::GameServer()
+{
+	return m_pGameServer;
+}
+
+CPlayer *CInteractions::GetPlayer(int ClientId)
+{
+	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "invalid client id %d", ClientId);
+	return GameServer()->m_apPlayers[ClientId];
+}
+
+CCharacter *CInteractions::Character(int ClientId)
+{
+	return GameServer()->GetPlayerChar(ClientId);
+}
+
+bool CInteractions::IsSolo(int ClientId)
+{
+	CCharacter *pChr = Character(ClientId);
+	return pChr && pChr->Core()->m_Solo;
+}
+
+int CInteractions::GetDDRaceTeam(int ClientId)
+{
+	return GameServer()->GetDDRaceTeam(ClientId);
+}
+
+void CInteractions::Init(class CGameContext *pGameServer, int OwnerId, uint32_t UniqueOwnerId)
+{
+	m_pGameServer = pGameServer;
+	m_OwnerId = OwnerId;
+	m_UniqueOwnerId = UniqueOwnerId;
+}
+
+void CInteractions::FillOwnerConnected(
+	bool OwnerAlive,
+	int DDRaceTeam,
+	bool Solo,
+	bool NoHitOthers,
+	bool NoHitSelf)
+{
+	m_OwnerAlive = OwnerAlive;
+	m_DDRaceTeam = DDRaceTeam;
+	m_Solo = Solo;
+	m_NoHitOthers = NoHitOthers;
+	m_NoHitSelf = NoHitSelf;
+}
+
+void CInteractions::FillOwnerDisconnected()
+{
+	m_OwnerAlive = false;
+	m_OwnerId = -1;
+	// m_UniqueOwnerId = 0; // TODO: yes no maybe?
+}
+
+bool CInteractions::CanSee(int ClientId)
+{
+	CPlayer *pPlayer = GetPlayer(ClientId);
+	if(!pPlayer)
+		return false; // Player doesn't exist
+
+	if(!(pPlayer->GetTeam() == TEAM_SPECTATORS || pPlayer->IsPaused()))
+	{ // Not spectator
+		if(ClientId != m_OwnerId)
+		{ // Actions of other players
+			if(!Character(ClientId))
+				return false; // Player is currently dead
+			if(pPlayer->m_ShowOthers == SHOW_OTHERS_ONLY_TEAM)
+			{
+				if(GetDDRaceTeam(ClientId) != m_DDRaceTeam && GetDDRaceTeam(ClientId) != TEAM_SUPER)
+					return false; // In different teams
+			}
+			else if(pPlayer->m_ShowOthers == SHOW_OTHERS_OFF)
+			{
+				if(m_Solo)
+					return false; // When in solo part don't show others
+				if(IsSolo(ClientId))
+					return false; // When in solo part don't show others
+				if(GetDDRaceTeam(ClientId) != m_DDRaceTeam && GetDDRaceTeam(ClientId) != TEAM_SUPER)
+					return false; // In different teams
+			}
+		} // See everything of yourself
+	}
+	else if(pPlayer->SpectatorId() != SPEC_FREEVIEW)
+	{ // Spectating specific player
+		if(pPlayer->SpectatorId() != m_OwnerId)
+		{ // Actions of other players
+			if(!Character(pPlayer->SpectatorId()))
+				return false; // Player is currently dead
+			if(pPlayer->m_ShowOthers == SHOW_OTHERS_ONLY_TEAM)
+			{
+				if(GetDDRaceTeam(pPlayer->SpectatorId()) != m_DDRaceTeam && GetDDRaceTeam(pPlayer->SpectatorId()) != TEAM_SUPER)
+					return false; // In different teams
+			}
+			else if(pPlayer->m_ShowOthers == SHOW_OTHERS_OFF)
+			{
+				if(m_Solo)
+					return false; // When in solo part don't show others
+				if(IsSolo(pPlayer->SpectatorId()))
+					return false; // When in solo part don't show others
+				if(GetDDRaceTeam(pPlayer->SpectatorId()) != m_DDRaceTeam && GetDDRaceTeam(pPlayer->SpectatorId()) != TEAM_SUPER)
+					return false; // In different teams
+			}
+		} // See everything of player you're spectating
+	}
+	else
+	{ // Freeview
+		if(pPlayer->m_SpecTeam)
+		{ // Show only players in own team when spectating
+			if(GetDDRaceTeam(ClientId) != m_DDRaceTeam && GetDDRaceTeam(ClientId) != TEAM_SUPER)
+				return false; // in different teams
+		}
+	}
+
+	return true;
+}
+
+bool CInteractions::CanHit(int ClientId)
+{
+	CPlayer *pPlayer = GetPlayer(ClientId);
+	if(!pPlayer)
+		return false;
+
+	if(m_DDRaceTeam && GetDDRaceTeam(ClientId) != m_DDRaceTeam)
+		return false;
+	if(m_Solo && m_UniqueOwnerId != pPlayer->GetUniqueCid())
+		return false;
+	if(m_NoHitOthers && m_UniqueOwnerId != pPlayer->GetUniqueCid())
+		return false;
+	if(m_NoHitSelf && m_UniqueOwnerId == pPlayer->GetUniqueCid())
+		return false;
+
+	return true;
+}
+
+CClientMask CInteractions::CanSeeMask()
+{
+	if(m_DDRaceTeam == TEAM_SUPER)
+	{
+		return CClientMask().set();
+	}
+
+	CClientMask Mask;
+	for(int i = 0; i < MAX_CLIENTS; ++i)
+	{
+		if(CanSee(i))
+		{
+			Mask.set(i);
+		}
+	}
+	return Mask;
+}
+
+CClientMask CInteractions::CanHitMask()
+{
+	if(m_DDRaceTeam == TEAM_SUPER)
+	{
+		return CClientMask().set();
+	}
+
+	CClientMask Mask;
+	for(int i = 0; i < MAX_CLIENTS; ++i)
+	{
+		if(CanHit(i))
+		{
+			Mask.set(i);
+		}
+	}
+	return Mask;
+}

--- a/src/game/server/interactions.h
+++ b/src/game/server/interactions.h
@@ -1,0 +1,38 @@
+#ifndef GAME_SERVER_INTERACTIONS_H
+#define GAME_SERVER_INTERACTIONS_H
+
+#include <engine/shared/protocol.h>
+
+class CInteractions
+{
+	class CGameContext *m_pGameServer;
+	class CGameContext *GameServer();
+	class CPlayer *GetPlayer(int ClientId);
+	class CCharacter *Character(int ClientId);
+	bool IsSolo(int ClientId);
+	int GetDDRaceTeam(int ClientId);
+
+	int m_OwnerId = 0;
+	uint32_t m_UniqueOwnerId = 0;
+	bool m_OwnerAlive = false;
+	int m_DDRaceTeam = 0;
+	bool m_Solo = false;
+	bool m_NoHitOthers = false;
+	bool m_NoHitSelf = false;
+
+public:
+	void Init(class CGameContext *pGameServer, int OwnerId, uint32_t UniqueOwnerId);
+	void FillOwnerConnected(
+		bool OwnerAlive,
+		int DDRaceTeam,
+		bool Solo,
+		bool NoHitOthers,
+		bool NoHitSelf);
+	void FillOwnerDisconnected();
+	bool CanSee(int ClientId);
+	bool CanHit(int ClientId);
+	CClientMask CanSeeMask();
+	CClientMask CanHitMask();
+};
+
+#endif

--- a/src/game/server/interactions.h
+++ b/src/game/server/interactions.h
@@ -3,14 +3,16 @@
 
 #include <engine/shared/protocol.h>
 
+class CGameContext;
+class CPlayer;
+class CCharacter;
+
 class CInteractions
 {
-	class CGameContext *m_pGameServer;
-	class CGameContext *GameServer();
-	class CPlayer *GetPlayer(int ClientId);
-	class CCharacter *Character(int ClientId);
-	bool IsSolo(int ClientId);
-	int GetDDRaceTeam(int ClientId);
+	const CPlayer *GetPlayer(const CGameContext *pGameServer, int ClientId) const;
+	const CCharacter *Character(const CGameContext *pGameServer, int ClientId) const;
+	bool IsSolo(const CGameContext *pGameServer, int ClientId) const;
+	int GetDDRaceTeam(const CGameContext *pGameServer, int ClientId) const;
 
 	int m_OwnerId = 0;
 	uint32_t m_UniqueOwnerId = 0;
@@ -21,7 +23,7 @@ class CInteractions
 	bool m_NoHitSelf = false;
 
 public:
-	void Init(class CGameContext *pGameServer, int OwnerId, uint32_t UniqueOwnerId);
+	void Init(int OwnerId, uint32_t UniqueOwnerId);
 	void FillOwnerConnected(
 		bool OwnerAlive,
 		int DDRaceTeam,
@@ -29,10 +31,10 @@ public:
 		bool NoHitOthers,
 		bool NoHitSelf);
 	void FillOwnerDisconnected();
-	bool CanSee(int ClientId);
-	bool CanHit(int ClientId);
-	CClientMask CanSeeMask();
-	CClientMask CanHitMask();
+	bool CanSee(const CGameContext *pGameServer, int ClientId) const;
+	bool CanHit(const CGameContext *pGameServer, int ClientId) const;
+	CClientMask CanSeeMask(const CGameContext *pGameServer) const;
+	CClientMask CanHitMask(const CGameContext *pGameServer) const;
 };
 
 #endif


### PR DESCRIPTION
This is a ~~work in progress~~ refactor for projectile visibility and interact state to solve https://github.com/ddnet/ddnet/issues/9446 and similar issues. The core problem is that projectiles use the owner character to lookup state. But the owner might be dead or disconnected or switch ddrace teams and similar.

The proposed fix is to store all state needed to determine if a projectile can hit or be seen directly on the projectile. It still queries the full state every tick from the character to not change any old behavior even if it was weird. This can still be done in a feature refactor. When the owner disconnects it just keeps the old state instead of resetting to some unset state as it is doing right now.

~~The code is work in progress and just an idea for now. It still needs to be finished and polished. Because this is time consuming I would like to have some maintainer feedback before I put a lot of time into this refactor.~~

After 2 weeks of no feedback I fully finished and tested the pr. Works fine and is ready to be merged.

This pr does not fix grenades or id reuse: #10398, #9446 but lays some good foundation for it

This pr already fixes #10417, #9229

https://github.com/user-attachments/assets/067fb779-b8fc-494d-800a-b214e5a644d1


