### PR TITLE
Return color instead of optional color

### DIFF
--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -66,7 +66,7 @@ public:
 		virtual int GetInteger(unsigned Index) const = 0;
 		virtual float GetFloat(unsigned Index) const = 0;
 		virtual const char *GetString(unsigned Index) const = 0;
-		virtual std::optional<ColorHSLA> GetColor(unsigned Index, float DarkestLighting) const = 0;
+		virtual ColorHSLA GetColor(unsigned Index, float DarkestLighting) const = 0;
 
 		virtual void RemoveArgument(unsigned Index) = 0;
 

--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -119,7 +119,7 @@ void SColorConfigVariable::CommandCallback(IConsole::IResult *pResult, void *pUs
 			return;
 
 		const auto Color = pResult->GetColor(0, pData->m_DarkestLighting);
-		const unsigned Value = Color->Pack(pData->m_DarkestLighting, pData->m_Alpha);
+		const unsigned Value = Color.Pack(pData->m_DarkestLighting, pData->m_Alpha);
 
 		*pData->m_pVariable = Value;
 		if(pResult->m_ClientId != IConsole::CLIENT_ID_GAME)
@@ -497,7 +497,7 @@ void CConfigManager::Con_Toggle(IConsole::IResult *pResult, void *pUserData)
 		else if(pVariable->m_Type == SConfigVariable::VAR_COLOR)
 		{
 			SColorConfigVariable *pColorVariable = static_cast<SColorConfigVariable *>(pVariable);
-			const bool EqualToFirst = *pColorVariable->m_pVariable == pResult->GetColor(1, pColorVariable->m_DarkestLighting).value_or(ColorHSLA(0, 0, 0)).Pack(pColorVariable->m_DarkestLighting, pColorVariable->m_Alpha);
+			const bool EqualToFirst = *pColorVariable->m_pVariable == pResult->GetColor(1, pColorVariable->m_DarkestLighting).Pack(pColorVariable->m_DarkestLighting, pColorVariable->m_Alpha);
 			const std::optional<ColorHSLA> Value = pResult->GetColor(EqualToFirst ? 2 : 1, pColorVariable->m_DarkestLighting);
 			pColorVariable->SetValue(Value.value_or(ColorHSLA(0, 0, 0)).Pack(pColorVariable->m_DarkestLighting, pColorVariable->m_Alpha));
 		}

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -78,11 +78,11 @@ float CConsole::CResult::GetFloat(unsigned Index) const
 	return str_tofloat(m_apArgs[Index], &Out) ? Out : 0.0f;
 }
 
-std::optional<ColorHSLA> CConsole::CResult::GetColor(unsigned Index, float DarkestLighting) const
+ColorHSLA CConsole::CResult::GetColor(unsigned Index, float DarkestLighting) const
 {
 	if(Index >= m_NumArgs)
-		return std::nullopt;
-	return ColorParse(m_apArgs[Index], DarkestLighting);
+		return ColorHSLA(0, 0, 0);
+	return ColorParse(m_apArgs[Index], DarkestLighting).value_or(ColorHSLA(0, 0, 0));
 }
 
 void CConsole::CCommand::SetAccessLevel(EAccessLevel AccessLevel)
@@ -287,7 +287,6 @@ int CConsole::ParseArgs(CResult *pResult, const char *pFormat, bool IsColor)
 				}
 				if(Command == 'i')
 				{
-					// don't validate colors here
 					if(!IsColor)
 					{
 						int Value;

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -106,7 +106,7 @@ class CConsole : public IConsole
 		const char *GetString(unsigned Index) const override;
 		int GetInteger(unsigned Index) const override;
 		float GetFloat(unsigned Index) const override;
-		std::optional<ColorHSLA> GetColor(unsigned Index, float DarkestLighting) const override;
+		ColorHSLA GetColor(unsigned Index, float DarkestLighting) const override;
 
 		// DDRace
 

--- a/src/rust-bridge/cpp/console.cpp
+++ b/src/rust-bridge/cpp/console.cpp
@@ -109,8 +109,8 @@ void cxxbridge1$IConsole_IResult$GetString(const ::IConsole_IResult &self, ::std
 }
 
 void cxxbridge1$IConsole_IResult$GetColor(const ::IConsole_IResult &self, ::std::uint32_t Index, float DarkestLighting, ::ColorHSLA *return$) noexcept {
-  std::optional<::ColorHSLA> (::IConsole_IResult::*GetColor$)(::std::uint32_t, float) const = &::IConsole_IResult::GetColor;
-  new(return$)::ColorHSLA((self.*GetColor$)(Index, DarkestLighting).value_or(::ColorHSLA(0, 0, 0)));
+  ::ColorHSLA (::IConsole_IResult::*GetColor$)(::std::uint32_t, float) const = &::IConsole_IResult::GetColor;
+  new (return$) ::ColorHSLA((self.*GetColor$)(Index, DarkestLighting));
 }
 
 ::std::int32_t cxxbridge1$IConsole_IResult$NumArguments(const ::IConsole_IResult &self) noexcept {


### PR DESCRIPTION
helps the rust bridge. See https://github.com/ddnet/ddnet/pull/10780 for details.

Alternative for #10780

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
