### PR TITLE
Add class to represent a rcon access level

### DIFF
--- a/src/engine/server/authmanager.cpp
+++ b/src/engine/server/authmanager.cpp
@@ -8,6 +8,35 @@
 #define MOD_IDENT "default_mod"
 #define HELPER_IDENT "default_helper"
 
+static const char *AuthLevelToName(int AuthLevel)
+{
+	switch(AuthLevel)
+	{
+	case AUTHED_ADMIN:
+		return ACCESS_LEVEL_NAME_ADMIN;
+	case AUTHED_MOD:
+		return ACCESS_LEVEL_NAME_MODERATOR;
+	case AUTHED_HELPER:
+		return ACCESS_LEVEL_NAME_HELPER;
+	}
+
+	dbg_assert(false, "Invalid auth level: %d", AuthLevel);
+	dbg_break();
+}
+
+static int AccessLevelNameToAuthLevel(const char *pAccessLevel)
+{
+	if(!str_comp(pAccessLevel, ACCESS_LEVEL_NAME_ADMIN))
+		return AUTHED_ADMIN;
+	if(!str_comp(pAccessLevel, ACCESS_LEVEL_NAME_MODERATOR))
+		return AUTHED_MOD;
+	if(!str_comp(pAccessLevel, ACCESS_LEVEL_NAME_HELPER))
+		return AUTHED_HELPER;
+
+	dbg_assert(false, "Invalid access level: %s", pAccessLevel);
+	dbg_break();
+}
+
 static MD5_DIGEST HashPassword(const char *pPassword, const unsigned char aSalt[SALT_BYTES])
 {
 	// Hash the password and the salt
@@ -28,6 +57,10 @@ CAuthManager::CAuthManager()
 
 void CAuthManager::Init()
 {
+	AddAccessLevel(ACCESS_LEVEL_NAME_ADMIN, AUTHED_ADMIN);
+	AddAccessLevel(ACCESS_LEVEL_NAME_MODERATOR, AUTHED_MOD);
+	AddAccessLevel(ACCESS_LEVEL_NAME_HELPER, AUTHED_HELPER);
+
 	size_t NumDefaultKeys = 0;
 	if(g_Config.m_SvRconPassword[0])
 		NumDefaultKeys++;
@@ -43,12 +76,12 @@ void CAuthManager::Init()
 	if(m_vKeys.size() == NumDefaultKeys && !g_Config.m_SvRconPassword[0])
 	{
 		secure_random_password(g_Config.m_SvRconPassword, sizeof(g_Config.m_SvRconPassword), 6);
-		AddDefaultKey(AUTHED_ADMIN, g_Config.m_SvRconPassword);
+		AddDefaultKey(ACCESS_LEVEL_NAME_ADMIN, g_Config.m_SvRconPassword);
 		m_Generated = true;
 	}
 }
 
-int CAuthManager::AddKeyHash(const char *pIdent, MD5_DIGEST Hash, const unsigned char *pSalt, int AuthLevel)
+int CAuthManager::AddKeyHash(const char *pIdent, MD5_DIGEST Hash, const unsigned char *pSalt, const char *pAccessLevel)
 {
 	if(FindKey(pIdent) >= 0)
 		return -1;
@@ -57,18 +90,18 @@ int CAuthManager::AddKeyHash(const char *pIdent, MD5_DIGEST Hash, const unsigned
 	str_copy(Key.m_aIdent, pIdent);
 	Key.m_Pw = Hash;
 	mem_copy(Key.m_aSalt, pSalt, SALT_BYTES);
-	Key.m_Level = AuthLevel;
+	Key.m_pAccessLevel = FindAccessLevelByName(pAccessLevel);
 
 	m_vKeys.push_back(Key);
 	return m_vKeys.size() - 1;
 }
 
-int CAuthManager::AddKey(const char *pIdent, const char *pPw, int AuthLevel)
+int CAuthManager::AddKey(const char *pIdent, const char *pPw, const char *pAccessLevel)
 {
 	// Generate random salt
 	unsigned char aSalt[SALT_BYTES];
 	secure_random_fill(aSalt, SALT_BYTES);
-	return AddKeyHash(pIdent, HashPassword(pPw, aSalt), aSalt, AuthLevel);
+	return AddKeyHash(pIdent, HashPassword(pPw, aSalt), aSalt, pAccessLevel);
 }
 
 void CAuthManager::RemoveKey(int Slot)
@@ -104,18 +137,22 @@ bool CAuthManager::CheckKey(int Slot, const char *pPw) const
 	return m_vKeys[Slot].m_Pw == HashPassword(pPw, m_vKeys[Slot].m_aSalt);
 }
 
-int CAuthManager::DefaultKey(int AuthLevel) const
+int CAuthManager::DefaultKey(const char *pAccessLevel) const
 {
-	if(AuthLevel < 0 || AuthLevel > AUTHED_ADMIN)
-		return 0;
-	return m_aDefault[AUTHED_ADMIN - AuthLevel];
+	if(!str_comp(pAccessLevel, ACCESS_LEVEL_NAME_ADMIN))
+		return m_aDefault[std::size(m_aDefault) - AUTHED_ADMIN];
+	if(!str_comp(pAccessLevel, ACCESS_LEVEL_NAME_MODERATOR))
+		return m_aDefault[std::size(m_aDefault) - AUTHED_MOD];
+	if(!str_comp(pAccessLevel, ACCESS_LEVEL_NAME_HELPER))
+		return m_aDefault[std::size(m_aDefault) - AUTHED_HELPER];
+	return 0;
 }
 
 int CAuthManager::KeyLevel(int Slot) const
 {
 	if(Slot < 0 || Slot >= (int)m_vKeys.size())
 		return false;
-	return m_vKeys[Slot].m_Level;
+	return m_vKeys[Slot].m_pAccessLevel->AuthLevel();
 }
 
 const char *CAuthManager::KeyIdent(int Slot) const
@@ -130,7 +167,7 @@ bool CAuthManager::IsValidIdent(const char *pIdent) const
 	return str_length(pIdent) < (int)sizeof(CKey().m_aIdent);
 }
 
