### PR TITLE
Extract some functions into base/str.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2006,6 +2006,8 @@ set_src(BASE GLOB_RECURSE src/base
   logger.h
   math.h
   rust.h
+  str.cpp
+  str.h
   system.cpp
   system.h
   tl/threading.h

--- a/src/base/str.cpp
+++ b/src/base/str.cpp
@@ -1,0 +1,196 @@
+#include "str.h"
+
+#include <cstring>
+
+int str_copy(char *dst, const char *src, int dst_size)
+{
+	dst[0] = '\0';
+	strncat(dst, src, dst_size - 1);
+	return str_utf8_fix_truncation(dst);
+}
+
+int str_length(const char *str)
+{
+	return (int)strlen(str);
+}
+
+char str_uppercase(char c)
+{
+	if(c >= 'a' && c <= 'z')
+		return 'A' + (c - 'a');
+	return c;
+}
+
+bool str_isnum(char c)
+{
+	return c >= '0' && c <= '9';
+}
+
+int str_isallnum(const char *str)
+{
+	while(*str)
+	{
+		if(!str_isnum(*str))
+			return 0;
+		str++;
+	}
+	return 1;
+}
+
+int str_isallnum_hex(const char *str)
+{
+	while(*str)
+	{
+		if(!str_isnum(*str) && !(*str >= 'a' && *str <= 'f') && !(*str >= 'A' && *str <= 'F'))
+			return 0;
+		str++;
+	}
+	return 1;
+}
+
+int str_isspace(char c)
+{
+	return c == ' ' || c == '\n' || c == '\r' || c == '\t';
+}
+
+static unsigned char str_byte_next(const char **ptr)
+{
+	unsigned char byte_value = **ptr;
+	(*ptr)++;
+	return byte_value;
+}
+
+static void str_byte_rewind(const char **ptr)
+{
+	(*ptr)--;
+}
+
+int str_utf8_decode(const char **ptr)
+{
+	// As per https://encoding.spec.whatwg.org/#utf-8-decoder.
+	unsigned char utf8_lower_boundary = 0x80;
+	unsigned char utf8_upper_boundary = 0xBF;
+	int utf8_code_point = 0;
+	int utf8_bytes_seen = 0;
+	int utf8_bytes_needed = 0;
+	while(true)
+	{
+		unsigned char byte_value = str_byte_next(ptr);
+		if(utf8_bytes_needed == 0)
+		{
+			if(byte_value <= 0x7F)
+			{
+				return byte_value;
+			}
+			else if(0xC2 <= byte_value && byte_value <= 0xDF)
+			{
+				utf8_bytes_needed = 1;
+				utf8_code_point = byte_value - 0xC0;
+			}
+			else if(0xE0 <= byte_value && byte_value <= 0xEF)
+			{
+				if(byte_value == 0xE0)
+					utf8_lower_boundary = 0xA0;
+				if(byte_value == 0xED)
+					utf8_upper_boundary = 0x9F;
+				utf8_bytes_needed = 2;
+				utf8_code_point = byte_value - 0xE0;
+			}
+			else if(0xF0 <= byte_value && byte_value <= 0xF4)
+			{
+				if(byte_value == 0xF0)
+					utf8_lower_boundary = 0x90;
+				if(byte_value == 0xF4)
+					utf8_upper_boundary = 0x8F;
+				utf8_bytes_needed = 3;
+				utf8_code_point = byte_value - 0xF0;
+			}
+			else
+			{
+				return -1; // Error.
+			}
+			utf8_code_point = utf8_code_point << (6 * utf8_bytes_needed);
+			continue;
+		}
+		if(!(utf8_lower_boundary <= byte_value && byte_value <= utf8_upper_boundary))
+		{
+			// Resetting variables not necessary, will be done when
+			// the function is called again.
+			str_byte_rewind(ptr);
+			return -1;
+		}
+		utf8_lower_boundary = 0x80;
+		utf8_upper_boundary = 0xBF;
+		utf8_bytes_seen += 1;
+		utf8_code_point = utf8_code_point + ((byte_value - 0x80) << (6 * (utf8_bytes_needed - utf8_bytes_seen)));
+		if(utf8_bytes_seen != utf8_bytes_needed)
+		{
+			continue;
+		}
+		// Resetting variables not necessary, see above.
+		return utf8_code_point;
+	}
+}
+
+void str_utf8_truncate(char *dst, int dst_size, const char *src, int truncation_len)
+{
+	int size = -1;
+	const char *cursor = src;
+	int pos = 0;
+	while(pos <= truncation_len && cursor - src < dst_size && size != cursor - src)
+	{
+		size = cursor - src;
+		if(str_utf8_decode(&cursor) == 0)
+		{
+			break;
+		}
+		pos++;
+	}
+	str_copy(dst, src, size + 1);
+}
+
+int str_utf8_fix_truncation(char *str)
+{
+	int len = str_length(str);
+	if(len > 0)
+	{
+		int last_char_index = str_utf8_rewind(str, len);
+		const char *last_char = str + last_char_index;
+		// Fix truncated UTF-8.
+		if(str_utf8_decode(&last_char) == -1)
+		{
+			str[last_char_index] = 0;
+			return last_char_index;
+		}
+	}
+	return len;
+}
+
+int str_utf8_isspace(int code)
+{
+	return code <= 0x0020 || code == 0x0085 || code == 0x00A0 || code == 0x034F ||
+	       code == 0x115F || code == 0x1160 || code == 0x1680 || code == 0x180E ||
+	       (code >= 0x2000 && code <= 0x200F) || (code >= 0x2028 && code <= 0x202F) ||
+	       (code >= 0x205F && code <= 0x2064) || (code >= 0x206A && code <= 0x206F) ||
+	       code == 0x2800 || code == 0x3000 || code == 0x3164 ||
+	       (code >= 0xFE00 && code <= 0xFE0F) || code == 0xFEFF || code == 0xFFA0 ||
+	       (code >= 0xFFF9 && code <= 0xFFFC);
+}
+
+int str_utf8_isstart(char c)
+{
+	if((c & 0xC0) == 0x80) /* 10xxxxxx */
+		return 0;
+	return 1;
+}
+
+int str_utf8_rewind(const char *str, int cursor)
+{
+	while(cursor)
+	{
+		cursor--;
+		if(str_utf8_isstart(*(str + cursor)))
+			break;
+	}
+	return cursor;
+}

--- a/src/base/str.h
+++ b/src/base/str.h
@@ -1,0 +1,149 @@
+#ifndef BASE_STR_H
+#define BASE_STR_H
+
+/**
+ * Copies a string to another.
+ *
+ * @ingroup Strings
+ *
+ * @param dst Pointer to a buffer that shall receive the string.
+ * @param src String to be copied.
+ * @param dst_size Size of the buffer dst.
+ *
+ * @return Length of written string, even if it has been truncated
+ *
+ * @remark The strings are treated as null-terminated strings.
+ * @remark Guarantees that dst string will contain null-termination.
+ */
+int str_copy(char *dst, const char *src, int dst_size);
+
+/**
+ * Copies a string to a fixed-size array of chars.
+ *
+ * @ingroup Strings
+ *
+ * @param dst Array that shall receive the string.
+ * @param src String to be copied.
+ *
+ * @remark The strings are treated as null-terminated strings.
+ * @remark Guarantees that dst string will contain null-termination.
+ */
+template<int N>
+void str_copy(char (&dst)[N], const char *src)
+{
+	str_copy(dst, src, N);
+}
+
+/**
+ * Returns the length of a null-terminated string.
+ *
+ * @ingroup Strings
+ *
+ * @param str Pointer to the string.
+ *
+ * @return Length of string in bytes excluding the null-termination.
+ */
+int str_length(const char *str);
+
+char str_uppercase(char c);
+
+bool str_isnum(char c);
+
+int str_isallnum(const char *str);
+
+int str_isallnum_hex(const char *str);
+
+/**
+ * Determines whether a character is whitespace.
+ *
+ * @ingroup Strings
+ *
+ * @param c the character to check.
+ *
+ * @return `1` if the character is whitespace, `0` otherwise.
+ *
+ * @remark The following characters are considered whitespace: ' ', '\n', '\r', '\t'.
+ */
+int str_isspace(char c);
+
+/**
+ * Decodes a UTF-8 codepoint.
+ *
+ * @ingroup Strings
+ *
+ * @param ptr Pointer to a UTF-8 string. This pointer will be moved forward.
+ *
+ * @return The Unicode codepoint. `-1` for invalid input and 0 for end of string.
+ *
+ * @remark This function will also move the pointer forward.
+ * @remark You may call this function again after an error occurred.
+ * @remark The strings are treated as null-terminated.
+ */
+int str_utf8_decode(const char **ptr);
+
+/**
+ * Truncates a UTF-8 encoded string to a given length.
+ *
+ * @ingroup Strings
+ *
+ * @param dst Pointer to a buffer that shall receive the string.
+ * @param dst_size Size of the buffer dst.
+ * @param str String to be truncated.
+ * @param truncation_len Maximum codepoints in the returned string.
+ *
+ * @remark The strings are treated as utf8-encoded null-terminated strings.
+ * @remark Guarantees that dst string will contain null-termination.
+ */
+void str_utf8_truncate(char *dst, int dst_size, const char *src, int truncation_len);
+
+/**
+ * Fixes truncation of a Unicode character at the end of a UTF-8 string.
+ *
+ * @ingroup Strings
+ *
+ * @param str UTF-8 string.
+ *
+ * @return The new string length.
+ *
+ * @remark The strings are treated as null-terminated.
+ */
+int str_utf8_fix_truncation(char *str);
+
+/**
+ * Checks whether the given Unicode codepoint renders as space.
+ *
+ * @ingroup Strings
+ *
+ * @param code Unicode codepoint to check.
+ *
+ * @return Whether the codepoint is a space.
+ */
+int str_utf8_isspace(int code);
+
+/**
+ * Checks whether a given byte is the start of a UTF-8 character.
+ *
+ * @ingroup Strings
+ *
+ * @param c Byte to check.
+ *
+ * @return Whether the char starts a UTF-8 character.
+ */
+int str_utf8_isstart(char c);
+
+/**
+ * Moves a cursor backwards in an UTF-8 string,
+ *
+ * @ingroup Strings
+ *
+ * @param str UTF-8 string.
+ * @param cursor Position in the string.
+ *
+ * @return New cursor position.
+ *
+ * @remark Won't move the cursor less then 0.
+ * @remark The strings are treated as null-terminated.
+ */
+int str_utf8_rewind(const char *str, int cursor);
+
+#endif

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3036,30 +3036,6 @@ void str_append(char *dst, const char *src, int dst_size)
 	str_utf8_fix_truncation(dst);
 }
 
