### PR TITLE
Move linked list iterator `NextCommandInfo` to `CConsole`

### DIFF
--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -82,7 +82,6 @@ public:
 		virtual const char *Name() const = 0;
 		virtual const char *Help() const = 0;
 		virtual const char *Params() const = 0;
-		virtual const ICommandInfo *NextCommandInfo(EAccessLevel AccessLevel, int FlagMask) const = 0;
 		virtual EAccessLevel GetAccessLevel() const = 0;
 	};
 
@@ -97,6 +96,7 @@ public:
 
 	virtual void Init() = 0;
 	virtual const ICommandInfo *FirstCommandInfo(EAccessLevel AccessLevel, int FlagMask) const = 0;
+	virtual const ICommandInfo *NextCommandInfo(const IConsole::ICommandInfo *pInfo, EAccessLevel AccessLevel, int FlagMask) const = 0;
 	virtual const ICommandInfo *GetCommandInfo(const char *pName, int FlagMask, bool Temp) = 0;
 	virtual int PossibleCommands(const char *pStr, int FlagMask, bool Temp, FPossibleCallback pfnCallback = EmptyPossibleCommandCallback, void *pUser = nullptr) = 0;
 	virtual void ParseArguments(int NumArgs, const char **ppArguments) = 0;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1483,7 +1483,7 @@ int CServer::NumRconCommands(int ClientId)
 	int Num = 0;
 	const IConsole::EAccessLevel AccessLevel = ConsoleAccessLevel(ClientId);
 	for(const IConsole::ICommandInfo *pCmd = Console()->FirstCommandInfo(AccessLevel, CFGFLAG_SERVER);
-		pCmd; pCmd = pCmd->NextCommandInfo(AccessLevel, CFGFLAG_SERVER))
+		pCmd; pCmd = Console()->NextCommandInfo(pCmd, AccessLevel, CFGFLAG_SERVER))
 	{
 		Num++;
 	}
