### PR TITLE
Cleanup editor object and component classes

### DIFF
--- a/src/game/editor/component.cpp
+++ b/src/game/editor/component.cpp
@@ -1,13 +1,39 @@
 #include "component.h"
 
+void CEditorComponent::OnInit(CEditor *pEditor)
+{
+	CEditorObject::OnInit(pEditor);
+	OnReset();
+}
+
+void CEditorComponent::OnReset()
+{
+}
+
+void CEditorComponent::OnMapLoad()
+{
+}
+
 bool CEditorComponent::OnInput(const IInput::CEvent &Event)
 {
 	for(CEditorComponent &Component : m_vSubComponents)
 	{
-		if(Component.OnInput(Event))
+		// Events with flag `FLAG_RELEASE` must always be forwarded to all components so keys being
+		// released can be handled in all components also after some components have been disabled.
+		if(Component.OnInput(Event) && (Event.m_Flags & ~IInput::FLAG_RELEASE) != 0)
+		{
 			return true;
+		}
 	}
 	return false;
+}
+
+void CEditorComponent::OnUpdate()
+{
+}
+
+void CEditorComponent::OnRender(CUIRect View)
+{
 }
 
 void CEditorComponent::InitSubComponents()

--- a/src/game/editor/component.h
+++ b/src/game/editor/component.h
@@ -1,23 +1,41 @@
 #ifndef GAME_EDITOR_COMPONENT_H
 #define GAME_EDITOR_COMPONENT_H
 
-#include "editor_object.h"
+#include <engine/input.h>
 
