### PR TITLE
Fix: ivec distance calculation overflows really fast

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3059,6 +3059,7 @@ if((GTEST_FOUND OR DOWNLOAD_GTEST) AND SERVER)
     timestamp.cpp
     unix.cpp
     uuid.cpp
+    vmath.cpp
   )
   set(TESTS_EXTRA
     src/engine/client/blocklist_driver.cpp

--- a/src/base/vmath.h
+++ b/src/base/vmath.h
@@ -96,6 +96,14 @@ inline T distance(const vector2_base<T> a, const vector2_base<T> &b)
 	return length(a - b);
 }
 
+template<>
+inline int distance(const vector2_base<int> a, const vector2_base<int> &b)
+{
+	vector2_base<float> Pos1(a.x, a.y);
+	vector2_base<float> Pos2(b.x, b.y);
+	return (int)std::round(distance(Pos1, Pos2));
+}
+
 template<Numeric T>
 constexpr T dot(const vector2_base<T> a, const vector2_base<T> &b)
 {
@@ -262,6 +270,14 @@ template<Numeric T>
 inline T distance(const vector3_base<T> &a, const vector3_base<T> &b)
 {
 	return length(a - b);
+}
+
+template<>
+inline int distance(const vector3_base<int> &a, const vector3_base<int> &b)
+{
+	vector3_base<float> Pos1(a.x, a.y, a.z);
+	vector3_base<float> Pos2(b.x, b.y, b.z);
+	return (int)std::round(distance(Pos1, Pos2));
 }
 
 template<Numeric T>

--- a/src/test/vmath.cpp
+++ b/src/test/vmath.cpp
@@ -1,0 +1,36 @@
+#include "test.h"
+#include <gtest/gtest.h>
+
+#include <base/vmath.h>
+
+TEST(VMath, DistanceVec2)
+{
+	vec2 Pos1(0, 0);
+	vec2 Pos2(30000, 40000);
+	float Distance = distance(Pos1, Pos2);
+	EXPECT_NEAR(Distance, 50000, 0.0005f);
+}
+
+TEST(VMath, DistanceVec3)
+{
+	vec3 Pos1(0, 0, 0);
+	vec3 Pos2(30000, 0, 40000);
+	float Distance = distance(Pos1, Pos2);
+	EXPECT_NEAR(Distance, 50000, 0.0005f);
+}
+
+TEST(VMath, DistanceIVec2)
+{
+	ivec2 Pos1(0, 0);
+	ivec2 Pos2(30000, 40000);
+	int Distance = distance(Pos1, Pos2);
+	EXPECT_NEAR(Distance, 50000, 0.0005f);
+}
+
+TEST(VMath, DistanceIVec3)
+{
+	ivec3 Pos1(0, 0, 0);
+	ivec3 Pos2(30000, 0, 40000);
+	int Distance = distance(Pos1, Pos2);
+	EXPECT_NEAR(Distance, 50000, 0.0005f);
+}


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

When using ivec2 I noticed, that the distance calculations are wrong. This already happens in the range of `ivec2(30000, 40000)` due to an overflow in the `dot` calculation. This PR introduces a fix with a template specialization and provides unit tests. Turns out this problem is even worse with `ivec3`.

As far as I can tell no physics are affected, as ivec2/ivec3 is **not** used in physics.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
