### PR TITLE
fix overlays using wrong visual on borders

### DIFF
--- a/src/game/client/components/render_layer.cpp
+++ b/src/game/client/components/render_layer.cpp
@@ -292,13 +292,13 @@ void CRenderLayerTile::RenderTileLayer(const ColorRGBA &Color, CTileLayerVisuals
 
 	if(ScreenRectX1 > (int)Visuals.m_Width || ScreenRectY1 > (int)Visuals.m_Height || ScreenRectX0 < 0 || ScreenRectY0 < 0)
 	{
-		RenderTileBorder(Color, ScreenRectX0, ScreenRectY0, ScreenRectX1, ScreenRectY1);
+		RenderTileBorder(Color, ScreenRectX0, ScreenRectY0, ScreenRectX1, ScreenRectY1, &Visuals);
 	}
 }
 
-void CRenderLayerTile::RenderTileBorder(const ColorRGBA &Color, int BorderX0, int BorderY0, int BorderX1, int BorderY1)
+void CRenderLayerTile::RenderTileBorder(const ColorRGBA &Color, int BorderX0, int BorderY0, int BorderX1, int BorderY1, CTileLayerVisuals *pTileLayerVisuals)
 {
-	CTileLayerVisuals &Visuals = m_VisualTiles.value();
+	CTileLayerVisuals &Visuals = *pTileLayerVisuals;
 
 	int Y0 = std::max(0, BorderY0);
 	int X0 = std::max(0, BorderX0);

--- a/src/game/client/components/render_layer.h
+++ b/src/game/client/components/render_layer.h
@@ -185,7 +185,7 @@ protected:
 	virtual void RenderTileLayerNoTileBuffer(const ColorRGBA &Color);
 
 	void RenderTileLayer(const ColorRGBA &Color, CTileLayerVisuals *pTileLayerVisuals = nullptr);
-	void RenderTileBorder(const ColorRGBA &Color, int BorderX0, int BorderY0, int BorderX1, int BorderY1);
+	void RenderTileBorder(const ColorRGBA &Color, int BorderX0, int BorderY0, int BorderX1, int BorderY1, CTileLayerVisuals *pTileLayerVisuals);
 	void RenderKillTileBorder(const ColorRGBA &Color);
 
 	std::optional<CRenderLayerTile::CTileLayerVisuals> m_VisualTiles;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Change/bug is only visual, nothing to worry about

closes #10544

Before:
<img width="2560" height="1440" alt="screenshot_2025-07-22_12-17-26" src="https://github.com/user-attachments/assets/61aeb9e8-9249-4443-9ac2-8fa8873b9106" />
<img width="2560" height="1440" alt="screenshot_2025-07-22_12-18-37" src="https://github.com/user-attachments/assets/d2d216a6-a049-4865-8139-f64bbfc9a5de" />

After:
<img width="2560" height="1440" alt="screenshot_2025-07-22_12-39-31" src="https://github.com/user-attachments/assets/37b17b64-61c5-4ab7-a225-3d2efdd4812e" />


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
