### PR TITLE
fix & cleanup: Quad opacity is different between vulkan and ogl1

### DIFF
--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -858,14 +858,11 @@ CRenderLayerQuads::CRenderLayerQuads(int GroupId, int LayerId, int Flags, CMapIt
 	m_pQuads = nullptr;
 }
 
-void CRenderLayerQuads::RenderQuadLayer(bool Force)
+void CRenderLayerQuads::RenderQuadLayer(float Alpha)
 {
 	CQuadLayerVisuals &Visuals = m_VisualQuad.value();
 	if(Visuals.m_BufferContainerIndex == -1)
 		return; // no visuals were created
-
-	if(!Force && (!g_Config.m_ClShowQuads || g_Config.m_ClOverlayEntities == 100))
-		return;
 
 	size_t QuadsRenderCount = 0;
 	size_t CurQuadOffset = 0;
@@ -877,6 +874,7 @@ void CRenderLayerQuads::RenderQuadLayer(bool Force)
 
 			ColorRGBA Color = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
 			m_pEnvelopeEval->EnvelopeEval(pQuad->m_ColorEnvOffset, pQuad->m_ColorEnv, Color, 4);
+			Color.a *= Alpha;
 
 			const bool IsFullyTransparent = Color.a <= 0.0f;
 			const bool NeedsFlush = QuadsRenderCount == gs_GraphicsMaxQuadsRenderCount || IsFullyTransparent;
@@ -912,15 +910,17 @@ void CRenderLayerQuads::RenderQuadLayer(bool Force)
 	{
 		SQuadRenderInfo &QInfo = m_vQuadRenderInfo[0];
 
+		ColorRGBA Color = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
 		if(m_QuadRenderGroup.m_ColorEnv >= 0)
 		{
-			ColorRGBA Color = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
 			m_pEnvelopeEval->EnvelopeEval(m_QuadRenderGroup.m_ColorEnvOffset, m_QuadRenderGroup.m_ColorEnv, Color, 4);
-
-			if(Color.a <= 0.0f)
-				return;
-			QInfo.m_Color = Color;
 		}
+
+		Color.a *= Alpha;
+		if(Color.a <= 0.0f)
+			return;
+
+		QInfo.m_Color = Color;
 
 		if(m_QuadRenderGroup.m_PosEnv >= 0)
 		{
@@ -1227,32 +1227,17 @@ void CRenderLayerQuads::CalculateClipping()
 void CRenderLayerQuads::Render(const CRenderLayerParams &Params)
 {
 	UseTexture(GetTexture());
-	if(Params.m_RenderType == ERenderType::RENDERTYPE_BACKGROUND_FORCE || Params.m_RenderType == ERenderType::RENDERTYPE_FULL_DESIGN)
+
+	bool Force = Params.m_RenderType == ERenderType::RENDERTYPE_BACKGROUND_FORCE || Params.m_RenderType == ERenderType::RENDERTYPE_FULL_DESIGN;
+	float Alpha = Force ? 1.f : (100 - Params.m_EntityOverlayVal) / 100.0f;
+	if(!Graphics()->IsQuadBufferingEnabled() || !Params.m_TileAndQuadBuffering)
 	{
-		if(g_Config.m_ClShowQuads || Params.m_RenderType == ERenderType::RENDERTYPE_FULL_DESIGN)
-		{
-			if(!Graphics()->IsQuadBufferingEnabled() || !Params.m_TileAndQuadBuffering)
-			{
-				Graphics()->BlendNormal();
-				RenderMap()->ForceRenderQuads(m_pQuads, m_pLayerQuads->m_NumQuads, LAYERRENDERFLAG_TRANSPARENT, m_pEnvelopeEval, 1.f);
-			}
-			else
-			{
-				RenderQuadLayer(true);
-			}
-		}
+		Graphics()->BlendNormal();
+		RenderMap()->ForceRenderQuads(m_pQuads, m_pLayerQuads->m_NumQuads, LAYERRENDERFLAG_TRANSPARENT, m_pEnvelopeEval, Alpha);
 	}
 	else
 	{
-		if(!Graphics()->IsQuadBufferingEnabled() || !Params.m_TileAndQuadBuffering)
-		{
-			Graphics()->BlendNormal();
-			RenderMap()->RenderQuads(m_pQuads, m_pLayerQuads->m_NumQuads, LAYERRENDERFLAG_TRANSPARENT, m_pEnvelopeEval);
-		}
-		else
-		{
-			RenderQuadLayer(false);
-		}
+		RenderQuadLayer(Alpha);
 	}
 }
 
@@ -1280,6 +1265,14 @@ bool CRenderLayerQuads::DoRender(const CRenderLayerParams &Params)
 		if(Right < 0.0f || Left > ScreenWidth || Bottom < 0.0f || Top > ScreenHeight)
 			return false;
 	}
+
+	// this option only deactivates quads in the background
+	if(Params.m_RenderType == ERenderType::RENDERTYPE_BACKGROUND || Params.m_RenderType == ERenderType::RENDERTYPE_BACKGROUND_FORCE)
+	{
+		if(!g_Config.m_ClShowQuads)
+			return false;
+	}
+
 	return true;
 }
 

--- a/src/game/map/render_layer.h
+++ b/src/game/map/render_layer.h
@@ -233,7 +233,7 @@ protected:
 		int m_BufferContainerIndex;
 		bool m_IsTextured;
 	};
