### PR TITLE
Cleanup: move TuneZone into section for laser and shotgun laser head rendering

### DIFF
--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -351,7 +351,6 @@ void CItems::RenderLaser(const CLaserData *pCurrent, bool IsPredicted)
 
 void CItems::RenderLaser(vec2 From, vec2 Pos, ColorRGBA OuterColor, ColorRGBA InnerColor, float TicksBody, float TicksHead, int Type) const
 {
-	int TuneZone = (Client()->State() == IClient::STATE_ONLINE && GameClient()->m_GameWorld.m_WorldConfig.m_UseTuneZones) ? Collision()->IsTune(Collision()->GetMapIndex(From)) : 0;
 	float Len = distance(Pos, From);
 
 	if(Len > 0)
@@ -365,7 +364,16 @@ void CItems::RenderLaser(vec2 From, vec2 Pos, ColorRGBA OuterColor, ColorRGBA In
 		vec2 Dir = normalize_pre_length(Pos - From, Len);
 
 		float Ms = TicksBody * 1000.0f / Client()->GameTickSpeed();
-		float a = Ms / (Type == LASERTYPE_RIFLE || Type == LASERTYPE_SHOTGUN ? GameClient()->GetTuning(TuneZone)->m_LaserBounceDelay : CTuningParams::DEFAULT.m_LaserBounceDelay);
+		float a;
+		if(Type == LASERTYPE_RIFLE || Type == LASERTYPE_SHOTGUN)
+		{
+			int TuneZone = (Client()->State() == IClient::STATE_ONLINE && GameClient()->m_GameWorld.m_WorldConfig.m_UseTuneZones) ? Collision()->IsTune(Collision()->GetMapIndex(From)) : 0;
+			a = Ms / GameClient()->GetTuning(TuneZone)->m_LaserBounceDelay;
+		}
+		else
+		{
+			a = Ms / CTuningParams::DEFAULT.m_LaserBounceDelay;
+		}
 		a = std::clamp(a, 0.0f, 1.0f);
 		float Ia = 1 - a;
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Move the tune zone. I noticed this has a minimal effect on rendering speed with the profiler, because this is also hit for draggers for example. This should be a bit cleaner, because the tune zone is only needed for laser and shotgun

tiny regression from #10559

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
