### PR TITLE
Consistently use `OnDialogClose` function for editor dialogs

### DIFF
--- a/src/engine/editor.h
+++ b/src/engine/editor.h
@@ -15,7 +15,6 @@ public:
 	virtual void OnActivate() = 0;
 	virtual void OnWindowResize() = 0;
 	virtual void OnClose() = 0;
-	virtual void OnDialogClose() = 0;
 	virtual bool HasUnsavedData() const = 0;
 	virtual bool HandleMapDrop(const char *pFilename, int StorageType) = 0;
 	virtual bool Load(const char *pFilename, int StorageType) = 0;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -798,7 +798,9 @@ bool CEditor::CallbackOpenMap(const char *pFileName, int StorageType, void *pUse
 	{
 		pEditor->m_ValidSaveFilename = StorageType == IStorage::TYPE_SAVE && (pEditor->m_pFileDialogPath == pEditor->m_aFileDialogCurrentFolder || (pEditor->m_pFileDialogPath == pEditor->m_aFileDialogCurrentLink && str_comp(pEditor->m_aFileDialogCurrentLink, "themes") == 0));
 		if(pEditor->m_Dialog == DIALOG_FILE)
-			pEditor->m_Dialog = DIALOG_NONE;
+		{
+			pEditor->OnDialogClose();
+		}
 		return true;
 	}
 	else
@@ -813,7 +815,7 @@ bool CEditor::CallbackAppendMap(const char *pFileName, int StorageType, void *pU
 	CEditor *pEditor = (CEditor *)pUser;
 	if(pEditor->Append(pFileName, StorageType))
 	{
-		pEditor->m_Dialog = DIALOG_NONE;
+		pEditor->OnDialogClose();
 		return true;
 	}
 	else
@@ -858,7 +860,7 @@ bool CEditor::CallbackSaveMap(const char *pFileName, int StorageType, void *pUse
 			return false;
 	}
 
-	pEditor->m_Dialog = DIALOG_NONE;
+	pEditor->OnDialogClose();
 	return true;
 }
 
@@ -877,7 +879,7 @@ bool CEditor::CallbackSaveCopyMap(const char *pFileName, int StorageType, void *
 
 	if(pEditor->Save(pFileName))
 	{
-		pEditor->m_Dialog = DIALOG_NONE;
+		pEditor->OnDialogClose();
 		return true;
 	}
 	else
@@ -905,7 +907,7 @@ bool CEditor::CallbackSaveImage(const char *pFileName, int StorageType, void *pU
 
 	if(CImageLoader::SavePng(pEditor->Storage()->OpenFile(pFileName, IOFLAG_WRITE, StorageType), pFileName, *pImg))
 	{
-		pEditor->m_Dialog = DIALOG_NONE;
+		pEditor->OnDialogClose();
 		return true;
 	}
 	else
@@ -936,7 +938,6 @@ bool CEditor::CallbackSaveSound(const char *pFileName, int StorageType, void *pU
 		io_write(File, pSound->m_pData, pSound->m_DataSize);
 		io_close(File);
 		pEditor->OnDialogClose();
-		pEditor->m_Dialog = DIALOG_NONE;
 		return true;
 	}
 	pEditor->ShowFileDialogError("Failed to open file '%s'.", pFileName);
@@ -970,7 +971,7 @@ bool CEditor::CallbackCustomEntities(const char *pFileName, int StorageType, voi
 	pEditor->Graphics()->UnloadTexture(&pEditor->m_EntitiesTexture);
 	pEditor->m_EntitiesTexture = pEditor->Graphics()->LoadTextureRawMove(ImgInfo, pEditor->GetTextureUsageFlag());
 
-	pEditor->m_Dialog = DIALOG_NONE;
+	pEditor->OnDialogClose();
 	return true;
 }
 
@@ -4552,7 +4553,7 @@ bool CEditor::ReplaceImage(const char *pFileName, int StorageType, bool CheckDup
 		if(!str_comp(m_Map.m_vpImages[i]->m_aName, pImg->m_aName))
 			m_SelectedImage = i;
 	}
-	m_Dialog = DIALOG_NONE;
+	OnDialogClose();
 	return true;
 }
 
@@ -4621,7 +4622,7 @@ bool CEditor::AddImage(const char *pFileName, int StorageType, void *pUser)
 				break;
 			}
 	}
