### PR TITLE
Fix editor prompt opening while other dialog active

### DIFF
--- a/src/game/editor/prompt.cpp
+++ b/src/game/editor/prompt.cpp
@@ -49,7 +49,7 @@ void CPrompt::SetInactive()
 
 bool CPrompt::OnInput(const IInput::CEvent &Event)
 {
-	if(Input()->ModifierIsPressed() && Input()->KeyIsPressed(KEY_P))
+	if(Editor()->m_Dialog == DIALOG_NONE && Input()->ModifierIsPressed() && Input()->KeyPress(KEY_P))
 	{
 		SetActive();
 	}


### PR DESCRIPTION
You were also able to active it repeatedly making it flicker. Noticeable when holding down CTRL+P.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
