### PR TITLE
Fix community icon pixel border rendering

### DIFF
--- a/src/game/client/components/community_icons.cpp
+++ b/src/game/client/components/community_icons.cpp
@@ -118,12 +118,14 @@ void CCommunityIcons::Render(const CCommunityIcon *pIcon, CUIRect Rect, bool Act
 {
 	Rect.VMargin(Rect.w / 2.0f - Rect.h, &Rect);
 
+	Graphics()->WrapClamp();
 	Graphics()->TextureSet(Active ? pIcon->m_OrgTexture : pIcon->m_GreyTexture);
 	Graphics()->QuadsBegin();
 	Graphics()->SetColor(1.0f, 1.0f, 1.0f, Active ? 1.0f : 0.5f);
 	IGraphics::CQuadItem QuadItem(Rect.x, Rect.y, Rect.w, Rect.h);
 	Graphics()->QuadsDrawTL(&QuadItem, 1);
 	Graphics()->QuadsEnd();
+	Graphics()->WrapNormal();
 }
 
 void CCommunityIcons::Load()


### PR DESCRIPTION
Screenshots:

- Before (border visible for Blockworlds icon here but it depends on the resolution):
![image](https://github.com/user-attachments/assets/240cb1f5-59b9-4526-8b62-4467cb2e7dcb)
- After:
![image](https://github.com/user-attachments/assets/1de28463-4a86-4734-8a13-5917b024cf94)


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
