### PR TITLE
Fix history undo not restoring visited quads and sound sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2533,6 +2533,8 @@ if(CLIENT)
     quick_action.h
     quick_actions.cpp
     quick_actions.h
+    references.cpp
+    references.h
     smooth_value.cpp
     smooth_value.h
     tileart.cpp

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6006,16 +6006,18 @@ void CEditor::RemoveUnusedEnvelopes()
 {
 	m_EnvelopeEditorHistory.BeginBulk();
 	int DeletedCount = 0;
-	for(size_t Envelope = 0; Envelope < m_Map.m_vpEnvelopes.size();)
+	for(size_t EnvelopeIndex = 0; EnvelopeIndex < m_Map.m_vpEnvelopes.size();)
 	{
-		if(IsEnvelopeUsed(Envelope))
+		if(IsEnvelopeUsed(EnvelopeIndex))
 		{
-			++Envelope;
+			++EnvelopeIndex;
 		}
 		else
 		{
-			m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEveloppeDelete>(this, Envelope));
-			m_Map.DeleteEnvelope(Envelope);
+			// deleting removes the shared ptr from the map
+			std::shared_ptr<CEnvelope> pEnvelope = m_Map.m_vpEnvelopes[EnvelopeIndex];
+			auto vpObjectReferences = m_Map.DeleteEnvelope(EnvelopeIndex);
+			m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeDelete>(this, EnvelopeIndex, vpObjectReferences, pEnvelope));
 			DeletedCount++;
 		}
 	}
@@ -6283,14 +6285,8 @@ void CEditor::SetHotEnvelopePoint(const CUIRect &View, const std::shared_ptr<CEn
 
 void CEditor::RenderEnvelopeEditor(CUIRect View)
 {
-	if(m_SelectedEnvelope < 0)
-		m_SelectedEnvelope = 0;
-	if(m_SelectedEnvelope >= (int)m_Map.m_vpEnvelopes.size())
-		m_SelectedEnvelope = m_Map.m_vpEnvelopes.size() - 1;
-
-	std::shared_ptr<CEnvelope> pEnvelope = nullptr;
-	if(m_SelectedEnvelope >= 0 && m_SelectedEnvelope < (int)m_Map.m_vpEnvelopes.size())
-		pEnvelope = m_Map.m_vpEnvelopes[m_SelectedEnvelope];
+	m_SelectedEnvelope = m_Map.m_vpEnvelopes.empty() ? -1 : std::clamp(m_SelectedEnvelope, 0, (int)m_Map.m_vpEnvelopes.size() - 1);
+	std::shared_ptr<CEnvelope> pEnvelope = m_Map.m_vpEnvelopes.empty() ? nullptr : m_Map.m_vpEnvelopes[m_SelectedEnvelope];
 
 	static EEnvelopeEditorOp s_Operation = EEnvelopeEditorOp::OP_NONE;
 	static std::vector<float> s_vAccurateDragValuesX = {};
@@ -6370,14 +6366,18 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			static int s_DeleteButton = 0;
 			if(DoButton_Editor(&s_DeleteButton, "✗", 0, &Button, BUTTONFLAG_LEFT, "Delete this envelope."))
 			{
-				m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEveloppeDelete>(this, m_SelectedEnvelope));
-				m_Map.DeleteEnvelope(m_SelectedEnvelope);
-				if(m_SelectedEnvelope >= (int)m_Map.m_vpEnvelopes.size())
-					m_SelectedEnvelope = m_Map.m_vpEnvelopes.size() - 1;
-				pEnvelope = m_SelectedEnvelope >= 0 ? m_Map.m_vpEnvelopes[m_SelectedEnvelope] : nullptr;
+				auto vpObjectReferences = m_Map.DeleteEnvelope(m_SelectedEnvelope);
+				m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeDelete>(this, m_SelectedEnvelope, vpObjectReferences, pEnvelope));
+
+				m_SelectedEnvelope = m_Map.m_vpEnvelopes.empty() ? -1 : std::clamp(m_SelectedEnvelope, 0, (int)m_Map.m_vpEnvelopes.size() - 1);
+				pEnvelope = m_Map.m_vpEnvelopes.empty() ? nullptr : m_Map.m_vpEnvelopes[m_SelectedEnvelope];
 				m_Map.OnModify();
 			}
+		}
 
+		// check again, because the last envelope might has been deleted
+		if(m_SelectedEnvelope >= 0)
+		{
 			// Move right button
 			ToolBar.VSplitRight(5.0f, &ToolBar, nullptr);
 			ToolBar.VSplitRight(25.0f, &ToolBar, &Button);

--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -1450,25 +1450,23 @@ void CEditorActionEnvelopeAdd::Redo()
 	m_pEditor->m_SelectedEnvelope = m_pEditor->m_Map.m_vpEnvelopes.size() - 1;
 }
 
