### PR TITLE
Disable `Load current map` action when not usable, fix tooltip, close popup menus when opening editor prompt

### DIFF
--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -80,6 +80,12 @@ void CUIElement::SUIElementRect::Draw(const CUIRect *pRect, ColorRGBA Color, int
 		0, -1, m_X, m_Y, 1, 1);
 }
 
+void SLabelProperties::SetColor(const ColorRGBA &Color)
+{
+	m_vColorSplits.clear();
+	m_vColorSplits.emplace_back(0, -1, Color);
+}
+
 /********************************************************
  UI
 *********************************************************/

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -215,6 +215,8 @@ struct SLabelProperties
 	bool m_EllipsisAtEnd = false;
 	bool m_EnableWidthCheck = true;
 	std::vector<STextColorSplit> m_vColorSplits = {};
+
+	void SetColor(const ColorRGBA &Color);
 };
 
 enum EButtonFlags : unsigned

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -221,7 +221,7 @@ int CEditor::DoButton_Env(const void *pId, const char *pText, int Checked, const
 
 int CEditor::DoButton_MenuItem(const void *pId, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip)
 {
-	if(Ui()->HotItem() == pId || Checked)
+	if((Ui()->HotItem() == pId && Checked == 0) || Checked > 0)
 		pRect->Draw(GetButtonColor(pId, Checked), IGraphics::CORNER_ALL, 3.0f);
 
 	CUIRect Rect;
@@ -230,6 +230,10 @@ int CEditor::DoButton_MenuItem(const void *pId, const char *pText, int Checked, 
 	SLabelProperties Props;
 	Props.m_MaxWidth = Rect.w;
 	Props.m_EllipsisAtEnd = true;
+	if(Checked < 0)
+	{
+		Props.SetColor(ColorRGBA(0.6f, 0.6f, 0.6f, 1.0f));
+	}
 	Ui()->DoLabel(&Rect, pText, 10.0f, TEXTALIGN_ML, Props);
 
 	return DoButton_Editor_Common(pId, pText, Checked, pRect, Flags, pToolTip);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -7363,17 +7363,9 @@ void CEditor::Render()
 		{
 			if(ShiftPressed)
 			{
-				if(HasUnsavedData())
+				if(!m_QuickActionLoadCurrentMap.Disabled())
 				{
-					if(!m_PopupEventWasActivated)
-					{
-						m_PopupEventType = POPEVENT_LOADCURRENT;
-						m_PopupEventActivated = true;
-					}
-				}
-				else
-				{
-					LoadCurrentMap();
+					m_QuickActionLoadCurrentMap.Call();
 				}
 			}
 			else

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -69,7 +69,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 
 	View.HSplitTop(2.0f, nullptr, &View);
 	View.HSplitTop(12.0f, &Slot, &View);
-	if(pEditor->DoButton_MenuItem(&s_OpenCurrentMapButton, pEditor->m_QuickActionLoadCurrentMap.Label(), 0, &Slot, BUTTONFLAG_LEFT, pEditor->m_QuickActionLoadCurrentMap.Description()))
+	if(pEditor->DoButton_MenuItem(&s_OpenCurrentMapButton, pEditor->m_QuickActionLoadCurrentMap.Label(), pEditor->m_QuickActionLoadCurrentMap.Disabled() ? -1 : 0, &Slot, BUTTONFLAG_LEFT, pEditor->m_QuickActionLoadCurrentMap.Description()))
 	{
 		pEditor->m_QuickActionLoadCurrentMap.Call();
 		return CUi::POPUP_CLOSE_CURRENT;

--- a/src/game/editor/prompt.cpp
+++ b/src/game/editor/prompt.cpp
@@ -35,6 +35,7 @@ void CPrompt::SetActive()
 	Editor()->m_Dialog = DIALOG_QUICK_PROMPT;
 	CEditorComponent::SetActive();
 
+	Ui()->ClosePopupMenus();
 	Ui()->SetActiveItem(&m_PromptInput);
 }
 

--- a/src/game/editor/quick_actions.h
+++ b/src/game/editor/quick_actions.h
@@ -232,18 +232,21 @@ REGISTER_QUICK_ACTION(
 	[&]() {
 		if(HasUnsavedData())
 		{
-			m_PopupEventType = POPEVENT_LOADCURRENT;
-			m_PopupEventActivated = true;
+			if(!m_PopupEventWasActivated)
+			{
+				m_PopupEventType = POPEVENT_LOADCURRENT;
+				m_PopupEventActivated = true;
+			}
 		}
 		else
 		{
 			LoadCurrentMap();
 		}
 	},
-	ALWAYS_FALSE,
+	[&]() -> bool { return Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK; },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"[Ctrl+Alt+L] Open the current ingame map for editing.")
+	"[Ctrl+Shift+L] Open the current ingame map for editing.")
 REGISTER_QUICK_ACTION(
 	Envelopes,
 	"Envelopes",


### PR DESCRIPTION
Disable the file popup menu button, quick action and hotkeys to load the current ingame map when neither ingame nor in the demo player.

Fix the tooltip of this action incorrectly describing the hotkey as Ctrl+Alt+L.

<img src="https://github.com/user-attachments/assets/2c6ed9b4-d986-4378-a7fe-2cd08ea21d70" />

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
