### PR TITLE
Tick gamecontext once with one player in unit tests

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1754,13 +1754,7 @@ void CGameContext::OnClientConnected(int ClientId, void *pData)
 
 	// Check which team the player should be on
 	const int StartTeam = (Spec || g_Config.m_SvTournamentMode) ? TEAM_SPECTATORS : m_pController->GetAutoTeam(ClientId);
-
-	if(m_apPlayers[ClientId])
-		delete m_apPlayers[ClientId];
-	m_apPlayers[ClientId] = new(ClientId) CPlayer(this, m_NextUniqueClientId, ClientId, StartTeam);
-	m_apPlayers[ClientId]->SetInitialAfk(Afk);
-	m_apPlayers[ClientId]->m_LastWhisperTo = LastWhisperTo;
-	m_NextUniqueClientId += 1;
+	CreatePlayer(ClientId, StartTeam, Afk, LastWhisperTo);
 
 	SendMotd(ClientId);
 	SendSettings(ClientId);
@@ -4204,6 +4198,17 @@ void CGameContext::CreateAllEntities(bool Initial)
 			}
 		}
 	}
+}
+
+CPlayer *CGameContext::CreatePlayer(int ClientId, int StartTeam, bool Afk, int LastWhisperTo)
+{
+	if(m_apPlayers[ClientId])
+		delete m_apPlayers[ClientId];
+	m_apPlayers[ClientId] = new(ClientId) CPlayer(this, m_NextUniqueClientId, ClientId, StartTeam);
+	m_apPlayers[ClientId]->SetInitialAfk(Afk);
+	m_apPlayers[ClientId]->m_LastWhisperTo = LastWhisperTo;
+	m_NextUniqueClientId += 1;
+	return m_apPlayers[ClientId];
 }
 
 void CGameContext::DeleteTempfile()

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -244,6 +244,7 @@ public:
 	char m_aaZoneLeaveMsg[NUM_TUNEZONES][256];
 
 	void CreateAllEntities(bool Initial);
+	CPlayer *CreatePlayer(int ClientId, int StartTeam, bool Afk, int LastWhisperTo);
 
 	char m_aDeleteTempfile[128];
 	void DeleteTempfile();

--- a/src/test/gameworld.cpp
+++ b/src/test/gameworld.cpp
@@ -1,4 +1,6 @@
 #include "test.h"
+#include <game/server/gamecontroller.h>
+#include <game/server/player.h>
 #include <gtest/gtest.h>
 
 #include <base/logger.h>
@@ -247,4 +249,15 @@ TEST_F(CTestGameWorld, IntersectEntity)
 		-1, // CollideWith
 		nullptr /* pThisOnly */);
 	EXPECT_EQ(pIntersectedChar, pChrRight);
+}
+
+TEST_F(CTestGameWorld, BasicTick)
+{
+	int ClientId = 0;
+	bool Afk = true;
+	int LastWhisperTo = -1;
+	const int StartTeam = GameServer()->m_pController->GetAutoTeam(ClientId);
+	GameServer()->CreatePlayer(ClientId, StartTeam, Afk, LastWhisperTo);
+
+	GameServer()->OnTick();
 }


### PR DESCRIPTION
No state is asserted yet. Just unlocking more code runtime during unit tests. This can catch some crashes for now and lays the foundation for more complex tests.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
