### PR TITLE
Allow using backslashes for line continuation in config files

### DIFF
--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -703,7 +703,7 @@ bool CConsole::ExecuteFile(const char *pFilename, int ClientId, bool LogFailure,
 		str_format(aBuf, sizeof(aBuf), "executing '%s'", pFilename);
 		Print(IConsole::OUTPUT_LEVEL_STANDARD, "console", aBuf);
 
-		while(const char *pLine = LineReader.Get())
+		while(const char *pLine = LineReader.Get(true))
 		{
 			ExecuteLine(pLine, ClientId);
 		}

--- a/src/engine/shared/linereader.cpp
+++ b/src/engine/shared/linereader.cpp
@@ -45,7 +45,7 @@ void CLineReader::OpenBuffer(char *pBuffer)
 	}
 }
 
-const char *CLineReader::Get()
+const char *CLineReader::Get(bool Multiline)
 {
 	dbg_assert(m_pBuffer != nullptr, "Line reader not initialized");
 	if(m_ReadLastLine)
@@ -64,6 +64,18 @@ const char *CLineReader::Get()
 			}
 			else
 			{
+				if(Multiline && m_BufferPos >= 1 && m_pBuffer[m_BufferPos - 1] == '\\')
+				{
+					m_pBuffer[m_BufferPos - 1] = ' ';
+					if(m_pBuffer[m_BufferPos] == '\r')
+					{
+						m_pBuffer[m_BufferPos] = ' ';
+						++m_BufferPos;
+					}
+					m_pBuffer[m_BufferPos] = ' ';
+					++m_BufferPos;
+					continue;
+				}
 				if(m_pBuffer[m_BufferPos] == '\r')
 				{
 					m_pBuffer[m_BufferPos] = '\0';

--- a/src/engine/shared/linereader.h
+++ b/src/engine/shared/linereader.h
@@ -18,6 +18,6 @@ public:
 	bool OpenFile(IOHANDLE File);
 	void OpenBuffer(char *pBuffer); // Buffer must have been allocated with malloc, will be freed by the line reader
 
-	const char *Get(); // Returned string is valid until the line reader is destroyed
+	const char *Get(bool Multiline = false); // Returned string is valid until the line reader is destroyed
 };
 #endif


### PR DESCRIPTION
Multiple nested binds is hard to read and edit without linebreaks, so I want to at least allow line continuation.
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
