### PR TITLE
Normalize storage and current folder paths on Windows

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2417,7 +2417,10 @@ int fs_storage_path(const char *appname, char *path, int max)
 		path[0] = '\0';
 		return -1;
 	}
-	str_format(path, max, "%s/%s", home.value().c_str(), appname);
+	str_copy(path, home.value().c_str(), max);
+	fs_normalize_path(path);
+	str_append(path, "/", max);
+	str_append(path, appname, max);
 	return 0;
 #else
 	char *home = getenv("HOME");
@@ -2606,6 +2609,7 @@ char *fs_getcwd(char *buffer, int buffer_size)
 		return nullptr;
 	}
 	str_copy(buffer, current_dir.value().c_str(), buffer_size);
+	fs_normalize_path(buffer);
 	return buffer;
 #else
 	char *result = getcwd(buffer, buffer_size);
@@ -2648,6 +2652,26 @@ void fs_split_file_extension(const char *filename, char *name, size_t name_size,
 			str_copy(extension, last_dot + 1, extension_size);
 		if(name != nullptr)
 			str_truncate(name, name_size, filename, last_dot - filename);
+	}
+}
+
+void fs_normalize_path(char *path)
+{
+	for(int i = 0; path[i] != '\0';)
+	{
+		if(path[i] == '\\')
+		{
+			path[i] = '/';
+		}
+		if(i > 0 && path[i] == '/' && path[i + 1] == '\0')
+		{
+			path[i] = '\0';
+			--i;
+		}
+		else
+		{
+			++i;
+		}
 	}
 }
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2166,6 +2166,18 @@ const char *fs_filename(const char *path);
 void fs_split_file_extension(const char *filename, char *name, size_t name_size, char *extension = nullptr, size_t extension_size = 0);
 
 /**
+ * Normalizes the given path: replaces backslashes with regular slashes
+ * and removes trailing slashes.
+ *
+ * @ingroup Filesystem
+ *
+ * @param path Path to normalize.
+ *
+ * @remark The strings are treated as null-terminated strings.
+ */
+void fs_normalize_path(char *path);
+
+/**
  * Get the parent directory of a directory.
  *
  * @ingroup Filesystem

--- a/src/test/fs.cpp
+++ b/src/test/fs.cpp
@@ -60,6 +60,28 @@ TEST(Filesystem, SplitFileExtension)
 	EXPECT_STREQ(aExt, "");
 }
 
+static void TestNormalizePath(const char *pInput, const char *pExpectedOutput)
+{
+	char aNormalized[256];
+	str_copy(aNormalized, pInput);
+	fs_normalize_path(aNormalized);
+	EXPECT_STREQ(aNormalized, pExpectedOutput);
+}
+
+TEST(Filesystem, NormalizePath)
+{
+	TestNormalizePath("", "");
+	TestNormalizePath("/", "/");
+	TestNormalizePath("\\", "/");
+	TestNormalizePath("//", "/");
+	TestNormalizePath("/////", "/");
+	TestNormalizePath("\\\\\\\\\\", "/");
+	TestNormalizePath("/a/b/c", "/a/b/c");
+	TestNormalizePath("\\a\\b\\c", "/a/b/c");
+	TestNormalizePath("C:\\Users", "C:/Users");
+	TestNormalizePath("C:\\", "C:");
+}
+
 TEST(Filesystem, StoragePath)
 {
 	char aStoragePath[IO_MAX_PATH_LENGTH];


### PR DESCRIPTION
Replace backslashes with regular slashes and remove trailing slashes to fix incorrect storage and current folder paths when `APPDATA` is mapped to a drive root or when launching with the current folder being a drive root.

See https://github.com/ddnet/ddnet/pull/10342#issuecomment-2994291876.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
