### PR TITLE
Fix editor crashes on maps with invalid envelope indices and tile layer images

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3695,7 +3695,10 @@ void CEditor::SetHotQuadPoint(const std::shared_ptr<CLayerQuads> &pLayer)
 	{
 		CQuad &Quad = pLayer->m_vQuads.at(i);
 
-		if(m_ShowTileInfo != SHOW_TILE_OFF && m_ShowEnvelopePreview != SHOWENV_NONE && Quad.m_PosEnv >= 0)
+		if(m_ShowTileInfo != SHOW_TILE_OFF &&
+			m_ShowEnvelopePreview != SHOWENV_NONE &&
+			Quad.m_PosEnv >= 0 &&
+			Quad.m_PosEnv < (int)m_Map.m_vpEnvelopes.size())
 		{
 			for(auto &EnvPoint : m_Map.m_vpEnvelopes[Quad.m_PosEnv]->m_vPoints)
 			{

--- a/src/game/editor/editor_props.cpp
+++ b/src/game/editor/editor_props.cpp
@@ -243,8 +243,10 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 			Shifter.VSplitRight(10.0f, &Shifter, &Inc);
 			Shifter.VSplitLeft(10.0f, &Dec, &Shifter);
 
-			if(CurValue <= 0)
+			if(CurValue <= 0 || CurValue > (int)m_Map.m_vpEnvelopes.size())
+			{
 				str_copy(aBuf, "None:");
+			}
 			else if(m_Map.m_vpEnvelopes[CurValue - 1]->m_aName[0])
 			{
 				str_format(aBuf, sizeof(aBuf), "%s:", m_Map.m_vpEnvelopes[CurValue - 1]->m_aName);
@@ -255,7 +257,9 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 				}
 			}
 			else
+			{
 				aBuf[0] = '\0';
+			}
 
 			auto NewValueRes = UiDoValueSelector((char *)&pIds[i], &Shifter, aBuf, CurValue, 0, m_Map.m_vpEnvelopes.size(), 1, 1.0f, "Select envelope.", false, false, IGraphics::CORNER_NONE);
 			int NewVal = NewValueRes.m_Value;

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -756,6 +756,12 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 					pTiles->m_Image = pTilemapItem->m_Image;
 					pTiles->m_HasGame = pTilemapItem->m_Flags & TILESLAYERFLAG_GAME;
 
+					// validate image index
+					if(pTiles->m_Image < -1 || pTiles->m_Image >= (int)m_vpImages.size())
+					{
+						pTiles->m_Image = -1;
+					}
+
 					// load layer name
 					if(pTilemapItem->m_Version >= 3)
 						IntsToStr(pTilemapItem->m_aName, std::size(pTilemapItem->m_aName), pTiles->m_aName, std::size(pTiles->m_aName));
@@ -870,8 +876,12 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 					std::shared_ptr<CLayerQuads> pQuads = std::make_shared<CLayerQuads>(m_pEditor);
 					pQuads->m_Flags = pLayerItem->m_Flags;
 					pQuads->m_Image = pQuadsItem->m_Image;
+
+					// validate image index
 					if(pQuads->m_Image < -1 || pQuads->m_Image >= (int)m_vpImages.size())
+					{
 						pQuads->m_Image = -1;
+					}
 
 					// load layer name
 					if(pQuadsItem->m_Version >= 2)
@@ -897,9 +907,11 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 					pSounds->m_Flags = pLayerItem->m_Flags;
 					pSounds->m_Sound = pSoundsItem->m_Sound;
 
-					// validate m_Sound
+					// validate sound index
 					if(pSounds->m_Sound < -1 || pSounds->m_Sound >= (int)m_vpSounds.size())
+					{
 						pSounds->m_Sound = -1;
+					}
 
 					// load layer name
 					IntsToStr(pSoundsItem->m_aName, std::size(pSoundsItem->m_aName), pSounds->m_aName, std::size(pSounds->m_aName));
@@ -926,9 +938,11 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 					pSounds->m_Flags = pLayerItem->m_Flags;
 					pSounds->m_Sound = pSoundsItem->m_Sound;
 
-					// validate m_Sound
+					// validate sound index
 					if(pSounds->m_Sound < -1 || pSounds->m_Sound >= (int)m_vpSounds.size())
+					{
 						pSounds->m_Sound = -1;
+					}
 
 					// load layer name
 					IntsToStr(pSoundsItem->m_aName, std::size(pSoundsItem->m_aName), pSounds->m_aName, std::size(pSounds->m_aName));


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
