### PR TITLE
Fix `mastersrv` page filename with newer doxygen versions

### DIFF
--- a/src/mastersrv/README.md
+++ b/src/mastersrv/README.md
@@ -1,6 +1,4 @@
-# mastersrv
-
-@page mastersrv
+# @page mastersrv mastersrv
 
 The mastersrv maintains a list of all registered DDNet (and Teeworlds) servers.
 Game servers try to register themselves with the mastersrv via an HTTP POST


### PR DESCRIPTION


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
