### PR TITLE
Fix "Add sound source" button's size (fixes #10606)

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1391,7 +1391,8 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 		std::shared_ptr<CLayer> pLayer = GetSelectedLayer(0);
 		if(pLayer && (pLayer->m_Type == LAYERTYPE_QUADS || pLayer->m_Type == LAYERTYPE_SOUNDS))
 		{
-			TB_Bottom.VSplitLeft(60.0f, &Button, &TB_Bottom);
+			// "Add sound source" button needs more space or the font size will be scaled down
+			TB_Bottom.VSplitLeft((pLayer->m_Type == LAYERTYPE_QUADS) ? 60.0f : 100.0f, &Button, &TB_Bottom);
 
 			if(pLayer->m_Type == LAYERTYPE_QUADS)
 			{


### PR DESCRIPTION
Makes the "Add sound source" button bigger so that the font size wouldn't be scaled down.
Fixes #10606.


https://github.com/user-attachments/assets/e3f8444b-5c81-48f6-86cb-41546325b6f5


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
