### PR TITLE
Make demo recorder always record local camera setting

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -401,6 +401,7 @@ public:
 	virtual void ApplySkin7InfoFromSnapObj(const protocol7::CNetObj_De_ClientInfo *pObj, int ClientId) = 0;
 	virtual int OnDemoRecSnap7(class CSnapshot *pFrom, class CSnapshot *pTo, int Conn) = 0;
 	virtual int TranslateSnap(class CSnapshot *pSnapDstSix, class CSnapshot *pSnapSrcSeven, int Conn, bool Dummy) = 0;
+	virtual void ProcessDemoSnapshot(class CSnapshot *pSnap) = 0;
 
 	virtual void InitializeLanguage() = 0;
 };

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -49,7 +49,6 @@
 
 #include <engine/shared/protocolglue.h>
 
-#include <game/client/projectile_data.h>
 #include <game/localization.h>
 #include <game/version.h>
 
@@ -2077,8 +2076,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 
 					if(!Dummy)
 					{
-						// for antiping: if the projectile netobjects from the server contains extra data, this is removed and the original content restored before recording demo
-						SnapshotRemoveExtraProjectileInfo(pTmpBuffer3);
+						GameClient()->ProcessDemoSnapshot(pTmpBuffer3);
 
 						unsigned char aSnapSeven[CSnapshot::MAX_SIZE];
 						CSnapshot *pSnapSeven = (CSnapshot *)aSnapSeven;

--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -54,7 +54,7 @@ private:
 
 	vec2 m_LastTargetPos;
 	float m_DyncamSmoothingSpeedBias;
-	bool m_IsSpectatingPlayer;
+	bool m_CanUseCameraInfo;
 	bool m_UsingAutoSpecCamera;
 
 	char m_aAutoSpecCameraTooltip[512];
@@ -105,7 +105,7 @@ public:
 
 	void UpdateCamera();
 	void ResetAutoSpecCamera();
-	bool SpectatingPlayer() const { return m_IsSpectatingPlayer; }
+	bool SpectatingPlayer() const { return m_CanUseCameraInfo; }
 	bool CanUseAutoSpecCamera() const;
 	void ToggleAutoSpecCamera();
 	void UpdateAutoSpecCameraTooltip();

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1568,7 +1568,7 @@ void CHud::RenderSpectatorHud()
 	TextRender()->Text(m_Width - 174.0f, m_Height - 15.0f + (15.f - 8.f) / 2.f, 8.0f, aBuf, -1.0f);
 
 	// draw the camera info
-	if(GameClient()->m_Camera.SpectatingPlayer() && GameClient()->m_Camera.CanUseAutoSpecCamera() && g_Config.m_ClSpecAutoSync)
+	if(Client()->State() != IClient::STATE_DEMOPLAYBACK && GameClient()->m_Camera.SpectatingPlayer() && GameClient()->m_Camera.CanUseAutoSpecCamera() && g_Config.m_ClSpecAutoSync)
 	{
 		bool AutoSpecCameraEnabled = GameClient()->m_Camera.m_AutoSpecCamera;
 		const char *pLabelText = Localize("AUTO", "Spectating Camera Mode Icon");

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -611,6 +611,7 @@ public:
 	void CollectManagedTeeRenderInfos(const std::function<void(const char *pSkinName)> &ActiveSkinAcceptor);
 
 	void RenderShutdownMessage() override;
+	void ProcessDemoSnapshot(CSnapshot *pSnap) override;
 
 	const char *GetItemName(int Type) const override;
 	const char *Version() const override;

--- a/src/game/client/projectile_data.cpp
+++ b/src/game/client/projectile_data.cpp
@@ -104,22 +104,14 @@ CProjectileData ExtractProjectileInfoDDNet(const CNetObj_DDNetProjectile *pProj)
 	return Result;
 }
 
-void SnapshotRemoveExtraProjectileInfo(CSnapshot *pSnap)
+void DemoObjectRemoveExtraProjectileInfo(CNetObj_Projectile *pProj)
 {
-	for(int Index = 0; Index < pSnap->NumItems(); Index++)
+	if(UseProjectileExtraInfo(pProj))
 	{
-		const CSnapshotItem *pItem = pSnap->GetItem(Index);
-		if(pItem->Type() == NETOBJTYPE_PROJECTILE)
-		{
-			CNetObj_Projectile *pProj = (CNetObj_Projectile *)((void *)pItem->Data());
-			if(UseProjectileExtraInfo(pProj))
-			{
-				CProjectileData Data = ExtractProjectileInfo(NETOBJTYPE_PROJECTILE, pProj, nullptr, nullptr);
-				pProj->m_X = Data.m_StartPos.x;
-				pProj->m_Y = Data.m_StartPos.y;
-				pProj->m_VelX = (int)(Data.m_StartVel.x * 100.0f);
-				pProj->m_VelY = (int)(Data.m_StartVel.y * 100.0f);
-			}
-		}
+		CProjectileData Data = ExtractProjectileInfo(NETOBJTYPE_PROJECTILE, pProj, nullptr, nullptr);
+		pProj->m_X = Data.m_StartPos.x;
+		pProj->m_Y = Data.m_StartPos.y;
+		pProj->m_VelX = (int)(Data.m_StartVel.x * 100.0f);
+		pProj->m_VelY = (int)(Data.m_StartVel.y * 100.0f);
 	}
 }

--- a/src/game/client/projectile_data.h
+++ b/src/game/client/projectile_data.h
@@ -32,6 +32,6 @@ CProjectileData ExtractProjectileInfo(int NetObjType, const void *pData, class C
 CProjectileData ExtractProjectileInfoDDRace(const CNetObj_DDRaceProjectile *pProj, class CGameWorld *pGameWorld, const CNetObj_EntityEx *pEntEx);
 CProjectileData ExtractProjectileInfoDDNet(const CNetObj_DDNetProjectile *pProj);
 
-void SnapshotRemoveExtraProjectileInfo(class CSnapshot *pSnap);
+void DemoObjectRemoveExtraProjectileInfo(CNetObj_Projectile *pProj);
 
 #endif // GAME_CLIENT_PROJECTILE_DATA_H


### PR DESCRIPTION
Reported by Aoe, who found out when playing demo in follow mode, Auto Sync Camera would reset to default zoom whenever the camera is recorded to be in freeview. This PR fixes that along with the following changes:

- Recorder now always record the local camera setting instead of following server feedback
- Disabled auto sync camera in non follow auto sync camera (previously it only records the recording PoV's camera setting making them mostly unavailable/unusable anyway)
- Removed the bottom right AUTO indicator when playing demo, player should only refer to the camera setting button in the demo control panel

Previously recorded demo will behave roughly the same, only when spectating other players (while in follow mode) would show the spectatee's PoV.

Newly recorded demo will always follow the recorders PoV closely.

Local camera setting is recorded by modifying the existing Snapshot before writing to demo, factored out the existing loop for removing extra projectile info so they shares the same loop. This also means if the server doesn't support camera setting, local pov will not be recorded.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
