### PR TITLE
Use `std::fill` to fill arrays when possible

### DIFF
--- a/src/engine/client/backend/opengl/backend_opengl3.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl3.cpp
@@ -886,8 +886,7 @@ void CCommandProcessorFragment_OpenGL3_3::AppendIndices(unsigned int NewIndicesC
 	glDeleteBuffers(1, &m_QuadDrawIndexBufferId);
 	m_QuadDrawIndexBufferId = NewIndexBufferId;
 
-	for(unsigned int &i : m_aLastIndexBufferBound)
-		i = 0;
+	std::fill(std::begin(m_aLastIndexBufferBound), std::end(m_aLastIndexBufferBound), 0);
 	for(auto &BufferContainer : m_vBufferContainers)
 	{
 		BufferContainer.m_LastIndexBufferBound = 0;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -604,7 +604,7 @@ int CServer::Init()
 	m_CurrentGameTick = MIN_TICK;
 
 	m_AnnouncementLastLine = -1;
-	mem_zero(m_aPrevStates, sizeof(m_aPrevStates));
+	std::fill(std::begin(m_aPrevStates), std::end(m_aPrevStates), 0);
 
 	return 0;
 }

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -26,7 +26,7 @@ CConsole::CResult::CResult(int ClientId) :
 	mem_zero(m_aStringStorage, sizeof(m_aStringStorage));
 	m_pArgsStart = nullptr;
 	m_pCommand = nullptr;
-	mem_zero(m_apArgs, sizeof(m_apArgs));
+	std::fill(std::begin(m_apArgs), std::end(m_apArgs), nullptr);
 }
 
 CConsole::CResult::CResult(const CResult &Other) :

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -255,10 +255,10 @@ void CSnapshotDelta::UndiffItem(const int *pPast, const int *pDiff, int *pOut, i
 
 CSnapshotDelta::CSnapshotDelta()
 {
-	mem_zero(m_aItemSizes, sizeof(m_aItemSizes));
-	mem_zero(m_aItemSizes7, sizeof(m_aItemSizes7));
-	mem_zero(m_aSnapshotDataRate, sizeof(m_aSnapshotDataRate));
-	mem_zero(m_aSnapshotDataUpdates, sizeof(m_aSnapshotDataUpdates));
+	std::fill(std::begin(m_aItemSizes), std::end(m_aItemSizes), 0);
+	std::fill(std::begin(m_aItemSizes7), std::end(m_aItemSizes7), 0);
+	std::fill(std::begin(m_aSnapshotDataRate), std::end(m_aSnapshotDataRate), 0);
+	std::fill(std::begin(m_aSnapshotDataUpdates), std::end(m_aSnapshotDataUpdates), 0);
 	mem_zero(&m_Empty, sizeof(m_Empty));
 }
 

--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -28,7 +28,7 @@ CCamera::CCamera()
 	m_GotoSwitchLastPos = ivec2(-1, -1);
 	m_GotoTeleLastPos = ivec2(-1, -1);
 
-	mem_zero(m_aLastPos, sizeof(m_aLastPos));
+	std::fill(std::begin(m_aLastPos), std::end(m_aLastPos), vec2(0.0f, 0.0f));
 	m_PrevCenter = vec2(0, 0);
 	m_Center = vec2(0, 0);
 
@@ -39,7 +39,7 @@ CCamera::CCamera()
 
 	m_LastTargetPos = vec2(0, 0);
 	m_DyncamTargetCameraOffset = vec2(0, 0);
-	mem_zero(m_aDyncamCurrentCameraOffset, sizeof(m_aDyncamCurrentCameraOffset));
+	std::fill(std::begin(m_aDyncamCurrentCameraOffset), std::end(m_aDyncamCurrentCameraOffset), vec2(0.0f, 0.0f));
 	m_DyncamSmoothingSpeedBias = 0.5f;
 
 	m_AutoSpecCamera = true;

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -19,9 +19,9 @@
 CControls::CControls()
 {
 	mem_zero(&m_aLastData, sizeof(m_aLastData));
-	mem_zero(m_aMousePos, sizeof(m_aMousePos));
-	mem_zero(m_aMousePosOnAction, sizeof(m_aMousePosOnAction));
-	mem_zero(m_aTargetPos, sizeof(m_aTargetPos));
+	std::fill(std::begin(m_aMousePos), std::end(m_aMousePos), vec2(0.0f, 0.0f));
+	std::fill(std::begin(m_aMousePosOnAction), std::end(m_aMousePosOnAction), vec2(0.0f, 0.0f));
+	std::fill(std::begin(m_aTargetPos), std::end(m_aTargetPos), vec2(0.0f, 0.0f));
 }
 
 void CControls::OnReset()

--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -92,11 +92,7 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 		}
 
 	// init LUT