-void CAuthManager::UpdateKeyHash(int Slot, MD5_DIGEST Hash, const unsigned char *pSalt, int AuthLevel)
+void CAuthManager::UpdateKeyHash(int Slot, MD5_DIGEST Hash, const unsigned char *pSalt, const char *pAccessLevel)
 {
 	if(Slot < 0 || Slot >= (int)m_vKeys.size())
 		return;
@@ -138,10 +175,10 @@ void CAuthManager::UpdateKeyHash(int Slot, MD5_DIGEST Hash, const unsigned char 
 	CKey *pKey = &m_vKeys[Slot];
 	pKey->m_Pw = Hash;
 	mem_copy(pKey->m_aSalt, pSalt, SALT_BYTES);
-	pKey->m_Level = AuthLevel;
+	pKey->m_pAccessLevel = FindAccessLevelByName(pAccessLevel);
 }
 
-void CAuthManager::UpdateKey(int Slot, const char *pPw, int AuthLevel)
+void CAuthManager::UpdateKey(int Slot, const char *pPw, const char *pAccessLevel)
 {
 	if(Slot < 0 || Slot >= (int)m_vKeys.size())
 		return;
@@ -149,17 +186,18 @@ void CAuthManager::UpdateKey(int Slot, const char *pPw, int AuthLevel)
 	// Generate random salt
 	unsigned char aSalt[SALT_BYTES];
 	secure_random_fill(aSalt, SALT_BYTES);
-	UpdateKeyHash(Slot, HashPassword(pPw, aSalt), aSalt, AuthLevel);
+	UpdateKeyHash(Slot, HashPassword(pPw, aSalt), aSalt, pAccessLevel);
 }
 
 void CAuthManager::ListKeys(FListCallback pfnListCallback, void *pUser)
 {
 	for(auto &Key : m_vKeys)
-		pfnListCallback(Key.m_aIdent, Key.m_Level, pUser);
+		pfnListCallback(Key.m_aIdent, Key.m_pAccessLevel->AuthLevel(), pUser);
 }
 
-void CAuthManager::AddDefaultKey(int Level, const char *pPw)
+void CAuthManager::AddDefaultKey(const char *pAccessLevel, const char *pPw)
 {
+	int Level = AccessLevelNameToAuthLevel(pAccessLevel);
 	if(Level < AUTHED_HELPER || Level > AUTHED_ADMIN)
 		return;
 
@@ -167,7 +205,7 @@ void CAuthManager::AddDefaultKey(int Level, const char *pPw)
 	int Index = AUTHED_ADMIN - Level;
 	if(m_aDefault[Index] >= 0)
 		return; // already exists
-	m_aDefault[Index] = AddKey(s_aaIdents[Index], pPw, Level);
+	m_aDefault[Index] = AddKey(s_aaIdents[Index], pPw, AuthLevelToName(Level));
 }
 
 bool CAuthManager::IsGenerated() const
@@ -181,4 +219,21 @@ int CAuthManager::NumNonDefaultKeys() const
 		return Slot >= 0;
 	});
 	return m_vKeys.size() - DefaultCount;
+}
+
+CAccessLevel *CAuthManager::FindAccessLevelByName(const char *pName)
+{
+	for(CAccessLevel &AccessLevel : m_vAccessLevels)
+		if(!str_comp(AccessLevel.Name(), pName))
+			return &AccessLevel;
+	return nullptr;
+}
+
+bool CAuthManager::AddAccessLevel(const char *pName, int Level)
+{
+	if(FindAccessLevelByName(pName))
+		return false;
+
+	m_vAccessLevels.emplace_back(pName, Level);
+	return true;
 }

