### PR TITLE
Feature: Implement quad clustering ⚡

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -505,6 +505,7 @@ MACRO_CONFIG_INT(DbgGraphs, dbg_graphs, 0, 0, 1, CFGFLAG_CLIENT, "Show performan
 MACRO_CONFIG_INT(DbgGfx, dbg_gfx, 0, 0, 4, CFGFLAG_CLIENT, "Show graphic library warnings and errors, if the GPU supports it (0: none, 1: minimal, 2: affects performance, 3: verbose, 4: all)")
 MACRO_CONFIG_INT(DbgRenderGroupClips, dbg_render_group_clips, 0, 0, 1, CFGFLAG_CLIENT, "Debug group clipping")
 MACRO_CONFIG_INT(DbgRenderQuadClips, dbg_render_quad_clips, 0, 0, 1, CFGFLAG_CLIENT, "Debug quad layer clipping")
+MACRO_CONFIG_INT(DbgRenderClusterClips, dbg_render_cluster_clips, 0, 0, 1, CFGFLAG_CLIENT, "Debug quad layer cluster clipping")
 #ifdef CONF_DEBUG
 MACRO_CONFIG_INT(DbgStress, dbg_stress, 0, 0, 1, CFGFLAG_CLIENT, "Stress systems (Debug build only)")
 MACRO_CONFIG_STR(DbgStressServer, dbg_stress_server, 32, "localhost", CFGFLAG_CLIENT, "Server to stress (Debug build only)")

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -109,6 +109,7 @@ void CMapLayers::OnRender()
 	m_Params.m_RenderText = g_Config.m_ClTextEntities;
 	m_Params.m_DebugRenderGroupClips = g_Config.m_DbgRenderGroupClips;
 	m_Params.m_DebugRenderQuadClips = g_Config.m_DbgRenderQuadClips;
+	m_Params.m_DebugRenderClusterClips = g_Config.m_DbgRenderClusterClips;
 
 	m_MapRenderer.Render(m_Params);
 }

--- a/src/game/map/render_layer.h
+++ b/src/game/map/render_layer.h
@@ -43,6 +43,7 @@ public:
 	bool m_RenderTileBorder;
 	bool m_DebugRenderGroupClips;
 	bool m_DebugRenderQuadClips;
+	bool m_DebugRenderClusterClips;
 };
 
 class CRenderLayer : public CRenderComponent
@@ -219,8 +220,6 @@ public:
 
 protected:
 	IGraphics::CTextureHandle GetTexture() const override { return m_TextureHandle; }
-	void CalculateClipping();
-	bool CalculateQuadClipping(int aQuadOffsetMin[2], int aQuadOffsetMax[2], bool Grouped);
 
 	class CQuadLayerVisuals : public CRenderComponent
 	{
@@ -233,29 +232,42 @@ protected:
 		int m_BufferContainerIndex;
 		bool m_IsTextured;
 	};
-	void RenderQuadLayer(float Alpha = 1.0f);
+	void RenderQuadLayer(float Alpha, const CRenderLayerParams &Params);
 
 	std::optional<CRenderLayerQuads::CQuadLayerVisuals> m_VisualQuad;
 	CMapItemLayerQuads *m_pLayerQuads;
 
-	std::vector<SQuadRenderInfo> m_vQuadRenderInfo;
-
-	bool m_Grouped;
-	class CQuadRenderGroup
+	class CClipRegion
 	{
 	public:
+		float m_X;
+		float m_Y;
+		float m_Width;
+		float m_Height;
+	};
+
+	class CQuadCluster
+	{
+	public:
+		bool m_Grouped;
+		int m_StartIndex;
+		int m_NumQuads;
+
 		int m_PosEnv;
 		float m_PosEnvOffset;
 		int m_ColorEnv;
 		float m_ColorEnvOffset;
 
-		// quad clipping
-		bool m_Clipped;
-		float m_ClipX;
-		float m_ClipY;
-		float m_ClipWidth;
-		float m_ClipHeight;
-	} m_QuadRenderGroup;
+		std::vector<SQuadRenderInfo> m_vQuadRenderInfo;
+		std::optional<CClipRegion> m_ClipRegion;
+	};
+
+	bool IsVisibleInClipRegion(const std::optional<CClipRegion> &ClipRegion) const;
+	void CalculateClipping(CQuadCluster &QuadCluster);
+	bool CalculateQuadClipping(const CQuadCluster &QuadCluster, int aQuadOffsetMin[2], int aQuadOffsetMax[2]) const;
+
+	std::optional<CClipRegion> m_LayerClip;
+	std::vector<CQuadCluster> m_vQuadClusters;
 
 	CQuad *m_pQuads;
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This PR breaks groups of quads into quad clusters, which all have their own clip region. This can improve fps a lot in map with lots of quads, because each quad cluster can be culled out or rendered all at once.

## Actual benchmarks:

See https://github.com/AssassinTee/ddnet-benchmarks how they're made.
(Note: nightly from 23.08.2025)

Average FPS:
<img width="985" height="590" alt="Unbenannt" src="https://github.com/user-attachments/assets/4b307037-6945-447f-8d4b-6b2a07a9b97f" />

Minimum Frametime (smaller = better):
<img width="985" height="590" alt="min FT" src="https://github.com/user-attachments/assets/433f44cf-e022-4416-a4fb-a8347b9c6107" />

Maximum Frametime (smaller = better):
<img width="985" height="590" alt="max Ft" src="https://github.com/user-attachments/assets/5af78a14-3508-4875-bb51-a6884625c547" />

I don't know why Mud has a very high maximum frametime. It might just be one frame, so take this with a grain of salt.

## Empirical crude benchmarks:

Top 5 maps with lots of quads according to Patiga (but list is outdated)

Vulkan benchmarks:

| Map | NumQuads | FPS 19.3 | FPS this PR |Comment |
| --- | --- | --- | --- | --- |
| Mud | 16038 | 800 | 4500 | **very huge improvement**, the rendered clip regions look insane |
| Gummy | 10697 | 4300++ | 4500++ | Doesn't really benefit, because it already benefits so much from grouping |
| Atomic | 9352 | 4200 | 5000+++ | the game is very unsure, but there is a 5 at front |
| Victory 2 | 8812 | 1300 | 3400 | **huge improvement**, but still bad somehow |
| run_world_war_zero | 8062 | <700 | 4600 | **very huge improvement** |

## ~Open questions:~ Experiments

I experimented with splitting quad clusters, seems like it just worsens performance

## Debug

You can debug with `dbg_render_layers 4` (4 - 7):
The map `Mud` for example:
<img width="2560" height="1440" alt="screenshot_2025-08-30_00-21-46" src="https://github.com/user-attachments/assets/34916322-e932-44b3-ab2a-119d3d19c8e3" />


## Future

This feature would benefit even more, if we'd implement clipping for rotating envelopes as well. While these are expensive to calculate perfectly, they may be easy to approximate for a quad

---

build on #10728
closes #10580

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
