### PR TITLE
Clean up: remove duplicated dead render code for quads

### DIFF
--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -194,15 +194,8 @@ void CMapLayers::OnMapLoad()
 			{
 				CMapItemLayerQuads *pQLayer = (CMapItemLayerQuads *)pLayer;
 
-				IGraphics::CTextureHandle TextureHandle;
-				if(pQLayer->m_Image >= 0 && pQLayer->m_Image < m_pImages->Num())
-					TextureHandle = m_pImages->Get(pQLayer->m_Image);
-				else
-					TextureHandle.Invalidate();
-
 				pRenderLayer = std::make_unique<CRenderLayerQuads>(
 					g, l,
-					TextureHandle,
 					pLayer->m_Flags,
 					pQLayer);
 			}

--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -843,7 +843,7 @@ void CRenderLayerTile::GetTileData(unsigned char *pIndex, unsigned char *pFlags,
  * Quad Layer *
  **************/
 
-CRenderLayerQuads::CRenderLayerQuads(int GroupId, int LayerId, IGraphics::CTextureHandle TextureHandle, int Flags, CMapItemLayerQuads *pLayerQuads) :
+CRenderLayerQuads::CRenderLayerQuads(int GroupId, int LayerId, int Flags, CMapItemLayerQuads *pLayerQuads) :
 	CRenderLayer(GroupId, LayerId, Flags)
 {
 	m_pLayerQuads = pLayerQuads;

--- a/src/game/map/render_layer.h
+++ b/src/game/map/render_layer.h
@@ -208,7 +208,7 @@ protected:
 class CRenderLayerQuads : public CRenderLayer
 {
 public:
-	CRenderLayerQuads(int GroupId, int LayerId, IGraphics::CTextureHandle TextureHandle, int Flags, CMapItemLayerQuads *pLayerQuads);
+	CRenderLayerQuads(int GroupId, int LayerId, int Flags, CMapItemLayerQuads *pLayerQuads);
 	void OnInit(IGraphics *pGraphics, ITextRender *pTextRender, CRenderMap *pRenderMap, IEnvelopeEval *pEnvelopeEval, IMap *pMap, IMapImages *pMapImages, std::shared_ptr<CMapBasedEnvelopePointAccess> &pEnvelopePoints, std::optional<FRenderUploadCallback> &FRenderUploadCallbackOptional) override;
 	virtual void Init() override;
 	bool IsValid() const override { return m_pLayerQuads->m_NumQuads > 0 && m_pQuads; }


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This code is duplicated. The tiles render layer also doesn't get a texture and this is already handled by the `Init` function, see https://github.com/ddnet/ddnet/blob/c781c6d2d2ad1d0aeb1125122ff004045b464de0/src/game/map/render_layer.cpp#L948

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
