### PR TITLE
Use `[::1],127.0.0.1` instead of `localhost` for local server

### DIFF
--- a/src/game/editor/quick_actions.cpp
+++ b/src/game/editor/quick_actions.cpp
@@ -254,6 +254,6 @@ void CEditor::TestMapLocally()
 		pGameClient->m_LocalServer.RunServer({"sv_register 0", aMapChange});
 		OnClose();
 		g_Config.m_ClEditor = 0;
-		Client()->Connect("localhost");
+		Client()->Connect("[::1],127.0.0.1");
 	}
 }


### PR DESCRIPTION
This is more robust in case `localhost` cannot be resolved or if the server is only available over either IPv4 or IPv6.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
