### PR TITLE
Move `ITextRender::SetCursor` to `CTextCursor`, init by default, remove unused `MoveCursor` and `SetCursorPosition` functions

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -1365,18 +1365,6 @@ public:
 		pCursor->m_vColorSplits = {};
 	}
 
-	void MoveCursor(CTextCursor *pCursor, float x, float y) const override
-	{
-		pCursor->m_X += x;
-		pCursor->m_Y += y;
-	}
-
-	void SetCursorPosition(CTextCursor *pCursor, float x, float y) const override
-	{
-		pCursor->m_X = x;
-		pCursor->m_Y = y;
-	}
-
 	void Text(float x, float y, float Size, const char *pText, float LineWidth = -1.0f) override
 	{
 		CTextCursor Cursor;

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -923,6 +923,24 @@ struct STextContainer
 	}
 };
 
+float CTextCursor::Height() const
+{
+	return m_LineCount * (m_AlignedFontSize + m_AlignedLineSpacing);
+}
+
+STextBoundingBox CTextCursor::BoundingBox() const
+{
+	return {m_StartX, m_StartY, m_LongestLineWidth, Height()};
+}
+
+void CTextCursor::SetPosition(vec2 Position)
+{
+	m_StartX = Position.x;
+	m_StartY = Position.y;
+	m_X = Position.x;
+	m_Y = Position.y;
+}
+
 struct SFontLanguageVariant
 {
 	char m_aLanguageFile[IO_MAX_PATH_LENGTH];
@@ -1328,55 +1346,20 @@ public:
 		m_pGlyphMap->SetVariantFaceByName(nullptr);
 	}
 
-	void SetCursor(CTextCursor *pCursor, float x, float y, float FontSize, int Flags) const override
-	{
-		pCursor->m_Flags = Flags;
-		pCursor->m_LineCount = 1;
-		pCursor->m_GlyphCount = 0;
-		pCursor->m_CharCount = 0;
-		pCursor->m_MaxLines = 0;
-
-		pCursor->m_LineSpacing = 0;
-		pCursor->m_AlignedLineSpacing = 0;
-
-		pCursor->m_StartX = x;
-		pCursor->m_StartY = y;
-		pCursor->m_LineWidth = -1.0f;
-		pCursor->m_X = x;
-		pCursor->m_Y = y;
-		pCursor->m_MaxCharacterHeight = 0.0f;
-		pCursor->m_LongestLineWidth = 0.0f;
-
-		pCursor->m_FontSize = FontSize;
-		pCursor->m_AlignedFontSize = FontSize;
-
-		pCursor->m_CalculateSelectionMode = TEXT_CURSOR_SELECTION_MODE_NONE;
-		pCursor->m_SelectionHeightFactor = 1.0f;
-		pCursor->m_PressMouse = vec2(0.0f, 0.0f);
-		pCursor->m_ReleaseMouse = vec2(0.0f, 0.0f);
-		pCursor->m_SelectionStart = 0;
-		pCursor->m_SelectionEnd = 0;
-
-		pCursor->m_CursorMode = TEXT_CURSOR_CURSOR_MODE_NONE;
-		pCursor->m_ForceCursorRendering = false;
-		pCursor->m_CursorCharacter = -1;
-		pCursor->m_CursorRenderedPosition = vec2(-1.0f, -1.0f);
-
-		pCursor->m_vColorSplits = {};
-	}
-
-	void Text(float x, float y, float Size, const char *pText, float LineWidth = -1.0f) override
+	void Text(float x, float y, float FontSize, const char *pText, float LineWidth = -1.0f) override
 	{
 		CTextCursor Cursor;
-		SetCursor(&Cursor, x, y, Size, TEXTFLAG_RENDER);
+		Cursor.SetPosition(vec2(x, y));
+		Cursor.m_FontSize = FontSize;
 		Cursor.m_LineWidth = LineWidth;
 		TextEx(&Cursor, pText, -1);
 	}
 
-	float TextWidth(float Size, const char *pText, int StrLength = -1, float LineWidth = -1.0f, int Flags = 0, const STextSizeProperties &TextSizeProps = {}) override
+	float TextWidth(float FontSize, const char *pText, int StrLength = -1, float LineWidth = -1.0f, int Flags = 0, const STextSizeProperties &TextSizeProps = {}) override
 	{
 		CTextCursor Cursor;
-		SetCursor(&Cursor, 0, 0, Size, Flags);
+		Cursor.m_FontSize = FontSize;
+		Cursor.m_Flags = Flags;
 		Cursor.m_LineWidth = LineWidth;
 		TextEx(&Cursor, pText, StrLength);
 		if(TextSizeProps.m_pHeight != nullptr)
@@ -1390,10 +1373,11 @@ public:
 		return Cursor.m_LongestLineWidth;
 	}
 
