### PR TITLE
Show "Start and connect to local server" button when no lan server is shown

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -242,9 +242,27 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 		{
 			if(ServerBrowser()->GetCurrentType() == IServerBrowser::TYPE_LAN)
 			{
+				CUIRect Label, Button;
+				View.HMargin((View.h - (16.0f + 18.0f + 8.0f)) / 2.0f, &Label);
+				Label.HSplitTop(16.0f, &Label, &Button);
+				Button.HSplitTop(8.0f, nullptr, &Button);
+				Button.VMargin((Button.w - 300.0f) / 2.0f, &Button);
 				char aBuf[128];
 				str_format(aBuf, sizeof(aBuf), Localize("No local servers found (ports %d-%d)"), IServerBrowser::LAN_PORT_BEGIN, IServerBrowser::LAN_PORT_END);
-				Ui()->DoLabel(&View, aBuf, 16.0f, TEXTALIGN_MC);
+				Ui()->DoLabel(&Label, aBuf, 16.0f, TEXTALIGN_MC);
+				static CButtonContainer s_StartLocalServerButton;
+				if(DoButton_Menu(&s_StartLocalServerButton, Localize("Start and connect to local server"), 0, &Button))
+				{
+					if(GameClient()->m_LocalServer.IsServerRunning())
+					{
+						RefreshBrowserTab(true);
+					}
+					else
+					{
+						GameClient()->m_LocalServer.RunServer({});
+					}
+					Client()->Connect("localhost");
+				}
 			}
 			else if(ServerBrowser()->IsServerlistError())
 			{


### PR DESCRIPTION
Closes #10718.

Before:

<img width="1920" height="1080" alt="图片" src="https://github.com/user-attachments/assets/24316906-4ae4-4f13-9d37-93e0f7974a2c" />

After:

<img width="1920" height="1080" alt="图片" src="https://github.com/user-attachments/assets/415008bd-1940-4c76-be5f-bf8a57335ecc" />


<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
