### PR TITLE
UI/UX improvement and refactoring of editor file browser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2484,6 +2484,8 @@ if(CLIENT)
     enums.h
     explanations.cpp
     explanations.h
+    file_browser.cpp
+    file_browser.h
     font_typer.cpp
     font_typer.h
     layer_selector.cpp

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -94,11 +94,6 @@ bool CEditor::IsVanillaImage(const char *pImage)
 	return std::any_of(std::begin(VANILLA_IMAGES), std::end(VANILLA_IMAGES), [pImage](const char *pVanillaImage) { return str_comp(pImage, pVanillaImage) == 0; });
 }
 
-static const char *FILETYPE_EXTENSIONS[CEditor::NUM_FILETYPES] = {
-	".map",
-	".png",
-	".opus"};
-
 void CEditor::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, void *pUser)
 {
 	CEditor *pThis = (CEditor *)pUser;
@@ -135,6 +130,10 @@ ColorRGBA CEditor::GetButtonColor(const void *pId, int Checked)
 
 	switch(Checked)
 	{
+	case EditorButtonChecked::DANGEROUS_ACTION:
+		if(Ui()->HotItem() == pId)
+			return ColorRGBA(1.0f, 0.0f, 0.0f, 0.75f);
+		return ColorRGBA(1.0f, 0.0f, 0.0f, 0.5f);
 	case 8: // invisible
 		return ColorRGBA(0, 0, 0, 0);
 	case 7: // selected + game layers
@@ -800,7 +799,7 @@ bool CEditor::CallbackOpenMap(const char *pFileName, int StorageType, void *pUse
 	CEditor *pEditor = (CEditor *)pUser;
 	if(pEditor->Load(pFileName, StorageType))
 	{
-		pEditor->m_ValidSaveFilename = StorageType == IStorage::TYPE_SAVE && (pEditor->m_pFileDialogPath == pEditor->m_aFileDialogCurrentFolder || (pEditor->m_pFileDialogPath == pEditor->m_aFileDialogCurrentLink && str_comp(pEditor->m_aFileDialogCurrentLink, "themes") == 0));
+		pEditor->m_ValidSaveFilename = StorageType == IStorage::TYPE_SAVE && pEditor->m_FileBrowser.IsValidSaveFilename();
 		if(pEditor->m_Dialog == DIALOG_FILE)
 		{
 			pEditor->OnDialogClose();
@@ -835,18 +834,14 @@ bool CEditor::CallbackSaveMap(const char *pFileName, int StorageType, void *pUse
 	dbg_assert(StorageType == IStorage::TYPE_SAVE, "Saving only allowed for IStorage::TYPE_SAVE");
 
 	CEditor *pEditor = static_cast<CEditor *>(pUser);
-	char aBuf[IO_MAX_PATH_LENGTH];
-	// add map extension
-	if(!str_endswith(pFileName, ".map"))
-	{
-		str_format(aBuf, sizeof(aBuf), "%s.map", pFileName);
-		pFileName = aBuf;
-	}
 
 	// Save map to specified file
 	if(pEditor->Save(pFileName))
 	{
-		str_copy(pEditor->m_aFileName, pFileName);
+		if(pEditor->m_aFileName != pFileName)
+		{
+			str_copy(pEditor->m_aFileName, pFileName);
+		}
 		pEditor->m_ValidSaveFilename = true;
 		pEditor->m_Map.m_Modified = false;
 	}
@@ -873,13 +868,6 @@ bool CEditor::CallbackSaveCopyMap(const char *pFileName, int StorageType, void *
 	dbg_assert(StorageType == IStorage::TYPE_SAVE, "Saving only allowed for IStorage::TYPE_SAVE");
 
 	CEditor *pEditor = static_cast<CEditor *>(pUser);
-	char aBuf[IO_MAX_PATH_LENGTH];
-	// add map extension
-	if(!str_endswith(pFileName, ".map"))
-	{
-		str_format(aBuf, sizeof(aBuf), "%s.map", pFileName);
-		pFileName = aBuf;
-	}
 
 	if(pEditor->Save(pFileName))
 	{
@@ -898,14 +886,6 @@ bool CEditor::CallbackSaveImage(const char *pFileName, int StorageType, void *pU
 	dbg_assert(StorageType == IStorage::TYPE_SAVE, "Saving only allowed for IStorage::TYPE_SAVE");
 
 	CEditor *pEditor = static_cast<CEditor *>(pUser);
-	char aBuf[IO_MAX_PATH_LENGTH];
-
-	// add file extension
-	if(!str_endswith(pFileName, ".png"))
-	{
-		str_format(aBuf, sizeof(aBuf), "%s.png", pFileName);
-		pFileName = aBuf;
-	}
 
 	std::shared_ptr<CEditorImage> pImg = pEditor->m_Map.m_vpImages[pEditor->m_SelectedImage];
 
@@ -926,17 +906,10 @@ bool CEditor::CallbackSaveSound(const char *pFileName, int StorageType, void *pU
 	dbg_assert(StorageType == IStorage::TYPE_SAVE, "Saving only allowed for IStorage::TYPE_SAVE");
 
 	CEditor *pEditor = static_cast<CEditor *>(pUser);
-	char aBuf[IO_MAX_PATH_LENGTH];
 
-	// add file extension
-	if(!str_endswith(pFileName, ".opus"))
-	{
-		str_format(aBuf, sizeof(aBuf), "%s.opus", pFileName);
-		pFileName = aBuf;
-	}
 	std::shared_ptr<CEditorSound> pSound = pEditor->m_Map.m_vpSounds[pEditor->m_SelectedSound];
-	IOHANDLE File = pEditor->Storage()->OpenFile(pFileName, IOFLAG_WRITE, StorageType);
 
+	IOHANDLE File = pEditor->Storage()->OpenFile(pFileName, IOFLAG_WRITE, StorageType);
 	if(File)
 	{
 		io_write(File, pSound->m_pData, pSound->m_DataSize);
@@ -4716,14 +4689,14 @@ bool CEditor::ReplaceSoundCallback(const char *pFileName, int StorageType, void 
 	return static_cast<CEditor *>(pUser)->ReplaceSound(pFileName, StorageType, true);
 }
 
-bool CEditor::IsAssetUsed(int FileType, int Index, void *pUser)
+bool CEditor::IsAssetUsed(CFileBrowser::EFileType FileType, int Index, void *pUser)
 {
 	CEditor *pEditor = (CEditor *)pUser;
 	for(const auto &pGroup : pEditor->m_Map.m_vpGroups)
 	{
 		for(const auto &pLayer : pGroup->m_vpLayers)
 		{
-			if(FileType == FILETYPE_IMG)
+			if(FileType == CFileBrowser::EFileType::IMAGE)
 			{
 				if(pLayer->m_Type == LAYERTYPE_TILES)
 				{
@@ -4742,7 +4715,7 @@ bool CEditor::IsAssetUsed(int FileType, int Index, void *pUser)
 					}
 				}
 			}
-			else if(FileType == FILETYPE_SOUND)
+			else if(FileType == CFileBrowser::EFileType::SOUND)
 			{
 				if(pLayer->m_Type == LAYERTYPE_SOUNDS)
 				{
@@ -5066,765 +5039,9 @@ void CEditor::RenderSounds(CUIRect ToolBox)
 		AddSoundButton.HSplitTop(5.0f, nullptr, &AddSoundButton);
 		AddSoundButton.HSplitTop(RowHeight, &AddSoundButton, nullptr);
 		if(DoButton_Editor(&s_AddSoundButton, "Add sound", 0, &AddSoundButton, BUTTONFLAG_LEFT, "Load a new sound to use in the map."))
-			InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_SOUND, "Add Sound", "Add", "mapres", false, AddSound, this);
+			m_FileBrowser.ShowFileDialog(IStorage::TYPE_ALL, CFileBrowser::EFileType::SOUND, "Add sound", "Add", "mapres", "", AddSound, this);
 	}
 	s_ScrollRegion.End();
-}
-
-static int EditorListdirCallback(const CFsFileInfo *pInfo, int IsDir, int StorageType, void *pUser)
-{
-	CEditor *pEditor = (CEditor *)pUser;
-	if((pInfo->m_pName[0] == '.' && (pInfo->m_pName[1] == 0 ||
-						(pInfo->m_pName[1] == '.' && pInfo->m_pName[2] == 0 && (pEditor->m_FileDialogShowingRoot || (!pEditor->m_FileDialogMultipleStorages && (!str_comp(pEditor->m_pFileDialogPath, "maps") || !str_comp(pEditor->m_pFileDialogPath, "mapres"))))))) ||
-		(!IsDir && ((pEditor->m_FileDialogFileType == CEditor::FILETYPE_MAP && !str_endswith(pInfo->m_pName, ".map")) ||
-				   (pEditor->m_FileDialogFileType == CEditor::FILETYPE_IMG && !str_endswith(pInfo->m_pName, ".png")) ||
-				   (pEditor->m_FileDialogFileType == CEditor::FILETYPE_SOUND && !str_endswith(pInfo->m_pName, ".opus")))))
-		return 0;
-
-	CEditor::CFilelistItem Item;
-	str_copy(Item.m_aFilename, pInfo->m_pName);
-	if(IsDir)
-		str_format(Item.m_aName, sizeof(Item.m_aName), "%s/", pInfo->m_pName);
-	else
-	{
-		int LenEnding = pEditor->m_FileDialogFileType == CEditor::FILETYPE_SOUND ? 5 : 4;
-		str_truncate(Item.m_aName, sizeof(Item.m_aName), pInfo->m_pName, str_length(pInfo->m_pName) - LenEnding);
-	}
-	Item.m_IsDir = IsDir != 0;
-	Item.m_IsLink = false;
-	Item.m_StorageType = StorageType;
-	Item.m_TimeModified = pInfo->m_TimeModified;
-	pEditor->m_vCompleteFileList.push_back(Item);
-
-	return 0;
-}
-
-void CEditor::SortFilteredFileList()
-{
-	if(m_SortByFilename == 1)
-	{
-		std::sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CEditor::CompareFilenameAscending);
-	}
-	else
-	{
-		std::sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CEditor::CompareFilenameDescending);
-	}
-
-	if(m_SortByTimeModified == 1)
-	{
-		std::stable_sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CEditor::CompareTimeModifiedAscending);
-	}
-	else if(m_SortByTimeModified == -1)
-	{
-		std::stable_sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CEditor::CompareTimeModifiedDescending);
-	}
-}
-
-void CEditor::RenderFileDialog()
-{
-	// GUI coordsys
-	Ui()->MapScreen();
-	CUIRect View = *Ui()->Screen();
-	CUIRect Preview = {0.0f, 0.0f, 0.0f, 0.0f};
-	float Width = View.w, Height = View.h;
-
-	View.Draw(ColorRGBA(0, 0, 0, 0.25f), 0, 0);
-	View.VMargin(150.0f, &View);
-	View.HMargin(50.0f, &View);
-	View.Draw(ColorRGBA(0, 0, 0, 0.75f), IGraphics::CORNER_ALL, 5.0f);
-	View.Margin(10.0f, &View);
-
-	CUIRect Title, FileBox, FileBoxLabel, ButtonBar, PathBox;
-	View.HSplitTop(18.0f, &Title, &View);
-	View.HSplitTop(5.0f, nullptr, &View); // some spacing
-	View.HSplitBottom(14.0f, &View, &ButtonBar);
-	View.HSplitBottom(10.0f, &View, nullptr); // some spacing
-	View.HSplitBottom(14.0f, &View, &PathBox);
-	View.HSplitBottom(5.0f, &View, nullptr); // some spacing
-	View.HSplitBottom(14.0f, &View, &FileBox);
-	FileBox.VSplitLeft(55.0f, &FileBoxLabel, &FileBox);
-	View.HSplitBottom(10.0f, &View, nullptr); // some spacing
-	if(m_FileDialogFileType == CEditor::FILETYPE_IMG || m_FileDialogFileType == CEditor::FILETYPE_SOUND)
-		View.VSplitMid(&View, &Preview);
-
-	// title bar
-	if(!m_FileDialogShowingRoot)
-	{
-		CUIRect ButtonTimeModified, ButtonFileName;
-		Title.VSplitRight(10.0f, &Title, nullptr);
-		Title.VSplitRight(90.0f, &Title, &ButtonTimeModified);
-		Title.VSplitRight(10.0f, &Title, nullptr);
-		Title.VSplitRight(90.0f, &Title, &ButtonFileName);
-		Title.VSplitRight(10.0f, &Title, nullptr);
-
-		const char *aSortIndicator[3] = {"▼", "", "▲"};
-
-		static int s_ButtonTimeModified = 0;
-		char aBufLabelButtonTimeModified[64];
-		str_format(aBufLabelButtonTimeModified, sizeof(aBufLabelButtonTimeModified), "Time modified %s", aSortIndicator[m_SortByTimeModified + 1]);
-		if(DoButton_Editor(&s_ButtonTimeModified, aBufLabelButtonTimeModified, 0, &ButtonTimeModified, BUTTONFLAG_LEFT, "Sort by time modified."))
-		{
-			if(m_SortByTimeModified == 1)
-			{
-				m_SortByTimeModified = -1;
-			}
-			else if(m_SortByTimeModified == -1)
-			{
-				m_SortByTimeModified = 0;
-			}
-			else
-			{
-				m_SortByTimeModified = 1;
-			}
-
-			RefreshFilteredFileList();
-		}
-
-		static int s_ButtonFileName = 0;
-		char aBufLabelButtonFilename[64];
-		str_format(aBufLabelButtonFilename, sizeof(aBufLabelButtonFilename), "Filename %s", aSortIndicator[m_SortByFilename + 1]);
-		if(DoButton_Editor(&s_ButtonFileName, aBufLabelButtonFilename, 0, &ButtonFileName, BUTTONFLAG_LEFT, "Sort by file name."))
-		{
-			if(m_SortByFilename == 1)
-			{
-				m_SortByFilename = -1;
-				m_SortByTimeModified = 0;
-			}
-			else
-			{
-				m_SortByFilename = 1;
-				m_SortByTimeModified = 0;
-			}
-
-			RefreshFilteredFileList();
-		}
-	}
-
-	Title.Draw(ColorRGBA(1, 1, 1, 0.25f), IGraphics::CORNER_ALL, 4.0f);
-	Title.VMargin(10.0f, &Title);
-	Ui()->DoLabel(&Title, m_pFileDialogTitle, 12.0f, TEXTALIGN_ML);
-
-	// pathbox
-	if(m_FilesSelectedIndex >= 0 && m_vpFilteredFileList[m_FilesSelectedIndex]->m_StorageType >= IStorage::TYPE_SAVE)
-	{
-		char aPath[IO_MAX_PATH_LENGTH], aBuf[128 + IO_MAX_PATH_LENGTH];
-		Storage()->GetCompletePath(m_vpFilteredFileList[m_FilesSelectedIndex]->m_StorageType, m_pFileDialogPath, aPath, sizeof(aPath));
-		str_format(aBuf, sizeof(aBuf), "Current path: %s", aPath);
-		Ui()->DoLabel(&PathBox, aBuf, 10.0f, TEXTALIGN_ML);
-	}
-
-	// filebox
-	static CListBox s_ListBox;
-	s_ListBox.SetActive(!Ui()->IsPopupOpen());
-
-	const auto &&UpdateFileNameInput = [this]() {
-		if(m_FilesSelectedIndex >= 0 && !m_vpFilteredFileList[m_FilesSelectedIndex]->m_IsDir)
-		{
-			char aNameWithoutExt[IO_MAX_PATH_LENGTH];
-			fs_split_file_extension(m_vpFilteredFileList[m_FilesSelectedIndex]->m_aFilename, aNameWithoutExt, sizeof(aNameWithoutExt));
-			m_FileDialogFileNameInput.Set(aNameWithoutExt);
-		}
-		else
-			m_FileDialogFileNameInput.Clear();
-	};
-	const auto &&UpdateSelectedIndex = [&]() {
-		m_FilesSelectedIndex = -1;
-		m_aFilesSelectedName[0] = '\0';
-		// find first valid entry, if it exists
-		for(size_t i = 0; i < m_vpFilteredFileList.size(); i++)
-		{
-			if(str_comp_nocase(m_vpFilteredFileList[i]->m_aName, m_FileDialogFileNameInput.GetString()) == 0)
-			{
-				m_FilesSelectedIndex = i;
-				str_copy(m_aFilesSelectedName, m_vpFilteredFileList[i]->m_aName);
-				break;
-			}
-		}
-		if(m_FilesSelectedIndex >= 0)
-			s_ListBox.ScrollToSelected();
-	};
-
-	if(m_FileDialogSaveAction)
-	{
-		Ui()->DoLabel(&FileBoxLabel, "Filename:", 10.0f, TEXTALIGN_ML);
-		if(DoEditBox(&m_FileDialogFileNameInput, &FileBox, 10.0f))
-		{
-			// remove '/' and '\'
-			for(int i = 0; m_FileDialogFileNameInput.GetString()[i]; ++i)
-			{
-				if(m_FileDialogFileNameInput.GetString()[i] == '/' || m_FileDialogFileNameInput.GetString()[i] == '\\')
-				{
-					m_FileDialogFileNameInput.SetRange(m_FileDialogFileNameInput.GetString() + i + 1, i, m_FileDialogFileNameInput.GetLength());
-					--i;
-				}
-			}
-			UpdateSelectedIndex();
-		}
-
-		if(m_FileDialogOpening)
-		{
-			Ui()->SetActiveItem(&m_FileDialogFileNameInput);
-			if(!m_FileDialogFileNameInput.IsEmpty())
-			{
-				UpdateSelectedIndex();
-			}
-		}
-	}
-	else
-	{
-		// render search bar
-		Ui()->DoLabel(&FileBoxLabel, "Search:", 10.0f, TEXTALIGN_ML);
-		if(m_FileDialogOpening || (Input()->KeyPress(KEY_F) && Input()->ModifierIsPressed()))
-		{
-			Ui()->SetActiveItem(&m_FileDialogFilterInput);
-			m_FileDialogFilterInput.SelectAll();
-		}
-		if(m_FileDialogOpening)
-		{
-			UpdateFileNameInput();
-		}
-		if(Ui()->DoClearableEditBox(&m_FileDialogFilterInput, &FileBox, 10.0f))
-		{
-			RefreshFilteredFileList();
-			if(m_vpFilteredFileList.empty())
-			{
-				m_FilesSelectedIndex = -1;
-			}
-			else if(m_FilesSelectedIndex == -1 || (!m_FileDialogFilterInput.IsEmpty() && !str_find_nocase(m_vpFilteredFileList[m_FilesSelectedIndex]->m_aName, m_FileDialogFilterInput.GetString())))
-			{
-				// we need to refresh selection
-				m_FilesSelectedIndex = -1;
-				for(size_t i = 0; i < m_vpFilteredFileList.size(); i++)
-				{
-					if(str_find_nocase(m_vpFilteredFileList[i]->m_aName, m_FileDialogFilterInput.GetString()))
-					{
-						m_FilesSelectedIndex = i;
-						break;
-					}
-				}
-				if(m_FilesSelectedIndex == -1)
-				{
-					// select first item
-					m_FilesSelectedIndex = 0;
-				}
-			}
-			if(m_FilesSelectedIndex >= 0)
-				str_copy(m_aFilesSelectedName, m_vpFilteredFileList[m_FilesSelectedIndex]->m_aName);
-			else
-				m_aFilesSelectedName[0] = '\0';
-			UpdateFileNameInput();
-			s_ListBox.ScrollToSelected();
-			m_FilePreviewState = PREVIEW_UNLOADED;
-		}
-	}
-
-	m_FileDialogOpening = false;
-
-	if(m_FilesSelectedIndex > -1)
-	{
-		if(m_FilePreviewState == PREVIEW_UNLOADED)
-		{
-			if(m_FileDialogFileType == CEditor::FILETYPE_IMG && str_endswith(m_vpFilteredFileList[m_FilesSelectedIndex]->m_aFilename, ".png"))
-			{
-				char aBuffer[IO_MAX_PATH_LENGTH];
-				str_format(aBuffer, sizeof(aBuffer), "%s/%s", m_pFileDialogPath, m_vpFilteredFileList[m_FilesSelectedIndex]->m_aFilename);
-				CImageInfo PreviewImageInfo;
-				if(Graphics()->LoadPng(PreviewImageInfo, aBuffer, m_vpFilteredFileList[m_FilesSelectedIndex]->m_StorageType))
-				{
-					Graphics()->UnloadTexture(&m_FilePreviewImage);
-					m_FilePreviewImageWidth = PreviewImageInfo.m_Width;
-					m_FilePreviewImageHeight = PreviewImageInfo.m_Height;
-					m_FilePreviewImage = Graphics()->LoadTextureRawMove(PreviewImageInfo, 0, aBuffer);
-					m_FilePreviewState = PREVIEW_LOADED;
-				}
-				else
-				{
-					m_FilePreviewState = PREVIEW_ERROR;
-				}
-			}
-			else if(m_FileDialogFileType == CEditor::FILETYPE_SOUND && str_endswith(m_vpFilteredFileList[m_FilesSelectedIndex]->m_aFilename, ".opus"))
-			{
-				char aBuffer[IO_MAX_PATH_LENGTH];
-				str_format(aBuffer, sizeof(aBuffer), "%s/%s", m_pFileDialogPath, m_vpFilteredFileList[m_FilesSelectedIndex]->m_aFilename);
-				Sound()->UnloadSample(m_FilePreviewSound);
-				m_FilePreviewSound = Sound()->LoadOpus(aBuffer, m_vpFilteredFileList[m_FilesSelectedIndex]->m_StorageType);
-				m_FilePreviewState = m_FilePreviewSound == -1 ? PREVIEW_ERROR : PREVIEW_LOADED;
-			}
-		}
-
-		if(m_FileDialogFileType == CEditor::FILETYPE_IMG)
-		{
-			Preview.Margin(10.0f, &Preview);
-			if(m_FilePreviewState == PREVIEW_LOADED)
-			{
-				CUIRect PreviewLabel, PreviewImage;
-				Preview.HSplitTop(20.0f, &PreviewLabel, &PreviewImage);
-
-				char aLabel[64];
-				str_format(aLabel, sizeof(aLabel), "Size: %d × %d", m_FilePreviewImageWidth, m_FilePreviewImageHeight);
-				Ui()->DoLabel(&PreviewLabel, aLabel, 12.0f, TEXTALIGN_ML);
-
-				int w = m_FilePreviewImageWidth;
-				int h = m_FilePreviewImageHeight;
-				if(m_FilePreviewImageWidth > PreviewImage.w)
-				{
-					h = m_FilePreviewImageHeight * PreviewImage.w / m_FilePreviewImageWidth;
-					w = PreviewImage.w;
-				}
-				if(h > PreviewImage.h)
-				{
-					w = w * PreviewImage.h / h;
-					h = PreviewImage.h;
-				}
-
-				Graphics()->TextureSet(m_FilePreviewImage);
-				Graphics()->BlendNormal();
-				Graphics()->QuadsBegin();
-				IGraphics::CQuadItem QuadItem(PreviewImage.x, PreviewImage.y, w, h);
-				Graphics()->QuadsDrawTL(&QuadItem, 1);
-				Graphics()->QuadsEnd();
-			}
-			else if(m_FilePreviewState == PREVIEW_ERROR)
-			{
-				SLabelProperties Props;
-				Props.m_MaxWidth = Preview.w;
-				Ui()->DoLabel(&Preview, "Failed to load the image (check the local console for details).", 12.0f, TEXTALIGN_TL, Props);
-			}
-		}
-		else if(m_FileDialogFileType == CEditor::FILETYPE_SOUND)
-		{
-			Preview.Margin(10.0f, &Preview);
-			if(m_FilePreviewState == PREVIEW_LOADED)
-			{
-				Preview.HSplitTop(20.0f, &Preview, nullptr);
-				Preview.VSplitLeft(Preview.h / 4.0f, nullptr, &Preview);
-
-				static int s_PlayPauseButton, s_StopButton, s_SeekBar = 0;
-				DoAudioPreview(Preview, &s_PlayPauseButton, &s_StopButton, &s_SeekBar, m_FilePreviewSound);
-			}
-			else if(m_FilePreviewState == PREVIEW_ERROR)
-			{
-				SLabelProperties Props;
-				Props.m_MaxWidth = Preview.w;
-				Ui()->DoLabel(&Preview, "Failed to load the sound (check the local console for details). Make sure you enabled sounds in the settings.", 12.0f, TEXTALIGN_TL, Props);
-			}
-		}
-	}
-
-	s_ListBox.DoStart(15.0f, m_vpFilteredFileList.size(), 1, 5, m_FilesSelectedIndex, &View, false);
-
-	for(size_t i = 0; i < m_vpFilteredFileList.size(); i++)
-	{
-		const CListboxItem Item = s_ListBox.DoNextItem(m_vpFilteredFileList[i], m_FilesSelectedIndex >= 0 && (size_t)m_FilesSelectedIndex == i);
-		if(!Item.m_Visible)
-			continue;
-
-		CUIRect Button, FileIcon, TimeModified;
-		Item.m_Rect.VSplitLeft(Item.m_Rect.h, &FileIcon, &Button);
-		Button.VSplitLeft(5.0f, nullptr, &Button);
-		Button.VSplitRight(100.0f, &Button, &TimeModified);
-		Button.VSplitRight(5.0f, &Button, nullptr);
-
-		const char *pIconType;
-		if(!m_vpFilteredFileList[i]->m_IsDir)
-		{
-			switch(m_FileDialogFileType)
-			{
-			case FILETYPE_MAP:
-				pIconType = FONT_ICON_MAP;
-				break;
-			case FILETYPE_IMG:
-				pIconType = FONT_ICON_IMAGE;
-				break;
-			case FILETYPE_SOUND:
-				pIconType = FONT_ICON_MUSIC;
-				break;
-			default:
-				pIconType = FONT_ICON_FILE;
-			}
-		}
-		else
-		{
-			if(m_vpFilteredFileList[i]->m_IsLink || str_comp(m_vpFilteredFileList[i]->m_aFilename, "..") == 0)
-				pIconType = FONT_ICON_FOLDER_TREE;
-			else
-				pIconType = FONT_ICON_FOLDER;
-		}
-
-		TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
-		TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING);
-		Ui()->DoLabel(&FileIcon, pIconType, 12.0f, TEXTALIGN_ML);
-		TextRender()->SetRenderFlags(0);
-		TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
-
-		SLabelProperties Props;
-		Props.m_MaxWidth = Button.w;
-		Props.m_EllipsisAtEnd = true;
-		Ui()->DoLabel(&Button, m_vpFilteredFileList[i]->m_aName, 10.0f, TEXTALIGN_ML, Props);
-
-		if(!m_vpFilteredFileList[i]->m_IsLink && str_comp(m_vpFilteredFileList[i]->m_aFilename, "..") != 0)
-		{
-			char aBufTimeModified[64];
-			str_timestamp_ex(m_vpFilteredFileList[i]->m_TimeModified, aBufTimeModified, sizeof(aBufTimeModified), "%d.%m.%Y %H:%M");
-			Ui()->DoLabel(&TimeModified, aBufTimeModified, 10.0f, TEXTALIGN_MR);
-		}
-	}
-
-	const int NewSelection = s_ListBox.DoEnd();
-	if(NewSelection != m_FilesSelectedIndex)
-	{
-		m_FilesSelectedIndex = NewSelection;
-		str_copy(m_aFilesSelectedName, m_vpFilteredFileList[m_FilesSelectedIndex]->m_aName);
-		const bool WasChanged = m_FileDialogFileNameInput.WasChanged();
-		UpdateFileNameInput();
-		if(!WasChanged) // ensure that changed flag is not set if it wasn't previously set, as this would reset the selection after DoEditBox is called
-			m_FileDialogFileNameInput.WasChanged(); // this clears the changed flag
-		m_FilePreviewState = PREVIEW_UNLOADED;
-	}
-
-	const float ButtonSpacing = ButtonBar.w > 600.0f ? 40.0f : 10.0f;
-
-	// the buttons
-	static int s_OkButton = 0;
-	static int s_CancelButton = 0;
-	static int s_RefreshButton = 0;
-	static int s_ShowDirectoryButton = 0;
-	static int s_DeleteButton = 0;
-	static int s_NewFolderButton = 0;
-
-	CUIRect Button;
-	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
-	const bool IsDir = m_FilesSelectedIndex >= 0 && m_vpFilteredFileList[m_FilesSelectedIndex]->m_IsDir;
-	if(DoButton_Editor(&s_OkButton, IsDir ? "Open" : m_pFileDialogButtonText, 0, &Button, BUTTONFLAG_LEFT, nullptr) || s_ListBox.WasItemActivated() || (s_ListBox.Active() && Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
-	{
-		if(IsDir) // folder
-		{
-			m_FileDialogFilterInput.Clear();
-			Ui()->SetActiveItem(&m_FileDialogFilterInput);
-			const bool ParentFolder = str_comp(m_vpFilteredFileList[m_FilesSelectedIndex]->m_aFilename, "..") == 0;
-			if(ParentFolder) // parent folder
-			{
-				str_copy(m_aFilesSelectedName, fs_filename(m_pFileDialogPath));
-				str_append(m_aFilesSelectedName, "/");
-				if(fs_parent_dir(m_pFileDialogPath))
-				{
-					if(str_comp(m_pFileDialogPath, m_aFileDialogCurrentFolder) == 0)
-					{
-						m_FileDialogShowingRoot = true;
-						if(m_FileDialogStorageType == IStorage::TYPE_ALL)
-						{
-							m_aFilesSelectedName[0] = '\0'; // will select first list item
-						}
-						else
-						{
-							Storage()->GetCompletePath(m_FileDialogStorageType, m_pFileDialogPath, m_aFilesSelectedName, sizeof(m_aFilesSelectedName));
-							str_append(m_aFilesSelectedName, "/");
-						}
-					}
-					else
-					{
-						m_pFileDialogPath = m_aFileDialogCurrentFolder; // leave the link
-						str_copy(m_aFilesSelectedName, m_aFileDialogCurrentLink);
-						str_append(m_aFilesSelectedName, "/");
-					}
-				}
-			}
-			else // sub folder
-			{
-				if(m_vpFilteredFileList[m_FilesSelectedIndex]->m_IsLink)
-				{
-					m_pFileDialogPath = m_aFileDialogCurrentLink; // follow the link
-					str_copy(m_aFileDialogCurrentLink, m_vpFilteredFileList[m_FilesSelectedIndex]->m_aFilename);
-				}
-				else
-				{
-					char aTemp[IO_MAX_PATH_LENGTH];
-					str_copy(aTemp, m_pFileDialogPath);
-					str_format(m_pFileDialogPath, IO_MAX_PATH_LENGTH, "%s/%s", aTemp, m_vpFilteredFileList[m_FilesSelectedIndex]->m_aFilename);
-				}
-				if(m_FileDialogShowingRoot)
-					m_FileDialogStorageType = m_vpFilteredFileList[m_FilesSelectedIndex]->m_StorageType;
-				m_FileDialogShowingRoot = false;
-			}
-			FilelistPopulate(m_FileDialogStorageType, ParentFolder);
-			UpdateFileNameInput();
-		}
-		else // file
-		{
-			const int StorageType = m_FilesSelectedIndex >= 0 ? m_vpFilteredFileList[m_FilesSelectedIndex]->m_StorageType : m_FileDialogStorageType;
-			str_format(m_aFileSaveName, sizeof(m_aFileSaveName), "%s/%s", m_pFileDialogPath, m_FileDialogFileNameInput.GetString());
-			if(!str_endswith(m_aFileSaveName, FILETYPE_EXTENSIONS[m_FileDialogFileType]))
-				str_append(m_aFileSaveName, FILETYPE_EXTENSIONS[m_FileDialogFileType]);
-
-			char aFilename[IO_MAX_PATH_LENGTH];
-			fs_split_file_extension(fs_filename(m_aFileSaveName), aFilename, sizeof(aFilename));
-			if(m_FileDialogSaveAction && !str_valid_filename(aFilename))
-			{
-				ShowFileDialogError("This name cannot be used for files and folders");
-			}
-			else if(m_FileDialogSaveAction && Storage()->FileExists(m_aFileSaveName, StorageType))
-			{
-				if(m_pfnFileDialogFunc == &CallbackSaveMap)
-					m_PopupEventType = POPEVENT_SAVE;
-				else if(m_pfnFileDialogFunc == &CallbackSaveCopyMap)
-					m_PopupEventType = POPEVENT_SAVE_COPY;
-				else if(m_pfnFileDialogFunc == &CallbackSaveImage)
-					m_PopupEventType = POPEVENT_SAVE_IMG;
-				else if(m_pfnFileDialogFunc == &CallbackSaveSound)
-					m_PopupEventType = POPEVENT_SAVE_SOUND;
-				else
-					dbg_assert(false, "m_pfnFileDialogFunc unhandled for saving");
-				m_PopupEventActivated = true;
-			}
-			else if(m_pfnFileDialogFunc && (m_FileDialogSaveAction || m_FilesSelectedIndex >= 0))
-			{
-				m_pfnFileDialogFunc(m_aFileSaveName, StorageType, m_pFileDialogUser);
-			}
-		}
-	}
-
-	ButtonBar.VSplitRight(ButtonSpacing, &ButtonBar, nullptr);
-	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
-	if(DoButton_Editor(&s_CancelButton, "Cancel", 0, &Button, BUTTONFLAG_LEFT, nullptr) || (s_ListBox.Active() && Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE)))
-	{
-		OnDialogClose();
-	}
-
-	ButtonBar.VSplitRight(ButtonSpacing, &ButtonBar, nullptr);
-	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
-	if(DoButton_Editor(&s_RefreshButton, "Refresh", 0, &Button, BUTTONFLAG_LEFT, nullptr) || (s_ListBox.Active() && (Input()->KeyIsPressed(KEY_F5) || (Input()->ModifierIsPressed() && Input()->KeyIsPressed(KEY_R)))))
-		FilelistPopulate(m_FileDialogLastPopulatedStorageType, true);
-
-	if(m_FilesSelectedIndex >= 0 && m_vpFilteredFileList[m_FilesSelectedIndex]->m_StorageType != IStorage::TYPE_ALL)
-	{
-		ButtonBar.VSplitRight(ButtonSpacing, &ButtonBar, nullptr);
-		ButtonBar.VSplitRight(90.0f, &ButtonBar, &Button);
-		if(DoButton_Editor(&s_ShowDirectoryButton, "Show directory", 0, &Button, BUTTONFLAG_LEFT, "Open the current directory in the file browser."))
-		{
-			char aOpenPath[IO_MAX_PATH_LENGTH];
-			Storage()->GetCompletePath(m_FilesSelectedIndex >= 0 ? m_vpFilteredFileList[m_FilesSelectedIndex]->m_StorageType : IStorage::TYPE_SAVE, m_pFileDialogPath, aOpenPath, sizeof(aOpenPath));
-			if(!Client()->ViewFile(aOpenPath))
-			{
-				ShowFileDialogError("Failed to open the directory '%s'.", aOpenPath);
-			}
-		}
-	}
-
-	ButtonBar.VSplitRight(ButtonSpacing, &ButtonBar, nullptr);
-	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
-	static CUi::SConfirmPopupContext s_ConfirmDeletePopupContext;
-	if(m_FilesSelectedIndex >= 0 && m_vpFilteredFileList[m_FilesSelectedIndex]->m_StorageType == IStorage::TYPE_SAVE && !m_vpFilteredFileList[m_FilesSelectedIndex]->m_IsLink && str_comp(m_vpFilteredFileList[m_FilesSelectedIndex]->m_aFilename, "..") != 0)
-	{
-		if(DoButton_Editor(&s_DeleteButton, "Delete", 0, &Button, BUTTONFLAG_LEFT, nullptr) || (s_ListBox.Active() && Ui()->ConsumeHotkey(CUi::HOTKEY_DELETE)))
-		{
-			s_ConfirmDeletePopupContext.Reset();
-			s_ConfirmDeletePopupContext.YesNoButtons();
-			str_format(s_ConfirmDeletePopupContext.m_aMessage, sizeof(s_ConfirmDeletePopupContext.m_aMessage), "Are you sure that you want to delete the %s '%s/%s'?", IsDir ? "folder" : "file", m_pFileDialogPath, m_vpFilteredFileList[m_FilesSelectedIndex]->m_aFilename);
-			Ui()->ShowPopupConfirm(Ui()->MouseX(), Ui()->MouseY(), &s_ConfirmDeletePopupContext);
-		}
-		if(s_ConfirmDeletePopupContext.m_Result == CUi::SConfirmPopupContext::CONFIRMED)
-		{
-			char aDeleteFilePath[IO_MAX_PATH_LENGTH];
-			str_format(aDeleteFilePath, sizeof(aDeleteFilePath), "%s/%s", m_pFileDialogPath, m_vpFilteredFileList[m_FilesSelectedIndex]->m_aFilename);
-			if(IsDir)
-			{
-				if(Storage()->RemoveFolder(aDeleteFilePath, IStorage::TYPE_SAVE))
-					FilelistPopulate(m_FileDialogLastPopulatedStorageType, true);
-				else
-					ShowFileDialogError("Failed to delete folder '%s'. Make sure it's empty first.", aDeleteFilePath);
-			}
-			else
-			{
-				if(Storage()->RemoveFile(aDeleteFilePath, IStorage::TYPE_SAVE))
-					FilelistPopulate(m_FileDialogLastPopulatedStorageType, true);
-				else
-					ShowFileDialogError("Failed to delete file '%s'.", aDeleteFilePath);
-			}
-			UpdateFileNameInput();
-		}
-		if(s_ConfirmDeletePopupContext.m_Result != CUi::SConfirmPopupContext::UNSET)
-			s_ConfirmDeletePopupContext.Reset();
-	}
-	else
-		s_ConfirmDeletePopupContext.Reset();
-
-	if(!m_FileDialogShowingRoot && m_FileDialogStorageType == IStorage::TYPE_SAVE)
-	{
-		ButtonBar.VSplitLeft(70.0f, &Button, &ButtonBar);
-		if(DoButton_Editor(&s_NewFolderButton, "New folder", 0, &Button, BUTTONFLAG_LEFT, nullptr))
-		{
-			m_FileDialogNewFolderNameInput.Clear();
-			static SPopupMenuId s_PopupNewFolderId;
-			constexpr float PopupWidth = 400.0f;
-			constexpr float PopupHeight = 110.0f;
-			Ui()->DoPopupMenu(&s_PopupNewFolderId, Width / 2.0f - PopupWidth / 2.0f, Height / 2.0f - PopupHeight / 2.0f, PopupWidth, PopupHeight, this, PopupNewFolder);
-			Ui()->SetActiveItem(&m_FileDialogNewFolderNameInput);
-		}
-	}
-}
-
-void CEditor::RefreshFilteredFileList()
-{
-	m_vpFilteredFileList.clear();
-	for(const CFilelistItem &Item : m_vCompleteFileList)
-	{
-		if(m_FileDialogFilterInput.IsEmpty() || str_find_nocase(Item.m_aName, m_FileDialogFilterInput.GetString()))
-		{
-			m_vpFilteredFileList.push_back(&Item);
-		}
-	}
-	if(!m_FileDialogShowingRoot)
-		SortFilteredFileList();
-	if(!m_vpFilteredFileList.empty())
-	{
-		if(m_aFilesSelectedName[0])
-		{
-			for(size_t i = 0; i < m_vpFilteredFileList.size(); i++)
-			{
-				if(m_aFilesSelectedName[0] && str_comp(m_vpFilteredFileList[i]->m_aName, m_aFilesSelectedName) == 0)
-				{
-					m_FilesSelectedIndex = i;
-					break;
-				}
-			}
-		}
-		m_FilesSelectedIndex = std::clamp<int>(m_FilesSelectedIndex, 0, m_vpFilteredFileList.size() - 1);
-		str_copy(m_aFilesSelectedName, m_vpFilteredFileList[m_FilesSelectedIndex]->m_aName);
-	}
-	else
-	{
-		m_FilesSelectedIndex = -1;
-		m_aFilesSelectedName[0] = '\0';
-	}
-}
-
-void CEditor::FilelistPopulate(int StorageType, bool KeepSelection)
-{
-	m_FileDialogLastPopulatedStorageType = StorageType;
-	m_vCompleteFileList.clear();
-	if(m_FileDialogShowingRoot)
-	{
-		{
-			CFilelistItem Item;
-			str_copy(Item.m_aFilename, m_pFileDialogPath);
-			str_copy(Item.m_aName, "All combined");
-			Item.m_IsDir = true;
-			Item.m_IsLink = true;
-			Item.m_StorageType = IStorage::TYPE_ALL;
-			Item.m_TimeModified = 0;
-			m_vCompleteFileList.push_back(Item);
-		}
-
-		for(int CheckStorageType = IStorage::TYPE_SAVE; CheckStorageType < Storage()->NumPaths(); ++CheckStorageType)
-		{
-			if(Storage()->FolderExists(m_pFileDialogPath, CheckStorageType))
-			{
-				CFilelistItem Item;
-				str_copy(Item.m_aFilename, m_pFileDialogPath);
-				Storage()->GetCompletePath(CheckStorageType, m_pFileDialogPath, Item.m_aName, sizeof(Item.m_aName));
-				str_append(Item.m_aName, "/", sizeof(Item.m_aName));
-				Item.m_IsDir = true;
-				Item.m_IsLink = true;
-				Item.m_StorageType = CheckStorageType;
-				Item.m_TimeModified = 0;
-				m_vCompleteFileList.push_back(Item);
-			}
-		}
-	}
-	else
-	{
-		// Add links for downloadedmaps and themes
-		if(!str_comp(m_pFileDialogPath, "maps"))
-		{
-			if(str_comp(m_pFileDialogButtonText, "Save") != 0 && Storage()->FolderExists("downloadedmaps", StorageType))
-			{
-				CFilelistItem Item;
-				str_copy(Item.m_aFilename, "downloadedmaps");
-				str_copy(Item.m_aName, "downloadedmaps/");
-				Item.m_IsDir = true;
-				Item.m_IsLink = true;
-				Item.m_StorageType = StorageType;
-				Item.m_TimeModified = 0;
-				m_vCompleteFileList.push_back(Item);
-			}
-
-			if(Storage()->FolderExists("themes", StorageType))
-			{
-				CFilelistItem Item;
-				str_copy(Item.m_aFilename, "themes");
-				str_copy(Item.m_aName, "themes/");
-				Item.m_IsDir = true;
-				Item.m_IsLink = true;
-				Item.m_StorageType = StorageType;
-				Item.m_TimeModified = 0;
-				m_vCompleteFileList.push_back(Item);
-			}
-		}
-		Storage()->ListDirectoryInfo(StorageType, m_pFileDialogPath, EditorListdirCallback, this);
-	}
-	RefreshFilteredFileList();
-	if(!KeepSelection)
-	{
-		m_FilesSelectedIndex = m_vpFilteredFileList.empty() ? -1 : 0;
-		if(m_FilesSelectedIndex >= 0)
-			str_copy(m_aFilesSelectedName, m_vpFilteredFileList[m_FilesSelectedIndex]->m_aName);
-		else
-			m_aFilesSelectedName[0] = '\0';
-	}
-	m_FilePreviewState = PREVIEW_UNLOADED;
-}
-
-void CEditor::InvokeFileDialog(int StorageType, int FileType, const char *pTitle, const char *pButtonText,
-	const char *pBasePath, bool FilenameAsDefault,
-	bool (*pfnFunc)(const char *pFileName, int StorageType, void *pUser), void *pUser)
-{
-	m_FileDialogStorageType = StorageType;
-	if(m_FileDialogStorageType == IStorage::TYPE_ALL)
-	{
-		int NumStoragesWithFolder = 0;
-		for(int CheckStorageType = IStorage::TYPE_SAVE; CheckStorageType < Storage()->NumPaths(); ++CheckStorageType)
-		{
-			if(Storage()->FolderExists(pBasePath, CheckStorageType))
-			{
-				NumStoragesWithFolder++;
-			}
-		}
-		m_FileDialogMultipleStorages = NumStoragesWithFolder > 1;
-	}
-	else
-	{
-		m_FileDialogMultipleStorages = false;
-	}
-	m_FileDialogSaveAction = m_FileDialogStorageType == IStorage::TYPE_SAVE;
-
-	Ui()->ClosePopupMenus();
-	m_pFileDialogTitle = pTitle;
-	m_pFileDialogButtonText = pButtonText;
-	m_pfnFileDialogFunc = pfnFunc;
-	m_pFileDialogUser = pUser;
-	m_FileDialogFileNameInput.Clear();
-	m_FileDialogFilterInput.Clear();
-	m_aFileDialogCurrentFolder[0] = 0;
-	m_aFileDialogCurrentLink[0] = 0;
-	m_pFileDialogPath = m_aFileDialogCurrentFolder;
-	m_FileDialogFileType = FileType;
-	m_FilePreviewState = PREVIEW_UNLOADED;
-	m_FileDialogOpening = true;
-	m_FileDialogShowingRoot = false;
-
-	if(FilenameAsDefault)
-	{
-		char aDefaultName[IO_MAX_PATH_LENGTH];
-		fs_split_file_extension(fs_filename(m_aFileName), aDefaultName, sizeof(aDefaultName));
-		m_FileDialogFileNameInput.Set(aDefaultName);
-	}
-	if(pBasePath)
-		str_copy(m_aFileDialogCurrentFolder, pBasePath);
-
-	FilelistPopulate(m_FileDialogStorageType);
-
-	m_FileDialogOpening = true;
-	m_Dialog = DIALOG_FILE;
 }
 
 void CEditor::ShowFileDialogError(const char *pFormat, ...)
@@ -8045,7 +7262,7 @@ void CEditor::Render()
 			// ctrl+a to append map
 			if(Input()->KeyPress(KEY_A) && ModPressed)
 			{
-				InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_MAP, "Append map", "Append", "maps", false, CallbackAppendMap, this);
+				m_FileBrowser.ShowFileDialog(IStorage::TYPE_ALL, CFileBrowser::EFileType::MAP, "Append map", "Append", "maps", "", CallbackAppendMap, this);
 			}
 		}
 
@@ -8096,30 +7313,34 @@ void CEditor::Render()
 				}
 				else
 				{
-					InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_MAP, "Load map", "Load", "maps", false, CallbackOpenMap, this);
+					m_FileBrowser.ShowFileDialog(IStorage::TYPE_ALL, CFileBrowser::EFileType::MAP, "Load map", "Load", "maps", "", CallbackOpenMap, this);
 				}
 			}
 		}
 
 		// ctrl+shift+alt+s to save copy
 		if(Input()->KeyPress(KEY_S) && ModPressed && ShiftPressed && AltPressed)
-			InvokeFileDialog(IStorage::TYPE_SAVE, FILETYPE_MAP, "Save map", "Save", "maps", true, CallbackSaveCopyMap, this);
+		{
+			char aDefaultName[IO_MAX_PATH_LENGTH];
+			fs_split_file_extension(fs_filename(m_aFileName), aDefaultName, sizeof(aDefaultName));
+			m_FileBrowser.ShowFileDialog(IStorage::TYPE_SAVE, CFileBrowser::EFileType::MAP, "Save map", "Save copy", "maps", aDefaultName, CallbackSaveCopyMap, this);
+		}
 		// ctrl+shift+s to save as
 		else if(Input()->KeyPress(KEY_S) && ModPressed && ShiftPressed)
+		{
 			m_QuickActionSaveAs.Call();
+		}
 		// ctrl+s to save
 		else if(Input()->KeyPress(KEY_S) && ModPressed)
 		{
-			if(m_aFileName[0] && m_ValidSaveFilename)
+			if(m_aFileName[0] != '\0' && m_ValidSaveFilename)
 			{
-				if(!m_PopupEventWasActivated)
-				{
-					str_copy(m_aFileSaveName, m_aFileName);
-					CallbackSaveMap(m_aFileSaveName, IStorage::TYPE_SAVE, this);
-				}
+				CallbackSaveMap(m_aFileName, IStorage::TYPE_SAVE, this);
 			}
 			else
-				InvokeFileDialog(IStorage::TYPE_SAVE, FILETYPE_MAP, "Save map", "Save", "maps", false, CallbackSaveMap, this);
+			{
+				m_FileBrowser.ShowFileDialog(IStorage::TYPE_SAVE, CFileBrowser::EFileType::MAP, "Save map", "Save", "maps", "", CallbackSaveMap, this);
+			}
 		}
 	}
 
@@ -8179,13 +7400,7 @@ void CEditor::Render()
 	RenderPressedKeys(View);
 	RenderSavingIndicator(View);
 
-	if(m_Dialog == DIALOG_FILE)
-	{
-		static int s_NullUiTarget = 0;
-		Ui()->SetHotItem(&s_NullUiTarget);
-		RenderFileDialog();
-	}
-	else if(m_Dialog == DIALOG_MAPSETTINGS_ERROR)
+	if(m_Dialog == DIALOG_MAPSETTINGS_ERROR)
 	{
 		static int s_NullUiTarget = 0;
 		Ui()->SetHotItem(&s_NullUiTarget);
@@ -8761,6 +7976,7 @@ void CEditor::Init()
 	m_vComponents.emplace_back(m_MapView);
 	m_vComponents.emplace_back(m_MapSettingsBackend);
 	m_vComponents.emplace_back(m_LayerSelector);
+	m_vComponents.emplace_back(m_FileBrowser);
 	m_vComponents.emplace_back(m_Prompt);
 	m_vComponents.emplace_back(m_FontTyper);
 	for(CEditorComponent &Component : m_vComponents)
@@ -9153,17 +8369,14 @@ void CEditor::OnClose()
 
 	if(m_ToolbarPreviewSound >= 0 && Sound()->IsPlaying(m_ToolbarPreviewSound))
 		Sound()->Pause(m_ToolbarPreviewSound);
-	if(m_FilePreviewSound >= 0 && Sound()->IsPlaying(m_FilePreviewSound))
-		Sound()->Pause(m_FilePreviewSound);
+
+	m_FileBrowser.OnEditorClose();
 }
 
 void CEditor::OnDialogClose()
 {
 	m_Dialog = DIALOG_NONE;
-	Graphics()->UnloadTexture(&m_FilePreviewImage);
-	Sound()->UnloadSample(m_FilePreviewSound);
-	m_FilePreviewSound = -1;
-	m_FilePreviewState = PREVIEW_UNLOADED;
+	m_FileBrowser.OnDialogClose();
 }
 
 void CEditor::LoadCurrentMap()

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -12,6 +12,7 @@
 #include <game/mapitems.h>
 
 #include <game/editor/enums.h>
+#include <game/editor/file_browser.h>
 #include <game/editor/mapitems/envelope.h>
 #include <game/editor/mapitems/layer.h>
 #include <game/editor/mapitems/layer_front.h>
@@ -123,6 +124,7 @@ class CEditor : public IEditor
 	std::vector<std::reference_wrapper<CEditorComponent>> m_vComponents;
 	CMapView m_MapView;
 	CLayerSelector m_LayerSelector;
+	CFileBrowser m_FileBrowser;
 	CPrompt m_Prompt;
 	CFontTyper m_FontTyper;
 
@@ -213,28 +215,10 @@ public:
 
 		m_aFileName[0] = '\0';
 		m_aFileNamePending[0] = '\0';
-		m_aFileSaveName[0] = '\0';
 		m_ValidSaveFilename = false;
 
 		m_PopupEventActivated = false;
 		m_PopupEventWasActivated = false;
-
-		m_FileDialogStorageType = 0;
-		m_FileDialogLastPopulatedStorageType = 0;
-		m_FileDialogSaveAction = false;
-		m_pFileDialogTitle = nullptr;
-		m_pFileDialogButtonText = nullptr;
-		m_pFileDialogUser = nullptr;
-		m_aFileDialogCurrentFolder[0] = '\0';
-		m_aFileDialogCurrentLink[0] = '\0';
-		m_aFilesSelectedName[0] = '\0';
-		m_pFileDialogPath = m_aFileDialogCurrentFolder;
-		m_FileDialogOpening = false;
-		m_FilesSelectedIndex = -1;
-
-		m_FilePreviewImage.Invalidate();
-		m_FilePreviewSound = -1;
-		m_FilePreviewState = PREVIEW_UNLOADED;
 
 		m_ToolbarPreviewSound = -1;
 
@@ -350,11 +334,8 @@ public:
 	bool PerformAutosave();
 	void HandleWriterFinishJobs();
 
-	void RefreshFilteredFileList();
-	void FilelistPopulate(int StorageType, bool KeepSelection = false);
-	void InvokeFileDialog(int StorageType, int FileType, const char *pTitle, const char *pButtonText,
-		const char *pBasepath, bool FilenameAsDefault,
-		bool (*pfnFunc)(const char *pFilename, int StorageType, void *pUser), void *pUser);
+	// TODO: The name of the ShowFileDialogError function is not accurate anymore, this is used for generic error messages.
+	//       Popups in UI should be shared_ptrs to make this even more generic.
 	struct SStringKeyComparator
 	{
 		bool operator()(const char *pLhs, const char *pRhs) const
@@ -363,8 +344,7 @@ public:
 		}
 	};
 	std::map<const char *, CUi::SMessagePopupContext *, SStringKeyComparator> m_PopupMessageContexts;
