### PR TITLE
Lazily initialize secure random API, avoid `std::mt19937`

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -11,7 +11,6 @@
 #include <cstring>
 #include <iomanip> // std::get_time
 #include <iterator> // std::size
-#include <random>
 #include <sstream> // std::istringstream
 #include <string_view>
 
@@ -2703,9 +2702,7 @@ int fs_remove(const char *filename)
 	}
 	const std::wstring wide_filename = windows_utf8_to_wide(filename);
 
-	thread_local std::mt19937 rand_generator(std::random_device{}());
-	std::uniform_int_distribution<unsigned> rand_distribution(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
-	unsigned random_num = rand_distribution(rand_generator);
+	unsigned random_num = secure_rand();
 	std::wstring wide_filename_temp;
 	do
 	{
@@ -4741,7 +4738,7 @@ int open_file(const char *path)
 
 struct SECURE_RANDOM_DATA
 {
-	int initialized;
+	bool initialized;
 #if defined(CONF_FAMILY_WINDOWS)
 	HCRYPTPROV provider;
 #else
@@ -4749,66 +4746,7 @@ struct SECURE_RANDOM_DATA
 #endif
 };
 
-static struct SECURE_RANDOM_DATA secure_random_data = {0};
-
-int secure_random_init()
-{
-	if(secure_random_data.initialized)
-	{
-		return 0;
-	}
-#if defined(CONF_FAMILY_WINDOWS)
-	if(CryptAcquireContext(&secure_random_data.provider, nullptr, nullptr, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
-	{
-		secure_random_data.initialized = 1;
-		return 0;
-	}
-	else
-	{
-		return 1;
-	}
-#else
-	secure_random_data.urandom = io_open("/dev/urandom", IOFLAG_READ);
-	if(secure_random_data.urandom)
-	{
-		secure_random_data.initialized = 1;
-		return 0;
-	}
-	else
-	{
-		return 1;
-	}
-#endif
-}
-
-int secure_random_uninit()
-{
-	if(!secure_random_data.initialized)
-	{
-		return 0;
-	}
-#if defined(CONF_FAMILY_WINDOWS)
-	if(CryptReleaseContext(secure_random_data.provider, 0))
-	{
-		secure_random_data.initialized = 0;
-		return 0;
-	}
-	else
-	{
-		return 1;
-	}
-#else
-	if(!io_close(secure_random_data.urandom))
-	{
-		secure_random_data.initialized = 0;
-		return 0;
-	}
-	else
-	{
-		return 1;
-	}
-#endif
-}
+static struct SECURE_RANDOM_DATA secure_random_data = {false};
 
 void generate_password(char *buffer, unsigned length, const unsigned short *random, unsigned random_length)
 {
@@ -4850,23 +4788,28 @@ void secure_random_fill(void *bytes, unsigned length)
 {
 	if(!secure_random_data.initialized)
 	{
-		dbg_msg("secure", "called secure_random_fill before secure_random_init");
-		dbg_break();
+#if defined(CONF_FAMILY_WINDOWS)
+		if(!CryptAcquireContext(&secure_random_data.provider, nullptr, nullptr, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
+		{
+			const DWORD LastError = GetLastError();
+			dbg_assert(false, "Failed to initialize secure random: CryptAcquireContext failure (%ld '%s')", LastError, windows_format_system_message(LastError).c_str());
+			dbg_break();
+		}
+#else
+		secure_random_data.urandom = io_open("/dev/urandom", IOFLAG_READ);
+		dbg_assert(secure_random_data.urandom != nullptr, "Failed to initialize secure random: failed to open /dev/urandom");
+#endif
+		secure_random_data.initialized = true;
 	}
 #if defined(CONF_FAMILY_WINDOWS)
 	if(!CryptGenRandom(secure_random_data.provider, length, (unsigned char *)bytes))
 	{
 		const DWORD LastError = GetLastError();
-		const std::string ErrorMsg = windows_format_system_message(LastError);
-		dbg_msg("secure", "CryptGenRandom failed: %ld %s", LastError, ErrorMsg.c_str());
+		dbg_assert(false, "CryptGenRandom failure (%ld '%s')", LastError, windows_format_system_message(LastError).c_str());
 		dbg_break();
 	}
 #else
-	if(length != io_read(secure_random_data.urandom, bytes, length))
-	{
-		dbg_msg("secure", "io_read returned with a short read");
-		dbg_break();
-	}
+	dbg_assert(length == io_read(secure_random_data.urandom, bytes, length), "io_read returned with a short read");
 #endif
 }
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2738,25 +2738,6 @@ int open_file(const char *path);
 void generate_password(char *buffer, unsigned length, const unsigned short *random, unsigned random_length);
 
 /**
- * Initializes the secure random module.
- * You *MUST* check the return value of this function.
- *
- * @ingroup Secure-Random
- *
- * @return `0` on success.
- */
-[[nodiscard]] int secure_random_init();
-
-/**
- * Uninitializes the secure random module.
- *
- * @ingroup Secure-Random
- *
- * @return `0` on success.
- */
-int secure_random_uninit();
-
-/**
  * Fills the buffer with the specified amount of random password characters.
  *
  * @ingroup Secure-Random

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4647,10 +4647,6 @@ int main(int argc, const char **argv)
 		PerformFinalCleanup();
 	};
 
-	const bool RandInitFailed = secure_random_init() != 0;
-	if(!RandInitFailed)
-		CleanerFunctions.emplace([]() { secure_random_uninit(); });
-
 	// Register SDL for cleanup before creating the kernel and client,
 	// so SDL is shutdown after kernel and client. Otherwise the client
 	// may crash when shutting down after SDL is already shutdown.
@@ -4781,15 +4777,6 @@ int main(int argc, const char **argv)
 		str_format(aBufName, sizeof(aBufName), "dumps/" GAME_NAME "_%s_crash_log_%s_%d_%s.RTP", CONF_PLATFORM_STRING, aDate, pid(), GIT_SHORTREV_HASH != nullptr ? GIT_SHORTREV_HASH : "");
 		pStorage->GetCompletePath(IStorage::TYPE_SAVE, aBufName, aBufPath, sizeof(aBufPath));
 		crashdump_init_if_available(aBufPath);
-	}
-
-	if(RandInitFailed)
-	{
-		const char *pError = "Failed to initialize the secure RNG.";
-		log_error("secure", "%s", pError);
-		pClient->ShowMessageBox({.m_pTitle = "Secure RNG Error", .m_pMessage = pError});
-		PerformAllCleanup();
-		return -1;
 	}
 
 	IConsole *pConsole = CreateConsole(CFGFLAG_CLIENT).release();

--- a/src/engine/server/main.cpp
+++ b/src/engine/server/main.cpp
@@ -92,11 +92,6 @@ int main(int argc, const char **argv)
 	vpLoggers.push_back(pFutureAssertionLogger);
 	log_set_global_logger(log_logger_collection(std::move(vpLoggers)).release());
 
-	if(secure_random_init() != 0)
-	{
-		log_error("secure", "could not initialize secure RNG");
-		return -1;
-	}
 	if(MysqlInit() != 0)
 	{
 		log_error("mysql", "failed to initialize MySQL library");
@@ -211,7 +206,6 @@ int main(int argc, const char **argv)
 	delete pKernel;
 
 	MysqlUninit();
-	secure_random_uninit();
 
 	return Ret;
 }

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -141,14 +141,7 @@ int main(int argc, const char **argv)
 	log_set_global_logger_default();
 	::testing::InitGoogleTest(&argc, const_cast<char **>(argv));
 	net_init();
-	if(secure_random_init())
-	{
-		fprintf(stderr, "random init failed\n");
-		return 1;
-	}
-	int Result = RUN_ALL_TESTS();
-	secure_random_uninit();
-	return Result;
+	return RUN_ALL_TESTS();
 }
 
 TEST(TestInfo, Sort)

--- a/src/tools/stun.cpp
+++ b/src/tools/stun.cpp
@@ -11,11 +11,6 @@ int main(int argc, const char **argv)
 	CCmdlineFix CmdlineFix(&argc, &argv);
 
 	log_set_global_logger_default();
-	if(secure_random_init() != 0)
-	{
-		log_error("stun", "could not initialize secure RNG");
-		return -1;
-	}
 
 	if(argc < 2)
 	{

--- a/src/tools/twping.cpp
+++ b/src/tools/twping.cpp
@@ -12,11 +12,6 @@ int main(int argc, const char **argv)
 	CCmdlineFix CmdlineFix(&argc, &argv);
 
 	log_set_global_logger_default();
-	if(secure_random_init() != 0)
-	{
-		log_error("twping", "could not initialize secure RNG");
-		return -1;
-	}
 
 	net_init();
 	NETADDR BindAddr;


### PR DESCRIPTION
See https://github.com/ddnet/ddnet/pull/10615#discussion_r2257635457

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
