### PR TITLE
Add cl_show_chat_client

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -81,6 +81,7 @@ MACRO_CONFIG_INT(ClShowChat, cl_showchat, 1, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE
 MACRO_CONFIG_INT(ClShowChatFriends, cl_show_chat_friends, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show only chat messages from friends")
 MACRO_CONFIG_INT(ClShowChatTeamMembersOnly, cl_show_chat_team_members_only, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show only chat messages from team members")
 MACRO_CONFIG_INT(ClShowChatSystem, cl_show_chat_system, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show chat messages from the server")
+MACRO_CONFIG_INT(ClShowChatClient, cl_show_chat_client, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show chat messages from the client such as echo")
 MACRO_CONFIG_INT(ClShowKillMessages, cl_showkillmessages, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show kill messages")
 MACRO_CONFIG_INT(ClShowFinishMessages, cl_show_finish_messages, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show finish messages")
 MACRO_CONFIG_INT(ClShowVotesAfterVoting, cl_show_votes_after_voting, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show votes window after voting")

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -641,6 +641,7 @@ void CChat::AddLine(int ClientId, int Team, const char *pLine)
 {
 	if(*pLine == 0 ||
 		(ClientId == SERVER_MSG && !g_Config.m_ClShowChatSystem) ||
+		(ClientId == CLIENT_MSG && !g_Config.m_ClShowChatClient) ||
 		(ClientId >= 0 && (GameClient()->m_aClients[ClientId].m_aName[0] == '\0' || // unknown client
 					  GameClient()->m_aClients[ClientId].m_ChatIgnore ||
 					  (GameClient()->m_Snap.m_LocalClientId != ClientId && g_Config.m_ClShowChatFriends && !GameClient()->m_aClients[ClientId].m_Friend) ||

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2492,7 +2492,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		str_format(aBuf, sizeof(aBuf), "%s (echo)", Localize("Client message"));
 		static CButtonContainer s_ClientMessageColor;
-		DoLine_ColorPicker(&s_ClientMessageColor, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &RightView, aBuf, &g_Config.m_ClMessageClientColor, ColorRGBA(0.5f, 0.78f, 1.0f));
+		DoLine_ColorPicker(&s_ClientMessageColor, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &RightView, aBuf, &g_Config.m_ClMessageClientColor, ColorRGBA(0.5f, 0.78f, 1.0f), true, &g_Config.m_ClShowChatClient);
 
 		// ***** Chat Preview ***** //
 		Ui()->DoLabel_AutoLineSize(Localize("Preview"), HeadlineFontSize,
@@ -2737,7 +2737,10 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 				TempY += RenderMessageBackground(PREVIEW_SPAMMER);
 			}
 
-			TempY += RenderMessageBackground(PREVIEW_CLIENT);
+			if(g_Config.m_ClShowChatClient)
+			{
+				TempY += RenderMessageBackground(PREVIEW_CLIENT);
+			}
 
 			Graphics()->QuadsEnd();
 		}
@@ -2775,8 +2778,12 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 				RenderTools()->RenderTee(pIdleState, &s_vLines[PREVIEW_SPAMMER].m_RenderInfo, EMOTE_NORMAL, vec2(1, 0.1f), vec2(X + RealTeeSizeHalved, Y + OffsetTeeY + FullHeightMinusTee / 2.0f + TWSkinUnreliableOffset));
 			Y += RenderPreview(PREVIEW_SPAMMER, X, Y).y;
 		}
+
 		// Client
-		RenderPreview(PREVIEW_CLIENT, X, Y);
+		if(g_Config.m_ClShowChatClient)
+		{
+			RenderPreview(PREVIEW_CLIENT, X, Y);
+		}
 
 		TextRender()->TextColor(TextRender()->DefaultTextColor());
 	}


### PR DESCRIPTION
#10757 plz discuss here, I don't really care if this accepted the implementation is simple

In reset scripts you either have to have seperate duplicated config for one where you don't have echos or this.

This is more important in TClient as you enable/disable things based on conditions (disable sewerslide then enable it if in pvp gamemode)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)

![image](https://github.com/user-attachments/assets/d5789281-c3b1-4be3-b5ad-8e99080742e4)
![image](https://github.com/user-attachments/assets/6b34ac11-c23c-489c-a1c1-771a7184195c)

