### PR TITLE
Show broadcast if it was sent to dummy

### DIFF
--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -12,6 +12,7 @@
 static constexpr ColorRGBA gs_ConsoleDefaultColor(1, 1, 1, 1);
 
 enum LEVEL : char;
+struct LOG_COLOR;
 struct CChecksumData;
 
 class IConsole : public IInterface
@@ -127,6 +128,7 @@ public:
 
 	virtual void SetAccessLevel(int AccessLevel) = 0;
 
+	static LOG_COLOR ColorToLogColor(ColorRGBA Color);
 	static LEVEL ToLogLevel(int ConsoleLevel);
 	static int ToLogLevelFilter(int ConsoleLevel);
 

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -337,6 +337,14 @@ char CConsole::NextParam(const char *&pFormat)
 	return *pFormat;
 }
 
+LOG_COLOR IConsole::ColorToLogColor(ColorRGBA Color)
+{
+	return LOG_COLOR{
+		(uint8_t)(Color.r * 255.0),
+		(uint8_t)(Color.g * 255.0),
+		(uint8_t)(Color.b * 255.0)};
+}
+
 LEVEL IConsole::ToLogLevel(int Level)
 {
 	switch(Level)
@@ -359,14 +367,6 @@ int IConsole::ToLogLevelFilter(int Level)
 		dbg_assert(0, "invalid log level filter");
 	}
 	return Level + 2;
-}
-
-static LOG_COLOR ColorToLogColor(ColorRGBA Color)
-{
-	return LOG_COLOR{
-		(uint8_t)(Color.r * 255.0),
-		(uint8_t)(Color.g * 255.0),
-		(uint8_t)(Color.b * 255.0)};
 }
 
 void CConsole::Print(int Level, const char *pFrom, const char *pStr, ColorRGBA PrintColor) const

--- a/src/game/client/components/broadcast.h
+++ b/src/game/client/components/broadcast.h
@@ -11,13 +11,12 @@
 class CBroadcast : public CComponent
 {
 	// broadcasts
-	char m_aBroadcastText[1024];
-	int m_BroadcastTick;
+	char m_aaBroadcastText[NUM_DUMMIES][1024];
+	int m_aBroadcastTick[NUM_DUMMIES];
 	float m_BroadcastRenderOffset;
 	STextContainerIndex m_TextContainerIndex;
 
 	void RenderServerBroadcast();
-	void OnBroadcastMessage(const CNetMsg_Sv_Broadcast *pMsg);
 
 public:
 	int Sizeof() const override { return sizeof(*this); }
@@ -26,7 +25,10 @@ public:
 	void OnRender() override;
 	void OnMessage(int MsgType, void *pRawMsg) override;
 
-	void DoBroadcast(const char *pText);
+	void DeleteBroadcastContainer();
+
+	void DoDummyBroadcast(const char *pText);
+	void DoBroadcast(const char *pText, bool Dummy = false);
 };
 
 #endif

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -511,6 +511,8 @@ void CGameClient::OnDummySwap()
 	m_DummyInput = m_Controls.m_aInputData[!g_Config.m_ClDummy];
 	m_Controls.m_aInputData[g_Config.m_ClDummy].m_Fire = tmp;
 	m_IsDummySwapping = 1;
+
+	m_Broadcast.DeleteBroadcastContainer();
 }
 
 int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
@@ -1054,6 +1056,11 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 			{
 				m_Chat.OnMessage(MsgId, pRawMsg);
 			}
+		}
+		if(MsgId == NETMSGTYPE_SV_BROADCAST)
+		{
+			const CNetMsg_Sv_Broadcast *pMsg = (CNetMsg_Sv_Broadcast *)pRawMsg;
+			m_Broadcast.DoDummyBroadcast(pMsg->m_pMessage);
 		}
 		return; // no need of all that stuff for the dummy
 	}

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3232,14 +3232,14 @@ void CGameContext::ConBroadcast(IConsole::IResult *pResult, void *pUserData)
 	pSelf->SendBroadcast(aBuf, -1);
 }
 
-void CGameContext::ConBroadcastId(IConsole::IResult *pResult, void *pUserData)
+void CGameContext::ConBroadcastPlayer(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 
 	const int Victim = pResult->GetVictim();
 	if(!CheckClientId(Victim) || !pSelf->m_apPlayers[Victim])
 	{
-		log_info("broadcast", "Client ID not found: %d", Victim);
+		log_info("broadcast", "Player not found: %d", Victim);
 		return;
 	}
 
@@ -3762,7 +3762,7 @@ void CGameContext::OnConsoleInit()
 	Console()->Register("random_unfinished_map", "?i[stars]", CFGFLAG_SERVER | CFGFLAG_STORE, ConRandomUnfinishedMap, this, "Random unfinished map");
 	Console()->Register("restart", "?i[seconds]", CFGFLAG_SERVER | CFGFLAG_STORE, ConRestart, this, "Restart in x seconds (0 = abort)");
 	Console()->Register("broadcast", "r[message]", CFGFLAG_SERVER, ConBroadcast, this, "Broadcast message");
-	Console()->Register("broadcast_pl", "v[id] r[message]", CFGFLAG_SERVER, ConBroadcastId, this, "Broadcast message to player with client ID");
+	Console()->Register("broadcast_pl", "v[id] r[message]", CFGFLAG_SERVER, ConBroadcastPlayer, this, "Broadcast message to a specific player");
 	Console()->Register("say", "r[message]", CFGFLAG_SERVER, ConSay, this, "Say in chat");
 	Console()->Register("set_team", "i[id] i[team-id] ?i[delay in minutes]", CFGFLAG_SERVER, ConSetTeam, this, "Set team of player to team");
 	Console()->Register("set_team_all", "i[team-id]", CFGFLAG_SERVER, ConSetTeamAll, this, "Set team of all players to team");

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -148,7 +148,7 @@ class CGameContext : public IGameServer
 	static void ConRandomUnfinishedMap(IConsole::IResult *pResult, void *pUserData);
 	static void ConRestart(IConsole::IResult *pResult, void *pUserData);
 	static void ConBroadcast(IConsole::IResult *pResult, void *pUserData);
-	static void ConBroadcastId(IConsole::IResult *pResult, void *pUserData);
+	static void ConBroadcastPlayer(IConsole::IResult *pResult, void *pUserData);
 	static void ConSay(IConsole::IResult *pResult, void *pUserData);
 	static void ConSetTeam(IConsole::IResult *pResult, void *pUserData);
 	static void ConSetTeamAll(IConsole::IResult *pResult, void *pUserData);


### PR DESCRIPTION
Fixes https://github.com/ddnet/ddnet/issues/10534

Supersedes #10536
> If only one player has a broadcast to show, then show it for both. If both players have a broadcast, then show the broadcast of the active player.


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