-	STextBoundingBox TextBoundingBox(float Size, const char *pText, int StrLength = -1, float LineWidth = -1.0f, float LineSpacing = 0.0f, int Flags = 0) override
+	STextBoundingBox TextBoundingBox(float FontSize, const char *pText, int StrLength = -1, float LineWidth = -1.0f, float LineSpacing = 0.0f, int Flags = 0) override
 	{
 		CTextCursor Cursor;
-		SetCursor(&Cursor, 0, 0, Size, Flags);
+		Cursor.m_FontSize = FontSize;
+		Cursor.m_Flags = Flags;
 		Cursor.m_LineWidth = LineWidth;
 		Cursor.m_LineSpacing = LineSpacing;
 		TextEx(&Cursor, pText, StrLength);

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -206,85 +206,50 @@ struct STextColorSplit
 class CTextCursor
 {
 public:
-	int m_Flags;
-	int m_LineCount;
-	int m_GlyphCount;
-	int m_CharCount;
-	int m_MaxLines;
+	int m_Flags = TEXTFLAG_RENDER;
+	int m_LineCount = 1;
+	int m_GlyphCount = 0;
+	int m_CharCount = 0;
+	int m_MaxLines = 0;
 
-	float m_StartX;
-	float m_StartY;
-	float m_LineWidth;
-	float m_X, m_Y;
-	float m_MaxCharacterHeight;
-	float m_LongestLineWidth;
+	float m_StartX = 0.0f;
+	float m_StartY = 0.0f;
+	float m_LineWidth = -1.0f;
+	float m_X = 0.0f;
+	float m_Y = 0.0f;
+	float m_MaxCharacterHeight = 0.0f;
+	float m_LongestLineWidth = 0.0f;
 
-	float m_FontSize;
-	float m_AlignedFontSize;
-	float m_LineSpacing;
-	float m_AlignedLineSpacing;
+	float m_FontSize = 0.0f;
+	float m_AlignedFontSize = 0.0f;
+	float m_LineSpacing = 0.0f;
+	float m_AlignedLineSpacing = 0.0f;
 
-	ETextCursorSelectionMode m_CalculateSelectionMode;
-	float m_SelectionHeightFactor;
+	ETextCursorSelectionMode m_CalculateSelectionMode = TEXT_CURSOR_SELECTION_MODE_NONE;
+	float m_SelectionHeightFactor = 1.0f;
 
 	// these coordinates are respected if selection mode is set to calculate @see ETextCursorSelectionMode
-	vec2 m_PressMouse;
+	vec2 m_PressMouse = vec2(0.0f, 0.0f);
 	// these coordinates are respected if selection/cursor mode is set to calculate @see ETextCursorSelectionMode / @see ETextCursorCursorMode
-	vec2 m_ReleaseMouse;
+	vec2 m_ReleaseMouse = vec2(0.0f, 0.0f);
 
 	// note m_SelectionStart can be bigger than m_SelectionEnd, depending on how the mouse cursor was dragged
 	// also note, that these are the character offsets decoded
-	int m_SelectionStart;
-	int m_SelectionEnd;
+	int m_SelectionStart = 0;
+	int m_SelectionEnd = 0;
 
-	ETextCursorCursorMode m_CursorMode;
-	bool m_ForceCursorRendering;
+	ETextCursorCursorMode m_CursorMode = TEXT_CURSOR_CURSOR_MODE_NONE;
+	bool m_ForceCursorRendering = false;
 	// note this is the decoded character offset
-	int m_CursorCharacter;
-	vec2 m_CursorRenderedPosition;
+	int m_CursorCharacter = -1;
+	vec2 m_CursorRenderedPosition = vec2(-1.0f, -1.0f);
 
 	// Color splits of the cursor to allow multicolored text
-	std::vector<STextColorSplit> m_vColorSplits;
+	std::vector<STextColorSplit> m_vColorSplits = {};
 
-	float Height() const
-	{
-		return m_LineCount * (m_AlignedFontSize + m_AlignedLineSpacing);
-	}
-
-	STextBoundingBox BoundingBox() const
-	{
-		return {m_StartX, m_StartY, m_LongestLineWidth, Height()};
-	}
-
-	void Reset()
-	{
-		m_Flags = 0;
-		m_LineCount = 0;
-		m_GlyphCount = 0;
-		m_CharCount = 0;
-		m_MaxLines = 0;
-		m_StartX = 0;
-		m_StartY = 0;
-		m_LineWidth = 0;
-		m_X = 0;
-		m_Y = 0;
-		m_MaxCharacterHeight = 0;
-		m_LongestLineWidth = 0;
-		m_FontSize = 0;
-		m_AlignedFontSize = 0;
-		m_LineSpacing = 0;
-		m_CalculateSelectionMode = TEXT_CURSOR_SELECTION_MODE_NONE;
-		m_SelectionHeightFactor = 0;
-		m_PressMouse = vec2();
-		m_ReleaseMouse = vec2();
-		m_SelectionStart = 0;
-		m_SelectionEnd = 0;
-		m_CursorMode = TEXT_CURSOR_CURSOR_MODE_NONE;
-		m_ForceCursorRendering = false;
-		m_CursorCharacter = 0;
-		m_CursorRenderedPosition = vec2();
-		m_vColorSplits.clear();
-	}
+	float Height() const;
+	STextBoundingBox BoundingBox() const;
+	void SetPosition(vec2 Position);
 };
 
 struct STextContainerUsages
@@ -315,8 +280,6 @@ class ITextRender : public IInterface
 {
 	MACRO_INTERFACE("textrender")
 public:
-	virtual void SetCursor(CTextCursor *pCursor, float x, float y, float FontSize, int Flags) const = 0;
-
 	virtual bool LoadFonts() = 0;
 	virtual void SetFontPreset(EFontPreset FontPreset) = 0;
 	virtual void SetFontLanguageVariant(const char *pLanguageFile) = 0;

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -316,8 +316,6 @@ class ITextRender : public IInterface
 	MACRO_INTERFACE("textrender")
 public:
 	virtual void SetCursor(CTextCursor *pCursor, float x, float y, float FontSize, int Flags) const = 0;
-	virtual void MoveCursor(CTextCursor *pCursor, float x, float y) const = 0;
-	virtual void SetCursorPosition(CTextCursor *pCursor, float x, float y) const = 0;
 
 	virtual bool LoadFonts() = 0;
 	virtual void SetFontPreset(EFontPreset FontPreset) = 0;

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -55,7 +55,8 @@ void CBroadcast::RenderServerBroadcast()
 	if(!m_TextContainerIndex.Valid())
 	{
 		CTextCursor Cursor;
-		TextRender()->SetCursor(&Cursor, m_BroadcastRenderOffset, 40.0f, 12.0f, TEXTFLAG_RENDER);
+		Cursor.SetPosition(vec2(m_BroadcastRenderOffset, 40.0f));
+		Cursor.m_FontSize = 12.0f;
 		Cursor.m_LineWidth = Width;
 		TextRender()->CreateTextContainer(m_TextContainerIndex, &Cursor, m_aBroadcastText);
 	}

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -729,7 +729,8 @@ void CGameConsole::CInstance::ScrollToCenter(int StartLine, int EndLine)
 void CGameConsole::CInstance::UpdateEntryTextAttributes(CBacklogEntry *pEntry) const
 {
 	CTextCursor Cursor;
-	m_pGameConsole->TextRender()->SetCursor(&Cursor, 0.0f, 0.0f, FONT_SIZE, 0);
+	Cursor.m_FontSize = FONT_SIZE;
+	Cursor.m_Flags = 0;
 	Cursor.m_LineWidth = m_pGameConsole->Ui()->Screen()->w - 10;
 	Cursor.m_MaxLines = 10;
 	Cursor.m_LineSpacing = LINE_SPACING;
@@ -1122,12 +1123,13 @@ void CGameConsole::OnRender()
 		const float InitialY = y;
 
 		// render prompt
-		CTextCursor Cursor;
-		TextRender()->SetCursor(&Cursor, x, y + FONT_SIZE / 2.0f, FONT_SIZE, TEXTFLAG_RENDER);
+		CTextCursor PromptCursor;
+		PromptCursor.SetPosition(vec2(x, y + FONT_SIZE / 2.0f));
+		PromptCursor.m_FontSize = FONT_SIZE;
 
 		char aPrompt[32];
 		Prompt(aPrompt);
-		TextRender()->TextEx(&Cursor, aPrompt);
+		TextRender()->TextEx(&PromptCursor, aPrompt);
 
 		// check if mouse is pressed
 		const vec2 WindowSize = vec2(Graphics()->WindowWidth(), Graphics()->WindowHeight());
@@ -1174,7 +1176,7 @@ void CGameConsole::OnRender()
 			pConsole->m_HasSelection = false;
 		}
 
-		x = Cursor.m_X;
+		x = PromptCursor.m_X;
 
 		if(m_ConsoleState == CONSOLE_OPEN)
 		{
@@ -1212,9 +1214,6 @@ void CGameConsole::OnRender()
 			pConsole->m_HasSelection = false; // Clear console selection if we have a line input selection
 
 		y -= pConsole->m_BoundingBox.m_H - FONT_SIZE;
-		TextRender()->SetCursor(&Cursor, x, y, FONT_SIZE, TEXTFLAG_RENDER);
-		Cursor.m_LineWidth = Screen.w - 10.0f - x;
-		Cursor.m_LineSpacing = LINE_SPACING;
 
 		if(pConsole->m_LastInputHeight != pConsole->m_BoundingBox.m_H)
 		{
@@ -1237,7 +1236,9 @@ void CGameConsole::OnRender()
 			pConsole->GetCommand(pConsole->m_aCompletionBuffer, aCmd);
 			Info.m_pCurrentCmd = aCmd;
 
-			TextRender()->SetCursor(&Info.m_Cursor, InitialX - Info.m_Offset, InitialY + RowHeight + 2.0f, FONT_SIZE, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
+			Info.m_Cursor.SetPosition(vec2(InitialX - Info.m_Offset, InitialY + RowHeight + 2.0f));
+			Info.m_Cursor.m_FontSize = FONT_SIZE;
+			Info.m_Cursor.m_Flags |= TEXTFLAG_STOP_AT_END;
 			Info.m_Cursor.m_LineWidth = std::numeric_limits<float>::max();
 			const int NumCommands = m_pConsole->PossibleCommands(Info.m_pCurrentCmd, pConsole->m_CompletionFlagmask, m_ConsoleType != CGameConsole::CONSOLETYPE_LOCAL && Client()->RconAuthed() && Client()->UseTempRconCommands(), PossibleCommandsRenderCallback, &Info);
 			pConsole->m_CompletionRenderOffset = Info.m_Offset;
@@ -1278,7 +1279,8 @@ void CGameConsole::OnRender()
 		else if(pConsole->m_Searching && !pConsole->m_Input.IsEmpty())
 		{ // Render current match and match count
 			CTextCursor MatchInfoCursor;
-			TextRender()->SetCursor(&MatchInfoCursor, InitialX, InitialY + RowHeight + 2.0f, FONT_SIZE, TEXTFLAG_RENDER);
+			MatchInfoCursor.SetPosition(vec2(InitialX, InitialY + RowHeight + 2.0f));
+			MatchInfoCursor.m_FontSize = FONT_SIZE;
 			TextRender()->TextColor(0.8f, 0.8f, 0.8f, 1.0f);
 			if(!pConsole->m_vSearchMatches.empty())
 			{
@@ -1367,13 +1369,15 @@ void CGameConsole::OnRender()
 			const int LinesNotRendered = pEntry->m_LineCount - minimum((int)std::floor((y - LocalOffsetY) / RowHeight), pEntry->m_LineCount);
 			pConsole->m_LinesRendered -= LinesNotRendered;
 
-			TextRender()->SetCursor(&Cursor, 0.0f, y - OffsetY, FONT_SIZE, TEXTFLAG_RENDER);
-			Cursor.m_LineWidth = Screen.w - 10.0f;
-			Cursor.m_MaxLines = pEntry->m_LineCount;
-			Cursor.m_LineSpacing = LINE_SPACING;
-			Cursor.m_CalculateSelectionMode = (m_ConsoleState == CONSOLE_OPEN && pConsole->m_MousePress.y < pConsole->m_BoundingBox.m_Y && (pConsole->m_MouseIsPress || (pConsole->m_CurSelStart != pConsole->m_CurSelEnd) || pConsole->m_HasSelection)) ? TEXT_CURSOR_SELECTION_MODE_CALCULATE : TEXT_CURSOR_SELECTION_MODE_NONE;
-			Cursor.m_PressMouse = pConsole->m_MousePress;
-			Cursor.m_ReleaseMouse = pConsole->m_MouseRelease;
+			CTextCursor EntryCursor;
+			EntryCursor.SetPosition(vec2(0.0f, y - OffsetY));
+			EntryCursor.m_FontSize = FONT_SIZE;
+			EntryCursor.m_LineWidth = Screen.w - 10.0f;
+			EntryCursor.m_MaxLines = pEntry->m_LineCount;
+			EntryCursor.m_LineSpacing = LINE_SPACING;
+			EntryCursor.m_CalculateSelectionMode = (m_ConsoleState == CONSOLE_OPEN && pConsole->m_MousePress.y < pConsole->m_BoundingBox.m_Y && (pConsole->m_MouseIsPress || (pConsole->m_CurSelStart != pConsole->m_CurSelEnd) || pConsole->m_HasSelection)) ? TEXT_CURSOR_SELECTION_MODE_CALCULATE : TEXT_CURSOR_SELECTION_MODE_NONE;
+			EntryCursor.m_PressMouse = pConsole->m_MousePress;
+			EntryCursor.m_ReleaseMouse = pConsole->m_MouseRelease;
 
 			if(pConsole->m_Searching && pConsole->m_CurrentMatchIndex != -1)
 			{
@@ -1382,24 +1386,24 @@ void CGameConsole::OnRender()
 
 				auto CurrentSelectedOccurrence = pConsole->m_vSearchMatches[pConsole->m_CurrentMatchIndex];
 
-				Cursor.m_vColorSplits.reserve(vMatches.size());
+				EntryCursor.m_vColorSplits.reserve(vMatches.size());
 				for(const auto &Match : vMatches)
 				{
 					bool IsSelected = CurrentSelectedOccurrence.m_EntryLine == Match.m_EntryLine && CurrentSelectedOccurrence.m_Pos == Match.m_Pos;
-					Cursor.m_vColorSplits.emplace_back(
+					EntryCursor.m_vColorSplits.emplace_back(
 						Match.m_Pos,
 						pConsole->m_Input.GetLength(),
 						IsSelected ? ms_SearchSelectedColor : ms_SearchHighlightColor);
 				}
 			}
 
-			TextRender()->TextEx(&Cursor, pEntry->m_aText, -1);
-			Cursor.m_vColorSplits = {};
+			TextRender()->TextEx(&EntryCursor, pEntry->m_aText, -1);
+			EntryCursor.m_vColorSplits = {};
 
-			if(Cursor.m_CalculateSelectionMode == TEXT_CURSOR_SELECTION_MODE_CALCULATE)
+			if(EntryCursor.m_CalculateSelectionMode == TEXT_CURSOR_SELECTION_MODE_CALCULATE)
 			{
-				pConsole->m_CurSelStart = minimum(Cursor.m_SelectionStart, Cursor.m_SelectionEnd);
-				pConsole->m_CurSelEnd = maximum(Cursor.m_SelectionStart, Cursor.m_SelectionEnd);
+				pConsole->m_CurSelStart = minimum(EntryCursor.m_SelectionStart, EntryCursor.m_SelectionEnd);
+				pConsole->m_CurSelEnd = maximum(EntryCursor.m_SelectionStart, EntryCursor.m_SelectionEnd);
 			}
 			pConsole->m_LinesRendered += First ? pEntry->m_LineCount - (pConsole->m_BacklogLastActiveLine - SkippedLines) : pEntry->m_LineCount;
 

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -242,8 +242,8 @@ void CHud::RenderScoreHud()
 				if(aRecreateTeamScore[t])
 				{
 					CTextCursor Cursor;
-					TextRender()->SetCursor(&Cursor, m_Width - ScoreWidthMax + (ScoreWidthMax - m_aScoreInfo[t].m_ScoreTextWidth) / 2 - Split, StartY + t * 20 + (18.f - 14.f) / 2.f, 14.0f, TEXTFLAG_RENDER);
-					Cursor.m_LineWidth = -1;
+					Cursor.SetPosition(vec2(m_Width - ScoreWidthMax + (ScoreWidthMax - m_aScoreInfo[t].m_ScoreTextWidth) / 2 - Split, StartY + t * 20 + (18.f - 14.f) / 2.f));
+					Cursor.m_FontSize = 14.0f;
 					TextRender()->RecreateTextContainer(m_aScoreInfo[t].m_TextScoreContainerIndex, &Cursor, aScoreTeam[t]);
 				}
 				if(m_aScoreInfo[t].m_TextScoreContainerIndex.Valid())
@@ -278,8 +278,8 @@ void CHud::RenderScoreHud()
 							float w = TextRender()->TextWidth(8.0f, pName, -1, -1.0f);
 
 							CTextCursor Cursor;
-							TextRender()->SetCursor(&Cursor, minimum(m_Width - w - 1.0f, m_Width - ScoreWidthMax - ImageSize - 2 * Split), StartY + (t + 1) * 20.0f - 2.0f, 8.0f, TEXTFLAG_RENDER);
-							Cursor.m_LineWidth = -1;
+							Cursor.SetPosition(vec2(minimum(m_Width - w - 1.0f, m_Width - ScoreWidthMax - ImageSize - 2 * Split), StartY + (t + 1) * 20.0f - 2.0f));
+							Cursor.m_FontSize = 8.0f;
 							TextRender()->RecreateTextContainer(m_aScoreInfo[t].m_OptionalNameTextContainerIndex, &Cursor, pName);
 						}
 
@@ -417,8 +417,8 @@ void CHud::RenderScoreHud()
 				if(RecreateScores)
 				{
 					CTextCursor Cursor;
-					TextRender()->SetCursor(&Cursor, m_Width - ScoreWidthMax + (ScoreWidthMax - m_aScoreInfo[t].m_ScoreTextWidth) - Split, StartY + t * 20 + (18.f - 14.f) / 2.f, 14.0f, TEXTFLAG_RENDER);
-					Cursor.m_LineWidth = -1;
+					Cursor.SetPosition(vec2(m_Width - ScoreWidthMax + (ScoreWidthMax - m_aScoreInfo[t].m_ScoreTextWidth) - Split, StartY + t * 20 + (18.f - 14.f) / 2.f));
+					Cursor.m_FontSize = 14.0f;
 					TextRender()->RecreateTextContainer(m_aScoreInfo[t].m_TextScoreContainerIndex, &Cursor, aScore[t]);
 				}
 				// draw score
@@ -441,9 +441,8 @@ void CHud::RenderScoreHud()
 							str_copy(m_aScoreInfo[t].m_aPlayerNameText, pName);
 
 							CTextCursor Cursor;
-							float w = TextRender()->TextWidth(8.0f, pName, -1, -1.0f);
-							TextRender()->SetCursor(&Cursor, minimum(m_Width - w - 1.0f, m_Width - ScoreWidthMax - ImageSize - 2 * Split - PosSize), StartY + (t + 1) * 20.0f - 2.0f, 8.0f, TEXTFLAG_RENDER);
-							Cursor.m_LineWidth = -1;
+							Cursor.SetPosition(vec2(minimum(m_Width - TextRender()->TextWidth(8.0f, pName) - 1.0f, m_Width - ScoreWidthMax - ImageSize - 2 * Split - PosSize), StartY + (t + 1) * 20.0f - 2.0f));
+							Cursor.m_FontSize = 8.0f;
 							TextRender()->RecreateTextContainer(m_aScoreInfo[t].m_OptionalNameTextContainerIndex, &Cursor, pName);
 						}
 
@@ -479,8 +478,8 @@ void CHud::RenderScoreHud()
 					str_copy(m_aScoreInfo[t].m_aRankText, aBuf);
 
 					CTextCursor Cursor;
-					TextRender()->SetCursor(&Cursor, m_Width - ScoreWidthMax - ImageSize - Split - PosSize, StartY + t * 20 + (18.f - 10.f) / 2.f, 10.0f, TEXTFLAG_RENDER);
-					Cursor.m_LineWidth = -1;
+					Cursor.SetPosition(vec2(m_Width - ScoreWidthMax - ImageSize - Split - PosSize, StartY + t * 20 + (18.f - 10.f) / 2.f));
+					Cursor.m_FontSize = 10.0f;
 					TextRender()->RecreateTextContainer(m_aScoreInfo[t].m_TextRankContainerIndex, &Cursor, aBuf);
 				}
 				if(m_aScoreInfo[t].m_TextRankContainerIndex.Valid())
@@ -539,8 +538,8 @@ void CHud::RenderTextInfo()
 		int DigitIndex = GetDigitsIndex(FramesPerSecond, 4);
 
 		CTextCursor Cursor;
-		TextRender()->SetCursor(&Cursor, m_Width - 10 - s_aTextWidth[DigitIndex], 5, 12, TEXTFLAG_RENDER);
-		Cursor.m_LineWidth = -1;
+		Cursor.SetPosition(vec2(m_Width - 10 - s_aTextWidth[DigitIndex], 5));
+		Cursor.m_FontSize = 12.0f;
 		auto OldFlags = TextRender()->GetRenderFlags();
 		TextRender()->SetRenderFlags(OldFlags | TEXT_RENDER_FLAG_ONE_TIME_USE);
 		if(m_FPSTextContainerIndex.Valid())
@@ -1397,7 +1396,7 @@ void CHud::UpdateMovementInformationTextContainer(STextContainerIndex &TextConta
 	str_format(aBuf, sizeof(aBuf), "%.2f", Value);
 
 	CTextCursor Cursor;
-	TextRender()->SetCursor(&Cursor, 0.0f, 0.0f, FontSize, TEXTFLAG_RENDER);
+	Cursor.m_FontSize = FontSize;
 	TextRender()->RecreateTextContainer(TextContainer, &Cursor, aBuf);
 }
 
@@ -1787,8 +1786,8 @@ void CHud::RenderDDRaceEffects()
 
 			TextRender()->TextColor(1, 1, 1, Alpha);
 			CTextCursor Cursor;
-			TextRender()->SetCursor(&Cursor, 150 * Graphics()->ScreenAspect() - TextRender()->TextWidth(12, aBuf, -1, -1.0f) / 2, 20, 12, TEXTFLAG_RENDER);
-			Cursor.m_LineWidth = -1.0f;
+			Cursor.SetPosition(vec2(150 * Graphics()->ScreenAspect() - TextRender()->TextWidth(12, aBuf) / 2, 20));
+			Cursor.m_FontSize = 12.0f;
 			TextRender()->RecreateTextContainer(m_DDRaceEffectsTextContainerIndex, &Cursor, aBuf);
 			if(m_FinishTimeDiff != 0.0f && m_DDRaceEffectsTextContainerIndex.Valid())
 			{
@@ -1804,9 +1803,10 @@ void CHud::RenderDDRaceEffects()
 					str_format(aBuf, sizeof(aBuf), "+%s", aTime);
 					TextRender()->TextColor(1.0f, 0.5f, 0.5f, Alpha); // red
 				}
-				TextRender()->SetCursor(&Cursor, 150 * Graphics()->ScreenAspect() - TextRender()->TextWidth(10, aBuf, -1, -1.0f) / 2, 34, 10, TEXTFLAG_RENDER);
-				Cursor.m_LineWidth = -1.0f;
-				TextRender()->AppendTextContainer(m_DDRaceEffectsTextContainerIndex, &Cursor, aBuf);
+				CTextCursor DiffCursor;
+				DiffCursor.SetPosition(vec2(150 * Graphics()->ScreenAspect() - TextRender()->TextWidth(10, aBuf) / 2, 34));
+				DiffCursor.m_FontSize = 10.0f;
+				TextRender()->AppendTextContainer(m_DDRaceEffectsTextContainerIndex, &DiffCursor, aBuf);
 			}
 			if(m_DDRaceEffectsTextContainerIndex.Valid())
 			{
@@ -1845,8 +1845,8 @@ void CHud::RenderDDRaceEffects()
 				TextRender()->TextColor(1, 1, 1, Alpha); // white
 
 			CTextCursor Cursor;
-			TextRender()->SetCursor(&Cursor, 150 * Graphics()->ScreenAspect() - TextRender()->TextWidth(10, aBuf, -1, -1.0f) / 2, 20, 10, TEXTFLAG_RENDER);
-			Cursor.m_LineWidth = -1.0f;
+			Cursor.SetPosition(vec2(150 * Graphics()->ScreenAspect() - TextRender()->TextWidth(10, aBuf) / 2, 20));
+			Cursor.m_FontSize = 10.0f;
 			TextRender()->RecreateTextContainer(m_DDRaceEffectsTextContainerIndex, &Cursor, aBuf);
 
 			if(m_DDRaceEffectsTextContainerIndex.Valid())

--- a/src/game/client/components/infomessages.cpp
+++ b/src/game/client/components/infomessages.cpp
@@ -156,7 +156,7 @@ void CInfoMessages::CreateTextContainersIfNotCreated(CInfoMsg &InfoMsg)
 	if(!InfoMsg.m_VictimTextContainerIndex.Valid() && InfoMsg.m_aVictimName[0] != '\0')
 	{
 		CTextCursor Cursor;
-		TextRender()->SetCursor(&Cursor, 0, 0, FONT_SIZE, TEXTFLAG_RENDER);
+		Cursor.m_FontSize = FONT_SIZE;
 		TextRender()->TextColor(NameColor(InfoMsg.m_aVictimIds[0]));
 		TextRender()->CreateTextContainer(InfoMsg.m_VictimTextContainerIndex, &Cursor, InfoMsg.m_aVictimName);
 	}
@@ -164,7 +164,7 @@ void CInfoMessages::CreateTextContainersIfNotCreated(CInfoMsg &InfoMsg)
 	if(!InfoMsg.m_KillerTextContainerIndex.Valid() && InfoMsg.m_aKillerName[0] != '\0')
 	{
 		CTextCursor Cursor;
-		TextRender()->SetCursor(&Cursor, 0, 0, FONT_SIZE, TEXTFLAG_RENDER);
+		Cursor.m_FontSize = FONT_SIZE;
 		TextRender()->TextColor(NameColor(InfoMsg.m_KillerId));
 		TextRender()->CreateTextContainer(InfoMsg.m_KillerTextContainerIndex, &Cursor, InfoMsg.m_aKillerName);
 	}
@@ -172,7 +172,7 @@ void CInfoMessages::CreateTextContainersIfNotCreated(CInfoMsg &InfoMsg)
 	if(!InfoMsg.m_DiffTextContainerIndex.Valid() && InfoMsg.m_aDiffText[0] != '\0')
 	{
 		CTextCursor Cursor;
-		TextRender()->SetCursor(&Cursor, 0, 0, FONT_SIZE, TEXTFLAG_RENDER);
+		Cursor.m_FontSize = FONT_SIZE;
 
 		if(InfoMsg.m_Diff > 0)
 			TextRender()->TextColor(1.0f, 0.5f, 0.5f, 1.0f); // red
@@ -187,7 +187,7 @@ void CInfoMessages::CreateTextContainersIfNotCreated(CInfoMsg &InfoMsg)
 	if(!InfoMsg.m_TimeTextContainerIndex.Valid() && InfoMsg.m_aTimeText[0] != '\0')
 	{
 		CTextCursor Cursor;
-		TextRender()->SetCursor(&Cursor, 0, 0, FONT_SIZE, TEXTFLAG_RENDER);
+		Cursor.m_FontSize = FONT_SIZE;
 		TextRender()->TextColor(TextRender()->DefaultTextColor());
 		TextRender()->CreateTextContainer(InfoMsg.m_TimeTextContainerIndex, &Cursor, InfoMsg.m_aTimeText);
 	}

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1327,37 +1327,42 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 		}
 
 		// name
-		CTextCursor Cursor;
-		TextRender()->SetCursor(&Cursor, Name.x, Name.y + (Name.h - (FontSize - 1.0f)) / 2.0f, FontSize - 1.0f, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
-		Cursor.m_LineWidth = Name.w;
+		CTextCursor NameCursor;
+		NameCursor.SetPosition(vec2(Name.x, Name.y + (Name.h - (FontSize - 1.0f)) / 2.0f));
+		NameCursor.m_FontSize = FontSize - 1.0f;
+		NameCursor.m_Flags |= TEXTFLAG_STOP_AT_END;
+		NameCursor.m_LineWidth = Name.w;
 		const char *pName = CurrentClient.m_aName;
 		bool Printed = false;
 		if(g_Config.m_BrFilterString[0])
 			Printed = PrintHighlighted(pName, [&](const char *pFilteredStr, const int FilterLen) {
-				TextRender()->TextEx(&Cursor, pName, (int)(pFilteredStr - pName));
+				TextRender()->TextEx(&NameCursor, pName, (int)(pFilteredStr - pName));
 				TextRender()->TextColor(gs_HighlightedTextColor);
-				TextRender()->TextEx(&Cursor, pFilteredStr, FilterLen);
+				TextRender()->TextEx(&NameCursor, pFilteredStr, FilterLen);
 				TextRender()->TextColor(TextRender()->DefaultTextColor());
-				TextRender()->TextEx(&Cursor, pFilteredStr + FilterLen, -1);
+				TextRender()->TextEx(&NameCursor, pFilteredStr + FilterLen, -1);
 			});
 		if(!Printed)
-			TextRender()->TextEx(&Cursor, pName, -1);
+			TextRender()->TextEx(&NameCursor, pName, -1);
 
 		// clan
-		TextRender()->SetCursor(&Cursor, Clan.x, Clan.y + (Clan.h - (FontSize - 2.0f)) / 2.0f, FontSize - 2.0f, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
-		Cursor.m_LineWidth = Clan.w;
+		CTextCursor ClanCursor;
+		ClanCursor.SetPosition(vec2(Clan.x, Clan.y + (Clan.h - (FontSize - 2.0f)) / 2.0f));
+		ClanCursor.m_FontSize = FontSize - 2.0f;
+		ClanCursor.m_Flags |= TEXTFLAG_STOP_AT_END;
+		ClanCursor.m_LineWidth = Clan.w;
 		const char *pClan = CurrentClient.m_aClan;
 		Printed = false;
 		if(g_Config.m_BrFilterString[0])
 			Printed = PrintHighlighted(pClan, [&](const char *pFilteredStr, const int FilterLen) {
-				TextRender()->TextEx(&Cursor, pClan, (int)(pFilteredStr - pClan));
+				TextRender()->TextEx(&ClanCursor, pClan, (int)(pFilteredStr - pClan));
 				TextRender()->TextColor(0.4f, 0.4f, 1.0f, 1.0f);
-				TextRender()->TextEx(&Cursor, pFilteredStr, FilterLen);
+				TextRender()->TextEx(&ClanCursor, pFilteredStr, FilterLen);
 				TextRender()->TextColor(TextRender()->DefaultTextColor());
-				TextRender()->TextEx(&Cursor, pFilteredStr + FilterLen, -1);
+				TextRender()->TextEx(&ClanCursor, pFilteredStr + FilterLen, -1);
 			});
 		if(!Printed)
-			TextRender()->TextEx(&Cursor, pClan, -1);
+			TextRender()->TextEx(&ClanCursor, pClan, -1);
 
 		// flag
 		GameClient()->m_CountryFlags.Render(CurrentClient.m_Country, ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f), Flag.x, Flag.y, Flag.w, Flag.h);

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -817,7 +817,7 @@ void CMenus::RenderServerInfoMotd(CUIRect Motd)
 	if(!m_MotdTextContainerIndex.Valid() || s_MotdLastUpdateTime == -1 || s_MotdLastUpdateTime != GameClient()->m_Motd.ServerMotdUpdateTime())
 	{
 		CTextCursor Cursor;
-		TextRender()->SetCursor(&Cursor, 0.0f, 0.0f, MotdFontSize, TEXTFLAG_RENDER);
+		Cursor.m_FontSize = MotdFontSize;
 		Cursor.m_LineWidth = Motd.w;
 		TextRender()->RecreateTextContainer(m_MotdTextContainerIndex, &Cursor, GameClient()->m_Motd.ServerMotd());
 		s_MotdHeight = Cursor.Height();

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1863,7 +1863,7 @@ void CMenus::RenderLanguageSettings(CUIRect MainView)
 	CreditsScroll.y += ScrollOffset.y;
 
 	CTextCursor Cursor;
-	TextRender()->SetCursor(&Cursor, 0.0f, 0.0f, CreditsFontSize, TEXTFLAG_RENDER);
+	Cursor.m_FontSize = CreditsFontSize;
 	Cursor.m_LineWidth = CreditsScroll.w - 2.0f * CreditsMargin;
 
 	const unsigned OldRenderFlags = TextRender()->GetRenderFlags();
@@ -2592,7 +2592,9 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 			if(LineIndex >= (int)s_vLines.size())
 				return vec2(0, 0);
 			CTextCursor LocalCursor;
-			TextRender()->SetCursor(&LocalCursor, x, y, RealFontSize, Render ? TEXTFLAG_RENDER : 0);
+			LocalCursor.SetPosition(vec2(x, y));
+			LocalCursor.m_FontSize = RealFontSize;
+			LocalCursor.m_Flags = Render ? TEXTFLAG_RENDER : 0;
 			LocalCursor.m_LineWidth = LineWidth;
 			const auto &Line = s_vLines[LineIndex];
 

--- a/src/game/client/components/motd.cpp
+++ b/src/game/client/components/motd.cpp
@@ -72,15 +72,12 @@ void CMotd::OnRender()
 		Graphics()->RenderQuadContainer(m_RectQuadContainer, -1);
 	}
 
-	const float TextWidth = RectWidth - 2.0f * FontSize;
-	const float TextX = RectX + FontSize;
-	const float TextY = RectY + FontSize;
-
 	if(!m_TextContainerIndex.Valid())
 	{
 		CTextCursor Cursor;
-		TextRender()->SetCursor(&Cursor, TextX, TextY, FontSize, TEXTFLAG_RENDER);
-		Cursor.m_LineWidth = TextWidth;
+		Cursor.SetPosition(vec2(RectX + FontSize, RectY + FontSize));
+		Cursor.m_FontSize = FontSize;
+		Cursor.m_LineWidth = RectWidth - 2.0f * FontSize;
 		TextRender()->CreateTextContainer(m_TextContainerIndex, &Cursor, ServerMotd());
 	}
 

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -260,7 +260,7 @@ protected:
 		else
 			str_format(m_aText, sizeof(m_aText), "%d:", m_ClientId);
 		CTextCursor Cursor;
-		This.TextRender()->SetCursor(&Cursor, 0.0f, 0.0f, m_FontSize, TEXTFLAG_RENDER);
+		Cursor.m_FontSize = m_FontSize;
 		This.TextRender()->CreateOrAppendTextContainer(m_TextContainerIndex, &Cursor, m_aText);
 	}
 
@@ -291,7 +291,7 @@ protected:
 		m_FontSize = Data.m_FontSize;
 		CTextCursor Cursor;
 		This.TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
-		This.TextRender()->SetCursor(&Cursor, 0.0f, 0.0f, m_FontSize, TEXTFLAG_RENDER);
+		Cursor.m_FontSize = m_FontSize;
 		This.TextRender()->CreateOrAppendTextContainer(m_TextContainerIndex, &Cursor, FontIcons::FONT_ICON_HEART);
 		This.TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 	}
@@ -324,7 +324,7 @@ protected:
 		m_FontSize = Data.m_FontSize;
 		str_copy(m_aText, Data.m_pName, sizeof(m_aText));
 		CTextCursor Cursor;
-		This.TextRender()->SetCursor(&Cursor, 0.0f, 0.0f, m_FontSize, TEXTFLAG_RENDER);
+		Cursor.m_FontSize = m_FontSize;
 		This.TextRender()->CreateOrAppendTextContainer(m_TextContainerIndex, &Cursor, m_aText);
 	}
 
@@ -353,7 +353,7 @@ protected:
 		m_FontSize = Data.m_FontSizeClan;
 		str_copy(m_aText, Data.m_pClan, sizeof(m_aText));
 		CTextCursor Cursor;
-		This.TextRender()->SetCursor(&Cursor, 0.0f, 0.0f, m_FontSize, TEXTFLAG_RENDER);
+		Cursor.m_FontSize = m_FontSize;
 		This.TextRender()->CreateOrAppendTextContainer(m_TextContainerIndex, &Cursor, m_aText);
 	}
 
@@ -433,7 +433,7 @@ protected:
 		m_StrongWeakId = Data.m_HookStrongWeakId;
 		str_format(m_aText, sizeof(m_aText), "%d", m_StrongWeakId);
 		CTextCursor Cursor;
-		This.TextRender()->SetCursor(&Cursor, 0.0f, 0.0f, m_FontSize, TEXTFLAG_RENDER);
+		Cursor.m_FontSize = m_FontSize;
 		This.TextRender()->CreateOrAppendTextContainer(m_TextContainerIndex, &Cursor, m_aText);
 	}
 

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -162,7 +162,8 @@ void CScoreboard::RenderSpectators(CUIRect Spectators)
 	Spectators.Margin(10.0f, &Spectators);
 
 	CTextCursor Cursor;
-	TextRender()->SetCursor(&Cursor, Spectators.x, Spectators.y, 22.0f, TEXTFLAG_RENDER);
+	Cursor.SetPosition(Spectators.TopLeft());
+	Cursor.m_FontSize = 22.0f;
 	Cursor.m_LineWidth = Spectators.w;
 	Cursor.m_MaxLines = round_truncate(Spectators.h / Cursor.m_FontSize);
 
@@ -533,7 +534,9 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 			// name
 			{
 				CTextCursor Cursor;
-				TextRender()->SetCursor(&Cursor, NameOffset, Row.y + (Row.h - FontSize) / 2.0f, FontSize, TEXTFLAG_RENDER | TEXTFLAG_ELLIPSIS_AT_END);
+				Cursor.SetPosition(vec2(NameOffset, Row.y + (Row.h - FontSize) / 2.0f));
+				Cursor.m_FontSize = FontSize;
+				Cursor.m_Flags |= TEXTFLAG_ELLIPSIS_AT_END;
 				Cursor.m_LineWidth = NameLength;
 				if(ClientData.m_AuthLevel)
 				{
@@ -566,7 +569,9 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 					TextRender()->TextColor(TextColor);
 				}
 				CTextCursor Cursor;
-				TextRender()->SetCursor(&Cursor, ClanOffset + (ClanLength - minimum(TextRender()->TextWidth(FontSize, ClientData.m_aClan), ClanLength)) / 2.0f, Row.y + (Row.h - FontSize) / 2.0f, FontSize, TEXTFLAG_RENDER | TEXTFLAG_ELLIPSIS_AT_END);
+				Cursor.SetPosition(vec2(ClanOffset + (ClanLength - minimum(TextRender()->TextWidth(FontSize, ClientData.m_aClan), ClanLength)) / 2.0f, Row.y + (Row.h - FontSize) / 2.0f));
+				Cursor.m_FontSize = FontSize;
+				Cursor.m_Flags |= TEXTFLAG_ELLIPSIS_AT_END;
 				Cursor.m_LineWidth = ClanLength;
 				TextRender()->TextEx(&Cursor, ClientData.m_aClan);
 			}

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -517,7 +517,9 @@ void CSpectator::OnRender()
 			TeeAlpha = 1.0f;
 		}
 		CTextCursor NameCursor;
