### PR TITLE
Fix `net_udp_create`/`net_tcp_create` return value documentation

### DIFF
--- a/src/base/system.h
+++ b/src/base/system.h
@@ -997,7 +997,7 @@ int net_socket_type(NETSOCKET sock);
  *
  * @param bindaddr Address to bind the socket to.
  *
- * @return On success it returns an handle to the socket. On failure it returns `NETSOCKET_INVALID`
+ * @return On success it returns an handle to the socket. On failure it returns `nullptr`.
  */
 NETSOCKET net_udp_create(NETADDR bindaddr);
 
@@ -1050,7 +1050,7 @@ void net_udp_close(NETSOCKET sock);
  *
  * @param bindaddr Address to bind the socket to.
  *
- * @return On success it returns an handle to the socket. On failure it returns NETSOCKET_INVALID.
+ * @return On success it returns an handle to the socket. On failure it returns `nullptr`.
  */
 NETSOCKET net_tcp_create(NETADDR bindaddr);
 


### PR DESCRIPTION


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
