### PR TITLE
Fix connection-oriented 0.7 packets being unpacked twice, move control packet size check, refactoring

### DIFF
--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -278,10 +278,18 @@ int CNetBase::UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct
 			*pSecurityToken = ToSecurityToken(pBuffer + 3);
 		}
 
+		const bool Control = (pPacket->m_Flags & NET_PACKETFLAG_CONTROL) != 0;
+
+		// Drop invalid control packets. At least one byte is required as the control message code.
+		if(Control && pPacket->m_DataSize == 0)
+		{
+			return -1;
+		}
+
 		if(pPacket->m_Flags & NET_PACKETFLAG_COMPRESSION)
 		{
 			// Don't allow compressed control packets.
-			if(pPacket->m_Flags & NET_PACKETFLAG_CONTROL)
+			if(Control)
 			{
 				return -1;
 			}

--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -3,6 +3,8 @@
 #include <base/system.h>
 #include <base/types.h>
 
+#include <engine/shared/protocolglue.h>
+
 #include "config.h"
 #include "huffman.h"
 #include "network.h"
@@ -185,14 +187,7 @@ void CNetBase::SendPacket(NETSOCKET Socket, NETADDR *pAddr, CNetPacketConstruct 
 
 	if(Sixup)
 	{
-		unsigned Flags = 0;
-		if(pPacket->m_Flags & NET_PACKETFLAG_CONTROL)
-			Flags |= 1;
-		if(pPacket->m_Flags & NET_PACKETFLAG_RESEND)
-			Flags |= 2;
-		if(pPacket->m_Flags & NET_PACKETFLAG_COMPRESSION)
-			Flags |= 4;
-		pPacket->m_Flags = Flags;
+		pPacket->m_Flags = PacketFlags_SixToSeven(pPacket->m_Flags);
 	}
 
 	// set header and send the packet if all things are good
@@ -279,15 +274,7 @@ int CNetBase::UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct
 
 		if(Sixup)
 		{
-			unsigned Flags = 0;
-			if(pPacket->m_Flags & 1)
-				Flags |= NET_PACKETFLAG_CONTROL;
-			if(pPacket->m_Flags & 2)
-				Flags |= NET_PACKETFLAG_RESEND;
-			if(pPacket->m_Flags & 4)
-				Flags |= NET_PACKETFLAG_COMPRESSION;
-			pPacket->m_Flags = Flags;
-
+			pPacket->m_Flags = PacketFlags_SevenToSix(pPacket->m_Flags);
 			*pSecurityToken = ToSecurityToken(pBuffer + 3);
 		}
 

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -9,6 +9,7 @@
 #include <base/types.h>
 
 #include <array>
+#include <optional>
 
 class CHuffman;
 class CNetBan;
@@ -611,6 +612,7 @@ public:
 	static void SendPacketConnlessWithToken7(NETSOCKET Socket, NETADDR *pAddr, const void *pData, int DataSize, SECURITY_TOKEN Token, SECURITY_TOKEN ResponseToken);
 	static void SendPacket(NETSOCKET Socket, NETADDR *pAddr, CNetPacketConstruct *pPacket, SECURITY_TOKEN SecurityToken, bool Sixup = false, bool NoCompress = false);
 
+	static std::optional<int> UnpackPacketFlags(unsigned char *pBuffer, int Size);
 	static int UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct *pPacket, bool &Sixup, SECURITY_TOKEN *pSecurityToken = nullptr, SECURITY_TOKEN *pResponseToken = nullptr);
 
 	// The backroom is ack-NET_MAX_SEQUENCE/2. Used for knowing if we acked a packet or not

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -607,8 +607,17 @@ int CNetServer::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken)
 			continue;
 		}
 
+		// Check size and unpack packet flags early so we can determine the sixup
+		// state correctly for connection-oriented packets before unpacking them.
+		std::optional<int> Flags = CNetBase::UnpackPacketFlags(pData, Bytes);
+		if(!Flags)
+		{
+			continue;
+		}
+
 		SECURITY_TOKEN Token;
-		bool Sixup = false;
+		int Slot = (*Flags & NET_PACKETFLAG_CONNLESS) == 0 ? GetClientSlot(Addr) : -1;
+		bool Sixup = Slot != -1 && m_aSlots[Slot].m_Connection.m_Sixup;
 		if(CNetBase::UnpackPacket(pData, Bytes, &m_RecvUnpacker.m_Data, Sixup, &Token, pResponseToken) == 0)
 		{
 			if(m_RecvUnpacker.m_Data.m_Flags & NET_PACKETFLAG_CONNLESS)
@@ -628,22 +637,10 @@ int CNetServer::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken)
 				}
 				return 1;
 			}