-int str_copy(char *dst, const char *src, int dst_size)
-{
-	dst[0] = '\0';
-	strncat(dst, src, dst_size - 1);
-	return str_utf8_fix_truncation(dst);
-}
-
-void str_utf8_truncate(char *dst, int dst_size, const char *src, int truncation_len)
-{
-	int size = -1;
-	const char *cursor = src;
-	int pos = 0;
-	while(pos <= truncation_len && cursor - src < dst_size && size != cursor - src)
-	{
-		size = cursor - src;
-		if(str_utf8_decode(&cursor) == 0)
-		{
-			break;
-		}
-		pos++;
-	}
-	str_copy(dst, src, size + 1);
-}
-
 void str_truncate(char *dst, int dst_size, const char *src, int truncation_len)
 {
 	int size = dst_size;
@@ -3068,11 +3044,6 @@ void str_truncate(char *dst, int dst_size, const char *src, int truncation_len)
 		size = truncation_len + 1;
 	}
 	str_copy(dst, src, size);
-}
-
-int str_length(const char *str)
-{
-	return (int)strlen(str);
 }
 
 int str_format_v(char *buffer, int buffer_size, const char *format, va_list args)
@@ -3970,45 +3941,6 @@ void net_stats(NETSTATS *stats_inout)
 	*stats_inout = network_stats;
 }
 
