### PR TITLE
Feature: Add a map renderer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2541,6 +2541,8 @@ if(CLIENT)
     tileart.cpp
   )
   set_src(GAME_MAP GLOB_RECURSE src/game/map
+    map_renderer.cpp
+    map_renderer.h
     render_component.cpp
     render_component.h
     render_interfaces.h

--- a/src/game/client/components/background.cpp
+++ b/src/game/client/components/background.cpp
@@ -12,7 +12,7 @@
 
 #include "background.h"
 
-CBackground::CBackground(int MapType, bool OnlineOnly) :
+CBackground::CBackground(ERenderType MapType, bool OnlineOnly) :
 	CMapLayers(MapType, OnlineOnly)
 {
 	m_pLayers = new CLayers;

--- a/src/game/client/components/background.h
+++ b/src/game/client/components/background.h
@@ -33,7 +33,7 @@ protected:
 	virtual CBackgroundEngineMap *CreateBGMap();
 
 public:
-	CBackground(int MapType = ERenderType::RENDERTYPE_BACKGROUND_FORCE, bool OnlineOnly = true);
+	CBackground(ERenderType MapType = ERenderType::RENDERTYPE_BACKGROUND_FORCE, bool OnlineOnly = true);
 	virtual ~CBackground();
 	int Sizeof() const override { return sizeof(*this); }
 

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -9,8 +9,6 @@
 
 using namespace std::chrono_literals;
 
-const int LAYER_DEFAULT_TILESET = -1;
-
 void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, IMap *pMap, CMapBasedEnvelopePointAccess *pEnvelopePoints, IClient *pClient, CGameClient *pGameClient, bool OnlineOnly)
 {
 	int EnvStart, EnvNum;
@@ -59,7 +57,7 @@ void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, 
 	EnvelopeEval(TimeOffsetMillis, Env, Result, Channels, this->m_pLayers->Map(), this->m_pEnvelopePoints.get(), this->Client(), this->GameClient(), this->m_OnlineOnly);
 }
 
-CMapLayers::CMapLayers(int Type, bool OnlineOnly)
+CMapLayers::CMapLayers(ERenderType Type, bool OnlineOnly)
 {
 	m_Type = Type;
 	m_OnlineOnly = OnlineOnly;
@@ -71,17 +69,11 @@ CMapLayers::CMapLayers(int Type, bool OnlineOnly)
 	m_Params.m_RenderTileBorder = true;
 }
 
-void CMapLayers::Unload()
-{
-	for(auto &pLayer : m_vpRenderLayers)
-		pLayer->Unload();
-	m_vpRenderLayers.clear();
-}
-
 void CMapLayers::OnInit()
 {
 	m_pLayers = Layers();
 	m_pImages = &GameClient()->m_MapImages;
+	m_MapRenderer.Clear();
 }
 
 CCamera *CMapLayers::GetCurCamera()
@@ -95,123 +87,14 @@ void CMapLayers::OnMapLoad()
 	FRenderUploadCallback FRenderCallback = [&](const char *pTitle, const char *pMessage, int IncreaseCounter) { GameClient()->m_Menus.RenderLoading(pTitle, pMessage, IncreaseCounter); };
 	auto FRenderCallbackOptional = std::make_optional<FRenderUploadCallback>(FRenderCallback);
 
-	bool PassedGameLayer = false;
-	Unload();
-
 	const char *pLoadingTitle = Localize("Loading map");
 	const char *pLoadingMessage = Localize("Uploading map data to GPU");
 	GameClient()->m_Menus.RenderLoading(pLoadingTitle, pLoadingMessage, 0);
 
-	for(int g = 0; g < m_pLayers->NumGroups(); g++)
-	{
-		CMapItemGroup *pGroup = m_pLayers->GetGroup(g);
-		std::unique_ptr<CRenderLayer> pRenderLayerGroup = std::make_unique<CRenderLayerGroup>(g, pGroup);
-		pRenderLayerGroup->OnInit(Graphics(), TextRender(), RenderMap(), this, m_pLayers->Map(), m_pImages, m_pEnvelopePoints, FRenderCallbackOptional);
-		if(!pRenderLayerGroup->IsValid())
-		{
-			dbg_msg("maplayers", "error group was null, group number = %d, total groups = %d", g, m_pLayers->NumGroups());
-			dbg_msg("maplayers", "this is here to prevent a crash but the source of this is unknown, please report this for it to get fixed");
-			dbg_msg("maplayers", "we need mapname and crc and the map that caused this if possible, and anymore info you think is relevant");
-			continue;
-		}
+	// can't do that in CMapLayers::OnInit, because some of this interfaces are not available yet
+	m_MapRenderer.OnInit(Graphics(), TextRender(), RenderMap());
 
-		for(int l = 0; l < pGroup->m_NumLayers; l++)
-		{
-			CMapItemLayer *pLayer = m_pLayers->GetLayer(pGroup->m_StartLayer + l);
-			int LayerType = GetLayerType(pLayer);
-			PassedGameLayer |= LayerType == LAYER_GAME;
-
-			if(m_Type == ERenderType::RENDERTYPE_BACKGROUND_FORCE || m_Type == ERenderType::RENDERTYPE_BACKGROUND)
-			{
-				if(PassedGameLayer)
-					return;
-			}
-			else if(m_Type == ERenderType::RENDERTYPE_FOREGROUND)
-			{
-				if(!PassedGameLayer)
-					continue;
-			}
-
-			if(pRenderLayerGroup)
-				m_vpRenderLayers.push_back(std::move(pRenderLayerGroup));
-
-			std::unique_ptr<CRenderLayer> pRenderLayer;
-
-			if(pLayer->m_Type == LAYERTYPE_TILES)
-			{
-				CMapItemLayerTilemap *pTileLayer = (CMapItemLayerTilemap *)pLayer;
-
-				switch(LayerType)
-				{
-				case LAYER_DEFAULT_TILESET:
-					pRenderLayer = std::make_unique<CRenderLayerTile>(
-						g, l,
-						pLayer->m_Flags,
-						pTileLayer);
-					break;
-				case LAYER_GAME:
-					pRenderLayer = std::make_unique<CRenderLayerEntityGame>(
-						g, l,
-						pLayer->m_Flags,
-						pTileLayer);
-					break;
-				case LAYER_FRONT:
-					pRenderLayer = std::make_unique<CRenderLayerEntityFront>(
-						g, l,
-						pLayer->m_Flags,
-						pTileLayer);
-					break;
-				case LAYER_TELE:
-					pRenderLayer = std::make_unique<CRenderLayerEntityTele>(
-						g, l,
-						pLayer->m_Flags,
-						pTileLayer);
-					break;
-				case LAYER_SPEEDUP:
-					pRenderLayer = std::make_unique<CRenderLayerEntitySpeedup>(
-						g, l,
-						pLayer->m_Flags,
-						pTileLayer);
-					break;
-				case LAYER_SWITCH:
-					pRenderLayer = std::make_unique<CRenderLayerEntitySwitch>(
-						g, l,
-						pLayer->m_Flags,
-						pTileLayer);
-					break;
-				case LAYER_TUNE:
-					pRenderLayer = std::make_unique<CRenderLayerEntityTune>(
-						g, l,
-						pLayer->m_Flags,
-						pTileLayer);
-					break;
-				default:
-					dbg_assert(false, "Unknown LayerType %d", LayerType);
-					break;
-				}
-			}
-			else if(pLayer->m_Type == LAYERTYPE_QUADS)
-			{
-				CMapItemLayerQuads *pQLayer = (CMapItemLayerQuads *)pLayer;
-
-				pRenderLayer = std::make_unique<CRenderLayerQuads>(
-					g, l,
-					pLayer->m_Flags,
-					pQLayer);
-			}
-
-			// just ignore invalid layers from rendering
-			if(pRenderLayer)
-			{
-				pRenderLayer->OnInit(Graphics(), TextRender(), RenderMap(), this, m_pLayers->Map(), m_pImages, m_pEnvelopePoints, FRenderCallbackOptional);
-				if(pRenderLayer->IsValid())
-				{
-					pRenderLayer->Init();
-					m_vpRenderLayers.push_back(std::move(pRenderLayer));
-				}
-			}
-		}
-	}
+	m_MapRenderer.Load(m_Type, m_pLayers, m_pImages, this, FRenderCallbackOptional);
 }
 
 void CMapLayers::OnRender()
