### PR TITLE
Refactor: Move render layers and create the IEnvelopeEval interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2394,8 +2394,6 @@ if(CLIENT)
     components/players.h
     components/race_demo.cpp
     components/race_demo.h
-    components/render_layer.cpp
-    components/render_layer.h
     components/scoreboard.cpp
     components/scoreboard.h
     components/skins.cpp
@@ -2537,6 +2535,12 @@ if(CLIENT)
     smooth_value.h
     tileart.cpp
   )
+  set(GAME_MAP
+    src/game/map/envelope_eval.cpp
+    src/game/map/envelope_eval.h
+    src/game/map/render_layer.cpp
+    src/game/map/render_layer.h
+  )
   set(GAME_GENERATED_CLIENT
     src/game/generated/checksum.cpp
     src/game/generated/client_data.cpp
@@ -2544,7 +2548,7 @@ if(CLIENT)
     src/game/generated/client_data7.cpp
     src/game/generated/client_data7.h
   )
-  set(CLIENT_SRC ${ENGINE_CLIENT} ${PLATFORM_CLIENT} ${GAME_CLIENT} ${GAME_EDITOR} ${GAME_GENERATED_CLIENT})
+  set(CLIENT_SRC ${ENGINE_CLIENT} ${PLATFORM_CLIENT} ${GAME_CLIENT} ${GAME_EDITOR} ${GAME_MAP} ${GAME_GENERATED_CLIENT})
 
   set(DEPS_CLIENT ${DEPS} ${GLEW_DEP} ${WAVPACK_DEP})
 

--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -5,7 +5,9 @@
 #include <game/client/component.h>
 #include <game/client/render.h>
 
-#include "render_layer.h"
+#include <game/map/envelope_eval.h>
+#include <game/map/render_layer.h>
+
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -35,7 +37,7 @@ class CMapLayers : public CComponent
 
 	CLayers *m_pLayers;
 	CMapImages *m_pImages;
-	std::shared_ptr<CMapBasedEnvelopePointAccess> m_pEnvelopePoints;
+	std::shared_ptr<IEnvelopeEval> m_pEnvelopePointAccess;
 
 	int m_Type;
 	bool m_OnlineOnly;
@@ -50,9 +52,7 @@ public:
 		TYPE_ALL = -1,
 	};
 
-	static void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, IMap *pMap, CMapBasedEnvelopePointAccess *pEnvelopePoints, IClient *pClient, CGameClient *pGameClient, bool OnlineOnly);
 	void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels);
