### PR TITLE
Fix non-destructive brush with unused tiles, refactoring

### DIFF
--- a/src/game/editor/mapitems/layer_front.cpp
+++ b/src/game/editor/mapitems/layer_front.cpp
@@ -38,6 +38,26 @@ void CLayerFront::Resize(int NewW, int NewH)
 		m_pEditor->m_Map.m_pGameLayer->Resize(NewW, NewH);
 }
 
+bool CLayerFront::IsEmpty() const
+{
+	for(int y = 0; y < m_Height; y++)
+	{
+		for(int x = 0; x < m_Width; x++)
+		{
+			const int Index = GetTile(x, y).m_Index;
+			if(Index == 0)
+			{
+				continue;
+			}
+			if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidFrontTile(Index))
+			{
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
 const char *CLayerFront::TypeName() const
 {
 	return "front";

--- a/src/game/editor/mapitems/layer_front.h
+++ b/src/game/editor/mapitems/layer_front.h
@@ -8,8 +8,10 @@ class CLayerFront : public CLayerTiles
 public:
 	CLayerFront(CEditor *pEditor, int w, int h);
 
-	void Resize(int NewW, int NewH) override;
 	void SetTile(int x, int y, CTile Tile) override;
+	void Resize(int NewW, int NewH) override;
+	[[nodiscard]] bool IsEmpty() const override;
+
 	const char *TypeName() const override;
 };
 

--- a/src/game/editor/mapitems/layer_game.cpp
+++ b/src/game/editor/mapitems/layer_game.cpp
@@ -14,7 +14,7 @@ CLayerGame::CLayerGame(CEditor *pEditor, int w, int h) :
 
 CLayerGame::~CLayerGame() = default;
 
-CTile CLayerGame::GetTile(int x, int y)
+CTile CLayerGame::GetTile(int x, int y) const
 {
 	if(m_pEditor->m_Map.m_pFrontLayer && m_pEditor->m_Map.m_pFrontLayer->GetTile(x, y).m_Index == TILE_THROUGH_CUT)
 	{

--- a/src/game/editor/mapitems/layer_game.cpp
+++ b/src/game/editor/mapitems/layer_game.cpp
@@ -60,6 +60,26 @@ void CLayerGame::SetTile(int x, int y, CTile Tile)
 	}
 }
 
+bool CLayerGame::IsEmpty() const
+{
+	for(int y = 0; y < m_Height; y++)
+	{
+		for(int x = 0; x < m_Width; x++)
+		{
+			const int Index = GetTile(x, y).m_Index;
+			if(Index == 0)
+			{
+				continue;
+			}
+			if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidGameTile(Index))
+			{
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
 CUi::EPopupMenuFunctionResult CLayerGame::RenderProperties(CUIRect *pToolbox)
 {
 	const CUi::EPopupMenuFunctionResult Result = CLayerTiles::RenderProperties(pToolbox);

--- a/src/game/editor/mapitems/layer_game.h
+++ b/src/game/editor/mapitems/layer_game.h
@@ -11,6 +11,8 @@ public:
 
 	[[nodiscard]] CTile GetTile(int x, int y) const override;
 	void SetTile(int x, int y, CTile Tile) override;
+	[[nodiscard]] bool IsEmpty() const override;
+
 	const char *TypeName() const override;
 
 	CUi::EPopupMenuFunctionResult RenderProperties(CUIRect *pToolbox) override;

--- a/src/game/editor/mapitems/layer_game.h
+++ b/src/game/editor/mapitems/layer_game.h
@@ -9,7 +9,7 @@ public:
 	CLayerGame(CEditor *pEditor, int w, int h);
 	~CLayerGame();
 
-	CTile GetTile(int x, int y) override;
+	[[nodiscard]] CTile GetTile(int x, int y) const override;
 	void SetTile(int x, int y, CTile Tile) override;
 	const char *TypeName() const override;
 

--- a/src/game/editor/mapitems/layer_speedup.cpp
+++ b/src/game/editor/mapitems/layer_speedup.cpp
@@ -55,13 +55,23 @@ void CLayerSpeedup::Shift(int Direction)
 	ShiftImpl(m_pSpeedupTile, Direction, m_pEditor->m_ShiftBy);
 }
 
-bool CLayerSpeedup::IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer)
+bool CLayerSpeedup::IsEmpty() const
 {
-	for(int y = 0; y < pLayer->m_Height; y++)
-		for(int x = 0; x < pLayer->m_Width; x++)
-			if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidSpeedupTile(pLayer->GetTile(x, y).m_Index))
+	for(int y = 0; y < m_Height; y++)
+	{
+		for(int x = 0; x < m_Width; x++)
+		{
+			const int Index = GetTile(x, y).m_Index;
+			if(Index == 0)
+			{
+				continue;
+			}
+			if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidSpeedupTile(Index))
+			{
 				return false;
-
+			}
+		}
+	}
 	return true;
 }
 
@@ -80,7 +90,7 @@ void CLayerSpeedup::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 		m_pEditor->m_SpeedupMaxSpeed = pSpeedupLayer->m_SpeedupMaxSpeed;
 	}
 
-	bool Destructive = m_pEditor->m_BrushDrawDestructive || IsEmpty(pSpeedupLayer);
+	bool Destructive = m_pEditor->m_BrushDrawDestructive || pSpeedupLayer->IsEmpty();
 
 	for(int y = 0; y < pSpeedupLayer->m_Height; y++)
 		for(int x = 0; x < pSpeedupLayer->m_Width; x++)
@@ -254,7 +264,7 @@ void CLayerSpeedup::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CU
 
 	std::shared_ptr<CLayerSpeedup> pLt = std::static_pointer_cast<CLayerSpeedup>(pBrush);
 
-	bool Destructive = m_pEditor->m_BrushDrawDestructive || Empty || IsEmpty(pLt);
+	bool Destructive = m_pEditor->m_BrushDrawDestructive || Empty || pLt->IsEmpty();
 
 	for(int y = 0; y < h; y++)
 	{

--- a/src/game/editor/mapitems/layer_speedup.h
+++ b/src/game/editor/mapitems/layer_speedup.h
@@ -30,7 +30,7 @@ public:
 
 	void Resize(int NewW, int NewH) override;
 	void Shift(int Direction) override;
-	bool IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer) override;
+	[[nodiscard]] bool IsEmpty() const override;
 	void BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos) override;
 	void BrushFlipX() override;
 	void BrushFlipY() override;

--- a/src/game/editor/mapitems/layer_switch.cpp
+++ b/src/game/editor/mapitems/layer_switch.cpp
@@ -57,13 +57,23 @@ void CLayerSwitch::Shift(int Direction)
 	ShiftImpl(m_pSwitchTile, Direction, m_pEditor->m_ShiftBy);
 }
 
