### PR TITLE
Properly clean buffer memory on map switch

### DIFF
--- a/src/game/client/component.h
+++ b/src/game/client/component.h
@@ -15,6 +15,7 @@ class CComponentInterfaces
 {
 public:
 	virtual void OnInterfacesInit(CGameClient *pClient);
+	virtual ~CComponentInterfaces() = default;
 
 protected:
 	/**

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -41,13 +41,18 @@ void CMapImages::OnInit()
 	Console()->Chain("cl_text_entities_size", ConchainClTextEntitiesSize, this);
 }
 
-void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
+void CMapImages::Unload()
 {
 	// unload all textures
 	for(int i = 0; i < m_Count; i++)
 	{
 		Graphics()->UnloadTexture(&m_aTextures[i]);
 	}
+}
+
+void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
+{
+	Unload();
 
 	int Start;
 	pMap->GetType(MAPITEMTYPE_IMAGE, &Start, &m_Count);

--- a/src/game/client/components/mapimages.h
+++ b/src/game/client/components/mapimages.h
@@ -60,6 +60,7 @@ public:
 	void OnMapLoadImpl(class CLayers *pLayers, class IMap *pMap);
 	void OnMapLoad() override;
 	void OnInit() override;
+	void Unload();
 	void LoadBackground(class CLayers *pLayers, class IMap *pMap);
 
 	// DDRace

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -71,6 +71,13 @@ CMapLayers::CMapLayers(int Type, bool OnlineOnly)
 	m_Params.m_RenderTileBorder = true;
 }
 
+void CMapLayers::Unload()
+{
+	for(auto &pLayer : m_vRenderLayers)
+		pLayer->Unload();
+	m_vRenderLayers.clear();
+}
+
 void CMapLayers::OnInit()
 {
 	m_pLayers = Layers();
@@ -86,7 +93,7 @@ void CMapLayers::OnMapLoad()
 {
 	m_pEnvelopePoints = std::make_shared<CMapBasedEnvelopePointAccess>(m_pLayers->Map());
 	bool PassedGameLayer = false;
-	m_vRenderLayers.clear();
+	Unload();
 
 	const char *pLoadingTitle = Localize("Loading map");
 	const char *pLoadingMessage = Localize("Uploading map data to GPU");

--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -58,6 +58,7 @@ public:
 	void OnInit() override;
 	void OnRender() override;
 	void OnMapLoad() override;
+	void Unload();
 
 	virtual CCamera *GetCurCamera();
 

--- a/src/game/client/components/render_layer.cpp
+++ b/src/game/client/components/render_layer.cpp
@@ -548,6 +548,7 @@ void CRenderLayerTile::UploadTileData(std::optional<CTileLayerVisuals> &VisualsO
 
 	// create the visual and set it in the optional, afterwards get it
 	CTileLayerVisuals v;
+	v.OnInterfacesInit(GameClient());
 	VisualsOptional = v;
 	CTileLayerVisuals &Visuals = VisualsOptional.value();
 
@@ -756,6 +757,20 @@ void CRenderLayerTile::UploadTileData(std::optional<CTileLayerVisuals> &VisualsO
 	RenderLoading();
 }
 
+void CRenderLayerTile::Unload()
+{
+	if(m_VisualTiles.has_value())
+	{
+		m_VisualTiles->Unload();
+		m_VisualTiles = std::nullopt;
+	}
+}
+
+void CRenderLayerTile::CTileLayerVisuals::Unload()
+{
+	Graphics()->DeleteBufferContainer(m_BufferContainerIndex);
+}
+
 int CRenderLayerTile::GetDataIndex(unsigned int &TileSize) const
 {
 	TileSize = sizeof(CTile);
@@ -897,6 +912,7 @@ void CRenderLayerQuads::Init()
 	std::vector<CTmpQuad> vTmpQuads;
 	std::vector<CTmpQuadTextured> vTmpQuadsTextured;
 	CQuadLayerVisuals v;
+	v.OnInterfacesInit(GameClient());
 	m_VisualQuad = v;
 	CQuadLayerVisuals *pQLayerVisuals = &(m_VisualQuad.value());
 
@@ -1025,6 +1041,20 @@ void CRenderLayerQuads::Init()
 		Graphics()->IndicesNumRequiredNotify(m_pLayerQuads->m_NumQuads * 6);
 	}
 	RenderLoading();
+}
+
+void CRenderLayerQuads::Unload()
+{
+	if(m_VisualQuad.has_value())
+	{
+		m_VisualQuad->Unload();
+		m_VisualQuad = std::nullopt;
+	}
+}
+
+void CRenderLayerQuads::CQuadLayerVisuals::Unload()
+{
+	Graphics()->DeleteBufferContainer(m_BufferContainerIndex);
 }
 
 void CRenderLayerQuads::CalculateClipping()
@@ -1281,6 +1311,16 @@ void CRenderLayerEntityTele::Init()
 	UploadTileData(m_VisualTeleNumbers, 1, false);
 }
 
+void CRenderLayerEntityTele::Unload()
+{
+	CRenderLayerTile::Unload();
+	if(m_VisualTeleNumbers.has_value())
+	{
+		m_VisualTeleNumbers->Unload();
+		m_VisualTeleNumbers = std::nullopt;
+	}
+}
+
 void CRenderLayerEntityTele::RenderTileLayerWithTileBuffer(const ColorRGBA &Color, const CRenderLayerParams &Params)
 {
 	Graphics()->BlendNormal();
@@ -1337,6 +1377,21 @@ void CRenderLayerEntitySpeedup::Init()
 	UploadTileData(m_VisualTiles, 0, true);
 	UploadTileData(m_VisualForce, 1, false);
 	UploadTileData(m_VisualMaxSpeed, 2, false);
+}
+
+void CRenderLayerEntitySpeedup::Unload()
+{
+	CRenderLayerTile::Unload();
+	if(m_VisualForce.has_value())
+	{
+		m_VisualForce->Unload();
+		m_VisualForce = std::nullopt;
+	}
+	if(m_VisualMaxSpeed.has_value())
+	{
+		m_VisualMaxSpeed->Unload();
+		m_VisualMaxSpeed = std::nullopt;
+	}
 }
 
 void CRenderLayerEntitySpeedup::GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const
@@ -1399,6 +1454,21 @@ void CRenderLayerEntitySwitch::Init()
 	UploadTileData(m_VisualTiles, 0, false);
 	UploadTileData(m_VisualSwitchNumberTop, 1, false);
 	UploadTileData(m_VisualSwitchNumberBottom, 2, false);
+}
+
+void CRenderLayerEntitySwitch::Unload()
+{
+	CRenderLayerTile::Unload();
+	if(m_VisualSwitchNumberTop.has_value())
+	{
+		m_VisualSwitchNumberTop->Unload();
+		m_VisualSwitchNumberTop = std::nullopt;
+	}
+	if(m_VisualSwitchNumberBottom.has_value())
+	{
+		m_VisualSwitchNumberBottom->Unload();
+		m_VisualSwitchNumberBottom = std::nullopt;
+	}
 }
 
 void CRenderLayerEntitySwitch::GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const

--- a/src/game/client/components/render_layer.h
+++ b/src/game/client/components/render_layer.h
@@ -52,6 +52,7 @@ public:
 	virtual bool DoRender(const CRenderLayerParams &Params) const = 0;
 	virtual bool IsValid() const { return true; }
 	virtual bool IsGroup() const { return false; }
+	virtual void Unload() = 0;
 
 	int GetGroup() const { return m_GroupId; }
 
@@ -82,6 +83,7 @@ public:
 	bool DoRender(const CRenderLayerParams &Params) const override;
 	bool IsValid() const override { return m_pGroup != nullptr; }
 	bool IsGroup() const override { return true; }
+	void Unload() override {}
 
 protected:
 	IGraphics::CTextureHandle GetTexture() const override { return IGraphics::CTextureHandle(); }
@@ -100,6 +102,7 @@ public:
 
 	virtual int GetDataIndex(unsigned int &TileSize) const;
 	bool IsValid() const override { return GetRawData() != nullptr; }
+	void Unload() override;
 
 protected:
 	virtual void *GetRawData() const;
@@ -114,7 +117,7 @@ private:
 	IGraphics::CTextureHandle m_TextureHandle;
 
 protected:
-	class CTileLayerVisuals
+	class CTileLayerVisuals : public CComponentInterfaces
 	{
 	public:
 		CTileLayerVisuals()
@@ -126,6 +129,7 @@ protected:
 		}
 
 		bool Init(unsigned int Width, unsigned int Height);
+		void Unload();
 
 		class CTileVisual
 		{
@@ -205,16 +209,18 @@ public:
 	bool IsValid() const override { return m_pLayerQuads->m_NumQuads > 0; }
 	virtual void Render(const CRenderLayerParams &Params) override;
 	virtual bool DoRender(const CRenderLayerParams &Params) const override;
+	void Unload() override;
 
 protected:
 	virtual IGraphics::CTextureHandle GetTexture() const override { return m_TextureHandle; }
 	void CalculateClipping();
 
-	class CQuadLayerVisuals
+	class CQuadLayerVisuals : public CComponentInterfaces
 	{
 	public:
 		CQuadLayerVisuals() :
 			m_QuadNum(0), m_BufferContainerIndex(-1), m_IsTextured(false) {}
+		void Unload();
 
 		int m_QuadNum;
 		int m_BufferContainerIndex;
@@ -287,6 +293,7 @@ public:
 	CRenderLayerEntityTele(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
 	int GetDataIndex(unsigned int &TileSize) const override;
 	void Init() override;
+	void Unload() override;
 
 protected:
 	void RenderTileLayerWithTileBuffer(const ColorRGBA &Color, const CRenderLayerParams &Params) override;
@@ -303,6 +310,7 @@ public:
 	CRenderLayerEntitySpeedup(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
 	int GetDataIndex(unsigned int &TileSize) const override;
 	void Init() override;
+	void Unload() override;
 
 protected:
 	void RenderTileLayerWithTileBuffer(const ColorRGBA &Color, const CRenderLayerParams &Params) override;
@@ -321,6 +329,7 @@ public:
 	CRenderLayerEntitySwitch(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
 	int GetDataIndex(unsigned int &TileSize) const override;
 	void Init() override;
+	void Unload() override;
 
 protected:
 	void RenderTileLayerWithTileBuffer(const ColorRGBA &Color, const CRenderLayerParams &Params) override;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This PR clears graphic buffer container cleanly on map switch (or background map switch)

You can test this by monitoring the Texture memory and the Buffer memory with STRG+SHIFT+D and switching between ctf1 and ctf5 for example. The textures are cleared properly, but the buffer memory always seems to hit a max value.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