-	pEditor->m_Dialog = DIALOG_NONE;
+	pEditor->OnDialogClose();
 	return true;
 }
 
@@ -4685,7 +4686,6 @@ bool CEditor::AddSound(const char *pFileName, int StorageType, void *pUser)
 	}
 
 	pEditor->OnDialogClose();
-	pEditor->m_Dialog = DIALOG_NONE;
 	return true;
 }
 
@@ -4742,7 +4742,6 @@ bool CEditor::ReplaceSound(const char *pFileName, int StorageType, bool CheckDup
 	pSound->m_DataSize = DataSize;
 
 	OnDialogClose();
-	m_Dialog = DIALOG_NONE;
 	return true;
 }
 
@@ -5624,7 +5623,6 @@ void CEditor::RenderFileDialog()
 	if(DoButton_Editor(&s_CancelButton, "Cancel", 0, &Button, BUTTONFLAG_LEFT, nullptr) || (s_ListBox.Active() && Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE)))
 	{
 		OnDialogClose();
-		m_Dialog = DIALOG_NONE;
 	}
 
 	ButtonBar.VSplitRight(ButtonSpacing, &ButtonBar, nullptr);
@@ -9209,6 +9207,7 @@ void CEditor::OnClose()
 
 void CEditor::OnDialogClose()
 {
+	m_Dialog = DIALOG_NONE;
 	Graphics()->UnloadTexture(&m_FilePreviewImage);
 	Sound()->UnloadSample(m_FilePreviewSound);
 	m_FilePreviewSound = -1;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -497,7 +497,7 @@ public:
 	void OnActivate() override;
 	void OnWindowResize() override;
 	void OnClose() override;
-	void OnDialogClose() override;
+	void OnDialogClose();
 	bool HasUnsavedData() const override { return m_Map.m_Modified; }
 	void UpdateMentions() override { m_Mentions++; }
 	void ResetMentions() override { m_Mentions = 0; }

--- a/src/game/editor/editor_server_settings.cpp
+++ b/src/game/editor/editor_server_settings.cpp
@@ -1008,7 +1008,7 @@ void CEditor::RenderMapSettingsErrorDialog()
 	if(DoButton_Editor(&s_ConfirmButton, "Confirm", CanConfirm ? 0 : -1, &ConfimButton, BUTTONFLAG_LEFT, nullptr) || (CanConfirm && Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
 	{
 		Execute();
-		m_Dialog = DIALOG_NONE;
+		OnDialogClose();
 	}
 
 	// Cancel - we load a new empty map
@@ -1016,7 +1016,7 @@ void CEditor::RenderMapSettingsErrorDialog()
 	{
 		Reset();
 		m_aFileName[0] = 0;
-		m_Dialog = DIALOG_NONE;
+		OnDialogClose();
 	}
 }
 

--- a/src/game/editor/prompt.cpp
+++ b/src/game/editor/prompt.cpp
@@ -43,7 +43,9 @@ void CPrompt::SetInactive()
 	m_ResetFilterResults = true;
 	m_PromptInput.Clear();
 	if(Editor()->m_Dialog == DIALOG_QUICK_PROMPT)
-		Editor()->m_Dialog = DIALOG_NONE;
+	{
+		Editor()->OnDialogClose();
+	}
 	CEditorComponent::SetInactive();
 }
 

--- a/src/game/editor/quadart.cpp
+++ b/src/game/editor/quadart.cpp
@@ -192,7 +192,7 @@ void CEditor::AddQuadArt(bool IgnoreHistory)
 		m_EditorHistory.RecordAction(std::make_shared<CEditorActionQuadArt>(this, m_QuadArtParameters));
 
 	m_Map.OnModify();
-	m_Dialog = DIALOG_NONE;
+	OnDialogClose();
 }
 
 bool CEditor::CallbackAddQuadArt(const char *pFilepath, int StorageType, void *pUser)

--- a/src/game/editor/tileart.cpp
+++ b/src/game/editor/tileart.cpp
@@ -167,7 +167,7 @@ void CEditor::AddTileart(bool IgnoreHistory)
 
 	m_TileartImageInfo.Free();
 	m_Map.OnModify();
-	m_Dialog = DIALOG_NONE;
+	OnDialogClose();
 }
 
 void CEditor::TileartCheckColors()


### PR DESCRIPTION
Ensure resources of editor dialogs are properly freed by always using the `OnDialogClose` function to close dialogs.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