@@ -219,57 +102,11 @@ void CMapLayers::OnRender()
 	if(m_OnlineOnly && Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 		return;
 
-	CUIRect Screen;
-	Graphics()->GetScreen(&Screen.x, &Screen.y, &Screen.w, &Screen.h);
-
 	// dynamic parameters for ingame rendering
 	m_Params.m_EntityOverlayVal = m_Type == RENDERTYPE_FULL_DESIGN ? 0 : g_Config.m_ClOverlayEntities;
 	m_Params.m_Center = GetCurCamera()->m_Center;
 	m_Params.m_Zoom = GetCurCamera()->m_Zoom;
 	m_Params.m_RenderText = g_Config.m_ClTextEntities;
 
-	bool DoRenderGroup = true;
-	for(auto &pRenderLayer : m_vpRenderLayers)
-	{
-		if(pRenderLayer->IsGroup())
-			DoRenderGroup = pRenderLayer->DoRender(m_Params);
-
-		if(!DoRenderGroup)
-			continue;
-
-		if(pRenderLayer->DoRender(m_Params))
-			pRenderLayer->Render(m_Params);
-	}
-
-	// Reset clip from last group
-	Graphics()->ClipDisable();
-
-	// don't reset screen on background
-	if(m_Type != ERenderType::RENDERTYPE_BACKGROUND && m_Type != ERenderType::RENDERTYPE_BACKGROUND_FORCE)
-	{
-		// reset the screen like it was before
-		Graphics()->MapScreen(Screen.x, Screen.y, Screen.w, Screen.h);
-	}
-	else
-	{
-		// reset the screen to the default interface
-		Graphics()->MapScreenToInterface(m_Params.m_Center.x, m_Params.m_Center.y, m_Params.m_Zoom);
-	}
-}
-
-int CMapLayers::GetLayerType(const CMapItemLayer *pLayer) const
-{
-	if(pLayer == (CMapItemLayer *)m_pLayers->GameLayer())
-		return LAYER_GAME;
-	else if(pLayer == (CMapItemLayer *)m_pLayers->FrontLayer())
-		return LAYER_FRONT;
-	else if(pLayer == (CMapItemLayer *)m_pLayers->SwitchLayer())
-		return LAYER_SWITCH;
-	else if(pLayer == (CMapItemLayer *)m_pLayers->TeleLayer())
-		return LAYER_TELE;
-	else if(pLayer == (CMapItemLayer *)m_pLayers->SpeedupLayer())
-		return LAYER_SPEEDUP;
-	else if(pLayer == (CMapItemLayer *)m_pLayers->TuneLayer())
-		return LAYER_TUNE;
-	return LAYER_DEFAULT_TILESET;
+	m_MapRenderer.Render(m_Params);
 }