-int str_isspace(char c)
-{
-	return c == ' ' || c == '\n' || c == '\r' || c == '\t';
-}
-
-char str_uppercase(char c)
-{
-	if(c >= 'a' && c <= 'z')
-		return 'A' + (c - 'a');
-	return c;
-}
-
-bool str_isnum(char c)
-{
-	return c >= '0' && c <= '9';
-}
-
-int str_isallnum(const char *str)
-{
-	while(*str)
-	{
-		if(!str_isnum(*str))
-			return 0;
-		str++;
-	}
-	return 1;
-}
-
-int str_isallnum_hex(const char *str)
-{
-	while(*str)
-	{
-		if(!str_isnum(*str) && !(*str >= 'a' && *str <= 'f') && !(*str >= 'A' && *str <= 'F'))
-			return 0;
-		str++;
-	}
-	return 1;
-}
-
 int str_toint(const char *str)
 {
 	return str_toint_base(str, 10);
@@ -4143,17 +4075,6 @@ const char *str_utf8_find_nocase(const char *haystack, const char *needle, const
 	return nullptr;
 }
 
-int str_utf8_isspace(int code)
-{
-	return code <= 0x0020 || code == 0x0085 || code == 0x00A0 || code == 0x034F ||
-	       code == 0x115F || code == 0x1160 || code == 0x1680 || code == 0x180E ||
-	       (code >= 0x2000 && code <= 0x200F) || (code >= 0x2028 && code <= 0x202F) ||
-	       (code >= 0x205F && code <= 0x2064) || (code >= 0x206A && code <= 0x206F) ||
-	       code == 0x2800 || code == 0x3000 || code == 0x3164 ||
-	       (code >= 0xFE00 && code <= 0xFE0F) || code == 0xFEFF || code == 0xFFA0 ||
-	       (code >= 0xFFF9 && code <= 0xFFFC);
-}
-
 const char *str_utf8_skip_whitespaces(const char *str)
 {
 	const char *str_old;
@@ -4199,41 +4120,6 @@ void str_utf8_trim_right(char *param)
 	}
 }
 