-CEditorActionEveloppeDelete::CEditorActionEveloppeDelete(CEditor *pEditor, int EnvelopeIndex) :
-	IEditorAction(pEditor), m_EnvelopeIndex(EnvelopeIndex), m_pEnv(pEditor->m_Map.m_vpEnvelopes[EnvelopeIndex])
+CEditorActionEnvelopeDelete::CEditorActionEnvelopeDelete(CEditor *pEditor, int EnvelopeIndex, std::vector<std::shared_ptr<IEditorEnvelopeReference>> &vpObjectReferences, std::shared_ptr<CEnvelope> &pEnvelope) :
+	IEditorAction(pEditor), m_EnvelopeIndex(EnvelopeIndex), m_pEnv(pEnvelope), m_vpObjectReferences(vpObjectReferences)
 {
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Delete envelope %d", m_EnvelopeIndex);
 }
 
-void CEditorActionEveloppeDelete::Undo()
+void CEditorActionEnvelopeDelete::Undo()
 {
 	// Undo is adding back the envelope
-	m_pEditor->m_Map.m_vpEnvelopes.insert(m_pEditor->m_Map.m_vpEnvelopes.begin() + m_EnvelopeIndex, m_pEnv);
-	m_pEditor->m_SelectedEnvelope = m_EnvelopeIndex;
+	m_pEditor->m_Map.InsertEnvelope(m_EnvelopeIndex, m_pEnv);
+	m_pEditor->m_Map.UpdateEnvelopeReferences(m_EnvelopeIndex, m_pEnv, m_vpObjectReferences);
 }
 
-void CEditorActionEveloppeDelete::Redo()
+void CEditorActionEnvelopeDelete::Redo()
 {
 	// Redo is erasing the same envelope index
-	m_pEditor->m_Map.m_vpEnvelopes.erase(m_pEditor->m_Map.m_vpEnvelopes.begin() + m_EnvelopeIndex);
-	if(m_pEditor->m_SelectedEnvelope >= (int)m_pEditor->m_Map.m_vpEnvelopes.size())
-		m_pEditor->m_SelectedEnvelope = m_pEditor->m_Map.m_vpEnvelopes.size() - 1;
+	m_pEditor->m_Map.DeleteEnvelope(m_EnvelopeIndex);
 }
 
 CEditorActionEnvelopeEdit::CEditorActionEnvelopeEdit(CEditor *pEditor, int EnvelopeIndex, EEditType EditType, int Previous, int Current) :

--- a/src/game/editor/editor_actions.h
+++ b/src/game/editor/editor_actions.h
@@ -3,6 +3,7 @@
 
 #include "editor.h"
 #include "editor_action.h"
+#include <game/editor/references.h>
 
 class CEditorActionLayerBase : public IEditorAction
 {
@@ -391,10 +392,10 @@ private:
 	std::shared_ptr<CEnvelope> m_pEnv;
 };
 
-class CEditorActionEveloppeDelete : public IEditorAction
+class CEditorActionEnvelopeDelete : public IEditorAction
 {
 public:
-	CEditorActionEveloppeDelete(CEditor *pEditor, int EnvelopeIndex);
+	CEditorActionEnvelopeDelete(CEditor *pEditor, int EnvelopeIndex, std::vector<std::shared_ptr<IEditorEnvelopeReference>> &vpObjectReferences, std::shared_ptr<CEnvelope> &pEnvelope);
 
 	void Undo() override;
 	void Redo() override;
@@ -402,6 +403,7 @@ public:
 private:
 	int m_EnvelopeIndex;
 	std::shared_ptr<CEnvelope> m_pEnv;
+	std::vector<std::shared_ptr<IEditorEnvelopeReference>> m_vpObjectReferences;
 };
 
 class CEditorActionEnvelopeEdit : public IEditorAction

--- a/src/game/editor/mapitems/map.h
+++ b/src/game/editor/mapitems/map.h
@@ -11,6 +11,7 @@
 #include <game/editor/editor_server_settings.h>
 #include <game/editor/mapitems/envelope.h>
 #include <game/editor/mapitems/layer.h>
+#include <game/editor/references.h>
 
 #include <functional>
 #include <memory>
@@ -91,10 +92,12 @@ public:
 	CMapInfo m_MapInfoTmp;
 
 	std::shared_ptr<CEnvelope> NewEnvelope(CEnvelope::EType Type);
-	void DeleteEnvelope(int Index);
+	void InsertEnvelope(int Index, std::shared_ptr<CEnvelope> &pEnvelope);
+	void UpdateEnvelopeReferences(int Index, std::shared_ptr<CEnvelope> &pEnvelope, std::vector<std::shared_ptr<IEditorEnvelopeReference>> &vpEditorObjectReferences);
+	std::vector<std::shared_ptr<IEditorEnvelopeReference>> DeleteEnvelope(int Index);
 	int MoveEnvelope(int IndexFrom, int IndexTo);
 	template<typename F>
