### PR TITLE
Improve envelope editor color bar: support non-linear, add border

### DIFF
--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -233,7 +233,7 @@ public:
 	virtual int NumPoints() const = 0;
 	virtual const CEnvPoint *GetPoint(int Index) const = 0;
 	virtual const CEnvPointBezier *GetBezier(int Index) const = 0;
-	int FindPointIndex(double TimeMillis) const;
+	int FindPointIndex(int Time) const;
 };
 
 class CMapBasedEnvelopePointAccess : public IEnvelopePointAccess

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -22,9 +22,9 @@
 
 using namespace std::chrono_literals;
 
-int IEnvelopePointAccess::FindPointIndex(double TimeMillis) const
+int IEnvelopePointAccess::FindPointIndex(int Time) const
 {
-	// binary search for the interval around TimeMillis
+	// binary search for the interval around Time
 	int Low = 0;
 	int High = NumPoints() - 2;
 	int FoundIndex = -1;
@@ -34,12 +34,12 @@ int IEnvelopePointAccess::FindPointIndex(double TimeMillis) const
 		int Mid = Low + (High - Low) / 2;
 		const CEnvPoint *pMid = GetPoint(Mid);
 		const CEnvPoint *pNext = GetPoint(Mid + 1);
-		if(TimeMillis >= pMid->m_Time && TimeMillis < pNext->m_Time)
+		if(Time >= pMid->m_Time && Time < pNext->m_Time)
 		{
 			FoundIndex = Mid;
 			break;
 		}
-		else if(TimeMillis < pMid->m_Time)
+		else if(Time < pMid->m_Time)
 		{
 			High = Mid - 1;
 		}

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6517,12 +6517,11 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 		}
 	}
 
-	bool ShowColorBar = false;
-	if(pEnvelope && pEnvelope->GetChannels() == 4)
+	const bool ShowColorBar = pEnvelope && pEnvelope->GetChannels() == 4;
+	if(ShowColorBar)
 	{
-		ShowColorBar = true;
 		View.HSplitTop(20.0f, &ColorBar, &View);
-		ColorBar.Margin(2.0f, &ColorBar);
+		ColorBar.HMargin(2.0f, &ColorBar);
 	}
 
 	RenderBackground(View, m_CheckerTexture, 32.0f, 0.1f);
@@ -6919,45 +6918,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 		// render colorbar
 		if(ShowColorBar)
 		{
-			Ui()->ClipEnable(&ColorBar);
-
-			float StartX = maximum(EnvelopeToScreenX(View, 0), ColorBar.x);
-			float EndX = EnvelopeToScreenX(View, pEnvelope->EndTime());
-			CUIRect BackgroundView{
-				StartX,
-				ColorBar.y,
-				minimum(EndX - StartX, ColorBar.x + ColorBar.w - StartX),
-				ColorBar.h};
-			RenderBackground(BackgroundView, m_CheckerTexture, 16.0f, 1.0f);
-
-			Graphics()->TextureClear();
-			Graphics()->QuadsBegin();
-			for(int i = 0; i < (int)pEnvelope->m_vPoints.size() - 1; i++)
-			{
-				float r0 = fx2f(pEnvelope->m_vPoints[i].m_aValues[0]);
-				float g0 = fx2f(pEnvelope->m_vPoints[i].m_aValues[1]);
-				float b0 = fx2f(pEnvelope->m_vPoints[i].m_aValues[2]);
-				float a0 = fx2f(pEnvelope->m_vPoints[i].m_aValues[3]);
-				float r1 = fx2f(pEnvelope->m_vPoints[i + 1].m_aValues[0]);
-				float g1 = fx2f(pEnvelope->m_vPoints[i + 1].m_aValues[1]);
-				float b1 = fx2f(pEnvelope->m_vPoints[i + 1].m_aValues[2]);
-				float a1 = fx2f(pEnvelope->m_vPoints[i + 1].m_aValues[3]);
-
-				IGraphics::CColorVertex aArray[] = {
-					IGraphics::CColorVertex(0, r0, g0, b0, a0),
-					IGraphics::CColorVertex(1, r1, g1, b1, a1),
-					IGraphics::CColorVertex(2, r1, g1, b1, a1),
-					IGraphics::CColorVertex(3, r0, g0, b0, a0)};
-				Graphics()->SetColorVertex(aArray, std::size(aArray));
-
-				float x0 = EnvelopeToScreenX(View, fxt2f(pEnvelope->m_vPoints[i].m_Time));
-				float x1 = EnvelopeToScreenX(View, fxt2f(pEnvelope->m_vPoints[i + 1].m_Time));
-
-				IGraphics::CQuadItem QuadItem(x0, ColorBar.y, x1 - x0, ColorBar.h);
-				Graphics()->QuadsDrawTL(&QuadItem, 1);
-			}
-			Graphics()->QuadsEnd();
-			Ui()->ClipDisable();
+			RenderEnvelopeEditorColorBar(ColorBar, pEnvelope);
 		}
 
 		// render handles