--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -4,21 +4,15 @@
 #define GAME_CLIENT_COMPONENTS_MAPLAYERS_H
 
 #include <game/client/component.h>
-#include <game/map/render_layer.h>
+#include <game/map/map_renderer.h>
 
 #include <cstdint>
 #include <memory>
-#include <vector>
 
 class CCamera;
 class CLayers;
 class CMapImages;
 class ColorRGBA;
-
-class CMapItemGroup;
-class CMapItemLayer;
-class CMapItemLayerTilemap;
-class CMapItemLayerQuads;
 
 class CMapLayers : public CComponent, public IEnvelopeEval
 {
@@ -29,14 +23,14 @@ class CMapLayers : public CComponent, public IEnvelopeEval
 	CMapImages *m_pImages;
 	std::shared_ptr<CMapBasedEnvelopePointAccess> m_pEnvelopePoints;
 
-	int m_Type;
+	ERenderType m_Type;
 	bool m_OnlineOnly;
 
 public:
 	static void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, IMap *pMap, CMapBasedEnvelopePointAccess *pEnvelopePoints, IClient *pClient, CGameClient *pGameClient, bool OnlineOnly);
 	void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels) override;
 
-	CMapLayers(int Type, bool OnlineOnly = true);
+	CMapLayers(ERenderType Type, bool OnlineOnly = true);
 	int Sizeof() const override { return sizeof(*this); }
 	void OnInit() override;
 	void OnRender() override;
@@ -46,9 +40,8 @@ public:
 	virtual CCamera *GetCurCamera();
 
 private:
-	std::vector<std::unique_ptr<CRenderLayer>> m_vpRenderLayers;
-	int GetLayerType(const CMapItemLayer *pLayer) const;
 	CRenderLayerParams m_Params;
+	CMapRenderer m_MapRenderer;
 };
 
 #endif

