### PR TITLE
Cleanup const in header files

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -367,7 +367,7 @@ void CCommandProcessor_SDL_GL::RunBuffer(CCommandBuffer *pBuffer)
 {
 	m_pGLBackend->StartCommands(pBuffer->m_CommandCount, pBuffer->m_RenderCallCount);
 
-	for(CCommandBuffer::SCommand *pCommand = pBuffer->Head(); pCommand; pCommand = pCommand->m_pNext)
+	for(const CCommandBuffer::SCommand *pCommand = pBuffer->Head(); pCommand; pCommand = pCommand->m_pNext)
 	{
 		auto Res = m_pGLBackend->RunCommand(pCommand);
 		if(Res == ERunCommandReturnTypes::RUN_COMMAND_COMMAND_HANDLED)

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -77,7 +77,7 @@ protected:
 	void StartProcessor(ICommandProcessor *pProcessor);
 	void StopProcessor();
 
-	bool HasWarning()
+	bool HasWarning() const
 	{
 		return m_Warning.m_WarningType != GFX_WARNING_TYPE_NONE;
 	}

--- a/src/engine/client/demoedit.h
+++ b/src/engine/client/demoedit.h
@@ -24,6 +24,6 @@ public:
 	CDemoEdit(const char *pNetVersion, CSnapshotDelta *pSnapshotDelta, IStorage *pStorage, const char *pDemo, const char *pDst, int StartTick, int EndTick);
 	void Run() override;
 	char *Destination() { return m_aDst; }
-	bool Success() { return m_Success; }
+	bool Success() const { return m_Success; }
 };
 #endif

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -624,10 +624,8 @@ public:
 		return true;
 	}
 
