### PR TITLE
Use words instead of numbers for access level commands

### DIFF
--- a/data/autoexec_server.cfg
+++ b/data/autoexec_server.cfg
@@ -149,40 +149,40 @@ stdout_output_level -1
 # Example: mod_command ban 1
 
 # Non-default commands to which moderators and helpers will have access
-access_level left 2
-access_level right 2
-access_level up 2
-access_level down 2
-access_level super 2
-access_level unsuper 2
-access_level tele 2
-access_level totele 2
-access_level totelecp 2
-access_level logout 2
-access_level ninja 2
-access_level grenade 2
-access_level shotgun 2
-access_level laser 2
-access_level weapons 2
-access_level unweapons 2
-access_level unlaser 2
-access_level unshotgun 2
-access_level ungrenade 2
-access_level unsolo 2
-access_level undeep 2
-access_level status 2
+access_level left helper
+access_level right helper
+access_level up helper
+access_level down helper
+access_level super helper
+access_level unsuper helper
+access_level tele helper
+access_level totele helper
+access_level totelecp helper
+access_level logout helper
+access_level ninja helper
+access_level grenade helper
+access_level shotgun helper
+access_level laser helper
+access_level weapons helper
+access_level unweapons helper
+access_level unlaser helper
+access_level unshotgun helper
+access_level ungrenade helper
+access_level unsolo helper
+access_level undeep helper
+access_level status helper
 
 # commands for moderators only
-access_level ban 1
-access_level unban 1
-access_level ban_range 1
-access_level unban_range 1
-access_level unban_all 1
-access_level bans 1
-access_level bans_save 1
-access_level kick 1
-access_level force_vote 1
-access_level moderate 1
+access_level ban moderator
+access_level unban moderator
+access_level ban_range moderator
+access_level unban_range moderator
+access_level unban_all moderator
+access_level bans moderator
+access_level bans_save moderator
+access_level kick moderator
+access_level force_vote moderator
+access_level moderate moderator
 
 
 # Restore original output level

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -109,6 +109,47 @@ const IConsole::CCommandInfo *CConsole::FirstCommandInfo(int AccessLevel, int Fl
 	return nullptr;
 }
 
+std::optional<int> CConsole::AccessLevelToInt(const char *pAccessLevel)
+{
+	// alias for legacy integer access levels
+	if(!str_comp(pAccessLevel, "0"))
+		return ACCESS_LEVEL_ADMIN;
+	if(!str_comp(pAccessLevel, "1"))
+		return ACCESS_LEVEL_MOD;
+	if(!str_comp(pAccessLevel, "2"))
+		return ACCESS_LEVEL_HELPER;
+	if(!str_comp(pAccessLevel, "3"))
+		return ACCESS_LEVEL_USER;
+
+	// string access levels
+	if(!str_comp(pAccessLevel, "admin"))
+		return ACCESS_LEVEL_ADMIN;
+	if(!str_comp(pAccessLevel, "moderator"))
+		return ACCESS_LEVEL_MOD;
+	if(!str_comp(pAccessLevel, "helper"))
+		return ACCESS_LEVEL_HELPER;
+	if(!str_comp(pAccessLevel, "all"))
+		return ACCESS_LEVEL_USER;
+	return std::nullopt;
+}
+
+const char *CConsole::AccessLevelToString(int AccessLevel)
+{
+	switch(AccessLevel)
+	{
+	case ACCESS_LEVEL_ADMIN:
+		return "admin";
+	case ACCESS_LEVEL_MOD:
+		return "moderator";
+	case ACCESS_LEVEL_HELPER:
+		return "helper";
+	case ACCESS_LEVEL_USER:
+		return "all";
+	}
+	dbg_assert(false, "invalid access level: %d", AccessLevel);
+	dbg_break();
+}
+
 // the maximum number of tokens occurs in a string of length CONSOLE_MAX_STR_LENGTH with tokens size 1 separated by single spaces
 
 int CConsole::ParseStart(CResult *pResult, const char *pString, int Length)