-int str_utf8_isstart(char c)
-{
-	if((c & 0xC0) == 0x80) /* 10xxxxxx */
-		return 0;
-	return 1;
-}
-
-int str_utf8_rewind(const char *str, int cursor)
-{
-	while(cursor)
-	{
-		cursor--;
-		if(str_utf8_isstart(*(str + cursor)))
-			break;
-	}
-	return cursor;
-}
-
-int str_utf8_fix_truncation(char *str)
-{
-	int len = str_length(str);
-	if(len > 0)
-	{
-		int last_char_index = str_utf8_rewind(str, len);
-		const char *last_char = str + last_char_index;
-		// Fix truncated UTF-8.
-		if(str_utf8_decode(&last_char) == -1)
-		{
-			str[last_char_index] = 0;
-			return last_char_index;
-		}
-	}
-	return len;
-}
-
 int str_utf8_forward(const char *str, int cursor)
 {
 	const char *ptr = str + cursor;
@@ -4275,85 +4161,6 @@ int str_utf8_encode(char *ptr, int chr)
 	}
 
 	return 0;
-}
-
-static unsigned char str_byte_next(const char **ptr)
-{
-	unsigned char byte_value = **ptr;
-	(*ptr)++;
-	return byte_value;
-}
-
-static void str_byte_rewind(const char **ptr)
-{
-	(*ptr)--;
-}
-
-int str_utf8_decode(const char **ptr)
-{
-	// As per https://encoding.spec.whatwg.org/#utf-8-decoder.
-	unsigned char utf8_lower_boundary = 0x80;
-	unsigned char utf8_upper_boundary = 0xBF;
-	int utf8_code_point = 0;
-	int utf8_bytes_seen = 0;
-	int utf8_bytes_needed = 0;
-	while(true)
-	{
-		unsigned char byte_value = str_byte_next(ptr);
-		if(utf8_bytes_needed == 0)
-		{
-			if(byte_value <= 0x7F)
-			{
-				return byte_value;
-			}
-			else if(0xC2 <= byte_value && byte_value <= 0xDF)
-			{
-				utf8_bytes_needed = 1;
-				utf8_code_point = byte_value - 0xC0;
-			}
-			else if(0xE0 <= byte_value && byte_value <= 0xEF)
-			{
-				if(byte_value == 0xE0)
-					utf8_lower_boundary = 0xA0;
-				if(byte_value == 0xED)
-					utf8_upper_boundary = 0x9F;
-				utf8_bytes_needed = 2;
-				utf8_code_point = byte_value - 0xE0;
-			}
-			else if(0xF0 <= byte_value && byte_value <= 0xF4)
-			{
-				if(byte_value == 0xF0)
-					utf8_lower_boundary = 0x90;
-				if(byte_value == 0xF4)
-					utf8_upper_boundary = 0x8F;
-				utf8_bytes_needed = 3;
-				utf8_code_point = byte_value - 0xF0;
-			}
-			else
-			{
-				return -1; // Error.
-			}
-			utf8_code_point = utf8_code_point << (6 * utf8_bytes_needed);
-			continue;
-		}
-		if(!(utf8_lower_boundary <= byte_value && byte_value <= utf8_upper_boundary))
-		{
-			// Resetting variables not necessary, will be done when
-			// the function is called again.
-			str_byte_rewind(ptr);
-			return -1;
-		}
-		utf8_lower_boundary = 0x80;
-		utf8_upper_boundary = 0xBF;
-		utf8_bytes_seen += 1;
-		utf8_code_point = utf8_code_point + ((byte_value - 0x80) << (6 * (utf8_bytes_needed - utf8_bytes_seen)));
-		if(utf8_bytes_seen != utf8_bytes_needed)
-		{
-			continue;
-		}
-		// Resetting variables not necessary, see above.
-		return utf8_code_point;
-	}
 }
 
 int str_utf8_check(const char *str)

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -9,6 +9,7 @@
 #define BASE_SYSTEM_H
 
 #include "detect.h"
