### PR TITLE
Move editor map to separate source and header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2518,6 +2518,7 @@ if(CLIENT)
     mapitems/layer_tune.cpp
     mapitems/layer_tune.h
     mapitems/map.cpp
+    mapitems/map.h
     mapitems/map_io.cpp
     mapitems/sound.cpp
     mapitems/sound.h

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -8764,7 +8764,6 @@ void CEditor::Init()
 	m_RenderTools.Init(m_pGraphics, m_pTextRender);
 	m_ZoomEnvelopeX.OnInit(this);
 	m_ZoomEnvelopeY.OnInit(this);
-	m_Map.m_pEditor = this;
 
 	m_vComponents.emplace_back(m_MapView);
 	m_vComponents.emplace_back(m_MapSettingsBackend);
@@ -9249,8 +9248,7 @@ bool CEditor::Load(const char *pFileName, int StorageType)
 
 bool CEditor::Append(const char *pFileName, int StorageType, bool IgnoreHistory)
 {
-	CEditorMap NewMap;
-	NewMap.m_pEditor = this;
+	CEditorMap NewMap(this);
 
 	const auto &&ErrorHandler = [this](const char *pErrorMessage) {
 		ShowFileDialogError("%s", pErrorMessage);

--- a/src/game/editor/mapitems/layer_group.cpp
+++ b/src/game/editor/mapitems/layer_group.cpp
@@ -37,30 +37,30 @@ void CLayerGroup::Convert(CUIRect *pRect) const
 void CLayerGroup::Mapping(float *pPoints) const
 {
 	float NormalParallaxZoom = std::clamp((double)(maximum(m_ParallaxX, m_ParallaxY)), 0., 100.);
-	float ParallaxZoom = m_pMap->m_pEditor->m_PreviewZoom ? NormalParallaxZoom : 100.0f;
+	float ParallaxZoom = m_pMap->Editor()->m_PreviewZoom ? NormalParallaxZoom : 100.0f;
 
-	m_pMap->m_pEditor->RenderTools()->MapScreenToWorld(
-		m_pMap->m_pEditor->MapView()->GetWorldOffset().x, m_pMap->m_pEditor->MapView()->GetWorldOffset().y,
+	m_pMap->Editor()->RenderTools()->MapScreenToWorld(
+		m_pMap->Editor()->MapView()->GetWorldOffset().x, m_pMap->Editor()->MapView()->GetWorldOffset().y,
 		m_ParallaxX, m_ParallaxY, ParallaxZoom, m_OffsetX, m_OffsetY,
-		m_pMap->m_pEditor->Graphics()->ScreenAspect(), m_pMap->m_pEditor->MapView()->GetWorldZoom(), pPoints);
+		m_pMap->Editor()->Graphics()->ScreenAspect(), m_pMap->Editor()->MapView()->GetWorldZoom(), pPoints);
 
-	pPoints[0] += m_pMap->m_pEditor->MapView()->GetEditorOffset().x;
-	pPoints[1] += m_pMap->m_pEditor->MapView()->GetEditorOffset().y;
-	pPoints[2] += m_pMap->m_pEditor->MapView()->GetEditorOffset().x;
-	pPoints[3] += m_pMap->m_pEditor->MapView()->GetEditorOffset().y;
+	pPoints[0] += m_pMap->Editor()->MapView()->GetEditorOffset().x;
+	pPoints[1] += m_pMap->Editor()->MapView()->GetEditorOffset().y;
+	pPoints[2] += m_pMap->Editor()->MapView()->GetEditorOffset().x;
+	pPoints[3] += m_pMap->Editor()->MapView()->GetEditorOffset().y;
 }
 
 void CLayerGroup::MapScreen() const
 {
 	float aPoints[4];
 	Mapping(aPoints);
-	m_pMap->m_pEditor->Graphics()->MapScreen(aPoints[0], aPoints[1], aPoints[2], aPoints[3]);
+	m_pMap->Editor()->Graphics()->MapScreen(aPoints[0], aPoints[1], aPoints[2], aPoints[3]);
 }
 
 void CLayerGroup::Render()
 {
 	MapScreen();
-	IGraphics *pGraphics = m_pMap->m_pEditor->Graphics();
+	IGraphics *pGraphics = m_pMap->Editor()->Graphics();
 
 	if(m_UseClipping)
 	{
@@ -86,14 +86,14 @@ void CLayerGroup::Render()
 				if(g_Config.m_EdShowIngameEntities && pLayer->IsEntitiesLayer() && (pLayer == m_pMap->m_pGameLayer || pLayer == m_pMap->m_pFrontLayer || pLayer == m_pMap->m_pSwitchLayer))
 				{
 					if(pLayer != m_pMap->m_pSwitchLayer)
-						m_pMap->m_pEditor->RenderGameEntities(pTiles);
-					m_pMap->m_pEditor->RenderSwitchEntities(pTiles);
+						m_pMap->Editor()->RenderGameEntities(pTiles);
+					m_pMap->Editor()->RenderSwitchEntities(pTiles);
 				}
 
 				if(pTiles->m_HasGame || pTiles->m_HasFront || pTiles->m_HasTele || pTiles->m_HasSpeedup || pTiles->m_HasTune || pTiles->m_HasSwitch)
 					continue;
 			}
-			if(m_pMap->m_pEditor->m_ShowDetail || !(pLayer->m_Flags & LAYERFLAG_DETAIL))
+			if(m_pMap->Editor()->m_ShowDetail || !(pLayer->m_Flags & LAYERFLAG_DETAIL))
 				pLayer->Render();
 		}
 	}

--- a/src/game/editor/mapitems/map.h
+++ b/src/game/editor/mapitems/map.h
@@ -1,0 +1,127 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#ifndef GAME_EDITOR_MAPITEMS_MAP_H
+#define GAME_EDITOR_MAPITEMS_MAP_H
+
+#include <base/types.h>
+
+#include <engine/shared/datafile.h>
+#include <engine/shared/jobs.h>
+
+#include <game/editor/editor_server_settings.h>
+#include <game/editor/mapitems/envelope.h>
+#include <game/editor/mapitems/layer.h>
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+class CEditor;
+class CEditorImage;
+class CEditorSound;
+class CLayerFront;
+class CLayerGroup;
+class CLayerGame;
+class CLayerImage;
+class CLayerSound;
+class CLayerSpeedup;
+class CLayerSwitch;
+class CLayerTele;
+class CLayerTune;
+class CQuad;
+
+class CDataFileWriterFinishJob : public IJob
+{
+	char m_aRealFileName[IO_MAX_PATH_LENGTH];
+	char m_aTempFileName[IO_MAX_PATH_LENGTH];
+	CDataFileWriter m_Writer;
+
+	void Run() override;
+
+public:
+	CDataFileWriterFinishJob(const char *pRealFileName, const char *pTempFileName, CDataFileWriter &&Writer);
+	const char *GetRealFileName() const { return m_aRealFileName; }
+	const char *GetTempFileName() const { return m_aTempFileName; }
+};
+
+class CEditorMap
+{
+public:
+	explicit CEditorMap(CEditor *pEditor) :
+		m_pEditor(pEditor)
+	{
+		Clean();
+	}
+
+	CEditor *Editor() const { return m_pEditor; }
+
+	bool m_Modified; // unsaved changes in manual save
+	bool m_ModifiedAuto; // unsaved changes in autosave
+	float m_LastModifiedTime;
+	float m_LastSaveTime;
+	float m_LastAutosaveUpdateTime;
+	void OnModify();
+
+	std::vector<std::shared_ptr<CLayerGroup>> m_vpGroups;
+	std::vector<std::shared_ptr<CEditorImage>> m_vpImages;
+	std::vector<std::shared_ptr<CEnvelope>> m_vpEnvelopes;
+	std::vector<std::shared_ptr<CEditorSound>> m_vpSounds;
+	std::vector<CEditorMapSetting> m_vSettings;
+
+	std::shared_ptr<CLayerGroup> m_pGameGroup;
+	std::shared_ptr<CLayerGame> m_pGameLayer;
+	std::shared_ptr<CLayerTele> m_pTeleLayer;
+	std::shared_ptr<CLayerSpeedup> m_pSpeedupLayer;
+	std::shared_ptr<CLayerFront> m_pFrontLayer;
+	std::shared_ptr<CLayerSwitch> m_pSwitchLayer;
+	std::shared_ptr<CLayerTune> m_pTuneLayer;
+
+	class CMapInfo
+	{
+	public:
+		char m_aAuthor[32];
+		char m_aVersion[16];
+		char m_aCredits[128];
+		char m_aLicense[32];
+
+		void Reset();
+		void Copy(const CMapInfo &Source);
+	};
+	CMapInfo m_MapInfo;
+	CMapInfo m_MapInfoTmp;
+
+	std::shared_ptr<CEnvelope> NewEnvelope(CEnvelope::EType Type);
+	void DeleteEnvelope(int Index);
+	void SwapEnvelopes(int Index0, int Index1);
+	template<typename F>
+	void VisitEnvelopeReferences(F &&Visitor);
+
+	std::shared_ptr<CLayerGroup> NewGroup();
+	int SwapGroups(int Index0, int Index1);
+	void DeleteGroup(int Index);
+	void ModifyImageIndex(const FIndexModifyFunction &pfnFunc);
+	void ModifyEnvelopeIndex(const FIndexModifyFunction &pfnFunc);
+	void ModifySoundIndex(const FIndexModifyFunction &pfnFunc);
+
+	void Clean();
+	void CreateDefault(IGraphics::CTextureHandle EntitiesTexture);
+
+	// io
+	bool Save(const char *pFilename, const std::function<void(const char *pErrorMessage)> &ErrorHandler);
+	bool PerformPreSaveSanityChecks(const std::function<void(const char *pErrorMessage)> &ErrorHandler);
+	bool Load(const char *pFilename, int StorageType, const std::function<void(const char *pErrorMessage)> &ErrorHandler);
+	void PerformSanityChecks(const std::function<void(const char *pErrorMessage)> &ErrorHandler);
+
+	void MakeGameGroup(std::shared_ptr<CLayerGroup> pGroup);
+	void MakeGameLayer(const std::shared_ptr<CLayer> &pLayer);
+	void MakeTeleLayer(const std::shared_ptr<CLayer> &pLayer);
+	void MakeSpeedupLayer(const std::shared_ptr<CLayer> &pLayer);
+	void MakeFrontLayer(const std::shared_ptr<CLayer> &pLayer);
+	void MakeSwitchLayer(const std::shared_ptr<CLayer> &pLayer);
+	void MakeTuneLayer(const std::shared_ptr<CLayer> &pLayer);
+
+private:
+	CEditor *m_pEditor;
+};
+
+#endif

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -29,6 +29,18 @@ public:
 	int m_SoundEnvOffset;
 };
 
+void CDataFileWriterFinishJob::Run()
+{
+	m_Writer.Finish();
+}
+
+CDataFileWriterFinishJob::CDataFileWriterFinishJob(const char *pRealFileName, const char *pTempFileName, CDataFileWriter &&Writer) :
+	m_Writer(std::move(Writer))
+{
+	str_copy(m_aRealFileName, pRealFileName);
+	str_copy(m_aTempFileName, pTempFileName);
+}
+
 bool CEditorMap::Save(const char *pFileName, const std::function<void(const char *pErrorMessage)> &ErrorHandler)
 {
 	char aFileNameTmp[IO_MAX_PATH_LENGTH];


### PR DESCRIPTION
Move the `CEditorMap` and `CDataFileWriterFinishJob` classes to a separate header file and move the function definitions to source files.

Add an explicit constructor for the `CEditorMap` class to ensure that the editor pointer is always initialized.

Add a getter `Editor()` for the editor pointer of the `CEditorMap` class, to make the member variable private.

This is preparation for moving various functions and members from the `CEditor` to the `CEditorMap` class and eventually supporting multiple maps at the same time.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
