### PR TITLE
Add constexpr and concepts to math functions

### DIFF
--- a/src/base/bezier.h
+++ b/src/base/bezier.h
@@ -12,13 +12,13 @@ class CCubicBezier
 	float b;
 	float c;
 	float d;
-	CCubicBezier(float a_, float b_, float c_, float d_) :
+	constexpr CCubicBezier(float a_, float b_, float c_, float d_) :
 		a(a_), b(b_), c(c_), d(d_)
 	{
 	}
 
 public:
-	CCubicBezier() {}
+	constexpr CCubicBezier() = default;
 	float Evaluate(float t) const;
 	float Derivative(float t) const;
 	static CCubicBezier With(float Start, float StartDerivative, float EndDerivative, float End);

--- a/src/base/math.h
+++ b/src/base/math.h
@@ -5,7 +5,11 @@
 
 #include <algorithm>
 #include <cmath>
+#include <concepts>
 #include <cstdlib>
+
+template<typename T>
+concept Numeric = std::integral<T> || std::floating_point<T>;
 
 constexpr float pi = 3.1415926535897932384626433f;
 
@@ -101,50 +105,50 @@ class fxp
 	int value;
 
 public:
-	void set(int v)
+	constexpr void set(int v)
 	{
 		value = v;
 	}
-	int get() const
+	constexpr int get() const
 	{
 		return value;
 	}
-	fxp &operator=(int v)
+	constexpr fxp &operator=(int v)
 	{
 		value = i2fx(v);
 		return *this;
 	}
-	fxp &operator=(float v)
+	constexpr fxp &operator=(float v)
 	{
 		value = f2fx(v);
 		return *this;
 	}
-	operator int() const
+	constexpr operator int() const
 	{
 		return fx2i(value);
 	}
-	operator float() const
+	constexpr operator float() const
 	{
 		return fx2f(value);
 	}
 };
 
-template<typename T>
+template<Numeric T>
 constexpr T minimum(T a, T b)
 {
 	return std::min(a, b);
 }
-template<typename T>
+template<Numeric T>
 constexpr T minimum(T a, T b, T c)
 {
 	return std::min(std::min(a, b), c);
 }
-template<typename T>
+template<Numeric T>
 constexpr T maximum(T a, T b)
 {
 	return std::max(a, b);
 }
-template<typename T>
+template<Numeric T>
 constexpr T maximum(T a, T b, T c)
 {
 	return std::max(std::max(a, b), c);
@@ -155,12 +159,12 @@ constexpr T absolute(T a)
 	return a < T(0) ? -a : a;
 }
 
-template<typename T>
+template<Numeric T>
 constexpr bool in_range(T a, T lower, T upper)
 {
 	return lower <= a && a <= upper;
 }
