### PR TITLE
Improve chat rendering performance

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -32,6 +32,7 @@ void CChat::CLine::Reset(CChat &This)
 {
 	This.TextRender()->DeleteTextContainer(m_TextContainerIndex);
 	This.Graphics()->DeleteQuadContainer(m_QuadContainerIndex);
+	m_Initialized = false;
 	m_Time = 0;
 	m_aText[0] = '\0';
 	m_aName[0] = '\0';
@@ -98,6 +99,8 @@ void CChat::RebuildChat()
 {
 	for(auto &Line : m_aLines)
 	{
+		if(!Line.m_Initialized)
+			continue;
 		TextRender()->DeleteTextContainer(Line.m_TextContainerIndex);
 		Graphics()->DeleteQuadContainer(Line.m_QuadContainerIndex);
 		// recalculate sizes
@@ -734,7 +737,11 @@ void CChat::AddLine(int ClientId, int Team, const char *pLine)
 	// 0 = global; 1 = team; 2 = sending whisper; 3 = receiving whisper
 
 	// If it's a client message, m_aText will have ": " prepended so we have to work around it.
-	if(PreviousLine.m_TeamNumber == Team && PreviousLine.m_ClientId == ClientId && str_comp(PreviousLine.m_aText, pLine) == 0 && PreviousLine.m_CustomColor == CustomColor)
+	if(PreviousLine.m_Initialized &&
+		PreviousLine.m_TeamNumber == Team &&
+		PreviousLine.m_ClientId == ClientId &&
+		str_comp(PreviousLine.m_aText, pLine) == 0 &&
+		PreviousLine.m_CustomColor == CustomColor)
 	{
 		PreviousLine.m_TimesRepeated++;
 		TextRender()->DeleteTextContainer(PreviousLine.m_TextContainerIndex);
@@ -751,7 +758,7 @@ void CChat::AddLine(int ClientId, int Team, const char *pLine)
 
 	CLine &CurrentLine = m_aLines[m_CurrentLine];
 	CurrentLine.Reset(*this);
-
+	CurrentLine.m_Initialized = true;
 	CurrentLine.m_Time = time();
 	CurrentLine.m_aYOffset[0] = -1.0f;
 	CurrentLine.m_aYOffset[1] = -1.0f;
@@ -937,7 +944,8 @@ void CChat::OnPrepareLines(float y)
 	for(int i = 0; i < MAX_LINES; i++)
 	{
 		CLine &Line = m_aLines[((m_CurrentLine - i) + MAX_LINES) % MAX_LINES];
-
+		if(!Line.m_Initialized)
+			break;
 		if(Now > Line.m_Time + 16 * time_freq() && !m_PrevShowChat)
 			break;
 
@@ -1254,6 +1262,8 @@ void CChat::OnRender()
 	for(int i = 0; i < MAX_LINES; i++)
 	{
 		CLine &Line = m_aLines[((m_CurrentLine - i) + MAX_LINES) % MAX_LINES];
+		if(!Line.m_Initialized)
+			break;
 		if(Now > Line.m_Time + 16 * time_freq() && !m_PrevShowChat)
 			break;
 

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -35,6 +35,7 @@ class CChat : public CComponent
 		CLine();
 		void Reset(CChat &This);
 
+		bool m_Initialized;
 		int64_t m_Time;
 		float m_aYOffset[2];
 		int m_ClientId;


### PR DESCRIPTION
Avoid iterating over and updating uninitialized chat lines every frame. Add member variable `bool m_Initialized` to the `CLine` class to make it explicit whether a chat line has been initialized. Also avoid uninitialized chat lines being considered when checking whether the current message is a repeat of the previous one.

On the map dm1 with 64 players at zoom 0 with the optimizations of #10864 as the baseline, this decreases the average frametime from 1164 µs to 1084 µs. The CPU time spent in the `CChat::OnPrepareLines` function in this scenario is reduced from 3.50% to 0.01% of the total CPU time.

Frametime comparison:

- <img src="https://github.com/user-attachments/assets/5e041913-46b3-48f2-878b-b3e0cd35debe" />
- <img src="https://github.com/user-attachments/assets/0e96c568-c3ca-4f68-85a4-18435ed3ecd7" />

Profiling comparison:

- Before: <img src="https://github.com/user-attachments/assets/22e727cc-3662-40b7-9b92-e19806ef90f3" />
- After: <img src="https://github.com/user-attachments/assets/89858ecc-f05d-4f93-bdc2-e90202b41e61" />

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
