### PR TITLE
Fixes to editor trackers

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -422,7 +422,7 @@ SEditResult<int> CEditor::UiDoValueSelector(void *pId, CUIRect *pRect, const cha
 	{
 		State = EEditState::EDITING;
 	}
-	if(((Ui()->CheckActiveItem(pId) && Ui()->CheckMouseLock()) || s_pLastTextId == pId) && s_pEditing != pId)
+	if(((Ui()->CheckActiveItem(pId) && Ui()->CheckMouseLock() && s_DidScroll) || s_pLastTextId == pId) && s_pEditing != pId)
 	{
 		State = EEditState::START;
 		s_pEditing = pId;

--- a/src/game/editor/editor_trackers.cpp
+++ b/src/game/editor/editor_trackers.cpp
@@ -15,6 +15,16 @@ CQuadEditTracker::~CQuadEditTracker()
 	m_vSelectedQuads.clear();
 }
 
+bool CQuadEditTracker::QuadPointChanged(const std::vector<CPoint> &vCurrentPoints, int QuadIndex)
+{
+	for(size_t i = 0; i < vCurrentPoints.size(); i++)
+	{
+		if(vCurrentPoints[i] != m_InitalPoints[QuadIndex][i])
+			return true;
+	}
+	return false;
+}
+
 void CQuadEditTracker::BeginQuadTrack(const std::shared_ptr<CLayerQuads> &pLayer, const std::vector<int> &vSelectedQuads, int GroupIndex, int LayerIndex)
 {
 	if(m_Tracking)
@@ -45,9 +55,12 @@ void CQuadEditTracker::EndQuadTrack()
 	{
 		auto &pQuad = m_pLayer->m_vQuads[QuadIndex];
 		auto vCurrentPoints = std::vector<CPoint>(pQuad.m_aPoints, pQuad.m_aPoints + 5);
-		vpActions.push_back(std::make_shared<CEditorActionEditQuadPoint>(m_pEditor, m_GroupIndex, m_LayerIndex, QuadIndex, m_InitalPoints[QuadIndex], vCurrentPoints));
+		if(QuadPointChanged(vCurrentPoints, QuadIndex))
+			vpActions.push_back(std::make_shared<CEditorActionEditQuadPoint>(m_pEditor, m_GroupIndex, m_LayerIndex, QuadIndex, m_InitalPoints[QuadIndex], vCurrentPoints));
 	}
-	m_pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionBulk>(m_pEditor, vpActions));
+
+	if(!vpActions.empty())
+		m_pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionBulk>(m_pEditor, vpActions));
 }
 
 void CQuadEditTracker::BeginQuadPropTrack(const std::shared_ptr<CLayerQuads> &pLayer, const std::vector<int> &vSelectedQuads, EQuadProp Prop, int GroupIndex, int LayerIndex)
