### PR TITLE
Fix modernize-use-override

### DIFF
--- a/src/engine/antibot.h
+++ b/src/engine/antibot.h
@@ -23,7 +23,6 @@ public:
 
 	// Commands
 	virtual void ConsoleCommand(const char *pCommand) = 0;
-	virtual ~IAntibot() = default;
 };
 
 class IEngineAntibot : public IAntibot
@@ -39,8 +38,6 @@ public:
 	virtual bool OnEngineClientMessage(int ClientId, const void *pData, int Size, int Flags) = 0;
 	virtual bool OnEngineServerMessage(int ClientId, const void *pData, int Size, int Flags) = 0;
 	virtual bool OnEngineSimulateClientMessage(int *pClientId, void *pBuffer, int BufferSize, int *pOutSize, int *pFlags) = 0;
-
-	virtual ~IEngineAntibot() = default;
 };
 
 #endif //ENGINE_ANTIBOT_H

--- a/src/engine/client/backend/opengl/backend_opengl.h
+++ b/src/engine/client/backend/opengl/backend_opengl.h
@@ -123,7 +123,6 @@ protected:
 
 public:
 	CCommandProcessorFragment_OpenGL();
-	virtual ~CCommandProcessorFragment_OpenGL() = default;
 
 	ERunCommandReturnTypes RunCommand(const CCommandBuffer::SCommand *pBaseCommand) override;
 };

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -186,7 +186,7 @@ class CCommandProcessor_SDL_GL : public CGraphicsBackend_Threaded::ICommandProce
 
 public:
 	CCommandProcessor_SDL_GL(EBackendType BackendType, int GLMajor, int GLMinor, int GLPatch);
-	virtual ~CCommandProcessor_SDL_GL();
+	~CCommandProcessor_SDL_GL() override;
 	void RunBuffer(CCommandBuffer *pBuffer) override;
 
 	const SGfxErrorContainer &GetError() const override;

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -38,7 +38,7 @@ public:
 
 	public:
 		CJoystick(CInput *pInput, int Index, SDL_Joystick *pDelegate);
-		virtual ~CJoystick() = default;
+		~CJoystick() override = default;
 
 		int GetIndex() const override { return m_Index; }
 		const char *GetName() const override { return m_aName; }

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -250,7 +250,7 @@ class CServerBrowser : public IServerBrowser
 {
 public:
 	CServerBrowser();
-	virtual ~CServerBrowser();
+	~CServerBrowser() override;
 
 	// interface functions
 	void Refresh(int Type, bool Force = false) override;

--- a/src/engine/client/video.h
+++ b/src/engine/client/video.h
@@ -42,7 +42,7 @@ class CVideo : public IVideo
 {
 public:
 	CVideo(IGraphics *pGraphics, ISound *pSound, IStorage *pStorage, int Width, int Height, const char *pName);
-	~CVideo();
+	~CVideo() override;
 
 	bool Start() override REQUIRES(!m_WriteLock);
 	void Stop() override;

--- a/src/engine/demo.h
+++ b/src/engine/demo.h
@@ -84,7 +84,6 @@ public:
 		TICK_NEXT, // go to the next tick
 	};
 
-	virtual ~IDemoPlayer() = default;
 	virtual void SetSpeed(float Speed) = 0;
 	virtual void SetSpeedIndex(int SpeedIndex) = 0;
 	virtual void AdjustSpeedIndex(int Offset) = 0;
@@ -111,7 +110,6 @@ public:
 		REMOVE_FILE,
 	};
 
-	virtual ~IDemoRecorder() = default;
 	virtual bool IsRecording() const = 0;
 	virtual int Stop(IDemoRecorder::EStopMode Mode, const char *pTargetFilename = "") = 0;
 	virtual int Length() const = 0;

