### PR TITLE
Add message to explain how to disable debug graphs

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -993,6 +993,9 @@ void CClient::RenderGraphs()
 	float sp = Graphics()->ScreenWidth() / 100.0f;
 	float x = Graphics()->ScreenWidth() - w - sp;
 
+	TextRender()->TextColor(TextRender()->DefaultTextColor());
+	TextRender()->Text(x, sp * 5 - 12.0f - 10.0f, 12.0f, Localize("Press Ctrl+Shift+G to disable debug graphs."));
+
 	m_FpsGraph.Scale(time_freq());
 	m_FpsGraph.Render(Graphics(), TextRender(), x, sp * 5, w, h, "FPS");
 	m_InputtimeMarginGraph.Scale(5 * time_freq());


### PR DESCRIPTION
As debug graphs are toggled independently from debug mode now.

![image](https://github.com/user-attachments/assets/3fd4f0bd-980c-443c-afed-456629e9c749)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
