### PR TITLE
Upgrade to C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,7 @@ if(NOT MSVC AND NOT HAIKU)
   endif()
 
   if(TARGET_OS STREQUAL "mac")
-    add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -std=gnu++17)
+    add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -std=gnu++20)
   endif()
 
   if(SECURITY_COMPILER_FLAGS)
@@ -339,6 +339,7 @@ if(NOT MSVC AND NOT HAIKU)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wsuggest-override)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wdynamic-class-memaccess) # clang
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wclass-memaccess) # gcc
+  add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wno-deprecated-enum-float-conversion) # c++20 arithmetic between floating-point type and enumeration type
   add_linker_flag_if_supported(OUR_FLAGS_LINK -Wno-alloc-size-larger-than) # save.cpp with LTO
   # add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wdouble-promotion) # Many occurrences
   # add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wnull-dereference) # Many occurrences
@@ -3574,7 +3575,7 @@ foreach(target ${TARGETS_LINK})
 endforeach()
 
 foreach(target ${TARGETS_OWN})
-  set_property(TARGET ${target} PROPERTY CXX_STANDARD 17)
+  set_property(TARGET ${target} PROPERTY CXX_STANDARD 20)
   set_property(TARGET ${target} PROPERTY CXX_STANDARD_REQUIRED ON)
   set_property(TARGET ${target} PROPERTY CXX_EXTENSIONS OFF)
 
@@ -3582,6 +3583,7 @@ foreach(target ${TARGETS_OWN})
     target_compile_options(${target} PRIVATE /wd4244) # Possible loss of data (float -> int, int -> float, etc.).
     target_compile_options(${target} PRIVATE /wd4267) # Possible loss of data (size_t - int on win64).
     target_compile_options(${target} PRIVATE /wd4800) # Implicit conversion of int to bool.
+    target_compile_options(${target} PRIVATE /wd5055) # C++20 operator deprecated between enumerations and floating-point types
   endif()
   if(TARGET_OS STREQUAL "windows")
     # See https://learn.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers

--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -496,6 +496,11 @@ std::unique_ptr<ILogger> log_logger_noop()
 	return std::make_unique<CLoggerNoOp>();
 }
 