--- a/src/engine/server/authmanager.h
+++ b/src/engine/server/authmanager.h
@@ -1,23 +1,47 @@
 #ifndef ENGINE_SERVER_AUTHMANAGER_H
 #define ENGINE_SERVER_AUTHMANAGER_H
 
+#include <base/hash.h>
+#include <base/system.h>
+#include <game/generated/protocol.h>
+
 #include <vector>
 
-#include <base/hash.h>
-
 #define SALT_BYTES 8
+
+#define ACCESS_LEVEL_NAME_ADMIN "admin"
+#define ACCESS_LEVEL_NAME_MODERATOR "moderator"
+#define ACCESS_LEVEL_NAME_HELPER "helper"
+
+class CAccessLevel
+{
+	char m_aName[64];
+	int m_AuthLevel = AUTHED_NO;
+
+public:
+	const char *Name() const { return m_aName; }
+	int AuthLevel() const { return m_AuthLevel; }
+
+	CAccessLevel(const char *pName, int AuthLevel) :
+		m_AuthLevel(AuthLevel)
+	{
+		str_copy(m_aName, pName);
+	}
+};
 
 class CAuthManager
 {
 private:
-	struct CKey
+	class CKey
 	{
+	public:
 		char m_aIdent[64];
 		MD5_DIGEST m_Pw;
 		unsigned char m_aSalt[SALT_BYTES];
-		int m_Level;
+		CAccessLevel *m_pAccessLevel = nullptr;
 	};
 	std::vector<CKey> m_vKeys;
+	std::vector<CAccessLevel> m_vAccessLevels;
 
 	int m_aDefault[3];
 	bool m_Generated;
@@ -28,21 +52,23 @@ public:
 	CAuthManager();
 
 	void Init();
-	int AddKeyHash(const char *pIdent, MD5_DIGEST Hash, const unsigned char *pSalt, int AuthLevel);
-	int AddKey(const char *pIdent, const char *pPw, int AuthLevel);
+	int AddKeyHash(const char *pIdent, MD5_DIGEST Hash, const unsigned char *pSalt, const char *pAccessLevel);
+	int AddKey(const char *pIdent, const char *pPw, const char *pAccessLevel);
 	void RemoveKey(int Slot);
 	int FindKey(const char *pIdent) const;
 	bool CheckKey(int Slot, const char *pPw) const;
-	int DefaultKey(int AuthLevel) const;
+	int DefaultKey(const char *pAccessLevel) const;
 	int KeyLevel(int Slot) const;
 	const char *KeyIdent(int Slot) const;
 	bool IsValidIdent(const char *pIdent) const;
-	void UpdateKeyHash(int Slot, MD5_DIGEST Hash, const unsigned char *pSalt, int AuthLevel);
-	void UpdateKey(int Slot, const char *pPw, int AuthLevel);
+	void UpdateKeyHash(int Slot, MD5_DIGEST Hash, const unsigned char *pSalt, const char *pAccessLevel);
+	void UpdateKey(int Slot, const char *pPw, const char *pAccessLevel);
 	void ListKeys(FListCallback pfnListCallbac, void *pUser);
-	void AddDefaultKey(int Level, const char *pPw);
+	void AddDefaultKey(const char *pAccessLevel, const char *pPw);
 	bool IsGenerated() const;
 	int NumNonDefaultKeys() const;
+	CAccessLevel *FindAccessLevelByName(const char *pName);
+	bool AddAccessLevel(const char *pName, int Level);
 };
 
 #endif //ENGINE_SERVER_AUTHMANAGER_H

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -463,7 +463,7 @@ public:
 	void LogoutClient(int ClientId, const char *pReason);
 	void LogoutKey(int Key, const char *pReason);
 
-	void ConchainRconPasswordChangeGeneric(int Level, const char *pCurrent, IConsole::IResult *pResult);
+	void ConchainRconPasswordChangeGeneric(const char *pAccessLevel, const char *pCurrent, IConsole::IResult *pResult);
 	static void ConchainRconPasswordChange(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainRconModPasswordChange(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainRconHelperPasswordChange(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);


### PR DESCRIPTION
Also refer to these access levels by name using a string. Instead of using an integer.

This is a preperation for #10681.
To be able to introduce new access levels at runtime and referring to them by name. This will also allow to store command access in the access level in the future. Instead of storing the access level in the command how it is done right now. That shift allows to have multiple access levels that can have access to a different set of commands. Right now access level access management is limited because the different levels are forced to inherit command access from the lower levels. Making it impossible to create roles with different responsibilities.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
