### PR TITLE
Allow gamemodes to pick their own spawn position

### DIFF
--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -49,8 +49,8 @@ protected:
 		float m_Score;
 	};
 
-	float EvaluateSpawnPos(CSpawnEval *pEval, vec2 Pos, int DDTeam);
-	void EvaluateSpawnType(CSpawnEval *pEval, int Type, int DDTeam);
+	virtual float EvaluateSpawnPos(CSpawnEval *pEval, vec2 Pos, int DDTeam);
+	virtual void EvaluateSpawnType(CSpawnEval *pEval, int Type, int DDTeam);
 
 	void ResetGame();
 


### PR DESCRIPTION
This pr falls under #7777 and can be rejected without the need for any further justification.
A #7777 violation precedent has been set by #10619

This comes in handy for ddnet forks that have gametypes with non standard spawn positions.

Tested in game using this patch

```diff
diff --git a/src/game/server/gamemodes/mod.cpp b/src/game/server/gamemodes/mod.cpp
index deff5d2fe..ab9f85aa6 100644
--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -24,3 +24,10 @@ void CGameControllerMod::Tick()
 
 	IGameController::Tick();
 }
+
+void CGameControllerMod::EvaluateSpawnType(CSpawnEval *pEval, int Type, int DDTeam)
+{
+	pEval->m_Got = true;
+	pEval->m_Score = 10;
+	pEval->m_Pos = vec2(10, 10);
+}
diff --git a/src/game/server/gamemodes/mod.h b/src/game/server/gamemodes/mod.h
index f74d5306a..f827b9e0c 100644
--- a/src/game/server/gamemodes/mod.h
+++ b/src/game/server/gamemodes/mod.h
@@ -10,5 +10,6 @@ public:
 	~CGameControllerMod();
 
 	void Tick() override;
+	void EvaluateSpawnType(CSpawnEval *pEval, int Type, int DDTeam) override;
 };
 #endif // GAME_SERVER_GAMEMODES_MOD_H
```

```
./DDNet-Server "sv_gametype mod"
```

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
