### PR TITLE
Fix `access_level` command crashing the server

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -4051,6 +4051,8 @@ void CServer::ConchainCommandAccessUpdate(IConsole::IResult *pResult, void *pUse
 			{
 				if(pThis->m_aClients[i].m_State == CServer::CClient::STATE_EMPTY)
 					continue;
+				if(!pThis->IsRconAuthed(i))
+					continue;
 				const int ClientAccessLevel = pThis->ConsoleAccessLevel(i);
 				if((pInfo->GetAccessLevel() > ClientAccessLevel && ClientAccessLevel < OldAccessLevel) ||
 					(pInfo->GetAccessLevel() < ClientAccessLevel && ClientAccessLevel > OldAccessLevel) ||


### PR DESCRIPTION
The command `access_level` that updates which rcon commands
helpers and moderators have access to also resends the rcon commands
to ALL clients. No matter if they are logged in or not.
Here all not logged in clients would be handled as helpers
which since https://github.com/ddnet/ddnet/pull/10772
is no longer allowed. So the server would die with an assert.

The fix is to only send rcon commands to authed players.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