--- a/src/engine/editor.h
+++ b/src/engine/editor.h
@@ -8,7 +8,6 @@ class IEditor : public IInterface
 {
 	MACRO_INTERFACE("editor")
 public:
-	virtual ~IEditor() = default;
 	virtual void Init() = 0;
 	virtual void OnUpdate() = 0;
 	virtual void OnRender() = 0;

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -16,8 +16,6 @@ class IEngine : public IInterface
 	MACRO_INTERFACE("engine")
 
 public:
-	virtual ~IEngine() = default;
-
 	virtual void Init() = 0;
 	virtual void AddJob(std::shared_ptr<IJob> pJob) = 0;
 	virtual void ShutdownJobs() = 0;

--- a/src/engine/favorites.h
+++ b/src/engine/favorites.h
@@ -26,8 +26,6 @@ public:
 		bool m_AllowPing;
 	};
 
-	virtual ~IFavorites() = default;
-
 	virtual TRISTATE IsFavorite(const NETADDR *pAddrs, int NumAddrs) const = 0;
 	// Only considers the addresses that are actually favorites.
 	virtual TRISTATE IsPingAllowed(const NETADDR *pAddrs, int NumAddrs) const = 0;

--- a/src/engine/ghost.h
+++ b/src/engine/ghost.h
@@ -19,8 +19,6 @@ class IGhostRecorder : public IInterface
 {
 	MACRO_INTERFACE("ghostrecorder")
 public:
-	virtual ~IGhostRecorder() = default;
-
 	virtual int Start(const char *pFilename, const char *pMap, const SHA256_DIGEST &MapSha256, const char *pName) = 0;
 	virtual void Stop(int Ticks, int Time) = 0;
 
@@ -32,8 +30,6 @@ class IGhostLoader : public IInterface
 {
 	MACRO_INTERFACE("ghostloader")
 public:
-	virtual ~IGhostLoader() = default;
-
 	virtual bool Load(const char *pFilename, const char *pMap, const SHA256_DIGEST &MapSha256, unsigned MapCrc) = 0;
 	virtual void Close() = 0;
 

--- a/src/engine/server/antibot.h
+++ b/src/engine/server/antibot.h
@@ -27,7 +27,7 @@ class CAntibot : public IEngineAntibot
 
 public:
 	CAntibot();
-	virtual ~CAntibot();
+	~CAntibot() override;
 
 	// Engine
 	void Init() override;

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -287,7 +287,7 @@ public:
 	std::shared_ptr<ILogger> m_pStdoutLogger = nullptr;
 
 	CServer();
-	~CServer();
+	~CServer() override;
 
 	bool IsClientNameAvailable(int ClientId, const char *pNameRequest);
 	bool SetClientNameImpl(int ClientId, const char *pNameRequest, bool Set);

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -152,7 +152,7 @@ class CConsole : public IConsole
 
 public:
 	CConsole(int FlagMask);
-	~CConsole();
+	~CConsole() override;
 
 	void Init() override;
 	const CCommandInfo *FirstCommandInfo(int AccessLevel, int FlagMask) const override;

--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -339,7 +339,7 @@ public:
 	// User
 	void Run(std::shared_ptr<IHttpRequest> pRequest) override;
 	void Shutdown() override;
-	~CHttp();
+	~CHttp() override;
 };
 
 #endif // ENGINE_SHARED_HTTP_H

--- a/src/engine/shared/jsonwriter.h
+++ b/src/engine/shared/jsonwriter.h
@@ -95,7 +95,7 @@ public:
 	 * The file will automatically be closed by the destructor.
 	 */
 	CJsonFileWriter(IOHANDLE IO);
-	~CJsonFileWriter();
+	~CJsonFileWriter() override;
 };
 
 /**
@@ -111,7 +111,7 @@ protected:
 
 public:
 	CJsonStringWriter() = default;
-	~CJsonStringWriter() = default;
+	~CJsonStringWriter() override = default;
 	std::string &&GetOutputString();
 };
 

--- a/src/game/client/component.h
+++ b/src/game/client/component.h
@@ -165,11 +165,6 @@ class CComponent : public CComponentInterfaces
 {
 public:
 	/**
-	 * The component virtual destructor.
-	 */
-	virtual ~CComponent() = default;
-
-	/**
 	 * Gets the size of the non-abstract component.
 	 */
 	virtual int Sizeof() const = 0;

