### PR TITLE
Save default configs

### DIFF
--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -384,7 +384,7 @@ bool CConfigManager::Save()
 	char aLineBuf[2048];
 	for(const SConfigVariable *pVariable : m_vpAllVariables)
 	{
-		if((pVariable->m_Flags & CFGFLAG_SAVE) != 0 && !pVariable->IsDefault())
+		if((pVariable->m_Flags & CFGFLAG_SAVE) != 0)
 		{
 			pVariable->Serialize(aLineBuf, sizeof(aLineBuf));
 			WriteLine(aLineBuf);


### PR DESCRIPTION

Idk if it's wanted but the change is simple so here's a PR

Pros:
* Allows us to change controversial defaults without upending peoples' config
* Easier for version control as lines are always in same place with same context

Cons:
* Bigger config files
* Can't change defaults for everyone at once

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
