### PR TITLE
fix automatic quad clipping for quads without position envelopes

### DIFF
--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -1102,6 +1102,16 @@ void CRenderLayerQuads::CQuadLayerVisuals::Unload()
 
 bool CRenderLayerQuads::CalculateEnvelopeClipping(int aEnvelopeOffsetMin[2], int aEnvelopeOffsetMax[2])
 {
+	if(m_QuadRenderGroup.m_PosEnv == -1)
+	{
+		for(int Channel = 0; Channel < 2; ++Channel)
+		{
+			aEnvelopeOffsetMin[Channel] = 0;
+			aEnvelopeOffsetMax[Channel] = 0;
+		}
+		return true;
+	}
+
 	int EnvStart, EnvNum;
 	m_pMap->GetType(MAPITEMTYPE_ENVELOPE, &EnvStart, &EnvNum);
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

small bug caused by #10629

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
