### PR TITLE
Refactor: make editor mapitems actual mapitems

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3930,7 +3930,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 				}
 			}
 
-			str_format(aBuf, sizeof(aBuf), "#%d %s", g, m_Map.m_vpGroups[g]->m_aName);
+			str_format(aBuf, sizeof(aBuf), "#%d %s", g, m_Map.m_vpGroups[g]->m_aGroupName);
 
 			bool Clicked;
 			bool Abrupted;
@@ -4089,8 +4089,8 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 				}
 			}
 
-			if(m_Map.m_vpGroups[g]->m_vpLayers[i]->m_aName[0])
-				str_copy(aBuf, m_Map.m_vpGroups[g]->m_vpLayers[i]->m_aName);
+			if(m_Map.m_vpGroups[g]->m_vpLayers[i]->m_aLayerName[0])
+				str_copy(aBuf, m_Map.m_vpGroups[g]->m_vpLayers[i]->m_aLayerName);
 			else
 			{
 				if(m_Map.m_vpGroups[g]->m_vpLayers[i]->m_Type == LAYERTYPE_TILES)

--- a/src/game/editor/mapitems/layer.h
+++ b/src/game/editor/mapitems/layer.h
@@ -22,7 +22,7 @@ public:
 	explicit CLayer(CEditor *pEditor)
 	{
 		m_Type = LAYERTYPE_INVALID;
-		str_copy(m_aName, "(invalid)");
+		str_copy(m_aLayerName, "(invalid)");
 		m_Visible = true;
 		m_Readonly = false;
 		m_Flags = 0;
@@ -31,7 +31,7 @@ public:
 
 	CLayer(const CLayer &Other)
 	{
-		str_copy(m_aName, Other.m_aName);
+		str_copy(m_aLayerName, Other.m_aLayerName);
 		m_Flags = Other.m_Flags;
 		m_pEditor = Other.m_pEditor;
 		m_Type = Other.m_Type;
@@ -68,7 +68,7 @@ public:
 		*pHeight = 0;
 	}
 
-	char m_aName[12];
+	char m_aLayerName[12];
 	int m_Type;
 	int m_Flags;
 

--- a/src/game/editor/mapitems/layer_front.cpp
+++ b/src/game/editor/mapitems/layer_front.cpp
@@ -3,7 +3,7 @@
 CLayerFront::CLayerFront(CEditor *pEditor, int w, int h) :
 	CLayerTiles(pEditor, w, h)
 {
-	str_copy(m_aName, "Front");
+	str_copy(m_aLayerName, "Front");
 	m_HasFront = true;
 }
 

--- a/src/game/editor/mapitems/layer_game.cpp
+++ b/src/game/editor/mapitems/layer_game.cpp
@@ -8,7 +8,7 @@
 CLayerGame::CLayerGame(CEditor *pEditor, int w, int h) :
 	CLayerTiles(pEditor, w, h)
 {
-	str_copy(m_aName, "Game");
+	str_copy(m_aLayerName, "Game");
 	m_HasGame = true;
 }
 

--- a/src/game/editor/mapitems/layer_group.cpp
+++ b/src/game/editor/mapitems/layer_group.cpp
@@ -7,7 +7,7 @@
 CLayerGroup::CLayerGroup()
 {
 	m_vpLayers.clear();
-	m_aName[0] = 0;
+	m_aGroupName[0] = 0;
 	m_Visible = true;
 	m_Collapse = false;
 	m_GameGroup = false;

--- a/src/game/editor/mapitems/layer_group.h
+++ b/src/game/editor/mapitems/layer_group.h
@@ -6,26 +6,14 @@
 #include <memory>
 #include <vector>
 
-class CLayerGroup
+class CLayerGroup : public CMapItemGroup
 {
 public:
 	class CEditorMap *m_pMap;
 
 	std::vector<std::shared_ptr<CLayer>> m_vpLayers;
 
-	int m_OffsetX;
-	int m_OffsetY;
-
-	int m_ParallaxX;
-	int m_ParallaxY;
-
-	int m_UseClipping;
-	int m_ClipX;
-	int m_ClipY;
-	int m_ClipW;
-	int m_ClipH;
-
-	char m_aName[12];
+	char m_aGroupName[12];
 	bool m_GameGroup;
 	bool m_Visible;
 	bool m_Collapse;

--- a/src/game/editor/mapitems/layer_quads.cpp
+++ b/src/game/editor/mapitems/layer_quads.cpp
@@ -11,12 +11,12 @@ CLayerQuads::CLayerQuads(CEditor *pEditor) :
 	CLayer(pEditor)
 {
 	m_Type = LAYERTYPE_QUADS;
-	m_aName[0] = '\0';
+	m_aLayerName[0] = '\0';
 	m_Image = -1;
 }
 
 CLayerQuads::CLayerQuads(const CLayerQuads &Other) :
-	CLayer(Other)
+	CLayer(Other), CMapItemLayerQuads(Other)
 {
 	m_Image = Other.m_Image;
 	m_vQuads = Other.m_vQuads;

--- a/src/game/editor/mapitems/layer_quads.h
+++ b/src/game/editor/mapitems/layer_quads.h
@@ -3,7 +3,7 @@
 
 #include "layer.h"
 
-class CLayerQuads : public CLayer
+class CLayerQuads : public CLayer, public CMapItemLayerQuads
 {
 public:
 	explicit CLayerQuads(CEditor *pEditor);
@@ -30,7 +30,6 @@ public:
 	std::shared_ptr<CLayer> Duplicate() const override;
 	const char *TypeName() const override;
 
-	int m_Image;
 	std::vector<CQuad> m_vQuads;
 };
 

--- a/src/game/editor/mapitems/layer_sounds.cpp
+++ b/src/game/editor/mapitems/layer_sounds.cpp
@@ -10,12 +10,12 @@ CLayerSounds::CLayerSounds(CEditor *pEditor) :
 	CLayer(pEditor)
 {
 	m_Type = LAYERTYPE_SOUNDS;
-	m_aName[0] = '\0';
+	m_aLayerName[0] = '\0';
 	m_Sound = -1;
 }
 
 CLayerSounds::CLayerSounds(const CLayerSounds &Other) :
-	CLayer(Other)
+	CLayer(Other), CMapItemLayerSounds(Other)
 {
 	m_Sound = Other.m_Sound;
 	m_vSources = Other.m_vSources;

--- a/src/game/editor/mapitems/layer_sounds.h
+++ b/src/game/editor/mapitems/layer_sounds.h
@@ -3,7 +3,7 @@
 
 #include "layer.h"
 
-class CLayerSounds : public CLayer
+class CLayerSounds : public CLayer, public CMapItemLayerSounds
 {
 public:
 	explicit CLayerSounds(CEditor *pEditor);
@@ -25,7 +25,6 @@ public:
 	std::shared_ptr<CLayer> Duplicate() const override;
 	const char *TypeName() const override;
 
-	int m_Sound;
 	std::vector<CSoundSource> m_vSources;
 };
 

--- a/src/game/editor/mapitems/layer_speedup.cpp
+++ b/src/game/editor/mapitems/layer_speedup.cpp
@@ -5,7 +5,7 @@
 CLayerSpeedup::CLayerSpeedup(CEditor *pEditor, int w, int h) :
 	CLayerTiles(pEditor, w, h)
 {
-	str_copy(m_aName, "Speedup");
+	str_copy(m_aLayerName, "Speedup");
 	m_HasSpeedup = true;
 
 	m_pSpeedupTile = new CSpeedupTile[w * h];
@@ -15,7 +15,7 @@ CLayerSpeedup::CLayerSpeedup(CEditor *pEditor, int w, int h) :
 CLayerSpeedup::CLayerSpeedup(const CLayerSpeedup &Other) :
 	CLayerTiles(Other)
 {
-	str_copy(m_aName, "Speedup copy");
+	str_copy(m_aLayerName, "Speedup copy");
 	m_HasSpeedup = true;
 
 	m_pSpeedupTile = new CSpeedupTile[m_Width * m_Height];

--- a/src/game/editor/mapitems/layer_switch.cpp
+++ b/src/game/editor/mapitems/layer_switch.cpp
@@ -5,7 +5,7 @@
 CLayerSwitch::CLayerSwitch(CEditor *pEditor, int w, int h) :
 	CLayerTiles(pEditor, w, h)
 {
-	str_copy(m_aName, "Switch");
+	str_copy(m_aLayerName, "Switch");
 	m_HasSwitch = true;
 
 	m_pSwitchTile = new CSwitchTile[w * h];
@@ -17,7 +17,7 @@ CLayerSwitch::CLayerSwitch(CEditor *pEditor, int w, int h) :
 CLayerSwitch::CLayerSwitch(const CLayerSwitch &Other) :
 	CLayerTiles(Other)
 {
-	str_copy(m_aName, "Switch copy");
+	str_copy(m_aLayerName, "Switch copy");
 	m_HasSwitch = true;
 
 	m_pSwitchTile = new CSwitchTile[m_Width * m_Height];

--- a/src/game/editor/mapitems/layer_tele.cpp
+++ b/src/game/editor/mapitems/layer_tele.cpp
@@ -5,7 +5,7 @@
 CLayerTele::CLayerTele(CEditor *pEditor, int w, int h) :
 	CLayerTiles(pEditor, w, h)
 {
-	str_copy(m_aName, "Tele");
+	str_copy(m_aLayerName, "Tele");
 	m_HasTele = true;
 
 	m_pTeleTile = new CTeleTile[w * h];
@@ -18,7 +18,7 @@ CLayerTele::CLayerTele(CEditor *pEditor, int w, int h) :
 CLayerTele::CLayerTele(const CLayerTele &Other) :
 	CLayerTiles(Other)
 {
-	str_copy(m_aName, "Tele copy");
+	str_copy(m_aLayerName, "Tele copy");
 	m_HasTele = true;
 
 	m_pTeleTile = new CTeleTile[m_Width * m_Height];

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -18,7 +18,7 @@ CLayerTiles::CLayerTiles(CEditor *pEditor, int w, int h) :
 	CLayer(pEditor)
 {
 	m_Type = LAYERTYPE_TILES;
-	m_aName[0] = '\0';
+	m_aLayerName[0] = '\0';
 	m_Width = w;
 	m_Height = h;
 	m_Image = -1;
@@ -45,7 +45,7 @@ CLayerTiles::CLayerTiles(CEditor *pEditor, int w, int h) :
 }
 
 CLayerTiles::CLayerTiles(const CLayerTiles &Other) :
-	CLayer(Other)
+	CLayer(Other), CMapItemLayerTilemap(Other)
 {
 	m_Width = Other.m_Width;
 	m_Height = Other.m_Height;

--- a/src/game/editor/mapitems/layer_tiles.h
+++ b/src/game/editor/mapitems/layer_tiles.h
@@ -31,7 +31,7 @@ struct RECTi
 	int w, h;
 };
 
-class CLayerTiles : public CLayer
+class CLayerTiles : public CLayer, public CMapItemLayerTilemap
 {
 protected:
 	template<typename T>
@@ -165,12 +165,6 @@ public:
 	void FlagModified(int x, int y, int w, int h);
 
 	bool m_HasGame;
-	int m_Image;
-	int m_Width;
-	int m_Height;
-	CColor m_Color;
-	int m_ColorEnv;
-	int m_ColorEnvOffset;
 	CTile *m_pTiles;
 
 	// DDRace

--- a/src/game/editor/mapitems/layer_tune.cpp
+++ b/src/game/editor/mapitems/layer_tune.cpp
@@ -5,7 +5,7 @@
 CLayerTune::CLayerTune(CEditor *pEditor, int w, int h) :
 	CLayerTiles(pEditor, w, h)
 {
-	str_copy(m_aName, "Tune");
+	str_copy(m_aLayerName, "Tune");
 	m_HasTune = true;
 
 	m_pTuneTile = new CTuneTile[w * h];
@@ -18,7 +18,7 @@ CLayerTune::CLayerTune(CEditor *pEditor, int w, int h) :
 CLayerTune::CLayerTune(const CLayerTune &Other) :
 	CLayerTiles(Other)
 {
-	str_copy(m_aName, "Tune copy");
+	str_copy(m_aLayerName, "Tune copy");
 	m_HasTune = true;
 
 	m_pTuneTile = new CTuneTile[m_Width * m_Height];

--- a/src/game/editor/mapitems/map.cpp
+++ b/src/game/editor/mapitems/map.cpp
@@ -271,7 +271,7 @@ void CEditorMap::MakeGameGroup(std::shared_ptr<CLayerGroup> pGroup)
 {
 	m_pGameGroup = std::move(pGroup);
 	m_pGameGroup->m_GameGroup = true;
-	str_copy(m_pGameGroup->m_aName, "Game");
+	str_copy(m_pGameGroup->m_aGroupName, "Game");
 }
 
 void CEditorMap::MakeTeleLayer(const std::shared_ptr<CLayer> &pLayer)

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -169,7 +169,7 @@ bool CEditorMap::Save(const char *pFileName, const std::function<void(const char
 		GItem.m_NumLayers = 0;
 
 		// save group name
-		StrToInts(GItem.m_aName, std::size(GItem.m_aName), pGroup->m_aName);
+		StrToInts(GItem.m_aName, std::size(GItem.m_aName), pGroup->m_aGroupName);
 
 		for(const std::shared_ptr<CLayer> &pLayer : pGroup->m_vpLayers)
 		{
@@ -183,7 +183,7 @@ bool CEditorMap::Save(const char *pFileName, const std::function<void(const char
 				Item.m_Version = 3;
 
 				Item.m_Layer.m_Version = 0; // was previously uninitialized, do not rely on it being 0
-				Item.m_Layer.m_Flags = pLayerTiles->m_Flags;
+				Item.m_Layer.m_Flags = pLayerTiles->CLayer::m_Flags;
 				Item.m_Layer.m_Type = pLayerTiles->m_Type;
 
 				Item.m_Color = pLayerTiles->m_Color;
@@ -238,7 +238,7 @@ bool CEditorMap::Save(const char *pFileName, const std::function<void(const char
 					Item.m_Data = Writer.AddData((size_t)pLayerTiles->m_Width * pLayerTiles->m_Height * sizeof(CTile), pLayerTiles->m_pTiles);
 
 				// save layer name
-				StrToInts(Item.m_aName, std::size(Item.m_aName), pLayerTiles->m_aName);
+				StrToInts(Item.m_aName, std::size(Item.m_aName), pLayerTiles->m_aLayerName);
 
 				// save item
 				Writer.AddItem(MAPITEMTYPE_LAYER, LayerCount, sizeof(Item), &Item);
@@ -288,7 +288,7 @@ bool CEditorMap::Save(const char *pFileName, const std::function<void(const char
 				}
 
 				// save layer name
-				StrToInts(Item.m_aName, std::size(Item.m_aName), pLayerQuads->m_aName);
+				StrToInts(Item.m_aName, std::size(Item.m_aName), pLayerQuads->m_aLayerName);
 
 				// save item
 				Writer.AddItem(MAPITEMTYPE_LAYER, LayerCount, sizeof(Item), &Item);
@@ -320,7 +320,7 @@ bool CEditorMap::Save(const char *pFileName, const std::function<void(const char
 				}
 
 				// save layer name
-				StrToInts(Item.m_aName, std::size(Item.m_aName), pLayerSounds->m_aName);
+				StrToInts(Item.m_aName, std::size(Item.m_aName), pLayerSounds->m_aLayerName);
 
 				// save item
 				Writer.AddItem(MAPITEMTYPE_LAYER, LayerCount, sizeof(Item), &Item);
@@ -682,7 +682,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 
 			// load group name
 			if(pGItem->m_Version >= 3)
-				IntsToStr(pGItem->m_aName, std::size(pGItem->m_aName), pGroup->m_aName, std::size(pGroup->m_aName));
+				IntsToStr(pGItem->m_aName, std::size(pGItem->m_aName), pGroup->m_aGroupName, std::size(pGroup->m_aGroupName));
 
 			for(int l = 0; l < pGItem->m_NumLayers; l++)
 			{
@@ -750,7 +750,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 						pTiles->m_ColorEnvOffset = pTilemapItem->m_ColorEnvOffset;
 					}
 
-					pTiles->m_Flags = pLayerItem->m_Flags;
+					pTiles->CLayer::m_Flags = pLayerItem->m_Flags;
 
 					pGroup->AddLayer(pTiles);
 					pTiles->m_Image = pTilemapItem->m_Image;
@@ -764,7 +764,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 
 					// load layer name
 					if(pTilemapItem->m_Version >= 3)
-						IntsToStr(pTilemapItem->m_aName, std::size(pTilemapItem->m_aName), pTiles->m_aName, std::size(pTiles->m_aName));
+						IntsToStr(pTilemapItem->m_aName, std::size(pTilemapItem->m_aName), pTiles->m_aLayerName, std::size(pTiles->m_aLayerName));
 
 					if(pTiles->m_HasTele)
 					{
@@ -885,7 +885,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 
 					// load layer name
 					if(pQuadsItem->m_Version >= 2)
-						IntsToStr(pQuadsItem->m_aName, std::size(pQuadsItem->m_aName), pQuads->m_aName, std::size(pQuads->m_aName));
+						IntsToStr(pQuadsItem->m_aName, std::size(pQuadsItem->m_aName), pQuads->m_aLayerName, std::size(pQuads->m_aLayerName));
 
 					if(pQuadsItem->m_NumQuads > 0)
 					{
@@ -914,7 +914,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 					}
 
 					// load layer name
-					IntsToStr(pSoundsItem->m_aName, std::size(pSoundsItem->m_aName), pSounds->m_aName, std::size(pSounds->m_aName));
+					IntsToStr(pSoundsItem->m_aName, std::size(pSoundsItem->m_aName), pSounds->m_aLayerName, std::size(pSounds->m_aLayerName));
 
 					// load data
 					if(pSoundsItem->m_NumSources > 0)
@@ -945,7 +945,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 					}
 
 					// load layer name
-					IntsToStr(pSoundsItem->m_aName, std::size(pSoundsItem->m_aName), pSounds->m_aName, std::size(pSounds->m_aName));
+					IntsToStr(pSoundsItem->m_aName, std::size(pSoundsItem->m_aName), pSounds->m_aLayerName, std::size(pSounds->m_aLayerName));
 
 					// load data
 					CSoundSourceDeprecated *pData = (CSoundSourceDeprecated *)DataFile.GetDataSwapped(pSoundsItem->m_Data);
@@ -1080,7 +1080,7 @@ void CEditorMap::PerformSanityChecks(const std::function<void(const char *pError
 						{
 							pLayerTiles->m_Image = -1;
 							char aBuf[IO_MAX_PATH_LENGTH + 128];
-							str_format(aBuf, sizeof(aBuf), "Error: The image '%s' (size %" PRIzu "x%" PRIzu ") has a width or height that is not divisible by 16 and therefore cannot be used for tile layers. The image of layer #%" PRIzu " '%s' in group #%" PRIzu " '%s' has been unset.", pImage->m_aName, pImage->m_Width, pImage->m_Height, LayerIndex, pLayer->m_aName, GroupIndex, pGroup->m_aName);
+							str_format(aBuf, sizeof(aBuf), "Error: The image '%s' (size %" PRIzu "x%" PRIzu ") has a width or height that is not divisible by 16 and therefore cannot be used for tile layers. The image of layer #%" PRIzu " '%s' in group #%" PRIzu " '%s' has been unset.", pImage->m_aName, pImage->m_Width, pImage->m_Height, LayerIndex, pLayer->m_aLayerName, GroupIndex, pGroup->m_aGroupName);
 							ErrorHandler(aBuf);
 						}
 					}

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -636,7 +636,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 		pEditor->Ui()->DoLabel(&Button, "Name:", 10.0f, TEXTALIGN_ML);
 		Button.VSplitLeft(40.0f, nullptr, &Button);
 		static CLineInput s_NameInput;
-		s_NameInput.SetBuffer(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_aName, sizeof(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_aName));
+		s_NameInput.SetBuffer(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_aGroupName, sizeof(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_aGroupName));
 		if(pEditor->DoEditBox(&s_NameInput, &Button, 10.0f))
 			pEditor->m_Map.OnModify();
 	}
@@ -775,7 +775,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 		Label.VSplitLeft(40.0f, &Label, &EditBox);
 		pEditor->Ui()->DoLabel(&Label, "Name:", 10.0f, TEXTALIGN_ML);
 		static CLineInput s_NameInput;
-		s_NameInput.SetBuffer(pCurrentLayer->m_aName, sizeof(pCurrentLayer->m_aName));
+		s_NameInput.SetBuffer(pCurrentLayer->m_aLayerName, sizeof(pCurrentLayer->m_aLayerName));
 		if(pEditor->DoEditBox(&s_NameInput, &EditBox, 10.0f))
 			pEditor->m_Map.OnModify();
 	}

--- a/src/game/editor/quadart.cpp
+++ b/src/game/editor/quadart.cpp
@@ -173,7 +173,7 @@ void CEditor::AddQuadArt(bool IgnoreHistory)
 	IStorage::StripPathAndExtension(m_QuadArtParameters.m_aFilename, aQuadArtName, sizeof(aQuadArtName));
 
 	std::shared_ptr<CLayerGroup> pGroup = m_Map.NewGroup();
-	str_copy(pGroup->m_aName, aQuadArtName);
+	str_copy(pGroup->m_aGroupName, aQuadArtName);
 	pGroup->m_UseClipping = true;
 	pGroup->m_ClipX = -1;
 	pGroup->m_ClipY = -1;
@@ -181,7 +181,7 @@ void CEditor::AddQuadArt(bool IgnoreHistory)
 	pGroup->m_ClipW = std::ceil(m_QuadArtImageInfo.m_Width * 1.f * m_QuadArtParameters.m_QuadPixelSize / m_QuadArtParameters.m_ImagePixelSize) + 2;
 
 	std::shared_ptr<CLayerQuads> pLayer = std::make_shared<CLayerQuads>(this);
-	str_copy(pLayer->m_aName, aQuadArtName);
+	str_copy(pLayer->m_aLayerName, aQuadArtName);
 	pGroup->AddLayer(pLayer);
 	pLayer->m_Flags |= LAYERFLAG_DETAIL;
 

--- a/src/game/editor/tileart.cpp
+++ b/src/game/editor/tileart.cpp
@@ -122,7 +122,7 @@ static std::shared_ptr<CLayerTiles> AddLayerWithImage(CEditor *pEditor, const st
 	pEditor->m_Map.m_vpImages.push_back(pEditorImage);
 
 	std::shared_ptr<CLayerTiles> pLayer = std::make_shared<CLayerTiles>(pEditor, Width, Height);
-	str_copy(pLayer->m_aName, pName);
+	str_copy(pLayer->m_aLayerName, pName);
 	pLayer->m_Image = pEditor->m_Map.m_vpImages.size() - 1;
 	pGroup->AddLayer(pLayer);
 
@@ -144,7 +144,7 @@ void CEditor::AddTileart(bool IgnoreHistory)
 	IStorage::StripPathAndExtension(m_aTileartFilename, aTileArtFileName, sizeof(aTileArtFileName));
 
 	std::shared_ptr<CLayerGroup> pGroup = m_Map.NewGroup();
-	str_copy(pGroup->m_aName, aTileArtFileName);
+	str_copy(pGroup->m_aGroupName, aTileArtFileName);
 
 	int ImageCount = m_Map.m_vpImages.size();
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This PR makes `EditorItems` actual `MapItems` (by subclassing). I tested before doing this if we could make the `EditorItems` hold `MapItems` as parameter containers instead, but this caused way too many changes at other places and was very unpractical!

This is the next step in a render-layer editor integration. RenderLayers expect MapItem-pointers as parameters. This would allow the rendering to **stay updated** if some parameters change and is the cleanest way of doing it. Otherwise you'd need to constantly update the render layers before each frame.

Example: CLayerQuads is now a CMapItemLayerQuads as well, which is expected by CRenderLayerQuads: https://github.com/ddnet/ddnet/blob/50d3f014267a3634007e39df7aca36d121451907/src/game/map/render_layer.cpp#L846

### Glossar

- Editor mapitem, like CLayerQuads -> EditorItem
- actual mapitem like CMapItemLayerQuads -> MapItem

### followups

- You _could_ make mapIO more efficient, but this is deliberately NOT part of this PR as this may be complicated and error prone
- Let EditorItems use render layers for rendering :partying_face: 


needed for #10753

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
