### PR TITLE
Lazily initialize `secure_random_*`

### DIFF
--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2738,25 +2738,6 @@ int open_file(const char *path);
 void generate_password(char *buffer, unsigned length, const unsigned short *random, unsigned random_length);
 
 /**
- * Initializes the secure random module.
- * You *MUST* check the return value of this function.
- *
- * @ingroup Secure-Random
- *
- * @return `0` on success.
- */
-[[nodiscard]] int secure_random_init();
-
-/**
- * Uninitializes the secure random module.
- *
- * @ingroup Secure-Random
- *
- * @return `0` on success.
- */
-int secure_random_uninit();
-
-/**
  * Fills the buffer with the specified amount of random password characters.
  *
  * @ingroup Secure-Random

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4647,10 +4647,6 @@ int main(int argc, const char **argv)
 		PerformFinalCleanup();
 	};
 
-	const bool RandInitFailed = secure_random_init() != 0;
-	if(!RandInitFailed)
-		CleanerFunctions.emplace([]() { secure_random_uninit(); });
-
 	// Register SDL for cleanup before creating the kernel and client,
 	// so SDL is shutdown after kernel and client. Otherwise the client
 	// may crash when shutting down after SDL is already shutdown.
@@ -4781,15 +4777,6 @@ int main(int argc, const char **argv)
 		str_format(aBufName, sizeof(aBufName), "dumps/" GAME_NAME "_%s_crash_log_%s_%d_%s.RTP", CONF_PLATFORM_STRING, aDate, pid(), GIT_SHORTREV_HASH != nullptr ? GIT_SHORTREV_HASH : "");
 		pStorage->GetCompletePath(IStorage::TYPE_SAVE, aBufName, aBufPath, sizeof(aBufPath));
 		crashdump_init_if_available(aBufPath);
-	}
-
-	if(RandInitFailed)
-	{
-		const char *pError = "Failed to initialize the secure RNG.";
-		log_error("secure", "%s", pError);
-		pClient->ShowMessageBox({.m_pTitle = "Secure RNG Error", .m_pMessage = pError});
-		PerformAllCleanup();
-		return -1;
 	}
 
 	IConsole *pConsole = CreateConsole(CFGFLAG_CLIENT).release();

--- a/src/engine/server/main.cpp
+++ b/src/engine/server/main.cpp
@@ -92,11 +92,6 @@ int main(int argc, const char **argv)
 	vpLoggers.push_back(pFutureAssertionLogger);
 	log_set_global_logger(log_logger_collection(std::move(vpLoggers)).release());
 
-	if(secure_random_init() != 0)
-	{
-		log_error("secure", "could not initialize secure RNG");
-		return -1;
-	}
 	if(MysqlInit() != 0)
 	{
 		log_error("mysql", "failed to initialize MySQL library");
@@ -211,7 +206,6 @@ int main(int argc, const char **argv)
 	delete pKernel;
 
 	MysqlUninit();
-	secure_random_uninit();
 
 	return Ret;
 }

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -141,14 +141,7 @@ int main(int argc, const char **argv)
 	log_set_global_logger_default();
 	::testing::InitGoogleTest(&argc, const_cast<char **>(argv));
 	net_init();
-	if(secure_random_init())
-	{
-		fprintf(stderr, "random init failed\n");
-		return 1;
-	}
-	int Result = RUN_ALL_TESTS();
-	secure_random_uninit();
-	return Result;
+	return RUN_ALL_TESTS();
 }
 
 TEST(TestInfo, Sort)

--- a/src/tools/stun.cpp
+++ b/src/tools/stun.cpp
@@ -11,11 +11,6 @@ int main(int argc, const char **argv)
 	CCmdlineFix CmdlineFix(&argc, &argv);
 
 	log_set_global_logger_default();
-	if(secure_random_init() != 0)
-	{
-		log_error("stun", "could not initialize secure RNG");
-		return -1;
-	}
 
 	if(argc < 2)
 	{

--- a/src/tools/twping.cpp
+++ b/src/tools/twping.cpp
@@ -12,11 +12,6 @@ int main(int argc, const char **argv)
 	CCmdlineFix CmdlineFix(&argc, &argv);
 
 	log_set_global_logger_default();
-	if(secure_random_init() != 0)
-	{
-		log_error("twping", "could not initialize secure RNG");
-		return -1;
-	}
 
 	net_init();
 	NETADDR BindAddr;


### PR DESCRIPTION
## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