--- a/src/game/client/components/background.h
+++ b/src/game/client/components/background.h
@@ -34,7 +34,7 @@ protected:
 
 public:
 	CBackground(ERenderType MapType = ERenderType::RENDERTYPE_BACKGROUND_FORCE, bool OnlineOnly = true);
-	virtual ~CBackground();
+	~CBackground() override;
 	int Sizeof() const override { return sizeof(*this); }
 
 	void OnInit() override;

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -41,7 +41,7 @@ class CBinds : public CComponent
 
 public:
 	CBinds();
-	~CBinds();
+	~CBinds() override;
 	int Sizeof() const override { return sizeof(*this); }
 
 	class CBindsSpecial : public CComponent

--- a/src/game/client/components/community_icons.h
+++ b/src/game/client/components/community_icons.h
@@ -61,7 +61,7 @@ private:
 
 	public:
 		CCommunityIconLoadJob(CCommunityIcons *pCommunityIcons, const char *pCommunityId, int StorageType);
-		~CCommunityIconLoadJob();
+		~CCommunityIconLoadJob() override;
 
 		CImageInfo &ImageInfo() { return m_ImageInfo; }
 		CImageInfo &ImageInfoGrayscale() { return m_ImageInfoGrayscale; }

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -185,7 +185,7 @@ public:
 	};
 
 	CGameConsole();
