### PR TITLE
Remove unnecessary `mem_zero` of (string) buffers

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1111,7 +1111,7 @@ void CGraphicsBackend_SDL_GL::GetCurrentVideoMode(CVideoMode &CurMode, float HiD
 CGraphicsBackend_SDL_GL::CGraphicsBackend_SDL_GL(TTranslateFunc &&TranslateFunc) :
 	CGraphicsBackend_Threaded(std::move(TranslateFunc))
 {
-	mem_zero(m_aErrorString, std::size(m_aErrorString));
+	m_aErrorString[0] = '\0';
 }
 
 int CGraphicsBackend_SDL_GL::Init(const char *pName, int *pScreen, int *pWidth, int *pHeight, int *pRefreshRate, int *pFsaaSamples, int Flags, int *pDesktopWidth, int *pDesktopHeight, int *pCurrentWidth, int *pCurrentHeight, IStorage *pStorage)

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -668,6 +668,7 @@ void CClient::DisconnectWithReason(const char *pReason)
 	}
 
 	m_aRconAuthed[0] = 0;
+	// Make sure to clear credentials completely from memory
 	mem_zero(m_aRconUsername, sizeof(m_aRconUsername));
 	mem_zero(m_aRconPassword, sizeof(m_aRconPassword));
 	m_MapDetailsPresent = false;

--- a/src/engine/server/databases/mysql.cpp
+++ b/src/engine/server/databases/mysql.cpp
@@ -152,7 +152,7 @@ CMysqlConnection::CMysqlConnection(CMysqlConfig Config) :
 	g_MysqlNumConnections += 1;
 	dbg_assert(g_MysqlState == MYSQLSTATE_INITIALIZED, "MySQL library not in initialized state");
 
-	mem_zero(m_aErrorDetail, sizeof(m_aErrorDetail));
+	m_aErrorDetail[0] = '\0';
 	mem_zero(&m_Mysql, sizeof(m_Mysql));
 	mysql_init(&m_Mysql);
 }

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -782,8 +782,7 @@ void CConsole::ConCommandAccess(IResult *pResult, void *pUser)
 void CConsole::ConCommandStatus(IResult *pResult, void *pUser)
 {
 	CConsole *pConsole = static_cast<CConsole *>(pUser);
-	char aBuf[240];
-	mem_zero(aBuf, sizeof(aBuf));
+	char aBuf[240] = "";
 	int Used = 0;
 	std::optional<int> AccessLevel = AccessLevelToInt(pResult->GetString(0));
 	if(!AccessLevel.has_value())
@@ -810,7 +809,6 @@ void CConsole::ConCommandStatus(IResult *pResult, void *pUser)
 			else
 			{
 				pConsole->Print(OUTPUT_LEVEL_STANDARD, "chatresp", aBuf);
-				mem_zero(aBuf, sizeof(aBuf));
 				str_copy(aBuf, pCommand->m_pName);
 				Used = Length;
 			}

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -188,7 +188,6 @@ int CDemoRecorder::Start(class IStorage *pStorage, class IConsole *pConsole, con
 		while(true)
 		{
 			unsigned char aChunk[1024 * 64];
-			mem_zero(aChunk, sizeof(aChunk));
 			int Bytes = io_read(MapFile, &aChunk, sizeof(aChunk));
 			if(Bytes <= 0)
 				break;

--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -74,7 +74,7 @@ void CNetConnection::Init(NETSOCKET Socket, bool BlockCloseMsg)
 
 	m_Socket = Socket;
 	m_BlockCloseMsg = BlockCloseMsg;
-	mem_zero(m_aErrorString, sizeof(m_aErrorString));
+	m_aErrorString[0] = '\0';
 }
 
 void CNetConnection::AckChunks(int Ack)
@@ -223,7 +223,7 @@ int CNetConnection::Connect(const NETADDR *pAddr, int NumAddrs)
 		m_aConnectAddrs[i] = pAddr[i];
 	}
 	m_NumConnectAddrs = NumAddrs;
-	mem_zero(m_aErrorString, sizeof(m_aErrorString));
+	m_aErrorString[0] = '\0';
 	m_State = EState::CONNECT;
 	SendConnect();
 	return 0;
@@ -251,7 +251,7 @@ int CNetConnection::Connect7(const NETADDR *pAddr, int NumAddrs)
 	m_NumConnectAddrs = NumAddrs;
 	SetPeerAddr(pAddr);
 	SetToken7(GenerateToken7(pAddr));
-	mem_zero(m_aErrorString, sizeof(m_aErrorString));
+	m_aErrorString[0] = '\0';
 	m_State = EState::WANT_TOKEN;
 	SendControlWithToken7(protocol7::NET_CTRLMSG_TOKEN, NET_TOKEN_NONE);
 	m_Sixup = true;
@@ -306,7 +306,7 @@ void CNetConnection::DirectInit(const NETADDR &Addr, SECURITY_TOKEN SecurityToke
 	m_State = EState::ONLINE;
 
 	SetPeerAddr(&Addr);
-	mem_zero(m_aErrorString, sizeof(m_aErrorString));
+	m_aErrorString[0] = '\0';
 
 	int64_t Now = time_get();
 	m_LastSendTime = Now;
@@ -443,7 +443,7 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr, SECURITY_
 						Reset();
 						m_State = EState::PENDING;
 						SetPeerAddr(pAddr);
-						mem_zero(m_aErrorString, sizeof(m_aErrorString));
+						m_aErrorString[0] = '\0';
 						m_LastSendTime = Now;
 						m_LastRecvTime = Now;
 						m_LastUpdateTime = Now;
@@ -597,7 +597,7 @@ void CNetConnection::SetTimedOut(const NETADDR *pAddr, int Sequence, int Ack, SE
 
 	m_State = EState::ONLINE;
 	SetPeerAddr(pAddr);
-	mem_zero(m_aErrorString, sizeof(m_aErrorString));
+	m_aErrorString[0] = '\0';
 	m_LastSendTime = Now;
 	m_LastRecvTime = Now;
 	m_LastUpdateTime = Now;

--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -47,7 +47,7 @@ CCamera::CCamera()
 	m_CanUseCameraInfo = false;
 	m_UsingAutoSpecCamera = false;
 
-	mem_zero(m_aAutoSpecCameraTooltip, sizeof(m_aAutoSpecCameraTooltip));
+	m_aAutoSpecCameraTooltip[0] = '\0';
 }
 
 float CCamera::CameraSmoothingProgress(float CurrentTime) const

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -137,7 +137,7 @@ void CChat::Reset()
 	m_EditingNewLine = true;
 	m_ServerSupportsCommandInfo = false;
 	m_ServerCommandsNeedSorting = false;
-	mem_zero(m_aCurrentInputText, sizeof(m_aCurrentInputText));
+	m_aCurrentInputText[0] = '\0';
 	DisableMode();
 	m_vServerCommands.clear();
 

--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -111,7 +111,7 @@ void CCountryFlags::OnInit()
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "countryflags", "failed to load country flags. folder='countryflags/'");
 		CCountryFlag DummyEntry;
 		DummyEntry.m_CountryCode = -1;
-		mem_zero(DummyEntry.m_aCountryCodeString, sizeof(DummyEntry.m_aCountryCodeString));
+		DummyEntry.m_aCountryCodeString[0] = '\0';
 		m_vCountryFlags.push_back(DummyEntry);
 	}
 

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -436,9 +436,7 @@ std::string CStatboard::ReplaceCommata(char *pStr)
 	if(!str_find(pStr, ","))
 		return pStr;
 
