### PR TITLE
Only handle `NET_CTRLMSG_TOKEN` for 0.7 control messages

### DIFF
--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -323,9 +323,9 @@ int CNetBase::UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct
 	// set the response token (a bit hacky because this function shouldn't know about control packets)
 	if(pPacket->m_Flags & NET_PACKETFLAG_CONTROL)
 	{
-		if(pPacket->m_DataSize >= 5) // control byte + token
+		if(pPacket->m_DataSize >= 1 + (int)sizeof(SECURITY_TOKEN)) // control byte + token
 		{
-			if(pPacket->m_aChunkData[0] == NET_CTRLMSG_CONNECT || pPacket->m_aChunkData[0] == protocol7::NET_CTRLMSG_TOKEN)
+			if(pPacket->m_aChunkData[0] == NET_CTRLMSG_CONNECT || (Sixup && pPacket->m_aChunkData[0] == protocol7::NET_CTRLMSG_TOKEN))
 			{
 				*pResponseToken = ToSecurityToken(&pPacket->m_aChunkData[1]);
 			}

--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -2,6 +2,8 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "config.h"
 #include "network.h"
+
+#include <base/log.h>
 #include <base/system.h>
 
 void CNetConnection::SetPeerAddr(const NETADDR *pAddr)
@@ -403,7 +405,7 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr, SECURITY_
 		}
 		else
 		{
-			if(CtrlMsg == protocol7::NET_CTRLMSG_TOKEN)
+			if(m_Sixup && CtrlMsg == protocol7::NET_CTRLMSG_TOKEN)
 			{
 				if(State() == EState::WANT_TOKEN)
 				{
@@ -411,10 +413,15 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr, SECURITY_
 					m_State = EState::CONNECT;
 					m_SecurityToken = ResponseToken;
 					SendControlWithToken7(NET_CTRLMSG_CONNECT, m_SecurityToken);
-					dbg_msg("connection", "got token, replying, token=%x mytoken=%x", m_SecurityToken, m_Token);
+					if(g_Config.m_Debug)
+					{
+						log_debug("connection", "got token, replying, token=%x mytoken=%x", m_SecurityToken, m_Token);
+					}
 				}
 				else if(g_Config.m_Debug)
-					dbg_msg("connection", "got token, token=%x", ResponseToken);
+				{
+					log_debug("connection", "got token, token=%x", ResponseToken);
+				}
 			}
 			else
 			{

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -510,7 +510,7 @@ void CNetServer::OnTokenCtrlMsg(NETADDR &Addr, int ControlMsg, const CNetPacketC
 
 int CNetServer::OnSixupCtrlMsg(NETADDR &Addr, CNetChunk *pChunk, int ControlMsg, const CNetPacketConstruct &Packet, SECURITY_TOKEN &ResponseToken, SECURITY_TOKEN Token)
 {
-	if(m_RecvUnpacker.m_Data.m_DataSize < 5 || ClientExists(Addr))
+	if(m_RecvUnpacker.m_Data.m_DataSize < 1 + (int)sizeof(SECURITY_TOKEN) || ClientExists(Addr))
 		return 0; // silently ignore
 
 	ResponseToken = ToSecurityToken(Packet.m_aChunkData + 1);


### PR DESCRIPTION
The control message code `protocol7::NET_CTRLMSG_TOKEN` was previously, incorrectly handled also if it was sent on 0.6 connections.

Furthermore, the network client did not check for the control message flag being set, which may have caused incorrect tokens to be added to the token cache if non-control packet data started with the value of `protocol7::NET_CTRLMSG_TOKEN`.

Avoid magic number for token control message size check.

Hide 0.7 connection debug message behind `debug` config.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options: combinations of DDNet client/server with/without sixup and 0.7 server/client
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
