### PR TITLE
Remove redundant inline in header files

### DIFF
--- a/src/base/color.h
+++ b/src/base/color.h
@@ -14,7 +14,7 @@
 	Function: RgbToHue
 		Determines the hue from RGB values
 */
-constexpr inline float RgbToHue(float r, float g, float b)
+constexpr float RgbToHue(float r, float g, float b)
 {
 	float h_min = minimum(r, g, b);
 	float h_max = maximum(r, g, b);
@@ -205,7 +205,7 @@ template<typename T, typename F>
 constexpr T color_cast(const F &) = delete;
 
 template<>
-constexpr inline ColorHSLA color_cast(const ColorRGBA &rgb)
+constexpr ColorHSLA color_cast(const ColorRGBA &rgb)
 {
 	float Min = minimum(rgb.r, rgb.g, rgb.b);
 	float Max = maximum(rgb.r, rgb.g, rgb.b);
@@ -219,7 +219,7 @@ constexpr inline ColorHSLA color_cast(const ColorRGBA &rgb)
 }
 
 template<>
-constexpr inline ColorRGBA color_cast(const ColorHSLA &hsl)
+constexpr ColorRGBA color_cast(const ColorHSLA &hsl)
 {
 	vec3 rgb = vec3(0, 0, 0);
 
@@ -261,27 +261,27 @@ constexpr inline ColorRGBA color_cast(const ColorHSLA &hsl)
 }
 
 template<>
-constexpr inline ColorHSLA color_cast(const ColorHSVA &hsv)
+constexpr ColorHSLA color_cast(const ColorHSVA &hsv)
 {
 	float l = hsv.v * (1 - hsv.s * 0.5f);
 	return ColorHSLA(hsv.h, (l == 0.0f || l == 1.0f) ? 0 : (hsv.v - l) / minimum(l, 1 - l), l, hsv.a);
 }
 
 template<>
-constexpr inline ColorHSVA color_cast(const ColorHSLA &hsl)
+constexpr ColorHSVA color_cast(const ColorHSLA &hsl)
 {
 	float v = hsl.l + hsl.s * minimum(hsl.l, 1 - hsl.l);
 	return ColorHSVA(hsl.h, v == 0.0f ? 0 : 2 - (2 * hsl.l / v), v, hsl.a);
 }
 
 template<>
-constexpr inline ColorRGBA color_cast(const ColorHSVA &hsv)
+constexpr ColorRGBA color_cast(const ColorHSVA &hsv)
 {
 	return color_cast<ColorRGBA>(color_cast<ColorHSLA>(hsv));
 }
 
 template<>
-constexpr inline ColorHSVA color_cast(const ColorRGBA &rgb)
+constexpr ColorHSVA color_cast(const ColorRGBA &rgb)
 {
 	return color_cast<ColorHSVA>(color_cast<ColorHSLA>(rgb));
 }

--- a/src/base/vmath.h
+++ b/src/base/vmath.h
@@ -82,7 +82,7 @@ public:
 };
 
 template<Numeric T>
-constexpr inline vector2_base<T> rotate(const vector2_base<T> &a, float angle)
+constexpr vector2_base<T> rotate(const vector2_base<T> &a, float angle)
 {
 	angle = angle * pi / 180.0f;
 	float s = std::sin(angle);
@@ -97,7 +97,7 @@ inline T distance(const vector2_base<T> a, const vector2_base<T> &b)
 }
 
 template<Numeric T>
-constexpr inline T dot(const vector2_base<T> a, const vector2_base<T> &b)
+constexpr T dot(const vector2_base<T> a, const vector2_base<T> &b)
 {
 	return a.x * b.x + a.y * b.y;
 }
@@ -114,12 +114,12 @@ inline float length(const vector2_base<T> &a)
 	return std::sqrt(static_cast<float>(dot(a, a)));
 }
 
-constexpr inline float length_squared(const vector2_base<float> &a)
+constexpr float length_squared(const vector2_base<float> &a)
 {
 	return dot(a, a);
 }
 
-constexpr inline float angle(const vector2_base<float> &a)
+constexpr float angle(const vector2_base<float> &a)
 {
 	if(a.x == 0 && a.y == 0)
 		return 0.0f;
@@ -132,7 +132,7 @@ constexpr inline float angle(const vector2_base<float> &a)
 }
 
 template<Numeric T>
