### PR TITLE
Use '= default' to define a trivial default constructor

### DIFF
--- a/src/base/color.h
+++ b/src/base/color.h
@@ -161,7 +161,7 @@ class ColorHSLA : public color4_base<ColorHSLA>
 {
 public:
 	using color4_base::color4_base;
-	constexpr ColorHSLA(){};
+	constexpr ColorHSLA() = default;
 
 	constexpr static const float DARKEST_LGT = 0.5f;
 	constexpr static const float DARKEST_LGT7 = 61.0f / 255.0f;
@@ -191,14 +191,14 @@ class ColorHSVA : public color4_base<ColorHSVA>
 {
 public:
 	using color4_base::color4_base;
-	constexpr ColorHSVA(){};
+	constexpr ColorHSVA() = default;
 };
 
 class ColorRGBA : public color4_base<ColorRGBA>
 {
 public:
 	using color4_base::color4_base;
-	constexpr ColorRGBA(){};
+	constexpr ColorRGBA() = default;
 };
 
 template<typename T, typename F>

--- a/src/base/logger.h
+++ b/src/base/logger.h
@@ -70,7 +70,7 @@ protected:
 	CLogFilter m_Filter;
 
 public:
-	virtual ~ILogger() {}
+	virtual ~ILogger() = default;
 
 	/**
 	 * Set a new filter. It's up to the logger implementation to actually

--- a/src/engine/gfx/image_loader.h
+++ b/src/engine/gfx/image_loader.h
@@ -35,9 +35,9 @@ public:
 
 class CImageLoader
 {
+public:
 	CImageLoader() = delete;
 
-public:
 	enum
 	{
 		PNGLITE_COLOR_TYPE = 1 << 0,


### PR DESCRIPTION
I think these were missed in #10599

Also moved the `= delete` because 

> /home/runner/work/ddnet/ddnet/src/engine/gfx/image_loader.h:38:2: error: deleted member function should be public [modernize-use-equals-delete,-warnings-as-errors]
   38 |         CImageLoader() = delete;

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