-			else
+			else // connection-oriented packet
 			{
-				// normal packet, find matching slot
-				int Slot = GetClientSlot(Addr);
-
-				if(!Sixup && Slot != -1 && m_aSlots[Slot].m_Connection.m_Sixup)
+				if(Slot != -1) // connection found
 				{
-					Sixup = true;
-					if(CNetBase::UnpackPacket(pData, Bytes, &m_RecvUnpacker.m_Data, Sixup, &Token))
-						continue;
-				}
-
-				if(Slot != -1)
-				{
-					// found
-
 					// control
 					if(m_RecvUnpacker.m_Data.m_Flags & NET_PACKETFLAG_CONTROL)
 						OnConnCtrlMsg(Addr, Slot, m_RecvUnpacker.m_Data.m_aChunkData[0], m_RecvUnpacker.m_Data);
@@ -654,10 +651,8 @@ int CNetServer::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken)
 							m_RecvUnpacker.Start(&Addr, &m_aSlots[Slot].m_Connection, Slot);
 					}
 				}
-				else
+				else // connection not found, client that wants to connect
 				{
-					// not found, client that wants to connect
-
 					if(Sixup)
 					{
 						// got 0.7 control msg

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -630,11 +630,6 @@ int CNetServer::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken)
 			}
 			else
 			{
-				// drop invalid ctrl packets
-				if(m_RecvUnpacker.m_Data.m_Flags & NET_PACKETFLAG_CONTROL &&
-					m_RecvUnpacker.m_Data.m_DataSize == 0)
-					continue;
-
 				// normal packet, find matching slot
 				int Slot = GetClientSlot(Addr);
 

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -546,20 +546,16 @@ int CNetServer::OnSixupCtrlMsg(NETADDR &Addr, CNetChunk *pChunk, int ControlMsg,
 
 int CNetServer::GetClientSlot(const NETADDR &Addr)
 {
-	int Slot = -1;
-
 	for(int i = 0; i < MaxClients(); i++)
 	{
 		if(m_aSlots[i].m_Connection.State() != NET_CONNSTATE_OFFLINE &&
 			m_aSlots[i].m_Connection.State() != NET_CONNSTATE_ERROR &&
 			net_addr_comp(m_aSlots[i].m_Connection.PeerAddress(), &Addr) == 0)
-
 		{
-			Slot = i;
+			return i;
 		}
 	}
-
-	return Slot;
+	return -1;
 }
 
 static bool IsDDNetControlMsg(const CNetPacketConstruct *pPacket)

--- a/src/engine/shared/protocolglue.cpp
+++ b/src/engine/shared/protocolglue.cpp
@@ -1,8 +1,45 @@
+#include <engine/shared/network.h>
+
 #include <game/generated/protocol.h>
 #include <game/generated/protocol7.h>
 #include <game/generated/protocolglue.h>
 
 #include "protocolglue.h"
+
+namespace protocol7 {
+
+enum
+{
+	NET_PACKETFLAG_CONTROL = 1,
+	NET_PACKETFLAG_RESEND = 2,
+	NET_PACKETFLAG_COMPRESSION = 4,
+};
+
+}
+
+int PacketFlags_SixToSeven(int Flags)
+{
+	int Seven = 0;
+	if(Flags & ::NET_PACKETFLAG_CONTROL)
+		Seven |= protocol7::NET_PACKETFLAG_CONTROL;
+	if(Flags & ::NET_PACKETFLAG_RESEND)
+		Seven |= protocol7::NET_PACKETFLAG_RESEND;
+	if(Flags & ::NET_PACKETFLAG_COMPRESSION)
+		Seven |= protocol7::NET_PACKETFLAG_COMPRESSION;
+	return Seven;
+}
+
+int PacketFlags_SevenToSix(int Flags)
+{
+	int Six = 0;
+	if(Flags & protocol7::NET_PACKETFLAG_CONTROL)
+		Six |= ::NET_PACKETFLAG_CONTROL;
+	if(Flags & protocol7::NET_PACKETFLAG_RESEND)
+		Six |= ::NET_PACKETFLAG_RESEND;
+	if(Flags & protocol7::NET_PACKETFLAG_COMPRESSION)
+		Six |= ::NET_PACKETFLAG_COMPRESSION;
+	return Six;
+}
 
 int GameFlags_ClampToSix(int Flags)
 {

--- a/src/engine/shared/protocolglue.h
+++ b/src/engine/shared/protocolglue.h
@@ -1,6 +1,9 @@
 #ifndef ENGINE_SHARED_PROTOCOLGLUE_H
 #define ENGINE_SHARED_PROTOCOLGLUE_H
 
+int PacketFlags_SixToSeven(int Flags);
+int PacketFlags_SevenToSix(int Flags);
+
 int GameFlags_ClampToSix(int Flags);
 int PlayerFlags_SevenToSix(int Flags);
 int PlayerFlags_SixToSeven(int Flags);


### PR DESCRIPTION
Connection-oriented 0.7 packets were first also incorrectly unpacked as 0.6 packets to determine that they are connection-oriented and subsequently unpacked correctly as 0.7 packets by considering the sixup-state of the current connection. Now, the packet size and flags are unpacked early, so the current connection slot and sixup state for connection-oriented packets can be determined based on the connless-flag before unpacking the remainder of the packet.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
