### PR TITLE
Improve debug graphs: add avg./min./max. values, add header/footer

### DIFF
--- a/src/engine/client/graph.cpp
+++ b/src/engine/client/graph.cpp
@@ -1,13 +1,17 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
+#include "graph.h"
+
 #include <engine/graphics.h>
 #include <engine/textrender.h>
 
-#include "graph.h"
+#include <limits>
 
-CGraph::CGraph(int MaxEntries) :
-	m_Entries(MaxEntries * (sizeof(SEntry) + 2 * CRingBufferBase::ITEM_SIZE), CRingBufferBase::FLAG_RECYCLE)
+CGraph::CGraph(int MaxEntries, int Precision, bool SummaryStats) :
+	m_Entries(MaxEntries * (sizeof(CEntry) + 2 * CRingBufferBase::ITEM_SIZE), CRingBufferBase::FLAG_RECYCLE),
+	m_Precision(Precision),
+	m_SummaryStats(SummaryStats)
 {
 }
 
@@ -16,18 +20,19 @@ void CGraph::Init(float Min, float Max)
 	m_Entries.Clear();
 	m_pFirstScaled = nullptr;
 	m_RenderedTotalTime = 0;
+	m_Average = 0.0f;
 	SetMin(Min);
 	SetMax(Max);
 }
 
 void CGraph::SetMin(float Min)
 {
-	m_MinRange = m_Min = Min;
+	m_MinRange = m_MinValue = m_MinAxis = Min;
 }
 
 void CGraph::SetMax(float Max)
 {
-	m_MaxRange = m_Max = Max;
+	m_MaxRange = m_MaxValue = m_MaxAxis = Max;
 }
 
 void CGraph::Scale(int64_t WantedTotalTime)
