### PR TITLE
Add Volume params to CEffects

### DIFF
--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -22,7 +22,7 @@ CEffects::CEffects()
 	m_Add100hz = false;
 }
 
-void CEffects::AirJump(vec2 Pos, float Alpha)
+void CEffects::AirJump(vec2 Pos, float Alpha, float Volume)
 {
 	CParticle p;
 	p.SetDefault();
@@ -45,7 +45,7 @@ void CEffects::AirJump(vec2 Pos, float Alpha)
 	GameClient()->m_Particles.Add(CParticles::GROUP_GENERAL, &p);
 
 	if(g_Config.m_SndGame)
-		GameClient()->m_Sounds.PlayAt(CSounds::CHN_WORLD, SOUND_PLAYER_AIRJUMP, 1.0f, Pos);
+		GameClient()->m_Sounds.PlayAt(CSounds::CHN_WORLD, SOUND_PLAYER_AIRJUMP, Volume, Pos);
 }
 
 void CEffects::DamageIndicator(vec2 Pos, vec2 Dir, float Alpha)
@@ -143,7 +143,7 @@ void CEffects::SmokeTrail(vec2 Pos, vec2 Vel, float Alpha, float TimePassed)
 	GameClient()->m_Particles.Add(CParticles::GROUP_PROJECTILE_TRAIL, &p, TimePassed);
 }
 
-void CEffects::SkidTrail(vec2 Pos, vec2 Vel, int Direction, float Alpha)
+void CEffects::SkidTrail(vec2 Pos, vec2 Vel, int Direction, float Alpha, float Volume)
 {
 	if(m_Add100hz)
 	{
@@ -167,7 +167,7 @@ void CEffects::SkidTrail(vec2 Pos, vec2 Vel, int Direction, float Alpha)
 		if(Now - m_SkidSoundTimer > time_freq() / 10)
 		{
 			m_SkidSoundTimer = Now;
-			GameClient()->m_Sounds.PlayAt(CSounds::CHN_WORLD, SOUND_PLAYER_SKID, 1.0f, Pos);
+			GameClient()->m_Sounds.PlayAt(CSounds::CHN_WORLD, SOUND_PLAYER_SKID, Volume, Pos);
 		}
 	}
 }
@@ -190,7 +190,7 @@ void CEffects::BulletTrail(vec2 Pos, float Alpha, float TimePassed)
 	GameClient()->m_Particles.Add(CParticles::GROUP_PROJECTILE_TRAIL, &p, TimePassed);
 }
 
-void CEffects::PlayerSpawn(vec2 Pos, float Alpha)
+void CEffects::PlayerSpawn(vec2 Pos, float Alpha, float Volume)
 {
 	for(int i = 0; i < 32; i++)
 	{
@@ -211,7 +211,7 @@ void CEffects::PlayerSpawn(vec2 Pos, float Alpha)
 		GameClient()->m_Particles.Add(CParticles::GROUP_GENERAL, &p);
 	}
 	if(g_Config.m_SndGame)
-		GameClient()->m_Sounds.PlayAt(CSounds::CHN_WORLD, SOUND_PLAYER_SPAWN, 1.0f, Pos);
+		GameClient()->m_Sounds.PlayAt(CSounds::CHN_WORLD, SOUND_PLAYER_SPAWN, Volume, Pos);
 }
 
 void CEffects::PlayerDeath(vec2 Pos, int ClientId, float Alpha)
@@ -392,7 +392,7 @@ void CEffects::Explosion(vec2 Pos, float Alpha)
 	}
 }
 
-void CEffects::HammerHit(vec2 Pos, float Alpha)
+void CEffects::HammerHit(vec2 Pos, float Alpha, float Volume)
 {
 	// add the explosion
 	CParticle p;
@@ -407,7 +407,7 @@ void CEffects::HammerHit(vec2 Pos, float Alpha)
 	p.m_StartAlpha = Alpha;
 	GameClient()->m_Particles.Add(CParticles::GROUP_EXPLOSIONS, &p);
 	if(g_Config.m_SndGame)
-		GameClient()->m_Sounds.PlayAt(CSounds::CHN_WORLD, SOUND_HAMMER_HIT, 1.0f, Pos);
+		GameClient()->m_Sounds.PlayAt(CSounds::CHN_WORLD, SOUND_HAMMER_HIT, Volume, Pos);
 }
 
 void CEffects::OnRender()

--- a/src/game/client/components/effects.h
+++ b/src/game/client/components/effects.h
@@ -29,12 +29,12 @@ public:
 
 	void BulletTrail(vec2 Pos, float Alpha, float TimePassed);
 	void SmokeTrail(vec2 Pos, vec2 Vel, float Alpha, float TimePassed);
-	void SkidTrail(vec2 Pos, vec2 Vel, int Direction, float Alpha);
+	void SkidTrail(vec2 Pos, vec2 Vel, int Direction, float Alpha, float Volume);
 	void Explosion(vec2 Pos, float Alpha);
-	void HammerHit(vec2 Pos, float Alpha);
-	void AirJump(vec2 Pos, float Alpha);
+	void HammerHit(vec2 Pos, float Alpha, float Volume);
+	void AirJump(vec2 Pos, float Alpha, float Volume);
 	void DamageIndicator(vec2 Pos, vec2 Dir, float Alpha);