@@ -90,7 +103,8 @@ void CQuadEditTracker::EndQuadPropTrack(EQuadProp Prop)
 		if(Prop == EQuadProp::PROP_POS_X || Prop == EQuadProp::PROP_POS_Y)
 		{
 			auto vCurrentPoints = std::vector<CPoint>(Quad.m_aPoints, Quad.m_aPoints + 5);
-			vpActions.push_back(std::make_shared<CEditorActionEditQuadPoint>(m_pEditor, m_GroupIndex, m_LayerIndex, QuadIndex, m_InitalPoints[QuadIndex], vCurrentPoints));
+			if(QuadPointChanged(vCurrentPoints, QuadIndex))
+				vpActions.push_back(std::make_shared<CEditorActionEditQuadPoint>(m_pEditor, m_GroupIndex, m_LayerIndex, QuadIndex, m_InitalPoints[QuadIndex], vCurrentPoints));
 		}
 		else
 		{
@@ -193,7 +207,8 @@ void CQuadEditTracker::EndQuadPointPropTrack(EQuadPointProp Prop)
 		if(Prop == EQuadPointProp::PROP_POS_X || Prop == EQuadPointProp::PROP_POS_Y)
 		{
 			auto vCurrentPoints = std::vector<CPoint>(Quad.m_aPoints, Quad.m_aPoints + 5);
-			vpActions.push_back(std::make_shared<CEditorActionEditQuadPoint>(m_pEditor, m_GroupIndex, m_LayerIndex, QuadIndex, m_InitalPoints[QuadIndex], vCurrentPoints));
+			if(QuadPointChanged(vCurrentPoints, QuadIndex))
+				vpActions.push_back(std::make_shared<CEditorActionEditQuadPoint>(m_pEditor, m_GroupIndex, m_LayerIndex, QuadIndex, m_InitalPoints[QuadIndex], vCurrentPoints));
 		}
 		else
 		{
@@ -237,7 +252,8 @@ void CQuadEditTracker::EndQuadPointPropTrackAll()
 			if(Prop == EQuadPointProp::PROP_POS_X || Prop == EQuadPointProp::PROP_POS_Y)
 			{
 				auto vCurrentPoints = std::vector<CPoint>(Quad.m_aPoints, Quad.m_aPoints + 5);
-				vpActions.push_back(std::make_shared<CEditorActionEditQuadPoint>(m_pEditor, m_GroupIndex, m_LayerIndex, QuadIndex, m_InitalPoints[QuadIndex], vCurrentPoints));
+				if(QuadPointChanged(vCurrentPoints, QuadIndex))
+					vpActions.push_back(std::make_shared<CEditorActionEditQuadPoint>(m_pEditor, m_GroupIndex, m_LayerIndex, QuadIndex, m_InitalPoints[QuadIndex], vCurrentPoints));
 			}
 			else
 			{
@@ -401,7 +417,8 @@ void CSoundSourceOperationTracker::HandlePointMove(EState State)
 	}
 	else if(State == EState::STATE_END)
 	{
-		m_pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionMoveSoundSource>(m_pEditor, m_pEditor->m_SelectedGroup, m_LayerIndex, m_pEditor->m_SelectedSource, m_Data.m_OriginalPoint, m_pSource->m_Position));
+		if(m_Data.m_OriginalPoint != m_pSource->m_Position)
+			m_pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionMoveSoundSource>(m_pEditor, m_pEditor->m_SelectedGroup, m_LayerIndex, m_pEditor->m_SelectedSource, m_Data.m_OriginalPoint, m_pSource->m_Position));
 	}
 }
 
@@ -444,9 +461,9 @@ int CLayerPropTracker::PropToValue(ELayerProp Prop)
 
 // -----------------------------------------------------------------------
 
-bool CLayerTilesPropTracker::EndChecker(ETilesProp Prop, EEditState State, int Value)
+bool CLayerTilesPropTracker::EndChecker(ETilesProp Prop, int Value)
 {
-	return (State == EEditState::END || State == EEditState::ONE_GO) && (Value != m_OriginalValue || Prop == ETilesProp::PROP_SHIFT);
+	return Value != m_OriginalValue || Prop == ETilesProp::PROP_SHIFT;
 }
 
 void CLayerTilesPropTracker::OnStart(ETilesProp Prop)
@@ -548,9 +565,9 @@ void CLayerTilesCommonPropTracker::OnEnd(ETilesCommonProp Prop, int Value)
 	m_pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionBulk>(m_pEditor, vpActions, aDisplay));
 }
 
-bool CLayerTilesCommonPropTracker::EndChecker(ETilesCommonProp Prop, EEditState State, int Value)
+bool CLayerTilesCommonPropTracker::EndChecker(ETilesCommonProp Prop, int Value)
 {
-	return (State == EEditState::END || State == EEditState::ONE_GO) && (Value != m_OriginalValue || Prop == ETilesCommonProp::PROP_SHIFT);
+	return Value != m_OriginalValue || Prop == ETilesCommonProp::PROP_SHIFT;
 }
 
 int CLayerTilesCommonPropTracker::PropToValue(ETilesCommonProp Prop)

