### PR TITLE
Make ClampTeam virtual

### DIFF
--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -141,7 +141,7 @@ public:
 	virtual const char *GetTeamName(int Team);
 	virtual int GetAutoTeam(int NotThisId);
 	virtual bool CanJoinTeam(int Team, int NotThisId, char *pErrorReason, int ErrorReasonSize);
-	int ClampTeam(int Team);
+	virtual int ClampTeam(int Team);
 
 	CClientMask GetMaskForPlayerWorldEvent(int Asker, int ExceptID = -1);
 


### PR DESCRIPTION
So basically even if a mod's gamecontroller override both _GetAutoTeam_ (responsible for getting the starting team of a player) and _CanJoinTeam_, the returned player team will be clamped by the _ClampTeam_ method in IGameController which won't allow any other team except TEAM_SPECTATORS and 0 (TEAM_RED or "not spectator" in DDRace).

https://github.com/ddnet/ddnet/blob/e387711b6a9722314f0e27c11dd97d8f0231d74f/src/game/server/gamecontext.cpp#L1761-L1763

https://github.com/ddnet/ddnet/blob/e387711b6a9722314f0e27c11dd97d8f0231d74f/src/game/server/player.cpp#L22-L31

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