-bool CLayerSwitch::IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer)
+bool CLayerSwitch::IsEmpty() const
 {
-	for(int y = 0; y < pLayer->m_Height; y++)
-		for(int x = 0; x < pLayer->m_Width; x++)
-			if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidSwitchTile(pLayer->GetTile(x, y).m_Index))
+	for(int y = 0; y < m_Height; y++)
+	{
+		for(int x = 0; x < m_Width; x++)
+		{
+			const int Index = GetTile(x, y).m_Index;
+			if(Index == 0)
+			{
+				continue;
+			}
+			if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidSwitchTile(Index))
+			{
 				return false;
-
+			}
+		}
+	}
 	return true;
 }
 
@@ -81,7 +91,7 @@ void CLayerSwitch::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 		m_pEditor->m_SwitchDelay = pSwitchLayer->m_SwitchDelay;
 	}
 
-	bool Destructive = m_pEditor->m_BrushDrawDestructive || IsEmpty(pSwitchLayer);
+	bool Destructive = m_pEditor->m_BrushDrawDestructive || pSwitchLayer->IsEmpty();
 
 	for(int y = 0; y < pSwitchLayer->m_Height; y++)
 		for(int x = 0; x < pSwitchLayer->m_Width; x++)
@@ -239,7 +249,7 @@ void CLayerSwitch::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUI
 
 	std::shared_ptr<CLayerSwitch> pLt = std::static_pointer_cast<CLayerSwitch>(pBrush);
 
-	bool Destructive = m_pEditor->m_BrushDrawDestructive || Empty || IsEmpty(pLt);
+	bool Destructive = m_pEditor->m_BrushDrawDestructive || Empty || pLt->IsEmpty();
 
 	for(int y = 0; y < h; y++)
 	{

--- a/src/game/editor/mapitems/layer_switch.h
+++ b/src/game/editor/mapitems/layer_switch.h
@@ -29,7 +29,7 @@ public:
 
 	void Resize(int NewW, int NewH) override;
 	void Shift(int Direction) override;
-	bool IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer) override;
+	[[nodiscard]] bool IsEmpty() const override;
 	void BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos) override;
 	void BrushFlipX() override;
 	void BrushFlipY() override;

--- a/src/game/editor/mapitems/layer_tele.cpp
+++ b/src/game/editor/mapitems/layer_tele.cpp
@@ -58,13 +58,23 @@ void CLayerTele::Shift(int Direction)
 	ShiftImpl(m_pTeleTile, Direction, m_pEditor->m_ShiftBy);
 }
 