@@ -1504,7 +1504,7 @@ void CServer::UpdateClientRconCommands(int ClientId)
 	for(int i = 0; i < MAX_RCONCMD_SEND && Client.m_pRconCmdToSend; ++i)
 	{
 		SendRconCmdAdd(Client.m_pRconCmdToSend, ClientId);
-		Client.m_pRconCmdToSend = Client.m_pRconCmdToSend->NextCommandInfo(AccessLevel, CFGFLAG_SERVER);
+		Client.m_pRconCmdToSend = Console()->NextCommandInfo(Client.m_pRconCmdToSend, AccessLevel, CFGFLAG_SERVER);
 		if(Client.m_pRconCmdToSend == nullptr)
 		{
 			SendRconCmdGroupEnd(ClientId);

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -82,18 +82,6 @@ std::optional<ColorHSLA> CConsole::CResult::GetColor(unsigned Index, float Darke
 	return ColorParse(m_apArgs[Index], DarkestLighting);
 }
 
-const IConsole::ICommandInfo *CConsole::CCommand::NextCommandInfo(EAccessLevel AccessLevel, int FlagMask) const
-{
-	const CCommand *pInfo = Next();
-	while(pInfo)
-	{
-		if(pInfo->m_Flags & FlagMask && pInfo->m_AccessLevel >= AccessLevel)
-			break;
-		pInfo = pInfo->Next();
-	}
-	return pInfo;
-}
-
 void CConsole::CCommand::SetAccessLevel(EAccessLevel AccessLevel)
 {
 	m_AccessLevel = AccessLevel;
@@ -108,6 +96,18 @@ const IConsole::ICommandInfo *CConsole::FirstCommandInfo(EAccessLevel AccessLeve
 	}
 
 	return nullptr;
+}
+
+const IConsole::ICommandInfo *CConsole::NextCommandInfo(const IConsole::ICommandInfo *pInfo, EAccessLevel AccessLevel, int FlagMask) const
+{
+	const CCommand *pNext = ((CCommand *)pInfo)->Next();
+	while(pNext)
+	{
+		if(pNext->m_Flags & FlagMask && pNext->GetAccessLevel() >= AccessLevel)
+			break;
+		pNext = pNext->Next();
+	}
+	return pNext;
 }
 
 std::optional<CConsole::EAccessLevel> CConsole::AccessLevelToEnum(const char *pAccessLevel)

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -31,7 +31,6 @@ class CConsole : public IConsole
 		FCommandCallback m_pfnCallback;
 		void *m_pUserData;
 
-		const ICommandInfo *NextCommandInfo(EAccessLevel AccessLevel, int FlagMask) const override;
 		const char *Name() const override { return m_pName; }
 		const char *Help() const override { return m_pHelp; }
 		const char *Params() const override { return m_pParams; }
@@ -168,6 +167,7 @@ public:
 
 	void Init() override;
 	const ICommandInfo *FirstCommandInfo(EAccessLevel AccessLevel, int FlagMask) const override;
+	const ICommandInfo *NextCommandInfo(const IConsole::ICommandInfo *pInfo, EAccessLevel AccessLevel, int FlagMask) const override;
 	const ICommandInfo *GetCommandInfo(const char *pName, int FlagMask, bool Temp) override;
 	int PossibleCommands(const char *pStr, int FlagMask, bool Temp, FPossibleCallback pfnCallback, void *pUser) override;
 

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -772,11 +772,11 @@ void CGameContext::ConPracticeCmdList(IConsole::IResult *pResult, void *pUserDat
 
 	char aPracticeCommands[256] = "Available practice commands: ";
 	for(const IConsole::ICommandInfo *pCmd = pSelf->Console()->FirstCommandInfo(IConsole::EAccessLevel::USER, CMDFLAG_PRACTICE);
-		pCmd; pCmd = pCmd->NextCommandInfo(IConsole::EAccessLevel::USER, CMDFLAG_PRACTICE))
+		pCmd; pCmd = pSelf->Console()->NextCommandInfo(pCmd, IConsole::EAccessLevel::USER, CMDFLAG_PRACTICE))
 	{
 		char aCommand[64];
 
-		str_format(aCommand, sizeof(aCommand), "/%s%s", pCmd->Name(), pCmd->NextCommandInfo(IConsole::EAccessLevel::USER, CMDFLAG_PRACTICE) ? ", " : "");
+		str_format(aCommand, sizeof(aCommand), "/%s%s", pCmd->Name(), pSelf->Console()->NextCommandInfo(pCmd, IConsole::EAccessLevel::USER, CMDFLAG_PRACTICE) ? ", " : "");
 
 		if(str_length(aCommand) + str_length(aPracticeCommands) > 255)
 		{

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1555,7 +1555,7 @@ void CGameContext::OnClientEnter(int ClientId)
 		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 	}
 	for(const IConsole::ICommandInfo *pCmd = Console()->FirstCommandInfo(IConsole::EAccessLevel::USER, CFGFLAG_CHAT);
-		pCmd; pCmd = pCmd->NextCommandInfo(IConsole::EAccessLevel::USER, CFGFLAG_CHAT))
+		pCmd; pCmd = Console()->NextCommandInfo(pCmd, IConsole::EAccessLevel::USER, CFGFLAG_CHAT))
 	{
 		const char *pName = pCmd->Name();
 


### PR DESCRIPTION
Needed for #10681

The method to get the first entry is already defined in the `CConsole` but the next was on the command it self. Which is proper linked list styled code. And it also worked because the command stores the access level so while iterating it has all the information it needs.

But when access levels become more complex this will no longer work. Because it is planned to no longer store that information on the command. Because there will be multiple different roles that can access a command and they are not strictly ordered by access level. So a simple integer comparison will not work.

The alternative would be moving all that context onto the command. That works by passing one callback and one callback context to every command on registration. I tried that approach too. It worked. But I think moving the `NextCommandInfo` one class scope further up is way smoother.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