-constexpr inline vector2_base<T> normalize_pre_length(const vector2_base<T> &v, T len)
+constexpr vector2_base<T> normalize_pre_length(const vector2_base<T> &v, T len)
 {
 	if(len == 0)
 		return vector2_base<T>();
@@ -163,7 +163,7 @@ typedef vector2_base<bool> bvec2;
 typedef vector2_base<int> ivec2;
 
 template<Numeric T>
-constexpr inline bool closest_point_on_line(vector2_base<T> line_pointA, vector2_base<T> line_pointB, vector2_base<T> target_point, vector2_base<T> &out_pos)
+constexpr bool closest_point_on_line(vector2_base<T> line_pointA, vector2_base<T> line_pointB, vector2_base<T> target_point, vector2_base<T> &out_pos)
 {
 	vector2_base<T> AB = line_pointB - line_pointA;
 	T SquaredMagnitudeAB = dot(AB, AB);
@@ -265,13 +265,13 @@ inline T distance(const vector3_base<T> &a, const vector3_base<T> &b)
 }
 
 template<Numeric T>
-constexpr inline T dot(const vector3_base<T> &a, const vector3_base<T> &b)
+constexpr T dot(const vector3_base<T> &a, const vector3_base<T> &b)
 {
 	return a.x * b.x + a.y * b.y + a.z * b.z;
 }
 
 template<Numeric T>
-constexpr inline vector3_base<T> cross(const vector3_base<T> &a, const vector3_base<T> &b)
+constexpr vector3_base<T> cross(const vector3_base<T> &a, const vector3_base<T> &b)
 {
 	return vector3_base<T>(
 		a.y * b.z - a.z * b.y,

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -137,28 +137,28 @@ public:
 	};
 
 	//
-	inline EClientState State() const { return m_State; }
-	inline ELoadingStateDetail LoadingStateDetail() const { return m_LoadingStateDetail; }
-	inline int64_t StateStartTime() const { return m_StateStartTime; }
+	EClientState State() const { return m_State; }
+	ELoadingStateDetail LoadingStateDetail() const { return m_LoadingStateDetail; }
+	int64_t StateStartTime() const { return m_StateStartTime; }
 	void SetLoadingStateDetail(ELoadingStateDetail LoadingStateDetail) { m_LoadingStateDetail = LoadingStateDetail; }
 
 	void SetLoadingCallback(TLoadingCallback &&Func) { m_LoadingCallback = std::move(Func); }
 
 	// tick time access
-	inline int PrevGameTick(int Conn) const { return m_aPrevGameTick[Conn]; }
-	inline int GameTick(int Conn) const { return m_aCurGameTick[Conn]; }
-	inline int PredGameTick(int Conn) const { return m_aPredTick[Conn]; }
-	inline float IntraGameTick(int Conn) const { return m_aGameIntraTick[Conn]; }
-	inline float PredIntraGameTick(int Conn) const { return m_aPredIntraTick[Conn]; }
-	inline float IntraGameTickSincePrev(int Conn) const { return m_aGameIntraTickSincePrev[Conn]; }
-	inline float GameTickTime(int Conn) const { return m_aGameTickTime[Conn]; }
-	inline int GameTickSpeed() const { return SERVER_TICK_SPEED; }
+	int PrevGameTick(int Conn) const { return m_aPrevGameTick[Conn]; }
+	int GameTick(int Conn) const { return m_aCurGameTick[Conn]; }
+	int PredGameTick(int Conn) const { return m_aPredTick[Conn]; }
+	float IntraGameTick(int Conn) const { return m_aGameIntraTick[Conn]; }
+	float PredIntraGameTick(int Conn) const { return m_aPredIntraTick[Conn]; }
+	float IntraGameTickSincePrev(int Conn) const { return m_aGameIntraTickSincePrev[Conn]; }
+	float GameTickTime(int Conn) const { return m_aGameTickTime[Conn]; }
+	int GameTickSpeed() const { return SERVER_TICK_SPEED; }
 
 	// other time access
-	inline float RenderFrameTime() const { return m_RenderFrameTime; }
-	inline float LocalTime() const { return m_LocalTime; }
-	inline float GlobalTime() const { return m_GlobalTime; }
-	inline float FrameTimeAverage() const { return m_FrameTimeAverage; }
+	float RenderFrameTime() const { return m_RenderFrameTime; }
+	float LocalTime() const { return m_LocalTime; }
+	float GlobalTime() const { return m_GlobalTime; }
+	float FrameTimeAverage() const { return m_FrameTimeAverage; }
 
 	// actions
 	virtual void Connect(const char *pAddress, const char *pPassword = nullptr) = 0;

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -593,7 +593,7 @@ public:
 	virtual bool IsBackendInitialized() = 0;
 
 protected:
-	inline CTextureHandle CreateTextureHandle(int Index)
+	CTextureHandle CreateTextureHandle(int Index)
 	{
 		CTextureHandle Tex;
 		Tex.m_Id = Index;


### PR DESCRIPTION
- `constexpr` functions are implicitly `inline`
- functions defined inside a `class` definition are implicitly `inline`

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