-bool CLayerTele::IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer)
+bool CLayerTele::IsEmpty() const
 {
-	for(int y = 0; y < pLayer->m_Height; y++)
-		for(int x = 0; x < pLayer->m_Width; x++)
-			if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidTeleTile(pLayer->GetTile(x, y).m_Index))
+	for(int y = 0; y < m_Height; y++)
+	{
+		for(int x = 0; x < m_Width; x++)
+		{
+			const int Index = GetTile(x, y).m_Index;
+			if(Index == 0)
+			{
+				continue;
+			}
+			if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidTeleTile(Index))
+			{
 				return false;
-
+			}
+		}
+	}
 	return true;
 }
 
@@ -79,7 +89,7 @@ void CLayerTele::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 	if(str_comp(pTeleLayer->m_aFileName, m_pEditor->m_aFileName))
 		m_pEditor->m_TeleNumber = pTeleLayer->m_TeleNum;
 
-	bool Destructive = m_pEditor->m_BrushDrawDestructive || IsEmpty(pTeleLayer);
+	bool Destructive = m_pEditor->m_BrushDrawDestructive || pTeleLayer->IsEmpty();
 
 	for(int y = 0; y < pTeleLayer->m_Height; y++)
 		for(int x = 0; x < pTeleLayer->m_Width; x++)
@@ -229,7 +239,7 @@ void CLayerTele::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRe
 
 	std::shared_ptr<CLayerTele> pLt = std::static_pointer_cast<CLayerTele>(pBrush);
 
-	bool Destructive = m_pEditor->m_BrushDrawDestructive || Empty || IsEmpty(pLt);
+	bool Destructive = m_pEditor->m_BrushDrawDestructive || Empty || pLt->IsEmpty();
 
 	for(int y = 0; y < h; y++)
 	{

--- a/src/game/editor/mapitems/layer_tele.h
+++ b/src/game/editor/mapitems/layer_tele.h
@@ -27,7 +27,7 @@ public:
 
 	void Resize(int NewW, int NewH) override;
 	void Shift(int Direction) override;
-	bool IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer) override;
+	[[nodiscard]] bool IsEmpty() const override;
 	void BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos) override;
 	void BrushFlipX() override;
 	void BrushFlipY() override;

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -76,7 +76,7 @@ CLayerTiles::~CLayerTiles()
 	delete[] m_pTiles;
 }
 
-CTile CLayerTiles::GetTile(int x, int y)
+CTile CLayerTiles::GetTile(int x, int y) const
 {
 	return m_pTiles[y * m_Width + x];
 }

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -248,31 +248,18 @@ bool CLayerTiles::IsEntitiesLayer() const
 	return m_pEditor->m_Map.m_pGameLayer.get() == this || m_pEditor->m_Map.m_pTeleLayer.get() == this || m_pEditor->m_Map.m_pSpeedupLayer.get() == this || m_pEditor->m_Map.m_pFrontLayer.get() == this || m_pEditor->m_Map.m_pSwitchLayer.get() == this || m_pEditor->m_Map.m_pTuneLayer.get() == this;
 }
 
-bool CLayerTiles::IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer)
+bool CLayerTiles::IsEmpty() const
 {
-	for(int y = 0; y < pLayer->m_Height; y++)
+	for(int y = 0; y < m_Height; y++)
 	{
-		for(int x = 0; x < pLayer->m_Width; x++)
+		for(int x = 0; x < m_Width; x++)
 		{
-			int Index = pLayer->GetTile(x, y).m_Index;
-			if(Index)
+			if(GetTile(x, y).m_Index != 0)
 			{
-				if(pLayer->m_HasGame)
-				{
-					if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidGameTile(Index))
-						return false;
-				}
-				else if(pLayer->m_HasFront)
-				{
-					if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidFrontTile(Index))
-						return false;
-				}
-				else
-					return false;
+				return false;
 			}
 		}
 	}
-
 	return true;
 }
 
@@ -530,7 +517,7 @@ void CLayerTiles::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIR
 
 	std::shared_ptr<CLayerTiles> pLt = std::static_pointer_cast<CLayerTiles>(pBrush);
 