+#ifdef __GNUC__
+// atomic_compare_exchange_strong_explicit is deprecated
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 void CFutureLogger::Set(std::shared_ptr<ILogger> pLogger)
 {
 	const CLockScope LockScope(m_PendingLock);
@@ -549,6 +554,10 @@ void CFutureLogger::OnFilterChange()
 		pLogger->SetFilter(m_Filter);
 	}
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 void CMemoryLogger::Log(const CLogMessage *pMessage)
 {

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -41,32 +41,29 @@ typedef int (*FS_LISTDIR_CALLBACK_FILEINFO)(const CFsFileInfo *info, int is_dir,
  */
 typedef struct NETSOCKET_INTERNAL *NETSOCKET;
 
-enum
-{
-	/**
-	 * The maximum bytes necessary to encode one Unicode codepoint with UTF-8.
-	 */
-	UTF8_BYTE_LENGTH = 4,
+/**
+* The maximum bytes necessary to encode one Unicode codepoint with UTF-8.
+*/
+inline constexpr auto UTF8_BYTE_LENGTH = 4;
 
-	IO_MAX_PATH_LENGTH = 512,
+inline constexpr auto IO_MAX_PATH_LENGTH = 512;
 
-	NETADDR_MAXSTRSIZE = 1 + (8 * 4 + 7) + 1 + 1 + 5 + 1, // [XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX]:XXXXX
+inline constexpr auto NETADDR_MAXSTRSIZE = 1 + (8 * 4 + 7) + 1 + 1 + 5 + 1; // [XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX]:XXXXX
 
-	NETTYPE_INVALID = 0,
-	NETTYPE_IPV4 = 1 << 0,
-	NETTYPE_IPV6 = 1 << 1,
-	NETTYPE_WEBSOCKET_IPV4 = 1 << 2,
-	NETTYPE_WEBSOCKET_IPV6 = 1 << 3,
-	NETTYPE_LINK_BROADCAST = 1 << 4,
-	/**
-	 * 0.7 address. This is a flag in NETADDR to avoid introducing a parameter to every networking function
-	 * to differenciate between 0.6 and 0.7 connections.
-	 */
-	NETTYPE_TW7 = 1 << 5,
+inline constexpr auto NETTYPE_INVALID = 0;
+inline constexpr auto NETTYPE_IPV4 = 1 << 0;
+inline constexpr auto NETTYPE_IPV6 = 1 << 1;
+inline constexpr auto NETTYPE_WEBSOCKET_IPV4 = 1 << 2;
+inline constexpr auto NETTYPE_WEBSOCKET_IPV6 = 1 << 3;
+inline constexpr auto NETTYPE_LINK_BROADCAST = 1 << 4;
+/**
+* 0.7 address. This is a flag in NETADDR to avoid introducing a parameter to every networking function
+* to differenciate between 0.6 and 0.7 connections.
+*/
+inline constexpr auto NETTYPE_TW7 = 1 << 5;
 
-	NETTYPE_ALL = NETTYPE_IPV4 | NETTYPE_IPV6 | NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6,
-	NETTYPE_MASK = NETTYPE_ALL | NETTYPE_LINK_BROADCAST | NETTYPE_TW7,
-};
+inline constexpr auto NETTYPE_ALL = NETTYPE_IPV4 | NETTYPE_IPV6 | NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6;
+inline constexpr auto NETTYPE_MASK = NETTYPE_ALL | NETTYPE_LINK_BROADCAST | NETTYPE_TW7;
 
 /**
  * @ingroup Network-General

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -1734,7 +1734,7 @@ CServerInfo::ERankState CCommunity::HasRank(const char *pMap) const
 	if(!HasRanks())
 		return CServerInfo::RANK_UNAVAILABLE;
 	const CCommunityMap Needle(pMap);
-	return m_FinishedMaps.count(Needle) == 0 ? CServerInfo::RANK_UNRANKED : CServerInfo::RANK_RANKED;
+	return !m_FinishedMaps.contains(Needle) ? CServerInfo::RANK_UNRANKED : CServerInfo::RANK_RANKED;
 }
 
 const std::vector<CCommunity> &CServerBrowser::Communities() const
@@ -1954,7 +1954,7 @@ template<typename TNamedElement, typename TElementName>
 static bool IsSubsetEquals(const std::vector<const TNamedElement *> &vpLeft, const std::set<TElementName> &Right)
 {
 	return vpLeft.size() <= Right.size() && std::all_of(vpLeft.begin(), vpLeft.end(), [&](const TNamedElement *pElem) {
-		return Right.count(TElementName(pElem->Name())) > 0;
+		return Right.contains(TElementName(pElem->Name()));
 	});
 }
 
@@ -2037,7 +2037,7 @@ void CExcludedCommunityCountryFilterList::Add(const char *pCountryName)
 void CExcludedCommunityCountryFilterList::Add(const char *pCommunityId, const char *pCountryName)
 {
 	CCommunityId CommunityId(pCommunityId);
-	if(m_Entries.find(CommunityId) == m_Entries.end())
+	if(!m_Entries.contains(CommunityId))
 	{
 		m_Entries[CommunityId] = {};
 	}
@@ -2074,8 +2074,7 @@ bool CExcludedCommunityCountryFilterList::Filtered(const char *pCountryName) con
 		return false;
 
 	const auto &CountryEntries = CommunityEntry->second;
-	return !IsSubsetEquals(m_pCommunityCache->SelectableCountries(), CountryEntries) &&
-	       CountryEntries.find(CCommunityCountryName(pCountryName)) != CountryEntries.end();
+	return !IsSubsetEquals(m_pCommunityCache->SelectableCountries(), CountryEntries) && CountryEntries.contains(CCommunityCountryName(pCountryName));
 }
 
 bool CExcludedCommunityCountryFilterList::Empty() const
@@ -2196,7 +2195,7 @@ void CExcludedCommunityTypeFilterList::Add(const char *pTypeName)
 void CExcludedCommunityTypeFilterList::Add(const char *pCommunityId, const char *pTypeName)
 {
 	CCommunityId CommunityId(pCommunityId);
-	if(m_Entries.find(CommunityId) == m_Entries.end())
+	if(!m_Entries.contains(CommunityId))
 	{
 		m_Entries[CommunityId] = {};
 	}
@@ -2233,8 +2232,7 @@ bool CExcludedCommunityTypeFilterList::Filtered(const char *pTypeName) const
 		return false;
 
 	const auto &TypeEntries = CommunityEntry->second;
-	return !IsSubsetEquals(m_pCommunityCache->SelectableTypes(), TypeEntries) &&
-	       TypeEntries.find(CCommunityTypeName(pTypeName)) != TypeEntries.end();
+	return !IsSubsetEquals(m_pCommunityCache->SelectableTypes(), TypeEntries) && TypeEntries.contains(CCommunityTypeName(pTypeName));
 }
 
 bool CExcludedCommunityTypeFilterList::Empty() const

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -797,7 +797,7 @@ CSkins::CSkinList &CSkins::SkinList()
 			}
 			NameMatch = std::make_pair<int, int>(pNameMatchStart - pSkinContainer->Name(), pNameMatchEnd - pNameMatchStart);
 		}
-		m_SkinList.m_vSkins.emplace_back(pSkinContainer.get(), m_Favorites.find(pSkinContainer->NormalizedName()) != m_Favorites.end(), SelectedMain, SelectedDummy, NameMatch);
+		m_SkinList.m_vSkins.emplace_back(pSkinContainer.get(), m_Favorites.contains(pSkinContainer->NormalizedName()), SelectedMain, SelectedDummy, NameMatch);
 	}
 
 	std::sort(m_SkinList.m_vSkins.begin(), m_SkinList.m_vSkins.end());
@@ -902,7 +902,7 @@ bool CSkins::IsFavorite(const char *pName) const
 {
 	char aNormalizedName[NORMALIZED_SKIN_NAME_LENGTH];
 	str_utf8_tolower(pName, aNormalizedName, sizeof(aNormalizedName));
-	return m_Favorites.find(aNormalizedName) != m_Favorites.end();
+	return m_Favorites.contains(aNormalizedName);
 }
 
 void CSkins::RandomizeSkin(int Dummy)

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -1252,28 +1252,28 @@ int CCollision::IsFrontTimeCheckpoint(int Index) const
 
 vec2 CCollision::TeleAllGet(int Number, size_t Offset)
 {
-	if(m_TeleIns.count(Number) > 0)
+	if(m_TeleIns.contains(Number))
 	{
 		if(m_TeleIns[Number].size() > Offset)
 			return m_TeleIns[Number][Offset];
 		else
 			Offset -= m_TeleIns[Number].size();
 	}
-	if(m_TeleOuts.count(Number) > 0)
+	if(m_TeleOuts.contains(Number))
 	{
 		if(m_TeleOuts[Number].size() > Offset)
 			return m_TeleOuts[Number][Offset];
 		else
 			Offset -= m_TeleOuts[Number].size();
 	}
-	if(m_TeleCheckOuts.count(Number) > 0)
+	if(m_TeleCheckOuts.contains(Number))
 	{
 		if(m_TeleCheckOuts[Number].size() > Offset)
 			return m_TeleCheckOuts[Number][Offset];
 		else
 			Offset -= m_TeleCheckOuts[Number].size();
 	}
-	if(m_TeleOthers.count(Number) > 0)
+	if(m_TeleOthers.contains(Number))
 	{
 		if(m_TeleOthers[Number].size() > Offset)
 			return m_TeleOthers[Number][Offset];
@@ -1284,13 +1284,13 @@ vec2 CCollision::TeleAllGet(int Number, size_t Offset)
 size_t CCollision::TeleAllSize(int Number)
 {
 	size_t Total = 0;
-	if(m_TeleIns.count(Number) > 0)
+	if(m_TeleIns.contains(Number))
 		Total += m_TeleIns[Number].size();
-	if(m_TeleOuts.count(Number) > 0)
+	if(m_TeleOuts.contains(Number))
 		Total += m_TeleOuts[Number].size();
-	if(m_TeleCheckOuts.count(Number) > 0)
+	if(m_TeleCheckOuts.contains(Number))
 		Total += m_TeleCheckOuts[Number].size();
-	if(m_TeleOthers.count(Number) > 0)
+	if(m_TeleOthers.contains(Number))
 		Total += m_TeleOthers[Number].size();
 	return Total;
 }

--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -453,7 +453,8 @@ void CEditorActionBulk::Undo()
 {
 	if(m_Reverse)
 	{
-		for(auto pIt = m_vpActions.rbegin(); pIt != m_vpActions.rend(); pIt++)
+		// reverse_view is not supported in gcc 10
+		for(auto pIt = m_vpActions.rbegin(); pIt != m_vpActions.rend(); pIt++) // NOLINT: modernize-loop-convert
 		{
 			auto &pAction = *pIt;
 			pAction->Undo();


### PR DESCRIPTION
Closes #6552

- Silenced the `deprecated-enum-float-conversion` warning. The DDNet codebase uses int enums a lot, so adding `static_cast` everywhere would reduce readability - https://github.com/ddnet/ddnet/pull/9607#discussion_r1932255887
- Replaced a large, unordered enum with `inline constexpr auto`, this avoids the `deprecated-enum-enum-conversion` warning and it makes sense in this case, as there are no other enums in that file
- Silenced the `atomic_compare_exchange_strong_explicit` deprecation warning in one place, as using the non-deprecated version fails to build on macOS
- Replaced `count > 0` with `contains` - required by clang tidy checks


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
