### PR TITLE
Minor improvements to `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ A non-exhaustive list of things that usually get rejected:
 
 Check the [list of issues](https://github.com/ddnet/ddnet/issues) to find issues to work on.
 Unlabeled issues have not been triaged yet and are usually not good candidates.
-Furthermore, the label https://github.com/ddnet/ddnet/labels/needs-discussion indicate issues that still need discussion before they can be implemented and issues with the label https://github.com/ddnet/ddnet/labels/fix-changes-physics are too involved for new contributors.
+Furthermore, the label https://github.com/ddnet/ddnet/labels/needs-discussion indicates issues that still need discussion before they can be implemented and issues with the label https://github.com/ddnet/ddnet/labels/fix-changes-physics are too involved for new contributors.
 Working on issues with the labels https://github.com/ddnet/ddnet/labels/good%20first%20issue, https://github.com/ddnet/ddnet/labels/bug and https://github.com/ddnet/ddnet/labels/feature-accepted is recommended.
 Make sure the issue is not already being worked on by someone else, by checking its assignment and whether there are open pull requests linked to it.
 If you would like to work on an issue, please comment on it to be assigned to it or if you have any questions.
@@ -44,15 +44,15 @@ code.
 There are a few style rules. Some of them are enforced by CI and some of them are manually checked by reviewers.
 If your github pipeline shows some errors please have a look at the logs and try to fix them.
 
-Such fix commits should ideally be squashed into one big commit using ``git commit --amend`` or ``git rebase -i``.
+Such fix commits should ideally be squashed into one big commit using `git commit --amend` or `git rebase -i`.
 
-A lot of the style offenses can be fixed automatically by running the fix script `./scripts/fix_style.py`
+A lot of the style offenses can be fixed automatically by running the fix script `./scripts/fix_style.py`.
 
-We use clang-format 10. If your package manager no longer provides this version, you can download it from https://pypi.org/project/clang-format/10.0.1.1/.
+We use clang-format 10 to format C++ code. If your package manager no longer provides this version, you can download it from https://pypi.org/project/clang-format/10.0.1.1/.
 
 ### Upper camel case for variables, methods, class names
 
-With the exception of base/system.{h,cpp}
+With the exception of files in the `src/base` folder.
 
 For single words
 
@@ -96,13 +96,13 @@ for(int ClientId = 0; ClientId < MAX_CLIENTS; ClientId++)
 }
 ```
 
-More examples can be found [here](https://github.com/ddnet/ddnet/pull/8288#issuecomment-2094097306)
+More examples can be found [here](https://github.com/ddnet/ddnet/pull/8288#issuecomment-2094097306).
 
 ### Our interpretation of the hungarian notation
 
-DDNet inherited the hungarian notation like prefixes from [Teeworlds](https://www.teeworlds.com/?page=docs&wiki=nomenclature)
+DDNet inherited the hungarian notation like prefixes from [Teeworlds](https://www.teeworlds.com/?page=docs&wiki=nomenclature).
 
-Only use the prefixes listed below. The ddnet code base does **NOT** follow the whole hungarian notation strictly.
+Only use the prefixes listed below. The DDNet code base does **NOT** follow the whole hungarian notation strictly.
 
 Do **NOT** use `c` for constants or `b` for booleans or `i` for integers.
 
@@ -121,7 +121,7 @@ C-style function pointers are pointers, but `std::function` are not.
 | `pfn` | Function pointers (NOT `std::function`) | `m_pfnUnknownCommandCallback = pfnCallback` |
 | `F` | Function type definitions | `typedef void (*FCommandCallback)(IResult *pResult, void *pUserData)`, `typedef std::function<int()> FButtonColorCallback` |
 
-Combine these appropriately
+Combine these appropriately.
 
 #### For classes
 
@@ -242,9 +242,9 @@ Constants can be static ✅:
 static constexpr int ANSWER = 42;
 ```
 
-### Getters should not have a Get prefix
+### Getters should not have a `Get` prefix
 
-While the code base already has a lot of methods that start with a ``Get`` prefix. If new getters are added they should not contain a prefix.
+While the code base already has a lot of methods that start with a `Get` prefix. If new getters are added they should not contain a prefix.
 
 ❌
 
@@ -280,6 +280,8 @@ class CFoo
 
 ### The usage of `class` should be favored over `struct`
 
+While there are still many `struct`s being used in the code, all new code should only use `class`es.
+
 ### Modern C++ should be used instead of old C styled code
 
 DDNet balances in being portable (easy to compile on all common distributions) and using modern features.
@@ -298,7 +300,7 @@ See https://github.com/ddnet/ddnet/issues/6436
 
 ### Filenames
 
-Code file names should be all lowercase and words should be separated with underscores.
+Names of files and folders should be all lowercase and words should be separated with underscores.
 
 ❌
 
@@ -318,7 +320,7 @@ Code documentation is required for all public declarations of functions, classes
 For other code, documentation is recommended for functions, classes etc. intended for reuse or when it improves clarity.
 
 We use [doxygen](https://www.doxygen.nl/) to generate code documentation.
-The documentation is updated regularly and available at https://codedoc.ddnet.org/
+The documentation is updated regularly and available at https://codedoc.ddnet.org/.
 
 We use [Javadoc style block comments](https://www.doxygen.nl/manual/docblocks.html) and prefix [doxygen commands](https://www.doxygen.nl/manual/commands.html) with `@`, not with `\`.
 


### PR DESCRIPTION
- Generalize point about filenames to names of all files and folders.
- Add sentence explaining use of `class`es over `struct`s in new code.
- Make some explanations more precise.
- Use only one pair of backticks for inline code.
- Add periods at the ends of sentences.
- Fix spelling.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