-template<typename T>
+template<Numeric T>
 constexpr bool in_range(T a, T upper)
 {
 	return in_range(a, 0, upper);

--- a/src/base/vmath.h
+++ b/src/base/vmath.h
@@ -10,7 +10,7 @@
 
 // ------------------------------------
 
-template<typename T>
+template<Numeric T>
 class vector2_base
 {
 public:
@@ -29,89 +29,91 @@ public:
 	{
 	}
 
-	vector2_base operator-() const { return vector2_base(-x, -y); }
-	vector2_base operator-(const vector2_base &vec) const { return vector2_base(x - vec.x, y - vec.y); }
-	vector2_base operator+(const vector2_base &vec) const { return vector2_base(x + vec.x, y + vec.y); }
-	vector2_base operator*(const T rhs) const { return vector2_base(x * rhs, y * rhs); }
-	vector2_base operator*(const vector2_base &vec) const { return vector2_base(x * vec.x, y * vec.y); }
-	vector2_base operator/(const T rhs) const { return vector2_base(x / rhs, y / rhs); }
-	vector2_base operator/(const vector2_base &vec) const { return vector2_base(x / vec.x, y / vec.y); }
+	constexpr vector2_base operator-() const { return vector2_base(-x, -y); }
+	constexpr vector2_base operator-(const vector2_base &vec) const { return vector2_base(x - vec.x, y - vec.y); }
+	constexpr vector2_base operator+(const vector2_base &vec) const { return vector2_base(x + vec.x, y + vec.y); }
+	constexpr vector2_base operator*(const T rhs) const { return vector2_base(x * rhs, y * rhs); }
+	constexpr vector2_base operator*(const vector2_base &vec) const { return vector2_base(x * vec.x, y * vec.y); }
+	constexpr vector2_base operator/(const T rhs) const { return vector2_base(x / rhs, y / rhs); }
+	constexpr vector2_base operator/(const vector2_base &vec) const { return vector2_base(x / vec.x, y / vec.y); }
 
-	const vector2_base &operator+=(const vector2_base &vec)
+	constexpr vector2_base &operator+=(const vector2_base &vec)
 	{
 		x += vec.x;
 		y += vec.y;
 		return *this;
 	}
-	const vector2_base &operator-=(const vector2_base &vec)
+	constexpr vector2_base &operator-=(const vector2_base &vec)
 	{
 		x -= vec.x;
 		y -= vec.y;
 		return *this;
 	}
-	const vector2_base &operator*=(const T rhs)
+	constexpr vector2_base &operator*=(const T rhs)
 	{
 		x *= rhs;
 		y *= rhs;
 		return *this;
 	}
-	const vector2_base &operator*=(const vector2_base &vec)
+	constexpr vector2_base &operator*=(const vector2_base &vec)
 	{
 		x *= vec.x;
 		y *= vec.y;
 		return *this;
 	}
-	const vector2_base &operator/=(const T rhs)
+	constexpr vector2_base &operator/=(const T rhs)
 	{
 		x /= rhs;
 		y /= rhs;
 		return *this;
 	}
-	const vector2_base &operator/=(const vector2_base &vec)
+	constexpr vector2_base &operator/=(const vector2_base &vec)
 	{
 		x /= vec.x;
 		y /= vec.y;
 		return *this;
 	}
 
-	bool operator==(const vector2_base &vec) const { return x == vec.x && y == vec.y; } //TODO: do this with an eps instead
-	bool operator!=(const vector2_base &vec) const { return x != vec.x || y != vec.y; }
+	constexpr bool operator==(const vector2_base &vec) const { return x == vec.x && y == vec.y; } // TODO: do this with an eps instead
+	constexpr bool operator!=(const vector2_base &vec) const { return x != vec.x || y != vec.y; }
 
-	T &operator[](const int index) { return index ? y : x; }
+	constexpr T &operator[](const int index) { return index ? y : x; }
 };
 
-template<typename T>
+template<Numeric T>
 constexpr inline vector2_base<T> rotate(const vector2_base<T> &a, float angle)
 {
 	angle = angle * pi / 180.0f;
 	float s = std::sin(angle);
 	float c = std::cos(angle);
-	return vector2_base<T>((T)(c * a.x - s * a.y), (T)(s * a.x + c * a.y));
+	return vector2_base<T>(static_cast<T>(c * a.x - s * a.y), static_cast<T>(s * a.x + c * a.y));
 }
 
-template<typename T>
+template<Numeric T>
 inline T distance(const vector2_base<T> a, const vector2_base<T> &b)
 {
 	return length(a - b);
 }
 
-template<typename T>
+template<Numeric T>
 constexpr inline T dot(const vector2_base<T> a, const vector2_base<T> &b)
 {
 	return a.x * b.x + a.y * b.y;
 }
 
-inline float length(const vector2_base<float> &a)
+template<std::floating_point T>
+inline float length(const vector2_base<T> &a)
 {
 	return std::sqrt(dot(a, a));
 }
 
-inline float length(const vector2_base<int> &a)
+template<std::integral T>
+inline float length(const vector2_base<T> &a)
 {
-	return std::sqrt(dot(a, a));
+	return std::sqrt(static_cast<float>(dot(a, a)));
 }
 
-inline float length_squared(const vector2_base<float> &a)
+constexpr inline float length_squared(const vector2_base<float> &a)
 {
 	return dot(a, a);
 }
@@ -128,7 +130,7 @@ constexpr inline float angle(const vector2_base<float> &a)
 	return result;
 }
 
