### PR TITLE
Fix dependency cache for mastersrv and masterping in the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,11 @@ jobs:
     
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
+      with:
+          workspaces: |
+              src/mastersrv
+              src/masterping
+              ./
 
     - name: Build mastersrv
       if: "!contains(matrix.os, 'ubuntu-22.04')"
@@ -282,6 +287,11 @@ jobs:
 
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
+      with:
+          workspaces: |
+              src/mastersrv
+              src/masterping
+              ./
 
     - name: Build Android app
       env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,11 @@ jobs:
       uses: actions/checkout@v4
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
+      with:
+           workspaces: |
+               src/mastersrv
+               src/masterping
+               ./
     - name: Run Rustfmt
       run:
         cargo fmt -- --check
@@ -49,6 +54,11 @@ jobs:
       uses: actions/checkout@v4
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
+      with:
+          workspaces:  |
+              src/mastersrv
+              src/masterping
+              ./
     - uses: EmbarkStudios/cargo-deny-action@v1
       with:
         command: check ${{ matrix.checks }}


### PR DESCRIPTION
Fixes https://github.com/ddnet/ddnet/issues/9938

The issue was that by default `Swatinem/rust-cache@v2` caches `target` only in the root directory workspace, but `src/mastersrv` and `src/masterping` have their own separate workspaces.

Tested this change in my own repo.

Build times _benchmark_ (before and after):
mastersrv:  32.40s -> 13.58s
masterping: 13.07s -> 0.97s
total:      45.47s -> 14.55s