--- a/src/game/editor/editor_trackers.h
+++ b/src/game/editor/editor_trackers.h
@@ -21,6 +21,8 @@ public:
 	CQuadEditTracker();
 	~CQuadEditTracker();
 
+	bool QuadPointChanged(const std::vector<CPoint> &vCurrentPoints, int QuadIndex);
+
 	void BeginQuadTrack(const std::shared_ptr<CLayerQuads> &pLayer, const std::vector<int> &vSelectedQuads, int GroupIndex = -1, int LayerIndex = -1);
 	void EndQuadTrack();
 
@@ -151,7 +153,7 @@ public:
 		m_CurrentLayerIndex = m_OriginalLayerIndex;
 
 		int Value = PropToValue(Prop);
-		if(StartChecker(Prop, State, Value))
+		if(State == EEditState::START || State == EEditState::ONE_GO)
 		{
 			m_Tracking = true;
 			m_OriginalValue = Value;
@@ -167,11 +169,12 @@ public:
 		m_CurrentGroupIndex = GroupIndex < 0 ? SPropTrackerHelper::GetDefaultGroupIndex(m_pEditor) : GroupIndex;
 		m_CurrentLayerIndex = LayerIndex < 0 ? SPropTrackerHelper::GetDefaultLayerIndex(m_pEditor) : LayerIndex;
 
-		int Value = PropToValue(Prop);
-		if(EndChecker(Prop, State, Value))
+		if(State == EEditState::END || State == EEditState::ONE_GO)
 		{
 			m_Tracking = false;
-			OnEnd(Prop, Value);
+			int Value = PropToValue(Prop);
+			if(EndChecker(Prop, Value))
+				OnEnd(Prop, Value);
 		}
 	}
 
@@ -179,13 +182,9 @@ protected:
 	virtual void OnStart(E Prop) {}
 	virtual void OnEnd(E Prop, int Value) {}
 	virtual int PropToValue(E Prop) { return 0; }
-	virtual bool StartChecker(E Prop, EEditState State, int Value)
+	virtual bool EndChecker(E Prop, int Value)
 	{
-		return State == EEditState::START || State == EEditState::ONE_GO;
-	}
-	virtual bool EndChecker(E Prop, EEditState State, int Value)
-	{
-		return (State == EEditState::END || State == EEditState::ONE_GO) && (Value != m_OriginalValue);
+		return Value != m_OriginalValue;
 	}
 
 	int m_OriginalValue;
@@ -217,7 +216,7 @@ public:
 protected:
 	void OnStart(ETilesProp Prop) override;
 	void OnEnd(ETilesProp Prop, int Value) override;
-	bool EndChecker(ETilesProp Prop, EEditState State, int Value) override;
+	bool EndChecker(ETilesProp Prop, int Value) override;
 
 	int PropToValue(ETilesProp Prop) override;
 
@@ -234,7 +233,7 @@ public:
 protected:
 	void OnStart(ETilesCommonProp Prop) override;
 	void OnEnd(ETilesCommonProp Prop, int Value) override;
-	bool EndChecker(ETilesCommonProp Prop, EEditState State, int Value) override;
+	bool EndChecker(ETilesCommonProp Prop, int Value) override;
 
 	int PropToValue(ETilesCommonProp Prop) override;
 


### PR DESCRIPTION
**CEditor::UiDoValueSelector**
Do not set `EEditState::START` until we scroll (the value changes).

**CQuadEditTracker** and **CSoundSourceOperationTracker**
Check if initial positions have changed before recording the action.

**CPropTracker**
Remove redundant `StartChecker` function completely and `EndChecker` function state checks.
Stop tracking on `EEditState::END` instead of that *AND* value change. Previously when original value didnt change:
\- prop A was saved as the start of an edit.
\- prop B was saved as the end of an edit.
\- prop A value != prop B value resulted in incorrect history.
Closes #8413 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