-		TextRender()->SetCursor(&NameCursor, Width / 2.0f + x + 50.0f, Height / 2.0f + y + BoxMove + (LineHeight - FontSize) / 2.f, FontSize, TEXTFLAG_RENDER | TEXTFLAG_ELLIPSIS_AT_END);
+		NameCursor.SetPosition(vec2(Width / 2.0f + x + 50.0f, Height / 2.0f + y + BoxMove + (LineHeight - FontSize) / 2.f));
+		NameCursor.m_FontSize = FontSize;
+		NameCursor.m_Flags |= TEXTFLAG_ELLIPSIS_AT_END;
 		NameCursor.m_LineWidth = 180.0f;
 		if(g_Config.m_ClShowIds)
 		{

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -302,7 +302,9 @@ void CStatboard::RenderGlobalStats()
 
 		char aBuf[128];
 		CTextCursor Cursor;
-		TextRender()->SetCursor(&Cursor, x + 64, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
+		Cursor.SetPosition(vec2(x + 64, y + (LineHeight * 0.95f - FontSize) / 2.f));
+		Cursor.m_FontSize = FontSize;
+		Cursor.m_Flags |= TEXTFLAG_STOP_AT_END;
 		Cursor.m_LineWidth = 220;
 		TextRender()->TextEx(&Cursor, GameClient()->m_aClients[pInfo->m_ClientId].m_aName, -1);
 

--- a/src/game/client/components/tooltips.cpp
+++ b/src/game/client/components/tooltips.cpp
@@ -124,7 +124,8 @@ void CTooltips::OnRender()
 		Rect.Margin(Padding, &Rect);
 
 		CTextCursor Cursor;
-		TextRender()->SetCursor(&Cursor, Rect.x, Rect.y, FontSize, TEXTFLAG_RENDER);
+		Cursor.SetPosition(Rect.TopLeft());
+		Cursor.m_FontSize = FontSize;
 		Cursor.m_LineWidth = Tooltip.m_WidthHint;
 
 		STextContainerIndex TextContainerIndex;

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -439,7 +439,8 @@ STextBoundingBox CLineInput::Render(const CUIRect *pRect, float FontSize, int Al
 		const STextBoundingBox BoundingBox = TextRender()->TextBoundingBox(FontSize, pDisplayStr, -1, LineWidth, LineSpacing);
 		const vec2 CursorPos = CUi::CalcAlignedCursorPos(pRect, BoundingBox.Size(), Align);
 
-		TextRender()->SetCursor(&Cursor, CursorPos.x, CursorPos.y, FontSize, TEXTFLAG_RENDER);
+		Cursor.SetPosition(CursorPos);
+		Cursor.m_FontSize = FontSize;
 		Cursor.m_LineWidth = LineWidth;
 		Cursor.m_ForceCursorRendering = Changed;
 		Cursor.m_LineSpacing = LineSpacing;
@@ -511,7 +512,9 @@ STextBoundingBox CLineInput::Render(const CUIRect *pRect, float FontSize, int Al
 		m_CaretPosition = Cursor.m_CursorRenderedPosition;
 
 		CTextCursor CaretCursor;
-		TextRender()->SetCursor(&CaretCursor, CursorPos.x, CursorPos.y, FontSize, 0);
+		CaretCursor.SetPosition(CursorPos);
+		CaretCursor.m_FontSize = FontSize;
+		CaretCursor.m_Flags = 0;
 		CaretCursor.m_LineWidth = LineWidth;
 		CaretCursor.m_LineSpacing = LineSpacing;
 		CaretCursor.m_CursorMode = TEXT_CURSOR_CURSOR_MODE_SET;
@@ -522,8 +525,8 @@ STextBoundingBox CLineInput::Render(const CUIRect *pRect, float FontSize, int Al
 	else
 	{
 		const STextBoundingBox BoundingBox = TextRender()->TextBoundingBox(FontSize, pDisplayStr, -1, LineWidth, LineSpacing);
-		const vec2 CursorPos = CUi::CalcAlignedCursorPos(pRect, BoundingBox.Size(), Align);
-		TextRender()->SetCursor(&Cursor, CursorPos.x, CursorPos.y, FontSize, TEXTFLAG_RENDER);
+		Cursor.SetPosition(CUi::CalcAlignedCursorPos(pRect, BoundingBox.Size(), Align));
+		Cursor.m_FontSize = FontSize;
 		Cursor.m_LineWidth = LineWidth;
 		Cursor.m_LineSpacing = LineSpacing;
 		Cursor.m_vColorSplits = vColorSplits;

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -47,7 +47,7 @@ void CUIElement::SUIElementRect::Reset()
 	m_Rounding = -1.0f;
 	m_Corners = -1;
 	m_Text.clear();
-	m_Cursor.Reset();
+	m_Cursor = CTextCursor();
 	m_TextColor = ColorRGBA(-1, -1, -1, -1);
 	m_TextOutlineColor = ColorRGBA(-1, -1, -1, -1);
 	m_QuadColor = ColorRGBA(-1, -1, -1, -1);
@@ -797,7 +797,9 @@ void CUi::DoLabel(const CUIRect *pRect, const char *pText, float Size, int Align
 	const vec2 CursorPos = CalcAlignedCursorPos(pRect, TextBounds.m_TextSize, Align, TextBounds.m_LineCount == 1 ? &TextBounds.m_BiggestCharacterHeight : nullptr);
 
 	CTextCursor Cursor;
-	TextRender()->SetCursor(&Cursor, CursorPos.x, CursorPos.y, Size, TEXTFLAG_RENDER | Flags);
+	Cursor.SetPosition(CursorPos);
+	Cursor.m_FontSize = Size;
+	Cursor.m_Flags |= Flags;
 	Cursor.m_vColorSplits = LabelProps.m_vColorSplits;
 	Cursor.m_LineWidth = (float)LabelProps.m_MaxWidth;
 	TextRender()->TextEx(&Cursor, pText, -1);
@@ -815,8 +817,9 @@ void CUi::DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, cons
 	}
 	else
 	{
-		const vec2 CursorPos = CalcAlignedCursorPos(pRect, TextBounds.m_TextSize, Align);
-		TextRender()->SetCursor(&Cursor, CursorPos.x, CursorPos.y, Size, TEXTFLAG_RENDER | Flags);
+		Cursor.SetPosition(CalcAlignedCursorPos(pRect, TextBounds.m_TextSize, Align));
+		Cursor.m_FontSize = Size;
+		Cursor.m_Flags |= Flags;
 	}
 	Cursor.m_LineWidth = LabelProps.m_MaxWidth;
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -7566,7 +7566,8 @@ void CEditor::RenderPressedKeys(CUIRect View)
 
 	Ui()->MapScreen();
 	CTextCursor Cursor;
-	TextRender()->SetCursor(&Cursor, View.x + 10, View.y + View.h - 24 - 10, 24.0f, TEXTFLAG_RENDER);
+	Cursor.SetPosition(vec2(View.x + 10, View.y + View.h - 24 - 10));
+	Cursor.m_FontSize = 24.0f;
 
 	int NKeys = 0;
 	for(int i = 0; i < KEY_LAST; i++)


### PR DESCRIPTION
Remove `ITextRender::SetCursor` function and add `CTextCursor::SetPosition` function instead. Initialize `CTextCursor` to common default values (zeroed position, flag for normal rendering) to simplify usage.

See https://github.com/ddnet/ddnet/issues/10607#issuecomment-3151980726

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
