### PR TITLE
Abstract servers udp io away with callbacks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2079,6 +2079,8 @@ set_src(ENGINE_SHARED GLOB_RECURSE src/engine/shared
   http.h
   huffman.cpp
   huffman.h
+  io_callbacks.cpp
+  io_callbacks.h
   jobs.cpp
   jobs.h
   json.cpp

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -7,6 +7,7 @@
 #include <engine/console.h>
 #include <engine/engine.h>
 #include <engine/shared/config.h>
+#include <engine/shared/io_callbacks.h>
 #include <engine/shared/jobs.h>
 #include <engine/shared/network.h>
 #include <engine/storage.h>
@@ -65,7 +66,9 @@ public:
 
 			// init the network
 			net_init();
-			CNetBase::Init();
+			CIoCallbacks IoCallbacks;
+			IoCallbacks.Init();
+			CNetBase::Init(&IoCallbacks);
 		}
 
 #if defined(CONF_PLATFORM_EMSCRIPTEN)

--- a/src/engine/shared/io_callbacks.cpp
+++ b/src/engine/shared/io_callbacks.cpp
@@ -1,0 +1,69 @@
+#include <base/system.h>
+#include <base/types.h>
+
+#include "io_callbacks.h"
+
+void CIoCallbacks::Init()
+{
+	m_pfnUdpCreate = IoNetwork::net_udp_create;
+	m_pfnUdpClose = IoNetwork::net_udp_close;
+	m_pfnUdpRecv = IoNetwork::net_udp_recv;
+	m_pfngUdpSend = IoNetwork::net_udp_send;
+	m_pfnSocketReadWait = IoNetwork::net_socket_read_wait;
+
+	m_pUser = nullptr;
+}
+
+NETSOCKET CIoCallbacks::UdpCreate(NETADDR BindAddr)
+{
+	return m_pfnUdpCreate(BindAddr, m_pUser);
+}
+
+void CIoCallbacks::UdpClose(NETSOCKET Sock)
+{
+	m_pfnUdpClose(Sock, m_pUser);
+}
+
+int CIoCallbacks::UdpRecv(NETSOCKET Sock, NETADDR *pAddr, unsigned char **ppData)
+{
+	return m_pfnUdpRecv(Sock, pAddr, ppData, m_pUser);
+}
+
+int CIoCallbacks::UdpSend(NETSOCKET Sock, const NETADDR *pAddr, const void *pData, int Size)
+{
+	return m_pfngUdpSend(Sock, pAddr, pData, Size, m_pUser);
+}
+
+int CIoCallbacks::SocketReadWait(NETSOCKET Sock, std::chrono::nanoseconds Nanoseconds)
+{
+	return m_pfnSocketReadWait(Sock, Nanoseconds, m_pUser);
+}
+
+namespace IoNetwork {
+
+NETSOCKET net_udp_create(NETADDR BindAddr, void *pUser)
+{
+	return ::net_udp_create(BindAddr);
+}
+
+void net_udp_close(NETSOCKET Sock, void *pUser)
+{
+	::net_udp_close(Sock);
+}
+
+int net_udp_recv(NETSOCKET Sock, NETADDR *pAddr, unsigned char **ppData, void *pUser)
+{
+	return ::net_udp_recv(Sock, pAddr, ppData);
+}
+
+int net_udp_send(NETSOCKET Sock, const NETADDR *pAddr, const void *pData, int Size, void *pUser)
+{
+	return ::net_udp_send(Sock, pAddr, pData, Size);
+}
+
+int net_socket_read_wait(NETSOCKET Sock, std::chrono::nanoseconds Nanoseconds, void *pUser)
+{
+	return ::net_socket_read_wait(Sock, Nanoseconds);
+}
+
+}; // namespace IoNetwork