-	void PlayerSpawn(vec2 Pos, float Alpha);
+	void PlayerSpawn(vec2 Pos, float Alpha, float Volume);
 	void PlayerDeath(vec2 Pos, int ClientId, float Alpha);
 	void PowerupShine(vec2 Pos, vec2 Size, float Alpha);
 	void FreezingFlakes(vec2 Pos, vec2 Size, float Alpha);

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -427,6 +427,8 @@ void CPlayers::RenderPlayer(
 	float Alpha = (OtherTeam || ClientId < 0) ? g_Config.m_ClShowOthersAlpha / 100.0f : 1.0f;
 	if(ClientId == -2) // ghost
 		Alpha = g_Config.m_ClRaceGhostAlpha / 100.0f;
+	// TODO: snd_game_volume_others
+	const float Volume = 1.0f;
 
 	// set size
 	RenderInfo.m_Size = 64.0f;
@@ -516,7 +518,7 @@ void CPlayers::RenderPlayer(
 
 	// do skidding
 	if(!InAir && WantOtherDir && length(Vel * 50) > 500.0f)
-		GameClient()->m_Effects.SkidTrail(Position, Vel, Player.m_Direction, Alpha);
+		GameClient()->m_Effects.SkidTrail(Position, Vel, Player.m_Direction, Alpha, Volume);
 
 	// draw gun
 	if(Player.m_Weapon >= 0)

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1351,8 +1351,9 @@ void CGameClient::ProcessEvents()
 	{
 		const IClient::CSnapItem Item = Client()->SnapGetItem(SnapType, Index);
 
-		// We don't have enough info about us, others, to know a correct alpha value.
-		float Alpha = 1.0f;
+		// TODO: We don't have enough info about us, others, to know a correct alpha or volume value.
+		const float Alpha = 1.0f;
+		const float Volume = 1.0f;
 
 		if(Item.m_Type == NETEVENTTYPE_DAMAGEIND)
 		{
@@ -1367,7 +1368,7 @@ void CGameClient::ProcessEvents()
 		else if(Item.m_Type == NETEVENTTYPE_HAMMERHIT)
 		{
 			const CNetEvent_HammerHit *pEvent = (const CNetEvent_HammerHit *)Item.m_pData;
-			m_Effects.HammerHit(vec2(pEvent->m_X, pEvent->m_Y), Alpha);
+			m_Effects.HammerHit(vec2(pEvent->m_X, pEvent->m_Y), Alpha, Volume);
 		}
 		else if(Item.m_Type == NETEVENTTYPE_BIRTHDAY)
 		{
@@ -1382,7 +1383,7 @@ void CGameClient::ProcessEvents()
 		else if(Item.m_Type == NETEVENTTYPE_SPAWN)
 		{
 			const CNetEvent_Spawn *pEvent = (const CNetEvent_Spawn *)Item.m_pData;
-			m_Effects.PlayerSpawn(vec2(pEvent->m_X, pEvent->m_Y), Alpha);
+			m_Effects.PlayerSpawn(vec2(pEvent->m_X, pEvent->m_Y), Alpha, Volume);
 		}
 		else if(Item.m_Type == NETEVENTTYPE_DEATH)
 		{
@@ -2260,7 +2261,8 @@ void CGameClient::OnNewSnapshot()
 				float Alpha = 1.0f;
 				if(IsOtherTeam(i))
 					Alpha = g_Config.m_ClShowOthersAlpha / 100.0f;
-				m_Effects.AirJump(Pos, Alpha);
+				const float Volume = IsOtherTeam(i) ? g_Config.m_SndGameVolumeOthers / 100.0f : 1.0f;
+				m_Effects.AirJump(Pos, Alpha, Volume);
 			}
 
 	if(g_Config.m_ClFreezeStars && !m_SuppressEvents)
@@ -2528,7 +2530,7 @@ void CGameClient::OnPredict()
 			int Events = pLocalChar->Core()->m_TriggeredEvents;
 			if(g_Config.m_ClPredict && !m_SuppressEvents)
 				if(Events & COREEVENT_AIR_JUMP)
-					m_Effects.AirJump(Pos, 1.0f);
+					m_Effects.AirJump(Pos, 1.0f, 1.0f);
 			if(g_Config.m_SndGame && !m_SuppressEvents)
 			{
 				if(Events & COREEVENT_GROUND_JUMP)
@@ -2548,7 +2550,7 @@ void CGameClient::OnPredict()
 			int Events = pDummyChar->Core()->m_TriggeredEvents;
 			if(g_Config.m_ClPredict && !m_SuppressEvents)
 				if(Events & COREEVENT_AIR_JUMP)
-					m_Effects.AirJump(Pos, 1.0f);
+					m_Effects.AirJump(Pos, 1.0f, 1.0f);
 		}
 	}
 


### PR DESCRIPTION
Even more of #10303

Prepares for allowing lower volume for other team (as is done with alpha, and similar to alpha everything is set to `1.0f` for now)

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