-
 	CMapLayers(int Type, bool OnlineOnly = true);
 	int Sizeof() const override { return sizeof(*this); }
 	void OnInit() override;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -102,14 +102,7 @@ static const char *FILETYPE_EXTENSIONS[CEditor::NUM_FILETYPES] = {
 void CEditor::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, void *pUser)
 {
 	CEditor *pThis = (CEditor *)pUser;
-	if(Env < 0 || Env >= (int)pThis->m_Map.m_vpEnvelopes.size())
-		return;
-
-	std::shared_ptr<CEnvelope> pEnv = pThis->m_Map.m_vpEnvelopes[Env];
-	float Time = pThis->m_AnimateTime;
-	Time *= pThis->m_AnimateSpeed;
-	Time += (TimeOffsetMillis / 1000.0f);
-	pEnv->Eval(Time, Result, Channels);
+	pThis->m_pEnvelopeEval->EnvelopeEval(TimeOffsetMillis, Env, Result, Channels, false);
 }
 
 /********************************************************
@@ -8781,6 +8774,8 @@ void CEditor::Init()
 
 	m_pBrush = std::make_shared<CLayerGroup>();
 	m_pBrush->m_pMap = &m_Map;
+
+	m_pEnvelopeEval = std::make_shared<CEnvelopeEvalEditor>(this);
 
 	Reset(false);
 }

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -26,6 +26,8 @@
 #include <game/editor/mapitems/layer_tune.h>
 #include <game/editor/mapitems/map.h>
 
+#include <game/map/envelope_eval.h>
+
 #include <engine/console.h>
 #include <engine/editor.h>
 #include <engine/engine.h>
@@ -698,6 +700,7 @@ public:
 	int m_ShiftBy;
 
 	static void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, void *pUser);
+	std::shared_ptr<IEnvelopeEval> m_pEnvelopeEval;
 
 	CLineInputBuffered<256> m_SettingsCommandInput;
 	CMapSettingsBackend m_MapSettingsBackend;

--- a/src/game/editor/mapitems/envelope.h
+++ b/src/game/editor/mapitems/envelope.h
@@ -26,6 +26,7 @@ public:
 	float EndTime() const;
 	int GetChannels() const;
 	EType Type() const { return m_Type; }
+	const IEnvelopePointAccess &PointAccess() const { return m_PointsAccess; }
 
 private:
 	void Resort();

--- a/src/game/map/envelope_eval.cpp
+++ b/src/game/map/envelope_eval.cpp
@@ -1,0 +1,103 @@
+#include <engine/map.h>
+#include <game/client/gameclient.h>
+#include <game/editor/editor.h>
+#include <game/mapitems.h>
+
+#include "envelope_eval.h"
+
+using namespace std::chrono_literals;
+
+CEnvelopeEvalGame::CEnvelopeEvalGame(CGameClient *pGameClient, IMap *pMap) :
+	m_EnvelopePointAccess(pMap)
+{
+	OnInterfacesInit(pGameClient);
+	m_pMap = pMap;
+}
+
+void CEnvelopeEvalGame::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, bool OnlineOnly)
+{
+	std::shared_ptr<const CMapItemEnvelope> pItem = GetEnvelope(Env);
+	if(!pItem || pItem->m_Channels <= 0)
+		return;
+	Channels = minimum<size_t>(Channels, pItem->m_Channels, CEnvPoint::MAX_CHANNELS);
+
+	m_EnvelopePointAccess.SetPointsRange(pItem->m_StartPoint, pItem->m_NumPoints);
+	if(m_EnvelopePointAccess.NumPoints() == 0)
+		return;
+
+	static std::chrono::nanoseconds s_Time{0};
+	static auto s_LastLocalTime = time_get_nanoseconds();
+	if(OnlineOnly && (pItem->m_Version < 2 || pItem->m_Synchronized))
+	{
+		if(GameClient()->m_Snap.m_pGameInfoObj)
+		{
+			// get the lerp of the current tick and prev
+			const auto TickToNanoSeconds = std::chrono::nanoseconds(1s) / (int64_t)Client()->GameTickSpeed();
+			const int MinTick = Client()->PrevGameTick(g_Config.m_ClDummy) - GameClient()->m_Snap.m_pGameInfoObj->m_RoundStartTick;
+			const int CurTick = Client()->GameTick(g_Config.m_ClDummy) - GameClient()->m_Snap.m_pGameInfoObj->m_RoundStartTick;
+			s_Time = std::chrono::nanoseconds((int64_t)(mix<double>(
+									    0,
+									    (CurTick - MinTick),
+									    (double)Client()->IntraGameTick(g_Config.m_ClDummy)) *
+								    TickToNanoSeconds.count())) +
+				 MinTick * TickToNanoSeconds;
+		}
+	}
+	else
+	{
+		const auto CurTime = time_get_nanoseconds();
+		s_Time += CurTime - s_LastLocalTime;
+		s_LastLocalTime = CurTime;
+	}
+	CRenderTools::RenderEvalEnvelope(&m_EnvelopePointAccess, s_Time + std::chrono::nanoseconds(std::chrono::milliseconds(TimeOffsetMillis)), Result, Channels);
+}
+
+std::shared_ptr<const CMapItemEnvelope> CEnvelopeEvalGame::GetEnvelope(int Env)
+{
+	int EnvStart, EnvNum;
+	m_pMap->GetType(MAPITEMTYPE_ENVELOPE, &EnvStart, &EnvNum);
+	if(Env < 0 || Env >= EnvNum)
+		return nullptr;
+	const CMapItemEnvelope *pItem = (CMapItemEnvelope *)m_pMap->GetItem(EnvStart + Env);
+
+	// specify no-op deleter as this memory is not handled by the pointer
+	return std::shared_ptr<const CMapItemEnvelope>(pItem, [](const CMapItemEnvelope *) {});
+}
+
+CEnvelopeEvalEditor::CEnvelopeEvalEditor(CEditor *pEditor)
+{
+	m_pEditor = pEditor;
+}
+
+void CEnvelopeEvalEditor::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, bool OnlineOnly)
+{
+	if(Env < 0 || Env >= (int)m_pEditor->m_Map.m_vpEnvelopes.size())
+		return;
+
+	std::shared_ptr<CEnvelope> pEnv = m_pEditor->m_Map.m_vpEnvelopes[Env];
+	float Time = m_pEditor->m_AnimateTime;
+	Time *= m_pEditor->m_AnimateSpeed;
+	Time += (TimeOffsetMillis / 1000.0f);
+	pEnv->Eval(Time, Result, Channels);
+}
+
+const IEnvelopePointAccess &CEnvelopeEvalEditor::PointAccess(int Env) const
+{
+	std::shared_ptr<CEnvelope> pEnv = m_pEditor->m_Map.m_vpEnvelopes[Env];
+	return pEnv->PointAccess();
+}
+
+std::shared_ptr<const CMapItemEnvelope> CEnvelopeEvalEditor::GetEnvelope(int Env)
+{
+	if(Env < 0 || Env >= (int)m_pEditor->m_Map.m_vpEnvelopes.size())
+		return nullptr;
+
+	std::shared_ptr<CMapItemEnvelope> Item = std::make_shared<CMapItemEnvelope>();
+	Item->m_Version = 2;
+	Item->m_Channels = m_pEditor->m_Map.m_vpEnvelopes[Env]->GetChannels();
+	Item->m_StartPoint = 0;
+	Item->m_NumPoints = m_pEditor->m_Map.m_vpEnvelopes[Env]->m_vPoints.size();
+	Item->m_Synchronized = m_pEditor->m_Map.m_vpEnvelopes[Env]->m_Synchronized;
+	StrToInts(Item->m_aName, std::size(Item->m_aName), m_pEditor->m_Map.m_vpEnvelopes[Env]->m_aName);
+	return Item;
+}

--- a/src/game/map/envelope_eval.h
+++ b/src/game/map/envelope_eval.h
@@ -1,0 +1,48 @@
+#ifndef GAME_MAP_ENVELOPE_EVAL_H
+#define GAME_MAP_ENVELOPE_EVAL_H
+
+#include <base/color.h>
+#include <game/client/component.h>
+#include <game/client/render.h>
+#include <game/mapitems.h>
+
+class CEditor;
+
+class IEnvelopeEval
+{
+public:
+	IEnvelopeEval() {}
+	virtual ~IEnvelopeEval() = default;
+	virtual void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, bool OnlineOnly) = 0;
+	virtual const IEnvelopePointAccess &PointAccess(int Env) const = 0;
+	virtual std::shared_ptr<const CMapItemEnvelope> GetEnvelope(int Env) = 0;
+
+private:
+};
+
+class CEnvelopeEvalGame : public IEnvelopeEval, public CComponentInterfaces
+{
+public:
+	CEnvelopeEvalGame(CGameClient *pGameClient, IMap *pMap);
+	void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, bool OnlineOnly) override;
+	const IEnvelopePointAccess &PointAccess(int Env) const override { return m_EnvelopePointAccess; }
+	std::shared_ptr<const CMapItemEnvelope> GetEnvelope(int Env) override;
+
+private:
+	IMap *m_pMap;
+	CMapBasedEnvelopePointAccess m_EnvelopePointAccess;
+};
+
+class CEnvelopeEvalEditor : public IEnvelopeEval
+{
+public:
+	CEnvelopeEvalEditor(CEditor *pEditor);
+	void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, bool OnlineOnly) override;
+	const IEnvelopePointAccess &PointAccess(int Env) const override;
+	std::shared_ptr<const CMapItemEnvelope> GetEnvelope(int Env) override;
+
+private:
+	CEditor *m_pEditor;
+};
+
+#endif

--- a/src/game/map/render_layer.h
+++ b/src/game/map/render_layer.h
@@ -1,5 +1,5 @@
-#ifndef GAME_CLIENT_COMPONENTS_RENDER_LAYER_H
-#define GAME_CLIENT_COMPONENTS_RENDER_LAYER_H
+#ifndef GAME_MAP_RENDER_LAYER_H
+#define GAME_MAP_RENDER_LAYER_H
 
 #include <cstdint>
 
@@ -18,6 +18,8 @@ using offset_ptr32 = unsigned int;
 #include <game/client/render.h>
 #include <game/mapitems.h>
 #include <game/mapitems_ex.h>
+
+#include "envelope_eval.h"
 
 class CMapLayers;
 class CMapItemLayerTilemap;
@@ -45,7 +47,7 @@ class CRenderLayer : public CComponentInterfaces
 public:
 	CRenderLayer(int GroupId, int LayerId, int Flags);
 	virtual ~CRenderLayer() = default;
-	void OnInit(CGameClient *pGameClient, IMap *pMap, CMapImages *pMapImages, std::shared_ptr<CMapBasedEnvelopePointAccess> &pEvelopePoints, bool OnlineOnly);
+	void OnInit(CGameClient *pGameClient, IMap *pMap, CMapImages *pMapImages, std::shared_ptr<IEnvelopeEval> &pEvelopePoints, bool OnlineOnly);
 
 	virtual void Init() = 0;
 	virtual void Render(const CRenderLayerParams &Params) = 0;
@@ -69,7 +71,7 @@ protected:
 
 	class IMap *m_pMap = nullptr;
 	class CMapImages *m_pMapImages = nullptr;
-	std::shared_ptr<CMapBasedEnvelopePointAccess> m_pEnvelopePoints;
+	std::shared_ptr<IEnvelopeEval> m_pEnvelopeEval;
 };
 
 class CRenderLayerGroup : public CRenderLayer


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Move the render layers into a new `game/map` directory. Render layers are not really client components. I can imagine a lot of other files belonging in this directory, but this is for a later day.

Also introduces the `IEnvelopeEval` interface which allows to generalize envelope evaluation between ingame and editor required for this change, in order to decouple the rendering more from other components.

next part of #10513 @Robyt3 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
