### PR TITLE
Move generated files to `src/generated`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1935,7 +1935,7 @@ function(generate_maps output_file script_parameter)
   )
 endfunction()
 
-file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/src/game/generated/")
+file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/src/generated/")
 execute_process(COMMAND git rev-parse --git-dir
   ERROR_QUIET
   WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
@@ -1949,33 +1949,33 @@ if(NOT PROJECT_GIT_DIR_ERROR)
     ${PROJECT_GIT_DIR}/logs/HEAD
   )
 endif()
-add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/src/game/generated/git_revision.cpp
+add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/src/generated/git_revision.cpp
   COMMAND ${Python3_EXECUTABLE}
     scripts/git_revision.py
-    > ${PROJECT_BINARY_DIR}/src/game/generated/git_revision.cpp
+    > ${PROJECT_BINARY_DIR}/src/generated/git_revision.cpp
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   DEPENDS
     ${GIT_REVISION_EXTRA_DEPS}
     scripts/git_revision.py
 )
-generate_source("src/game/generated/client_data.cpp" "client_content_source")
-generate_source("src/game/generated/client_data.h" "client_content_header")
-generate_source("src/game/generated/data_types.h" "content_types_header")
-generate_source("src/game/generated/protocol.cpp" "network_source")
-generate_source("src/game/generated/protocol.h" "network_header")
-generate_source("src/game/generated/server_data.cpp" "server_content_source")
-generate_source("src/game/generated/server_data.h" "server_content_header")
+generate_source("src/generated/client_data.cpp" "client_content_source")
+generate_source("src/generated/client_data.h" "client_content_header")
+generate_source("src/generated/data_types.h" "content_types_header")
+generate_source("src/generated/protocol.cpp" "network_source")
+generate_source("src/generated/protocol.h" "network_header")
+generate_source("src/generated/server_data.cpp" "server_content_source")
+generate_source("src/generated/server_data.h" "server_content_header")
 
-generate_source7("src/game/generated/protocol7.cpp" "network_source")
-generate_source7("src/game/generated/protocol7.h" "network_header")
-generate_source7("src/game/generated/client_data7.cpp" "client_content_source")
-generate_source7("src/game/generated/client_data7.h" "client_content_header")
+generate_source7("src/generated/protocol7.cpp" "network_source")
+generate_source7("src/generated/protocol7.h" "network_header")
+generate_source7("src/generated/client_data7.cpp" "client_content_source")
+generate_source7("src/generated/client_data7.h" "client_content_header")
 
-generate_maps("src/game/generated/protocolglue.h" "map_header")
-generate_maps("src/game/generated/protocolglue.cpp" "map_source")
+generate_maps("src/generated/protocolglue.h" "map_header")
+generate_maps("src/generated/protocolglue.cpp" "map_source")
 
