### PR TITLE
Add enums `EState` for `CNetConnection`/`CConsoleNetConnection`

### DIFF
--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -69,13 +69,6 @@ enum
 	NET_MAX_CONSOLE_CLIENTS = 4,
 	NET_MAX_SEQUENCE = 1 << 10,
 
-	NET_CONNSTATE_OFFLINE = 0,
-	NET_CONNSTATE_TOKEN = 1,
-	NET_CONNSTATE_CONNECT = 2,
-	NET_CONNSTATE_PENDING = 3,
-	NET_CONNSTATE_ONLINE = 4,
-	NET_CONNSTATE_ERROR = 5,
-
 	NET_PACKETFLAG_UNUSED = 1 << 0,
 	NET_PACKETFLAG_TOKEN = 1 << 1,
 	NET_PACKETFLAG_CONTROL = 1 << 2,
@@ -228,16 +221,24 @@ class CNetConnection
 	// that. this should be fixed.
 	friend class CNetRecvUnpacker;
 
+public:
+	enum class EState
+	{
+		OFFLINE,
+		WANT_TOKEN,
+		CONNECT,
+		PENDING,
+		ONLINE,
+		ERROR,
+	};
+
+	SECURITY_TOKEN m_SecurityToken;
+
 private:
 	unsigned short m_Sequence;
 	unsigned short m_Ack;
 	unsigned short m_PeerAck;
-	unsigned m_State;
-
-public:
-	SECURITY_TOKEN m_SecurityToken;
-
-private:
+	EState m_State;
 	int m_RemoteClosed;
 	bool m_BlockCloseMsg;
 	bool m_UnknownSeq;
@@ -299,7 +300,7 @@ public:
 
 	const char *ErrorString();
 	void SignalResend();
