### PR TITLE
Add checks for maximum number of chunks per packet

### DIFF
--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -68,6 +68,7 @@ enum
 	NET_MAX_CLIENTS = 64,
 	NET_MAX_CONSOLE_CLIENTS = 4,
 	NET_MAX_SEQUENCE = 1 << 10,
+	NET_MAX_PACKET_CHUNKS = 0xFF,
 
 	NET_PACKETFLAG_UNUSED = 1 << 0,
 	NET_PACKETFLAG_TOKEN = 1 << 1,
@@ -614,6 +615,8 @@ public:
 	static void Init();
 	static int Compress(const void *pData, int DataSize, void *pOutput, int OutputSize);
 	static int Decompress(const void *pData, int DataSize, void *pOutput, int OutputSize);
+
+	static bool IsValidConnectionOrientedPacket(const CNetPacketConstruct *pPacket);
 
 	static void SendControlMsg(NETSOCKET Socket, NETADDR *pAddr, int Ack, int ControlMsg, const void *pExtra, int ExtraSize, SECURITY_TOKEN SecurityToken, bool Sixup = false);
 	static void SendControlMsgWithToken7(NETSOCKET Socket, NETADDR *pAddr, TOKEN Token, int Ack, int ControlMsg, TOKEN MyToken, bool Extended);

--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -97,9 +97,13 @@ void CNetConnection::SignalResend()
 
 int CNetConnection::Flush()
 {
-	int NumChunks = m_Construct.m_NumChunks;
-	if(!NumChunks && !m_Construct.m_Flags)
+	// Only flush the connection if there is at least one chunk to flush,
+	// or if a resend should be signaled.
+	const int NumChunks = m_Construct.m_NumChunks;
+	if(!NumChunks && (m_Construct.m_Flags & NET_PACKETFLAG_RESEND) == 0)
+	{
 		return 0;
+	}
 
 	// send of the packets
 	m_Construct.m_Ack = m_Ack;
@@ -121,8 +125,11 @@ int CNetConnection::QueueChunkEx(int Flags, int DataSize, const void *pData, int
 	unsigned char *pChunkData;
 
 	// check if we have space for it, if not, flush the connection
-	if(m_Construct.m_DataSize + DataSize + NET_MAX_CHUNKHEADERSIZE > (int)sizeof(m_Construct.m_aChunkData) - (int)sizeof(SECURITY_TOKEN))
+	if(m_Construct.m_DataSize + DataSize + NET_MAX_CHUNKHEADERSIZE > (int)sizeof(m_Construct.m_aChunkData) - (int)sizeof(SECURITY_TOKEN) ||
+		m_Construct.m_NumChunks == NET_MAX_PACKET_CHUNKS)
+	{
 		Flush();
+	}
 
 	// pack all the data
 	CNetChunkHeader Header;

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -270,6 +270,8 @@ int CNetServer::TryAcceptClient(NETADDR &Addr, SECURITY_TOKEN SecurityToken, boo
 
 void CNetServer::SendMsgs(NETADDR &Addr, const CPacker **ppMsgs, int Num)
 {
+	dbg_assert(Num > 0 && Num <= NET_MAX_PACKET_CHUNKS, "Number of messages invalid: %d", Num);
+
 	CNetPacketConstruct Construct;
 	mem_zero(&Construct, sizeof(Construct));
 	unsigned char *pChunkData = &Construct.m_aChunkData[Construct.m_DataSize];


### PR DESCRIPTION
Flush the connection when the maximum number of chunks per packet has been reached, which is 255 due to the value being packed into 1 byte in the chunk header. Otherwise, the number of chunks would be truncated when sending a packet with more chunks. This should have been unlikely to happen in practice, but it could be forced to occur by having the server send a lot of small messages like empty snapshots or rcon lines.

Discard any non-control, non-resend packets that specify zero chunks in their header and discard any control packets that do not specify zero chunks in their header.

Add assertions to the `CNetBase::SendPacket` and `CNetServer::SendMsgs` functions to ensure that the number of chunks per packet is valid when the header is packed.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options: all combinations of DDNet and Vanilla 0.7 server/client
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