-	void ShowFileDialogError(const char *pFormat, ...)
-		GNUC_ATTRIBUTE((format(printf, 2, 3)));
+	[[gnu::format(printf, 2, 3)]] void ShowFileDialogError(const char *pFormat, ...);
 
 	void Reset(bool CreateDefault = true);
 	bool Save(const char *pFilename) override;
@@ -433,7 +413,6 @@ public:
 
 	char m_aFileName[IO_MAX_PATH_LENGTH];
 	char m_aFileNamePending[IO_MAX_PATH_LENGTH];
-	char m_aFileSaveName[IO_MAX_PATH_LENGTH];
 	bool m_ValidSaveFilename;
 
 	enum
@@ -443,10 +422,6 @@ public:
 		POPEVENT_LOADCURRENT,
 		POPEVENT_LOADDROP,
 		POPEVENT_NEW,
-		POPEVENT_SAVE,
-		POPEVENT_SAVE_COPY,
-		POPEVENT_SAVE_IMG,
-		POPEVENT_SAVE_SOUND,
 		POPEVENT_LARGELAYER,
 		POPEVENT_PREVENTUNUSEDTILES,
 		POPEVENT_IMAGEDIV16,
@@ -483,109 +458,7 @@ public:
 	int m_Mentions = 0;
 	bool m_IngameMoved = false;
 