-	SCommand *Head()
-	{
-		return m_pCmdBufferHead;
-	}
+	const SCommand *Head() const { return m_pCmdBufferHead; }
+	SCommand *Head() { return const_cast<SCommand *>(const_cast<const CCommandBuffer *>(this)->Head()); }
 
 	void Reset()
 	{
@@ -873,7 +871,7 @@ class CGraphics_Threaded : public IEngineGraphics
 
 	template<typename TName>
 	void AddCmd(
-		TName &Cmd, std::function<bool()> FailFunc = [] { return true; })
+		TName &Cmd, const std::function<bool()> &FailFunc = [] { return true; })
 	{
 		if(m_pCommandBuffer->AddCommandUnsafe(Cmd))
 			return;

--- a/src/engine/server/name_ban.h
+++ b/src/engine/server/name_ban.h
@@ -36,7 +36,7 @@ class CNameBans
 
 public:
 	void InitConsole(IConsole *pConsole);
-	void Ban(const char *pName, const char *pReason, const int Distance, const bool IsSubstring);
+	void Ban(const char *pName, const char *pReason, int Distance, bool IsSubstring);
 	void Unban(const char *pName);
 	void Dump() const;
 	const CNameBan *IsBanned(const char *pName) const;

--- a/src/game/client/components/freezebars.h
+++ b/src/game/client/components/freezebars.h
@@ -4,8 +4,8 @@
 
 class CFreezeBars : public CComponent
 {
-	void RenderFreezeBar(const int ClientId);
-	void RenderFreezeBarPos(float x, const float y, const float Width, const float Height, float Progress, float Alpha = 1.0f);
+	void RenderFreezeBar(int ClientId);
+	void RenderFreezeBarPos(float x, float y, float Width, float Height, float Progress, float Alpha = 1.0f);
 	bool IsPlayerInfoAvailable(int ClientId) const;
 
 public:

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -567,7 +567,7 @@ public:
 
 	void OnReset();
 
-	size_t ComponentCount() { return m_vpAll.size(); }
+	size_t ComponentCount() const { return m_vpAll.size(); }
 
 	// hooks
 	void OnConnected() override;
@@ -655,15 +655,15 @@ public:
 	int LastRaceTick() const;
 	int CurrentRaceTime() const;
 
-	bool IsTeamPlay() { return m_Snap.m_pGameInfoObj && m_Snap.m_pGameInfoObj->m_GameFlags & GAMEFLAG_TEAMS; }
+	bool IsTeamPlay() const { return m_Snap.m_pGameInfoObj && m_Snap.m_pGameInfoObj->m_GameFlags & GAMEFLAG_TEAMS; }
 
-	bool AntiPingPlayers() { return g_Config.m_ClAntiPing && g_Config.m_ClAntiPingPlayers && !m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK && (m_aTuning[g_Config.m_ClDummy].m_PlayerCollision || m_aTuning[g_Config.m_ClDummy].m_PlayerHooking); }
-	bool AntiPingGrenade() { return g_Config.m_ClAntiPing && g_Config.m_ClAntiPingGrenade && !m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK; }
-	bool AntiPingWeapons() { return g_Config.m_ClAntiPing && g_Config.m_ClAntiPingWeapons && !m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK; }
-	bool AntiPingGunfire() { return AntiPingGrenade() && AntiPingWeapons() && g_Config.m_ClAntiPingGunfire; }
+	bool AntiPingPlayers() const { return g_Config.m_ClAntiPing && g_Config.m_ClAntiPingPlayers && !m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK && (m_aTuning[g_Config.m_ClDummy].m_PlayerCollision || m_aTuning[g_Config.m_ClDummy].m_PlayerHooking); }
+	bool AntiPingGrenade() const { return g_Config.m_ClAntiPing && g_Config.m_ClAntiPingGrenade && !m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK; }
+	bool AntiPingWeapons() const { return g_Config.m_ClAntiPing && g_Config.m_ClAntiPingWeapons && !m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK; }
+	bool AntiPingGunfire() const { return AntiPingGrenade() && AntiPingWeapons() && g_Config.m_ClAntiPingGunfire; }
 	bool Predict() const;
-	bool PredictDummy() { return g_Config.m_ClPredictDummy && Client()->DummyConnected() && m_Snap.m_LocalClientId >= 0 && m_PredictedDummyId >= 0 && !m_aClients[m_PredictedDummyId].m_Paused; }
-	const CTuningParams *GetTuning(int i) { return &m_aTuningList[i]; }
+	bool PredictDummy() const { return g_Config.m_ClPredictDummy && Client()->DummyConnected() && m_Snap.m_LocalClientId >= 0 && m_PredictedDummyId >= 0 && !m_aClients[m_PredictedDummyId].m_Paused; }
+	const CTuningParams *GetTuning(int i) const { return &m_aTuningList[i]; }
 	ColorRGBA GetDDTeamColor(int DDTeam, float Lightness = 0.5f) const;
 	void FormatClientId(int ClientId, char (&aClientId)[16], EClientIdFormat Format) const;
 
@@ -769,7 +769,7 @@ public:
 		IGraphics::CTextureHandle m_SpriteNinjaBarEmpty;
 		IGraphics::CTextureHandle m_SpriteNinjaBarEmptyRight;
 
-		bool IsSixup()
+		bool IsSixup() const
 		{
 			return m_SpriteNinjaBarFullLeft.IsValid();
 		}

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -85,9 +85,9 @@ public:
 	bool m_LastRefillJumps;
 
 	// Setters/Getters because i don't want to modify vanilla vars access modifiers
-	int GetLastWeapon() { return m_LastWeapon; }
+	int GetLastWeapon() const { return m_LastWeapon; }
 	void SetLastWeapon(int LastWeap) { m_LastWeapon = LastWeap; }
-	int GetActiveWeapon() { return m_Core.m_ActiveWeapon; }
+	int GetActiveWeapon() const { return m_Core.m_ActiveWeapon; }
 	void SetActiveWeapon(int ActiveWeapon);
 	CCharacterCore GetCore() { return m_Core; }
 	void SetCore(CCharacterCore Core) { m_Core = Core; }
@@ -109,9 +109,9 @@ public:
 			m_Input.m_TargetY = m_LatestInput.m_TargetY = -1;
 		}
 	};
-	int GetJumped() { return m_Core.m_Jumped; }
-	int GetAttackTick() { return m_AttackTick; }
-	int GetStrongWeakId() { return m_StrongWeakId; }
+	int GetJumped() const { return m_Core.m_Jumped; }
+	int GetAttackTick() const { return m_AttackTick; }
+	int GetStrongWeakId() const { return m_StrongWeakId; }
 
 	CCharacter(CGameWorld *pGameWorld, int Id, CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended = nullptr);
 	void Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, bool IsLocal);