@@ -48,7 +53,7 @@ void CGraph::Scale(int64_t WantedTotalTime)
 			m_pFirstScaled = m_Entries.Last();
 			while(m_pFirstScaled)
 			{
-				SEntry *pPrev = m_Entries.Prev(m_pFirstScaled);
+				CEntry *pPrev = m_Entries.Prev(m_pFirstScaled);
 				if(pPrev == nullptr)
 					break;
 				if(pPrev->m_Time < EndTime - WantedTotalTime)
@@ -68,7 +73,7 @@ void CGraph::Scale(int64_t WantedTotalTime)
 		if(m_pFirstScaled)
 		{
 			m_pFirstScaled->m_ApplyColor = true;
-			SEntry *pNext = m_Entries.Next(m_pFirstScaled);
+			CEntry *pNext = m_Entries.Next(m_pFirstScaled);
 			if(pNext != nullptr)
 			{
 				pNext->m_ApplyColor = true;
@@ -82,14 +87,43 @@ void CGraph::Scale(int64_t WantedTotalTime)
 	}
 
 	// Scale Y axis
-	m_Min = m_MinRange;
-	m_Max = m_MaxRange;
-	for(SEntry *pEntry = m_pFirstScaled; pEntry != nullptr; pEntry = m_Entries.Next(pEntry))
+	m_Average = 0.0f;
+	size_t NumValues = 0;
+	m_MinAxis = m_MinRange;
+	m_MaxAxis = m_MaxRange;
+	m_MinValue = std::numeric_limits<float>::max();
+	m_MaxValue = std::numeric_limits<float>::min();
+	for(CEntry *pEntry = m_pFirstScaled; pEntry != nullptr; pEntry = m_Entries.Next(pEntry))
 	{
-		if(pEntry->m_Value > m_Max)
-			m_Max = pEntry->m_Value;
-		else if(pEntry->m_Value < m_Min)
-			m_Min = pEntry->m_Value;
+		const float Value = pEntry->m_Value;
+		m_Average += Value;
+		++NumValues;
+
+		if(Value > m_MaxAxis)
+		{
+			m_MaxAxis = Value;
+		}
+		else if(Value < m_MinAxis)
+		{
+			m_MinAxis = Value;
+		}
+
+		if(Value > m_MaxValue)
+		{
+			m_MaxValue = Value;
+		}
+		else if(Value < m_MinValue)
+		{
+			m_MinValue = Value;
+		}
+	}
+	if(m_MaxValue < m_MinValue)
+	{
+		m_MinValue = m_MaxValue = 0.0f;
+	}
+	if(NumValues)
+	{
+		m_Average /= NumValues;
 	}
 }
 
@@ -100,21 +134,21 @@ void CGraph::Add(float Value, ColorRGBA Color)
 
 void CGraph::InsertAt(int64_t Time, float Value, ColorRGBA Color)
 {
-	SEntry *pEntry = m_Entries.Allocate(sizeof(SEntry));
+	CEntry *pEntry = m_Entries.Allocate(sizeof(CEntry));
 	pEntry->m_Time = Time;
 	pEntry->m_Value = Value;
 	pEntry->m_Color = Color;
 
 	// Determine whether the line (pPrev, pEntry) has different
 	// vertex colors than the line (pPrevPrev, pPrev).
-	SEntry *pPrev = m_Entries.Prev(pEntry);
+	CEntry *pPrev = m_Entries.Prev(pEntry);
 	if(pPrev == nullptr)
 	{
 		pEntry->m_ApplyColor = true;
 	}
 	else
 	{
-		SEntry *pPrevPrev = m_Entries.Prev(pPrev);
+		CEntry *pPrevPrev = m_Entries.Prev(pPrev);
 		if(pPrevPrev == nullptr)
 		{
 			pEntry->m_ApplyColor = true;
@@ -126,76 +160,97 @@ void CGraph::InsertAt(int64_t Time, float Value, ColorRGBA Color)
 	}
 }
 
+void CGraph::RenderDataLines(IGraphics *pGraphics, float x, float y, float w, float h)
+{
+	if(m_pFirstScaled == nullptr)
+	{
+		return;
+	}
+
+	IGraphics::CLineItemBatch LineItemBatch;
+	pGraphics->LinesBatchBegin(&LineItemBatch);
+
+	const int64_t StartTime = m_pFirstScaled->m_Time;
+
+	CEntry *pEntry0 = m_pFirstScaled;
+	int a0 = round_to_int((pEntry0->m_Time - StartTime) * w / m_RenderedTotalTime);
+	int v0 = round_to_int((pEntry0->m_Value - m_MinAxis) * h / (m_MaxAxis - m_MinAxis));
+	while(pEntry0 != nullptr)
+	{
+		CEntry *pEntry1 = m_Entries.Next(pEntry0);
+		if(pEntry1 == nullptr)
+			break;
+
+		const int a1 = round_to_int((pEntry1->m_Time - StartTime) * w / m_RenderedTotalTime);
+		const int v1 = round_to_int((pEntry1->m_Value - m_MinAxis) * h / (m_MaxAxis - m_MinAxis));
+
+		if(pEntry1->m_ApplyColor)
+		{
+			pGraphics->LinesBatchEnd(&LineItemBatch);
+			pGraphics->LinesBatchBegin(&LineItemBatch);
+
+			const IGraphics::CColorVertex aColorVertices[] = {
+				IGraphics::CColorVertex(0, pEntry0->m_Color.r, pEntry0->m_Color.g, pEntry0->m_Color.b, pEntry0->m_Color.a),
+				IGraphics::CColorVertex(1, pEntry1->m_Color.r, pEntry1->m_Color.g, pEntry1->m_Color.b, pEntry1->m_Color.a)};
+			pGraphics->SetColorVertex(aColorVertices, std::size(aColorVertices));
+		}
+		const IGraphics::CLineItem Item = IGraphics::CLineItem(
+			x + a0,
+			y + h - v0,
+			x + a1,
+			y + h - v1);
+		pGraphics->LinesBatchDraw(&LineItemBatch, &Item, 1);
+
+		pEntry0 = pEntry1;
+		a0 = a1;
+		v0 = v1;
+	}
+	pGraphics->LinesBatchEnd(&LineItemBatch);
+}
+
 void CGraph::Render(IGraphics *pGraphics, ITextRender *pTextRender, float x, float y, float w, float h, const char *pDescription)
 {
+	const float FontSize = 12.0f;
+	const float Spacing = 2.0f;
+	const float HeaderHeight = FontSize + 2.0f * Spacing;
+
 	pGraphics->TextureClear();
 
 	pGraphics->QuadsBegin();
-	pGraphics->SetColor(0.0f, 0.0f, 0.0f, 0.75f);
-	IGraphics::CQuadItem QuadItem(x, y, w, h);
-	pGraphics->QuadsDrawTL(&QuadItem, 1);
+	pGraphics->SetColor(ColorRGBA(0.0f, 0.0f, 0.0f, 0.7f));
+	const IGraphics::CQuadItem ItemHeader(x, y, w, HeaderHeight);
+	pGraphics->QuadsDrawTL(&ItemHeader, 1);
+	const IGraphics::CQuadItem ItemFooter(x, y + h - HeaderHeight, w, HeaderHeight);
+	pGraphics->QuadsDrawTL(&ItemFooter, 1);
+	pGraphics->SetColor(ColorRGBA(0.0f, 0.0f, 0.0f, 0.6f));
+	const IGraphics::CQuadItem ItemGraph(x, y + HeaderHeight, w, h - 2.0f * HeaderHeight);
+	pGraphics->QuadsDrawTL(&ItemGraph, 1);
 	pGraphics->QuadsEnd();
 
 	pGraphics->LinesBegin();
-	pGraphics->SetColor(0.95f, 0.95f, 0.95f, 1.0f);
-	IGraphics::CLineItem LineItem(x, y + h / 2, x + w, y + h / 2);
-	pGraphics->LinesDraw(&LineItem, 1);
-
-	pGraphics->SetColor(0.5f, 0.5f, 0.5f, 0.75f);
-	IGraphics::CLineItem aLineItems[2] = {
-		IGraphics::CLineItem(x, y + (h * 3) / 4, x + w, y + (h * 3) / 4),
-		IGraphics::CLineItem(x, y + h / 4, x + w, y + h / 4)};
+	pGraphics->SetColor(ColorRGBA(0.5f, 0.5f, 0.5f, 0.75f));
+	const IGraphics::CLineItem aLineItems[] = {
+		IGraphics::CLineItem(ItemGraph.m_X, ItemGraph.m_Y + (ItemGraph.m_Height * 3) / 4, ItemGraph.m_X + ItemGraph.m_Width, ItemGraph.m_Y + (ItemGraph.m_Height * 3) / 4),
+		IGraphics::CLineItem(ItemGraph.m_X, ItemGraph.m_Y + ItemGraph.m_Height / 2, ItemGraph.m_X + ItemGraph.m_Width, ItemGraph.m_Y + ItemGraph.m_Height / 2),
+		IGraphics::CLineItem(ItemGraph.m_X, ItemGraph.m_Y + ItemGraph.m_Height / 4, ItemGraph.m_X + ItemGraph.m_Width, ItemGraph.m_Y + ItemGraph.m_Height / 4)};
 	pGraphics->LinesDraw(aLineItems, std::size(aLineItems));
 	pGraphics->LinesEnd();
 
-	if(m_pFirstScaled != nullptr)
+	RenderDataLines(pGraphics, ItemGraph.m_X, ItemGraph.m_Y + 1.0f, ItemGraph.m_Width, ItemGraph.m_Height + 2.0f);
+
+	char aBuf[128];
+
+	pTextRender->Text(ItemHeader.m_X + Spacing, ItemHeader.m_Y + Spacing, FontSize, pDescription);
+
+	if(m_SummaryStats)
 	{
-		IGraphics::CLineItemBatch LineItemBatch;
-		pGraphics->LinesBatchBegin(&LineItemBatch);
-
-		const int64_t StartTime = m_pFirstScaled->m_Time;
-
-		SEntry *pEntry0 = m_pFirstScaled;
-		int a0 = round_to_int((pEntry0->m_Time - StartTime) * w / m_RenderedTotalTime);
-		int v0 = round_to_int((pEntry0->m_Value - m_Min) * h / (m_Max - m_Min));
-		while(pEntry0 != nullptr)
-		{
-			SEntry *pEntry1 = m_Entries.Next(pEntry0);
-			if(pEntry1 == nullptr)
-				break;
-
-			const int a1 = round_to_int((pEntry1->m_Time - StartTime) * w / m_RenderedTotalTime);
-			const int v1 = round_to_int((pEntry1->m_Value - m_Min) * h / (m_Max - m_Min));
-
-			if(pEntry1->m_ApplyColor)
-			{
-				pGraphics->LinesBatchEnd(&LineItemBatch);
-				pGraphics->LinesBatchBegin(&LineItemBatch);
-
-				IGraphics::CColorVertex aColorVertices[] = {
-					IGraphics::CColorVertex(0, pEntry0->m_Color.r, pEntry0->m_Color.g, pEntry0->m_Color.b, pEntry0->m_Color.a),
-					IGraphics::CColorVertex(1, pEntry1->m_Color.r, pEntry1->m_Color.g, pEntry1->m_Color.b, pEntry1->m_Color.a)};
-				pGraphics->SetColorVertex(aColorVertices, std::size(aColorVertices));
-			}
-			const IGraphics::CLineItem Item = IGraphics::CLineItem(x + a0, y + h - v0, x + a1, y + h - v1);
-			pGraphics->LinesBatchDraw(&LineItemBatch, &Item, 1);
-
-			pEntry0 = pEntry1;
-			a0 = a1;
-			v0 = v1;
-		}
-		pGraphics->LinesBatchEnd(&LineItemBatch);
+		str_format(aBuf, sizeof(aBuf), "Avg. %.*f   ↓ %.*f   ↑ %.*f", m_Precision, m_Average, m_Precision, m_MinValue, m_Precision, m_MaxValue);
+		pTextRender->Text(ItemFooter.m_X + Spacing, ItemFooter.m_Y + ItemFooter.m_Height - FontSize - Spacing, FontSize, aBuf);
 	}
 
-	const float FontSize = 12.0f;
-	const float Spacing = 2.0f;
+	str_format(aBuf, sizeof(aBuf), "%.*f", m_Precision, m_MaxAxis);
+	pTextRender->Text(ItemHeader.m_X + ItemHeader.m_Width - pTextRender->TextWidth(FontSize, aBuf) - Spacing, ItemHeader.m_Y + Spacing, FontSize, aBuf);
 
-	pTextRender->Text(x + Spacing, y + h - FontSize - Spacing, FontSize, pDescription);
-
-	char aBuf[32];
-	str_format(aBuf, sizeof(aBuf), "%.2f", m_Max);
-	pTextRender->Text(x + w - pTextRender->TextWidth(FontSize, aBuf) - Spacing, y + Spacing, FontSize, aBuf);
-
-	str_format(aBuf, sizeof(aBuf), "%.2f", m_Min);
-	pTextRender->Text(x + w - pTextRender->TextWidth(FontSize, aBuf) - Spacing, y + h - FontSize - Spacing, FontSize, aBuf);
+	str_format(aBuf, sizeof(aBuf), "%.*f", m_Precision, m_MinAxis);
+	pTextRender->Text(ItemFooter.m_X + ItemFooter.m_Width - pTextRender->TextWidth(FontSize, aBuf) - Spacing, ItemFooter.m_Y + ItemFooter.m_Height - FontSize - Spacing, FontSize, aBuf);
 }

--- a/src/engine/client/graph.h
+++ b/src/engine/client/graph.h
@@ -16,21 +16,28 @@ class ITextRender;
 class CGraph
 {
 private:
-	struct SEntry
+	class CEntry
 	{
+	public:
 		int64_t m_Time;
 		float m_Value;
 		ColorRGBA m_Color;
 		bool m_ApplyColor;
 	};
-	SEntry *m_pFirstScaled = nullptr;
+	CEntry *m_pFirstScaled = nullptr;
 	int64_t m_RenderedTotalTime = 0;
-	float m_Min, m_Max;
+	float m_Average;
+	float m_MinAxis, m_MaxAxis;
+	float m_MinValue, m_MaxValue;
 	float m_MinRange, m_MaxRange;
-	CDynamicRingBuffer<SEntry> m_Entries;
+	CDynamicRingBuffer<CEntry> m_Entries;
+	int m_Precision;
+	bool m_SummaryStats;
+
+	void RenderDataLines(IGraphics *pGraphics, float x, float y, float w, float h);
 
 public:
-	CGraph(int MaxEntries);
+	CGraph(int MaxEntries, int Precision, bool SummaryStats);
 
 	void Init(float Min, float Max);
 	void SetMin(float Min);

--- a/src/game/client/components/debughud.cpp
+++ b/src/game/client/components/debughud.cpp
@@ -15,8 +15,8 @@
 static constexpr int64_t GRAPH_MAX_VALUES = 128;
 
 CDebugHud::CDebugHud() :
-	m_RampGraph(GRAPH_MAX_VALUES),
-	m_ZoomedInGraph(GRAPH_MAX_VALUES)
+	m_RampGraph(GRAPH_MAX_VALUES, 2, false),
+	m_ZoomedInGraph(GRAPH_MAX_VALUES, 2, false)
 {
 }
 
@@ -170,9 +170,10 @@ void CDebugHud::RenderTuning()
 
 	// Render Velspeed.X * Ramp Graphs
 	Graphics()->MapScreen(0.0f, 0.0f, Graphics()->ScreenWidth(), Graphics()->ScreenHeight());
-	const float GraphSpacing = Graphics()->ScreenWidth() / 100.0f;
-	const float GraphW = Graphics()->ScreenWidth() / 4.0f;
-	const float GraphH = Graphics()->ScreenHeight() / 6.0f;
+	// Make sure graph positions and sizes are aligned with pixels to avoid lines overlapping graph edges
+	const float GraphSpacing = std::round(Graphics()->ScreenWidth() / 100.0f);
+	const float GraphW = std::round(Graphics()->ScreenWidth() / 4.0f);
+	const float GraphH = std::round(Graphics()->ScreenHeight() / 6.0f);
 	const float GraphX = GraphW;
 	const float GraphY = Graphics()->ScreenHeight() - GraphH - GraphSpacing;
 
@@ -238,7 +239,7 @@ void CDebugHud::RenderTuning()
 	str_format(aBuf, sizeof(aBuf), "Velspeed.X * Ramp in Bps (Velspeed %d to %d)", StepSizeRampGraph / 32, 128 * StepSizeRampGraph / 32);
 	m_RampGraph.Render(Graphics(), TextRender(), GraphX, GraphY, GraphW, GraphH, aBuf);
 	str_format(aBuf, sizeof(aBuf), "Max Velspeed before it ramps off:  %.2f Bps", m_SpeedTurningPoint / 32);
-	TextRender()->Text(GraphX, GraphY - GraphFontSize, GraphFontSize, aBuf);
+	TextRender()->Text(GraphX + 2.0f, GraphY + GraphH - GraphFontSize - 2.0f, GraphFontSize, aBuf);
 	str_format(aBuf, sizeof(aBuf), "Zoomed in on turning point (Velspeed %d to %d)", ((int)m_MiddleOfZoomedInGraph - 64 * StepSizeZoomedInGraph) / 32, ((int)m_MiddleOfZoomedInGraph + 64 * StepSizeZoomedInGraph) / 32);
 	m_ZoomedInGraph.Render(Graphics(), TextRender(), GraphX + GraphW + GraphSpacing, GraphY, GraphW, GraphH, aBuf);
 }


### PR DESCRIPTION
Add label to debug graphs showing the average, minimum and maximum of the currently shown range of values. The existing minimum and maximum values describe the axis values used for rendering instead of the actual minimum and maximum values.

Reduce overall background opacity of debug graphs. Add separate header and footer with darker background, to avoid graph data lines overlapping the labels.

Hide unnecessary decimal places for values in the FPS graph.

Move graph description label to the top left corner of graphs.

Make the center grid line of graphs the same color as the other grid lines, as the highlighted center line is not useful for most graphs.

Align graphs and their sizes with whole numbers to avoid graph data lines sometimes going beyond the background.

Screenshots with `dbg_graphs 1; dbg_tuning 2`:
- Before: <img width="1920" height="1080" alt="screenshot_2025-07-16_18-19-17" src="https://github.com/user-attachments/assets/84b219f1-567b-45e2-b796-8b9059edbb48" />
- After: <img width="1920" height="1080" alt="screenshot_2025-07-18_14-01-12" src="https://github.com/user-attachments/assets/be4c78ad-edfb-4635-b67f-0305ec5a656f" />


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
