### PR TITLE
Consistent trailing slash handling for download urls

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1611,7 +1611,8 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 					char aEscaped[256];
 					EscapeUrl(aEscaped, m_aMapdownloadFilename + 15); // cut off downloadedmaps/
 					bool UseConfigUrl = str_comp(g_Config.m_ClMapDownloadUrl, "https://maps.ddnet.org") != 0 || m_aMapDownloadUrl[0] == '\0';
-					str_format(aUrl, sizeof(aUrl), "%s/%s", UseConfigUrl ? g_Config.m_ClMapDownloadUrl : m_aMapDownloadUrl, aEscaped);
+					const char *pBaseUrl = UseConfigUrl ? g_Config.m_ClMapDownloadUrl : m_aMapDownloadUrl;
+					str_format(aUrl, sizeof(aUrl), "%s%s%s", pBaseUrl, str_endswith(pBaseUrl, "/") ? "" : "/", aEscaped);
 
 					m_pMapdownloadTask = HttpGetFile(pMapUrl ? pMapUrl : aUrl, Storage(), m_aMapdownloadFilenameTemp, IStorage::TYPE_SAVE);
 					m_pMapdownloadTask->Timeout(CTimeout{g_Config.m_ClMapDownloadConnectTimeoutMs, 0, g_Config.m_ClMapDownloadLowSpeedLimit, g_Config.m_ClMapDownloadLowSpeedTime});

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -1004,7 +1004,7 @@ void CSkins::CSkinDownloadJob::Run()
 	EscapeUrl(aEscapedName, m_aName);
 
 	char aUrl[IO_MAX_PATH_LENGTH];
-	str_format(aUrl, sizeof(aUrl), "%s%s.png", pBaseUrl, aEscapedName);
+	str_format(aUrl, sizeof(aUrl), "%s%s%s.png", pBaseUrl, str_endswith(pBaseUrl, "/") ? "" : "/", aEscapedName);
 
 	char aPathReal[IO_MAX_PATH_LENGTH];
 	str_format(aPathReal, sizeof(aPathReal), "downloadedskins/%s.png", m_aName);


### PR DESCRIPTION
Before it was just based on default values for the respective configs.
You can now provide similar urls for both configs without one or the other not working. (similar meaning `skins.example.com` and `maps.example.com`)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
