### PR TITLE
Easier to read rcon command update code

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -4048,13 +4048,19 @@ void CServer::ConchainCommandAccessUpdate(IConsole::IResult *pResult, void *pUse
 					continue;
 				if(!pThis->IsRconAuthed(i))
 					continue;
+
 				const int ClientAccessLevel = pThis->ConsoleAccessLevel(i);
-				if((pInfo->GetAccessLevel() > ClientAccessLevel && ClientAccessLevel < OldAccessLevel) ||
-					(pInfo->GetAccessLevel() < ClientAccessLevel && ClientAccessLevel > OldAccessLevel) ||
-					(pThis->m_aClients[i].m_pRconCmdToSend && str_comp(pResult->GetString(0), pThis->m_aClients[i].m_pRconCmdToSend->m_pName) >= 0))
+				bool HadAccess = OldAccessLevel >= ClientAccessLevel;
+				bool HasAccess = pInfo->GetAccessLevel() >= ClientAccessLevel;
+
+				// Nothing changed
+				if(HadAccess == HasAccess)
+					continue;
+				// Command not sent yet. The sending will happen in alphabetical order with correctly updated permissions.
+				if(pThis->m_aClients[i].m_pRconCmdToSend && str_comp(pResult->GetString(0), pThis->m_aClients[i].m_pRconCmdToSend->m_pName) >= 0)
 					continue;
 
-				if(OldAccessLevel < pInfo->GetAccessLevel())
+				if(HasAccess)
 					pThis->SendRconCmdAdd(pInfo, i);
 				else
 					pThis->SendRconCmdRem(pInfo, i);


### PR DESCRIPTION
Before this change the code was non obvious to me. All the code does is not update the client if nothing changed.

The access levels in general are a bit confusing. Because lower access levels have more power. So reading 4 comparisons with greater and less than and these access levels is quite complex.

Also it does nothing if the command was not sent to the client yet. This check relies on the reader to know that if `m_pRconCmdToSend` is not `nullptr` the client is currently receiving rcon commands. And that these commands are sent in alphabetical order. And that on every send step their access level is checked. So the `str_comp() >= 0` checks if the changed command was already sent or not. Because if it was not sent yet we do not need to inform the client now since it will happen later automatically anyways.

And finally it checks if the commands access level increased or decreased. But what this really is about is if the client has access to it or not. Somehow the old check magically worked because there are not many access levels and because of the huge amount of prior checks. But it hides the true intention of the code.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