-	void RenderQuadLayer(bool ForceRender = false);
+	void RenderQuadLayer(float Alpha = 1.0f);
 
 	std::optional<CRenderLayerQuads::CQuadLayerVisuals> m_VisualQuad;
 	CMapItemLayerQuads *m_pLayerQuads;

--- a/src/game/map/render_map.cpp
+++ b/src/game/map/render_map.cpp
@@ -373,14 +373,6 @@ static void Rotate(const CPoint *pCenter, CPoint *pPoint, float Rotation)
 	pPoint->y = (int)(x * std::sin(Rotation) + y * std::cos(Rotation) + pCenter->y);
 }
 
-void CRenderMap::RenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags, IEnvelopeEval *pEnvEval)
-{
-	if(!g_Config.m_ClShowQuads || g_Config.m_ClOverlayEntities == 100)
-		return;
-
-	ForceRenderQuads(pQuads, NumQuads, RenderFlags, pEnvEval, (100 - g_Config.m_ClOverlayEntities) / 100.0f);
-}
-
 void CRenderMap::ForceRenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags, IEnvelopeEval *pEnvEval, float Alpha)
 {
 	Graphics()->TrianglesBegin();

--- a/src/game/map/render_map.h
+++ b/src/game/map/render_map.h
@@ -63,7 +63,6 @@ public:
 
 	// map render methods (render_map.cpp)
 	static void RenderEvalEnvelope(const IEnvelopePointAccess *pPoints, std::chrono::nanoseconds TimeNanos, ColorRGBA &Result, size_t Channels);
-	void RenderQuads(CQuad *pQuads, int NumQuads, int Flags, IEnvelopeEval *pEnvEval);
 	void ForceRenderQuads(CQuad *pQuads, int NumQuads, int Flags, IEnvelopeEval *pEnvEval, float Alpha = 1.0f);
 	void RenderTile(int x, int y, unsigned char Index, float Scale, ColorRGBA Color);
 	void RenderTilemap(CTile *pTiles, int w, int h, float Scale, ColorRGBA Color, int RenderFlags);


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

When I started this PR this was meant to be a cleanup of the `DoRender` logic as many render skips are still part of the Render routine for quads.

Then I noticed 2 bugs:
1. `m_ClShowQuads` also hides quads in the foreground. This is not was this option is supposed to do, it should only hide quads in the background in order to increase performance with the cost of design. This can hide gameplay relevant map parts.
2. the opacity of quads doesn't decrease in vulkan, if you increase overlay entities (only in ogl1)

only hiding background, the organ is in the foreground and has a hitbox:

<img width="2560" height="1440" alt="screenshot_2025-08-28_10-20-34" src="https://github.com/user-attachments/assets/5695cb18-5b84-4eef-b9dd-8b0f20c22233" />

The tooltip of the option says, that it should hide quads in the background (translates to "Quads are shown as background decoration"):

<img width="2560" height="1440" alt="screenshot_2025-08-28_10-24-24" src="https://github.com/user-attachments/assets/7bc47cb2-891e-4edd-8f16-50d27217bcc0" />

I don't believe this bug was necessarily caused by me, since the logic before my rework of this was already convoluted

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