@@ -128,12 +128,12 @@ public:
 	int GetOverriddenTuneZone() const;
 	int GetPureTuneZone() const;
 
-	bool HammerHitDisabled() { return m_Core.m_HammerHitDisabled; }
-	bool ShotgunHitDisabled() { return m_Core.m_ShotgunHitDisabled; }
-	bool LaserHitDisabled() { return m_Core.m_LaserHitDisabled; }
-	bool GrenadeHitDisabled() { return m_Core.m_GrenadeHitDisabled; }
+	bool HammerHitDisabled() const { return m_Core.m_HammerHitDisabled; }
+	bool ShotgunHitDisabled() const { return m_Core.m_ShotgunHitDisabled; }
+	bool LaserHitDisabled() const { return m_Core.m_LaserHitDisabled; }
+	bool GrenadeHitDisabled() const { return m_Core.m_GrenadeHitDisabled; }
 
-	bool IsSuper() { return m_Core.m_Super; }
+	bool IsSuper() const { return m_Core.m_Super; }
 
 private:
 	// weapon info

--- a/src/game/client/prediction/entities/dragger.h
+++ b/src/game/client/prediction/entities/dragger.h
@@ -21,7 +21,7 @@ public:
 	CDragger(CGameWorld *pGameWorld, int Id, const CLaserData *pData);
 	bool Match(CDragger *pDragger);
 	void Read(const CLaserData *pData);
-	float GetStrength() { return m_Strength; }
+	float GetStrength() const { return m_Strength; }
 
 	void Tick() override;
 };

--- a/src/game/client/prediction/entities/laser.h
+++ b/src/game/client/prediction/entities/laser.h
@@ -16,9 +16,9 @@ public:
 
 	void Tick() override;
 
-	const vec2 &GetFrom() { return m_From; }
-	const int &GetOwner() { return m_Owner; }
-	const int &GetEvalTick() { return m_EvalTick; }
+	const vec2 &GetFrom() const { return m_From; }
+	const int &GetOwner() const { return m_Owner; }
+	const int &GetEvalTick() const { return m_EvalTick; }
 	CLaser(CGameWorld *pGameWorld, int Id, CLaserData *pLaser);
 	bool Match(CLaser *pLaser);
 	CLaserData GetData() const;

--- a/src/game/client/prediction/entities/pickup.h
+++ b/src/game/client/prediction/entities/pickup.h
@@ -17,7 +17,7 @@ public:
 	CPickup(CGameWorld *pGameWorld, int Id, const CPickupData *pPickup);
 	void FillInfo(CNetObj_Pickup *pPickup);
 	bool Match(CPickup *pPickup);
-	bool InDDNetTile() { return m_IsCoreActive; }
+	bool InDDNetTile() const { return m_IsCoreActive; }
 
 	int Type() const { return m_Type; }
 	int Subtype() const { return m_Subtype; }

--- a/src/game/client/prediction/entities/projectile.h
+++ b/src/game/client/prediction/entities/projectile.h
@@ -34,9 +34,9 @@ public:
 	bool Match(CProjectile *pProj);
 	void SetBouncing(int Value);
 
-	const vec2 &GetDirection() { return m_Direction; }
-	const int &GetOwner() { return m_Owner; }
-	const int &GetStartTick() { return m_StartTick; }
+	const vec2 &GetDirection() const { return m_Direction; }
+	const int &GetOwner() const { return m_Owner; }
+	const int &GetStartTick() const { return m_StartTick; }
 	CProjectile(CGameWorld *pGameWorld, int Id, const CProjectileData *pProj);
 
 private:

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -56,9 +56,10 @@ public:
 	CCollision *m_pCollision;
 
 	// getter for server variables
-	int GameTick() { return m_GameTick; }
-	int GameTickSpeed() { return SERVER_TICK_SPEED; }
-	CCollision *Collision() { return m_pCollision; }
+	int GameTick() const { return m_GameTick; }
+	int GameTickSpeed() const { return SERVER_TICK_SPEED; }
+	const CCollision *Collision() const { return m_pCollision; }
+	CCollision *Collision() { return const_cast<CCollision *>(const_cast<const CGameWorld *>(this)->Collision()); }
 	CTeamsCore *Teams() { return &m_Teams; }
 	std::vector<SSwitchers> &Switchers() { return m_Core.m_vSwitchers; }
 	CTuningParams *Tuning();
