### PR TITLE
Refactor: split up quad clipping into multiple functions

### DIFF
--- a/src/game/map/render_layer.h
+++ b/src/game/map/render_layer.h
@@ -219,6 +219,8 @@ public:
 protected:
 	virtual IGraphics::CTextureHandle GetTexture() const override { return m_TextureHandle; }
 	void CalculateClipping();
+	bool CalculateEnvelopeClipping(int aEnvelopeOffsetMin[2], int aEnvelopeOffsetMax[2]);
+	void CalculateQuadClipping(int aQuadOffsetMin[2], int aQuadOffsetMax[2]);
 
 	class CQuadLayerVisuals : public CRenderComponent
 	{


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Split up quad clipping. This makes reading and handling and maintaining this feature easier and prevents deeply nested code

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