-	enum
-	{
-		FILETYPE_MAP,
-		FILETYPE_IMG,
-		FILETYPE_SOUND,
-		NUM_FILETYPES
-	};
-
-	int m_FileDialogStorageType;
-	int m_FileDialogLastPopulatedStorageType;
-	bool m_FileDialogSaveAction;
-	const char *m_pFileDialogTitle;
-	const char *m_pFileDialogButtonText;
-	bool (*m_pfnFileDialogFunc)(const char *pFileName, int StorageType, void *pUser);
-	void *m_pFileDialogUser;
-	CLineInputBuffered<IO_MAX_PATH_LENGTH> m_FileDialogFileNameInput;
-	char m_aFileDialogCurrentFolder[IO_MAX_PATH_LENGTH];
-	char m_aFileDialogCurrentLink[IO_MAX_PATH_LENGTH];
-	char m_aFilesSelectedName[IO_MAX_PATH_LENGTH];
-	CLineInputBuffered<IO_MAX_PATH_LENGTH> m_FileDialogFilterInput;
-	char *m_pFileDialogPath;
-	int m_FileDialogFileType;
-	bool m_FileDialogMultipleStorages = false;
-	bool m_FileDialogShowingRoot = false;
-	int m_FilesSelectedIndex;
-	CLineInputBuffered<IO_MAX_PATH_LENGTH> m_FileDialogNewFolderNameInput;
-
-	IGraphics::CTextureHandle m_FilePreviewImage;
-	int m_FilePreviewSound;
-	EPreviewState m_FilePreviewState;
-	int m_FilePreviewImageWidth;
-	int m_FilePreviewImageHeight;
-	bool m_FileDialogOpening;
-
 	int m_ToolbarPreviewSound;
