### PR TITLE
Fix style of static netbase variables

### DIFF
--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -604,9 +604,9 @@ public:
 // TODO: both, fix these. This feels like a junk class for stuff that doesn't fit anywhere
 class CNetBase
 {
-	static IOHANDLE ms_DataLogSent;
-	static IOHANDLE ms_DataLogRecv;
-	static CHuffman ms_Huffman;
+	static IOHANDLE DATA_LOG_SENT;
+	static IOHANDLE DATA_LOG_RECV;
+	static CHuffman HUFFMAN;
 
 public:
 	static void OpenLog(IOHANDLE DataLogSent, IOHANDLE DataLogRecv);


### PR DESCRIPTION
According to king magnus him self it is `ms_DataLogSent` (a static member)
  https://github.com/ddnet/ddnet/commit/878ede3080ab2cfb627aca505c397d9765052996#diff-ea1ca43f087dedba41e761115d64ae243eccdeaf70ac8584f8f65c74dc6a2e7bR328

According to maintainer heinrich it is `DATA_LOG_SENT`
  > That's not a member variable, it's a static variable.

  https://github.com/ddnet/ddnet/issues/8319#issuecomment-2293219298
