### PR TITLE
Extract some functions into base/fs.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1994,6 +1994,8 @@ set_src(BASE GLOB_RECURSE src/base
   crashdump.cpp
   detect.h
   dynamic.h
+  fs.cpp
+  fs.h
   hash.cpp
   hash.h
   hash_bundled.cpp

--- a/src/base/fs.cpp
+++ b/src/base/fs.cpp
@@ -1,0 +1,75 @@
+#include <base/fs.h>
+#include <base/log.h>
+#include <base/system.h>
+#include <base/types.h>
+
+#include <cerrno>
+#include <cstring>
+
+#if defined(CONF_FAMILY_UNIX)
+#include <sys/stat.h>
+#include <unistd.h>
+
+#elif defined(CONF_FAMILY_WINDOWS)
+#include <io.h>
+#include <string>
+#include <windows.h>
+#else
+#error NOT IMPLEMENTED
+#endif
+
+int fs_makedir(const char *path)
+{
+#if defined(CONF_FAMILY_WINDOWS)
+	const std::wstring wide_path = windows_utf8_to_wide(path);
+	if(CreateDirectoryW(wide_path.c_str(), nullptr) != 0)
+	{
+		return 0;
+	}
+	const DWORD error = GetLastError();
+	if(error == ERROR_ALREADY_EXISTS)
+	{
+		return 0;
+	}
+	log_error("filesystem", "Failed to create folder '%s' (%ld '%s')", path, error, windows_format_system_message(error).c_str());
+	return -1;
+#else
+#if defined(CONF_PLATFORM_HAIKU)
+	if(fs_is_dir(path))
+	{
+		return 0;
+	}
+#endif
+	if(mkdir(path, 0755) == 0 || errno == EEXIST)
+	{
+		return 0;
+	}
+	log_error("filesystem", "Failed to create folder '%s' (%d '%s')", path, errno, strerror(errno));
+	return -1;
+#endif
+}
+
+int fs_removedir(const char *path)
+{
+#if defined(CONF_FAMILY_WINDOWS)
+	const std::wstring wide_path = windows_utf8_to_wide(path);
+	if(RemoveDirectoryW(wide_path.c_str()) != 0)
+	{
+		return 0;
+	}
+	const DWORD error = GetLastError();
+	if(error == ERROR_FILE_NOT_FOUND)
+	{
+		return 0;
+	}
+	log_error("filesystem", "Failed to remove folder '%s' (%ld '%s')", path, error, windows_format_system_message(error).c_str());
+	return -1;
+#else
+	if(rmdir(path) == 0 || errno == ENOENT)
+	{
+		return 0;
+	}
+	log_error("filesystem", "Failed to remove folder '%s' (%d '%s')", path, errno, strerror(errno));
+	return -1;
+#endif
+}

--- a/src/base/fs.h
+++ b/src/base/fs.h
@@ -1,0 +1,35 @@
+#ifndef BASE_FS_H
+#define BASE_FS_H
+
+/**
+ * Creates a directory.
+ *
+ * @ingroup Filesystem
+ *
+ * @param path Directory to create.
+ *
+ * @return `0` on success. Negative value on failure.
+ *
+ * @remark Does not create several directories if needed. "a/b/c" will
+ *         result in a failure if b or a does not exist.
+ *
+ * @remark The strings are treated as null-terminated strings.
+ */
+int fs_makedir(const char *path);
+
+/**
+ * Removes a directory.
+ *
+ * @ingroup Filesystem
+ *
+ * @param path Directory to remove.
+ *
+ * @return `0` on success. Negative value on failure.
+ *
+ * @remark Cannot remove a non-empty directory.
+ *
+ * @remark The strings are treated as null-terminated strings.
+ */
+int fs_removedir(const char *path);
+
+#endif

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2522,62 +2522,6 @@ int fs_makedir_rec_for(const char *path)
 	return 0;
 }
 
-int fs_makedir(const char *path)
-{
-#if defined(CONF_FAMILY_WINDOWS)
-	const std::wstring wide_path = windows_utf8_to_wide(path);
-	if(CreateDirectoryW(wide_path.c_str(), nullptr) != 0)
-	{
-		return 0;
-	}
-	const DWORD error = GetLastError();
-	if(error == ERROR_ALREADY_EXISTS)
-	{
-		return 0;
-	}
-	log_error("filesystem", "Failed to create folder '%s' (%ld '%s')", path, error, windows_format_system_message(error).c_str());
-	return -1;
-#else
-#if defined(CONF_PLATFORM_HAIKU)
-	if(fs_is_dir(path))
-	{
-		return 0;
-	}
-#endif
-	if(mkdir(path, 0755) == 0 || errno == EEXIST)
-	{
-		return 0;
-	}
-	log_error("filesystem", "Failed to create folder '%s' (%d '%s')", path, errno, strerror(errno));
-	return -1;
-#endif
-}
-
-int fs_removedir(const char *path)
-{
-#if defined(CONF_FAMILY_WINDOWS)
-	const std::wstring wide_path = windows_utf8_to_wide(path);
-	if(RemoveDirectoryW(wide_path.c_str()) != 0)
-	{
-		return 0;
-	}
-	const DWORD error = GetLastError();
-	if(error == ERROR_FILE_NOT_FOUND)
-	{
-		return 0;
-	}
-	log_error("filesystem", "Failed to remove folder '%s' (%ld '%s')", path, error, windows_format_system_message(error).c_str());
-	return -1;
-#else
-	if(rmdir(path) == 0 || errno == ENOENT)
-	{
-		return 0;
-	}
-	log_error("filesystem", "Failed to remove folder '%s' (%d '%s')", path, errno, strerror(errno));
-	return -1;
-#endif
-}
-
 int fs_is_file(const char *path)
 {
 #if defined(CONF_FAMILY_WINDOWS)

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -9,6 +9,7 @@
 #define BASE_SYSTEM_H
 
 #include "detect.h"
+#include "fs.h"
 #include "str.h"
 #include "types.h"
 
@@ -1909,37 +1910,6 @@ void fs_listdir(const char *dir, FS_LISTDIR_CALLBACK cb, int type, void *user);
  * @remark The strings are treated as null-terminated strings.
  */
 void fs_listdir_fileinfo(const char *dir, FS_LISTDIR_CALLBACK_FILEINFO cb, int type, void *user);
-
-/**
- * Creates a directory.
- *
- * @ingroup Filesystem
- *
- * @param path Directory to create.
- *
- * @return `0` on success. Negative value on failure.
- *
- * @remark Does not create several directories if needed. "a/b/c" will
- *         result in a failure if b or a does not exist.
- *
- * @remark The strings are treated as null-terminated strings.
- */
-int fs_makedir(const char *path);
-
-/**
- * Removes a directory.
- *
- * @ingroup Filesystem
- *
- * @param path Directory to remove.
- *
- * @return `0` on success. Negative value on failure.
- *
- * @remark Cannot remove a non-empty directory.
- *
- * @remark The strings are treated as null-terminated strings.
- */
-int fs_removedir(const char *path);
 
 /**
  * Recursively creates parent directories for a file or directory.


### PR DESCRIPTION
This is the start of a bigger move. Moving all `fs_` prefixed functions into their own file.

Cousin pr #10855
Helps with #10093
Replaced #10185

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
