### PR TITLE
Feature: implement automatic quad clipping for rotating quads

### DIFF
--- a/src/game/map/envelope_extrema.cpp
+++ b/src/game/map/envelope_extrema.cpp
@@ -6,10 +6,12 @@ CEnvelopeExtrema::CEnvelopeExtrema(IMap *pMap) :
 	m_pMap = pMap;
 
 	m_EnvelopeExtremaItemNone.m_Available = true;
+	m_EnvelopeExtremaItemNone.m_Rotating = false;
 	m_EnvelopeExtremaItemNone.m_Minima = ivec2(0, 0);
 	m_EnvelopeExtremaItemNone.m_Maxima = ivec2(0, 0);
 
 	m_EnvelopeExtremaItemInvalid.m_Available = false;
+	m_EnvelopeExtremaItemInvalid.m_Rotating = false;
 	m_EnvelopeExtremaItemInvalid.m_Minima = ivec2(0, 0);
 	m_EnvelopeExtremaItemInvalid.m_Maxima = ivec2(0, 0);
 
@@ -27,6 +29,7 @@ void CEnvelopeExtrema::CalculateEnvelope(const CMapItemEnvelope *pEnvelopeItem, 
 		EnvExt.m_Maxima[Channel] = std::numeric_limits<int>::min(); // maximum of channel
 	}
 	EnvExt.m_Available = false;
+	EnvExt.m_Rotating = false;
 
 	// check if the envelope is a position envelope
 	if(pEnvelopeItem->m_Channels != 3)
@@ -36,9 +39,9 @@ void CEnvelopeExtrema::CalculateEnvelope(const CMapItemEnvelope *pEnvelopeItem, 
 	{
 		const CEnvPoint *pEnvPoint = m_EnvelopePoints.GetPoint(PointId);
 
-		// rotation is not implemented for clipping
+		// check if quad is rotating
 		if(pEnvPoint->m_aValues[2] != 0)
-			return;
+			EnvExt.m_Rotating = true;
 
 		for(int Channel = 0; Channel < 2; ++Channel)
 		{

--- a/src/game/map/envelope_extrema.h
+++ b/src/game/map/envelope_extrema.h
@@ -15,6 +15,7 @@ public:
 	{
 	public:
 		bool m_Available;
+		bool m_Rotating;
 		ivec2 m_Minima;
 		ivec2 m_Maxima;
 	};

--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -1128,20 +1128,48 @@ bool CRenderLayerQuads::CalculateQuadClipping(int aQuadOffsetMin[2], int aQuadOf
 	{
 		const CQuad *pQuad = &m_pQuads[i];
 
+		const CEnvelopeExtrema::CEnvelopeExtremaItem &Extrema = m_pEnvelopeManager->EnvelopeExtrema()->GetExtrema(pQuad->m_PosEnv);
+		if(!Extrema.m_Available)
+			return false;
+
 		// calculate clip region
-		for(int QuadIdPoint = 0; QuadIdPoint < 4; ++QuadIdPoint)
+		if(!Extrema.m_Rotating)
 		{
+			for(int QuadIdPoint = 0; QuadIdPoint < 4; ++QuadIdPoint)
+			{
+				for(int Channel = 0; Channel < 2; ++Channel)
+				{
+					int OffsetMinimum = pQuad->m_aPoints[QuadIdPoint][Channel];
+					int OffsetMaximum = pQuad->m_aPoints[QuadIdPoint][Channel];
+
+					// calculate env offsets for every ungrouped quad
+					if(!Grouped && pQuad->m_PosEnv >= 0)
+					{
+						OffsetMinimum += Extrema.m_Minima[Channel];
+						OffsetMaximum += Extrema.m_Maxima[Channel];
+					}
+					aQuadOffsetMin[Channel] = std::min(aQuadOffsetMin[Channel], OffsetMinimum);
+					aQuadOffsetMax[Channel] = std::max(aQuadOffsetMax[Channel], OffsetMaximum);
+				}
+			}
+		}
+		else
+		{
+			const CPoint &Center = pQuad->m_aPoints[4];
+			int MaxDistance = 0;
+			for(int QuadIdPoint = 0; QuadIdPoint < 4; ++QuadIdPoint)
+			{
+				const CPoint &QuadPoint = pQuad->m_aPoints[QuadIdPoint];
+				int Distance = (int)std::ceil(std::sqrt(1.0 * (Center.x - QuadPoint.x) * (Center.x - QuadPoint.x) + (Center.y - QuadPoint.y) * (Center.y - QuadPoint.y)));
+				MaxDistance = std::max(Distance, MaxDistance);
+			}
+
 			for(int Channel = 0; Channel < 2; ++Channel)
 			{
-				int OffsetMinimum = pQuad->m_aPoints[QuadIdPoint][Channel];
-				int OffsetMaximum = pQuad->m_aPoints[QuadIdPoint][Channel];
-
-				// calculate env offsets for every ungrouped quad
+				int OffsetMinimum = Center[Channel] - MaxDistance;
+				int OffsetMaximum = Center[Channel] + MaxDistance;
 				if(!Grouped && pQuad->m_PosEnv >= 0)
 				{
-					const CEnvelopeExtrema::CEnvelopeExtremaItem &Extrema = m_pEnvelopeManager->EnvelopeExtrema()->GetExtrema(m_QuadRenderGroup.m_PosEnv);
-					if(!Extrema.m_Available)
-						return false;
 					OffsetMinimum += Extrema.m_Minima[Channel];
 					OffsetMaximum += Extrema.m_Maxima[Channel];
 				}
@@ -1154,9 +1182,10 @@ bool CRenderLayerQuads::CalculateQuadClipping(int aQuadOffsetMin[2], int aQuadOf
 	// add env offsets for the quad group
 	if(Grouped && m_QuadRenderGroup.m_PosEnv >= 0)
 	{
+		const CEnvelopeExtrema::CEnvelopeExtremaItem &Extrema = m_pEnvelopeManager->EnvelopeExtrema()->GetExtrema(m_QuadRenderGroup.m_PosEnv);
+
 		for(int Channel = 0; Channel < 2; ++Channel)
 		{
-			const CEnvelopeExtrema::CEnvelopeExtremaItem &Extrema = m_pEnvelopeManager->EnvelopeExtrema()->GetExtrema(m_QuadRenderGroup.m_PosEnv);
 			aQuadOffsetMin[Channel] += Extrema.m_Minima[Channel];
 			aQuadOffsetMax[Channel] += Extrema.m_Maxima[Channel];
 		}


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

After implementing this, all quadlayers should always be automatically clipped (assuming no bugged/invalid maps). If any rotation is present, the max distance from the center of a quad to the furthest corner is added to the bounding box calculation.

## Clipping debug view:

You can debug with `dbg_render_layers 2`

Group 3 contains rotating quads

https://github.com/user-attachments/assets/bd7872b2-67c0-4fb2-860a-d43db1087e73

## Benchmarks:

I see NO effects on my current benchmarking map set. This doesn't mean, that there is no effect or that no maps exists which benefit from this.

<img width="985" height="590" alt="Unbenannt" src="https://github.com/user-attachments/assets/a11c9593-7e57-4b08-89a6-aa82032d53ec" />

## Notes:

@Jupeyy The calculations are done as you suggested, with the green bounding box.
But only if the envelope contains rotation at all. Otherwise it resumes to the old behavior

<img width="1080" height="908" alt="Unbenannt" src="https://github.com/user-attachments/assets/63339887-f8bc-4028-a5cb-4f982ea90de2" />

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