-add_custom_command(OUTPUT "src/game/generated/wordlist.h"
-  COMMAND ${Python3_EXECUTABLE} scripts/wordlist.py > ${PROJECT_BINARY_DIR}/src/game/generated/wordlist.h
+add_custom_command(OUTPUT "src/generated/wordlist.h"
+  COMMAND ${Python3_EXECUTABLE} scripts/wordlist.py > ${PROJECT_BINARY_DIR}/src/generated/wordlist.h
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   DEPENDS
     scripts/wordlist.py
@@ -2179,12 +2179,12 @@ set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "src/game/version
 # A bit hacky, but these are needed to register all the UUIDs, even for stuff
 # that doesn't link game.
 set(ENGINE_UUID_SHARED
-  src/game/generated/protocolglue.cpp
-  src/game/generated/protocolglue.h
-  src/game/generated/protocol7.cpp
-  src/game/generated/protocol7.h
-  src/game/generated/protocol.cpp
-  src/game/generated/protocol.h
+  src/generated/protocolglue.cpp
+  src/generated/protocolglue.h
+  src/generated/protocol7.cpp
+  src/generated/protocol7.h
+  src/generated/protocol.cpp
+  src/generated/protocol.h
   src/game/mapitems_ex.cpp
   src/game/mapitems_ex.h
   src/game/mapitems_ex_types.h
@@ -2196,11 +2196,11 @@ foreach(s ${GAME_SHARED})
 endforeach()
 list(REMOVE_ITEM GAME_SHARED ${ENGINE_UUID_SHARED})
 set(GAME_GENERATED_SHARED
-  src/game/generated/data_types.h
-  src/game/generated/git_revision.cpp
-  src/game/generated/protocol.h
-  src/game/generated/protocol7.h
-  src/game/generated/protocolglue.h
+  src/generated/data_types.h
+  src/generated/git_revision.cpp
+  src/generated/protocol.h
+  src/generated/protocol7.h
+  src/generated/protocolglue.h
 )
 set(DEPS ${DEP_JSON} ${DEP_MD5} ${ZLIB_DEP})
 
@@ -2555,11 +2555,11 @@ if(CLIENT)
     render_map.h
   )
   set(GAME_GENERATED_CLIENT
-    src/game/generated/checksum.cpp
-    src/game/generated/client_data.cpp
-    src/game/generated/client_data.h
-    src/game/generated/client_data7.cpp
-    src/game/generated/client_data7.h
+    src/generated/checksum.cpp
+    src/generated/client_data.cpp
+    src/generated/client_data.h
+    src/generated/client_data7.cpp
+    src/generated/client_data7.h
   )
   set(CLIENT_SRC ${ENGINE_CLIENT} ${PLATFORM_CLIENT} ${GAME_CLIENT} ${GAME_EDITOR} ${GAME_MAP} ${GAME_GENERATED_CLIENT})
 
@@ -2801,9 +2801,9 @@ if(SERVER)
     teeinfo.h
   )
   set(GAME_GENERATED_SERVER
-    "src/game/generated/server_data.cpp"
-    "src/game/generated/server_data.h"
-    "src/game/generated/wordlist.h"
+    "src/generated/server_data.cpp"
+    "src/generated/server_data.h"
+    "src/generated/wordlist.h"
   )
   set(SERVER_SRC ${ENGINE_SERVER_WITHOUT_MAIN} ${GAME_SERVER} ${GAME_GENERATED_SERVER})
   if(TARGET_OS STREQUAL "windows")
@@ -2988,12 +2988,12 @@ configure_file(cmake/checksummed_extra.txt checksummed_extra.txt)
 string(REPLACE ";" "\n" CHECKSUM_SRC_FILE "${CHECKSUM_SRC}")
 file(WRITE ${PROJECT_BINARY_DIR}/checksummed_files.txt ${CHECKSUM_SRC_FILE})
 
-add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/src/game/generated/checksum.cpp
+add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/src/generated/checksum.cpp
   COMMAND ${Python3_EXECUTABLE}
     scripts/checksum.py
     ${PROJECT_BINARY_DIR}/checksummed_files.txt
     ${PROJECT_BINARY_DIR}/checksummed_extra.txt
-    > ${PROJECT_BINARY_DIR}/src/game/generated/checksum.cpp
+    > ${PROJECT_BINARY_DIR}/src/generated/checksum.cpp
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   DEPENDS
     ${CHECKSUM_SRC}

--- a/datasrc/compile.py
+++ b/datasrc/compile.py
@@ -44,8 +44,8 @@ def EmitFlags(names):
 
 
 def gen_network_header():
-	print("#ifndef GAME_GENERATED_PROTOCOL_H")
-	print("#define GAME_GENERATED_PROTOCOL_H")
+	print("#ifndef GENERATED_PROTOCOL_H")
+	print("#define GENERATED_PROTOCOL_H")
 	print("class CUnpacker;")
 	print("#include <engine/message.h>")
 	print(network.RawHeader)
@@ -130,7 +130,7 @@ public:
 };
 	""")
 
-	print("#endif // GAME_GENERATED_PROTOCOL_H")
+	print("#endif // GENERATED_PROTOCOL_H")
 
 
 def gen_network_source():
@@ -453,15 +453,15 @@ def gen_common_content_source():
 
 
 def gen_content_types_header():
-	print("#ifndef CONTENT_TYPES_HEADER")
-	print("#define CONTENT_TYPES_HEADER")
+	print("#ifndef GENERATED_DATA_TYPES_H")
+	print("#define GENERATED_DATA_TYPES_H")
 	gen_common_content_types_header()
 	print("#endif")
 
 
 def gen_client_content_header():
-	print("#ifndef CLIENT_CONTENT_HEADER")
-	print("#define CLIENT_CONTENT_HEADER")
+	print("#ifndef GENERATED_CLIENT_DATA_H")
+	print("#define GENERATED_CLIENT_DATA_H")
 	gen_common_content_header()
 	print("#endif")
 
@@ -472,8 +472,8 @@ def gen_client_content_source():
 
 
 def gen_server_content_header():
-	print("#ifndef SERVER_CONTENT_HEADER")
-	print("#define SERVER_CONTENT_HEADER")
+	print("#ifndef GENERATED_SERVER_DATA_H")
+	print("#define GENERATED_SERVER_DATA_H")
 	gen_common_content_header()
 	print("#endif")
 

--- a/datasrc/crosscompile.py
+++ b/datasrc/crosscompile.py
@@ -36,7 +36,7 @@ def output_map_source(name, m):
 def main():
 	map_header = "map_header" in sys.argv
 	map_source = "map_source" in sys.argv
-	guard = "GAME_GENERATED_PROTOCOLGLUE"
+	guard = "GENERATED_PROTOCOLGLUE_H"
 	if map_header:
 		print("#ifndef " + guard)
 		print("#define " + guard)

--- a/datasrc/seven/compile.py
+++ b/datasrc/seven/compile.py
@@ -49,12 +49,12 @@ def main():
 	gen_server_content_source = "server_content_source" in sys.argv
 
 	if gen_client_content_header:
-		print("#ifndef CLIENT_CONTENT7_HEADER")
-		print("#define CLIENT_CONTENT7_HEADER")
+		print("#ifndef GENERATED_CLIENT_DATA7_H")
+		print("#define GENERATED_CLIENT_DATA7_H")
 
 	if gen_server_content_header:
-		print("#ifndef SERVER_CONTENT7_HEADER")
-		print("#define SERVER_CONTENT7_HEADER")
+		print("#ifndef GENERATED_SERVER_DATA7_H")
+		print("#define GENERATED_SERVER_DATA7_H")
 
 
 	if gen_client_content_header or gen_server_content_header:
@@ -84,8 +84,8 @@ def main():
 # NETWORK
 	if gen_network_header:
 
-		print("#ifndef GAME_GENERATED_PROTOCOL7_H")
-		print("#define GAME_GENERATED_PROTOCOL7_H")
+		print("#ifndef GENERATED_PROTOCOL7_H")
+		print("#define GENERATED_PROTOCOL7_H")
 		print("class CUnpacker;")
 		print("class CSnapshot;")
 		print("#include <engine/message.h>")
@@ -166,7 +166,7 @@ def main():
 	""")
 
 		print("}")
-		print("#endif // GAME_GENERATED_PROTOCOL7_H")
+		print("#endif // GENERATED_PROTOCOL7_H")
 
 
 	if gen_network_source:

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -12,8 +12,8 @@
 #include <engine/friends.h>
 #include <engine/shared/translation_context.h>
 
