### PR TITLE
Add `CEditor::ActiveHistory` function

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -7990,9 +7990,9 @@ void CEditor::Render()
 	{
 		// handle undo/redo hotkeys
 		if(Input()->KeyPress(KEY_Z) && Input()->ModifierIsPressed() && !Input()->ShiftIsPressed())
-			UndoLastAction();
+			ActiveHistory().Undo();
 		if((Input()->KeyPress(KEY_Y) && Input()->ModifierIsPressed()) || (Input()->KeyPress(KEY_Z) && Input()->ModifierIsPressed() && Input()->ShiftIsPressed()))
-			RedoLastAction();
+			ActiveHistory().Redo();
 
 		// handle brush save/load hotkeys
 		for(int i = KEY_1; i <= KEY_0; i++)
@@ -9386,24 +9386,20 @@ bool CEditor::Append(const char *pFileName, int StorageType, bool IgnoreHistory)
 	return true;
 }
 
-void CEditor::UndoLastAction()
+CEditorHistory &CEditor::ActiveHistory()
 {
 	if(m_ActiveExtraEditor == EXTRAEDITOR_SERVER_SETTINGS)
-		m_ServerSettingsHistory.Undo();
+	{
+		return m_ServerSettingsHistory;
+	}
 	else if(m_ActiveExtraEditor == EXTRAEDITOR_ENVELOPES)
-		m_EnvelopeEditorHistory.Undo();
+	{
+		return m_EnvelopeEditorHistory;
+	}
 	else
-		m_EditorHistory.Undo();
-}
-
-void CEditor::RedoLastAction()
-{
-	if(m_ActiveExtraEditor == EXTRAEDITOR_SERVER_SETTINGS)
-		m_ServerSettingsHistory.Redo();
-	else if(m_ActiveExtraEditor == EXTRAEDITOR_ENVELOPES)
-		m_EnvelopeEditorHistory.Redo();
-	else
-		m_EditorHistory.Redo();
+	{
+		return m_EditorHistory;
+	}
 }
 
 void CEditor::AdjustBrushSpecialTiles(bool UseNextFree, int Adjust)

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -970,8 +970,7 @@ public:
 	CEnvelopeEditorOperationTracker m_EnvOpTracker;
 
 private:
-	void UndoLastAction();
-	void RedoLastAction();
+	CEditorHistory &ActiveHistory();
 
 	std::map<int, CPoint[5]> m_QuadDragOriginalPoints;
 };


### PR DESCRIPTION
To replace `UndoLastAction` and `RedoLastAction` functions and reduce duplicate code.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
