### PR TITLE
Make str_length constexpr

### DIFF
--- a/src/base/str.cpp
+++ b/src/base/str.cpp
@@ -37,11 +37,6 @@ void str_truncate(char *dst, int dst_size, const char *src, int truncation_len)
 	str_copy(dst, src, size);
 }
 
-int str_length(const char *str)
-{
-	return (int)strlen(str);
-}
-
 char str_uppercase(char c)
 {
 	if(c >= 'a' && c <= 'z')

--- a/src/base/str.h
+++ b/src/base/str.h
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 
 /**
  * Copies a string to another.
@@ -93,7 +94,10 @@ void str_truncate(char *dst, int dst_size, const char *src, int truncation_len);
  *
  * @return Length of string in bytes excluding the null-termination.
  */
-int str_length(const char *str);
+[[nodiscard]] constexpr int str_length(const char *str)
+{
+	return static_cast<int>(std::char_traits<char>::length(str));
+}
 
 char str_uppercase(char c);
 


### PR DESCRIPTION
- Made `str_length` constexpr. Verified in the IDA decompiler that `str_length("text")` is correctly evaluated at compile time on my MSVC compiler

Follow up from https://github.com/ddnet/ddnet/pull/10441#discussion_r2283115971

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
