### PR TITLE
Fix lambda variable name in CEffects::OnRender 

### DIFF
--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -417,14 +417,14 @@ void CEffects::OnRender()
 		Speed = DemoPlayer()->BaseInfo()->m_Speed;
 
 	const int64_t Now = time();
-	auto FUpdateClock = [&](bool &Add, int64_t &LastUpdate, int Frequency) {
+	auto UpdateClock = [&](bool &Add, int64_t &LastUpdate, int Frequency) {
 		Add = Now - LastUpdate > time_freq() / ((float)Frequency * Speed);
 		if(Add)
 			LastUpdate = Now;
 	};
-	FUpdateClock(m_Add5hz, m_LastUpdate5hz, 5);
-	FUpdateClock(m_Add50hz, m_LastUpdate50hz, 50);
-	FUpdateClock(m_Add100hz, m_LastUpdate100hz, 100);
+	UpdateClock(m_Add5hz, m_LastUpdate5hz, 5);
+	UpdateClock(m_Add50hz, m_LastUpdate50hz, 50);
+	UpdateClock(m_Add100hz, m_LastUpdate100hz, 100);
 
 	if(m_Add50hz)
 		GameClient()->m_Flow.Update();


### PR DESCRIPTION
Should be a trivial change

`FUpdateClock` -> `UpdateClock` (variable name not a type)

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