-	~CGameConsole();
+	~CGameConsole() override;
 	int Sizeof() const override { return sizeof(*this); }
 
 	void PrintLine(int Type, const char *pLine);

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -48,7 +48,7 @@ private:
 	{
 	public:
 		CAbstractSkinLoadJob(CSkins *pSkins, const char *pName);
-		virtual ~CAbstractSkinLoadJob();
+		~CAbstractSkinLoadJob() override;
 
 		CSkinLoadData m_Data;
 		bool m_NotFound = false;

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -25,7 +25,7 @@ class CCharacter : public CEntity
 	friend class CGameWorld;
 
 public:
-	~CCharacter();
+	~CCharacter() override;
 
 	void PreTick() override;
 	void Tick() override;

--- a/src/game/editor/mapitems/image.h
+++ b/src/game/editor/mapitems/image.h
@@ -10,7 +10,7 @@ class CEditorImage : public CImageInfo, public CEditorComponent
 {
 public:
 	explicit CEditorImage(CEditor *pEditor);
-	~CEditorImage();
+	~CEditorImage() override;
 
 	void OnInit(CEditor *pEditor) override;
 	void AnalyseTileFlags();

--- a/src/game/editor/mapitems/layer_game.h
+++ b/src/game/editor/mapitems/layer_game.h
@@ -7,7 +7,7 @@ class CLayerGame : public CLayerTiles
 {
 public:
 	CLayerGame(CEditor *pEditor, int w, int h);
-	~CLayerGame();
+	~CLayerGame() override;
 
 	[[nodiscard]] CTile GetTile(int x, int y) const override;
 	void SetTile(int x, int y, CTile Tile) override;

--- a/src/game/editor/mapitems/layer_quads.h
+++ b/src/game/editor/mapitems/layer_quads.h
@@ -8,7 +8,7 @@ class CLayerQuads : public CLayer
 public:
 	explicit CLayerQuads(CEditor *pEditor);
 	CLayerQuads(const CLayerQuads &Other);
-	~CLayerQuads();
+	~CLayerQuads() override;
 
 	void Render(bool QuadPicker = false) override;
 	CQuad *NewQuad(int x, int y, int Width, int Height);

--- a/src/game/editor/mapitems/layer_sounds.h
+++ b/src/game/editor/mapitems/layer_sounds.h
@@ -8,7 +8,7 @@ class CLayerSounds : public CLayer
 public:
 	explicit CLayerSounds(CEditor *pEditor);
 	CLayerSounds(const CLayerSounds &Other);
-	~CLayerSounds();
+	~CLayerSounds() override;
 
 	void Render(bool Tileset = false) override;
 	CSoundSource *NewSource(int x, int y);

--- a/src/game/editor/mapitems/layer_speedup.h
+++ b/src/game/editor/mapitems/layer_speedup.h
@@ -21,7 +21,7 @@ class CLayerSpeedup : public CLayerTiles
 public:
 	CLayerSpeedup(CEditor *pEditor, int w, int h);
 	CLayerSpeedup(const CLayerSpeedup &Other);
-	~CLayerSpeedup();
+	~CLayerSpeedup() override;
 
 	CSpeedupTile *m_pSpeedupTile;
 	int m_SpeedupForce;

--- a/src/game/editor/mapitems/layer_switch.h
+++ b/src/game/editor/mapitems/layer_switch.h
@@ -21,7 +21,7 @@ class CLayerSwitch : public CLayerTiles
 public:
 	CLayerSwitch(CEditor *pEditor, int w, int h);
 	CLayerSwitch(const CLayerSwitch &Other);
-	~CLayerSwitch();
+	~CLayerSwitch() override;
 
 	CSwitchTile *m_pSwitchTile;
 	unsigned char m_SwitchNumber;

--- a/src/game/editor/mapitems/layer_tele.h
+++ b/src/game/editor/mapitems/layer_tele.h
@@ -19,7 +19,7 @@ class CLayerTele : public CLayerTiles
 public:
 	CLayerTele(CEditor *pEditor, int w, int h);
 	CLayerTele(const CLayerTele &Other);
-	~CLayerTele();
+	~CLayerTele() override;
 
 	CTeleTile *m_pTeleTile;
 	unsigned char m_TeleNum;

--- a/src/game/editor/mapitems/layer_tiles.h
+++ b/src/game/editor/mapitems/layer_tiles.h
@@ -106,7 +106,7 @@ protected:
 public:
 	CLayerTiles(CEditor *pEditor, int w, int h);
 	CLayerTiles(const CLayerTiles &Other);
-	~CLayerTiles();
+	~CLayerTiles() override;
 
 	[[nodiscard]] virtual CTile GetTile(int x, int y) const;
 	virtual void SetTile(int x, int y, CTile Tile);

--- a/src/game/editor/mapitems/layer_tune.h
+++ b/src/game/editor/mapitems/layer_tune.h
@@ -19,7 +19,7 @@ class CLayerTune : public CLayerTiles
 public:
 	CLayerTune(CEditor *pEditor, int w, int h);
 	CLayerTune(const CLayerTune &Other);
-	~CLayerTune();
+	~CLayerTune() override;
 
 	CTuneTile *m_pTuneTile;
 	unsigned char m_TuningNumber;

--- a/src/game/editor/mapitems/sound.h
+++ b/src/game/editor/mapitems/sound.h
@@ -8,7 +8,7 @@ class CEditorSound : public CEditorComponent
 {
 public:
 	explicit CEditorSound(CEditor *pEditor);
-	~CEditorSound();
+	~CEditorSound() override;
 
 	int m_SoundId = -1;
 	char m_aName[IO_MAX_PATH_LENGTH] = "";

--- a/src/game/map/render_layer.h
+++ b/src/game/map/render_layer.h
@@ -48,7 +48,6 @@ class CRenderLayer : public CRenderComponent
 {
 public:
 	CRenderLayer(int GroupId, int LayerId, int Flags);
-	virtual ~CRenderLayer() = default;
 	virtual void OnInit(IGraphics *pGraphics, ITextRender *pTextRender, CRenderMap *pRenderMap, std::shared_ptr<CEnvelopeManager> &pEnvelopeManager, IMap *pMap, IMapImages *pMapImages, std::optional<FRenderUploadCallback> &FRenderUploadCallbackOptional);
 
 	virtual void Init() = 0;
@@ -79,7 +78,7 @@ class CRenderLayerGroup : public CRenderLayer
 {
 public:
 	CRenderLayerGroup(int GroupId, CMapItemGroup *pGroup);
-	virtual ~CRenderLayerGroup() = default;
+	~CRenderLayerGroup() override = default;
 	void Init() override {}
 	void Render(const CRenderLayerParams &Params) override;
 	bool DoRender(const CRenderLayerParams &Params) override;
@@ -97,7 +96,7 @@ class CRenderLayerTile : public CRenderLayer
 {
 public:
 	CRenderLayerTile(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
-	virtual ~CRenderLayerTile() = default;
+	~CRenderLayerTile() override = default;
 	void Render(const CRenderLayerParams &Params) override;
 	bool DoRender(const CRenderLayerParams &Params) override;
 	void Init() override;
@@ -211,14 +210,14 @@ class CRenderLayerQuads : public CRenderLayer
 public:
 	CRenderLayerQuads(int GroupId, int LayerId, int Flags, CMapItemLayerQuads *pLayerQuads);
 	void OnInit(IGraphics *pGraphics, ITextRender *pTextRender, CRenderMap *pRenderMap, std::shared_ptr<CEnvelopeManager> &pEnvelopeManager, IMap *pMap, IMapImages *pMapImages, std::optional<FRenderUploadCallback> &FRenderUploadCallbackOptional) override;
-	virtual void Init() override;
+	void Init() override;
 	bool IsValid() const override { return m_pLayerQuads->m_NumQuads > 0 && m_pQuads; }
-	virtual void Render(const CRenderLayerParams &Params) override;
-	virtual bool DoRender(const CRenderLayerParams &Params) override;
+	void Render(const CRenderLayerParams &Params) override;
+	bool DoRender(const CRenderLayerParams &Params) override;
 	void Unload() override;
 
 protected:
-	virtual IGraphics::CTextureHandle GetTexture() const override { return m_TextureHandle; }
+	IGraphics::CTextureHandle GetTexture() const override { return m_TextureHandle; }
 	void CalculateClipping();
 	bool CalculateQuadClipping(int aQuadOffsetMin[2], int aQuadOffsetMax[2], bool Grouped);
 
@@ -267,7 +266,7 @@ class CRenderLayerEntityBase : public CRenderLayerTile
 {
 public:
 	CRenderLayerEntityBase(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
-	virtual ~CRenderLayerEntityBase() = default;
+	~CRenderLayerEntityBase() override = default;
 	bool DoRender(const CRenderLayerParams &Params) override;
 
 protected:

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -204,7 +204,7 @@ public:
 
 	CGameContext();
 	CGameContext(int Reset);
-	~CGameContext();
+	~CGameContext() override;
 
 	void Clear();
 

--- a/src/game/server/gamemodes/DDRace.h
+++ b/src/game/server/gamemodes/DDRace.h
@@ -8,7 +8,7 @@ class CGameControllerDDRace : public IGameController
 {
 public:
 	CGameControllerDDRace(class CGameContext *pGameServer);
-	~CGameControllerDDRace();
+	~CGameControllerDDRace() override;
 
 	CScore *Score();
 

--- a/src/game/server/gamemodes/mod.h
+++ b/src/game/server/gamemodes/mod.h
@@ -7,7 +7,7 @@ class CGameControllerMod : public IGameController
 {
 public:
 	CGameControllerMod(class CGameContext *pGameServer);
-	~CGameControllerMod();
+	~CGameControllerMod() override;
 
 	void Tick() override;
 };


### PR DESCRIPTION
Should fix all `modernize-use-override` warnings for clang-tidy in header files https://github.com/ddnet/ddnet/pull/10588
Added missing `override`s, removed unnecessary default destructors from interfaces that inherit other virtual classes

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
