### PR TITLE
Add `CUIRect::DrawOutline` function to draw rectangle outline

### DIFF
--- a/src/game/client/ui_rect.cpp
+++ b/src/game/client/ui_rect.cpp
@@ -175,3 +175,17 @@ void CUIRect::Draw4(ColorRGBA ColorTopLeft, ColorRGBA ColorTopRight, ColorRGBA C
 {
 	s_pGraphics->DrawRect4(x, y, w, h, ColorTopLeft, ColorTopRight, ColorBottomLeft, ColorBottomRight, Corners, Rounding);
 }
+
+void CUIRect::DrawOutline(ColorRGBA Color) const
+{
+	const IGraphics::CLineItem aArray[] = {
+		IGraphics::CLineItem(x, y, x + w, y),
+		IGraphics::CLineItem(x + w, y, x + w, y + h),
+		IGraphics::CLineItem(x + w, y + h, x, y + h),
+		IGraphics::CLineItem(x, y + h, x, y)};
+	s_pGraphics->TextureClear();
+	s_pGraphics->LinesBegin();
+	s_pGraphics->SetColor(Color);
+	s_pGraphics->LinesDraw(aArray, std::size(aArray));
+	s_pGraphics->LinesEnd();
+}

--- a/src/game/client/ui_rect.h
+++ b/src/game/client/ui_rect.h
@@ -137,6 +137,13 @@ public:
 	void Draw4(ColorRGBA ColorTopLeft, ColorRGBA ColorTopRight, ColorRGBA ColorBottomLeft, ColorRGBA ColorBottomRight, int Corners, float Rounding) const;
 
 	/**
+	 * Draws the outline of *this* CUIRect using lines.
+	 *
+	 * @param Color The color to draw the outline in.
+	 */
+	void DrawOutline(ColorRGBA Color) const;
+
+	/**
 	 * Returns the top-left position of *this* CUIRect as a vec2.
 	 *
 	 * @return Top-left position as vec2.

--- a/src/game/editor/map_view.cpp
+++ b/src/game/editor/map_view.cpp
@@ -63,18 +63,11 @@ void CMapView::RenderGroupBorder()
 			std::shared_ptr<CLayer> pLayer = Editor()->GetSelectedLayerType(i, LAYERTYPE_TILES);
 			if(pLayer)
 			{
-				float w, h;
-				pLayer->GetSize(&w, &h);
-
-				IGraphics::CLineItem aArray[4] = {
-					IGraphics::CLineItem(0, 0, w, 0),
-					IGraphics::CLineItem(w, 0, w, h),
-					IGraphics::CLineItem(w, h, 0, h),
-					IGraphics::CLineItem(0, h, 0, 0)};
-				Graphics()->TextureClear();
-				Graphics()->LinesBegin();
-				Graphics()->LinesDraw(aArray, std::size(aArray));
-				Graphics()->LinesEnd();
+				CUIRect BorderRect;
+				BorderRect.x = 0.0f;
+				BorderRect.y = 0.0f;
+				pLayer->GetSize(&BorderRect.w, &BorderRect.h);
+				BorderRect.DrawOutline(ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f));
 			}
 		}
 	}

--- a/src/game/editor/mapitems/layer_quads.cpp
+++ b/src/game/editor/mapitems/layer_quads.cpp
@@ -96,16 +96,7 @@ CQuad *CLayerQuads::NewQuad(int x, int y, int Width, int Height)
 
 void CLayerQuads::BrushSelecting(CUIRect Rect)
 {
-	// draw selection rectangle
-	IGraphics::CLineItem Array[4] = {
-		IGraphics::CLineItem(Rect.x, Rect.y, Rect.x + Rect.w, Rect.y),
-		IGraphics::CLineItem(Rect.x + Rect.w, Rect.y, Rect.x + Rect.w, Rect.y + Rect.h),
-		IGraphics::CLineItem(Rect.x + Rect.w, Rect.y + Rect.h, Rect.x, Rect.y + Rect.h),
-		IGraphics::CLineItem(Rect.x, Rect.y + Rect.h, Rect.x, Rect.y)};
-	Graphics()->TextureClear();
-	Graphics()->LinesBegin();
-	Graphics()->LinesDraw(Array, 4);
-	Graphics()->LinesEnd();
+	Rect.DrawOutline(ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f));
 }
 
 int CLayerQuads::BrushGrab(std::shared_ptr<CLayerGroup> pBrush, CUIRect Rect)

--- a/src/game/editor/mapitems/layer_sounds.cpp
+++ b/src/game/editor/mapitems/layer_sounds.cpp
@@ -112,16 +112,7 @@ CSoundSource *CLayerSounds::NewSource(int x, int y)
 
 void CLayerSounds::BrushSelecting(CUIRect Rect)
 {
-	// draw selection rectangle
-	IGraphics::CLineItem Array[4] = {
-		IGraphics::CLineItem(Rect.x, Rect.y, Rect.x + Rect.w, Rect.y),
-		IGraphics::CLineItem(Rect.x + Rect.w, Rect.y, Rect.x + Rect.w, Rect.y + Rect.h),
-		IGraphics::CLineItem(Rect.x + Rect.w, Rect.y + Rect.h, Rect.x, Rect.y + Rect.h),
-		IGraphics::CLineItem(Rect.x, Rect.y + Rect.h, Rect.x, Rect.y)};
-	Graphics()->TextureClear();
-	Graphics()->LinesBegin();
-	Graphics()->LinesDraw(Array, 4);
-	Graphics()->LinesEnd();
+	Rect.DrawOutline(ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f));
 }
 
 int CLayerSounds::BrushGrab(std::shared_ptr<CLayerGroup> pBrush, CUIRect Rect)

--- a/src/game/editor/proof_mode.cpp
+++ b/src/game/editor/proof_mode.cpp
@@ -120,7 +120,7 @@ void CProofMode::RenderScreenSizes()
 
 			if(i == 0)
 			{
-				IGraphics::CLineItem aArray[2] = {
+				IGraphics::CLineItem aArray[] = {
 					IGraphics::CLineItem(aPoints[0], aPoints[1], aPoints[2], aPoints[1]),
 					IGraphics::CLineItem(aPoints[0], aPoints[3], aPoints[2], aPoints[3])};
 				Graphics()->LinesDraw(aArray, std::size(aArray));
@@ -128,7 +128,7 @@ void CProofMode::RenderScreenSizes()
 
 			if(i != 0)
 			{
-				IGraphics::CLineItem aArray[4] = {
+				IGraphics::CLineItem aArray[] = {
 					IGraphics::CLineItem(aPoints[0], aPoints[1], aLastPoints[0], aLastPoints[1]),
 					IGraphics::CLineItem(aPoints[2], aPoints[1], aLastPoints[2], aLastPoints[1]),
 					IGraphics::CLineItem(aPoints[0], aPoints[3], aLastPoints[0], aLastPoints[3]),
@@ -138,7 +138,7 @@ void CProofMode::RenderScreenSizes()
 
 			if(i == NumSteps)
 			{
-				IGraphics::CLineItem aArray[2] = {
+				IGraphics::CLineItem aArray[] = {
 					IGraphics::CLineItem(aPoints[0], aPoints[1], aPoints[0], aPoints[3]),
 					IGraphics::CLineItem(aPoints[2], aPoints[1], aPoints[2], aPoints[3])};
 				Graphics()->LinesDraw(aArray, std::size(aArray));
@@ -146,37 +146,29 @@ void CProofMode::RenderScreenSizes()
 
 			mem_copy(aLastPoints, aPoints, sizeof(aPoints));
 		}
+		Graphics()->LinesEnd();
 
 		// two screen sizes (green and red border)
 		{
 			Graphics()->SetColor(1, 0, 0, 1);
-			for(int i = 0; i < 2; i++)
+			for(int Pass = 0; Pass < 2; Pass++)
 			{
 				float aPoints[4];
 				const float aAspects[] = {4.0f / 3.0f, 16.0f / 10.0f, 5.0f / 4.0f, 16.0f / 9.0f};
-				float Aspect = aAspects[i];
-
+				const ColorRGBA aColors[] = {ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f), ColorRGBA(0.0f, 1.0f, 0.0f, 1.0f)};
 				float Zoom = (m_ProofBorders == PROOF_BORDER_MENU) ? 0.7f : 1.0f;
 				RenderTools()->MapScreenToWorld(
 					WorldOffset.x, WorldOffset.y,
-					100.0f, 100.0f, 100.0f, 0.0f, 0.0f, Aspect, Zoom, aPoints);
+					100.0f, 100.0f, 100.0f, 0.0f, 0.0f, aAspects[Pass], Zoom, aPoints);
 
-				CUIRect r;
-				r.x = aPoints[0];
-				r.y = aPoints[1];
-				r.w = aPoints[2] - aPoints[0];
-				r.h = aPoints[3] - aPoints[1];
-
-				IGraphics::CLineItem aArray[4] = {
-					IGraphics::CLineItem(r.x, r.y, r.x + r.w, r.y),
-					IGraphics::CLineItem(r.x + r.w, r.y, r.x + r.w, r.y + r.h),
-					IGraphics::CLineItem(r.x + r.w, r.y + r.h, r.x, r.y + r.h),
-					IGraphics::CLineItem(r.x, r.y + r.h, r.x, r.y)};
-				Graphics()->LinesDraw(aArray, std::size(aArray));
-				Graphics()->SetColor(0, 1, 0, 1);
+				CUIRect Rect;
+				Rect.x = aPoints[0];
+				Rect.y = aPoints[1];
+				Rect.w = aPoints[2] - aPoints[0];
+				Rect.h = aPoints[3] - aPoints[1];
+				Rect.DrawOutline(aColors[Pass]);
 			}
 		}
-		Graphics()->LinesEnd();
 
 		// tee position (blue circle) and other screen positions
 		{


### PR DESCRIPTION
Avoid duplicate code for rendering various selection rectangles in the editor.

Use `std::size` for line and vertex arrays and avoid redundant array sizes.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
