### PR TITLE
Don't recompile everything on component change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2323,6 +2323,7 @@ if(CLIENT)
     animstate.h
     component.cpp
     component.h
+    component_list.h
     components/background.cpp
     components/background.h
     components/binds.cpp

--- a/src/game/client/component.h
+++ b/src/game/client/component.h
@@ -15,6 +15,8 @@ class CComponentInterfaces
 {
 public:
 	virtual void OnInterfacesInit(CGameClient *pClient);
+	
+	virtual ~CComponentInterfaces() = default;
 
 protected:
 	/**
@@ -158,13 +160,6 @@ private:
 class CComponent : public CComponentInterfaces
 {
 public:
-	/**
-	 * The component virtual destructor.
-	 */
-	virtual ~CComponent()
-	{
-	}
-
 	/**
 	 * Gets the size of the non-abstract component.
 	 */

--- a/src/game/client/component.h
+++ b/src/game/client/component.h
@@ -15,7 +15,7 @@ class CComponentInterfaces
 {
 public:
 	virtual void OnInterfacesInit(CGameClient *pClient);
-	
+
 	virtual ~CComponentInterfaces() = default;
 
 protected:

--- a/src/game/client/component_list.h
+++ b/src/game/client/component_list.h
@@ -1,0 +1,55 @@
+// This file can be included several times.
+
+#ifndef COMPONENT
+#error "The component macros must be defined"
+#define COMPONENT(x) ;
+#define SUBCOMPONENT(x, y) ;
+#define COMPONENTINTERFACE(x) ;
+#endif
+
+COMPONENT(LocalServer)
+COMPONENT(Flow)
+COMPONENT(Skins)
+COMPONENT(Skins7)
+COMPONENT(CountryFlags)
+COMPONENT(MapImages)
+COMPONENT(Effects) // doesn't render anything, just updates effects
+COMPONENT(Binds)
+SUBCOMPONENT(Binds, m_SpecialBinds)
+COMPONENT(Controls)
+COMPONENT(Camera)
+COMPONENT(Sounds)
+COMPONENT(Voting)
+COMPONENT(Particles) // doesn't render anything, just updates all the particles
+COMPONENT(RaceDemo)
+COMPONENT(MapSounds)
+COMPONENT(Background) // render instead of m_MapLayersBackground when g_Config.m_ClOverlayEntities == 100
+COMPONENT(MapLayersBackground) // first to render
+SUBCOMPONENT(Particles, m_RenderTrail)
+SUBCOMPONENT(Particles, m_RenderTrailExtra)
+COMPONENT(Items)
+COMPONENT(Ghost)
+COMPONENT(Players)
+COMPONENT(MapLayersForeground)
+SUBCOMPONENT(Particles, m_RenderExplosions)
+COMPONENT(NamePlates)
+SUBCOMPONENT(Particles, m_RenderExtra)
+SUBCOMPONENT(Particles, m_RenderGeneral)
+COMPONENT(FreezeBars)
+COMPONENT(DamageInd)
+COMPONENT(Hud)
+COMPONENT(Spectator)
+COMPONENT(Emoticon)
+COMPONENT(InfoMessages)
+COMPONENT(Chat)
+COMPONENT(Broadcast)
+COMPONENT(DebugHud)
+COMPONENT(TouchControls)
+COMPONENT(Scoreboard)
+COMPONENT(Statboard)
+COMPONENT(Motd)
+COMPONENT(Menus)
+COMPONENT(Tooltips)
+SUBCOMPONENT(Menus, m_Binder)
+COMPONENT(GameConsole)
+COMPONENT(MenuBackground)

--- a/src/game/client/components/background.h
+++ b/src/game/client/components/background.h
@@ -5,8 +5,6 @@
 
 #include <game/client/components/maplayers.h>
 
-#include <cstdint>
-
 class CLayers;
 class CMapImages;
 

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -1,13 +1,16 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "binds.h"
+
 #include <base/log.h>
 #include <base/system.h>
+
 #include <engine/config.h>
 #include <engine/shared/config.h>
 
 #include <game/client/components/chat.h>
 #include <game/client/components/console.h>
+#include <game/client/components/menus.h>
 #include <game/client/gameclient.h>
 
 static constexpr LOG_COLOR BIND_PRINT_COLOR{255, 255, 204};

--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -6,13 +6,15 @@
 #include <base/log.h>
 #include <base/math.h>
 #include <base/vmath.h>
+
+#include <game/client/components/controls.h>
+
 #include <game/client/gameclient.h>
 #include <game/collision.h>
 #include <game/localization.h>
 #include <game/mapitems.h>
 
 #include "camera.h"
-#include "controls.h"
 
 #include <limits>
 

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -9,6 +9,7 @@
 #include <game/client/components/chat.h>
 #include <game/client/components/menus.h>
 #include <game/client/components/scoreboard.h>
+#include <game/client/components/spectator.h>
 #include <game/client/gameclient.h>
 #include <game/collision.h>
 

--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -1,16 +1,18 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <engine/graphics.h>
+#include <engine/keys.h>
 #include <engine/shared/config.h>
-#include <game/generated/protocol.h>
 
 #include "chat.h"
 #include "emoticon.h"
+
+#include <game/generated/protocol.h>
+
 #include <game/client/animstate.h>
+#include <game/client/gameclient.h>
 #include <game/client/render.h>
 #include <game/client/ui.h>
-
-#include <game/client/gameclient.h>
 
 CEmoticon::CEmoticon()
 {

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -5,8 +5,13 @@
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 
-#include <game/client/animstate.h>
+#include <game/client/components/camera.h>
+#include <game/client/components/controls.h>
+#include <game/client/components/players.h>
 #include <game/client/components/scoreboard.h>
+#include <game/client/components/voting.h>
+
+#include <game/client/animstate.h>
 #include <game/client/gameclient.h>
 #include <game/client/prediction/entities/character.h>
 #include <game/client/render.h>
@@ -18,11 +23,7 @@
 
 #include <cmath>
 
-#include "binds.h"
-#include "camera.h"
-#include "controls.h"
 #include "hud.h"
-#include "voting.h"
 
 CHud::CHud()
 {

--- a/src/game/client/components/local_server.cpp
+++ b/src/game/client/components/local_server.cpp
@@ -1,3 +1,7 @@
+#include <engine/client/updater.h>
+
+#include <game/client/components/menus.h>
+
 #include <game/client/gameclient.h>
 
 #include <game/localization.h>

--- a/src/game/client/components/local_server.h
+++ b/src/game/client/components/local_server.h
@@ -1,6 +1,8 @@
 #ifndef GAME_CLIENT_COMPONENTS_LOCAL_SERVER_H
 #define GAME_CLIENT_COMPONENTS_LOCAL_SERVER_H
 
+#include <engine/shared/config.h>
+
 #include <base/types.h>
 
 #include <game/client/component.h>

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -1,7 +1,12 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include <game/client/components/camera.h>
+#include <game/client/components/menus.h>
+
 #include <game/client/gameclient.h>
 #include <game/localization.h>
+
+#include <engine/map.h>
 
 #include "maplayers.h"
 

--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -6,7 +6,7 @@
 #include <game/client/render.h>
 
 #include "render_layer.h"
-#include <cstdint>
+
 #include <memory>
 #include <vector>
 
@@ -64,6 +64,20 @@ public:
 private:
 	std::vector<std::unique_ptr<CRenderLayer>> m_vRenderLayers;
 	int GetLayerType(const CMapItemLayer *pLayer) const;
+};
+
+class CMapLayersBackground : public CMapLayers
+{
+public:
+	CMapLayersBackground() :
+		CMapLayers{CMapLayers::TYPE_BACKGROUND} {}
+};
+
+class CMapLayersForeground : public CMapLayers
+{
+public:
+	CMapLayersForeground() :
+		CMapLayers{CMapLayers::TYPE_FOREGROUND} {}
 };
 
 #endif

--- a/src/game/client/components/mapsounds.cpp
+++ b/src/game/client/components/mapsounds.cpp
@@ -6,7 +6,9 @@
 #include <engine/sound.h>
 
 #include <game/client/components/camera.h>
+#include <game/client/components/maplayers.h>
 #include <game/client/components/sounds.h>
+
 #include <game/client/gameclient.h>
 #include <game/layers.h>
 #include <game/localization.h>

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -9,6 +9,8 @@
 #include <game/client/components/camera.h>
 #include <game/client/components/mapimages.h>
 #include <game/client/components/maplayers.h>
+#include <game/client/components/menus.h>
+
 #include <game/client/gameclient.h>
 
 #include <game/layers.h>

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1,6 +1,5 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -12,6 +11,8 @@
 #include <base/vmath.h>
 
 #include <engine/client.h>
+#include <engine/client/serverbrowser.h>
+#include <engine/client/updater.h>
 #include <engine/config.h>
 #include <engine/editor.h>
 #include <engine/friends.h>
@@ -23,18 +24,20 @@
 #include <engine/storage.h>
 #include <engine/textrender.h>
 
-#include <game/generated/protocol.h>
-
-#include <engine/client/updater.h>
-
-#include <game/client/animstate.h>
 #include <game/client/components/binds.h>
 #include <game/client/components/console.h>
+#include <game/client/components/effects.h>
+#include <game/client/components/items.h>
 #include <game/client/components/menu_background.h>
+#include <game/client/components/skins.h>
 #include <game/client/components/sounds.h>
+#include <game/client/components/tooltips.h>
+
+#include <game/client/animstate.h>
 #include <game/client/gameclient.h>
 #include <game/client/ui_listbox.h>
 #include <game/generated/client_data.h>
+#include <game/generated/protocol.h>
 #include <game/localization.h>
 
 #include "menus.h"

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -18,8 +18,9 @@
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 
-#include <game/client/component.h>
 #include <game/client/components/mapimages.h>
+
+#include <game/client/component.h>
 #include <game/client/lineinput.h>
 #include <game/client/render.h>
 #include <game/client/ui.h>

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -12,8 +12,12 @@
 #include <engine/shared/localization.h>
 #include <engine/textrender.h>
 
-#include <game/client/animstate.h>
 #include <game/client/components/countryflags.h>
+#include <game/client/components/menu_background.h>
+#include <game/client/components/skins.h>
+#include <game/client/components/tooltips.h>
+
+#include <game/client/animstate.h>
 #include <game/client/gameclient.h>
 #include <game/client/render.h>
 #include <game/client/ui.h>

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -12,7 +12,19 @@
 #include <engine/storage.h>
 #include <engine/textrender.h>
 
+#include <game/client/components/camera.h>
+#include <game/client/components/chat.h>
 #include <game/client/components/console.h>
+#include <game/client/components/damageind.h>
+#include <game/client/components/infomessages.h>
+#include <game/client/components/maplayers.h>
+#include <game/client/components/menu_background.h>
+#include <game/client/components/particles.h>
+#include <game/client/components/scoreboard.h>
+#include <game/client/components/sounds.h>
+#include <game/client/components/statboard.h>
+#include <game/client/components/tooltips.h>
+
 #include <game/client/gameclient.h>
 #include <game/client/render.h>
 #include <game/client/ui.h>
@@ -20,7 +32,6 @@
 #include <game/generated/client_data.h>
 #include <game/localization.h>
 
-#include "maplayers.h"
 #include "menus.h"
 
 #include <chrono>

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -16,9 +16,13 @@
 #include <game/generated/client_data.h>
 #include <game/generated/protocol.h>
 
-#include <game/client/animstate.h>
+#include <game/client/components/camera.h>
+#include <game/client/components/console.h>
 #include <game/client/components/countryflags.h>
+#include <game/client/components/tooltips.h>
 #include <game/client/components/touch_controls.h>
+
+#include <game/client/animstate.h>
 #include <game/client/gameclient.h>
 #include <game/client/render.h>
 #include <game/client/ui.h>
@@ -26,11 +30,11 @@
 #include <game/client/ui_scrollregion.h>
 #include <game/localization.h>
 
+#include "ghost.h"
 #include "menus.h"
 #include "motd.h"
 #include "voting.h"
 
-#include "ghost.h"
 #include <engine/keys.h>
 #include <engine/storage.h>
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -4,6 +4,7 @@
 #include <base/math.h>
 #include <base/system.h>
 
+#include <engine/editor.h>
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
 #include <engine/shared/linereader.h>
@@ -15,10 +16,19 @@
 
 #include <game/generated/protocol.h>
 
-#include <game/client/animstate.h>
+#include <game/client/components/binds.h>
 #include <game/client/components/chat.h>
+#include <game/client/components/console.h>
+#include <game/client/components/countryflags.h>
+#include <game/client/components/emoticon.h>
 #include <game/client/components/menu_background.h>
+#include <game/client/components/menus.h>
+#include <game/client/components/nameplates.h>
+#include <game/client/components/skins.h>
 #include <game/client/components/sounds.h>
+#include <game/client/components/tooltips.h>
+
+#include <game/client/animstate.h>
 #include <game/client/gameclient.h>
 #include <game/client/render.h>
 #include <game/client/skin.h>
@@ -26,11 +36,6 @@
 #include <game/client/ui_listbox.h>
 #include <game/client/ui_scrollregion.h>
 #include <game/localization.h>
-
-#include "binds.h"
-#include "countryflags.h"
-#include "menus.h"
-#include "skins.h"
 
 #include <array>
 #include <chrono>

--- a/src/game/client/components/menus_settings7.cpp
+++ b/src/game/client/components/menus_settings7.cpp
@@ -3,7 +3,9 @@
 #include <base/math.h>
 #include <base/system.h>
 
+#include <engine/editor.h>
 #include <engine/graphics.h>
+#include <engine/keys.h>
 #include <engine/shared/config.h>
 #include <engine/shared/linereader.h>
 #include <engine/shared/localization.h>
@@ -12,22 +14,25 @@
 #include <engine/textrender.h>
 #include <engine/updater.h>
 
-#include <game/generated/protocol.h>
+#include <game/client/components/chat.h>
+#include <game/client/components/console.h>
+#include <game/client/components/menu_background.h>
+#include <game/client/components/skins7.h>
+#include <game/client/components/sounds.h>
+#include <game/client/components/tooltips.h>
 
 #include <game/client/animstate.h>
-#include <game/client/components/chat.h>
-#include <game/client/components/menu_background.h>
-#include <game/client/components/sounds.h>
 #include <game/client/gameclient.h>
 #include <game/client/render.h>
 #include <game/client/skin.h>
 #include <game/client/ui.h>
 #include <game/client/ui_listbox.h>
 #include <game/client/ui_scrollregion.h>
+
+#include <game/generated/protocol.h>
 #include <game/localization.h>
 
 #include "menus.h"
-#include "skins7.h"
 
 #include <vector>
 

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -1,5 +1,6 @@
 #include <base/system.h>
 
+#include <engine/keys.h>
 #include <engine/shared/config.h>
 #include <engine/storage.h>
 #include <engine/textrender.h>
@@ -7,6 +8,9 @@
 #include <game/client/gameclient.h>
 #include <game/client/ui_listbox.h>
 #include <game/localization.h>
+
+#include <game/client/components/console.h>
+#include <game/client/components/tooltips.h>
 
 #include "menus.h"
 

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -1,5 +1,6 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include <engine/editor.h>
 #include <engine/graphics.h>
 #include <engine/keys.h>
 #include <engine/serverbrowser.h>
@@ -10,6 +11,12 @@
 
 #include <game/client/gameclient.h>
 #include <game/client/ui.h>
+
+#include <game/client/components/console.h>
+#include <game/client/components/local_server.h>
+#include <game/client/components/menu_background.h>
+#include <game/client/components/menus.h>
+#include <game/client/components/tooltips.h>
 
 #include <game/generated/client_data.h>
 #include <game/localization.h>

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -10,6 +10,10 @@
 #include <game/client/gameclient.h>
 #include <game/client/prediction/entities/character.h>
 
+#include <game/client/components/camera.h>
+#include <game/client/components/controls.h>
+#include <game/client/components/skins.h>
+
 #include <memory>
 #include <vector>
 

--- a/src/game/client/components/nameplates.h
+++ b/src/game/client/components/nameplates.h
@@ -5,6 +5,8 @@
 
 #include <engine/shared/protocol.h>
 
+#include <game/generated/protocol.h>
+
 #include <game/client/component.h>
 
 enum class EHookStrongWeakState

--- a/src/game/client/components/particles.cpp
+++ b/src/game/client/components/particles.cpp
@@ -5,6 +5,7 @@
 #include <engine/graphics.h>
 
 #include "particles.h"
+
 #include <game/client/render.h>
 #include <game/generated/client_data.h>
 

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -5,17 +5,18 @@
 #include <engine/demo.h>
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
+
 #include <game/gamecore.h>
 #include <game/generated/client_data.h>
 #include <game/generated/client_data7.h>
 #include <game/generated/protocol.h>
-
 #include <game/mapitems.h>
 
 #include <game/client/animstate.h>
 #include <game/client/gameclient.h>
 #include <game/client/render.h>
 
+#include <game/client/components/camera.h>
 #include <game/client/components/controls.h>
 #include <game/client/components/effects.h>
 #include <game/client/components/flow.h>

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -11,6 +11,7 @@
 
 #include "race_demo.h"
 
+#include <game/client/components/menus.h>
 #include <game/client/gameclient.h>
 
 #include <chrono>

--- a/src/game/client/components/render_layer.cpp
+++ b/src/game/client/components/render_layer.cpp
@@ -1,9 +1,12 @@
-#include "render_layer.h"
-#include "maplayers.h"
-
 #include <engine/graphics.h>
+#include <engine/map.h>
 #include <engine/shared/config.h>
 #include <engine/storage.h>
+
+#include <game/client/components/mapimages.h>
+#include <game/client/components/maplayers.h>
+#include <game/client/components/menus.h>
+#include <game/client/components/render_layer.h>
 
 #include <game/client/gameclient.h>
 #include <game/layers.h>

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -7,16 +7,18 @@
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 
-#include <game/generated/protocol.h>
-
-#include <game/client/animstate.h>
 #include <game/client/components/countryflags.h>
 #include <game/client/components/motd.h>
+#include <game/client/components/skins7.h>
 #include <game/client/components/statboard.h>
+
+#include <game/client/animstate.h>
 #include <game/client/gameclient.h>
 #include <game/client/render.h>
 #include <game/client/ui.h>
+
 #include <game/generated/client_data7.h>
+#include <game/generated/protocol.h>
 #include <game/localization.h>
 
 CScoreboard::CScoreboard()

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -14,6 +14,8 @@
 #include <engine/shared/http.h>
 #include <engine/storage.h>
 
+#include <game/client/components/menus.h>
+
 #include <game/client/gameclient.h>
 #include <game/generated/client_data.h>
 #include <game/localization.h>

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -3,17 +3,22 @@
 
 #include <limits>
 
+#include <engine/demo.h>
 #include <engine/graphics.h>
+#include <engine/keys.h>
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 
 #include <game/generated/protocol.h>
 
+#include <game/client/components/camera.h>
+#include <game/client/components/console.h>
+#include <game/client/components/menus.h>
+
 #include <game/client/animstate.h>
 #include <game/client/render.h>
 #include <game/localization.h>
 
-#include "camera.h"
 #include "spectator.h"
 
 #include <game/client/gameclient.h>

--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -7,10 +7,13 @@
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 
+#include <game/client/components/binds.h>
 #include <game/client/components/scoreboard.h>
 #include <game/client/components/sounds.h>
+
 #include <game/client/gameclient.h>
 #include <game/client/render.h>
+
 #include <game/generated/protocol.h>
 #include <game/localization.h>
 

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -3,7 +3,6 @@
 #ifndef GAME_CLIENT_GAMECLIENT_H
 #define GAME_CLIENT_GAMECLIENT_H
 
-#include "render.h"
 #include <base/color.h>
 #include <base/vmath.h>
 #include <engine/client.h>
@@ -19,49 +18,11 @@
 
 #include <game/client/prediction/gameworld.h>
 #include <game/client/race.h>
+#include <game/client/render.h>
+#include <game/client/ui.h>
 
 #include <game/generated/protocol7.h>
 #include <game/generated/protocolglue.h>
-
-// components
-#include "components/background.h"
-#include "components/binds.h"
-#include "components/broadcast.h"
-#include "components/camera.h"
-#include "components/chat.h"
-#include "components/console.h"
-#include "components/controls.h"
-#include "components/countryflags.h"
-#include "components/damageind.h"
-#include "components/debughud.h"
-#include "components/effects.h"
-#include "components/emoticon.h"
-#include "components/flow.h"
-#include "components/freezebars.h"
-#include "components/ghost.h"
-#include "components/hud.h"
-#include "components/infomessages.h"
-#include "components/items.h"
-#include "components/local_server.h"
-#include "components/mapimages.h"
-#include "components/maplayers.h"
-#include "components/mapsounds.h"
-#include "components/menu_background.h"
-#include "components/menus.h"
-#include "components/motd.h"
-#include "components/nameplates.h"
-#include "components/particles.h"
-#include "components/players.h"
-#include "components/race_demo.h"
-#include "components/scoreboard.h"
-#include "components/skins.h"
-#include "components/skins7.h"
-#include "components/sounds.h"
-#include "components/spectator.h"
-#include "components/statboard.h"
-#include "components/tooltips.h"
-#include "components/touch_controls.h"
-#include "components/voting.h"
 
 #include <vector>
 
@@ -127,55 +88,24 @@ enum class EClientIdFormat
 	INDENT_FORCE, // for rendering settings preview
 };
 
+#define COMPONENT(x) class C##x;
+#define SUBCOMPONENT(x, y) ;
+#include "component_list.h"
+#undef COMPONENT
+#undef SUBCOMPONENT
 class CGameClient : public IGameClient
 {
+#define COMPONENT(x) std::unique_ptr<class C##x> m_p##x;
+#define SUBCOMPONENT(x, y) ;
+#include "component_list.h"
+#undef COMPONENT
+#undef SUBCOMPONENT
 public:
-	// all components
-	CInfoMessages m_InfoMessages;
-	CCamera m_Camera;
-	CChat m_Chat;
-	CMotd m_Motd;
-	CBroadcast m_Broadcast;
-	CGameConsole m_GameConsole;
-	CBinds m_Binds;
-	CParticles m_Particles;
-	CMenus m_Menus;
-	CSkins m_Skins;
-	CSkins7 m_Skins7;
-	CCountryFlags m_CountryFlags;
-	CFlow m_Flow;
-	CHud m_Hud;
-	CDebugHud m_DebugHud;
-	CControls m_Controls;
-	CEffects m_Effects;
-	CScoreboard m_Scoreboard;
-	CStatboard m_Statboard;
-	CSounds m_Sounds;
-	CEmoticon m_Emoticon;
-	CDamageInd m_DamageInd;
-	CTouchControls m_TouchControls;
-	CVoting m_Voting;
-	CSpectator m_Spectator;
-
-	CPlayers m_Players;
-	CNamePlates m_NamePlates;
-	CFreezeBars m_FreezeBars;
-	CItems m_Items;
-	CMapImages m_MapImages;
-
-	CMapLayers m_MapLayersBackground = CMapLayers{CMapLayers::TYPE_BACKGROUND};
-	CMapLayers m_MapLayersForeground = CMapLayers{CMapLayers::TYPE_FOREGROUND};
-	CBackground m_Background;
-	CMenuBackground m_MenuBackground;
-
-	CMapSounds m_MapSounds;
-
-	CRaceDemo m_RaceDemo;
-	CGhost m_Ghost;
-
-	CTooltips m_Tooltips;
-
-	CLocalServer m_LocalServer;
+#define COMPONENT(x) class C##x &m_##x;
+#define SUBCOMPONENT(x, y) ;
+#include "component_list.h"
+#undef COMPONENT
+#undef SUBCOMPONENT
 
 private:
 	std::vector<class CComponent *> m_vpAll;
@@ -255,6 +185,8 @@ private:
 	int m_PrevLocalId = -1;
 
 public:
+	CGameClient();
+
 	IKernel *Kernel() { return IInterface::Kernel(); }
 	IEngine *Engine() const { return m_pEngine; }
 	class IGraphics *Graphics() const { return m_pGraphics; }

--- a/src/game/client/sixup_translate_connless.cpp
+++ b/src/game/client/sixup_translate_connless.cpp
@@ -1,4 +1,8 @@
+#include <engine/client/client.h>
+#include <engine/serverbrowser.h>
 #include <engine/shared/masterserver.h>
+#include <engine/shared/network.h>
+
 #include <game/client/gameclient.h>
 
 void CClient::PreprocessConnlessPacket7(CNetChunk *pPacket)

--- a/src/game/client/sixup_translate_game.cpp
+++ b/src/game/client/sixup_translate_game.cpp
@@ -1,10 +1,18 @@
 #include <base/system.h>
+
 #include <engine/shared/protocol7.h>
+
 #include <game/gamecore.h>
 #include <game/generated/protocol7.h>
 #include <game/localization.h>
 
 #include <game/client/gameclient.h>
+
+#include <game/client/components/broadcast.h>
+#include <game/client/components/chat.h>
+#include <game/client/components/skins7.h>
+#include <game/client/components/sounds.h>
+#include <game/client/components/voting.h>
 
 enum
 {

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1,8 +1,6 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
-#include <algorithm>
-
 #include <base/color.h>
 #include <base/system.h>
 
@@ -17,12 +15,17 @@
 #include <engine/graphics.h>
 #include <engine/input.h>
 #include <engine/keys.h>
+#include <engine/serverbrowser.h>
 #include <engine/shared/config.h>
 #include <engine/shared/filecollection.h>
 #include <engine/storage.h>
 #include <engine/textrender.h>
 
 #include <game/client/components/camera.h>
+#include <game/client/components/items.h>
+#include <game/client/components/mapimages.h>
+#include <game/client/components/sounds.h>
+
 #include <game/client/gameclient.h>
 #include <game/client/lineinput.h>
 #include <game/client/render.h>
@@ -40,6 +43,7 @@
 #include "editor.h"
 #include "editor_actions.h"
 
+#include <algorithm>
 #include <chrono>
 #include <iterator>
 #include <limits>

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -12,6 +12,9 @@
 #include <engine/textrender.h>
 #include <limits>
 
+#include <game/client/components/local_server.h>
+#include <game/client/components/menus.h>
+
 #include <game/client/gameclient.h>
 #include <game/client/ui_scrollregion.h>
 #include <game/editor/mapitems/image.h>

--- a/src/game/editor/quick_actions.cpp
+++ b/src/game/editor/quick_actions.cpp
@@ -1,4 +1,7 @@
 #include <engine/keys.h>
+
+#include <game/client/components/local_server.h>
+#include <game/client/components/menus.h>
 #include <game/client/gameclient.h>
 #include <game/mapitems.h>
 


### PR DESCRIPTION
Will speed up prototyping a ton as recompiles a lot less and less effort into not changing the header has to be done

Next on the list, preventing full recompile on version.h change and config_variables.h change

Seems to work

![image](https://github.com/user-attachments/assets/2841057e-7fef-48fb-aa53-d45b42d5af29)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