-	void VisitEnvelopeReferences(F &&Visitor);
+	std::vector<std::shared_ptr<IEditorEnvelopeReference>> VisitEnvelopeReferences(F &&Visitor);
 
 	std::shared_ptr<CLayerGroup> NewGroup();
 	int MoveGroup(int IndexFrom, int IndexTo);

--- a/src/game/editor/references.cpp
+++ b/src/game/editor/references.cpp
@@ -1,0 +1,37 @@
+#include "references.h"
+
+void CLayerTilesEnvelopeReference::SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvIndex)
+{
+	if(pEnvelope->Type() == CEnvelope::EType::COLOR)
+	{
+		m_pLayerTiles->m_ColorEnv = EnvIndex;
+	}
+}
+
+void CLayerQuadsEnvelopeReference::SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvIndex)
+{
+	for(auto &QuadIndex : m_vQuadIndices)
+	{
+		if(QuadIndex >= 0 && QuadIndex < (int)m_pLayerQuads->m_vQuads.size())
+		{
+			if(pEnvelope->Type() == CEnvelope::EType::COLOR)
+				m_pLayerQuads->m_vQuads[QuadIndex].m_ColorEnv = EnvIndex;
+			else if(pEnvelope->Type() == CEnvelope::EType::POSITION)
+				m_pLayerQuads->m_vQuads[QuadIndex].m_PosEnv = EnvIndex;
+		}
+	}
+}
+
+void CLayerSoundEnvelopeReference::SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvIndex)
+{
+	for(auto &SoundSourceIndex : m_vSoundSourceIndices)
+	{
+		if(SoundSourceIndex >= 0 && SoundSourceIndex <= (int)m_pLayerSounds->m_vSources.size())
+		{
+			if(pEnvelope->Type() == CEnvelope::EType::SOUND)
+				m_pLayerSounds->m_vSources[SoundSourceIndex].m_SoundEnv = EnvIndex;
+			else if(pEnvelope->Type() == CEnvelope::EType::POSITION)
+				m_pLayerSounds->m_vSources[SoundSourceIndex].m_PosEnv = EnvIndex;
+		}
+	}
+}

--- a/src/game/editor/references.h
+++ b/src/game/editor/references.h
@@ -1,0 +1,55 @@
+#ifndef GAME_EDITOR_REFERENCES_H
+#define GAME_EDITOR_REFERENCES_H
+
+#include <game/editor/mapitems/envelope.h>
+#include <game/editor/mapitems/layer_quads.h>
+#include <game/editor/mapitems/layer_sounds.h>
+#include <game/editor/mapitems/layer_tiles.h>
+
+class IEditorEnvelopeReference
+{
+public:
+	virtual void SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvIndex) = 0;
+	virtual ~IEditorEnvelopeReference() = default;
+};
+
+class CLayerTilesEnvelopeReference : public IEditorEnvelopeReference
+{
+public:
+	CLayerTilesEnvelopeReference(std::shared_ptr<CLayerTiles> pLayerTiles) :
+		m_pLayerTiles(pLayerTiles) {}
+	void SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvIndex) override;
+
+private:
+	std::shared_ptr<CLayerTiles> m_pLayerTiles;
+};
+
+class CLayerQuadsEnvelopeReference : public IEditorEnvelopeReference
+{
+public:
+	CLayerQuadsEnvelopeReference(std::shared_ptr<CLayerQuads> pLayerQuads) :
+		m_pLayerQuads(pLayerQuads) {}
+	void SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvIndex) override;
+	void AddQuadIndex(int QuadIndex) { m_vQuadIndices.push_back(QuadIndex); }
+	bool Empty() const { return m_vQuadIndices.empty(); }
+
+private:
+	std::vector<int> m_vQuadIndices;
+	std::shared_ptr<CLayerQuads> m_pLayerQuads;
+};
+
+class CLayerSoundEnvelopeReference : public IEditorEnvelopeReference
+{
+public:
+	CLayerSoundEnvelopeReference(std::shared_ptr<CLayerSounds> pLayerSounds) :
+		m_pLayerSounds(pLayerSounds) {}
+	void SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvIndex) override;
+	void AddSoundSourceIndex(int SoundSourceIndex) { m_vSoundSourceIndices.push_back(SoundSourceIndex); }
+	bool Empty() const { return m_vSoundSourceIndices.empty(); }
+
+private:
+	std::vector<int> m_vSoundSourceIndices;
+	std::shared_ptr<CLayerSounds> m_pLayerSounds;
+};
+
+#endif


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This PR properly fixes issues with the history of deleting envelopes. However I am not happy how this is handled, since I need to collect all quad indices that might get affected by deleting an envelope in order to restore it later.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
