### PR TITLE
track flags for rendering

### DIFF
--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -623,22 +623,15 @@ void CItems::OnRender()
 		}
 	}
 
-	int Num = Client()->SnapNumItems(IClient::SNAP_CURRENT);
-
 	// render flag
-	for(int i = 0; i < Num; i++)
+	for(const auto &FlagItem : GameClient()->SnapFlags())
 	{
-		const IClient::CSnapItem Item = Client()->SnapGetItem(IClient::SNAP_CURRENT, i);
-
-		if(Item.m_Type == NETOBJTYPE_FLAG)
+		const void *pPrev = Client()->SnapFindItem(IClient::SNAP_PREV, FlagItem.m_Type, FlagItem.m_Id);
+		if(pPrev)
 		{
-			const void *pPrev = Client()->SnapFindItem(IClient::SNAP_PREV, Item.m_Type, Item.m_Id);
-			if(pPrev)
-			{
-				const void *pPrevGameData = Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_GAMEDATA, GameClient()->m_Snap.m_GameDataSnapId);
-				RenderFlag(static_cast<const CNetObj_Flag *>(pPrev), static_cast<const CNetObj_Flag *>(Item.m_pData),
-					static_cast<const CNetObj_GameData *>(pPrevGameData), GameClient()->m_Snap.m_pGameDataObj);
-			}
+			const void *pPrevGameData = Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_GAMEDATA, GameClient()->m_Snap.m_GameDataSnapId);
+			RenderFlag(static_cast<const CNetObj_Flag *>(pPrev), static_cast<const CNetObj_Flag *>(FlagItem.m_pData),
+				static_cast<const CNetObj_GameData *>(pPrevGameData), GameClient()->m_Snap.m_pGameDataObj);
 		}
 	}
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -677,6 +677,7 @@ void CGameClient::OnReset()
 	m_PrevPredictedWorld.CopyWorld(&m_PredictedWorld);
 
 	m_vSnapEntities.clear();
+	m_vSnapFlags.clear();
 
 	std::fill(std::begin(m_aDDRaceMsgSent), std::end(m_aDDRaceMsgSent), false);
 	std::fill(std::begin(m_aShowOthers), std::end(m_aShowOthers), SHOW_OTHERS_NOT_SET);
@@ -4586,6 +4587,8 @@ void CGameClient::SnapCollectEntities()
 	std::vector<CSnapEntities> vItemData;
 	std::vector<CSnapEntities> vItemEx;
 
+	m_vSnapFlags.clear();
+
 	for(int Index = 0; Index < NumSnapItems; Index++)
 	{
 		const IClient::CSnapItem Item = Client()->SnapGetItem(IClient::SNAP_CURRENT, Index);
@@ -4593,6 +4596,8 @@ void CGameClient::SnapCollectEntities()
 			vItemEx.push_back({Item, nullptr});
 		else if(Item.m_Type == NETOBJTYPE_PICKUP || Item.m_Type == NETOBJTYPE_DDNETPICKUP || Item.m_Type == NETOBJTYPE_LASER || Item.m_Type == NETOBJTYPE_DDNETLASER || Item.m_Type == NETOBJTYPE_PROJECTILE || Item.m_Type == NETOBJTYPE_DDRACEPROJECTILE || Item.m_Type == NETOBJTYPE_DDNETPROJECTILE)
 			vItemData.push_back({Item, nullptr});
+		else if(Item.m_Type == NETOBJTYPE_FLAG)
+			m_vSnapFlags.push_back(Item);
 	}
 
 	// sort by id

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -853,6 +853,7 @@ public:
 	bool m_ExtrasSkinLoaded = false;
 
 	const std::vector<CSnapEntities> &SnapEntities() { return m_vSnapEntities; }
+	const std::vector<CClient::CSnapItem> &SnapFlags() { return m_vSnapFlags; }
 
 	int m_MultiViewTeam;
 	float m_MultiViewPersonalZoom;
@@ -866,6 +867,7 @@ public:
 
 private:
 	std::vector<CSnapEntities> m_vSnapEntities;
+	std::vector<CClient::CSnapItem> m_vSnapFlags;
 	void SnapCollectEntities();
 
 	bool m_aDDRaceMsgSent[NUM_DUMMIES];


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

As @Robyt3 and me noticed, the flag rendering uses a lot of performance, because it iterates over **all** snap items. Instead I'd just save them in a vector similar to the entities and render them therefore more permanently

I checked afterwards with a profiler and **never** hit this function again

<img width="1347" height="287" alt="Unbenannt" src="https://github.com/user-attachments/assets/3a989a64-4d5f-4e3f-ae15-db2d958e924e" />

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
