### PR TITLE
Fix hook collision line when a player is next to a tele

### DIFF
--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -256,6 +256,13 @@ void CPlayers::RenderHookCollLine(
 
 				int Tele;
 				int Hit = Collision()->IntersectLineTeleHook(OldPos, NewPos, &FinishPos, nullptr, &Tele);
+
+				if(ClientId >= 0 && GameClient()->IntersectCharacter(OldPos, FinishPos, FinishPos, ClientId) != -1)
+				{
+					HookCollColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClHookCollColorTeeColl));
+					break;
+				}
+
 				if(!DoBreak && Hit == TILE_TELEINHOOK)
 				{
 					if(Collision()->TeleOuts(Tele - 1).size() != 1)
@@ -278,12 +285,6 @@ void CPlayers::RenderHookCollLine(
 					{
 						HookCollColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClHookCollColorHookableColl));
 					}
-				}
-
-				if(ClientId >= 0 && GameClient()->IntersectCharacter(OldPos, FinishPos, FinishPos, ClientId) != -1)
-				{
-					HookCollColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClHookCollColorTeeColl));
-					break;
 				}
 
 				if(Hit && Hit != TILE_TELEINHOOK)


### PR DESCRIPTION
Fixes #10432
When a player intersects the line it should break instantly, instead of doing 1 tele hook iteration. Seems to work correctly now

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
