### PR TITLE
Avoid need for secure random to be initialized for `fs_*` functions

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <iomanip> // std::get_time
 #include <iterator> // std::size
+#include <random>
 #include <sstream> // std::istringstream
 #include <string_view>
 
@@ -2702,7 +2703,9 @@ int fs_remove(const char *filename)
 	}
 	const std::wstring wide_filename = windows_utf8_to_wide(filename);
 
-	unsigned random_num = secure_rand();
+	thread_local std::mt19937 rand_generator(std::random_device{}());
+	std::uniform_int_distribution<unsigned> rand_distribution(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
+	unsigned random_num = rand_distribution(rand_generator);
 	std::wstring wide_filename_temp;
 	do
 	{


### PR DESCRIPTION
The temporary filename to remove files on Windows does not need to be cryptographically secure. This avoids having to initialize the secure random functions to use filesystem functions, which was causing the `config_retrieve` tool to crash.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
