### PR TITLE
Add `/specteam X` to spectate a specific team

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1636,10 +1636,21 @@ void CGameContext::ConSpecTeam(IConsole::IResult *pResult, void *pUserData)
 	if(!pPlayer)
 		return;
 
-	if(pResult->NumArguments())
-		pPlayer->m_SpecTeam = pResult->GetInteger(0);
+	if(!pResult->NumArguments())
+	{
+		if(pPlayer->m_SpecTeam != CPlayer::SPECTEAM_ALL)
+		{
+			pPlayer->m_SpecTeam = CPlayer::SPECTEAM_ALL;
+		}
+		else
+		{
+			pPlayer->m_SpecTeam = CPlayer::SPECTEAM_OWN;
+		}
+	}
 	else
-		pPlayer->m_SpecTeam = !pPlayer->m_SpecTeam;
+	{
+		pPlayer->m_SpecTeam = pResult->GetInteger(0);
+	}
 }
 
 void CGameContext::ConSayTime(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1206,8 +1206,13 @@ bool CCharacter::CanSnapCharacter(int SnappingClient)
 	{
 		if(pSnapPlayer->SpectatorId() != SPEC_FREEVIEW && !CanCollide(pSnapPlayer->SpectatorId()) && (pSnapPlayer->m_ShowOthers == SHOW_OTHERS_OFF || (pSnapPlayer->m_ShowOthers == SHOW_OTHERS_ONLY_TEAM && !SameTeam(pSnapPlayer->SpectatorId()))))
 			return false;
-		else if(pSnapPlayer->SpectatorId() == SPEC_FREEVIEW && !CanCollide(SnappingClient) && pSnapPlayer->m_SpecTeam && !SameTeam(SnappingClient))
-			return false;
+		else if(pSnapPlayer->SpectatorId() == SPEC_FREEVIEW)
+		{
+			if(pSnapPlayer->m_SpecTeam == CPlayer::SPECTEAM_OWN && !SameTeam(SnappingClient) && !CanCollide(SnappingClient))
+				return false;
+			else if(pSnapPlayer->m_SpecTeam >= 0 && Team() != pSnapPlayer->m_SpecTeam && pSnapChar != this)
+				return false;
+		}
 	}
 	else if(pSnapChar && !pSnapChar->m_Core.m_Super && !CanCollide(SnappingClient) && (pSnapPlayer->m_ShowOthers == SHOW_OTHERS_OFF || (pSnapPlayer->m_ShowOthers == SHOW_OTHERS_ONLY_TEAM && !SameTeam(SnappingClient))))
 		return false;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4028,7 +4028,7 @@ void CGameContext::RegisterChatCommands()
 
 	Console()->Register("showothers", "?i['0'|'1'|'2']", CFGFLAG_CHAT | CFGFLAG_SERVER, ConShowOthers, this, "Whether to show players from other teams or not (off by default), optional i = 0 for off, i = 1 for on, i = 2 for own team only");
 	Console()->Register("showall", "?i['0'|'1']", CFGFLAG_CHAT | CFGFLAG_SERVER, ConShowAll, this, "Whether to show players at any distance (off by default), optional i = 0 for off else for on");
-	Console()->Register("specteam", "?i['0'|'1']", CFGFLAG_CHAT | CFGFLAG_SERVER, ConSpecTeam, this, "Whether to show players from other teams when spectating (on by default), optional i = 0 for off else for on");
+	Console()->Register("specteam", "?i[id]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConSpecTeam, this, "Whether to show players from other teams when spectating (on by default), or optionally specify which team to spectate");
 	Console()->Register("ninjajetpack", "?i['0'|'1']", CFGFLAG_CHAT | CFGFLAG_SERVER, ConNinjaJetpack, this, "Whether to use ninja jetpack or not. Makes jetpack look more awesome");
 	Console()->Register("saytime", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, ConSayTime, this, "Privately messages someone's current time in this current running race (your time by default)");
 	Console()->Register("saytimeall", "", CFGFLAG_CHAT | CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, ConSayTimeAll, this, "Publicly messages everyone your current time in this current running race");

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -115,7 +115,7 @@ void CPlayer::Reset()
 	m_ShowAll = g_Config.m_SvShowAllDefault;
 	m_EnableSpectatorCount = true;
 	m_ShowDistance = vec2(1200, 800);
-	m_SpecTeam = false;
+	m_SpecTeam = CPlayer::SPECTEAM_ALL;
 	m_NinjaJetpack = false;
 
 	m_Paused = PAUSE_NONE;

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -183,7 +183,12 @@ public:
 	bool m_ShowAll;
 	bool m_EnableSpectatorCount;
 	vec2 m_ShowDistance;
-	bool m_SpecTeam;
+	enum
+	{
+		SPECTEAM_ALL = -1,
+		SPECTEAM_OWN = -2,
+	};
+	int m_SpecTeam;
 	bool m_NinjaJetpack;
 
 	// camera info is used sparingly for converting aim target to absolute world coordinates

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -620,10 +620,16 @@ CClientMask CGameTeams::TeamMask(int Team, int ExceptId, int Asker, int VersionF
 		}
 		else
 		{ // Freeview
-			if(GetPlayer(i)->m_SpecTeam)
+			const int SpecTeam = GetPlayer(i)->m_SpecTeam;
+			if(SpecTeam == CPlayer::SPECTEAM_OWN)
 			{ // Show only players in own team when spectating
 				if(m_Core.Team(i) != Team && m_Core.Team(i) != TEAM_SUPER)
 					continue; // in different teams
+			}
+			else if(SpecTeam >= 0)
+			{
+				if(m_Core.Team(i) != SpecTeam && m_Core.Team(i) != TEAM_SUPER)
+					continue;
 			}
 		}
 


### PR DESCRIPTION
Closes #10429

Without arguments, `/specteam` will behave as a toggle (old behavior). With an argument, you will only see the specified team and your own character

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
