### PR TITLE
Fix flaky `Time.Nanoseconds` test by increasing sleep time

### DIFF
--- a/src/test/time.cpp
+++ b/src/test/time.cpp
@@ -23,7 +23,7 @@ TEST(Time, Season)
 TEST(Time, Nanoseconds)
 {
 	const std::chrono::nanoseconds Time1 = time_get_nanoseconds();
-	std::this_thread::sleep_for(std::chrono::microseconds(1));
+	std::this_thread::sleep_for(std::chrono::milliseconds(1));
 	const std::chrono::nanoseconds Time2 = time_get_nanoseconds();
 	EXPECT_LT(Time1, Time2);
 }


### PR DESCRIPTION

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
