### PR TITLE
Fix `OnDeactivate()` called unexpectedly

### DIFF
--- a/src/game/client/components/touch_controls.cpp
+++ b/src/game/client/components/touch_controls.cpp
@@ -347,13 +347,13 @@ void CTouchControls::CTouchButtonBehavior::SetActive(const IInput::CTouchFingerS
 	}
 }
 
-void CTouchControls::CTouchButtonBehavior::SetInactive()
+void CTouchControls::CTouchButtonBehavior::SetInactive(bool ByFinger)
 {
-	if(m_Active)
+	if(m_Active && ByFinger)
 	{
-		m_Active = false;
 		OnDeactivate();
 	}
+	m_Active = false;
 }
 
 bool CTouchControls::CTouchButtonBehavior::IsActive() const
@@ -1005,7 +1005,7 @@ void CTouchControls::UpdateButtons(const std::vector<IInput::CTouchFingerState> 
 		});
 		if(PrevActiveTouchButton != m_vTouchButtons.end())
 		{
-			PrevActiveTouchButton->m_pBehavior->SetInactive();
+			PrevActiveTouchButton->m_pBehavior->SetInactive(true);
 		}
 		TouchButton.m_pBehavior->SetActive(*FingerInsideButton);
 	}
@@ -1028,7 +1028,7 @@ void CTouchControls::UpdateButtons(const std::vector<IInput::CTouchFingerState> 
 				if(ActiveFinger != vRemainingTouchFingerStates.end())
 					vRemainingTouchFingerStates.erase(ActiveFinger);
 			}
-			TouchButton.m_pBehavior->SetInactive();
+			TouchButton.m_pBehavior->SetInactive(false);
 			continue;
 		}
 		if(!TouchButton.m_pBehavior->IsActive())
@@ -1040,7 +1040,7 @@ void CTouchControls::UpdateButtons(const std::vector<IInput::CTouchFingerState> 
 		});
 		if(ActiveFinger == vRemainingTouchFingerStates.end())
 		{
-			TouchButton.m_pBehavior->SetInactive();
+			TouchButton.m_pBehavior->SetInactive(true);
 		}
 		else
 		{

--- a/src/game/client/components/touch_controls.h
+++ b/src/game/client/components/touch_controls.h
@@ -218,7 +218,7 @@ private:
 
 		void Reset();
 		void SetActive(const IInput::CTouchFingerState &FingerState);
-		void SetInactive();
+		void SetInactive(bool ByFinger);
 		bool IsActive() const;
 		bool IsActive(const IInput::CTouchFinger &Finger) const;
 


### PR DESCRIPTION
Now `OnDeactivate()` won't be called due to visibility change.

Currently, `SetInactive()` of a button is called either:
1. The button is/becomes invisible
2. The finger triggering the button released or moved to another button

In most cases, players only want `OnDeactivate()` to be called by their fingers, i.e. the second situation. Now if 'SetInactive()' is called with arg `ByFinger == true`, `OnDeactivate()` can be called This mainly prevents players to trigger two extra-menus together, which sometimes makes some buttons invisible. See videos below

Note this also means OnActivate() can be called multiple times without OnDeactivate() being called

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
