### PR TITLE
Fix UI elements below editor prompt dialog being usable

### DIFF
--- a/src/game/editor/prompt.cpp
+++ b/src/game/editor/prompt.cpp
@@ -78,6 +78,9 @@ void CPrompt::OnRender(CUIRect _)
 		return;
 	}
 
+	// Prevent UI elements below the prompt dialog from being activated.
+	Ui()->SetHotItem(this);
+
 	static CListBox s_ListBox;
 	CUIRect Prompt, PromptBox;
 	CUIRect Suggestions;


### PR DESCRIPTION
Standard practice for all modal popups is to set a placeholder UI element ID as the hot item, to prevent UI elements rendered below the popup from being hovered and activated.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
