### PR TITLE
Fix skin prefix setting not working correctly anymore

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -518,7 +518,10 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 
 		SkinPrefix.HSplitTop(20.0f, &Button, &SkinPrefix);
 		static CLineInput s_SkinPrefixInput(g_Config.m_ClSkinPrefix, sizeof(g_Config.m_ClSkinPrefix));
-		Ui()->DoClearableEditBox(&s_SkinPrefixInput, &Button, 14.0f);
+		if(Ui()->DoClearableEditBox(&s_SkinPrefixInput, &Button, 14.0f))
+		{
+			ShouldRefresh = true;
+		}
 
 		SkinPrefix.HSplitTop(2.0f, nullptr, &SkinPrefix);
 
@@ -531,6 +534,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 			if(DoButton_Menu(&s_aPrefixButtons[i], s_apSkinPrefixes[i], 0, &Button))
 			{
 				str_copy(g_Config.m_ClSkinPrefix, s_apSkinPrefixes[i]);
+				ShouldRefresh = true;
 			}
 		}
 	}

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -246,7 +246,7 @@ public:
 	CSkinList &SkinList();
 
 	const CSkinContainer *FindContainerOrNullptr(const char *pName);
-	const CSkin *FindOrNullptr(const char *pName, bool IgnorePrefix = false);
+	const CSkin *FindOrNullptr(const char *pName);
 	const CSkin *Find(const char *pName);
 
 	void AddFavorite(const char *pName);
@@ -254,6 +254,8 @@ public:
 	bool IsFavorite(const char *pName) const;
 
 	void RandomizeSkin(int Dummy);
+
+	const char *SkinPrefix() const;
 
 	static bool IsSpecialSkin(const char *pName);
 
@@ -315,7 +317,7 @@ private:
 	bool LoadSkinData(const char *pName, CSkinLoadData &Data) const;
 	void LoadSkinFinish(CSkinContainer *pSkinContainer, const CSkinLoadData &Data);
 	void LoadSkinDirect(const char *pName);
-	const CSkin *FindImpl(const char *pName);
+	const CSkinContainer *FindContainerImpl(const char *pName);
 	static int SkinScan(const char *pName, int IsDir, int StorageType, void *pUser);
 
 	void UpdateUnloadSkins(CSkinLoadingStats &Stats);


### PR DESCRIPTION
Adapt `CSkins::FindContainerOrNullptr` function to consider skin prefix instead of only considering it in the `FindOrNullptr` function.

Refresh skins when changing skin prefix config variable.

When loading a skin whose name begins with the configured skin prefix, also correctly reload skins that have the unprefixed name.

Closes #10655.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
