### PR TITLE
Move GetAuthLevel out of server.cpp

### DIFF
--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -138,6 +138,14 @@ public:
 	virtual void SetFlagMask(int FlagMask) = 0;
 };
 
+/**
+ * Converts auth level string to auth level enum (integer)
+ *
+ * @param pLevel should be either "admin", "mod", "moderator" or "helper"
+ * @return -1 on error otherwise one of the auth enums such as `AUTHED_ADMIN`
+ */
+int GetAuthLevel(const char *pLevel);
+
 std::unique_ptr<IConsole> CreateConsole(int FlagMask);
 
 #endif // FILE_ENGINE_CONSOLE_H

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3458,19 +3458,6 @@ void CServer::ConStatus(IConsole::IResult *pResult, void *pUser)
 	}
 }
 
-static int GetAuthLevel(const char *pLevel)
-{
-	int Level = -1;
-	if(!str_comp_nocase(pLevel, "admin"))
-		Level = AUTHED_ADMIN;
-	else if(str_startswith(pLevel, "mod"))
-		Level = AUTHED_MOD;
-	else if(!str_comp_nocase(pLevel, "helper"))
-		Level = AUTHED_HELPER;
-
-	return Level;
-}
-
 void CServer::AuthRemoveKey(int KeySlot)
 {
 	m_AuthManager.RemoveKey(KeySlot);

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -7,8 +7,10 @@
 #include <base/system.h>
 
 #include <engine/client/checksum.h>
+#include <engine/console.h>
 #include <engine/shared/protocol.h>
 #include <engine/storage.h>
+#include <game/generated/protocol.h>
 
 #include "config.h"
 #include "console.h"
@@ -1067,6 +1069,19 @@ const IConsole::CCommandInfo *CConsole::GetCommandInfo(const char *pName, int Fl
 	}
 
 	return nullptr;
+}
+
+int GetAuthLevel(const char *pLevel)
+{
+	int Level = -1;
+	if(!str_comp_nocase(pLevel, "admin"))
+		Level = AUTHED_ADMIN;
+	else if(!str_comp_nocase(pLevel, "mod") || !str_comp_nocase(pLevel, "moderator"))
+		Level = AUTHED_MOD;
+	else if(!str_comp_nocase(pLevel, "helper"))
+		Level = AUTHED_HELPER;
+
+	return Level;
 }
 
 std::unique_ptr<IConsole> CreateConsole(int FlagMask) { return std::make_unique<CConsole>(FlagMask); }


### PR DESCRIPTION
Makes it available to the entire code base.
Because it is a useful helper that in the future will also be used by console.cpp

Also be more specific about the "mod" and "moderator" cases.

This is a preparation for a refactor preparing #10681

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