-
-	struct CFilelistItem
-	{
-		char m_aFilename[IO_MAX_PATH_LENGTH];
-		char m_aName[IO_MAX_PATH_LENGTH];
-		bool m_IsDir;
-		bool m_IsLink;
-		int m_StorageType;
-		time_t m_TimeModified;
-	};
-	std::vector<CFilelistItem> m_vCompleteFileList;
-	std::vector<const CFilelistItem *> m_vpFilteredFileList;
-
-	static bool CompareFilenameAscending(const CFilelistItem *pLhs, const CFilelistItem *pRhs)
-	{
-		if(str_comp(pLhs->m_aFilename, "..") == 0)
-			return true;
-		if(str_comp(pRhs->m_aFilename, "..") == 0)
-			return false;
-		if(pLhs->m_IsLink != pRhs->m_IsLink)
-			return pLhs->m_IsLink;
-		if(pLhs->m_IsDir != pRhs->m_IsDir)
-			return pLhs->m_IsDir;
-		return str_comp_filenames(pLhs->m_aName, pRhs->m_aName) < 0;
-	}
-
-	static bool CompareFilenameDescending(const CFilelistItem *pLhs, const CFilelistItem *pRhs)
-	{
-		if(str_comp(pLhs->m_aFilename, "..") == 0)
-			return true;
-		if(str_comp(pRhs->m_aFilename, "..") == 0)
-			return false;
-		if(pLhs->m_IsLink != pRhs->m_IsLink)
-			return pLhs->m_IsLink;
-		if(pLhs->m_IsDir != pRhs->m_IsDir)
-			return pLhs->m_IsDir;
-		return str_comp_filenames(pLhs->m_aName, pRhs->m_aName) > 0;
-	}
-
-	static bool CompareTimeModifiedAscending(const CFilelistItem *pLhs, const CFilelistItem *pRhs)
-	{
-		if(str_comp(pLhs->m_aFilename, "..") == 0)
-			return true;
-		if(str_comp(pRhs->m_aFilename, "..") == 0)
-			return false;
-		if(pLhs->m_IsLink != pRhs->m_IsLink)
-			return pLhs->m_IsLink;
-		if(pLhs->m_IsDir != pRhs->m_IsDir)
-			return pLhs->m_IsDir;
-		return pLhs->m_TimeModified < pRhs->m_TimeModified;
-	}
-
-	static bool CompareTimeModifiedDescending(const CFilelistItem *pLhs, const CFilelistItem *pRhs)
-	{
-		if(str_comp(pLhs->m_aFilename, "..") == 0)
-			return true;
-		if(str_comp(pRhs->m_aFilename, "..") == 0)
-			return false;
-		if(pLhs->m_IsLink != pRhs->m_IsLink)
-			return pLhs->m_IsLink;
-		if(pLhs->m_IsDir != pRhs->m_IsDir)
-			return pLhs->m_IsDir;
-		return pLhs->m_TimeModified > pRhs->m_TimeModified;
-	}
-
-	void SortFilteredFileList();
-	int m_SortByFilename = 1;
-	int m_SortByTimeModified = 0;
 
 	std::vector<std::string> m_vSelectEntitiesFiles;
 	std::string m_SelectEntitiesImage;
@@ -760,7 +633,6 @@ public:
 	static CUi::EPopupMenuFunctionResult PopupEnvPointCurveType(void *pContext, CUIRect View, bool Active);
 	static CUi::EPopupMenuFunctionResult PopupImage(void *pContext, CUIRect View, bool Active);
 	static CUi::EPopupMenuFunctionResult PopupSound(void *pContext, CUIRect View, bool Active);
-	static CUi::EPopupMenuFunctionResult PopupNewFolder(void *pContext, CUIRect View, bool Active);
 	static CUi::EPopupMenuFunctionResult PopupMapInfo(void *pContext, CUIRect View, bool Active);
 	static CUi::EPopupMenuFunctionResult PopupEvent(void *pContext, CUIRect View, bool Active);
 	static CUi::EPopupMenuFunctionResult PopupSelectImage(void *pContext, CUIRect View, bool Active);
@@ -879,7 +751,7 @@ public:
 	static bool ReplaceSoundCallback(const char *pFileName, int StorageType, void *pUser);
 	static bool AddImage(const char *pFilename, int StorageType, void *pUser);
 	static bool AddSound(const char *pFileName, int StorageType, void *pUser);