@@ -7648,6 +7609,104 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			}
 		}
 	}
+}
+
+void CEditor::RenderEnvelopeEditorColorBar(CUIRect ColorBar, const std::shared_ptr<CEnvelope> &pEnvelope)
+{
+	if(pEnvelope->m_vPoints.size() < 2)
+	{
+		return;
+	}
+	const float ViewStartTime = ScreenToEnvelopeX(ColorBar, ColorBar.x);
+	const float ViewEndTime = ScreenToEnvelopeX(ColorBar, ColorBar.x + ColorBar.w);
+	if(ViewEndTime < 0.0f || ViewStartTime > pEnvelope->EndTime())
+	{
+		return;
+	}
+	const float StartX = maximum(EnvelopeToScreenX(ColorBar, 0.0f), ColorBar.x);
+	const float TotalWidth = minimum(EnvelopeToScreenX(ColorBar, pEnvelope->EndTime()) - StartX, ColorBar.x + ColorBar.w - StartX);
+
+	Ui()->ClipEnable(&ColorBar);
+	CUIRect ColorBarBackground = CUIRect{StartX, ColorBar.y, TotalWidth, ColorBar.h};
+	RenderBackground(ColorBarBackground, m_CheckerTexture, ColorBarBackground.h, 1.0f);
+	Graphics()->TextureClear();
+	Graphics()->QuadsBegin();
+
+	int PointBeginIndex = pEnvelope->FindPointIndex(f2fxt(ViewStartTime));
+	if(PointBeginIndex == -1)
+	{
+		PointBeginIndex = 0;
+	}
+	int PointEndIndex = pEnvelope->FindPointIndex(f2fxt(ViewEndTime));
+	if(PointEndIndex == -1)
+	{
+		PointEndIndex = (int)pEnvelope->m_vPoints.size() - 2;
+	}
+	for(int PointIndex = PointBeginIndex; PointIndex <= PointEndIndex; PointIndex++)
+	{
+		const auto &PointStart = pEnvelope->m_vPoints[PointIndex];
+		const auto &PointEnd = pEnvelope->m_vPoints[PointIndex + 1];
+		const float PointStartTime = fxt2f(PointStart.m_Time);
+		const float PointEndTime = fxt2f(PointEnd.m_Time);
+
+		int Steps;
+		if(PointStart.m_Curvetype == CURVETYPE_LINEAR || PointStart.m_Curvetype == CURVETYPE_STEP)
+		{
+			Steps = 1; // let the GPU do the work
+		}
+		else
+		{
+			const float ClampedPointStartX = maximum(EnvelopeToScreenX(ColorBar, PointStartTime), ColorBar.x);
+			const float ClampedPointEndX = minimum(EnvelopeToScreenX(ColorBar, PointEndTime), ColorBar.x + ColorBar.w);
+			Steps = std::clamp((int)std::sqrt(5.0f * (ClampedPointEndX - ClampedPointStartX)), 1, 250);
+		}
+		const float OverallSectionStartTime = Steps == 1 ? PointStartTime : maximum(PointStartTime, ViewStartTime);
+		const float OverallSectionEndTime = Steps == 1 ? PointEndTime : minimum(PointEndTime, ViewEndTime);
+		float SectionStartTime = OverallSectionStartTime;
+		float SectionStartX = EnvelopeToScreenX(ColorBar, SectionStartTime);
+		for(int Step = 1; Step <= Steps; Step++)
+		{
+			const float SectionEndTime = OverallSectionStartTime + (OverallSectionEndTime - OverallSectionStartTime) * (Step / (float)Steps);
+			const float SectionEndX = EnvelopeToScreenX(ColorBar, SectionEndTime);
+
+			ColorRGBA StartColor;
+			if(Step == 1 && OverallSectionStartTime == PointStartTime)
+			{
+				StartColor = ColorRGBA(fx2f(PointStart.m_aValues[0]), fx2f(PointStart.m_aValues[1]), fx2f(PointStart.m_aValues[2]), fx2f(PointStart.m_aValues[3]));
+			}
+			else
+			{
+				StartColor = ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f);
+				pEnvelope->Eval(SectionStartTime, StartColor, 4);
+			}
+
+			ColorRGBA EndColor;
+			if(PointStart.m_Curvetype == CURVETYPE_STEP)
+			{
+				EndColor = StartColor;
+			}
+			else if(Step == Steps && OverallSectionEndTime == PointEndTime)
+			{
+				EndColor = ColorRGBA(fx2f(PointEnd.m_aValues[0]), fx2f(PointEnd.m_aValues[1]), fx2f(PointEnd.m_aValues[2]), fx2f(PointEnd.m_aValues[3]));
+			}
+			else
+			{
+				EndColor = ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f);
+				pEnvelope->Eval(SectionEndTime, EndColor, 4);
+			}
+
+			Graphics()->SetColor4(StartColor, EndColor, StartColor, EndColor);
+			const IGraphics::CQuadItem QuadItem(SectionStartX, ColorBar.y, SectionEndX - SectionStartX, ColorBar.h);
+			Graphics()->QuadsDrawTL(&QuadItem, 1);
+
+			SectionStartTime = SectionEndTime;
+			SectionStartX = SectionEndX;
+		}
+	}
+	Graphics()->QuadsEnd();
+	Ui()->ClipDisable();
+	ColorBarBackground.h -= Ui()->Screen()->h / Graphics()->ScreenHeight(); // hack to fix alignment of bottom border
+	ColorBarBackground.DrawOutline(ColorRGBA(0.7f, 0.7f, 0.7f, 1.0f));
 }
 
 void CEditor::RenderEditorHistory(CUIRect View)

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -894,6 +894,7 @@ public:
 	void RenderTooltip(CUIRect TooltipRect);
 
 	void RenderEnvelopeEditor(CUIRect View);