+#include <game/client/ui_rect.h>
+#include <game/editor/editor_object.h>
+
+#include <functional>
 #include <vector>
 
 class CEditorComponent : public CEditorObject
 {
 public:
 	/**
-	 * Gets called before `OnRender`. Should return true
-	 * if the event was consumed. By default the events
-	 * are forwarded to the subcomponents.
+	 * Initialize the component and interface pointers.
+	 * Needs to be the first function that is called.
+	 * The default implentation also resets the component.
 	 */
-	bool OnInput(const IInput::CEvent &Event) override;
+	void OnInit(CEditor *pEditor) override;
+
+	virtual void OnReset();
+
+	virtual void OnMapLoad();
 
 	/**
-	 * Initialise all registered subcomponents.
-	 * Needs to be called after the interfaces have been initialised.
+	 * Gets called before @link OnRender @endlink. Should return `true`
+	 * if the event was consumed.
+	 */
+	virtual bool OnInput(const IInput::CEvent &Event);
+
+	virtual void OnUpdate();
+
+	virtual void OnRender(CUIRect View);
+
+	/**
+	 * Initialize all registered subcomponents.
+	 * Needs to be called after the interfaces have been initialized.
 	 */
 	void InitSubComponents();
 

--- a/src/game/editor/editor_object.cpp
+++ b/src/game/editor/editor_object.cpp
@@ -1,78 +1,33 @@
 #include "editor_object.h"
 
-#include "editor.h"
+#include <game/editor/editor.h>
 
 void CEditorObject::OnInit(CEditor *pEditor)
 {
 	m_pEditor = pEditor;
-	OnReset();
 }
-
-void CEditorObject::OnUpdate()
-{
-	if(IsActive())
-		OnActive();
-	else if(IsHot())
-		OnHot();
-}
-
-bool CEditorObject::OnInput(const IInput::CEvent &Event)
-{
-	return false;
-}
-
-void CEditorObject::OnRender(CUIRect View) {}
-
-void CEditorObject::OnReset() {}
-void CEditorObject::OnMapLoad() {}
-
-bool CEditorObject::IsHot()
-{
-	return Ui()->HotItem() == this;
-}
-
-void CEditorObject::SetHot()
-{
-	Ui()->SetHotItem(this);
-}
-
-void CEditorObject::UnsetHot()
-{
-	if(IsHot())
-		Ui()->SetHotItem(nullptr);
-}
-
-void CEditorObject::OnHot() {}
-
-bool CEditorObject::IsActive()
-{
-	return Ui()->CheckActiveItem(this);
-}
-
-void CEditorObject::SetActive()
-{
-	SetHot();
-	Ui()->SetActiveItem(this);
-}
-
-void CEditorObject::SetInactive()
-{
-	if(IsActive())
-		Ui()->SetActiveItem(nullptr);
-}
-
-void CEditorObject::OnActive() {}
 
 CEditor *CEditorObject::Editor() { return m_pEditor; }
 const CEditor *CEditorObject::Editor() const { return m_pEditor; }
 IInput *CEditorObject::Input() { return m_pEditor->Input(); }
+const IInput *CEditorObject::Input() const { return m_pEditor->Input(); }
 IClient *CEditorObject::Client() { return m_pEditor->Client(); }
+const IClient *CEditorObject::Client() const { return m_pEditor->Client(); }
 CConfig *CEditorObject::Config() { return m_pEditor->Config(); }
+const CConfig *CEditorObject::Config() const { return m_pEditor->Config(); }
 IConsole *CEditorObject::Console() { return m_pEditor->Console(); }
+const IConsole *CEditorObject::Console() const { return m_pEditor->Console(); }
 IEngine *CEditorObject::Engine() { return m_pEditor->Engine(); }
+const IEngine *CEditorObject::Engine() const { return m_pEditor->Engine(); }
 IGraphics *CEditorObject::Graphics() { return m_pEditor->Graphics(); }
+const IGraphics *CEditorObject::Graphics() const { return m_pEditor->Graphics(); }
 ISound *CEditorObject::Sound() { return m_pEditor->Sound(); }
+const ISound *CEditorObject::Sound() const { return m_pEditor->Sound(); }
 ITextRender *CEditorObject::TextRender() { return m_pEditor->TextRender(); }
+const ITextRender *CEditorObject::TextRender() const { return m_pEditor->TextRender(); }
 IStorage *CEditorObject::Storage() { return m_pEditor->Storage(); }
+const IStorage *CEditorObject::Storage() const { return m_pEditor->Storage(); }
 CUi *CEditorObject::Ui() { return m_pEditor->Ui(); }
+const CUi *CEditorObject::Ui() const { return m_pEditor->Ui(); }
 CRenderMap *CEditorObject::RenderMap() { return m_pEditor->RenderMap(); }
+const CRenderMap *CEditorObject::RenderMap() const { return m_pEditor->RenderMap(); }

--- a/src/game/editor/editor_object.h
+++ b/src/game/editor/editor_object.h
@@ -1,13 +1,8 @@
 #ifndef GAME_EDITOR_EDITOR_OBJECT_H
 #define GAME_EDITOR_EDITOR_OBJECT_H
 
-#include <functional>
-
-#include <engine/input.h>
-#include <game/client/ui_rect.h>
-
-class CUi;
 class CEditor;
+class IInput;
 class IClient;
 class CConfig;
 class IConsole;
@@ -16,6 +11,7 @@ class IGraphics;
 class ISound;
 class ITextRender;
 class IStorage;
+class CUi;
 class CRenderTools;
 class CRenderMap;
 
@@ -25,59 +21,35 @@ public:
 	virtual ~CEditorObject() = default;
 
 	/**
-	 * Initialise the component and interface pointers.
+	 * Initialize the interface pointers.
 	 * Needs to be the first function that is called.
-	 * The default implentation also resets the component.
 	 */
 	virtual void OnInit(CEditor *pEditor);
-
-	/**
-	 * Maybe calls `OnHot` or `OnActive`.
-	 */
-	virtual void OnUpdate();
-
-	/**
-	 * Gets called before `OnRender`. Should return true
-	 * if the event was consumed.
-	 */
-	virtual bool OnInput(const IInput::CEvent &Event);
-
-	virtual void OnRender(CUIRect View);
-
-	/**
-	 * Gets called after `OnRender` when the component is hot but not active.
-	 */
-	virtual void OnHot();
-
-	/**
-	 * Gets called after `OnRender` when the component is active.
-	 */
-	virtual void OnActive();
-
-	virtual void OnReset();
-	virtual void OnMapLoad();
-
-	bool IsHot();
-	void SetHot();
-	void UnsetHot();
-
-	bool IsActive();
-	void SetActive();
-	void SetInactive();
 
 	CEditor *Editor();
 	const CEditor *Editor() const;
 	IInput *Input();
+	const IInput *Input() const;
 	IClient *Client();
+	const IClient *Client() const;
 	CConfig *Config();
+	const CConfig *Config() const;
 	IConsole *Console();
+	const IConsole *Console() const;
 	IEngine *Engine();
+	const IEngine *Engine() const;
 	IGraphics *Graphics();
+	const IGraphics *Graphics() const;
 	ISound *Sound();
+	const ISound *Sound() const;
 	ITextRender *TextRender();
+	const ITextRender *TextRender() const;
 	IStorage *Storage();
+	const IStorage *Storage() const;
 	CUi *Ui();
+	const CUi *Ui() const;
 	CRenderMap *RenderMap();
+	const CRenderMap *RenderMap() const;
 
 private:
 	CEditor *m_pEditor;

--- a/src/game/editor/prompt.cpp
+++ b/src/game/editor/prompt.cpp
@@ -27,14 +27,12 @@ static bool FuzzyMatch(const char *pHaystack, const char *pNeedle)
 
 bool CPrompt::IsActive()
 {
-	return CEditorComponent::IsActive() || Editor()->m_Dialog == DIALOG_QUICK_PROMPT;
+	return Editor()->m_Dialog == DIALOG_QUICK_PROMPT;
 }
 
 void CPrompt::SetActive()
 {
 	Editor()->m_Dialog = DIALOG_QUICK_PROMPT;
-	CEditorComponent::SetActive();
-
 	Ui()->ClosePopupMenus();
 	Ui()->SetActiveItem(&m_PromptInput);
 }
@@ -47,7 +45,6 @@ void CPrompt::SetInactive()
 	{
 		Editor()->OnDialogClose();
 	}
-	CEditorComponent::SetInactive();
 }
 
 bool CPrompt::OnInput(const IInput::CEvent &Event)


### PR DESCRIPTION
Remove unnecessary, mostly unused functions for hot/active editor object handling.

Move component lifecycle callbacks consistently to `CEditorComponent`, making `CEditorObject` only the owner of editor interface pointers.

Add separate `const` interface getter functions to `CEditorObject`.

Properly handle key-release events in subcomponents like in regular components.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