+#include "str.h"
 #include "types.h"
 
 #include <chrono>
@@ -1240,54 +1241,6 @@ void str_append(char (&dst)[N], const char *src)
 }
 
 /**
- * Copies a string to another.
- *
- * @ingroup Strings
- *
- * @param dst Pointer to a buffer that shall receive the string.
- * @param src String to be copied.
- * @param dst_size Size of the buffer dst.
- *
- * @return Length of written string, even if it has been truncated
- *
- * @remark The strings are treated as null-terminated strings.
- * @remark Guarantees that dst string will contain null-termination.
- */
-int str_copy(char *dst, const char *src, int dst_size);
-
-/**
- * Copies a string to a fixed-size array of chars.
- *
- * @ingroup Strings
- *
- * @param dst Array that shall receive the string.
- * @param src String to be copied.
- *
- * @remark The strings are treated as null-terminated strings.
- * @remark Guarantees that dst string will contain null-termination.
- */
-template<int N>
-void str_copy(char (&dst)[N], const char *src)
-{
-	str_copy(dst, src, N);
-}
-
-/**
- * Truncates a UTF-8 encoded string to a given length.
- *
- * @ingroup Strings
- *
- * @param dst Pointer to a buffer that shall receive the string.
- * @param dst_size Size of the buffer dst.
- * @param str String to be truncated.
- * @param truncation_len Maximum codepoints in the returned string.
- *
- * @remark The strings are treated as utf8-encoded null-terminated strings.
- * @remark Guarantees that dst string will contain null-termination.
- */
-void str_utf8_truncate(char *dst, int dst_size, const char *src, int truncation_len);
-
-/**
  * Truncates a string to a given length.
  *
  * @ingroup Strings
@@ -1302,17 +1255,6 @@ void str_utf8_truncate(char *dst, int dst_size, const char *src, int truncation_
  * @remark Guarantees that dst string will contain null-termination.
  */
 void str_truncate(char *dst, int dst_size, const char *src, int truncation_len);