+	void RenderEnvelopeEditorColorBar(CUIRect ColorBar, const std::shared_ptr<CEnvelope> &pEnvelope);
 
 	void RenderMapSettingsErrorDialog();
 	void RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEditorLast);

--- a/src/game/editor/mapitems/envelope.cpp
+++ b/src/game/editor/mapitems/envelope.cpp
@@ -129,6 +129,11 @@ float CEnvelope::EndTime() const
 	return m_vPoints.back().m_Time / 1000.0f;
 }
 
+int CEnvelope::FindPointIndex(int Time) const
+{
+	return m_PointsAccess.FindPointIndex(Time);
+}
+
 int CEnvelope::GetChannels() const
 {
 	switch(m_Type)

--- a/src/game/editor/mapitems/envelope.h
+++ b/src/game/editor/mapitems/envelope.h
@@ -24,6 +24,7 @@ public:
 	void Eval(float Time, ColorRGBA &Result, size_t Channels);
 	void AddPoint(int Time, int v0, int v1 = 0, int v2 = 0, int v3 = 0);
 	float EndTime() const;
+	int FindPointIndex(int Time) const;
 	int GetChannels() const;
 	EType Type() const { return m_Type; }
 


### PR DESCRIPTION
Implement correct preview of envelope color in envelope editor color bar for envelope curve types besides linear, by evaluating sections between envelope points in multiple steps. Only use one step for linear and step curve types to improve performance.

Draw highlighting border around the color bar. Remove inconsistent margin on left and right sides when zoomed in.

Screenshots:
- Before: <img src="https://github.com/user-attachments/assets/06970a23-3487-4db4-80fc-eb713857642f" />
- After:  <img src="https://github.com/user-attachments/assets/18d336d8-d0a4-4a5c-a934-188c259d7b04" />


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
