### PR TITLE
Add voting for team0mode

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -144,6 +144,7 @@ void CPlayer::Reset()
 	m_NotEligibleForFinish = false;
 	m_EligibleForFinishCheck = 0;
 	m_VotedForPractice = false;
+	m_VotedForTeam0Mode = false;
 	m_SwapTargetsClientId = -1;
 	m_BirthdayAnnounced = false;
 	m_RescueMode = RESCUEMODE_AUTO;

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -235,6 +235,7 @@ public:
 	bool m_NotEligibleForFinish;
 	int64_t m_EligibleForFinishCheck;
 	bool m_VotedForPractice;
+	bool m_VotedForTeam0Mode;
 	int m_SwapTargetsClientId; //Client ID of the swap target for the given player
 	bool m_BirthdayAnnounced;
 

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -58,6 +58,7 @@ void CGameTeams::ResetRoundState(int Team)
 		if(m_Core.Team(i) == Team && GameServer()->m_apPlayers[i])
 		{
 			GameServer()->m_apPlayers[i]->m_VotedForPractice = false;
+			GameServer()->m_apPlayers[i]->m_VotedForTeam0Mode = false;
 			GameServer()->m_apPlayers[i]->m_SwapTargetsClientId = -1;
 			m_aLastSwap[i] = 0;
 		}
@@ -483,6 +484,7 @@ void CGameTeams::SetForceCharacterTeam(int ClientId, int Team)
 		if(GetPlayer(ClientId))
 		{
 			GetPlayer(ClientId)->m_VotedForPractice = false;
+			GetPlayer(ClientId)->m_VotedForTeam0Mode = false;
 			GetPlayer(ClientId)->m_SwapTargetsClientId = -1;
 		}
 		m_pGameContext->m_World.RemoveEntitiesFromPlayer(ClientId);
@@ -523,6 +525,7 @@ void CGameTeams::KillTeam(int Team, int NewStrongId, int ExceptId)
 		if(m_Core.Team(i) == Team && GameServer()->m_apPlayers[i])
 		{
 			GameServer()->m_apPlayers[i]->m_VotedForPractice = false;
+			GameServer()->m_apPlayers[i]->m_VotedForTeam0Mode = false;
 			if(i != ExceptId)
 			{
 				GameServer()->m_apPlayers[i]->KillCharacter(WEAPON_SELF, false);


### PR DESCRIPTION
Closes #10431
Just adds voting for `/team0mode`. Old behavior, as disabling it, etc. is not changed.

More detailed description:
While `team0mode` is not enabled, you can vote for it with `/team0mode` or vote against it with `/team0mode 0` - this works the same way as in `/practice`
Once `team0mode` is enabled, a single `/team0mode 0` can disable it (if you're not racing). This avoids the need for an additional command like `/unteam0mode` and keeps the old behavior 


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