-	int State() const { return m_State; }
+	EState State() const { return m_State; }
 	const NETADDR *PeerAddress() const { return &m_PeerAddr; }
 	const std::array<char, NETADDR_MAXSTRSIZE> &PeerAddressString(bool IncludePort) const
 	{
@@ -336,8 +337,16 @@ public:
 
 class CConsoleNetConnection
 {
+public:
+	enum class EState
+	{
+		OFFLINE,
+		ONLINE,
+		ERROR,
+	};
+
 private:
-	int m_State;
+	EState m_State;
 
 	NETADDR m_PeerAddr;
 	NETSOCKET m_Socket;
@@ -354,7 +363,7 @@ public:
 	int Init(NETSOCKET Socket, const NETADDR *pAddr);
 	void Disconnect(const char *pReason);
 
-	int State() const { return m_State; }
+	EState State() const { return m_State; }
 	const NETADDR *PeerAddress() const { return &m_PeerAddr; }
 	const char *ErrorString() const { return m_aErrorString; }
 

--- a/src/engine/shared/network_client.cpp
+++ b/src/engine/shared/network_client.cpp
@@ -47,7 +47,7 @@ void CNetClient::Disconnect(const char *pReason)
 void CNetClient::Update()
 {
 	m_Connection.Update();
-	if(m_Connection.State() == NET_CONNSTATE_ERROR)
+	if(m_Connection.State() == CNetConnection::EState::ERROR)
 		Disconnect(m_Connection.ErrorString());
 	m_pStun->Update();
 	m_TokenCache.Update();
@@ -116,7 +116,7 @@ int CNetClient::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken, bool Six
 			}
 			else
 			{
-				if(m_Connection.State() != NET_CONNSTATE_OFFLINE && m_Connection.State() != NET_CONNSTATE_ERROR && m_Connection.Feed(&m_RecvUnpacker.m_Data, &Addr, Token, *pResponseToken))
+				if(m_Connection.State() != CNetConnection::EState::OFFLINE && m_Connection.State() != CNetConnection::EState::ERROR && m_Connection.Feed(&m_RecvUnpacker.m_Data, &Addr, Token, *pResponseToken))
 					m_RecvUnpacker.Start(&Addr, &m_Connection, 0);
 			}
 		}
@@ -163,9 +163,9 @@ int CNetClient::Send(CNetChunk *pChunk)
 
 int CNetClient::State()
 {
-	if(m_Connection.State() == NET_CONNSTATE_ONLINE)
+	if(m_Connection.State() == CNetConnection::EState::ONLINE)
 		return NETSTATE_ONLINE;
-	if(m_Connection.State() == NET_CONNSTATE_OFFLINE)
+	if(m_Connection.State() == CNetConnection::EState::OFFLINE)
 		return NETSTATE_OFFLINE;
 	return NETSTATE_CONNECTING;
 }

--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -37,7 +37,7 @@ void CNetConnection::Reset(bool Rejoin)
 		m_TimeoutProtected = false;
 		m_TimeoutSituation = false;
 
-		m_State = NET_CONNSTATE_OFFLINE;
+		m_State = EState::OFFLINE;
 		m_Token = -1;
 		m_SecurityToken = NET_SECURITY_TOKEN_UNKNOWN;
 		m_Sixup = false;
@@ -115,7 +115,7 @@ int CNetConnection::Flush()
 
 int CNetConnection::QueueChunkEx(int Flags, int DataSize, const void *pData, int Sequence)
 {
-	if(m_State == NET_CONNSTATE_OFFLINE || m_State == NET_CONNSTATE_ERROR)
+	if(m_State == EState::OFFLINE || m_State == EState::ERROR)
 		return -1;
 
 	unsigned char *pChunkData;
@@ -202,7 +202,7 @@ void CNetConnection::Resend()
 
 int CNetConnection::Connect(const NETADDR *pAddr, int NumAddrs)
 {
-	if(State() != NET_CONNSTATE_OFFLINE)
+	if(State() != EState::OFFLINE)
 		return -1;
 
 	// init connection
@@ -215,7 +215,7 @@ int CNetConnection::Connect(const NETADDR *pAddr, int NumAddrs)
 	}
 	m_NumConnectAddrs = NumAddrs;
 	mem_zero(m_aErrorString, sizeof(m_aErrorString));
-	m_State = NET_CONNSTATE_CONNECT;
+	m_State = EState::CONNECT;
 	SendConnect();
 	return 0;
 }
@@ -229,7 +229,7 @@ void CNetConnection::SendControlWithToken7(int ControlMsg, SECURITY_TOKEN Respon
 
 int CNetConnection::Connect7(const NETADDR *pAddr, int NumAddrs)
 {
-	if(State() != NET_CONNSTATE_OFFLINE)
+	if(State() != EState::OFFLINE)
 		return -1;
 
 	// init connection
@@ -243,7 +243,7 @@ int CNetConnection::Connect7(const NETADDR *pAddr, int NumAddrs)
 	SetPeerAddr(pAddr);
 	SetToken7(GenerateToken7(pAddr));
 	mem_zero(m_aErrorString, sizeof(m_aErrorString));
-	m_State = NET_CONNSTATE_TOKEN;
+	m_State = EState::WANT_TOKEN;
 	SendControlWithToken7(NET_CTRLMSG_TOKEN, NET_TOKEN_NONE);
 	m_Sixup = true;
 	return 0;
@@ -251,7 +251,7 @@ int CNetConnection::Connect7(const NETADDR *pAddr, int NumAddrs)
 
 void CNetConnection::SetToken7(TOKEN Token)
 {
-	if(State() != NET_CONNSTATE_OFFLINE)
+	if(State() != EState::OFFLINE)
 		return;
 
 	m_Token = Token;
@@ -266,7 +266,7 @@ TOKEN CNetConnection::GenerateToken7(const NETADDR *pPeerAddr)
 
 void CNetConnection::Disconnect(const char *pReason)
 {
-	if(State() == NET_CONNSTATE_OFFLINE)
+	if(State() == EState::OFFLINE)
 		return;
 
 	if(m_RemoteClosed == 0)
@@ -294,7 +294,7 @@ void CNetConnection::DirectInit(const NETADDR &Addr, SECURITY_TOKEN SecurityToke
 {
 	Reset();
 
-	m_State = NET_CONNSTATE_ONLINE;
+	m_State = EState::ONLINE;
 
 	SetPeerAddr(&Addr);
 	mem_zero(m_aErrorString, sizeof(m_aErrorString));
@@ -312,12 +312,12 @@ void CNetConnection::DirectInit(const NETADDR &Addr, SECURITY_TOKEN SecurityToke
 int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr, SECURITY_TOKEN SecurityToken, SECURITY_TOKEN ResponseToken)
 {
 	// Disregard packets from the wrong address, unless we don't know our peer yet.
-	if(State() != NET_CONNSTATE_OFFLINE && State() != NET_CONNSTATE_CONNECT && *pAddr != m_PeerAddr)
+	if(State() != EState::OFFLINE && State() != EState::CONNECT && *pAddr != m_PeerAddr)
 	{
 		return 0;
 	}
 
-	if(!m_Sixup && State() != NET_CONNSTATE_OFFLINE && m_SecurityToken != NET_SECURITY_TOKEN_UNKNOWN && m_SecurityToken != NET_SECURITY_TOKEN_UNSUPPORTED)
+	if(!m_Sixup && State() != EState::OFFLINE && m_SecurityToken != NET_SECURITY_TOKEN_UNKNOWN && m_SecurityToken != NET_SECURITY_TOKEN_UNSUPPORTED)
 	{
 		// supposed to have a valid token in this packet, check it
 		if(pPacket->m_DataSize < (int)sizeof(m_SecurityToken))
@@ -361,7 +361,7 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr, SECURITY_
 		if(CtrlMsg == NET_CTRLMSG_CLOSE)
 		{
 			bool IsPeer;
-			if(m_State != NET_CONNSTATE_CONNECT)
+			if(m_State != EState::CONNECT)
 			{
 				IsPeer = m_PeerAddr == *pAddr;
 			}
@@ -379,7 +379,7 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr, SECURITY_
 			}
 			if(IsPeer)
 			{
-				m_State = NET_CONNSTATE_ERROR;
+				m_State = EState::ERROR;
 				m_RemoteClosed = 1;
 
 				char aStr[256] = {0};
@@ -405,10 +405,10 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr, SECURITY_
 		{
 			if(CtrlMsg == NET_CTRLMSG_TOKEN)
 			{
-				if(State() == NET_CONNSTATE_TOKEN)
+				if(State() == EState::WANT_TOKEN)
 				{
 					m_LastRecvTime = Now;
-					m_State = NET_CONNSTATE_CONNECT;
+					m_State = EState::CONNECT;
 					m_SecurityToken = ResponseToken;
 					SendControlWithToken7(NET_CTRLMSG_CONNECT, m_SecurityToken);
 					dbg_msg("connection", "got token, replying, token=%x mytoken=%x", m_SecurityToken, m_Token);
@@ -418,7 +418,7 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr, SECURITY_
 			}
 			else
 			{
-				if(State() == NET_CONNSTATE_OFFLINE)
+				if(State() == EState::OFFLINE)
 				{
 					if(CtrlMsg == NET_CTRLMSG_CONNECT)
 					{
@@ -427,7 +427,7 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr, SECURITY_
 
 						// send response and init connection
 						Reset();
-						m_State = NET_CONNSTATE_PENDING;
+						m_State = EState::PENDING;
 						SetPeerAddr(pAddr);
 						mem_zero(m_aErrorString, sizeof(m_aErrorString));
 						m_LastSendTime = Now;
@@ -450,7 +450,7 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr, SECURITY_
 							dbg_msg("connection", "got connection, sending connect+accept");
 					}
 				}
-				else if(State() == NET_CONNSTATE_CONNECT)
+				else if(State() == EState::CONNECT)
 				{
 					// connection made
 					if(CtrlMsg == NET_CTRLMSG_CONNECTACCEPT)
@@ -471,7 +471,7 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr, SECURITY_
 						if(!IsSixup())
 							SendControl(NET_CTRLMSG_ACCEPT, nullptr, 0);
 						m_LastRecvTime = Now;
-						m_State = NET_CONNSTATE_ONLINE;
+						m_State = EState::ONLINE;
 						if(g_Config.m_Debug)
 							dbg_msg("connection", "got connect+accept, sending accept. connection online");
 					}
@@ -481,16 +481,16 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr, SECURITY_
 	}
 	else
 	{
-		if(State() == NET_CONNSTATE_PENDING)
+		if(State() == EState::PENDING)
 		{
 			m_LastRecvTime = Now;
-			m_State = NET_CONNSTATE_ONLINE;
+			m_State = EState::ONLINE;
 			if(g_Config.m_Debug)
 				dbg_msg("connection", "connecting online");
 		}
 	}
 
-	if(State() == NET_CONNSTATE_ONLINE)
+	if(State() == EState::ONLINE)
 	{
 		m_LastRecvTime = Now;
 		AckChunks(pPacket->m_Ack);
@@ -503,23 +503,23 @@ int CNetConnection::Update()
 {
 	int64_t Now = time_get();
 
-	if(State() == NET_CONNSTATE_ERROR && m_TimeoutSituation && (Now - m_LastRecvTime) > time_freq() * g_Config.m_ConnTimeoutProtection)
+	if(State() == EState::ERROR && m_TimeoutSituation && (Now - m_LastRecvTime) > time_freq() * g_Config.m_ConnTimeoutProtection)
 	{
 		m_TimeoutSituation = false;
 		SetError("Timeout Protection over");
 	}
 
-	if(State() == NET_CONNSTATE_OFFLINE || State() == NET_CONNSTATE_ERROR)
+	if(State() == EState::OFFLINE || State() == EState::ERROR)
 		return 0;
 
 	m_TimeoutSituation = false;
 
 	// check for timeout
-	if(State() != NET_CONNSTATE_OFFLINE &&
-		State() != NET_CONNSTATE_CONNECT &&
+	if(State() != EState::OFFLINE &&
+		State() != EState::CONNECT &&
 		(Now - m_LastRecvTime) > time_freq() * g_Config.m_ConnTimeout)
 	{
-		m_State = NET_CONNSTATE_ERROR;
+		m_State = EState::ERROR;
 		SetError("Timeout");
 		m_TimeoutSituation = true;
 	}
@@ -532,7 +532,7 @@ int CNetConnection::Update()
 		// check if we have some really old stuff laying around and abort if not acked
 		if(Now - pResend->m_FirstSendTime > time_freq() * g_Config.m_ConnTimeout)
 		{
-			m_State = NET_CONNSTATE_ERROR;
+			m_State = EState::ERROR;
 			char aBuf[128];
 			str_format(aBuf, sizeof(aBuf), "Too weak connection (not acked for %d seconds)", g_Config.m_ConnTimeout);
 			SetError(aBuf);
@@ -547,7 +547,7 @@ int CNetConnection::Update()
 	}
 
 	// send keep alives if nothing has happened for 250ms
-	if(State() == NET_CONNSTATE_ONLINE)
+	if(State() == EState::ONLINE)
 	{
 		if(time_get() - m_LastSendTime > time_freq() / 2) // flush connection after 500ms if needed
 		{
@@ -559,12 +559,12 @@ int CNetConnection::Update()
 		if(time_get() - m_LastSendTime > time_freq())
 			SendControl(NET_CTRLMSG_KEEPALIVE, nullptr, 0);
 	}
-	else if(State() == NET_CONNSTATE_CONNECT)
+	else if(State() == EState::CONNECT)
 	{
 		if(time_get() - m_LastSendTime > time_freq() / 2) // send a new connect every 500ms
 			SendConnect();
 	}
-	else if(State() == NET_CONNSTATE_PENDING)
+	else if(State() == EState::PENDING)
 	{
 		if(time_get() - m_LastSendTime > time_freq() / 2) // send a new connect/accept every 500ms
 			SendControl(NET_CTRLMSG_CONNECTACCEPT, SECURITY_TOKEN_MAGIC, sizeof(SECURITY_TOKEN_MAGIC));
@@ -581,7 +581,7 @@ void CNetConnection::SetTimedOut(const NETADDR *pAddr, int Sequence, int Ack, SE
 	m_Ack = Ack;
 	m_RemoteClosed = 0;
 
-	m_State = NET_CONNSTATE_ONLINE;
+	m_State = EState::ONLINE;
 	SetPeerAddr(pAddr);
 	mem_zero(m_aErrorString, sizeof(m_aErrorString));
 	m_LastSendTime = Now;

--- a/src/engine/shared/network_console.cpp
+++ b/src/engine/shared/network_console.cpp
@@ -80,7 +80,7 @@ int CNetConsole::AcceptClient(NETSOCKET Socket, const NETADDR *pAddr)
 	int FreeSlot = -1;
 	for(int i = 0; i < NET_MAX_CONSOLE_CLIENTS; i++)
 	{
-		if(m_aSlots[i].m_Connection.State() == NET_CONNSTATE_OFFLINE)
+		if(m_aSlots[i].m_Connection.State() == CConsoleNetConnection::EState::OFFLINE)
 		{
 			if(FreeSlot == -1)
 			{
@@ -124,9 +124,9 @@ void CNetConsole::Update()
 
 	for(int i = 0; i < NET_MAX_CONSOLE_CLIENTS; i++)
 	{
-		if(m_aSlots[i].m_Connection.State() == NET_CONNSTATE_ONLINE)
+		if(m_aSlots[i].m_Connection.State() == CConsoleNetConnection::EState::ONLINE)
 			m_aSlots[i].m_Connection.Update();
-		if(m_aSlots[i].m_Connection.State() == NET_CONNSTATE_ERROR)
+		if(m_aSlots[i].m_Connection.State() == CConsoleNetConnection::EState::ERROR)
 			Drop(i, m_aSlots[i].m_Connection.ErrorString());
 	}
 }
@@ -135,7 +135,7 @@ int CNetConsole::Recv(char *pLine, int MaxLength, int *pClientId)
 {
 	for(int i = 0; i < NET_MAX_CONSOLE_CLIENTS; i++)
 	{
-		if(m_aSlots[i].m_Connection.State() == NET_CONNSTATE_ONLINE && m_aSlots[i].m_Connection.Recv(pLine, MaxLength))
+		if(m_aSlots[i].m_Connection.State() == CConsoleNetConnection::EState::ONLINE && m_aSlots[i].m_Connection.Recv(pLine, MaxLength))
 		{
 			if(pClientId)
 				*pClientId = i;
@@ -147,7 +147,7 @@ int CNetConsole::Recv(char *pLine, int MaxLength, int *pClientId)
 
 int CNetConsole::Send(int ClientId, const char *pLine)
 {
-	if(m_aSlots[ClientId].m_Connection.State() == NET_CONNSTATE_ONLINE)
+	if(m_aSlots[ClientId].m_Connection.State() == CConsoleNetConnection::EState::ONLINE)
 		return m_aSlots[ClientId].m_Connection.Send(pLine);
 	else
 		return -1;

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -108,7 +108,7 @@ void CNetServer::Update()
 	for(int i = 0; i < MaxClients(); i++)
 	{
 		m_aSlots[i].m_Connection.Update();
-		if(m_aSlots[i].m_Connection.State() == NET_CONNSTATE_ERROR &&
+		if(m_aSlots[i].m_Connection.State() == CNetConnection::EState::ERROR &&
 			(!m_aSlots[i].m_Connection.m_TimeoutProtected ||
 				!m_aSlots[i].m_Connection.m_TimeoutSituation))
 		{
@@ -154,8 +154,8 @@ int CNetServer::NumClientsWithAddr(NETADDR Addr)
 	int FoundAddr = 0;
 	for(int i = 0; i < MaxClients(); ++i)
 	{
-		if(m_aSlots[i].m_Connection.State() == NET_CONNSTATE_OFFLINE ||
-			(m_aSlots[i].m_Connection.State() == NET_CONNSTATE_ERROR &&
+		if(m_aSlots[i].m_Connection.State() == CNetConnection::EState::OFFLINE ||
+			(m_aSlots[i].m_Connection.State() == CNetConnection::EState::ERROR &&
 				(!m_aSlots[i].m_Connection.m_TimeoutProtected ||
 					!m_aSlots[i].m_Connection.m_TimeoutSituation)))
 			continue;
@@ -228,7 +228,7 @@ int CNetServer::TryAcceptClient(NETADDR &Addr, SECURITY_TOKEN SecurityToken, boo
 	int Slot = -1;
 	for(int i = 0; i < MaxClients(); i++)
 	{
-		if(m_aSlots[i].m_Connection.State() == NET_CONNSTATE_OFFLINE)
+		if(m_aSlots[i].m_Connection.State() == CNetConnection::EState::OFFLINE)
 		{
 			Slot = i;
 			break;
@@ -548,8 +548,8 @@ int CNetServer::GetClientSlot(const NETADDR &Addr)
 {
 	for(int i = 0; i < MaxClients(); i++)
 	{
-		if(m_aSlots[i].m_Connection.State() != NET_CONNSTATE_OFFLINE &&
-			m_aSlots[i].m_Connection.State() != NET_CONNSTATE_ERROR &&
+		if(m_aSlots[i].m_Connection.State() != CNetConnection::EState::OFFLINE &&
+			m_aSlots[i].m_Connection.State() != CNetConnection::EState::ERROR &&
 			net_addr_comp(m_aSlots[i].m_Connection.PeerAddress(), &Addr) == 0)
 		{
 			return i;
@@ -730,7 +730,7 @@ void CNetServer::SetMaxClientsPerIp(int Max)
 
 bool CNetServer::SetTimedOut(int ClientId, int OrigId)
 {
-	if(m_aSlots[ClientId].m_Connection.State() != NET_CONNSTATE_ERROR)
+	if(m_aSlots[ClientId].m_Connection.State() != CNetConnection::EState::ERROR)
 		return false;
 
 	m_aSlots[ClientId].m_Connection.SetTimedOut(ClientAddr(OrigId), m_aSlots[OrigId].m_Connection.SeqSequence(), m_aSlots[OrigId].m_Connection.AckSequence(), m_aSlots[OrigId].m_Connection.SecurityToken(), m_aSlots[OrigId].m_Connection.ResendBuffer(), m_aSlots[OrigId].m_Connection.m_Sixup);


### PR DESCRIPTION
Add separate enums to reduce coupling and because the console connection uses less states.

Rename state `TOKEN` to `WANT_TOKEN` because it would collide with the type `TOKEN`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
