### PR TITLE
Allow GameServer to adjust high bandwidth mode for individual clients

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -309,9 +309,18 @@ public:
 	virtual void OnShutdown(void *pPersistentData) = 0;
 
 	virtual void OnTick() = 0;
-	virtual void OnPreSnap() = 0;
-	virtual void OnSnap(int ClientId) = 0;
-	virtual void OnPostSnap() = 0;
+
+	// Snap for a specific client.
+	//
+	// GlobalSnap is true when sending snapshots to all clients,
+	// otherwise only forced high bandwidth clients would receive snap.
+	virtual void OnSnap(int ClientId, bool GlobalSnap) = 0;
+
+	// Called after sending snapshots to all clients.
+	//
+	// Note if any client has force high bandwidth enabled,
+	// this will not be called when only sending snapshots to these clients.
+	virtual void OnPostGlobalSnap() = 0;
 
 	virtual void OnMessage(int MsgId, CUnpacker *pUnpacker, int ClientId) = 0;
 
@@ -342,6 +351,7 @@ public:
 
 	virtual bool IsClientReady(int ClientId) const = 0;
 	virtual bool IsClientPlayer(int ClientId) const = 0;
+	virtual bool IsClientHighBandwidth(int ClientId) const = 0;
 
 	virtual int PersistentDataSize() const = 0;
 	virtual int PersistentClientDataSize() const = 0;

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -163,6 +163,7 @@ public:
 		int m_Flags;
 		bool m_ShowIps;
 		bool m_DebugDummy;
+		bool m_ForceHighBandwidthOnSpectate;
 		NETADDR m_DebugDummyAddr;
 		std::array<char, NETADDR_MAXSTRSIZE> m_aDebugDummyAddrString;
 		std::array<char, NETADDR_MAXSTRSIZE> m_aDebugDummyAddrStringNoPort;
@@ -435,6 +436,7 @@ public:
 	static void ConLogout(IConsole::IResult *pResult, void *pUser);
 	static void ConShowIps(IConsole::IResult *pResult, void *pUser);
 	static void ConHideAuthStatus(IConsole::IResult *pResult, void *pUser);
+	static void ConForceHighBandwidthOnSpectate(IConsole::IResult *pResult, void *pUser);
 
 	static void ConAuthAdd(IConsole::IResult *pResult, void *pUser);
 	static void ConAuthAddHashed(IConsole::IResult *pResult, void *pUser);

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1316,7 +1316,7 @@ void CCharacter::Snap(int SnappingClient)
 	pDDNetCharacter->m_TuneZoneOverride = -1;
 }
 
-void CCharacter::PostSnap()
+void CCharacter::PostGlobalSnap()
 {
 	m_TriggeredEvents7 = 0;
 }

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -42,8 +42,9 @@ public:
 	void TickDeferred() override;
 	void TickPaused() override;
 	void Snap(int SnappingClient) override;
-	void PostSnap() override;
 	void SwapClients(int Client1, int Client2) override;
+
+	void PostGlobalSnap();
 
 	bool CanSnapCharacter(int SnappingClient);
 	bool IsSnappingCharacterInView(int SnappingClientId);
@@ -151,7 +152,6 @@ private:
 
 	int m_Health;
 	int m_Armor;
-
 	int m_TriggeredEvents7;
 
 	// the player core for the physics