-
-/**
- * Returns the length of a null-terminated string.
- *
- * @ingroup Strings
- *
- * @param str Pointer to the string.
- *
- * @return Length of string in bytes excluding the null-termination.
- */
-int str_length(const char *str);
 
 /**
  * Performs printf formatting into a buffer.
@@ -2222,27 +2164,6 @@ int64_t str_toint64_base(const char *str, int base = 10);
 float str_tofloat(const char *str);
 bool str_tofloat(const char *str, float *out);
 
-/**
- * Determines whether a character is whitespace.
- *
- * @ingroup Strings
- *
- * @param c the character to check.
- *
- * @return `1` if the character is whitespace, `0` otherwise.
- *
- * @remark The following characters are considered whitespace: ' ', '\n', '\r', '\t'.
- */
-int str_isspace(char c);
-
-char str_uppercase(char c);
-
-bool str_isnum(char c);
-
-int str_isallnum(const char *str);
-
-int str_isallnum_hex(const char *str);
-
 unsigned str_quickhash(const char *str);
 
 int str_utf8_to_skeleton(const char *str, int *buf, int buf_len);
@@ -2333,28 +2254,6 @@ int str_utf8_comp_nocase_num(const char *a, const char *b, int num);
 const char *str_utf8_find_nocase(const char *haystack, const char *needle, const char **end = nullptr);
 
 /**
- * Checks whether the given Unicode codepoint renders as space.
- *
- * @ingroup Strings
- *
- * @param code Unicode codepoint to check.
- *
- * @return Whether the codepoint is a space.
- */
-int str_utf8_isspace(int code);
-
-/**
- * Checks whether a given byte is the start of a UTF-8 character.
- *
- * @ingroup Strings
- *
- * @param c Byte to check.
- *
- * @return Whether the char starts a UTF-8 character.
- */
-int str_utf8_isstart(char c);
-
-/**
  * Skips leading characters that render as spaces.
  *
  * @ingroup Strings
@@ -2379,34 +2278,6 @@ const char *str_utf8_skip_whitespaces(const char *str);
 void str_utf8_trim_right(char *param);
 
 /**
- * Moves a cursor backwards in an UTF-8 string,
- *
- * @ingroup Strings
- *
- * @param str UTF-8 string.
- * @param cursor Position in the string.
- *
- * @return New cursor position.
- *
- * @remark Won't move the cursor less then 0.
- * @remark The strings are treated as null-terminated.
- */
-int str_utf8_rewind(const char *str, int cursor);
-
-/**
- * Fixes truncation of a Unicode character at the end of a UTF-8 string.
- *
- * @ingroup Strings
- *
- * @param str UTF-8 string.
- *
- * @return The new string length.
- *
- * @remark The strings are treated as null-terminated.
- */
-int str_utf8_fix_truncation(char *str);
-
-/**
  * Moves a cursor forwards in an UTF-8 string.
  *
  * @ingroup Strings
@@ -2420,21 +2291,6 @@ int str_utf8_fix_truncation(char *str);
  * @remark The strings are treated as null-terminated.
  */
 int str_utf8_forward(const char *str, int cursor);
-
-/**
- * Decodes a UTF-8 codepoint.
- *
- * @ingroup Strings
- *
- * @param ptr Pointer to a UTF-8 string. This pointer will be moved forward.
- *
- * @return The Unicode codepoint. `-1` for invalid input and 0 for end of string.
- *
- * @remark This function will also move the pointer forward.
- * @remark You may call this function again after an error occurred.
- * @remark The strings are treated as null-terminated.
- */
-int str_utf8_decode(const char **ptr);
 
 /**
  * Encode a UTF-8 character.


### PR DESCRIPTION
This is the start of a bigger move. Moving all `str_` prefixed functions into their own file.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
