### PR TITLE
Add basic integration test to open and close editor, fix use of uninitialized value when parsing map commands

### DIFF
--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -544,6 +544,14 @@ def client_can_connect(test_env):
 	client.wait_for_exit()
 
 @test
+def open_editor(test_env):
+	client = test_env.client(["maps/coverage.map"])
+	client.wait_for_log_exact("editor/load: Loaded map 'maps/coverage.map'", timeout=10)
+	client.command("cl_editor 0")
+	client.exit()
+	client.wait_for_exit()
+
+@test
 def smoke_test(test_env):
 	client1 = test_env.client(["logfile client1.log", "player_name client1"])
 	server = test_env.server(["logfile server.log", "sv_demo_chat 1", "sv_map coverage", "sv_tee_historian 1"])

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 
 #include <base/color.h>
+#include <base/log.h>
 #include <base/system.h>
 
 #if defined(CONF_FAMILY_UNIX)
@@ -9233,6 +9234,8 @@ bool CEditor::Load(const char *pFileName, int StorageType)
 
 		for(CEditorComponent &Component : m_vComponents)
 			Component.OnMapLoad();
+
+		log_info("editor/load", "Loaded map '%s'", m_aFileName);
 	}
 	else
 	{

--- a/src/game/editor/editor_server_settings.cpp
+++ b/src/game/editor/editor_server_settings.cpp
@@ -1370,8 +1370,8 @@ void CMapSettingsBackend::CContext::ParseArgs(const char *pLineInputStr, const c
 
 	// Also keep track of the visual X position of each argument within the input
 	float PosX = 0;
-	const float WW = m_pBackend->TextRender()->TextWidth(m_FontSize, " ");
-	PosX += m_pBackend->TextRender()->TextWidth(m_FontSize, m_aCommand);
+	const float WW = m_pLineInput != nullptr ? m_pBackend->TextRender()->TextWidth(m_FontSize, " ") : 0.0f;
+	PosX += m_pLineInput != nullptr ? m_pBackend->TextRender()->TextWidth(m_FontSize, m_aCommand) : 0.0f;
 
 	// Parsing beings
 	while(*pIterator)
@@ -1535,7 +1535,7 @@ void CMapSettingsBackend::CContext::ParseArgs(const char *pLineInputStr, const c
 			}
 		}
 
-		PosX += m_pBackend->TextRender()->TextWidth(m_FontSize, pArgStart, Length); // Advance argument position
+		PosX += m_pLineInput != nullptr ? m_pBackend->TextRender()->TextWidth(m_FontSize, pArgStart, Length) : 0.0f; // Advance argument position
 		ArgIndex++;
 	}
 }


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
