### PR TITLE
Add ability to disable sv_practice_by_default without server restart

### DIFF
--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -165,6 +165,7 @@ class CGameContext : public IGameServer
 	static void ConAntibot(IConsole::IResult *pResult, void *pUserData);
 	static void ConchainSpecialMotdupdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainSettingUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+	static void ConchainPracticeByDefaultUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConDumpLog(IConsole::IResult *pResult, void *pUserData);
 
 	void Construct(int Resetting);

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -1320,7 +1320,11 @@ void CGameTeams::SetPractice(int Team, bool Enabled)
 	if(Team < TEAM_FLOCK || Team >= TEAM_SUPER)
 		return;
 	if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && Team == TEAM_FLOCK)
-		return;
+	{
+		// allow to enable practice in team 0, for practice by default
+		if(!g_Config.m_SvTestingCommands)
+			return;
+	}
 
 	m_aPractice[Team] = Enabled;
 }


### PR DESCRIPTION
I have `sv_practice_by_default` enabled on my server for testing purposes. Sometimes, I need to disable it and have to remember to reload the server when testing team related features or spectating, since practice mode forces the spec char. 

This change adds an option to disable it without a server reload by calling `SetPractice` on all teams. Note that `sv_practice_by_default` only works with `sv_test_cmds`, which is restricted to the initial config and isn't enabled on offical DDNet servers, but is on test servers

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