-#include <game/generated/protocol.h>
-#include <game/generated/protocol7.h>
+#include <generated/protocol.h>
+#include <generated/protocol7.h>
 
 #include <functional>
 #include <optional>

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -40,15 +40,14 @@
 #include <engine/shared/protocol.h>
 #include <engine/shared/protocol7.h>
 #include <engine/shared/protocol_ex.h>
+#include <engine/shared/protocolglue.h>
 #include <engine/shared/rust_version.h>
 #include <engine/shared/snapshot.h>
 #include <engine/shared/uuid_manager.h>
 
-#include <game/generated/protocol.h>
-#include <game/generated/protocol7.h>
-#include <game/generated/protocolglue.h>
-
-#include <engine/shared/protocolglue.h>
+#include <generated/protocol.h>
+#include <generated/protocol7.h>
+#include <generated/protocolglue.h>
 
 #include <game/localization.h>
 #include <game/version.h>

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -20,8 +20,8 @@
 #include <engine/shared/jobs.h>
 #include <engine/storage.h>
 
-#include <game/generated/client_data.h>
-#include <game/generated/client_data7.h>
+#include <generated/data_types.h>
+
 #include <game/localization.h>
 
 #if defined(CONF_VIDEORECORDER)

--- a/src/engine/client/graphics_threaded_sprites.cpp
+++ b/src/engine/client/graphics_threaded_sprites.cpp
@@ -1,8 +1,8 @@
 #include "graphics_threaded.h"
 #include <engine/graphics.h>
 
