### PR TITLE
sql: Make it clear ranks will be auto-inserted regularly

### DIFF
--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -1730,7 +1730,7 @@ bool CScoreWorker::SaveTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 			else
 			{
 				str_copy(pResult->m_aBroadcast,
-					"Database connection failed, teamsave written to a file instead. Admins will add it manually in a few days.",
+					"Database connection failed, teamsave written to a file instead. On official DDNet servers this will automatically be inserted into the database every full hour.",
 					sizeof(pResult->m_aBroadcast));
 				if(str_comp(pData->m_aServer, g_Config.m_SvSqlServerName) == 0)
 				{


### PR DESCRIPTION
I get pinged for these regularly and just run move-sqlite.sh manually. So I switched it to be hourly instead.
## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
