### PR TITLE
Move `ConsoleAccessLevel` to server

### DIFF
--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -206,12 +206,9 @@ public:
 		{
 			return m_State != STATE_EMPTY && !m_DebugDummy;
 		}
-
-		int ConsoleAccessLevel() const
-		{
-			return m_Authed == AUTHED_ADMIN ? IConsole::ACCESS_LEVEL_ADMIN : m_Authed == AUTHED_MOD ? IConsole::ACCESS_LEVEL_MOD : IConsole::ACCESS_LEVEL_HELPER;
-		}
 	};
+
+	int ConsoleAccessLevel(int ClientId) const;
 
 	CClient m_aClients[MAX_CLIENTS];
 	int m_aIdMap[MAX_CLIENTS * VANILLA_MAX_CLIENTS];


### PR DESCRIPTION
The `CClient` does not know his own client id.
It also has no access to the `CServer`.
Both of these things are highly inconvienient for my plan of deleting `CClient::m_Authed` and the rcon level feature #10681

The advantages from the previous refactor #10761 still exist:

- Move complex code from header to source file.
- Replace complex ternary with switch statement.
- Error instead of defaulting to helper when someone is not authed at all.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
