### PR TITLE
Fix incorrect `data` directory being used in integration test

### DIFF
--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -97,7 +97,7 @@ class TestRunner:
 		self.ddnet_server = ddnet_server
 		self.ddnet_mastersrv = ddnet_mastersrv
 		self.repo_dir = repo_dir
-		self.data_dir = os.path.join(repo_dir, "data")
+		self.data_dir = os.path.join(dir, "data")
 		self.dir = dir
 		self.extra_env_vars = {}
 		self.keep_tmpdirs = keep_tmpdirs


### PR DESCRIPTION
The `data` folder inside the specified build folder should be used by the client instead of the `data` folder in the project root, as the latter does not contain the compiled Vulkan shaders.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
