### PR TITLE
Make spawn type enum protected to be used by controllers

### DIFF
--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -19,6 +19,7 @@ class IGameController
 {
 	friend class CSaveTeam; // need access to GameServer() and Server()
 
+protected:
 	enum ESpawnType
 	{
 		SPAWNTYPE_DEFAULT = 0,
@@ -27,6 +28,8 @@ class IGameController
 
 		NUM_SPAWNTYPES
 	};
+
+private:
 	std::vector<vec2> m_avSpawnPoints[NUM_SPAWNTYPES];
 
 	class CGameContext *m_pGameServer;


### PR DESCRIPTION
Custom game modes can override `CanSpawn` and implement their own spawn type picking.
This became harder because in #10846 a private enum was introduced.

https://github.com/ddnet/ddnet/pull/10846#issuecomment-3261701115

This change does not help ddnet. I would need that in my fork ddnet-insta to avoid creating some kind of hack.
I would argue this fixes a regression introduced by #10846 and this change does not cause more maintenance for ddnet.

But it still falls under #7777 and can be rejected without the need for any further justification.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