@@ -102,8 +103,10 @@ public:
 	void Clear();
 
 	CTuningParams *m_pTuningList;
-	CTuningParams *TuningList() { return m_pTuningList; }
-	CTuningParams *GetTuning(int i) { return &TuningList()[i]; }
+	const CTuningParams *TuningList() const { return m_pTuningList; }
+	CTuningParams *TuningList() { return const_cast<CTuningParams *>(const_cast<const CGameWorld *>(this)->TuningList()); }
+	const CTuningParams *GetTuning(int i) const { return &TuningList()[i]; }
+	CTuningParams *GetTuning(int i) { return const_cast<CTuningParams *>(const_cast<const CGameWorld *>(this)->GetTuning(i)); }
 
 	const CMapBugs *m_pMapBugs;
 	bool EmulateBug(int Bug) const;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -849,7 +849,9 @@ private:
 };
 
 // make sure to inline this function
-inline class IGraphics *CLayer::Graphics() { return m_pEditor->Graphics(); }
-inline class ITextRender *CLayer::TextRender() { return m_pEditor->TextRender(); }
+inline const class IGraphics *CLayer::Graphics() const { return m_pEditor->Graphics(); }
+inline class IGraphics *CLayer::Graphics() { return const_cast<IGraphics *>(const_cast<const CLayer *>(this)->Graphics()); }
+inline const class ITextRender *CLayer::TextRender() const { return m_pEditor->TextRender(); }
+inline class ITextRender *CLayer::TextRender() { return const_cast<ITextRender *>(const_cast<const CLayer *>(this)->TextRender()); }
 
 #endif

--- a/src/game/editor/mapitems/layer.h
+++ b/src/game/editor/mapitems/layer.h
@@ -16,7 +16,9 @@ class CLayer
 {
 public:
 	class CEditor *m_pEditor;
+	const class IGraphics *Graphics() const;
 	class IGraphics *Graphics();
+	const class ITextRender *TextRender() const;
 	class ITextRender *TextRender();
 
 	explicit CLayer(CEditor *pEditor)

--- a/src/game/editor/quadart.h
+++ b/src/game/editor/quadart.h
@@ -29,7 +29,7 @@ private:
 	ivec2 GetOptimizedQuadSize(const ColorRGBA &Pixel, const ivec2 &Pos);
 	void MarkPixelAsVisited(const ivec2 &Pos, const ivec2 &Size);
 
-	size_t FindSuperPixelSize(const ColorRGBA &Pixel, const ivec2 &Pos, const size_t CurrentSize);
+	size_t FindSuperPixelSize(const ColorRGBA &Pixel, const ivec2 &Pos, size_t CurrentSize);
 
 	ColorRGBA GetPixelClamped(const ivec2 &Pos) const;
 	bool IsPixelOptimizable(const ivec2 &Pos, const ColorRGBA &Pixel) const;

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -156,7 +156,7 @@ public:
 		m_pPrng = nullptr;
 	}
 
-	int RandomOr0(int BelowThis)
+	int RandomOr0(int BelowThis) const
 	{
 		if(BelowThis <= 1 || !m_pPrng)
 		{

--- a/src/game/server/gameworld.h
+++ b/src/game/server/gameworld.h
@@ -196,8 +196,10 @@ public:
 	CTuningParams *Tuning();
 
 	CTuningParams *m_pTuningList;
-	CTuningParams *TuningList() { return m_pTuningList; }
-	CTuningParams *GetTuning(int i) { return &TuningList()[i]; }
+	const CTuningParams *TuningList() const { return m_pTuningList; }
+	CTuningParams *TuningList() { return const_cast<CTuningParams *>(const_cast<const CGameWorld *>(this)->TuningList()); }
+	const CTuningParams *GetTuning(int i) const { return &TuningList()[i]; }
+	CTuningParams *GetTuning(int i) { return const_cast<CTuningParams *>(const_cast<const CGameWorld *>(this)->GetTuning(i)); }
 };
 
 #endif


### PR DESCRIPTION
Should fix all `readability-make-member-function-const` for clang-tidy in header files https://github.com/ddnet/ddnet/pull/10588

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
