### PR TITLE
Add ``CGameServer::OnSetTimedOut`` in preperation for 128 slots

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -356,6 +356,7 @@ public:
 	virtual void OnPreTickTeehistorian() = 0;
 
 	virtual void OnSetAuthed(int ClientId, int Level) = 0;
+	virtual void OnSetTimedOut(int ClientId) = 0;
 	virtual bool PlayerExists(int ClientId) const = 0;
 
 	virtual void TeehistorianRecordAntibot(const void *pData, int DataSize) = 0;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -4408,12 +4408,13 @@ bool CServer::SetTimedOut(int ClientId, int OrigId)
 	{
 		LogoutClient(ClientId, "Timeout Protection");
 	}
-	DelClientCallback(OrigId, "Timeout Protection used", this);
 	m_aClients[ClientId].m_Authed = AUTHED_NO;
 	m_aClients[ClientId].m_Flags = m_aClients[OrigId].m_Flags;
 	m_aClients[ClientId].m_DDNetVersion = m_aClients[OrigId].m_DDNetVersion;
 	m_aClients[ClientId].m_GotDDNetVersionPacket = m_aClients[OrigId].m_GotDDNetVersionPacket;
 	m_aClients[ClientId].m_DDNetVersionSettled = m_aClients[OrigId].m_DDNetVersionSettled;
+	GameServer()->OnSetTimedOut(ClientId);
+	DelClientCallback(OrigId, "Timeout Protection used", this);
 	return true;
 }
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4591,6 +4591,10 @@ void CGameContext::OnSetAuthed(int ClientId, int Level)
 	}
 }
 
+void CGameContext::OnSetTimedOut(int ClientId)
+{
+}
+
 bool CGameContext::IsRunningVote(int ClientId) const
 {
 	return m_VoteCloseTime && m_VoteCreator == ClientId;

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -623,6 +623,7 @@ public:
 	void SendRecord(int ClientId);
 	void SendFinish(int ClientId, float Time, float PreviousBestTime);
 	void OnSetAuthed(int ClientId, int Level) override;
+	void OnSetTimedOut(int ClientId) override;
 
 	void ResetTuning();
 };


### PR DESCRIPTION
This will come in handy for the planned 128 player support and reduces the diff of the currently pending pr #9274

This commit alone without 128 player support is a bit weird and empty. But it is also a rather complicated change. The gameserver, gamecontroller and antibot get the client drop with a different state now. This is why reviewing and merging this independently has its advantages. Reviewing and testing this independently reduces the risk. And makes reasoning about the 128 player pr easier and merging it safer.