--- a/src/game/map/map_renderer.cpp
+++ b/src/game/map/map_renderer.cpp
@@ -1,0 +1,190 @@
+#include <base/log.h>
+
+#include "map_renderer.h"
+
+const int LAYER_DEFAULT_TILESET = -1;
+
+void CMapRenderer::Clear()
+{
+	for(auto &pLayer : m_vpRenderLayers)
+		pLayer->Unload();
+	m_vpRenderLayers.clear();
+}
+
+void CMapRenderer::Load(ERenderType Type, CLayers *pLayers, IMapImages *pMapImages, IEnvelopeEval *pEnvelopeEval, std::optional<FRenderUploadCallback> RenderCallbackOptional)
+{
+	Clear();
+
+	std::shared_ptr<CMapBasedEnvelopePointAccess> pEnvelopePoints = std::make_shared<CMapBasedEnvelopePointAccess>(pLayers->Map());
+	bool PassedGameLayer = false;
+
+	for(int GroupId = 0; GroupId < pLayers->NumGroups(); GroupId++)
+	{
+		CMapItemGroup *pGroup = pLayers->GetGroup(GroupId);
+		std::unique_ptr<CRenderLayer> pRenderLayerGroup = std::make_unique<CRenderLayerGroup>(GroupId, pGroup);
+		pRenderLayerGroup->OnInit(Graphics(), TextRender(), RenderMap(), pEnvelopeEval, pLayers->Map(), pMapImages, pEnvelopePoints, RenderCallbackOptional);
+		if(!pRenderLayerGroup->IsValid())
+		{
+			log_error("map_renderer", "error group was null, group number = %d, total groups = %d", GroupId, pLayers->NumGroups());
+			log_error("map_renderer", "this is here to prevent a crash but the source of this is unknown, please report this for it to get fixed");
+			log_error("map_renderer", "we need mapname and crc and the map that caused this if possible, and anymore info you think is relevant");
+			continue;
+		}
+
+		for(int LayerId = 0; LayerId < pGroup->m_NumLayers; LayerId++)
+		{
+			CMapItemLayer *pLayer = pLayers->GetLayer(pGroup->m_StartLayer + LayerId);
+			int LayerType = GetLayerType(pLayer, pLayers);
+			PassedGameLayer |= LayerType == LAYER_GAME;
+
+			if(Type == ERenderType::RENDERTYPE_BACKGROUND_FORCE || Type == ERenderType::RENDERTYPE_BACKGROUND)
+			{
+				if(PassedGameLayer)
+					return;
+			}
+			else if(Type == ERenderType::RENDERTYPE_FOREGROUND)
+			{
+				if(!PassedGameLayer)
+					continue;
+			}
+
+			if(pRenderLayerGroup)
+				m_vpRenderLayers.push_back(std::move(pRenderLayerGroup));
+
+			std::unique_ptr<CRenderLayer> pRenderLayer;
+
+			if(pLayer->m_Type == LAYERTYPE_TILES)
+			{
+				CMapItemLayerTilemap *pTileLayer = (CMapItemLayerTilemap *)pLayer;
+
+				switch(LayerType)
+				{
+				case LAYER_DEFAULT_TILESET:
+					pRenderLayer = std::make_unique<CRenderLayerTile>(
+						GroupId,
+						LayerId,
+						pLayer->m_Flags,
+						pTileLayer);
+					break;
+				case LAYER_GAME:
+					pRenderLayer = std::make_unique<CRenderLayerEntityGame>(
+						GroupId,
+						LayerId,
+						pLayer->m_Flags,
+						pTileLayer);
+					break;
+				case LAYER_FRONT:
+					pRenderLayer = std::make_unique<CRenderLayerEntityFront>(
+						GroupId,
+						LayerId,
+						pLayer->m_Flags,
+						pTileLayer);
+					break;
+				case LAYER_TELE:
+					pRenderLayer = std::make_unique<CRenderLayerEntityTele>(
+						GroupId,
+						LayerId,
+						pLayer->m_Flags,
+						pTileLayer);
+					break;
+				case LAYER_SPEEDUP:
+					pRenderLayer = std::make_unique<CRenderLayerEntitySpeedup>(
+						GroupId,
+						LayerId,
+						pLayer->m_Flags,
+						pTileLayer);
+					break;
+				case LAYER_SWITCH:
+					pRenderLayer = std::make_unique<CRenderLayerEntitySwitch>(
+						GroupId,
+						LayerId,
+						pLayer->m_Flags,
+						pTileLayer);
+					break;
+				case LAYER_TUNE:
+					pRenderLayer = std::make_unique<CRenderLayerEntityTune>(
+						GroupId,
+						LayerId,
+						pLayer->m_Flags,
+						pTileLayer);
+					break;
+				default:
+					dbg_assert(false, "Unknown LayerType %d", LayerType);
+					break;
+				}
+			}
+			else if(pLayer->m_Type == LAYERTYPE_QUADS)
+			{
+				CMapItemLayerQuads *pQLayer = (CMapItemLayerQuads *)pLayer;
+
+				pRenderLayer = std::make_unique<CRenderLayerQuads>(
+					GroupId,
+					LayerId,
+					pLayer->m_Flags,
+					pQLayer);
+			}
+
+			// just ignore invalid layers from rendering
+			if(pRenderLayer)
+			{
+				pRenderLayer->OnInit(Graphics(), TextRender(), RenderMap(), pEnvelopeEval, pLayers->Map(), pMapImages, pEnvelopePoints, RenderCallbackOptional);
+				if(pRenderLayer->IsValid())
+				{
+					pRenderLayer->Init();
+					m_vpRenderLayers.push_back(std::move(pRenderLayer));
+				}
+			}
+		}
+	}
+}
+
+void CMapRenderer::Render(const CRenderLayerParams &Params)
+{
+	float ScreenXLeft, ScreenYTop, ScreenXRight, ScreenYBottom;
+	Graphics()->GetScreen(&ScreenXLeft, &ScreenYTop, &ScreenXRight, &ScreenYBottom);
+
+	bool DoRenderGroup = true;
+	for(auto &pRenderLayer : m_vpRenderLayers)
+	{
+		if(pRenderLayer->IsGroup())
+			DoRenderGroup = pRenderLayer->DoRender(Params);
+
+		if(!DoRenderGroup)
+			continue;
+
+		if(pRenderLayer->DoRender(Params))
+			pRenderLayer->Render(Params);
+	}
+
+	// Reset clip from last group
+	Graphics()->ClipDisable();
+
+	// don't reset screen on background
+	if(Params.m_RenderType != ERenderType::RENDERTYPE_BACKGROUND && Params.m_RenderType != ERenderType::RENDERTYPE_BACKGROUND_FORCE)
+	{
+		// reset the screen like it was before
+		Graphics()->MapScreen(ScreenXLeft, ScreenYTop, ScreenXRight, ScreenYBottom);
+	}
+	else
+	{
+		// reset the screen to the default interface
+		Graphics()->MapScreenToInterface(Params.m_Center.x, Params.m_Center.y, Params.m_Zoom);
+	}
+}
+
+int CMapRenderer::GetLayerType(const CMapItemLayer *pLayer, const CLayers *pLayers) const
+{
+	if(pLayer == (CMapItemLayer *)pLayers->GameLayer())
+		return LAYER_GAME;
+	else if(pLayer == (CMapItemLayer *)pLayers->FrontLayer())
+		return LAYER_FRONT;
+	else if(pLayer == (CMapItemLayer *)pLayers->SwitchLayer())
+		return LAYER_SWITCH;
+	else if(pLayer == (CMapItemLayer *)pLayers->TeleLayer())
+		return LAYER_TELE;
+	else if(pLayer == (CMapItemLayer *)pLayers->SpeedupLayer())
+		return LAYER_SPEEDUP;
+	else if(pLayer == (CMapItemLayer *)pLayers->TuneLayer())
+		return LAYER_TUNE;
+	return LAYER_DEFAULT_TILESET;
+}