-	bool Destructive = m_pEditor->m_BrushDrawDestructive || Empty || IsEmpty(pLt);
+	bool Destructive = m_pEditor->m_BrushDrawDestructive || Empty || pLt->IsEmpty();
 
 	for(int y = 0; y < h; y++)
 	{
@@ -574,7 +561,7 @@ void CLayerTiles::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 	int sx = ConvertX(WorldPos.x);
 	int sy = ConvertY(WorldPos.y);
 
-	bool Destructive = m_pEditor->m_BrushDrawDestructive || IsEmpty(pTileLayer);
+	bool Destructive = m_pEditor->m_BrushDrawDestructive || pTileLayer->IsEmpty();
 
 	for(int y = 0; y < pTileLayer->m_Height; y++)
 		for(int x = 0; x < pTileLayer->m_Width; x++)

--- a/src/game/editor/mapitems/layer_tiles.h
+++ b/src/game/editor/mapitems/layer_tiles.h
@@ -101,7 +101,7 @@ public:
 	CLayerTiles(const CLayerTiles &Other);
 	~CLayerTiles();
 
-	virtual CTile GetTile(int x, int y);
+	[[nodiscard]] virtual CTile GetTile(int x, int y) const;
 	virtual void SetTile(int x, int y, CTile Tile);
 	void SetTileIgnoreHistory(int x, int y, CTile Tile) const;
 

--- a/src/game/editor/mapitems/layer_tiles.h
+++ b/src/game/editor/mapitems/layer_tiles.h
@@ -119,7 +119,7 @@ public:
 
 	bool IsEntitiesLayer() const override;
 
-	virtual bool IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer);
+	[[nodiscard]] virtual bool IsEmpty() const;
 	void BrushSelecting(CUIRect Rect) override;
 	int BrushGrab(std::shared_ptr<CLayerGroup> pBrush, CUIRect Rect) override;
 	void FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRect Rect) override;

--- a/src/game/editor/mapitems/layer_tune.cpp
+++ b/src/game/editor/mapitems/layer_tune.cpp
@@ -58,13 +58,23 @@ void CLayerTune::Shift(int Direction)
 	ShiftImpl(m_pTuneTile, Direction, m_pEditor->m_ShiftBy);
 }
 
-bool CLayerTune::IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer)
+bool CLayerTune::IsEmpty() const
 {
-	for(int y = 0; y < pLayer->m_Height; y++)
-		for(int x = 0; x < pLayer->m_Width; x++)
-			if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidTuneTile(pLayer->GetTile(x, y).m_Index))
+	for(int y = 0; y < m_Height; y++)
+	{
+		for(int x = 0; x < m_Width; x++)
+		{
+			const int Index = GetTile(x, y).m_Index;
+			if(Index == 0)
+			{
+				continue;
+			}
+			if(m_pEditor->IsAllowPlaceUnusedTiles() || IsValidTuneTile(Index))
+			{
 				return false;
-
+			}
+		}
+	}
 	return true;
 }
 
@@ -81,7 +91,7 @@ void CLayerTune::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 		m_pEditor->m_TuningNum = pTuneLayer->m_TuningNumber;
 	}
 
-	bool Destructive = m_pEditor->m_BrushDrawDestructive || IsEmpty(pTuneLayer);
+	bool Destructive = m_pEditor->m_BrushDrawDestructive || pTuneLayer->IsEmpty();
 
 	for(int y = 0; y < pTuneLayer->m_Height; y++)
 		for(int x = 0; x < pTuneLayer->m_Width; x++)
@@ -215,7 +225,7 @@ void CLayerTune::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRe
 
 	std::shared_ptr<CLayerTune> pLt = std::static_pointer_cast<CLayerTune>(pBrush);
 
-	bool Destructive = m_pEditor->m_BrushDrawDestructive || Empty || IsEmpty(pLt);
+	bool Destructive = m_pEditor->m_BrushDrawDestructive || Empty || pLt->IsEmpty();
 
 	for(int y = 0; y < h; y++)
 	{

--- a/src/game/editor/mapitems/layer_tune.h
+++ b/src/game/editor/mapitems/layer_tune.h
@@ -26,7 +26,7 @@ public:
 
 	void Resize(int NewW, int NewH) override;
 	void Shift(int Direction) override;
-	bool IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer) override;
+	[[nodiscard]] bool IsEmpty() const override;
 	void BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos) override;
 	void BrushFlipX() override;
 	void BrushFlipY() override;


### PR DESCRIPTION
Fix inconsistent behavior when drawing with a non-destructive brush with unused tiles enabled. Previously, tile index `0` was not considered empty for speedup, switch, tele and tune layers when drawing a brush in non-destructive mode, but only for game, front and regular tile layers. Now, tile index `0` is consistently considered empty for all types of tiles and entities layers.

Make the `CLayerTiles::IsEmpty` function a real member function acting on `this` layer instead of acting on a pointer being passed as an argument.

Mark the `CLayerTiles::IsEmpty` function as `const` and `[[nodiscard]]`.

Move implementation for game and front layers from `CLayerTiles` class to subclasses `CLayerGame` and `CLayerFront`, consistently with the implementation for the other entities layers.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