--- a/src/game/server/entity.h
+++ b/src/game/server/entity.h
@@ -124,12 +124,6 @@ public: // TODO: Maybe make protected
 	virtual void Snap(int SnappingClient) {}
 
 	/*
-		Function: PostSnap
-			Called after all clients received their snapshot.
-	*/
-	virtual void PostSnap() {}
-
-	/*
 		Function: SwapClients
 			Called when two players have swapped their client ids.
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4453,8 +4453,11 @@ void CGameContext::LoadMapSettings()
 	Console()->ExecuteFile(aBuf, IConsole::CLIENT_ID_NO_GAME);
 }
 
-void CGameContext::OnSnap(int ClientId)
+void CGameContext::OnSnap(int ClientId, bool GlobalSnap)
 {
+	// sixup should only snap during global snap
+	dbg_assert(!Server()->IsSixup(ClientId) || GlobalSnap, "sixup should only snap during global snap");
+
 	// add tuning to demo
 	CTuningParams StandardTuning;
 	if(Server()->IsRecording(ClientId > -1 ? ClientId : MAX_CLIENTS) && mem_comp(&StandardTuning, &m_Tuning, sizeof(CTuningParams)) != 0)
@@ -4478,12 +4481,21 @@ void CGameContext::OnSnap(int ClientId)
 		m_apPlayers[ClientId]->FakeSnap();
 
 	m_World.Snap(ClientId);
-	m_Events.Snap(ClientId);
+
+	// events are only sent on global snapshots
+	if(GlobalSnap)
+	{
+		m_Events.Snap(ClientId);
+	}
 }
-void CGameContext::OnPreSnap() {}
-void CGameContext::OnPostSnap()
+
+void CGameContext::OnPostGlobalSnap()
 {
-	m_World.PostSnap();
+	for(auto &pPlayer : m_apPlayers)
+	{
+		if(pPlayer && pPlayer->GetCharacter())
+			pPlayer->GetCharacter()->PostGlobalSnap();
+	}
 	m_Events.Clear();
 }
 
@@ -4556,6 +4568,13 @@ bool CGameContext::IsClientReady(int ClientId) const
 bool CGameContext::IsClientPlayer(int ClientId) const
 {
 	return m_apPlayers[ClientId] && m_apPlayers[ClientId]->GetTeam() != TEAM_SPECTATORS;
+}
+
+bool CGameContext::IsClientHighBandwidth(int ClientId) const
+{
+	// force high bandwidth is not supported for sixup
+	return m_apPlayers[ClientId] && !Server()->IsSixup(ClientId) && Server()->GetAuthedState(ClientId) &&
+	       (m_apPlayers[ClientId]->GetTeam() == TEAM_SPECTATORS || m_apPlayers[ClientId]->IsPaused());
 }
 
 CUuid CGameContext::GameUuid() const { return m_GameUuid; }

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -318,9 +318,8 @@ public:
 	void OnShutdown(void *pPersistentData) override;
 
 	void OnTick() override;
-	void OnPreSnap() override;
-	void OnSnap(int ClientId) override;
-	void OnPostSnap() override;
+	void OnSnap(int ClientId, bool GlobalSnap) override;
+	void OnPostGlobalSnap() override;
 
 	void UpdatePlayerMaps();
 
@@ -363,6 +362,8 @@ public:
 
 	bool IsClientReady(int ClientId) const override;
 	bool IsClientPlayer(int ClientId) const override;
+	// Whether the client is allowed to have high bandwidth.
+	bool IsClientHighBandwidth(int ClientId) const override;
 	int PersistentDataSize() const override { return sizeof(CPersistentData); }
 	int PersistentClientDataSize() const override { return sizeof(CPersistentClientData); }
 

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -129,19 +129,6 @@ void CGameWorld::Snap(int SnappingClient)
 	}
 }
 
-void CGameWorld::PostSnap()
-{
-	for(auto *pEnt : m_apFirstEntityTypes)
-	{
-		for(; pEnt;)
-		{
-			m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
-			pEnt->PostSnap();
-			pEnt = m_pNextTraverseEntity;
-		}
-	}
-}
-
 void CGameWorld::Reset()
 {
 	// reset all entities

--- a/src/game/server/gameworld.h
+++ b/src/game/server/gameworld.h
@@ -156,12 +156,6 @@ public:
 	void Snap(int SnappingClient);
 
 	/*
-		Function: PostSnap
-			Called after all clients received their snapshot.
-	*/
-	void PostSnap();
-
-	/*
 		Function: Tick
 			Calls Tick on all the entities in the world to progress
 			the world to the next tick.


### PR DESCRIPTION
Motivation: @Learath2 told me to do this

Moved high bandwidth mode guard into the snapshot loop.

Removed `OnPostSnap` and `OnPreSnap` to prevent future utilization creating missing/mismatched state between snapshot since snapshots are processed at different rate now, these two hooks have 0 usage in 0.6 and only one usage for sixup and has been handled by special case.

Introduced the `GlobalSnap` concept to make sure state dependent information are processed at the correct rate (e.g. Events)

`force_high_bandwidth_on_spectate` rcon command will enable high bandwidth mode only for the caller player, no client shall receive exclusive high bandwidth snapshots when playing.

Requires heavy testing please.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
