### PR TITLE
Cleanup inline and virtual in header files

### DIFF
--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -88,6 +88,7 @@ public:
 	class IJoystick
 	{
 	public:
+		virtual ~IJoystick() = default;
 		virtual int GetIndex() const = 0;
 		virtual const char *GetName() const = 0;
 		virtual int GetNumAxes() const = 0;

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -63,7 +63,7 @@ public:
 	virtual void SetClientDDNetVersion(int ClientId, int DDNetVersion) = 0;
 	virtual const NETADDR *ClientAddr(int ClientId) const = 0;
 	virtual const std::array<char, NETADDR_MAXSTRSIZE> &ClientAddrStringImpl(int ClientId, bool IncludePort) const = 0;
-	inline const char *ClientAddrString(int ClientId, bool IncludePort) const { return ClientAddrStringImpl(ClientId, IncludePort).data(); }
+	const char *ClientAddrString(int ClientId, bool IncludePort) const { return ClientAddrStringImpl(ClientId, IncludePort).data(); }
 
 	/**
 	 * Returns the version of the client with the given client ID.
@@ -79,7 +79,7 @@ public:
 	virtual int SendMsg(CMsgPacker *pMsg, int Flags, int ClientId) = 0;
 
 	template<class T, typename std::enable_if<!protocol7::is_sixup<T>::value, int>::type = 0>
-	inline int SendPackMsg(const T *pMsg, int Flags, int ClientId)
+	int SendPackMsg(const T *pMsg, int Flags, int ClientId)
 	{
 		int Result = 0;
 		if(ClientId == -1)
@@ -96,7 +96,7 @@ public:
 	}
 
 	template<class T, typename std::enable_if<protocol7::is_sixup<T>::value, int>::type = 1>
-	inline int SendPackMsg(const T *pMsg, int Flags, int ClientId)
+	int SendPackMsg(const T *pMsg, int Flags, int ClientId)
 	{
 		int Result = 0;
 		if(ClientId == -1)

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -244,6 +244,7 @@ public:
 class IFilterList
 {
 public:
+	virtual ~IFilterList() = default;
 	virtual void Add(const char *pElement) = 0;
 	virtual void Remove(const char *pElement) = 0;
 	virtual void Clear() = 0;
@@ -254,6 +255,7 @@ public:
 class ICommunityCache
 {
 public:
+	virtual ~ICommunityCache() = default;
 	virtual void Update(bool Force) = 0;
 	virtual const std::vector<const CCommunity *> &SelectedCommunities() const = 0;
 	virtual const std::vector<const CCommunityCountry *> &SelectableCountries() const = 0;

--- a/src/engine/sound.h
+++ b/src/engine/sound.h
@@ -102,7 +102,7 @@ public:
 	virtual void UnpauseAudioDevice() = 0;
 
 protected:
-	inline CVoiceHandle CreateVoiceHandle(int Index, int Age)
+	CVoiceHandle CreateVoiceHandle(int Index, int Age)
 	{
 		CVoiceHandle Voice;
 		Voice.m_Id = Index;

--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -68,7 +68,7 @@ public:
 	 * @param Steps - Zoom steps, 0.0f converts to default zoom (returns 1.0f)
 	 * @return converted zoom value
 	 **/
-	static inline float ZoomStepsToValue(float Steps) { return std::pow(CCamera::ZOOM_STEP, Steps); }
+	static float ZoomStepsToValue(float Steps) { return std::pow(CCamera::ZOOM_STEP, Steps); }
 
 	vec2 m_Center;
 	bool m_ZoomSet;

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -158,8 +158,8 @@ class CGameConsole : public CComponent
 	bool m_WantsSelectionCopy = false;
 	CUi::CTouchState m_TouchState;
 
-	static inline constexpr ColorRGBA ms_SearchHighlightColor = ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f);
-	static inline constexpr ColorRGBA ms_SearchSelectedColor = ColorRGBA(1.0f, 1.0f, 0.0f, 1.0f);
+	static constexpr ColorRGBA ms_SearchHighlightColor = ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f);
+	static constexpr ColorRGBA ms_SearchSelectedColor = ColorRGBA(1.0f, 1.0f, 0.0f, 1.0f);
 
 	int PossibleMaps(const char *pStr, IConsole::FPossibleCallback pfnCallback = IConsole::EmptyPossibleCommandCallback, void *pUser = nullptr);
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -149,7 +149,7 @@ class CEditor : public IEditor, public IEnvelopeEval
 	};
 
 	std::shared_ptr<CLayerGroup> m_apSavedBrushes[10];
-	static inline constexpr ColorRGBA ms_DefaultPropColor = ColorRGBA(1, 1, 1, 0.5f);
+	static constexpr ColorRGBA ms_DefaultPropColor = ColorRGBA(1, 1, 1, 0.5f);
 
 public:
 	class IInput *Input() const { return m_pInput; }