-	static bool IsAssetUsed(int FileType, int Index, void *pUser);
+	static bool IsAssetUsed(CFileBrowser::EFileType FileType, int Index, void *pUser);
 
 	bool IsEnvelopeUsed(int EnvelopeIndex) const;
 	void RemoveUnusedEnvelopes();
@@ -914,7 +786,6 @@ public:
 	void SetHotEnvelopePoint(const CUIRect &View, const std::shared_ptr<CEnvelope> &pEnvelope, int ActiveChannels);
 
 	void RenderMenubar(CUIRect Menubar);
-	void RenderFileDialog();
 
 	void SelectGameLayer();
 	std::vector<int> SortImages();

--- a/src/game/editor/editor_ui.h
+++ b/src/game/editor/editor_ui.h
@@ -15,6 +15,11 @@ struct SEditBoxDropdownContext
 	int m_Width = 0;
 };
 
+// TODO: add and use constants for other special Checked-values in CEditor::GetButtonColor
+namespace EditorButtonChecked {
+[[maybe_unused]] static constexpr int DANGEROUS_ACTION = 9;
+}
+
 namespace EditorFontSizes {
 [[maybe_unused]] static constexpr float MENU = 10.0f;
 }

--- a/src/game/editor/file_browser.cpp
+++ b/src/game/editor/file_browser.cpp
@@ -1,0 +1,1001 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+
+#include "file_browser.h"
+
+#include <engine/keys.h>
+#include <engine/sound.h>
+#include <engine/storage.h>
+
+#include <game/editor/editor.h>
+
+using namespace FontIcons;
+
+static constexpr const char *FILETYPE_EXTENSIONS[] = {
+	".map",
+	".png",
+	".opus"};
+
+void CFileBrowser::ShowFileDialog(
+	int StorageType, EFileType FileType,
+	const char *pTitle, const char *pButtonText,
+	const char *pInitialPath, const char *pInitialFilename,
+	FFileDialogOpenCallback pfnOpenCallback, void *pOpenCallbackUser)
+{
+	m_StorageType = StorageType;
+	m_FileType = FileType;
+	if(m_StorageType == IStorage::TYPE_ALL)
+	{
+		int NumStoragesWithFolder = 0;
+		for(int CheckStorageType = IStorage::TYPE_SAVE; CheckStorageType < Storage()->NumPaths(); ++CheckStorageType)
+		{
+			if(Storage()->FolderExists(pInitialPath, CheckStorageType))
+			{
+				NumStoragesWithFolder++;
+			}
+		}
+		m_MultipleStorages = NumStoragesWithFolder > 1;
+	}
+	else
+	{
+		m_MultipleStorages = false;
+	}
+	m_SaveAction = m_StorageType == IStorage::TYPE_SAVE;
+
+	Ui()->ClosePopupMenus();
+	str_copy(m_aTitle, pTitle);
+	str_copy(m_aButtonText, pButtonText);
+	m_pfnOpenCallback = pfnOpenCallback;
+	m_pOpenCallbackUser = pOpenCallbackUser;
+	m_ShowingRoot = false;
+	str_copy(m_aInitialFolder, pInitialPath);
+	str_copy(m_aCurrentFolder, pInitialPath);
+	m_aCurrentLink[0] = '\0';
+	m_pCurrentPath = m_aCurrentFolder;
+	m_FilenameInput.Set(pInitialFilename);
+	m_FilterInput.Clear();
+	dbg_assert(m_PreviewState == EPreviewState::UNLOADED, "Preview was not unloaded before showing file dialog");
+	m_ListBox.Reset();
+
+	FilelistPopulate(m_StorageType, false);
+
+	if(m_SaveAction)
+	{
+		Ui()->SetActiveItem(&m_FilenameInput);
+		if(!m_FilenameInput.IsEmpty())
+		{
+			UpdateSelectedIndex(m_FilenameInput.GetString());
+		}
+	}
+	else
+	{
+		Ui()->SetActiveItem(&m_FilterInput);
+		UpdateFilenameInput();
+	}
+
+	Editor()->m_Dialog = DIALOG_FILE;
+}
+
+void CFileBrowser::OnRender(CUIRect _)
+{
+	if(Editor()->m_Dialog != DIALOG_FILE)
+	{
+		return;
+	}
+
+	Ui()->MapScreen();
+	CUIRect View = *Ui()->Screen();
+	CUIRect Preview = {0.0f, 0.0f, 0.0f, 0.0f};
+	const float OriginalWidth = View.w;
+	const float OriginalHeight = View.h;
+
+	// Prevent UI elements below the file browser from being activated.
+	Ui()->SetHotItem(this);
+
+	View.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.25f), IGraphics::CORNER_NONE, 0.0f);
+	View.VMargin(150.0f, &View);
+	View.HMargin(50.0f, &View);
+	View.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.75f), IGraphics::CORNER_ALL, 5.0f);
+	View.Margin(10.0f, &View);
+
+	CUIRect Title, FileBox, FileBoxLabel, ButtonBar, PathBox;
+	View.HSplitTop(20.0f, &Title, &View);
+	View.HSplitTop(5.0f, nullptr, &View);
+	View.HSplitBottom(20.0f, &View, &ButtonBar);
+	View.HSplitBottom(5.0f, &View, nullptr);
+	View.HSplitBottom(15.0f, &View, &PathBox);
+	View.HSplitBottom(5.0f, &View, nullptr);
+	View.HSplitBottom(15.0f, &View, &FileBox);
+	FileBox.VSplitLeft(55.0f, &FileBoxLabel, &FileBox);
+	View.HSplitBottom(5.0f, &View, nullptr);
+	if(CanPreviewFile())
+	{
+		View.VSplitMid(&View, &Preview);
+	}
+
+	// Title bar sort buttons
+	if(!m_ShowingRoot)
+	{
+		CUIRect ButtonTimeModified, ButtonFilename;
+		Title.VSplitRight(m_ListBox.ScrollbarWidthMax(), &Title, nullptr);
+		Title.VSplitRight(90.0f, &Title, &ButtonTimeModified);
+		Title.VSplitRight(5.0f, &Title, nullptr);
+		Title.VSplitRight(90.0f, &Title, &ButtonFilename);
+		Title.VSplitRight(5.0f, &Title, nullptr);
+
+		static constexpr const char *SORT_INDICATORS[] = {"", "▲", "▼"};
+
+		char aLabelButtonSortTimeModified[64];
+		str_format(aLabelButtonSortTimeModified, sizeof(aLabelButtonSortTimeModified), "Time modified %s", SORT_INDICATORS[(int)m_SortByTimeModified]);
+		if(Editor()->DoButton_Editor(&m_ButtonSortTimeModifiedId, aLabelButtonSortTimeModified, 0, &ButtonTimeModified, BUTTONFLAG_LEFT, "Sort by time modified."))
+		{
+			if(m_SortByTimeModified == ESortDirection::ASCENDING)
+			{
+				m_SortByTimeModified = ESortDirection::DESCENDING;
+			}
+			else if(m_SortByTimeModified == ESortDirection::DESCENDING)
+			{
+				m_SortByTimeModified = ESortDirection::NEUTRAL;
+			}
+			else
+			{
+				m_SortByTimeModified = ESortDirection::ASCENDING;
+			}
+
+			RefreshFilteredFileList();
+		}
+
+		char aLabelButtonSortFilename[64];
+		str_format(aLabelButtonSortFilename, sizeof(aLabelButtonSortFilename), "Filename %s", SORT_INDICATORS[(int)m_SortByFilename]);
+		if(Editor()->DoButton_Editor(&m_ButtonSortFilenameId, aLabelButtonSortFilename, 0, &ButtonFilename, BUTTONFLAG_LEFT, "Sort by filename."))
+		{
+			if(m_SortByFilename == ESortDirection::DESCENDING)
+			{
+				m_SortByFilename = ESortDirection::ASCENDING;
+				m_SortByTimeModified = ESortDirection::NEUTRAL;
+			}
+			else
+			{
+				m_SortByFilename = ESortDirection::DESCENDING;
+				m_SortByTimeModified = ESortDirection::NEUTRAL;
+			}
+
+			RefreshFilteredFileList();
+		}
+	}
+
+	// Title
+	Title.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), IGraphics::CORNER_ALL, 5.0f);
+	Title.VMargin(10.0f, &Title);
+	Ui()->DoLabel(&Title, m_aTitle, 12.0f, TEXTALIGN_ML);
+
+	// Current path
+	if(m_SelectedFileIndex >= 0 && m_vpFilteredFileList[m_SelectedFileIndex]->m_StorageType >= IStorage::TYPE_SAVE)
+	{
+		char aPath[IO_MAX_PATH_LENGTH];
+		Storage()->GetCompletePath(m_vpFilteredFileList[m_SelectedFileIndex]->m_StorageType, m_pCurrentPath, aPath, sizeof(aPath));
+		char aPathLabel[128 + IO_MAX_PATH_LENGTH];
+		str_format(aPathLabel, sizeof(aPathLabel), "Current path: %s", aPath);
+		Ui()->DoLabel(&PathBox, aPathLabel, 10.0f, TEXTALIGN_ML, {.m_MaxWidth = PathBox.w, .m_EllipsisAtEnd = true});
+	}
+
+	m_ListBox.SetActive(!Ui()->IsPopupOpen());
+
+	// Filename/filter input
+	if(m_SaveAction)
+	{
+		// Filename input when saving
+		Ui()->DoLabel(&FileBoxLabel, "Filename:", 10.0f, TEXTALIGN_ML);
+		if(Ui()->DoEditBox(&m_FilenameInput, &FileBox, 10.0f))
+		{
+			// Remove '/' and '\'
+			for(int i = 0; m_FilenameInput.GetString()[i]; ++i)
+			{
+				if(m_FilenameInput.GetString()[i] == '/' || m_FilenameInput.GetString()[i] == '\\')
+				{
+					m_FilenameInput.SetRange(m_FilenameInput.GetString() + i + 1, i, m_FilenameInput.GetLength());
+					--i;
+				}
+			}
+			UpdateSelectedIndex(m_FilenameInput.GetString());
+		}
+	}
+	else
+	{
+		// Filter input when loading
+		Ui()->DoLabel(&FileBoxLabel, "Search:", 10.0f, TEXTALIGN_ML);
+		if(Input()->KeyPress(KEY_F) && Input()->ModifierIsPressed())
+		{
+			Ui()->SetActiveItem(&m_FilterInput);
+			m_FilterInput.SelectAll();
+		}
+		if(Ui()->DoClearableEditBox(&m_FilterInput, &FileBox, 10.0f))
+		{
+			RefreshFilteredFileList();
+			if(m_vpFilteredFileList.empty())
+			{
+				m_SelectedFileIndex = -1;
+			}
+			else if(m_SelectedFileIndex == -1 ||
+				(!m_FilterInput.IsEmpty() && !str_find_nocase(m_vpFilteredFileList[m_SelectedFileIndex]->m_aDisplayName, m_FilterInput.GetString())))
+			{
+				m_SelectedFileIndex = -1;
+				for(size_t i = 0; i < m_vpFilteredFileList.size(); i++)
+				{
+					if(str_find_nocase(m_vpFilteredFileList[i]->m_aDisplayName, m_FilterInput.GetString()))
+					{
+						m_SelectedFileIndex = i;
+						break;
+					}
+				}
+				if(m_SelectedFileIndex == -1)
+				{
+					m_SelectedFileIndex = 0;
+				}
+			}
+			str_copy(m_aSelectedFileDisplayName, m_SelectedFileIndex >= 0 ? m_vpFilteredFileList[m_SelectedFileIndex]->m_aDisplayName : "");
+			UpdateFilenameInput();
+			m_ListBox.ScrollToSelected();
+			m_PreviewState = EPreviewState::UNLOADED;
+		}
+	}
+
+	// File preview
+	if(m_SelectedFileIndex >= 0 && CanPreviewFile())
+	{
+		UpdateFilePreview();
+		Preview.Margin(10.0f, &Preview);
+		RenderFilePreview(Preview);
+	}
+
+	// File list
+	m_ListBox.DoStart(15.0f, m_vpFilteredFileList.size(), 1, 5, m_SelectedFileIndex, &View, false, IGraphics::CORNER_ALL, true);
+
+	for(size_t i = 0; i < m_vpFilteredFileList.size(); i++)
+	{
+		const CListboxItem Item = m_ListBox.DoNextItem(m_vpFilteredFileList[i], m_SelectedFileIndex >= 0 && (size_t)m_SelectedFileIndex == i);
+		if(!Item.m_Visible)
+		{
+			continue;
+		}
+
+		CUIRect Button, FileIcon, TimeModified;
+		Item.m_Rect.VMargin(2.0f, &Button);
+		Button.VSplitLeft(Button.h, &FileIcon, &Button);
+		Button.VSplitLeft(5.0f, nullptr, &Button);
+		Button.VSplitRight(100.0f, &Button, &TimeModified);
+		Button.VSplitRight(5.0f, &Button, nullptr);
+
+		TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
+		TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING);
+		Ui()->DoLabel(&FileIcon, DetermineFileFontIcon(m_vpFilteredFileList[i]), 12.0f, TEXTALIGN_ML);
+		TextRender()->SetRenderFlags(0);
+		TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
+
+		Ui()->DoLabel(&Button, m_vpFilteredFileList[i]->m_aDisplayName, 10.0f, TEXTALIGN_ML, {.m_MaxWidth = Button.w, .m_EllipsisAtEnd = true});
+
+		if(!m_vpFilteredFileList[i]->m_IsLink && str_comp(m_vpFilteredFileList[i]->m_aFilename, "..") != 0)
+		{
+			char aLabelTimeModified[64];
+			str_timestamp_ex(m_vpFilteredFileList[i]->m_TimeModified, aLabelTimeModified, sizeof(aLabelTimeModified), "%d.%m.%Y %H:%M");
+			Ui()->DoLabel(&TimeModified, aLabelTimeModified, 10.0f, TEXTALIGN_MR);
+		}
+	}
+
+	const int NewSelection = m_ListBox.DoEnd();
+	if(NewSelection != m_SelectedFileIndex)
+	{
+		m_SelectedFileIndex = NewSelection;
+		str_copy(m_aSelectedFileDisplayName, m_SelectedFileIndex >= 0 ? m_vpFilteredFileList[m_SelectedFileIndex]->m_aDisplayName : "");
+		const bool WasChanged = m_FilenameInput.WasChanged();
+		UpdateFilenameInput();
+		if(!WasChanged) // ensure that changed flag is not set if it wasn't previously set, as this would reset the selection after DoEditBox is called
+		{
+			m_FilenameInput.WasChanged(); // this clears the changed flag
+		}
+		m_PreviewState = EPreviewState::UNLOADED;
+	}
+
+	// Buttons
+	const float ButtonSpacing = ButtonBar.w > 600.0f ? 40.0f : 10.0f;
+
+	CUIRect Button;
+	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
+	const bool IsDir = m_SelectedFileIndex >= 0 && m_vpFilteredFileList[m_SelectedFileIndex]->m_IsDir;
+	const char *pOpenTooltip = IsDir ? "Open the selected folder." : (m_SaveAction ? "Save file with the specified name." : "Open the selected file.");
+	if(Editor()->DoButton_Editor(&m_ButtonOkId, IsDir ? "Open" : m_aButtonText, 0, &Button, BUTTONFLAG_LEFT, pOpenTooltip) ||
+		m_ListBox.WasItemActivated() ||
+		(m_ListBox.Active() && Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
+	{
+		if(IsDir)
+		{
+			m_FilterInput.Clear();
+			Ui()->SetActiveItem(&m_FilterInput);
+			const bool ParentFolder = str_comp(m_vpFilteredFileList[m_SelectedFileIndex]->m_aFilename, "..") == 0;
+			if(ParentFolder)
+			{
+				str_copy(m_aSelectedFileDisplayName, fs_filename(m_pCurrentPath));
+				str_append(m_aSelectedFileDisplayName, "/");
+				if(fs_parent_dir(m_pCurrentPath))
+				{
+					if(str_comp(m_pCurrentPath, m_aCurrentFolder) == 0)
+					{
+						m_ShowingRoot = true;
+						if(m_StorageType == IStorage::TYPE_ALL)
+						{
+							m_aSelectedFileDisplayName[0] = '\0'; // will select first list item
+						}
+						else
+						{
+							Storage()->GetCompletePath(m_StorageType, m_pCurrentPath, m_aSelectedFileDisplayName, sizeof(m_aSelectedFileDisplayName));
+							str_append(m_aSelectedFileDisplayName, "/");
+						}
+					}
+					else
+					{
+						m_pCurrentPath = m_aCurrentFolder; // leave the link
+						str_copy(m_aSelectedFileDisplayName, m_aCurrentLink);
+						str_append(m_aSelectedFileDisplayName, "/");
+					}
+				}
+			}
+			else // sub folder
+			{
+				if(m_vpFilteredFileList[m_SelectedFileIndex]->m_IsLink)
+				{
+					m_pCurrentPath = m_aCurrentLink; // follow the link
+					str_copy(m_aCurrentLink, m_vpFilteredFileList[m_SelectedFileIndex]->m_aFilename);
+				}
+				else
+				{
+					str_append(m_pCurrentPath, "/", IO_MAX_PATH_LENGTH);
+					str_append(m_pCurrentPath, m_vpFilteredFileList[m_SelectedFileIndex]->m_aFilename, IO_MAX_PATH_LENGTH);
+				}
+				if(m_ShowingRoot)
+				{
+					m_StorageType = m_vpFilteredFileList[m_SelectedFileIndex]->m_StorageType;
+				}
+				m_ShowingRoot = false;
+			}
+			FilelistPopulate(m_StorageType, ParentFolder);
+			UpdateFilenameInput();
+		}
+		else // file
+		{
+			const int StorageType = m_SelectedFileIndex >= 0 ? m_vpFilteredFileList[m_SelectedFileIndex]->m_StorageType : m_StorageType;
+			char aSaveFilePath[IO_MAX_PATH_LENGTH];
+			str_format(aSaveFilePath, sizeof(aSaveFilePath), "%s/%s", m_pCurrentPath, m_FilenameInput.GetString());
+			if(!str_endswith(aSaveFilePath, FILETYPE_EXTENSIONS[(int)m_FileType]))
+			{
+				str_append(aSaveFilePath, FILETYPE_EXTENSIONS[(int)m_FileType]);
+			}
+
+			char aFilename[IO_MAX_PATH_LENGTH];
+			fs_split_file_extension(fs_filename(aSaveFilePath), aFilename, sizeof(aFilename));
+			if(m_SaveAction && !str_valid_filename(aFilename))
+			{
+				Editor()->ShowFileDialogError("This name cannot be used for files and folders.");
+			}
+			else if(m_SaveAction && Storage()->FileExists(aSaveFilePath, StorageType))
+			{
+				m_PopupConfirmOverwrite.m_pFileBrowser = this;
+				str_copy(m_PopupConfirmOverwrite.m_aOverwritePath, aSaveFilePath);
+				constexpr float PopupWidth = 400.0f;
+				constexpr float PopupHeight = 150.0f;
+				Ui()->DoPopupMenu(&m_PopupConfirmOverwrite,
+					OriginalWidth / 2.0f - PopupWidth / 2.0f, OriginalHeight / 2.0f - PopupHeight / 2.0f, PopupWidth, PopupHeight,
+					&m_PopupConfirmOverwrite, CPopupConfirmOverwrite::Render);
+			}
+			else if(m_pfnOpenCallback && (m_SaveAction || m_SelectedFileIndex >= 0))
+			{
+				m_pfnOpenCallback(aSaveFilePath, StorageType, m_pOpenCallbackUser);
+			}
+		}
+	}
+
+	ButtonBar.VSplitRight(ButtonSpacing, &ButtonBar, nullptr);
+	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
+	if(Editor()->DoButton_Editor(&m_ButtonCancelId, "Cancel", 0, &Button, BUTTONFLAG_LEFT, "Close this dialog.") ||
+		(m_ListBox.Active() && Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE)))
+	{
+		Editor()->OnDialogClose();
+	}
+
+	ButtonBar.VSplitRight(ButtonSpacing, &ButtonBar, nullptr);
+	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
+	if(Editor()->DoButton_Editor(&m_ButtonRefreshId, "Refresh", 0, &Button, BUTTONFLAG_LEFT, "Refresh the list of files.") ||
+		(m_ListBox.Active() && (Input()->KeyIsPressed(KEY_F5) || (Input()->ModifierIsPressed() && Input()->KeyIsPressed(KEY_R)))))
+	{
+		FilelistPopulate(m_StorageType, true);
+	}
+
+	if(m_SelectedFileIndex >= 0 && m_vpFilteredFileList[m_SelectedFileIndex]->m_StorageType != IStorage::TYPE_ALL)
+	{
+		ButtonBar.VSplitRight(ButtonSpacing, &ButtonBar, nullptr);
+		ButtonBar.VSplitRight(90.0f, &ButtonBar, &Button);
+		if(Editor()->DoButton_Editor(&m_ButtonShowDirectoryId, "Show directory", 0, &Button, BUTTONFLAG_LEFT, "Open the current directory in the file browser."))
+		{
+			char aOpenPath[IO_MAX_PATH_LENGTH];
+			Storage()->GetCompletePath(m_vpFilteredFileList[m_SelectedFileIndex]->m_StorageType, m_pCurrentPath, aOpenPath, sizeof(aOpenPath));
+			if(!Client()->ViewFile(aOpenPath))
+			{
+				Editor()->ShowFileDialogError("Failed to open the directory '%s'.", aOpenPath);
+			}
+		}
+	}
+
+	ButtonBar.VSplitRight(ButtonSpacing, &ButtonBar, nullptr);
+	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
+	if(m_SelectedFileIndex >= 0 &&
+		m_vpFilteredFileList[m_SelectedFileIndex]->m_StorageType == IStorage::TYPE_SAVE &&
+		!m_vpFilteredFileList[m_SelectedFileIndex]->m_IsLink &&
+		str_comp(m_vpFilteredFileList[m_SelectedFileIndex]->m_aFilename, "..") != 0)
+	{
+		if(Editor()->DoButton_Editor(&m_ButtonDeleteId, "Delete", 0, &Button, BUTTONFLAG_LEFT, IsDir ? "Delete the selected folder." : "Delete the selected file.") ||
+			(m_ListBox.Active() && Ui()->ConsumeHotkey(CUi::HOTKEY_DELETE)))
+		{
+			m_PopupConfirmDelete.m_pFileBrowser = this;
+			m_PopupConfirmDelete.m_IsDirectory = IsDir;
+			str_format(m_PopupConfirmDelete.m_aDeletePath, sizeof(m_PopupConfirmDelete.m_aDeletePath), "%s/%s", m_pCurrentPath, m_vpFilteredFileList[m_SelectedFileIndex]->m_aFilename);
+			constexpr float PopupWidth = 400.0f;
+			constexpr float PopupHeight = 150.0f;
+			Ui()->DoPopupMenu(&m_PopupConfirmDelete,
+				OriginalWidth / 2.0f - PopupWidth / 2.0f, OriginalHeight / 2.0f - PopupHeight / 2.0f, PopupWidth, PopupHeight,
+				&m_PopupConfirmDelete, CPopupConfirmDelete::Render);
+		}
+	}
+
+	if(!m_ShowingRoot && m_StorageType == IStorage::TYPE_SAVE)
+	{
+		ButtonBar.VSplitLeft(70.0f, &Button, &ButtonBar);
+		if(Editor()->DoButton_Editor(&m_ButtonNewFolderId, "New folder", 0, &Button, BUTTONFLAG_LEFT, "Create a new folder."))
+		{
+			m_PopupNewFolder.m_pFileBrowser = this;
+			m_PopupNewFolder.m_NewFolderNameInput.Clear();
+			constexpr float PopupWidth = 400.0f;
+			constexpr float PopupHeight = 110.0f;
+			Ui()->DoPopupMenu(&m_PopupNewFolder,
+				OriginalWidth / 2.0f - PopupWidth / 2.0f, OriginalHeight / 2.0f - PopupHeight / 2.0f, PopupWidth, PopupHeight,
+				&m_PopupNewFolder, CPopupNewFolder::Render);
+			Ui()->SetActiveItem(&m_PopupNewFolder.m_NewFolderNameInput);
+		}
+	}
+}
+
+bool CFileBrowser::IsValidSaveFilename() const
+{
+	return m_pCurrentPath == m_aCurrentFolder ||
+	       (m_pCurrentPath == m_aCurrentLink && str_startswith(m_aCurrentLink, "themes"));
+}
+
+void CFileBrowser::OnEditorClose()
+{
+	if(m_PreviewSound >= 0 && Sound()->IsPlaying(m_PreviewSound))
+	{
+		Sound()->Pause(m_PreviewSound);
+	}
+}
+
+void CFileBrowser::OnDialogClose()
+{
+	m_PreviewState = EPreviewState::UNLOADED;
+	Graphics()->UnloadTexture(&m_PreviewImage);
+	m_PreviewImageWidth = -1;
+	m_PreviewImageHeight = -1;
+	Sound()->UnloadSample(m_PreviewSound);
+	m_PreviewSound = -1;
+}
+
+bool CFileBrowser::CanPreviewFile() const
+{
+	return m_FileType == CFileBrowser::EFileType::IMAGE ||
+	       m_FileType == CFileBrowser::EFileType::SOUND;
+}
+
+void CFileBrowser::UpdateFilePreview()
+{
+	if(m_PreviewState != EPreviewState::UNLOADED ||
+		!str_endswith(m_vpFilteredFileList[m_SelectedFileIndex]->m_aFilename, FILETYPE_EXTENSIONS[(int)m_FileType]))
+	{
+		return;
+	}
+
+	if(m_FileType == CFileBrowser::EFileType::IMAGE)
+	{
+		char aImagePath[IO_MAX_PATH_LENGTH];
+		str_format(aImagePath, sizeof(aImagePath), "%s/%s", m_pCurrentPath, m_vpFilteredFileList[m_SelectedFileIndex]->m_aFilename);
+		CImageInfo PreviewImageInfo;
+		if(Graphics()->LoadPng(PreviewImageInfo, aImagePath, m_vpFilteredFileList[m_SelectedFileIndex]->m_StorageType))
+		{
+			Graphics()->UnloadTexture(&m_PreviewImage);
+			m_PreviewImageWidth = PreviewImageInfo.m_Width;
+			m_PreviewImageHeight = PreviewImageInfo.m_Height;
+			m_PreviewImage = Graphics()->LoadTextureRawMove(PreviewImageInfo, 0, aImagePath);
+			m_PreviewState = EPreviewState::LOADED;
+		}
+		else
+		{
+			m_PreviewState = EPreviewState::ERROR;
+		}
+	}
+	else if(m_FileType == CFileBrowser::EFileType::SOUND)
+	{
+		char aSoundPath[IO_MAX_PATH_LENGTH];
+		str_format(aSoundPath, sizeof(aSoundPath), "%s/%s", m_pCurrentPath, m_vpFilteredFileList[m_SelectedFileIndex]->m_aFilename);
+		Sound()->UnloadSample(m_PreviewSound);
+		m_PreviewSound = Sound()->LoadOpus(aSoundPath, m_vpFilteredFileList[m_SelectedFileIndex]->m_StorageType);
+		m_PreviewState = m_PreviewSound == -1 ? EPreviewState::ERROR : EPreviewState::LOADED;
+	}
+}
+
+void CFileBrowser::RenderFilePreview(CUIRect Preview)
+{
+	if(m_FileType == CFileBrowser::EFileType::IMAGE)
+	{
+		if(m_PreviewState == EPreviewState::LOADED)
+		{
+			CUIRect PreviewLabel, PreviewImage;
+			Preview.HSplitTop(20.0f, &PreviewLabel, &PreviewImage);
+
+			char aSizeLabel[64];
+			str_format(aSizeLabel, sizeof(aSizeLabel), "Size: %d × %d", m_PreviewImageWidth, m_PreviewImageHeight);
+			Ui()->DoLabel(&PreviewLabel, aSizeLabel, 12.0f, TEXTALIGN_ML);
+
+			int Width = m_PreviewImageWidth;
+			int Height = m_PreviewImageHeight;
+			if(m_PreviewImageWidth > PreviewImage.w)
+			{
+				Height = m_PreviewImageHeight * PreviewImage.w / m_PreviewImageWidth;
+				Width = PreviewImage.w;
+			}
+			if(Height > PreviewImage.h)
+			{
+				Width = Width * PreviewImage.h / Height;
+				Height = PreviewImage.h;
+			}
+
+			Graphics()->TextureSet(m_PreviewImage);
+			Graphics()->BlendNormal();
+			Graphics()->QuadsBegin();
+			IGraphics::CQuadItem QuadItem(PreviewImage.x, PreviewImage.y, Width, Height);
+			Graphics()->QuadsDrawTL(&QuadItem, 1);
+			Graphics()->QuadsEnd();
+		}
+		else if(m_PreviewState == EPreviewState::ERROR)
+		{
+			Ui()->DoLabel(&Preview, "Failed to load the image (check the local console for details).", 12.0f, TEXTALIGN_TL, {.m_MaxWidth = Preview.w});
+		}
+	}
+	else if(m_FileType == CFileBrowser::EFileType::SOUND)
+	{
+		if(m_PreviewState == EPreviewState::LOADED)
+		{
+			Preview.HSplitTop(20.0f, &Preview, nullptr);
+			Preview.VSplitLeft(Preview.h / 4.0f, nullptr, &Preview);
+			Editor()->DoAudioPreview(Preview, &m_ButtonPlayPauseId, &m_ButtonStopId, &m_SeekBarId, m_PreviewSound);
+		}
+		else if(m_PreviewState == EPreviewState::ERROR)
+		{
+			Ui()->DoLabel(&Preview, "Failed to load the sound (check the local console for details). Make sure you enabled sounds in the settings.", 12.0f, TEXTALIGN_TL, {.m_MaxWidth = Preview.w});
+		}
+	}
+}
+
+const char *CFileBrowser::DetermineFileFontIcon(const CFilelistItem *pItem) const
+{
+	if(!pItem->m_IsDir)
+	{
+		switch(m_FileType)
+		{
+		case EFileType::MAP:
+			return FONT_ICON_MAP;
+		case EFileType::IMAGE:
+			return FONT_ICON_IMAGE;
+		case EFileType::SOUND:
+			return FONT_ICON_MUSIC;
+		default:
+			dbg_assert(false, "m_FileType invalid: %d", (int)m_FileType);
+			dbg_break();
+		}
+	}
+	else if(pItem->m_IsLink || str_comp(pItem->m_aFilename, "..") == 0)
+	{
+		return FONT_ICON_FOLDER_TREE;
+	}
+	else
+	{
+		return FONT_ICON_FOLDER;
+	}
+}
+
+void CFileBrowser::UpdateFilenameInput()
+{
+	if(m_SelectedFileIndex >= 0 && !m_vpFilteredFileList[m_SelectedFileIndex]->m_IsDir)
+	{
+		char aNameWithoutExt[IO_MAX_PATH_LENGTH];
+		fs_split_file_extension(m_vpFilteredFileList[m_SelectedFileIndex]->m_aFilename, aNameWithoutExt, sizeof(aNameWithoutExt));
+		m_FilenameInput.Set(aNameWithoutExt);
+	}
+	else
+	{
+		m_FilenameInput.Clear();
+	}
+}
+
+void CFileBrowser::UpdateSelectedIndex(const char *pDisplayName)
+{
+	m_SelectedFileIndex = -1;
+	m_aSelectedFileDisplayName[0] = '\0';
+	for(size_t i = 0; i < m_vpFilteredFileList.size(); i++)
+	{
+		if(str_comp_nocase(m_vpFilteredFileList[i]->m_aDisplayName, pDisplayName) == 0)
+		{
+			m_SelectedFileIndex = i;
+			str_copy(m_aSelectedFileDisplayName, m_vpFilteredFileList[i]->m_aDisplayName);
+			break;
+		}
+	}
+	if(m_SelectedFileIndex >= 0)
+	{
+		m_ListBox.ScrollToSelected();
+	}
+}
+
+void CFileBrowser::SortFilteredFileList()
+{
+	if(m_SortByFilename == ESortDirection::ASCENDING)
+	{
+		std::sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CFileBrowser::CompareFilenameAscending);
+	}
+	else
+	{
+		std::sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CFileBrowser::CompareFilenameDescending);
+	}
+
+	if(m_SortByTimeModified == ESortDirection::ASCENDING)
+	{
+		std::stable_sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CFileBrowser::CompareTimeModifiedAscending);
+	}
+	else if(m_SortByTimeModified == ESortDirection::DESCENDING)
+	{
+		std::stable_sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CFileBrowser::CompareTimeModifiedDescending);
+	}
+}
+
+void CFileBrowser::RefreshFilteredFileList()
+{
+	m_vpFilteredFileList.clear();
+	for(const CFilelistItem &Item : m_vCompleteFileList)
+	{
+		if(m_FilterInput.IsEmpty() || str_find_nocase(Item.m_aDisplayName, m_FilterInput.GetString()))
+		{
+			m_vpFilteredFileList.push_back(&Item);
+		}
+	}
+	if(!m_ShowingRoot)
+	{
+		SortFilteredFileList();
+	}
+	if(!m_vpFilteredFileList.empty())
+	{
+		if(m_aSelectedFileDisplayName[0] != '\0')
+		{
+			for(size_t i = 0; i < m_vpFilteredFileList.size(); i++)
+			{
+				if(str_comp(m_vpFilteredFileList[i]->m_aDisplayName, m_aSelectedFileDisplayName) == 0)
+				{
+					m_SelectedFileIndex = i;
+					break;
+				}
+			}
+		}
+		m_SelectedFileIndex = std::clamp<int>(m_SelectedFileIndex, 0, m_vpFilteredFileList.size() - 1);
+		str_copy(m_aSelectedFileDisplayName, m_vpFilteredFileList[m_SelectedFileIndex]->m_aDisplayName);
+	}
+	else
+	{
+		m_SelectedFileIndex = -1;
+		m_aSelectedFileDisplayName[0] = '\0';
+	}
+}
+
+void CFileBrowser::FilelistPopulate(int StorageType, bool KeepSelection)
+{
+	m_vCompleteFileList.clear();
+	if(m_ShowingRoot)
+	{
+		{
+			CFilelistItem Item;
+			str_copy(Item.m_aFilename, m_pCurrentPath);
+			str_copy(Item.m_aDisplayName, "All combined");
+			Item.m_IsDir = true;
+			Item.m_IsLink = true;
+			Item.m_StorageType = IStorage::TYPE_ALL;
+			Item.m_TimeModified = 0;
+			m_vCompleteFileList.push_back(Item);
+		}
+
+		for(int CheckStorageType = IStorage::TYPE_SAVE; CheckStorageType < Storage()->NumPaths(); ++CheckStorageType)
+		{
+			if(Storage()->FolderExists(m_pCurrentPath, CheckStorageType))
+			{
+				CFilelistItem Item;
+				str_copy(Item.m_aFilename, m_pCurrentPath);
+				Storage()->GetCompletePath(CheckStorageType, m_pCurrentPath, Item.m_aDisplayName, sizeof(Item.m_aDisplayName));
+				str_append(Item.m_aDisplayName, "/", sizeof(Item.m_aDisplayName));
+				Item.m_IsDir = true;
+				Item.m_IsLink = true;
+				Item.m_StorageType = CheckStorageType;
+				Item.m_TimeModified = 0;
+				m_vCompleteFileList.push_back(Item);
+			}
+		}
+	}
+	else
+	{
+		// Add links for downloadedmaps and themes
+		if(!str_comp(m_pCurrentPath, "maps"))
+		{
+			if(!m_SaveAction && Storage()->FolderExists("downloadedmaps", StorageType))
+			{
+				CFilelistItem Item;
+				str_copy(Item.m_aFilename, "downloadedmaps");
+				str_copy(Item.m_aDisplayName, "downloadedmaps/");
+				Item.m_IsDir = true;
+				Item.m_IsLink = true;
+				Item.m_StorageType = StorageType;
+				Item.m_TimeModified = 0;
+				m_vCompleteFileList.push_back(Item);
+			}
+
+			if(Storage()->FolderExists("themes", StorageType))
+			{
+				CFilelistItem Item;
+				str_copy(Item.m_aFilename, "themes");
+				str_copy(Item.m_aDisplayName, "themes/");
+				Item.m_IsDir = true;
+				Item.m_IsLink = true;
+				Item.m_StorageType = StorageType;
+				Item.m_TimeModified = 0;
+				m_vCompleteFileList.push_back(Item);
+			}
+		}
+		Storage()->ListDirectoryInfo(StorageType, m_pCurrentPath, DirectoryListingCallback, this);
+	}
+	RefreshFilteredFileList();
+	if(!KeepSelection)
+	{
+		m_SelectedFileIndex = m_vpFilteredFileList.empty() ? -1 : 0;
+		str_copy(m_aSelectedFileDisplayName, m_SelectedFileIndex >= 0 ? m_vpFilteredFileList[m_SelectedFileIndex]->m_aDisplayName : "");
+	}
+	m_PreviewState = EPreviewState::UNLOADED;
+}
+
+int CFileBrowser::DirectoryListingCallback(const CFsFileInfo *pInfo, int IsDir, int StorageType, void *pUser)
+{
+	CFileBrowser *pFileBrowser = static_cast<CFileBrowser *>(pUser);
+	if(IsDir)
+	{
+		if(str_comp(pInfo->m_pName, ".") == 0)
+		{
+			return 0;
+		}
+		if(str_comp(pInfo->m_pName, "..") == 0 &&
+			!pFileBrowser->m_MultipleStorages &&
+			str_comp(pFileBrowser->m_aInitialFolder, pFileBrowser->m_pCurrentPath) == 0)
+		{
+			return 0;
+		}
+	}
+	else
+	{
+		if(!str_endswith(pInfo->m_pName, FILETYPE_EXTENSIONS[(int)pFileBrowser->m_FileType]))
+		{
+			return 0;
+		}
+	}
+
+	CFilelistItem Item;
+	str_copy(Item.m_aFilename, pInfo->m_pName);
+	if(IsDir)
+	{
+		str_format(Item.m_aDisplayName, sizeof(Item.m_aDisplayName), "%s/", pInfo->m_pName);
+	}
+	else
+	{
+		fs_split_file_extension(pInfo->m_pName, Item.m_aDisplayName, sizeof(Item.m_aDisplayName));
+	}
+	Item.m_IsDir = IsDir != 0;
+	Item.m_IsLink = false;
+	Item.m_StorageType = StorageType;
+	Item.m_TimeModified = pInfo->m_TimeModified;
+	pFileBrowser->m_vCompleteFileList.push_back(Item);
+	return 0;
+}
+
+std::optional<bool> CFileBrowser::CompareCommon(const CFilelistItem *pLhs, const CFilelistItem *pRhs)
+{
+	if(str_comp(pLhs->m_aFilename, "..") == 0)
+	{
+		return true;
+	}
+	if(str_comp(pRhs->m_aFilename, "..") == 0)
+	{
+		return false;
+	}
+	if(pLhs->m_IsLink != pRhs->m_IsLink)
+	{
+		return pLhs->m_IsLink;
+	}
+	if(pLhs->m_IsDir != pRhs->m_IsDir)
+	{
+		return pLhs->m_IsDir;
+	}
+	return std::nullopt;
+}
+
+bool CFileBrowser::CompareFilenameAscending(const CFilelistItem *pLhs, const CFilelistItem *pRhs)
+{
+	return CompareCommon(pLhs, pRhs).value_or(str_comp_filenames(pLhs->m_aDisplayName, pRhs->m_aDisplayName) < 0);
+}
+
+bool CFileBrowser::CompareFilenameDescending(const CFilelistItem *pLhs, const CFilelistItem *pRhs)
+{
+	return CompareCommon(pLhs, pRhs).value_or(str_comp_filenames(pLhs->m_aDisplayName, pRhs->m_aDisplayName) > 0);
+}
+
+bool CFileBrowser::CompareTimeModifiedAscending(const CFilelistItem *pLhs, const CFilelistItem *pRhs)
+{
+	return CompareCommon(pLhs, pRhs).value_or(pLhs->m_TimeModified < pRhs->m_TimeModified);
+}
+
+bool CFileBrowser::CompareTimeModifiedDescending(const CFilelistItem *pLhs, const CFilelistItem *pRhs)
+{
+	return CompareCommon(pLhs, pRhs).value_or(pLhs->m_TimeModified > pRhs->m_TimeModified);
+}
+
+CUi::EPopupMenuFunctionResult CFileBrowser::CPopupNewFolder::Render(void *pContext, CUIRect View, bool Active)
+{
+	CPopupNewFolder *pNewFolderContext = static_cast<CPopupNewFolder *>(pContext);
+	CFileBrowser *pFileBrowser = pNewFolderContext->m_pFileBrowser;
+	CEditor *pEditor = pFileBrowser->Editor();
+
+	CUIRect Label, ButtonBar, FolderName, ButtonCancel, ButtonCreate;
+
+	View.Margin(10.0f, &View);
+	View.HSplitBottom(20.0f, &View, &ButtonBar);
+	ButtonBar.VSplitLeft(110.0f, &ButtonCancel, &ButtonBar);
+	ButtonBar.VSplitRight(110.0f, &ButtonBar, &ButtonCreate);
+
+	View.HSplitTop(20.0f, &Label, &View);
+	pFileBrowser->Ui()->DoLabel(&Label, "Create new folder", 20.0f, TEXTALIGN_MC);
+	View.HSplitTop(10.0f, nullptr, &View);
+
+	View.HSplitTop(20.0f, &Label, &View);
+	pFileBrowser->Ui()->DoLabel(&Label, "Name:", 10.0f, TEXTALIGN_ML);
+	Label.VSplitLeft(50.0f, nullptr, &FolderName);
+	FolderName.HMargin(2.0f, &FolderName);
+	pEditor->DoEditBox(&pNewFolderContext->m_NewFolderNameInput, &FolderName, 12.0f);
+
+	if(pEditor->DoButton_Editor(&pNewFolderContext->m_ButtonCancelId, "Cancel", 0, &ButtonCancel, BUTTONFLAG_LEFT, nullptr))
+	{
+		return CUi::POPUP_CLOSE_CURRENT;
+	}
+
+	if(pEditor->DoButton_Editor(&pNewFolderContext->m_ButtonCreateId, "Create", 0, &ButtonCreate, BUTTONFLAG_LEFT, nullptr) ||
+		(Active && pFileBrowser->Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
+	{
+		char aFolderPath[IO_MAX_PATH_LENGTH];
+		str_format(aFolderPath, sizeof(aFolderPath), "%s/%s", pFileBrowser->m_pCurrentPath, pNewFolderContext->m_NewFolderNameInput.GetString());
+		if(!str_valid_filename(pNewFolderContext->m_NewFolderNameInput.GetString()))
+		{
+			pEditor->ShowFileDialogError("This name cannot be used for files and folders.");
+		}
+		else if(!pFileBrowser->Storage()->CreateFolder(aFolderPath, pFileBrowser->m_StorageType))
+		{
+			pEditor->ShowFileDialogError("Failed to create the folder '%s'.", aFolderPath);
+		}
+		else
+		{
+			char aFolderDisplayName[IO_MAX_PATH_LENGTH];
+			str_format(aFolderDisplayName, sizeof(aFolderDisplayName), "%s/", pNewFolderContext->m_NewFolderNameInput.GetString());
+			pFileBrowser->FilelistPopulate(pFileBrowser->m_StorageType, false);
+			pFileBrowser->UpdateSelectedIndex(aFolderDisplayName);
+			return CUi::POPUP_CLOSE_CURRENT;
+		}
+	}
+
+	return CUi::POPUP_KEEP_OPEN;
+}
+
+CUi::EPopupMenuFunctionResult CFileBrowser::CPopupConfirmDelete::Render(void *pContext, CUIRect View, bool Active)
+{
+	CPopupConfirmDelete *pConfirmDeleteContext = static_cast<CPopupConfirmDelete *>(pContext);
+	CFileBrowser *pFileBrowser = pConfirmDeleteContext->m_pFileBrowser;
+	CEditor *pEditor = pFileBrowser->Editor();
+
+	CUIRect Label, ButtonBar, ButtonCancel, ButtonDelete;
+	View.Margin(10.0f, &View);
+	View.HSplitBottom(20.0f, &View, &ButtonBar);
+	View.HSplitTop(20.0f, &Label, &View);
+	ButtonBar.VSplitLeft(110.0f, &ButtonCancel, &ButtonBar);
+	ButtonBar.VSplitRight(110.0f, &ButtonBar, &ButtonDelete);
+
+	pFileBrowser->Ui()->DoLabel(&Label, "Confirm delete", 20.0f, TEXTALIGN_MC);
+
+	char aMessage[IO_MAX_PATH_LENGTH + 128];
+	str_format(aMessage, sizeof(aMessage), "Are you sure that you want to delete the %s '%s'?",
+		pConfirmDeleteContext->m_IsDirectory ? "folder" : "file", pConfirmDeleteContext->m_aDeletePath);
+	pFileBrowser->Ui()->DoLabel(&View, aMessage, 10.0f, TEXTALIGN_ML, {.m_MaxWidth = View.w});
+
+	if(pEditor->DoButton_Editor(&pConfirmDeleteContext->m_ButtonCancelId, "Cancel", 0, &ButtonCancel, BUTTONFLAG_LEFT, nullptr))
+	{
+		return CUi::POPUP_CLOSE_CURRENT;
+	}
+
+	if(pEditor->DoButton_Editor(&pConfirmDeleteContext->m_ButtonDeleteId, "Delete", EditorButtonChecked::DANGEROUS_ACTION, &ButtonDelete, BUTTONFLAG_LEFT, nullptr) ||
+		(Active && pFileBrowser->Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
+	{
+		if(pConfirmDeleteContext->m_IsDirectory)
+		{
+			if(pFileBrowser->Storage()->RemoveFolder(pConfirmDeleteContext->m_aDeletePath, IStorage::TYPE_SAVE))
+			{
+				pFileBrowser->FilelistPopulate(IStorage::TYPE_SAVE, true);
+			}
+			else
+			{
+				pEditor->ShowFileDialogError("Failed to delete folder '%s'. Make sure it's empty first. Check the local console for details.", pConfirmDeleteContext->m_aDeletePath);
+			}
+		}
+		else
+		{
+			if(pFileBrowser->Storage()->RemoveFile(pConfirmDeleteContext->m_aDeletePath, IStorage::TYPE_SAVE))
+			{
+				pFileBrowser->FilelistPopulate(IStorage::TYPE_SAVE, true);
+			}
+			else
+			{
+				pEditor->ShowFileDialogError("Failed to delete file '%s'. Check the local console for details.", pConfirmDeleteContext->m_aDeletePath);
+			}
+		}
+		pFileBrowser->UpdateFilenameInput();
+		return CUi::POPUP_CLOSE_CURRENT;
+	}
+
+	return CUi::POPUP_KEEP_OPEN;
+}
+
+CUi::EPopupMenuFunctionResult CFileBrowser::CPopupConfirmOverwrite::Render(void *pContext, CUIRect View, bool Active)
+{
+	CPopupConfirmOverwrite *pConfirmOverwriteContext = static_cast<CPopupConfirmOverwrite *>(pContext);
+	CFileBrowser *pFileBrowser = pConfirmOverwriteContext->m_pFileBrowser;
+	CEditor *pEditor = pFileBrowser->Editor();
+
+	CUIRect Label, ButtonBar, ButtonCancel, ButtonOverride;
+	View.Margin(10.0f, &View);
+	View.HSplitBottom(20.0f, &View, &ButtonBar);
+	View.HSplitTop(20.0f, &Label, &View);
+	ButtonBar.VSplitLeft(110.0f, &ButtonCancel, &ButtonBar);
+	ButtonBar.VSplitRight(110.0f, &ButtonBar, &ButtonOverride);
+
+	pFileBrowser->Ui()->DoLabel(&Label, "Confirm overwrite", 20.0f, TEXTALIGN_MC);
+
+	char aMessage[IO_MAX_PATH_LENGTH + 128];
+	str_format(aMessage, sizeof(aMessage), "The file '%s' already exists.\n\nAre you sure that you want to overwrite it?",
+		pConfirmOverwriteContext->m_aOverwritePath);
+	pFileBrowser->Ui()->DoLabel(&View, aMessage, 10.0f, TEXTALIGN_ML, {.m_MaxWidth = View.w});
+
+	if(pEditor->DoButton_Editor(&pConfirmOverwriteContext->m_ButtonCancelId, "Cancel", 0, &ButtonCancel, BUTTONFLAG_LEFT, nullptr))
+	{
+		return CUi::POPUP_CLOSE_CURRENT;
+	}
+
+	if(pEditor->DoButton_Editor(&pConfirmOverwriteContext->m_ButtonOverwriteId, "Overwrite", EditorButtonChecked::DANGEROUS_ACTION, &ButtonOverride, BUTTONFLAG_LEFT, nullptr) ||
+		(Active && pFileBrowser->Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
+	{
+		pFileBrowser->m_pfnOpenCallback(pConfirmOverwriteContext->m_aOverwritePath, IStorage::TYPE_SAVE, pFileBrowser->m_pOpenCallbackUser);
+		return CUi::POPUP_CLOSE_CURRENT;
+	}
+
+	return CUi::POPUP_KEEP_OPEN;
+}

--- a/src/game/editor/file_browser.h
+++ b/src/game/editor/file_browser.h
@@ -1,0 +1,215 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#ifndef GAME_EDITOR_FILE_BROWSER_H
+#define GAME_EDITOR_FILE_BROWSER_H
+
+#include "component.h"
+
+#include <base/types.h>
+
+#include <game/client/ui.h>
+#include <game/client/ui_listbox.h>
+
+#include <optional>
+#include <vector>
+
+class CFileBrowser : public CEditorComponent
+{
+public:
+	enum class EFileType
+	{
+		MAP,
+		IMAGE,
+		SOUND,
+	};
+	typedef bool (*FFileDialogOpenCallback)(const char *pFilename, int StorageType, void *pUser);
+
+	void ShowFileDialog(
+		int StorageType, EFileType FileType,
+		const char *pTitle, const char *pButtonText,
+		const char *pInitialPath, const char *pInitialFilename,
+		FFileDialogOpenCallback pfnOpenCallback, void *pOpenCallbackUser);
+	void OnRender(CUIRect _) override;
+	bool IsValidSaveFilename() const;
+
+	void OnEditorClose();
+	void OnDialogClose();
+
+private:
+	/**
+	 * Storage type for which the file browser is currently showing entries.
+	 */
+	int m_StorageType = 0;
+	/**
+	 * File type for which the file browser is currently showing entries.
+	 */
+	EFileType m_FileType = EFileType::MAP;
+	/**
+	 * `true` if file browser was opened with the intent to save a file.
+	 * `false` if file browser was opened with the intent to open an existing file for reading.
+	 */
+	bool m_SaveAction = false;
+	/**
+	 * Whether multiple storage locations with the initial folder are available.
+	 */
+	bool m_MultipleStorages = false;
+	/**
+	 * Title text of the file dialog.
+	 */
+	char m_aTitle[128] = "";
+	/**
+	 * Text of the confirmation button that opens/saves the file.
+	 */
+	char m_aButtonText[64] = "";
+	/**
+	 * Callback function that will be called when the confirmation button is pressed.
+	 */
+	FFileDialogOpenCallback m_pfnOpenCallback = nullptr;
+	/**
+	 * User data for @link m_pfnOpenCallback @endlink.
+	 */
+	void *m_pOpenCallbackUser = nullptr;
+	/**
+	 * Whether the list of storages is currently being shown, if @link m_MultipleStorages @endlink is `true`.
+	 */
+	bool m_ShowingRoot = false;
+	/**
+	 * Path of the initial folder that the file browser was opened with.
+	 */
+	char m_aInitialFolder[IO_MAX_PATH_LENGTH] = "";
+	/**
+	 * Path of the current folder being shown in the file browser.
+	 */
+	char m_aCurrentFolder[IO_MAX_PATH_LENGTH] = "";
+	/**
+	 * Path of the current link being shown in the file browser.
+	 */
+	char m_aCurrentLink[IO_MAX_PATH_LENGTH] = "";
+	/**
+	 * Current path being shown in the file browser, which either points to @link m_aCurrentFolder @endlink or @link m_aCurrentLink @endlink.
+	 */
+	char *m_pCurrentPath = m_aCurrentFolder;
+	/**
+	 * Input for the filename when saving files and also buffer for the selected file's name in general.
+	 */
+	CLineInputBuffered<IO_MAX_PATH_LENGTH> m_FilenameInput;
+	/**
+	 * Input for the file search when opening files for reading.
+	 */
+	CLineInputBuffered<IO_MAX_PATH_LENGTH> m_FilterInput;
+	/**
+	 * Index of the selected file list entry in @link m_vpFilteredFileList @endlink.
+	 */
+	int m_SelectedFileIndex = -1;
+	/**
+	 * Display name of the selected file list entry in @link m_vpFilteredFileList @endlink and @link m_vCompleteFileList @endlink.
+	 */
+	char m_aSelectedFileDisplayName[IO_MAX_PATH_LENGTH] = "";
+
+	// File list
+	class CFilelistItem
+	{
+	public:
+		char m_aFilename[IO_MAX_PATH_LENGTH];
+		char m_aDisplayName[IO_MAX_PATH_LENGTH];
+		bool m_IsDir;
+		bool m_IsLink;
+		int m_StorageType;
+		time_t m_TimeModified;
+	};
+	std::vector<CFilelistItem> m_vCompleteFileList;
+	std::vector<const CFilelistItem *> m_vpFilteredFileList;
+	enum class ESortDirection
+	{
+		NEUTRAL,
+		ASCENDING,
+		DESCENDING,
+	};
+	ESortDirection m_SortByFilename = ESortDirection::ASCENDING;
+	ESortDirection m_SortByTimeModified = ESortDirection::NEUTRAL;
+
+	// File preview
+	enum class EPreviewState
+	{
+		UNLOADED,
+		LOADED,
+		ERROR,
+	};
+	EPreviewState m_PreviewState = EPreviewState::UNLOADED;
+	IGraphics::CTextureHandle m_PreviewImage;
+	int m_PreviewImageWidth = 0;
+	int m_PreviewImageHeight = 0;
+	int m_PreviewSound = -1;
+
+	// UI elements
+	CListBox m_ListBox;
+	const char m_ButtonSortTimeModifiedId = 0;
+	const char m_ButtonSortFilenameId = 0;
+	const char m_ButtonPlayPauseId = 0;
+	const char m_ButtonStopId = 0;
+	const char m_SeekBarId = 0;
+	const char m_ButtonOkId = 0;
+	const char m_ButtonCancelId = 0;
+	const char m_ButtonRefreshId = 0;
+	const char m_ButtonShowDirectoryId = 0;
+	const char m_ButtonDeleteId = 0;
+	const char m_ButtonNewFolderId = 0;
+
+	bool CanPreviewFile() const;
+	void UpdateFilePreview();
+	void RenderFilePreview(CUIRect Preview);
+	const char *DetermineFileFontIcon(const CFilelistItem *pItem) const;
+	void UpdateFilenameInput();
+	void UpdateSelectedIndex(const char *pDisplayName);
+	void SortFilteredFileList();
+	void RefreshFilteredFileList();
+	void FilelistPopulate(int StorageType, bool KeepSelection);
+	static int DirectoryListingCallback(const CFsFileInfo *pInfo, int IsDir, int StorageType, void *pUser);
+	static std::optional<bool> CompareCommon(const CFilelistItem *pLhs, const CFilelistItem *pRhs);
+	static bool CompareFilenameAscending(const CFilelistItem *pLhs, const CFilelistItem *pRhs);
+	static bool CompareFilenameDescending(const CFilelistItem *pLhs, const CFilelistItem *pRhs);
+	static bool CompareTimeModifiedAscending(const CFilelistItem *pLhs, const CFilelistItem *pRhs);
+	static bool CompareTimeModifiedDescending(const CFilelistItem *pLhs, const CFilelistItem *pRhs);
+
+	class CPopupNewFolder : public SPopupMenuId
+	{
+	public:
+		CFileBrowser *m_pFileBrowser;
+		CLineInputBuffered<IO_MAX_PATH_LENGTH> m_NewFolderNameInput;
+		static CUi::EPopupMenuFunctionResult Render(void *pContext, CUIRect View, bool Active);
+
+	private:
+		const char m_ButtonCancelId = 0;
+		const char m_ButtonCreateId = 0;
+	};
+	CPopupNewFolder m_PopupNewFolder;
+
+	class CPopupConfirmDelete : public SPopupMenuId
+	{
+	public:
+		CFileBrowser *m_pFileBrowser;
+		bool m_IsDirectory;
+		char m_aDeletePath[IO_MAX_PATH_LENGTH];
+		static CUi::EPopupMenuFunctionResult Render(void *pContext, CUIRect View, bool Active);
+
+	private:
+		const char m_ButtonCancelId = 0;
+		const char m_ButtonDeleteId = 0;
+	};
+	CPopupConfirmDelete m_PopupConfirmDelete;
+
+	class CPopupConfirmOverwrite : public SPopupMenuId
+	{
+	public:
+		CFileBrowser *m_pFileBrowser;
+		char m_aOverwritePath[IO_MAX_PATH_LENGTH];
+		static CUi::EPopupMenuFunctionResult Render(void *pContext, CUIRect View, bool Active);
+
+	private:
+		const char m_ButtonCancelId = 0;
+		const char m_ButtonOverwriteId = 0;
+	};
+	CPopupConfirmOverwrite m_PopupConfirmOverwrite;
+};
+
+#endif

--- a/src/game/editor/quick_actions.h
+++ b/src/game/editor/quick_actions.h
@@ -217,7 +217,11 @@ REGISTER_QUICK_ACTION(
 REGISTER_QUICK_ACTION(
 	SaveAs,
 	"Save as",
-	[&]() { InvokeFileDialog(IStorage::TYPE_SAVE, FILETYPE_MAP, "Save map", "Save as", "maps", true, CEditor::CallbackSaveMap, this); },
+	[&]() {
+		char aDefaultName[IO_MAX_PATH_LENGTH];
+		fs_split_file_extension(fs_filename(m_aFileName), aDefaultName, sizeof(aDefaultName));
+		m_FileBrowser.ShowFileDialog(IStorage::TYPE_SAVE, CFileBrowser::EFileType::MAP, "Save map", "Save as", "maps", aDefaultName, CallbackSaveMap, this);
+	},
 	ALWAYS_FALSE,
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
@@ -267,7 +271,7 @@ REGISTER_QUICK_ACTION(
 REGISTER_QUICK_ACTION(
 	AddImage,
 	"Add image",
-	[&]() { InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_IMG, "Add Image", "Add", "mapres", false, AddImage, this); },
+	[&]() { m_FileBrowser.ShowFileDialog(IStorage::TYPE_ALL, CFileBrowser::EFileType::IMAGE, "Add image", "Add", "mapres", "", AddImage, this); },
 	ALWAYS_FALSE,
 	ALWAYS_FALSE,
 	DEFAULT_BTN,


### PR DESCRIPTION
Do not show a confirmation popup anymore when saving a map to its current file with the Save button in the File menu. This makes the behavior consistent with the Ctrl+S behavior, which also does not show a confirmation popup. This is also consistent with the behavior of other applications, that do not ask whether to overwrite the existing file when using the "Save" or Ctrl+S action.

Automatically highlight newly created folder when using the New folder popup.

Add large, centered popup for confirming deletion of files and folders. Add red background for confirmation buttons that delete/overwrite files and folders.

<img src="https://github.com/user-attachments/assets/6462d4ae-5eb6-44c6-99f3-d0a3ec65e151" />

Reset scroll position of the file list to then top when reopening the file browser.

Fix storage locations not correctly being detected as saveable when opening maps from sub-folders of folder links, e.g. folders inside the `themes` link.

Fix parent folder entries being missing inside sub-folders if there is only one storage location available.

Minor improvements of the file browser UI layout. Slightly increase margins and button sizes. Add tooltips for buttons.

- Before: <img src="https://github.com/user-attachments/assets/49c3f290-d772-4622-a83e-4dbb51765016" />

- After: <img src="https://github.com/user-attachments/assets/525985eb-5808-4f50-9cc4-42e5e5e51d03" />

Move all variables and functions related to the editor file browser from the `CEditor` class to a separate class `CFileBrowser` in separate files. Encapsulate most member variables and functions. Avoid all static variables for file browser. Further encapsulate members specifically used for popup menus.

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