--- a/src/engine/shared/io_callbacks.h
+++ b/src/engine/shared/io_callbacks.h
@@ -1,0 +1,43 @@
+#ifndef ENGINE_SHARED_IO_CALLBACKS_H
+#define ENGINE_SHARED_IO_CALLBACKS_H
+
+#include <base/types.h>
+#include <chrono>
+
+typedef NETSOCKET (*FUdpCreate)(NETADDR BindAddr, void *pUser);
+typedef void (*FUdpClose)(NETSOCKET Sock, void *pUser);
+typedef int (*FUdpRecv)(NETSOCKET Sock, NETADDR *pAddr, unsigned char **ppData, void *pUser);
+typedef int (*FUdpSend)(NETSOCKET Sock, const NETADDR *pAddr, const void *pData, int Size, void *pUser);
+typedef int (*FSocketReadWait)(NETSOCKET Sock, std::chrono::nanoseconds Nanoseconds, void *pUser);
+
+class CIoCallbacks
+{
+	FUdpCreate m_pfnUdpCreate = nullptr;
+	FUdpClose m_pfnUdpClose = nullptr;
+	FUdpRecv m_pfnUdpRecv = nullptr;
+	FUdpSend m_pfngUdpSend = nullptr;
+	FSocketReadWait m_pfnSocketReadWait = nullptr;
+
+	void *m_pUser = nullptr;
+
+public:
+	void Init();
+
+	NETSOCKET UdpCreate(NETADDR BindAddr);
+	void UdpClose(NETSOCKET Sock);
+	int UdpRecv(NETSOCKET Sock, NETADDR *pAddr, unsigned char **ppData);
+	int UdpSend(NETSOCKET Sock, const NETADDR *pAddr, const void *pData, int Size);
+	int SocketReadWait(NETSOCKET Sock, std::chrono::nanoseconds Nanoseconds);
+};
+
+namespace IoNetwork {
+
+NETSOCKET net_udp_create(NETADDR BindAddr, void *pUser);
+void net_udp_close(NETSOCKET Sock, void *pUser);
+int net_udp_recv(NETSOCKET Sock, NETADDR *pAddr, unsigned char **ppData, void *pUser);
+int net_udp_send(NETSOCKET Sock, const NETADDR *pAddr, const void *pData, int Size, void *pUser);
+int net_socket_read_wait(NETSOCKET Sock, std::chrono::nanoseconds Nanoseconds, void *pUser);
+
+}; // namespace IoNetwork
+
+#endif

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -7,6 +7,7 @@
 #include "stun.h"
 
 #include <base/types.h>
+#include <engine/shared/io_callbacks.h>
 
 #include <array>
 
@@ -410,6 +411,8 @@ class CNetServer
 	NETFUNC_CLIENTREJOIN m_pfnClientRejoin;
 	void *m_pUser;
 
+	CIoCallbacks m_IoCallbacks;
+
 	unsigned char m_aSecurityTokenSeed[16];
 
 	// vanilla connect flood detection
@@ -438,7 +441,7 @@ public:
 	int SetCallbacks(NETFUNC_NEWCLIENT pfnNewClient, NETFUNC_NEWCLIENT_NOAUTH pfnNewClientNoAuth, NETFUNC_CLIENTREJOIN pfnClientRejoin, NETFUNC_DELCLIENT pfnDelClient, void *pUser);
 
 	//
-	bool Open(NETADDR BindAddr, CNetBan *pNetBan, int MaxClients, int MaxClientsPerIp);
+	bool Open(NETADDR BindAddr, CNetBan *pNetBan, int MaxClients, int MaxClientsPerIp, CIoCallbacks *pIoCallbacks);
 	void Close();
 
 	//
@@ -599,9 +602,11 @@ class CNetBase
 	static CHuffman ms_Huffman;
 
 public:
+	static CIoCallbacks IO_CALLBACKS;
+
 	static void OpenLog(IOHANDLE DataLogSent, IOHANDLE DataLogRecv);
 	static void CloseLog();
-	static void Init();
+	static void Init(CIoCallbacks *pIoCallbacks);
 	static int Compress(const void *pData, int DataSize, void *pOutput, int OutputSize);
 	static int Decompress(const void *pData, int DataSize, void *pOutput, int OutputSize);
 

--- a/src/engine/shared/network_stun.cpp
+++ b/src/engine/shared/network_stun.cpp
@@ -73,7 +73,7 @@ void CStun::CProtocol::Update()
 	m_NumUnsuccessfulTries += 1;
 	unsigned char aBuf[32];
 	int Size = StunMessagePrepare(aBuf, sizeof(aBuf), &m_Stun);
-	if(net_udp_send(m_Socket, &m_StunServer, aBuf, Size) == -1)
+	if(CNetBase::IO_CALLBACKS.UdpSend(m_Socket, &m_StunServer, aBuf, Size) == -1)
 	{
 		log_debug(IndexToSystem(m_Index), "couldn't send stun request");
 		return;

--- a/src/tools/demo_extract_chat.cpp
+++ b/src/tools/demo_extract_chat.cpp
@@ -3,6 +3,7 @@
 
 #include <engine/client.h>
 #include <engine/shared/demo.h>
+#include <engine/shared/io_callbacks.h>
 #include <engine/shared/network.h>
 #include <engine/shared/snapshot.h>
 #include <engine/storage.h>
@@ -213,7 +214,9 @@ static int ExtractDemoChat(const char *pDemoFilePath, IStorage *pStorage)
 	DemoPlayer.SetListener(&Listener);
 
 	const CDemoPlayer::CPlaybackInfo *pInfo = DemoPlayer.Info();
-	CNetBase::Init();
+	CIoCallbacks IoCallbacks;
+	IoCallbacks.Init();
+	CNetBase::Init(&IoCallbacks);
 	DemoPlayer.Play();
 
 	while(DemoPlayer.IsPlaying())


### PR DESCRIPTION
This concept is inspired by libtw2 to allow testing the server in unit testes by sending data through custom callbacks instead of using a real network socket.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