-template<typename T>
+template<Numeric T>
 constexpr inline vector2_base<T> normalize_pre_length(const vector2_base<T> &v, T len)
 {
 	if(len == 0)
@@ -159,7 +161,7 @@ typedef vector2_base<float> vec2;
 typedef vector2_base<bool> bvec2;
 typedef vector2_base<int> ivec2;
 
-template<typename T>
+template<Numeric T>
 constexpr inline bool closest_point_on_line(vector2_base<T> line_pointA, vector2_base<T> line_pointB, vector2_base<T> target_point, vector2_base<T> &out_pos)
 {
 	vector2_base<T> AB = line_pointB - line_pointA;
@@ -177,7 +179,7 @@ constexpr inline bool closest_point_on_line(vector2_base<T> line_pointA, vector2
 }
 
 // ------------------------------------
-template<typename T>
+template<Numeric T>
 class vector3_base
 {
 public:
@@ -200,50 +202,50 @@ public:
 	{
 	}
 
-	vector3_base operator-(const vector3_base &vec) const { return vector3_base(x - vec.x, y - vec.y, z - vec.z); }
-	vector3_base operator-() const { return vector3_base(-x, -y, -z); }
-	vector3_base operator+(const vector3_base &vec) const { return vector3_base(x + vec.x, y + vec.y, z + vec.z); }
-	vector3_base operator*(const T rhs) const { return vector3_base(x * rhs, y * rhs, z * rhs); }
-	vector3_base operator*(const vector3_base &vec) const { return vector3_base(x * vec.x, y * vec.y, z * vec.z); }
-	vector3_base operator/(const T rhs) const { return vector3_base(x / rhs, y / rhs, z / rhs); }
-	vector3_base operator/(const vector3_base &vec) const { return vector3_base(x / vec.x, y / vec.y, z / vec.z); }
+	constexpr vector3_base operator-(const vector3_base &vec) const { return vector3_base(x - vec.x, y - vec.y, z - vec.z); }
+	constexpr vector3_base operator-() const { return vector3_base(-x, -y, -z); }
+	constexpr vector3_base operator+(const vector3_base &vec) const { return vector3_base(x + vec.x, y + vec.y, z + vec.z); }
+	constexpr vector3_base operator*(const T rhs) const { return vector3_base(x * rhs, y * rhs, z * rhs); }
+	constexpr vector3_base operator*(const vector3_base &vec) const { return vector3_base(x * vec.x, y * vec.y, z * vec.z); }
+	constexpr vector3_base operator/(const T rhs) const { return vector3_base(x / rhs, y / rhs, z / rhs); }
+	constexpr vector3_base operator/(const vector3_base &vec) const { return vector3_base(x / vec.x, y / vec.y, z / vec.z); }
 
-	const vector3_base &operator+=(const vector3_base &vec)
+	constexpr vector3_base &operator+=(const vector3_base &vec)
 	{
 		x += vec.x;
 		y += vec.y;
 		z += vec.z;
 		return *this;
 	}
-	const vector3_base &operator-=(const vector3_base &vec)
+	constexpr vector3_base &operator-=(const vector3_base &vec)
 	{
 		x -= vec.x;
 		y -= vec.y;
 		z -= vec.z;
 		return *this;
 	}
-	const vector3_base &operator*=(const T rhs)
+	constexpr vector3_base &operator*=(const T rhs)
 	{
 		x *= rhs;
 		y *= rhs;
 		z *= rhs;
 		return *this;
 	}
-	const vector3_base &operator*=(const vector3_base &vec)
+	constexpr vector3_base &operator*=(const vector3_base &vec)
 	{
 		x *= vec.x;
 		y *= vec.y;
 		z *= vec.z;
 		return *this;
 	}
-	const vector3_base &operator/=(const T rhs)
+	constexpr vector3_base &operator/=(const T rhs)
 	{
 		x /= rhs;
 		y /= rhs;
 		z /= rhs;
 		return *this;
 	}
-	const vector3_base &operator/=(const vector3_base &vec)
+	constexpr vector3_base &operator/=(const vector3_base &vec)
 	{
 		x /= vec.x;
 		y /= vec.y;
@@ -251,23 +253,23 @@ public:
 		return *this;
 	}
 
-	bool operator==(const vector3_base &vec) const { return x == vec.x && y == vec.y && z == vec.z; } //TODO: do this with an eps instead
-	bool operator!=(const vector3_base &vec) const { return x != vec.x || y != vec.y || z != vec.z; }
+	constexpr bool operator==(const vector3_base &vec) const { return x == vec.x && y == vec.y && z == vec.z; } // TODO: do this with an eps instead
+	constexpr bool operator!=(const vector3_base &vec) const { return x != vec.x || y != vec.y || z != vec.z; }
 };
 
-template<typename T>
+template<Numeric T>
 inline T distance(const vector3_base<T> &a, const vector3_base<T> &b)
 {
 	return length(a - b);
 }
 
-template<typename T>
+template<Numeric T>
 constexpr inline T dot(const vector3_base<T> &a, const vector3_base<T> &b)
 {
 	return a.x * b.x + a.y * b.y + a.z * b.z;
 }
 
-template<typename T>
+template<Numeric T>
 constexpr inline vector3_base<T> cross(const vector3_base<T> &a, const vector3_base<T> &b)
 {
 	return vector3_base<T>(
@@ -297,7 +299,7 @@ typedef vector3_base<int> ivec3;
 
 // ------------------------------------
 
-template<typename T>
+template<Numeric T>
 class vector4_base
 {
 public:
@@ -324,15 +326,15 @@ public:
 	{
 	}
 
-	vector4_base operator+(const vector4_base &vec) const { return vector4_base(x + vec.x, y + vec.y, z + vec.z, w + vec.w); }
-	vector4_base operator-(const vector4_base &vec) const { return vector4_base(x - vec.x, y - vec.y, z - vec.z, w - vec.w); }
-	vector4_base operator-() const { return vector4_base(-x, -y, -z, -w); }
-	vector4_base operator*(const vector4_base &vec) const { return vector4_base(x * vec.x, y * vec.y, z * vec.z, w * vec.w); }
-	vector4_base operator*(const T rhs) const { return vector4_base(x * rhs, y * rhs, z * rhs, w * rhs); }
-	vector4_base operator/(const vector4_base &vec) const { return vector4_base(x / vec.x, y / vec.y, z / vec.z, w / vec.w); }
-	vector4_base operator/(const T vec) const { return vector4_base(x / vec, y / vec, z / vec, w / vec); }
+	constexpr vector4_base operator+(const vector4_base &vec) const { return vector4_base(x + vec.x, y + vec.y, z + vec.z, w + vec.w); }
+	constexpr vector4_base operator-(const vector4_base &vec) const { return vector4_base(x - vec.x, y - vec.y, z - vec.z, w - vec.w); }
+	constexpr vector4_base operator-() const { return vector4_base(-x, -y, -z, -w); }
+	constexpr vector4_base operator*(const vector4_base &vec) const { return vector4_base(x * vec.x, y * vec.y, z * vec.z, w * vec.w); }
+	constexpr vector4_base operator*(const T rhs) const { return vector4_base(x * rhs, y * rhs, z * rhs, w * rhs); }
+	constexpr vector4_base operator/(const vector4_base &vec) const { return vector4_base(x / vec.x, y / vec.y, z / vec.z, w / vec.w); }
+	constexpr vector4_base operator/(const T vec) const { return vector4_base(x / vec, y / vec, z / vec, w / vec); }
 
-	const vector4_base &operator+=(const vector4_base &vec)
+	constexpr vector4_base &operator+=(const vector4_base &vec)
 	{
 		x += vec.x;
 		y += vec.y;
@@ -340,7 +342,7 @@ public:
 		w += vec.w;
 		return *this;
 	}
-	const vector4_base &operator-=(const vector4_base &vec)
+	constexpr vector4_base &operator-=(const vector4_base &vec)
 	{
 		x -= vec.x;
 		y -= vec.y;
@@ -348,7 +350,7 @@ public:
 		w -= vec.w;
 		return *this;
 	}
-	const vector4_base &operator*=(const T rhs)
+	constexpr vector4_base &operator*=(const T rhs)
 	{
 		x *= rhs;
 		y *= rhs;
@@ -356,7 +358,7 @@ public:
 		w *= rhs;
 		return *this;
 	}
-	const vector4_base &operator*=(const vector4_base &vec)
+	constexpr vector4_base &operator*=(const vector4_base &vec)
 	{
 		x *= vec.x;
 		y *= vec.y;
@@ -364,7 +366,7 @@ public:
 		w *= vec.w;
 		return *this;
 	}
-	const vector4_base &operator/=(const T rhs)
+	constexpr vector4_base &operator/=(const T rhs)
 	{
 		x /= rhs;
 		y /= rhs;
@@ -372,7 +374,7 @@ public:
 		w /= rhs;
 		return *this;
 	}
-	const vector4_base &operator/=(const vector4_base &vec)
+	constexpr vector4_base &operator/=(const vector4_base &vec)
 	{
 		x /= vec.x;
 		y /= vec.y;
@@ -381,8 +383,8 @@ public:
 		return *this;
 	}
 
-	bool operator==(const vector4_base &vec) const { return x == vec.x && y == vec.y && z == vec.z && w == vec.w; } //TODO: do this with an eps instead
-	bool operator!=(const vector4_base &vec) const { return x != vec.x || y != vec.y || z != vec.z || w != vec.w; }
+	constexpr bool operator==(const vector4_base &vec) const { return x == vec.x && y == vec.y && z == vec.z && w == vec.w; } // TODO: do this with an eps instead
+	constexpr bool operator!=(const vector4_base &vec) const { return x != vec.x || y != vec.y || z != vec.z || w != vec.w; }
 };
 
 typedef vector4_base<float> vec4;


### PR DESCRIPTION
Made all functions in the math headers constexpr, except std::cos and std::sqrt etc, which only become constexpr in C++23
Also added a Numeric concept to the vectors to prevent invalid types e.g. vec2 of a non-numeric class

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
