### PR TITLE
Remove inconsistent composition handling of server settings input

### DIFF
--- a/src/game/editor/editor_server_settings.cpp
+++ b/src/game/editor/editor_server_settings.cpp
@@ -294,10 +294,6 @@ void CEditor::DoMapSettingsEditBox(CMapSettingsBackend::CContext *pContext, cons
 	auto &Context = *pContext;
 	Context.SetFontSize(FontSize);
 
-	// Set current active context if input is active
-	if(pLineInput->IsActive())
-		CMapSettingsBackend::ms_pActiveContext = pContext;
-
 	// Small utility to render a floating part above the input rect.
 	// Use to display either the error or the current argument name
 	const float PartMargin = 4.0f;
@@ -1049,8 +1045,6 @@ void CEditor::MapSettingsDropdownRenderCallback(const SPossibleValueMatch &Match
 }
 
 // ----------------------------------------
-
-CMapSettingsBackend::CContext *CMapSettingsBackend::ms_pActiveContext = nullptr;
 
 void CMapSettingsBackend::OnInit(CEditor *pEditor)
 {
@@ -2075,28 +2069,6 @@ void CMapSettingsBackend::CContext::GetCommandHelpText(char *pStr, int Length) c
 	str_copy(pStr, m_pCurrentSetting->m_pHelp, Length);
 }
 
-void CMapSettingsBackend::CContext::UpdateCompositionString()
-{
-	if(!m_pLineInput)
-		return;
-
-	const bool HasComposition = m_pBackend->Input()->HasComposition();
-
-	if(HasComposition)
-	{
-		const size_t CursorOffset = m_pLineInput->GetCursorOffset();
-		const size_t DisplayCursorOffset = m_pLineInput->OffsetFromActualToDisplay(CursorOffset);
-		const std::string DisplayStr = std::string(m_pLineInput->GetString());
-		std::string CompositionBuffer = DisplayStr.substr(0, DisplayCursorOffset) + m_pBackend->Input()->GetComposition() + DisplayStr.substr(DisplayCursorOffset);
-		if(CompositionBuffer != m_CompositionStringBuffer)
-		{
-			m_CompositionStringBuffer = CompositionBuffer;
-			Update();
-			UpdateCursor();
-		}
-	}
-}
-
 template<int N>
 void CMapSettingsBackend::CContext::FormatDisplayValue(const char *pValue, char (&aOut)[N])
 {
@@ -2110,20 +2082,6 @@ void CMapSettingsBackend::CContext::FormatDisplayValue(const char *pValue, char 
 	{
 		str_copy(aOut, pValue);
 	}
-}
-
-bool CMapSettingsBackend::OnInput(const IInput::CEvent &Event)
-{
-	if(ms_pActiveContext)
-		return ms_pActiveContext->OnInput(Event);
-
-	return false;
-}
-
-void CMapSettingsBackend::OnUpdate()
-{
-	if(ms_pActiveContext && ms_pActiveContext->m_pLineInput && ms_pActiveContext->m_pLineInput->IsActive())
-		ms_pActiveContext->UpdateCompositionString();
 }
 
 void CMapSettingsBackend::OnMapLoad()

--- a/src/game/editor/editor_server_settings.h
+++ b/src/game/editor/editor_server_settings.h
@@ -199,8 +199,6 @@ public: // General methods
 	CMapSettingsBackend() = default;
 
 	void OnInit(CEditor *pEditor) override;
-	bool OnInput(const IInput::CEvent &Event) override;
-	void OnUpdate() override;
 	void OnMapLoad() override;
 
 public: // Constraints methods
@@ -281,7 +279,6 @@ public: // CContext
 		void ParseArgs(const char *pLineInputStr, const char *pStr);
 		bool OnInput(const IInput::CEvent &Event);
 		const char *InputString() const;
-		void UpdateCompositionString();
 
 		template<int N>
 		void FormatDisplayValue(const char *pValue, char (&aOut)[N]);
@@ -386,8 +383,6 @@ private: // Backend fields
 	std::map<std::shared_ptr<IMapSetting>, std::vector<SParsedMapSettingArg>> m_ParsedCommandArgs; // Parsed available settings arguments, used for validation
 	TSettingsArgumentValues m_PossibleValuesPerCommand;
 	std::map<std::string, FLoaderFunction> m_LoaderFunctions;
-
-	static CContext *ms_pActiveContext;
 
 	friend class CEditor;
 


### PR DESCRIPTION
The composition text of lineinputs should generally only be considered after it has been confirmed. The `static` context pointer and overriding `OnInput` and `OnUpdate` is therefore also unnecessary, as the active lineinput already works by default.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
