### PR TITLE
Break IDE again in tuning.h

### DIFF
--- a/src/game/tuning.h
+++ b/src/game/tuning.h
@@ -4,6 +4,7 @@
 // This file can be included several times.
 
 #ifndef MACRO_TUNING_PARAM
+#error "The config macro must be defined"
 #define MACRO_TUNING_PARAM(Name, ScriptName, Value, Description)
 #endif
 


### PR DESCRIPTION
https://github.com/ddnet/ddnet/pull/10538#pullrequestreview-3037296432

Now matches the config variables one. But also reintroduces an error in my IDE ._. but at least at a more controlled position than without any of these shenanigans.