@@ -710,7 +751,13 @@ void CConsole::ConCommandAccess(IResult *pResult, void *pUser)
 	{
 		if(pResult->NumArguments() == 2)
 		{
-			pCommand->SetAccessLevel(pResult->GetInteger(1));
+			std::optional<int> AccessLevel = AccessLevelToInt(pResult->GetString(1));
+			if(!AccessLevel.has_value())
+			{
+				log_error("console", "Invalid access level '%s'. Allowed values are admin, moderator, helper and all.", pResult->GetString(1));
+				return;
+			}
+			pCommand->SetAccessLevel(AccessLevel.value());
 			str_format(aBuf, sizeof(aBuf), "moderator access for '%s' is now %s", pResult->GetString(0), pCommand->GetAccessLevel() ? "enabled" : "disabled");
 			pConsole->Print(OUTPUT_LEVEL_STANDARD, "console", aBuf);
 			str_format(aBuf, sizeof(aBuf), "helper access for '%s' is now %s", pResult->GetString(0), pCommand->GetAccessLevel() >= ACCESS_LEVEL_HELPER ? "enabled" : "disabled");
@@ -738,10 +785,16 @@ void CConsole::ConCommandStatus(IResult *pResult, void *pUser)
 	char aBuf[240];
 	mem_zero(aBuf, sizeof(aBuf));
 	int Used = 0;
+	std::optional<int> AccessLevel = AccessLevelToInt(pResult->GetString(0));
+	if(!AccessLevel.has_value())
+	{
+		log_error("console", "Invalid access level '%s'. Allowed values are admin, moderator, helper and all.", pResult->GetString(0));
+		return;
+	}
 
 	for(CCommand *pCommand = pConsole->m_pFirstCommand; pCommand; pCommand = pCommand->m_pNext)
 	{
-		if(pCommand->m_Flags & pConsole->m_FlagMask && pCommand->GetAccessLevel() >= std::clamp(pResult->GetInteger(0), (int)ACCESS_LEVEL_ADMIN, (int)ACCESS_LEVEL_USER))
+		if(pCommand->m_Flags & pConsole->m_FlagMask && pCommand->GetAccessLevel() >= AccessLevel.value())
 		{
 			int Length = str_length(pCommand->m_pName);
 			if(Used + Length + 2 < (int)(sizeof(aBuf)))
@@ -772,9 +825,7 @@ void CConsole::ConUserCommandStatus(IResult *pResult, void *pUser)
 	CConsole *pConsole = static_cast<CConsole *>(pUser);
 	CResult Result(pResult->m_ClientId);
 	Result.m_pCommand = "access_status";
-	char aBuf[4];
-	str_format(aBuf, sizeof(aBuf), "%d", (int)IConsole::ACCESS_LEVEL_USER);
-	Result.AddArgument(aBuf);
+	Result.AddArgument(AccessLevelToString((int)IConsole::ACCESS_LEVEL_USER));
 
 	CConsole::ConCommandStatus(&Result, pConsole);
 }
@@ -809,8 +860,8 @@ CConsole::CConsole(int FlagMask)
 	Register("echo", "r[text]", CFGFLAG_SERVER, Con_Echo, this, "Echo the text");
 	Register("exec", "r[file]", CFGFLAG_SERVER | CFGFLAG_CLIENT, Con_Exec, this, "Execute the specified file");
 
-	Register("access_level", "s[command] ?i[accesslevel]", CFGFLAG_SERVER, ConCommandAccess, this, "Specify command accessibility (admin = 0, moderator = 1, helper = 2, all = 3)");
-	Register("access_status", "i[accesslevel]", CFGFLAG_SERVER, ConCommandStatus, this, "List all commands which are accessible for admin = 0, moderator = 1, helper = 2, all = 3");
+	Register("access_level", "s[command] ?s['admin'|'moderator'|'helper'|'all']", CFGFLAG_SERVER, ConCommandAccess, this, "Specify command accessibility for given access level");
+	Register("access_status", "s['admin'|'moderator'|'helper'|'all']", CFGFLAG_SERVER, ConCommandStatus, this, "List all commands which are accessible for given access level");
 	Register("cmdlist", "", CFGFLAG_SERVER | CFGFLAG_CHAT, ConUserCommandStatus, this, "List all commands which are accessible for users");
 
 	// DDRace

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -8,6 +8,7 @@
 #include <engine/console.h>
 #include <engine/storage.h>
 
+#include <optional>
 #include <vector>
 
 class CConsole : public IConsole
@@ -177,6 +178,22 @@ public:
 	void InitChecksum(CChecksumData *pData) const override;
 
 	void SetAccessLevel(int AccessLevel) override;
+
+	/**
+	 * Converts access level string to access level enum (integer).
+	 *
+	 * @param pAccesssLevel should be either "admin", "mod", "moderator", "helper" or "user".
+	 * @return `std::nullopt` on error otherwise one of the auth enums such as `ACCESS_LEVEL_ADMIN`.
+	 */
+	static std::optional<int> AccessLevelToInt(const char *pAccessLevel);
+
+	/**
+	 * Converts access level enum (integer) to access level string.
+	 *
+	 * @param AccessLevel should be one of these: `ACCESS_LEVEL_ADMIN`, `ACCESS_LEVEL_MOD`, `ACCESS_LEVEL_HELPER` or `ACCESS_LEVEL_USER`.
+	 * @return `nullptr` on error or access level string like "admin".
+	 */
+	static const char *AccessLevelToString(int AccessLevel);
 
 	static std::optional<ColorHSLA> ColorParse(const char *pStr, float DarkestLighting);
 


### PR DESCRIPTION
Use words instead of numbers for access level commands

The new encouraged way to refer to access levels in configs is
to use the access level name as a string. The magic number
integer is still kept as an backwards compatibility alias.

And there is currently no plan to deprecate the old alias.

Here a example config

```
# old, still works
access_level ban 1

# new, does the same
access_level ban moderator

# old, still works
access_level kick 2

# new, does the same
access_level kick helper
```

This is a preparation for #10681

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
