### PR TITLE
Clean up `CCharacter::Die`

### DIFF
--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -76,6 +76,8 @@ public:
 
 	void Die(int Killer, int Weapon, bool SendKillMsg = true);
 	bool TakeDamage(vec2 Force, int Dmg, int From, int Weapon);
+	void SendDeathMessageIfNotInLockedTeam(int Killer, int Weapon, int ModeSpecial);
+	void CancelSwapRequests();
 
 	bool Spawn(class CPlayer *pPlayer, vec2 Pos);
 	bool Remove();


### PR DESCRIPTION
Full disclosure I need this downstream for https://github.com/ddnet-insta/ddnet-insta/issues/392#issuecomment-3204413675.
So this falls under #7777 and can be rejected without the need for any further justification.

But I think while my motivation is fully downstream oriented this can also benefit ddnet directly with easier to read and reuseable code. The concept was also pitched by josspit here https://github.com/ddnet/ddnet/issues/9994#issuecomment-2768905835

The idea is to have these "root" methods only call other methods instead of putting the implementation directly. This turns the die method from a huge spaghet into a digestable table of contents. Comments justifying chunks of code can be replaced by descriptive method names.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
