### PR TITLE
Fix crash due to instant finger releasing

### DIFF
--- a/src/game/client/components/touch_controls.cpp
+++ b/src/game/client/components/touch_controls.cpp
@@ -1024,8 +1024,9 @@ void CTouchControls::UpdateButtons(const std::vector<IInput::CTouchFingerState> 
 				const auto ActiveFinger = std::find_if(vRemainingTouchFingerStates.begin(), vRemainingTouchFingerStates.end(), [&](const IInput::CTouchFingerState &TouchFingerState) {
 					return TouchFingerState.m_Finger == TouchButton.m_pBehavior->m_Finger;
 				});
-				dbg_assert(ActiveFinger != vRemainingTouchFingerStates.end(), "Active button finger not found");
-				vRemainingTouchFingerStates.erase(ActiveFinger);
+				// ActiveFinger could be released during this progress.
+				if(ActiveFinger != vRemainingTouchFingerStates.end())
+					vRemainingTouchFingerStates.erase(ActiveFinger);
 			}
 			TouchButton.m_pBehavior->SetInactive();
 			continue;


### PR DESCRIPTION
The crash reason:

Frame 1: finger press, OnActivate() is called, dummy is connected. 
Frame 2: finger release, button goes invisible due to visibility "-dummy-connect" does not satisfy. The button is now invisible and haven't been deactivated. After that UpdateButton() is called,  entering "Invisible but activating" button check part, where code assume the finger hasn't released. So dbg_assert is triggered because the finger has released. The way to fix this:
dbg_assert is removed.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