-	if(DefaultIndex != 0)
-		for(size_t &CodeIndexLUT : m_aCodeIndexLUT)
-			CodeIndexLUT = DefaultIndex;
-	else
-		mem_zero(m_aCodeIndexLUT, sizeof(m_aCodeIndexLUT));
+	std::fill(std::begin(m_aCodeIndexLUT), std::end(m_aCodeIndexLUT), DefaultIndex);
 	for(size_t i = 0; i < m_vCountryFlags.size(); ++i)
 		m_aCodeIndexLUT[maximum(0, (m_vCountryFlags[i].m_CountryCode - CODE_LB) % CODE_RANGE)] = i;
 }

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -19,7 +19,7 @@
 CMapImages::CMapImages()
 {
 	m_Count = 0;
-	mem_zero(m_aEntitiesIsLoaded, sizeof(m_aEntitiesIsLoaded));
+	std::fill(std::begin(m_aEntitiesIsLoaded), std::end(m_aEntitiesIsLoaded), false);
 	m_SpeedupArrowIsLoaded = false;
 
 	str_copy(m_aEntitiesPath, "editor/entities_clear");

--- a/src/game/client/prediction/entities/dragger.cpp
+++ b/src/game/client/prediction/entities/dragger.cpp
@@ -27,7 +27,7 @@ void CDragger::LookForPlayersToDrag()
 {
 	// Create a list of players who are in the range of the dragger
 	CEntity *apPlayersInRange[MAX_CLIENTS];
-	mem_zero(apPlayersInRange, sizeof(apPlayersInRange));
+	std::fill(std::begin(apPlayersInRange), std::end(apPlayersInRange), nullptr);
 
 	int NumPlayersInRange = GameWorld()->FindEntities(m_Pos,
 		g_Config.m_SvDraggerRange - CCharacterCore::PhysicalSize(),

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -253,7 +253,7 @@ public:
 
 		m_QuadKnifeActive = false;
 		m_QuadKnifeCount = 0;
-		mem_zero(m_aQuadKnifePoints, sizeof(m_aQuadKnifePoints));
+		std::fill(std::begin(m_aQuadKnifePoints), std::end(m_aQuadKnifePoints), vec2(0.0f, 0.0f));
 
 		for(size_t i = 0; i < std::size(m_aSavedColors); ++i)
 		{

--- a/src/game/editor/mapitems/image.cpp
+++ b/src/game/editor/mapitems/image.cpp
@@ -25,7 +25,7 @@ void CEditorImage::OnInit(CEditor *pEditor)
 
 void CEditorImage::AnalyseTileFlags()
 {
-	mem_zero(m_aTileFlags, sizeof(m_aTileFlags));
+	std::fill(std::begin(m_aTileFlags), std::end(m_aTileFlags), 0);
 
 	size_t TileWidth = m_Width / 16;
 	size_t TileHeight = m_Height / 16;

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -28,7 +28,7 @@ CDragger::CDragger(CGameWorld *pGameWorld, vec2 Pos, float Strength, bool Ignore
 	{
 		TargetId = -1;
 	}
-	mem_zero(m_apDraggerBeam, sizeof(m_apDraggerBeam));
+	std::fill(std::begin(m_apDraggerBeam), std::end(m_apDraggerBeam), nullptr);
 	GameWorld()->InsertEntity(this);
 }
 
@@ -57,7 +57,7 @@ void CDragger::LookForPlayersToDrag()
 {
 	// Create a list of players who are in the range of the dragger
 	CEntity *apPlayersInRange[MAX_CLIENTS];
-	mem_zero(apPlayersInRange, sizeof(apPlayersInRange));
+	std::fill(std::begin(apPlayersInRange), std::end(apPlayersInRange), nullptr);
 
 	int NumPlayersInRange = GameServer()->m_World.FindEntities(m_Pos,
 		g_Config.m_SvDraggerRange - CCharacterCore::PhysicalSize(),
@@ -68,13 +68,10 @@ void CDragger::LookForPlayersToDrag()
 	bool aCanStillBeTeamTarget[MAX_CLIENTS];
 	bool aIsTarget[MAX_CLIENTS];
 	int aMinDistInTeam[MAX_CLIENTS];
-	mem_zero(aCanStillBeTeamTarget, sizeof(aCanStillBeTeamTarget));
-	mem_zero(aMinDistInTeam, sizeof(aMinDistInTeam));
-	mem_zero(aIsTarget, sizeof(aIsTarget));
-	for(int &TargetId : aClosestTargetIdInTeam)
-	{
-		TargetId = -1;
-	}
+	std::fill(std::begin(aCanStillBeTeamTarget), std::end(aCanStillBeTeamTarget), false);
+	std::fill(std::begin(aMinDistInTeam), std::end(aMinDistInTeam), 0);
+	std::fill(std::begin(aIsTarget), std::end(aIsTarget), false);
+	std::fill(std::begin(aClosestTargetIdInTeam), std::end(aClosestTargetIdInTeam), -1);
 
 	for(int i = 0; i < NumPlayersInRange; i++)
 	{

--- a/src/game/server/entities/gun.cpp
+++ b/src/game/server/entities/gun.cpp
@@ -24,8 +24,8 @@ CGun::CGun(CGameWorld *pGameWorld, vec2 Pos, bool Freeze, bool Explosive, int La
 	m_Number = Number;
 	m_EvalTick = Server()->Tick();
 
-	mem_zero(m_aLastFireTeam, sizeof(m_aLastFireTeam));
-	mem_zero(m_aLastFireSolo, sizeof(m_aLastFireSolo));
+	std::fill(std::begin(m_aLastFireTeam), std::end(m_aLastFireTeam), 0);
+	std::fill(std::begin(m_aLastFireSolo), std::end(m_aLastFireSolo), 0);
 	GameWorld()->InsertEntity(this);
 }
 
@@ -47,7 +47,7 @@ void CGun::Fire()
 {
 	// Create a list of players who are in the range of the turret
 	CEntity *apPlayersInRange[MAX_CLIENTS];
-	mem_zero(apPlayersInRange, sizeof(apPlayersInRange));
+	std::fill(std::begin(apPlayersInRange), std::end(apPlayersInRange), nullptr);
 
 	int NumPlayersInRange = GameServer()->m_World.FindEntities(m_Pos, g_Config.m_SvPlasmaRange,
 		apPlayersInRange, MAX_CLIENTS, CGameWorld::ENTTYPE_CHARACTER);
@@ -56,12 +56,9 @@ void CGun::Fire()
 	int aTargetIdInTeam[MAX_CLIENTS];
 	bool aIsTarget[MAX_CLIENTS];
 	int aMinDistInTeam[MAX_CLIENTS];
-	mem_zero(aMinDistInTeam, sizeof(aMinDistInTeam));
-	mem_zero(aIsTarget, sizeof(aIsTarget));
-	for(int &TargetId : aTargetIdInTeam)
-	{
-		TargetId = -1;
-	}
+	std::fill(std::begin(aMinDistInTeam), std::end(aMinDistInTeam), 0);
+	std::fill(std::begin(aIsTarget), std::end(aIsTarget), false);
+	std::fill(std::begin(aTargetIdInTeam), std::end(aTargetIdInTeam), -1);
 
 	for(int i = 0; i < NumPlayersInRange; i++)
 	{

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -83,7 +83,7 @@ void CGameContext::Construct(int Resetting)
 		pPlayer = nullptr;
 
 	mem_zero(&m_aLastPlayerInput, sizeof(m_aLastPlayerInput));
-	mem_zero(&m_aPlayerHasInput, sizeof(m_aPlayerHasInput));
+	std::fill(std::begin(m_aPlayerHasInput), std::end(m_aPlayerHasInput), false);
 
 	m_pController = nullptr;
 
@@ -460,7 +460,7 @@ void CGameContext::SnapSwitchers(int SnappingClient)
 		return;
 
 	pSwitchState->m_HighestSwitchNumber = std::clamp((int)Switchers().size() - 1, 0, 255);
-	mem_zero(pSwitchState->m_aStatus, sizeof(pSwitchState->m_aStatus));
+	std::fill(std::begin(pSwitchState->m_aStatus), std::end(pSwitchState->m_aStatus), 0);
 
 	std::vector<std::pair<int, int>> vEndTicks; // <EndTick, SwitchNumber>
 
@@ -478,8 +478,8 @@ void CGameContext::SnapSwitchers(int SnappingClient)
 	}
 
 	// send the endtick of switchers that are about to toggle back (up to four, prioritizing those with the earliest endticks)
-	mem_zero(pSwitchState->m_aSwitchNumbers, sizeof(pSwitchState->m_aSwitchNumbers));
-	mem_zero(pSwitchState->m_aEndTicks, sizeof(pSwitchState->m_aEndTicks));
+	std::fill(std::begin(pSwitchState->m_aSwitchNumbers), std::end(pSwitchState->m_aSwitchNumbers), 0);
+	std::fill(std::begin(pSwitchState->m_aEndTicks), std::end(pSwitchState->m_aEndTicks), 0);
 
 	std::sort(vEndTicks.begin(), vEndTicks.end());
 	const int NumTimedSwitchers = minimum((int)vEndTicks.size(), (int)std::size(pSwitchState->m_aEndTicks));


### PR DESCRIPTION
Improve readability and type safety by using `std::fill` instead of `mem_zero`.

Also use `std::fill` in non-zero cases.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