--- a/src/game/editor/editor_server_settings.h
+++ b/src/game/editor/editor_server_settings.h
@@ -223,11 +223,11 @@ public: // Backend methods
 public: // CContext
 	class CContext
 	{
-		static inline constexpr ColorRGBA ms_ArgumentStringColor = ColorRGBA(84.0f / 255.0f, 1.0f, 1.0f, 1.0f);
-		static inline constexpr ColorRGBA ms_ArgumentNumberColor = ColorRGBA(0.1f, 0.9f, 0.05f, 1.0f);
-		static inline constexpr ColorRGBA ms_ArgumentUnknownColor = ColorRGBA(0.6f, 0.6f, 0.6f, 1.0f);
-		static inline constexpr ColorRGBA ms_CommentColor = ColorRGBA(0.5f, 0.5f, 0.5f, 1.0f);
-		static inline constexpr ColorRGBA ms_ErrorColor = ColorRGBA(240.0f / 255.0f, 70.0f / 255.0f, 70.0f / 255.0f, 1.0f);
+		static constexpr ColorRGBA ms_ArgumentStringColor = ColorRGBA(84.0f / 255.0f, 1.0f, 1.0f, 1.0f);
+		static constexpr ColorRGBA ms_ArgumentNumberColor = ColorRGBA(0.1f, 0.9f, 0.05f, 1.0f);
+		static constexpr ColorRGBA ms_ArgumentUnknownColor = ColorRGBA(0.6f, 0.6f, 0.6f, 1.0f);
+		static constexpr ColorRGBA ms_CommentColor = ColorRGBA(0.5f, 0.5f, 0.5f, 1.0f);
+		static constexpr ColorRGBA ms_ErrorColor = ColorRGBA(240.0f / 255.0f, 70.0f / 255.0f, 70.0f / 255.0f, 1.0f);
 
 		friend class CMapSettingsBackend;
 

--- a/src/game/editor/editor_trackers.h
+++ b/src/game/editor/editor_trackers.h
@@ -78,7 +78,7 @@ public:
 
 	void Begin(EEnvelopeEditorOp Operation);
 	void Stop(bool Switch = true);
-	inline void Reset() { m_TrackedOp = EEnvelopeEditorOp::OP_NONE; }
+	void Reset() { m_TrackedOp = EEnvelopeEditorOp::OP_NONE; }
 
 	CEditor *m_pEditor;
 
@@ -137,6 +137,7 @@ template<typename T, typename E>
 class CPropTracker
 {
 public:
+	virtual ~CPropTracker() = default;
 	CPropTracker(CEditor *pEditor) :
 		m_pEditor(pEditor), m_OriginalValue(0), m_pObject(nullptr), m_OriginalLayerIndex(-1), m_OriginalGroupIndex(-1), m_CurrentLayerIndex(-1), m_CurrentGroupIndex(-1), m_Tracking(false) {}
 	CEditor *m_pEditor;

--- a/src/game/editor/mapitems/layer_switch.h
+++ b/src/game/editor/mapitems/layer_switch.h
@@ -43,7 +43,7 @@ public:
 	ivec2 m_GotoSwitchLastPos;
 
 	EditorTileStateChangeHistory<SSwitchTileStateChange> m_History;
-	inline void ClearHistory() override
+	void ClearHistory() override
 	{
 		CLayerTiles::ClearHistory();
 		m_History.clear();

--- a/src/game/editor/mapitems/layer_tele.h
+++ b/src/game/editor/mapitems/layer_tele.h
@@ -41,7 +41,7 @@ public:
 	ivec2 m_GotoTeleLastPos;
 
 	EditorTileStateChangeHistory<STeleTileStateChange> m_History;
-	inline void ClearHistory() override
+	void ClearHistory() override
 	{
 		CLayerTiles::ClearHistory();
 		m_History.clear();

--- a/src/game/editor/mapitems/layer_tiles.h
+++ b/src/game/editor/mapitems/layer_tiles.h
@@ -197,7 +197,7 @@ public:
 	bool m_KnownTextModeLayer = false;
 
 	EditorTileStateChangeHistory<STileStateChange> m_TilesHistory;
-	inline virtual void ClearHistory() { m_TilesHistory.clear(); }
+	virtual void ClearHistory() { m_TilesHistory.clear(); }
 
 	static bool HasAutomapEffect(ETilesProp Prop);
 

--- a/src/game/editor/mapitems/layer_tune.h
+++ b/src/game/editor/mapitems/layer_tune.h
@@ -40,7 +40,7 @@ public:
 	ivec2 m_GotoTuneLastPos;
 
 	EditorTileStateChangeHistory<STuneTileStateChange> m_History;
-	inline void ClearHistory() override
+	void ClearHistory() override
 	{
 		CLayerTiles::ClearHistory();
 		m_History.clear();

--- a/src/game/map/render_interfaces.h
+++ b/src/game/map/render_interfaces.h
@@ -30,6 +30,7 @@ public:
 class IMapImages
 {
 public:
+	virtual ~IMapImages() = default;
 	virtual IGraphics::CTextureHandle Get(int Index) const = 0;
 	virtual int Num() const = 0;
 	// DDRace

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -619,9 +619,9 @@ public:
 	};
 	int m_VoteVictim;
 
-	inline bool IsOptionVote() const { return m_VoteType == VOTE_TYPE_OPTION; }
-	inline bool IsKickVote() const { return m_VoteType == VOTE_TYPE_KICK; }
-	inline bool IsSpecVote() const { return m_VoteType == VOTE_TYPE_SPECTATE; }
+	bool IsOptionVote() const { return m_VoteType == VOTE_TYPE_OPTION; }
+	bool IsKickVote() const { return m_VoteType == VOTE_TYPE_KICK; }
+	bool IsSpecVote() const { return m_VoteType == VOTE_TYPE_SPECTATE; }
 
 	bool IsRunningVote(int ClientId) const;
 	bool IsRunningKickOrSpecVote(int ClientId) const;


### PR DESCRIPTION
This should fix all the `cppcoreguidelines-virtual-class-destructor` and `readability-redundant-inline-specifier` for https://github.com/ddnet/ddnet/pull/10588

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
