### PR TITLE
Automatic quad clipping

### DIFF
--- a/src/base/vmath.h
+++ b/src/base/vmath.h
@@ -78,6 +78,7 @@ public:
 	constexpr bool operator!=(const vector2_base &vec) const { return x != vec.x || y != vec.y; }
 
 	constexpr T &operator[](const int index) { return index ? y : x; }
+	constexpr const T &operator[](const int index) const { return index ? y : x; }
 };
 
 template<Numeric T>

--- a/src/game/client/components/render_layer.h
+++ b/src/game/client/components/render_layer.h
@@ -204,6 +204,7 @@ public:
 
 protected:
 	virtual IGraphics::CTextureHandle GetTexture() const override { return m_TextureHandle; }
+	void CalculateClipping();
 
 	class CQuadLayerVisuals
 	{
@@ -230,6 +231,13 @@ protected:
 		float m_PosEnvOffset;
 		int m_ColorEnv;
 		float m_ColorEnvOffset;
+
+		// quad clipping
+		bool m_Clipped;
+		float m_ClipX;
+		float m_ClipY;
+		float m_ClipWidth;
+		float m_ClipHeight;
 	} m_QuadRenderGroup;
 
 private:


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Without putting quad layers into a group with clipping enabled, we need to check every quad if it needs to be rendered. This can be very exhaustive with huge quad layers, which is the reason why the quad-pixelart-tool adds a group and calculates clipping.

This PR introduces automatic (optional) clipping to a quad layer itself, which gets calculated on map-setup-time. This might improve FPS, because it just skips rendering the layer if a player is outside the clipping region. This works best in maps, where a huge amount of quads are regional. It is also a step towards quad clustering.

The clip region calculation also takes envelopes into account.

**Caveats:**
- Clipping is only done to grouped quad layers (all quads containing the same Envs), because otherwise the calculation gets too expensive. You'd need to calculate every minimum and maximum position offset for every Env in advance.
- Rotation disables the automatic clipping, because you can't easily determine offsets with envelope points anymore. (The quad itself can be rotated, this is only about rotation in envelopes)
- Bezier curves are not clipped perfectly, but reasonably approximated

**Screenshots:**

- Envelopeless quads clipping region
<img width="2560" height="1440" alt="screenshot_2025-07-16_16-53-06" src="https://github.com/user-attachments/assets/1976daa6-64f1-48fd-beec-7ec33e46c686" />

- pixel art test
<img width="2560" height="1440" alt="screenshot_2025-07-17_09-12-39" src="https://github.com/user-attachments/assets/da59c378-73e8-4cd5-a107-f3786c851b97" />

**Videos:**

- perfect clipping for linear envelopes

https://github.com/user-attachments/assets/b048a309-c3c2-4d20-ab06-9cc69033f3bd

- imperfect clipping for bezier envelopes

https://github.com/user-attachments/assets/535daa65-4934-4ae6-b708-92d2294144da

**Test maps:**

- linear test in attachment
- bezier test in attachment
- unclipped mona lisa in attachment, **do not open in editor if you don't have a powerful computer**
- `Abyss` and `CyberSpace` might be good ddnet test maps

[quad-clip-test-maps.zip](https://github.com/user-attachments/files/21291723/quad-clip-test-maps.zip)

**Debugging clip region:**

The red line shown in the image is **not** part of the PR and are only there to show, that this feature is tested and working. If you wish to debug quad clipping, add this lines to the end of `CQuadRenderLayer::Render`:

```C++
	if(m_QuadRenderGroup.m_Clipped)
	{
		Graphics()->TextureClear();
		Graphics()->LinesBegin();
		Graphics()->SetColor(1.0f, 0.0f, 0.0f, 1.0f);
		IGraphics::CLineItem LineItems[4] = {
			IGraphics::CLineItem(m_QuadRenderGroup.m_ClipX, m_QuadRenderGroup.m_ClipY, m_QuadRenderGroup.m_ClipX, m_QuadRenderGroup.m_ClipY + m_QuadRenderGroup.m_ClipHeight),
			IGraphics::CLineItem(m_QuadRenderGroup.m_ClipX + m_QuadRenderGroup.m_ClipWidth, m_QuadRenderGroup.m_ClipY, m_QuadRenderGroup.m_ClipX + m_QuadRenderGroup.m_ClipWidth, m_QuadRenderGroup.m_ClipY + m_QuadRenderGroup.m_ClipHeight),
			IGraphics::CLineItem(m_QuadRenderGroup.m_ClipX, m_QuadRenderGroup.m_ClipY, m_QuadRenderGroup.m_ClipX + m_QuadRenderGroup.m_ClipWidth, m_QuadRenderGroup.m_ClipY),
			IGraphics::CLineItem(m_QuadRenderGroup.m_ClipX, m_QuadRenderGroup.m_ClipY + m_QuadRenderGroup.m_ClipHeight, m_QuadRenderGroup.m_ClipX + m_QuadRenderGroup.m_ClipWidth, m_QuadRenderGroup.m_ClipY + m_QuadRenderGroup.m_ClipHeight),
		};
		Graphics()->LinesDraw(LineItems, 4);
		Graphics()->LinesEnd();
	}
```

**Benchmarks:**

I did see improvements in the released ddnet maps, but only minor ones. I could do a proper analysis of multiple maps to show some benefits if requested. You can clearly see a difference on the mona lisa map, which is admittedly more of an outlier map.

**Last words:**

The rendering now cries for proper quad grouping

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
