### PR TITLE
Fix color being transparent when editing multiple layers in editor

### DIFF
--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -1277,6 +1277,13 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropSta
 			if(pLayer->m_Height > State.m_Height)
 				State.m_Height = pLayer->m_Height;
 		}
+
+		int Color = 0;
+		Color |= vpLayers[0]->m_Color.r << 24;
+		Color |= vpLayers[0]->m_Color.g << 16;
+		Color |= vpLayers[0]->m_Color.b << 8;
+		Color |= vpLayers[0]->m_Color.a;
+		State.m_Color = Color;
 	}
 
 	{


### PR DESCRIPTION
Uses the color of the right-clicked layer. More intuitive than using the color of the first layer.

Closes #8412 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