-#include <game/generated/client_data.h>
-#include <game/generated/client_data7.h>
+#include <generated/client_data.h>
+#include <generated/client_data7.h>
 
 void CGraphics_Threaded::SelectSprite(const CDataSprite *pSprite, int Flags)
 {

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -15,9 +15,9 @@
 #include "message.h"
 #include <engine/shared/jsonwriter.h>
 #include <engine/shared/protocol.h>
-#include <game/generated/protocol.h>
-#include <game/generated/protocol7.h>
-#include <game/generated/protocolglue.h>
+#include <generated/protocol.h>
+#include <generated/protocol7.h>
+#include <generated/protocolglue.h>
 
 struct CAntibotRoundData;
 

--- a/src/engine/server/authmanager.cpp
+++ b/src/engine/server/authmanager.cpp
@@ -2,7 +2,7 @@
 #include <base/hash_ctxt.h>
 #include <base/system.h>
 #include <engine/shared/config.h>
-#include <game/generated/protocol.h>
+#include <generated/protocol.h>
 
 #define ADMIN_IDENT "default_admin"
 #define MOD_IDENT "default_mod"

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -9,7 +9,7 @@
 #include <engine/map.h>
 #include <engine/shared/protocol.h>
 
-#include <game/generated/protocol7.h>
+#include <generated/protocol7.h>
 
 #include "kernel.h"
 

--- a/src/engine/shared/protocolglue.cpp
+++ b/src/engine/shared/protocolglue.cpp
@@ -1,8 +1,8 @@
 #include <engine/shared/network.h>
 
-#include <game/generated/protocol.h>
-#include <game/generated/protocol7.h>
-#include <game/generated/protocolglue.h>
+#include <generated/protocol.h>
+#include <generated/protocol7.h>
+#include <generated/protocolglue.h>
 
 #include "protocolglue.h"
 

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -10,8 +10,8 @@
 #include <base/math.h>
 #include <base/system.h>
 
-#include <game/generated/protocol7.h>
-#include <game/generated/protocolglue.h>
+#include <generated/protocol7.h>
+#include <generated/protocolglue.h>
 
 // CSnapshot
 

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -6,8 +6,8 @@
 #include <cstddef>
 #include <cstdint>
 
-#include <game/generated/protocol.h>
-#include <game/generated/protocol7.h>
+#include <generated/protocol.h>
+#include <generated/protocol7.h>
 
 // CSnapshot
 

--- a/src/engine/shared/translation_context.h
+++ b/src/engine/shared/translation_context.h
@@ -2,7 +2,7 @@
 #define ENGINE_SHARED_TRANSLATION_CONTEXT_H
 
 #include <engine/shared/protocol.h>
-#include <game/generated/protocol7.h>
+#include <generated/protocol7.h>
 
 #include <engine/client/enums.h>
 

--- a/src/game/client/animstate.cpp
+++ b/src/game/client/animstate.cpp
@@ -2,7 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
 #include <base/math.h>
-#include <game/generated/client_data.h>
+#include <generated/client_data.h>
 
 #include "animstate.h"
 

--- a/src/game/client/animstate.h
+++ b/src/game/client/animstate.h
@@ -3,7 +3,7 @@
 #ifndef GAME_CLIENT_ANIMSTATE_H
 #define GAME_CLIENT_ANIMSTATE_H
 
-#include <game/generated/client_data.h>
+#include <generated/data_types.h>
 
 class CAnimState
 {

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -4,7 +4,7 @@
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 
-#include <game/generated/protocol.h>
+#include <generated/protocol.h>
 
 #include <game/client/gameclient.h>
 

--- a/src/game/client/components/broadcast.h
+++ b/src/game/client/components/broadcast.h
@@ -4,7 +4,7 @@
 #define GAME_CLIENT_COMPONENTS_BROADCAST_H
 
 #include <engine/textrender.h>
-#include <game/generated/protocol.h>
+#include <generated/protocol.h>
 
 #include <game/client/component.h>
 

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -8,8 +8,8 @@
 #include <engine/shared/csv.h>
 #include <engine/textrender.h>
 
-#include <game/generated/protocol.h>
-#include <game/generated/protocol7.h>
+#include <generated/protocol.h>
+#include <generated/protocol7.h>
 
 #include <game/client/animstate.h>
 #include <game/client/components/scoreboard.h>

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -12,7 +12,7 @@
 #include <game/client/component.h>
 #include <game/client/lineinput.h>
 #include <game/client/render.h>
-#include <game/generated/protocol7.h>
+#include <generated/protocol7.h>
 
 constexpr auto SAVES_FILE = "ddnet-saves.txt";
 

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -6,7 +6,7 @@
 #include <base/math.h>
 #include <base/system.h>
 
-#include <game/generated/client_data.h>
+#include <generated/client_data.h>
 
 #include <engine/console.h>
 #include <engine/engine.h>

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -8,7 +8,7 @@
 #include <engine/client.h>
 
 #include <game/client/component.h>
-#include <game/generated/protocol.h>
+#include <generated/protocol.h>
 
 class CControls : public CComponent
 {

--- a/src/game/client/components/damageind.cpp
+++ b/src/game/client/components/damageind.cpp
@@ -3,9 +3,11 @@
 #include <base/color.h>
 #include <engine/demo.h>
 #include <engine/graphics.h>
+
+#include <generated/client_data.h>
+#include <generated/protocol.h>
+
 #include <game/client/gameclient.h>
-#include <game/generated/client_data.h>
-#include <game/generated/protocol.h>
 
 #include "damageind.h"
 

--- a/src/game/client/components/debughud.cpp
+++ b/src/game/client/components/debughud.cpp
@@ -4,7 +4,7 @@
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 
-#include <game/generated/protocol.h>
+#include <generated/protocol.h>
 
 #include <game/client/gameclient.h>
 #include <game/client/prediction/entities/character.h>

--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -5,7 +5,7 @@
 
 #include <engine/shared/config.h>
 
-#include <game/generated/client_data.h>
+#include <generated/client_data.h>
 
 #include <game/client/components/damageind.h>
 #include <game/client/components/flow.h>

--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -2,7 +2,8 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
-#include <game/generated/protocol.h>
+
+#include <generated/protocol.h>
 
 #include "chat.h"
 #include "emoticon.h"

--- a/src/game/client/components/ghost.h
+++ b/src/game/client/components/ghost.h
@@ -3,10 +3,10 @@
 #ifndef GAME_CLIENT_COMPONENTS_GHOST_H
 #define GAME_CLIENT_COMPONENTS_GHOST_H
 
+#include <generated/protocol.h>
+
 #include <game/client/component.h>
 #include <game/client/components/menus.h>
-#include <game/generated/protocol.h>
-
 #include <game/client/render.h>
 
 struct CNetObj_Character;

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -5,12 +5,13 @@
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 
+#include <generated/client_data.h>
+#include <generated/protocol.h>
+
 #include <game/client/animstate.h>
 #include <game/client/components/scoreboard.h>
 #include <game/client/gameclient.h>
 #include <game/client/prediction/entities/character.h>
-#include <game/generated/client_data.h>
-#include <game/generated/protocol.h>
 
 #include <game/layers.h>
 #include <game/localization.h>

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -5,8 +5,10 @@
 #include <engine/client.h>
 #include <engine/shared/protocol.h>
 #include <engine/textrender.h>
+
+#include <generated/protocol.h>
+
 #include <game/client/component.h>
-#include <game/generated/protocol.h>
 
 struct SScoreInfo
 {

--- a/src/game/client/components/infomessages.cpp
+++ b/src/game/client/components/infomessages.cpp
@@ -4,8 +4,10 @@
 #include <engine/shared/config.h>
 #include <engine/shared/protocol.h>
 #include <engine/textrender.h>
-#include <game/generated/client_data.h>
-#include <game/generated/protocol.h>
+
+#include <generated/client_data.h>
+#include <generated/protocol.h>
+
 #include <game/localization.h>
 
 #include "infomessages.h"

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -4,8 +4,8 @@
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
 
-#include <game/generated/client_data.h>
-#include <game/generated/protocol.h>
+#include <generated/client_data.h>
+#include <generated/protocol.h>
 
 #include <game/mapitems.h>
 

--- a/src/game/client/components/items.h
+++ b/src/game/client/components/items.h
@@ -2,8 +2,9 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef GAME_CLIENT_COMPONENTS_ITEMS_H
 #define GAME_CLIENT_COMPONENTS_ITEMS_H
+#include <generated/protocol.h>
+
 #include <game/client/component.h>
-#include <game/generated/protocol.h>
 
 class CProjectileData;
 class CLaserData;

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -9,8 +9,9 @@
 #include <engine/storage.h>
 #include <engine/textrender.h>
 
+#include <generated/client_data.h>
+
 #include <game/client/gameclient.h>
-#include <game/generated/client_data.h>
 #include <game/layers.h>
 #include <game/localization.h>
 #include <game/mapitems.h>

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -12,6 +12,7 @@
 #include <base/vmath.h>
 
 #include <engine/client.h>
+#include <engine/client/updater.h>
 #include <engine/config.h>
 #include <engine/editor.h>
 #include <engine/friends.h>
@@ -23,9 +24,8 @@
 #include <engine/storage.h>
 #include <engine/textrender.h>
 
-#include <game/generated/protocol.h>
-
-#include <engine/client/updater.h>
+#include <generated/client_data.h>
+#include <generated/protocol.h>
 
 #include <game/client/animstate.h>
 #include <game/client/components/binds.h>
@@ -34,7 +34,6 @@
 #include <game/client/components/sounds.h>
 #include <game/client/gameclient.h>
 #include <game/client/ui_listbox.h>
-#include <game/generated/client_data.h>
 #include <game/localization.h>
 
 #include "menus.h"

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -12,11 +12,12 @@
 #include <engine/storage.h>
 #include <engine/textrender.h>
 
+#include <generated/client_data.h>
+
 #include <game/client/components/console.h>
 #include <game/client/gameclient.h>
 #include <game/client/ui.h>
 #include <game/client/ui_listbox.h>
-#include <game/generated/client_data.h>
 #include <game/localization.h>
 
 #include "maplayers.h"

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -13,8 +13,8 @@
 #include <engine/shared/localization.h>
 #include <engine/textrender.h>
 
-#include <game/generated/client_data.h>
-#include <game/generated/protocol.h>
+#include <generated/client_data.h>
+#include <generated/protocol.h>
 
 #include <game/client/animstate.h>
 #include <game/client/components/countryflags.h>

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -13,7 +13,7 @@
 #include <engine/textrender.h>
 #include <engine/updater.h>
 
-#include <game/generated/protocol.h>
+#include <generated/protocol.h>
 
 #include <game/client/animstate.h>
 #include <game/client/components/chat.h>

--- a/src/game/client/components/menus_settings7.cpp
+++ b/src/game/client/components/menus_settings7.cpp
@@ -12,7 +12,7 @@
 #include <engine/textrender.h>
 #include <engine/updater.h>
 
-#include <game/generated/protocol.h>
+#include <generated/protocol.h>
 
 #include <game/client/animstate.h>
 #include <game/client/components/chat.h>

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -8,10 +8,10 @@
 #include <engine/client/updater.h>
 #include <engine/shared/config.h>
 
+#include <generated/client_data.h>
+
 #include <game/client/gameclient.h>
 #include <game/client/ui.h>
-
-#include <game/generated/client_data.h>
 #include <game/localization.h>
 #include <game/version.h>
 

--- a/src/game/client/components/motd.cpp
+++ b/src/game/client/components/motd.cpp
@@ -5,8 +5,9 @@
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 
+#include <generated/protocol.h>
+
 #include <game/client/gameclient.h>
-#include <game/generated/protocol.h>
 
 #include "motd.h"
 

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -4,7 +4,7 @@
 
 #include <engine/shared/protocol7.h>
 
-#include <game/generated/client_data.h>
+#include <generated/client_data.h>
 
 #include <game/client/animstate.h>
 #include <game/client/gameclient.h>

--- a/src/game/client/components/particles.cpp
+++ b/src/game/client/components/particles.cpp
@@ -4,8 +4,9 @@
 #include <engine/demo.h>
 #include <engine/graphics.h>
 
+#include <generated/client_data.h>
+
 #include "particles.h"
-#include <game/generated/client_data.h>
 
 #include <game/client/gameclient.h>
 

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -6,9 +6,10 @@
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
 #include <game/gamecore.h>
-#include <game/generated/client_data.h>
-#include <game/generated/client_data7.h>
-#include <game/generated/protocol.h>
+
+#include <generated/client_data.h>
+#include <generated/client_data7.h>
+#include <generated/protocol.h>
 
 #include <game/mapitems.h>
 

--- a/src/game/client/components/players.h
+++ b/src/game/client/components/players.h
@@ -4,8 +4,9 @@
 #define GAME_CLIENT_COMPONENTS_PLAYERS_H
 #include <game/client/component.h>
 
+#include <generated/protocol.h>
+
 #include <game/client/render.h>
-#include <game/generated/protocol.h>
 
 class CPlayers : public CComponent
 {

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -7,7 +7,8 @@
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 
-#include <game/generated/protocol.h>
+#include <generated/client_data7.h>
+#include <generated/protocol.h>
 
 #include <game/client/animstate.h>
 #include <game/client/components/countryflags.h>
@@ -15,7 +16,6 @@
 #include <game/client/components/statboard.h>
 #include <game/client/gameclient.h>
 #include <game/client/ui.h>
-#include <game/generated/client_data7.h>
 #include <game/localization.h>
 
 CScoreboard::CScoreboard()

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -7,6 +7,8 @@
 #include <base/math.h>
 #include <base/system.h>
 
+#include <generated/client_data.h>
+
 #include <engine/engine.h>
 #include <engine/gfx/image_manipulation.h>
 #include <engine/graphics.h>
@@ -15,7 +17,6 @@
 #include <engine/storage.h>
 
 #include <game/client/gameclient.h>
-#include <game/generated/client_data.h>
 #include <game/localization.h>
 
 using namespace std::chrono_literals;

--- a/src/game/client/components/skins7.h
+++ b/src/game/client/components/skins7.h
@@ -9,10 +9,11 @@
 #include <engine/client/enums.h>
 #include <engine/graphics.h>
 
+#include <generated/protocol.h>
+#include <generated/protocol7.h>
+
 #include <game/client/component.h>
 #include <game/client/render.h>
-#include <game/generated/protocol.h>
-#include <game/generated/protocol7.h>
 
 #include <chrono>
 #include <vector>

--- a/src/game/client/components/sounds.cpp
+++ b/src/game/client/components/sounds.cpp
@@ -6,10 +6,12 @@
 #include <engine/engine.h>
 #include <engine/shared/config.h>
 #include <engine/sound.h>
+
+#include <generated/client_data.h>
+
 #include <game/client/components/camera.h>
 #include <game/client/components/menus.h>
 #include <game/client/gameclient.h>
-#include <game/generated/client_data.h>
 #include <game/localization.h>
 
 CSoundLoading::CSoundLoading(CGameClient *pGameClient, bool Render) :

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -7,7 +7,7 @@
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 
-#include <game/generated/protocol.h>
+#include <generated/protocol.h>
 
 #include <game/client/animstate.h>
 #include <game/localization.h>

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -3,11 +3,13 @@
 #include <engine/shared/config.h>
 #include <engine/storage.h>
 #include <engine/textrender.h>
+
+#include <generated/client_data.h>
+
 #include <game/client/animstate.h>
 #include <game/client/components/motd.h>
 #include <game/client/components/statboard.h>
 #include <game/client/gameclient.h>
-#include <game/generated/client_data.h>
 #include <game/localization.h>
 
 CStatboard::CStatboard()

--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -7,10 +7,11 @@
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 
+#include <generated/protocol.h>
+
 #include <game/client/components/scoreboard.h>
 #include <game/client/components/sounds.h>
 #include <game/client/gameclient.h>
-#include <game/generated/protocol.h>
 #include <game/localization.h>
 
 void CVoting::ConCallvote(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -21,9 +21,11 @@
 #include <engine/textrender.h>
 #include <engine/updater.h>
 
-#include <game/generated/client_data.h>
-#include <game/generated/client_data7.h>
-#include <game/generated/protocol.h>
+#include <generated/client_data.h>
+#include <generated/client_data7.h>
+#include <generated/protocol.h>
+#include <generated/protocol7.h>
+#include <generated/protocolglue.h>
 
 #include <base/log.h>
 #include <base/math.h>
@@ -39,9 +41,6 @@
 #include <game/localization.h>
 #include <game/mapitems.h>
 #include <game/version.h>
-
-#include <game/generated/protocol7.h>
-#include <game/generated/protocolglue.h>
 
 #include "components/background.h"
 #include "components/binds.h"

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -21,8 +21,8 @@
 #include <game/client/prediction/gameworld.h>
 #include <game/client/race.h>
 
-#include <game/generated/protocol7.h>
-#include <game/generated/protocolglue.h>
+#include <generated/protocol7.h>
+#include <generated/protocolglue.h>
 
 // components
 #include "components/background.h"

--- a/src/game/client/laser_data.cpp
+++ b/src/game/client/laser_data.cpp
@@ -4,9 +4,10 @@
 #include "laser_data.h"
 
 #include <engine/shared/snapshot.h>
-#include <game/client/prediction/gameworld.h>
-#include <game/generated/protocol.h>
 
+#include <generated/protocol.h>
+
+#include <game/client/prediction/gameworld.h>
 #include <game/collision.h>
 
 CLaserData ExtractLaserInfo(int NetObjType, const void *pData, CGameWorld *pGameWorld, const CNetObj_EntityEx *pEntEx)

--- a/src/game/client/pickup_data.cpp
+++ b/src/game/client/pickup_data.cpp
@@ -4,8 +4,10 @@
 #include "pickup_data.h"
 
 #include <engine/shared/snapshot.h>
+
+#include <generated/protocol.h>
+
 #include <game/collision.h>
-#include <game/generated/protocol.h>
 
 CPickupData ExtractPickupInfo(int NetObjType, const void *pData, const CNetObj_EntityEx *pEntEx)
 {

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1,8 +1,10 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <engine/shared/config.h>
+
+#include <generated/client_data.h>
+
 #include <game/collision.h>
-#include <game/generated/client_data.h>
 #include <game/mapitems.h>
 
 #include "character.h"

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -3,10 +3,10 @@
 #ifndef GAME_CLIENT_PREDICTION_ENTITIES_CHARACTER_H
 #define GAME_CLIENT_PREDICTION_ENTITIES_CHARACTER_H
 
-#include <game/client/prediction/entity.h>
+#include <generated/protocol.h>
 
+#include <game/client/prediction/entity.h>
 #include <game/gamecore.h>
-#include <game/generated/protocol.h>
 #include <game/race_state.h>
 
 enum

--- a/src/game/client/prediction/entities/dragger.cpp
+++ b/src/game/client/prediction/entities/dragger.cpp
@@ -4,9 +4,10 @@
 
 #include <engine/shared/config.h>
 
+#include <generated/protocol.h>
+
 #include <game/client/laser_data.h>
 #include <game/collision.h>
-#include <game/generated/protocol.h>
 #include <game/mapitems.h>
 
 void CDragger::Tick()

--- a/src/game/client/prediction/entities/laser.cpp
+++ b/src/game/client/prediction/entities/laser.cpp
@@ -1,10 +1,12 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "laser.h"
+
+#include <generated/protocol.h>
+
 #include "character.h"
 #include <game/client/laser_data.h>
 #include <game/collision.h>
-#include <game/generated/protocol.h>
 #include <game/mapitems.h>
 
 #include <engine/shared/config.h>

--- a/src/game/client/prediction/entities/pickup.cpp
+++ b/src/game/client/prediction/entities/pickup.cpp
@@ -1,10 +1,12 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "pickup.h"
+
+#include <generated/protocol.h>
+
 #include "character.h"
 #include <game/client/pickup_data.h>
 #include <game/collision.h>
-#include <game/generated/protocol.h>
 #include <game/mapitems.h>
 
 static constexpr int gs_PickupPhysSize = 14;

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -2,9 +2,10 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <engine/shared/config.h>
 
+#include <generated/protocol.h>
+
 #include <game/client/projectile_data.h>
 #include <game/collision.h>
-#include <game/generated/protocol.h>
 #include <game/mapitems.h>
 
 #include "character.h"

--- a/src/game/client/projectile_data.cpp
+++ b/src/game/client/projectile_data.cpp
@@ -4,9 +4,10 @@
 #include "projectile_data.h"
 
 #include <engine/shared/snapshot.h>
-#include <game/client/prediction/gameworld.h>
-#include <game/generated/protocol.h>
 
+#include <generated/protocol.h>
+
+#include <game/client/prediction/gameworld.h>
 #include <game/collision.h>
 
 static bool UseProjectileExtraInfo(const CNetObj_Projectile *pProj)

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -10,10 +10,10 @@
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
 
-#include <game/generated/client_data.h>
-#include <game/generated/client_data7.h>
-#include <game/generated/protocol.h>
-#include <game/generated/protocol7.h>
+#include <generated/client_data.h>
+#include <generated/client_data7.h>
+#include <generated/protocol.h>
+#include <generated/protocol7.h>
 
 #include <game/mapitems.h>
 

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -8,9 +8,11 @@
 #include <base/color.h>
 #include <base/vmath.h>
 
+#include <generated/protocol.h>
+#include <generated/protocol7.h>
+
 #include <game/client/skin.h>
 #include <game/client/ui_rect.h>
-#include <game/generated/protocol7.h>
 
 #include <functional>
 #include <memory>
@@ -30,8 +32,6 @@ class CEnvPointBezier;
 class CEnvPointBezier_upstream;
 class CMapItemGroup;
 class CQuad;
-
-#include <game/generated/protocol.h>
 
 class CSkinDescriptor
 {

--- a/src/game/client/sixup_translate_game.cpp
+++ b/src/game/client/sixup_translate_game.cpp
@@ -1,10 +1,12 @@
 #include <base/system.h>
+
 #include <engine/shared/protocol7.h>
-#include <game/gamecore.h>
-#include <game/generated/protocol7.h>
-#include <game/localization.h>
+
+#include <generated/protocol7.h>
 
 #include <game/client/gameclient.h>
+#include <game/gamecore.h>
+#include <game/localization.h>
 
 enum
 {

--- a/src/game/client/sixup_translate_snapshot.cpp
+++ b/src/game/client/sixup_translate_snapshot.cpp
@@ -1,8 +1,10 @@
 #include <engine/shared/protocolglue.h>
 #include <engine/shared/snapshot.h>
 #include <engine/shared/translation_context.h>
+
+#include <generated/protocol7.h>
+
 #include <game/client/gameclient.h>
-#include <game/generated/protocol7.h>
 
 int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven, int Conn, bool Dummy)
 {

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -23,6 +23,8 @@
 #include <engine/storage.h>
 #include <engine/textrender.h>
 
+#include <generated/client_data.h>
+
 #include <game/client/components/camera.h>
 #include <game/client/gameclient.h>
 #include <game/client/lineinput.h>
@@ -30,7 +32,6 @@
 #include <game/client/ui_listbox.h>
 #include <game/client/ui_scrollregion.h>
 #include <game/editor/explanations.h>
-#include <game/generated/client_data.h>
 #include <game/localization.h>
 
 #include <game/editor/editor_history.h>

--- a/src/game/editor/mapitems/layer_sounds.cpp
+++ b/src/game/editor/mapitems/layer_sounds.cpp
@@ -1,8 +1,9 @@
 #include "layer_sounds.h"
 
+#include <generated/client_data.h>
+
 #include <game/editor/editor.h>
 #include <game/editor/editor_actions.h>
-#include <game/generated/client_data.h>
 
 static const float s_SourceVisualSize = 32.0f;
 

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -9,7 +9,9 @@
 #include <vector>
 
 #include <engine/shared/protocol.h>
-#include <game/generated/protocol.h>
+
+#include <generated/protocol.h>
+
 #include <game/teamscore.h>
 
 #include "prng.h"

--- a/src/game/map/render_map.cpp
+++ b/src/game/map/render_map.cpp
@@ -12,7 +12,7 @@
 
 #include "render_map.h"
 
-#include <game/generated/client_data.h>
+#include <generated/client_data.h>
 
 #include <game/mapitems.h>
 #include <game/mapitems_ex.h>

--- a/src/game/mapitems_ex.h
+++ b/src/game/mapitems_ex.h
@@ -1,6 +1,6 @@
 #ifndef GAME_MAPITEMS_EX_H
 #define GAME_MAPITEMS_EX_H
-#include <game/generated/protocol.h>
+#include <generated/protocol.h>
 
 enum
 {

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -11,8 +11,9 @@
 #include <engine/antibot.h>
 #include <engine/shared/config.h>
 
-#include <game/generated/protocol.h>
-#include <game/generated/server_data.h>
+#include <generated/protocol.h>
+#include <generated/server_data.h>
+
 #include <game/mapitems.h>
 #include <game/team_state.h>
 

--- a/src/game/server/entities/door.cpp
+++ b/src/game/server/entities/door.cpp
@@ -2,12 +2,12 @@
 #include "door.h"
 #include "character.h"
 
-#include <game/generated/protocol.h>
-#include <game/mapitems.h>
-#include <game/teamscore.h>
+#include <generated/protocol.h>
 
+#include <game/mapitems.h>
 #include <game/server/gamecontext.h>
 #include <game/server/player.h>
+#include <game/teamscore.h>
 
 CDoor::CDoor(CGameWorld *pGameWorld, vec2 Pos, float Rotation, int Length,
 	int Number) :

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -6,9 +6,9 @@
 #include <engine/server.h>
 #include <engine/shared/config.h>
 
-#include <game/generated/protocol.h>
-#include <game/mapitems.h>
+#include <generated/protocol.h>
 
+#include <game/mapitems.h>
 #include <game/server/gamecontext.h>
 #include <game/server/player.h>
 #include <game/server/teams.h>

--- a/src/game/server/entities/dragger_beam.cpp
+++ b/src/game/server/entities/dragger_beam.cpp
@@ -6,9 +6,9 @@
 #include <engine/server.h>
 #include <engine/shared/config.h>
 
-#include <game/generated/protocol.h>
-#include <game/mapitems.h>
+#include <generated/protocol.h>
 
+#include <game/mapitems.h>
 #include <game/server/gamecontext.h>
 #include <game/server/save.h>
 

--- a/src/game/server/entities/gun.cpp
+++ b/src/game/server/entities/gun.cpp
@@ -6,9 +6,9 @@
 #include <engine/server.h>
 #include <engine/shared/config.h>
 
-#include <game/generated/protocol.h>
-#include <game/mapitems.h>
+#include <generated/protocol.h>
 
+#include <game/mapitems.h>
 #include <game/server/gamecontext.h>
 #include <game/server/player.h>
 #include <game/server/teams.h>

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -5,9 +5,9 @@
 
 #include <engine/shared/config.h>
 
-#include <game/generated/protocol.h>
-#include <game/mapitems.h>
+#include <generated/protocol.h>
 
+#include <game/mapitems.h>
 #include <game/server/gamecontext.h>
 #include <game/server/gamemodes/DDRace.h>
 

--- a/src/game/server/entities/light.cpp
+++ b/src/game/server/entities/light.cpp
@@ -4,12 +4,12 @@
 
 #include <engine/server.h>
 
-#include <game/generated/protocol.h>
-#include <game/mapitems.h>
-#include <game/teamscore.h>
+#include <generated/protocol.h>
 
+#include <game/mapitems.h>
 #include <game/server/gamecontext.h>
 #include <game/server/player.h>
+#include <game/teamscore.h>
 
 CLight::CLight(CGameWorld *pGameWorld, vec2 Pos, float Rotation, int Length,
 	int Layer, int Number) :

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -3,12 +3,12 @@
 #include "pickup.h"
 #include "character.h"
 
-#include <game/generated/protocol.h>
-#include <game/mapitems.h>
-#include <game/teamscore.h>
+#include <generated/protocol.h>
 
+#include <game/mapitems.h>
 #include <game/server/gamecontext.h>
 #include <game/server/player.h>
+#include <game/teamscore.h>
 
 static constexpr int gs_PickupPhysSize = 14;
 

--- a/src/game/server/entities/plasma.cpp
+++ b/src/game/server/entities/plasma.cpp
@@ -4,10 +4,10 @@
 
 #include <engine/server.h>
 
-#include <game/generated/protocol.h>
-#include <game/teamscore.h>
+#include <generated/protocol.h>
 
 #include <game/server/gamecontext.h>
+#include <game/teamscore.h>
 
 const float PLASMA_ACCEL = 1.1f;
 

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -5,7 +5,8 @@
 
 #include <engine/shared/config.h>
 
-#include <game/generated/protocol.h>
+#include <generated/protocol.h>
+
 #include <game/mapitems.h>
 
 #include <game/server/gamecontext.h>

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -26,8 +26,8 @@
 #include <game/mapitems.h>
 #include <game/version.h>
 
-#include <game/generated/protocol7.h>
-#include <game/generated/protocolglue.h>
+#include <generated/protocol7.h>
+#include <generated/protocolglue.h>
 
 #include "entities/character.h"
 #include "gamemodes/DDRace.h"

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -6,8 +6,9 @@
 #include <engine/console.h>
 #include <engine/server.h>
 
+#include <generated/protocol.h>
+
 #include <game/collision.h>
-#include <game/generated/protocol.h>
 #include <game/layers.h>
 #include <game/mapbugs.h>
 #include <game/voting.h>

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -3,7 +3,9 @@
 #include <engine/shared/config.h>
 
 #include <engine/shared/protocolglue.h>
-#include <game/generated/protocol.h>
+
+#include <generated/protocol.h>
+
 #include <game/mapitems.h>
 #include <game/server/score.h>
 #include <game/teamscore.h>

--- a/src/game/server/save.h
+++ b/src/game/server/save.h
@@ -3,7 +3,9 @@
 
 #include <base/vmath.h>
 #include <engine/shared/protocol.h>
-#include <game/generated/protocol.h>
+
+#include <generated/protocol.h>
+
 #include <game/team_state.h>
 
 #include <optional>

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -4,7 +4,9 @@
 #include <engine/shared/console.h>
 #include <engine/shared/linereader.h>
 #include <engine/storage.h>
-#include <game/generated/wordlist.h>
+
+#include <generated/wordlist.h>
+
 #include <game/server/gamemodes/DDRace.h>
 #include <game/team_state.h>
 

--- a/src/game/server/teehistorian.h
+++ b/src/game/server/teehistorian.h
@@ -4,7 +4,7 @@
 #include <base/hash.h>
 #include <engine/console.h>
 #include <engine/shared/protocol.h>
-#include <game/generated/protocol.h>
+#include <generated/protocol.h>
 
 #include <ctime>
 

--- a/src/game/server/teeinfo.cpp
+++ b/src/game/server/teeinfo.cpp
@@ -1,6 +1,6 @@
 #include <base/color.h>
 #include <base/system.h>
-#include <game/generated/protocol7.h>
+#include <generated/protocol7.h>
 
 #include "teeinfo.h"
 

--- a/src/test/gameworld.cpp
+++ b/src/test/gameworld.cpp
@@ -15,7 +15,9 @@
 #include <engine/server/server_logger.h>
 #include <engine/shared/assertion_logger.h>
 #include <engine/shared/config.h>
-#include <game/generated/protocol.h>
+
+#include <generated/protocol.h>
+
 #include <game/server/entities/character.h>
 #include <game/server/gamecontext.h>
 #include <game/server/gameworld.h>

--- a/src/test/snapshot.cpp
+++ b/src/test/snapshot.cpp
@@ -1,8 +1,10 @@
 #include <gtest/gtest.h>
 
 #include <base/system.h>
+
 #include <engine/shared/snapshot.h>
-#include <game/generated/protocol.h>
+
+#include <generated/protocol.h>
 
 TEST(Snapshot, CrcOneInt)
 {


### PR DESCRIPTION
The generated files are not game-specific and also used in the engine.

Fix inconsistent header guard naming in generated files.

Reorder includes as necessary, but avoid larger changes to unrelated includes.

Closes #3777.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
