### PR TITLE
Fix `CLineInput::m_WasCursorChanged` being uninitialized

### DIFF
--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -28,6 +28,7 @@ void CLineInput::SetBuffer(char *pStr, size_t MaxSize, size_t MaxChars)
 	m_MaxSize = MaxSize;
 	m_MaxChars = MaxChars;
 	m_WasChanged = m_pStr && pLastStr && m_WasChanged;
+	m_WasCursorChanged = m_pStr && pLastStr && m_WasCursorChanged;
 	if(!pLastStr)
 	{
 		m_CursorPos = m_SelectionStart = m_SelectionEnd = m_LastCompositionCursorPos = 0;


### PR DESCRIPTION

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [X] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