-	char aOutbuf[256];
-	mem_zero(aOutbuf, sizeof(aOutbuf));
-
+	char aOutbuf[256] = "";
 	for(int i = 0, skip = 0; i < 64; i++)
 	{
 		if(pStr[i] == ',')
@@ -450,7 +448,6 @@ std::string CStatboard::ReplaceCommata(char *pStr)
 		else
 			aOutbuf[i + skip] = pStr[i];
 	}
-
 	return aOutbuf;
 }
 

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -769,9 +769,7 @@ void CGameContext::ConPracticeCmdList(IConsole::IResult *pResult, void *pUserDat
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 
-	char aPracticeCommands[256];
-	mem_zero(aPracticeCommands, sizeof(aPracticeCommands));
-	str_append(aPracticeCommands, "Available practice commands: ");
+	char aPracticeCommands[256] = "Available practice commands: ";
 	for(const IConsole::CCommandInfo *pCmd = pSelf->Console()->FirstCommandInfo(IConsole::ACCESS_LEVEL_USER, CMDFLAG_PRACTICE);
 		pCmd; pCmd = pCmd->NextCommandInfo(IConsole::ACCESS_LEVEL_USER, CMDFLAG_PRACTICE))
 	{
@@ -782,7 +780,7 @@ void CGameContext::ConPracticeCmdList(IConsole::IResult *pResult, void *pUserDat
 		if(str_length(aCommand) + str_length(aPracticeCommands) > 255)
 		{
 			pSelf->SendChatTarget(pResult->m_ClientId, aPracticeCommands);
-			mem_zero(aPracticeCommands, sizeof(aPracticeCommands));
+			aPracticeCommands[0] = '\0';
 		}
 		str_append(aPracticeCommands, aCommand);
 	}


### PR DESCRIPTION
Replace unnecessary `mem_zero` of entire string buffers with zero assignment of first character.

Avoid `mem_zero` entirely if the buffer contents are overridden by a subsequent operation.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
