### PR TITLE
Fix client crash with out-of-bounds switch numbers

### DIFF
--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -302,7 +302,8 @@ int CCollision::GetMoveRestrictions(CALLBACK_SWITCHACTIVE pfnSwitchActive, void 
 		{
 			CDoorTile DoorTile;
 			GetDoorTile(ModMapIndex, &DoorTile);
-			if(pfnSwitchActive(DoorTile.m_Number, pUser))
+			if(in_range(DoorTile.m_Number, 0, m_HighestSwitchNumber) &&
+				pfnSwitchActive(DoorTile.m_Number, pUser))
 			{
 				Restrictions |= ::GetMoveRestrictions(d, DoorTile.m_Index, DoorTile.m_Flags);
 			}


### PR DESCRIPTION
Only call the active switch callback if the switch number is valid, thereby ignore switch tiles with invalid number for the movement restriction calculation.

Closes #10574.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [X] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