--- a/src/game/map/map_renderer.h
+++ b/src/game/map/map_renderer.h
@@ -1,0 +1,24 @@
+#ifndef GAME_MAP_MAP_RENDERER_H
+#define GAME_MAP_MAP_RENDERER_H
+
+#include <engine/map.h>
+#include <game/layers.h>
+#include <game/map/render_component.h>
+#include <game/map/render_layer.h>
+
+class CMapRenderer : public CRenderComponent
+{
+public:
+	CMapRenderer() = default;
+
+	void Clear();
+	void Load(ERenderType Type, CLayers *pLayers, IMapImages *pMapImages, IEnvelopeEval *pEnvelopeEval, std::optional<FRenderUploadCallback> RenderCallbackOptional);
+	void Render(const CRenderLayerParams &Params);
+
+private:
+	int GetLayerType(const CMapItemLayer *pLayer, const CLayers *pLayers) const;
+
+	std::vector<std::unique_ptr<CRenderLayer>> m_vpRenderLayers;
+};
+
+#endif


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Break up `CMapLayers` and create a standalone map-renderer-class.
We now have a component which can render a map without the client, you only need to define 3 interfaces namely:
- IEnvelopeEval, to evaluate envelopes (could just be unanimated for preview)
- CLayers, we need data to load a map from
- IMapImages, some interface which knows where the images of the maps are

Why?
- Step towards #2892
- Step towards a standalone map renderer tool

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
