### PR TITLE
Order and group all `#include`s with Clang Format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -34,13 +34,28 @@ CommentPragmas: ''
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
+IncludeBlocks: Regroup
 IncludeCategories:
   - Regex:           '^"'
     Priority:        1
-  - Regex:           '^<(engine|game|mastersrv|versionsrv>'
+  - Regex:           '^<antibot/'
     Priority:        2
-  - Regex:           '.*'
+  - Regex:           '^<base/'
     Priority:        3
+  - Regex:           '^<engine/'
+    Priority:        4
+  - Regex:           '^<generated/'
+    Priority:        5
+  - Regex:           '^<game/'
+    Priority:        6
+  - Regex:           '^<android/'
+    Priority:        7
+  - Regex:           '^<steam/'
+    Priority:        8
+  - Regex:           '^<.*\.h>'
+    Priority:        9
+  - Regex:           '.*'
+    Priority:        10
 IncludeIsMainRegex: '$'
 IndentWidth: 8
 KeepEmptyLinesAtTheStartOfBlocks: false

--- a/src/android/android_main.cpp
+++ b/src/android/android_main.cpp
@@ -6,12 +6,11 @@
 
 #include <engine/shared/linereader.h>
 
-#include <string>
-#include <vector>
-
+#include <SDL.h>
 #include <jni.h>
 
-#include <SDL.h>
+#include <string>
+#include <vector>
 
 static bool UnpackAsset(const char *pFilename)
 {

--- a/src/base/color.cpp
+++ b/src/base/color.cpp
@@ -1,4 +1,5 @@
 #include "color.h"
+
 #include "system.h"
 
 template<typename T>

--- a/src/base/fs.cpp
+++ b/src/base/fs.cpp
@@ -12,8 +12,9 @@
 
 #elif defined(CONF_FAMILY_WINDOWS)
 #include <io.h>
-#include <string>
 #include <windows.h>
+
+#include <string>
 #else
 #error NOT IMPLEMENTED
 #endif

--- a/src/base/hash.cpp
+++ b/src/base/hash.cpp
@@ -1,6 +1,6 @@
 #include "hash.h"
-#include "hash_ctxt.h"
 
+#include "hash_ctxt.h"
 #include "system.h"
 
 const SHA256_DIGEST SHA256_ZEROED = {{0}};

--- a/src/base/hash_ctxt.h
+++ b/src/base/hash_ctxt.h
@@ -2,6 +2,7 @@
 #define BASE_HASH_CTXT_H
 
 #include "hash.h"
+
 #include <cstdint>
 
 #if defined(CONF_OPENSSL)

--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -1,6 +1,5 @@
-#include "logger.h"
-
 #include "color.h"
+#include "logger.h"
 #include "system.h"
 
 #include <atomic>

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -1,5 +1,12 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "system.h"
+
+#include "lock.h"
+#include "logger.h"
+
+#include <sys/types.h>
+
 #include <atomic>
 #include <cctype>
 #include <charconv>
@@ -15,35 +22,30 @@
 #include <sstream> // std::istringstream
 #include <string_view>
 
-#include "lock.h"
-#include "logger.h"
-#include "system.h"
-
-#include <sys/types.h>
-
 #if defined(CONF_WEBSOCKETS)
 #include <engine/shared/websockets.h>
 #endif
 
 #if defined(CONF_FAMILY_UNIX)
-#include <csignal>
-#include <locale>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/utsname.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <csignal>
+#include <locale>
+
 /* unix net includes */
 #include <arpa/inet.h>
-#include <cerrno>
+#include <dirent.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <pthread.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 
-#include <dirent.h>
+#include <cerrno>
 
 #if defined(CONF_PLATFORM_MACOS)
 // some lock and pthread functions are already defined in headers
@@ -63,12 +65,6 @@
 #endif
 
 #elif defined(CONF_FAMILY_WINDOWS)
-#include <windows.h>
-#include <winsock2.h>
-#include <ws2tcpip.h>
-
-#include <cerrno>
-#include <cfenv>
 #include <io.h>
 #include <objbase.h>
 #include <process.h>
@@ -77,6 +73,12 @@
 #include <shlobj.h> // SHChangeNotify, SHGetKnownFolderPath
 #include <shlwapi.h>
 #include <wincrypt.h>
+#include <windows.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+#include <cerrno>
+#include <cfenv>
 #else
 #error NOT IMPLEMENTED
 #endif

--- a/src/base/tl/threading.h
+++ b/src/base/tl/threading.h
@@ -2,6 +2,7 @@
 #define BASE_TL_THREADING_H
 
 #include "../system.h"
+
 #include <atomic>
 
 class CSemaphore

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -1,11 +1,11 @@
 #ifndef BASE_TYPES_H
 #define BASE_TYPES_H
 
+#include <base/detect.h>
+
 #include <cstdint>
 #include <ctime>
 #include <functional>
-
-#include <base/detect.h>
 
 #if defined(CONF_FAMILY_UNIX)
 #include <sys/types.h> // pid_t

--- a/src/base/vmath.h
+++ b/src/base/vmath.h
@@ -3,10 +3,10 @@
 #ifndef BASE_VMATH_H
 #define BASE_VMATH_H
 
+#include "math.h"
+
 #include <cmath>
 #include <cstdint>
-
-#include "math.h"
 
 // ------------------------------------
 

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -2,10 +2,10 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef ENGINE_CLIENT_H
 #define ENGINE_CLIENT_H
-#include "kernel.h"
-
 #include "graphics.h"
+#include "kernel.h"
 #include "message.h"
+
 #include <base/hash.h>
 
 #include <engine/client/enums.h>

--- a/src/engine/client/backend/backend_base.cpp
+++ b/src/engine/client/backend/backend_base.cpp
@@ -1,4 +1,5 @@
 #include "backend_base.h"
+
 #include <base/system.h>
 
 bool CCommandProcessorFragment_GLBase::Texture2DTo3D(uint8_t *pImageBuffer, int ImageWidth, int ImageHeight, size_t PixelSize, int SplitCountWidth, int SplitCountHeight, uint8_t *pTarget3DImageData, int &Target3DImageWidth, int &Target3DImageHeight)

--- a/src/engine/client/backend/backend_base.h
+++ b/src/engine/client/backend/backend_base.h
@@ -1,9 +1,8 @@
 #ifndef ENGINE_CLIENT_BACKEND_BACKEND_BASE_H
 #define ENGINE_CLIENT_BACKEND_BACKEND_BASE_H
 
-#include <engine/graphics.h>
-
 #include <engine/client/graphics_threaded.h>
+#include <engine/graphics.h>
 
 #include <SDL_video.h>
 

--- a/src/engine/client/backend/glsl_shader_compiler.cpp
+++ b/src/engine/client/backend/glsl_shader_compiler.cpp
@@ -1,6 +1,7 @@
 #include "glsl_shader_compiler.h"
 
 #include <base/system.h>
+
 #include <engine/graphics.h>
 
 CGLSLCompiler::CGLSLCompiler(int OpenGLVersionMajor, int OpenGLVersionMinor, int OpenGLVersionPatch, bool IsOpenGLES, float TextureLODBias)

--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -1,20 +1,17 @@
 #include "backend_opengl.h"
 
-#include <engine/graphics.h>
-
-#include <engine/client/backend_sdl.h>
-
 #include <base/detect.h>
 #include <base/system.h>
 
+#include <engine/client/backend_sdl.h>
+#include <engine/graphics.h>
+
 #if defined(BACKEND_AS_OPENGL_ES) || !defined(CONF_BACKEND_OPENGL_ES)
 
+#include <engine/client/backend/glsl_shader_compiler.h>
 #include <engine/client/backend/opengl/opengl_sl.h>
 #include <engine/client/backend/opengl/opengl_sl_program.h>
 #include <engine/client/blocklist_driver.h>
-
-#include <engine/client/backend/glsl_shader_compiler.h>
-
 #include <engine/gfx/image_manipulation.h>
 
 #ifndef BACKEND_AS_OPENGL_ES

--- a/src/engine/client/backend/opengl/backend_opengl.h
+++ b/src/engine/client/backend/opengl/backend_opengl.h
@@ -12,9 +12,8 @@
 
 #include <base/system.h>
 
-#include <engine/client/graphics_defines.h>
-
 #include <engine/client/backend/backend_base.h>
+#include <engine/client/graphics_defines.h>
 
 class CGLSLTWProgram;
 class CGLSLPrimitiveProgram;

--- a/src/engine/client/backend/opengl/backend_opengl3.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl3.cpp
@@ -10,14 +10,11 @@
 #include <GLES3/gl3.h>
 #endif
 
-#include <engine/client/backend_sdl.h>
-
+#include <engine/client/backend/glsl_shader_compiler.h>
 #include <engine/client/backend/opengl/opengl_sl.h>
 #include <engine/client/backend/opengl/opengl_sl_program.h>
-
+#include <engine/client/backend_sdl.h>
 #include <engine/gfx/image_manipulation.h>
-
-#include <engine/client/backend/glsl_shader_compiler.h>
 
 #if defined(CONF_PLATFORM_EMSCRIPTEN)
 // WebGL2 defines the type of a buffer at the first bind to a buffer target

--- a/src/engine/client/backend/opengl/opengl_sl.cpp
+++ b/src/engine/client/backend/opengl/opengl_sl.cpp
@@ -5,14 +5,14 @@
 
 #if defined(BACKEND_AS_OPENGL_ES) || !defined(CONF_BACKEND_OPENGL_ES)
 
-#include <cstdio>
-#include <engine/shared/linereader.h>
-#include <engine/storage.h>
-#include <string>
-#include <vector>
-
 #include <engine/client/backend/glsl_shader_compiler.h>
 #include <engine/graphics.h>
+#include <engine/shared/linereader.h>
+#include <engine/storage.h>
+
+#include <cstdio>
+#include <string>
+#include <vector>
 
 #ifndef BACKEND_AS_OPENGL_ES
 #include <GL/glew.h>

--- a/src/engine/client/backend/opengl/opengl_sl_program.cpp
+++ b/src/engine/client/backend/opengl/opengl_sl_program.cpp
@@ -1,4 +1,5 @@
 #include "opengl_sl_program.h"
+
 #include "opengl_sl.h"
 
 #include <base/detect.h>

--- a/src/engine/client/backend/opengl/opengl_sl_program.h
+++ b/src/engine/client/backend/opengl/opengl_sl_program.h
@@ -12,6 +12,7 @@
 
 #include <base/color.h>
 #include <base/vmath.h>
+
 #include <engine/client/graphics_defines.h>
 
 class CGLSL;

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -1,8 +1,11 @@
 #if defined(CONF_BACKEND_VULKAN)
 
-#include <engine/client/backend/vulkan/backend_vulkan.h>
+#include <base/log.h>
+#include <base/math.h>
+#include <base/system.h>
 
 #include <engine/client/backend/backend_base.h>
+#include <engine/client/backend/vulkan/backend_vulkan.h>
 #include <engine/client/backend_sdl.h>
 #include <engine/client/graphics_threaded.h>
 #include <engine/gfx/image_manipulation.h>
@@ -11,9 +14,10 @@
 #include <engine/shared/localization.h>
 #include <engine/storage.h>
 
-#include <base/log.h>
-#include <base/math.h>
-#include <base/system.h>
+#include <SDL_video.h>
+#include <SDL_vulkan.h>
+#include <vulkan/vk_platform.h>
+#include <vulkan/vulkan_core.h>
 
 #include <algorithm>
 #include <array>
@@ -32,12 +36,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-#include <SDL_video.h>
-#include <SDL_vulkan.h>
-
-#include <vulkan/vk_platform.h>
-#include <vulkan/vulkan_core.h>
 
 #ifndef VK_API_VERSION_MAJOR
 #define VK_API_VERSION_MAJOR VK_VERSION_MAJOR

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -4,16 +4,16 @@
 #include <GL/glew.h>
 #endif
 
-#include <SDL.h>
-#include <SDL_messagebox.h>
-#include <SDL_vulkan.h>
-
 #include <base/log.h>
 #include <base/math.h>
 #include <base/tl/threading.h>
 
 #include <engine/shared/config.h>
 #include <engine/shared/localization.h>
+
+#include <SDL.h>
+#include <SDL_messagebox.h>
+#include <SDL_vulkan.h>
 
 #if defined(CONF_VIDEORECORDER)
 #include <engine/shared/video.h>

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -1,15 +1,13 @@
 #ifndef ENGINE_CLIENT_BACKEND_SDL_H
 #define ENGINE_CLIENT_BACKEND_SDL_H
 
-#include <SDL_video.h>
-
 #include <base/detect.h>
 
+#include <engine/client/backend/backend_base.h>
+#include <engine/client/graphics_threaded.h>
 #include <engine/graphics.h>
 
-#include <engine/client/graphics_threaded.h>
-
-#include <engine/client/backend/backend_base.h>
+#include <SDL_video.h>
 
 #include <atomic>
 #include <condition_variable>

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1,6 +1,12 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
+#include "client.h"
+
+#include "demoedit.h"
+#include "friends.h"
+#include "serverbrowser.h"
+
 #include <base/hash.h>
 #include <base/hash_ctxt.h>
 #include <base/log.h>
@@ -8,13 +14,12 @@
 #include <base/math.h>
 #include <base/system.h>
 
-#include <engine/external/json-parser/json.h>
-
 #include <engine/config.h>
 #include <engine/console.h>
 #include <engine/discord.h>
 #include <engine/editor.h>
 #include <engine/engine.h>
+#include <engine/external/json-parser/json.h>
 #include <engine/favorites.h>
 #include <engine/graphics.h>
 #include <engine/input.h>
@@ -22,11 +27,6 @@
 #include <engine/map.h>
 #include <engine/notifications.h>
 #include <engine/serverbrowser.h>
-#include <engine/sound.h>
-#include <engine/steam.h>
-#include <engine/storage.h>
-#include <engine/textrender.h>
-
 #include <engine/shared/assertion_logger.h>
 #include <engine/shared/compression.h>
 #include <engine/shared/config.h>
@@ -44,6 +44,10 @@
 #include <engine/shared/rust_version.h>
 #include <engine/shared/snapshot.h>
 #include <engine/shared/uuid_manager.h>
+#include <engine/sound.h>
+#include <engine/steam.h>
+#include <engine/storage.h>
+#include <engine/textrender.h>
 
 #include <generated/protocol.h>
 #include <generated/protocol7.h>
@@ -51,11 +55,6 @@
 
 #include <game/localization.h>
 #include <game/version.h>
-
-#include "client.h"
-#include "demoedit.h"
-#include "friends.h"
-#include "serverbrowser.h"
 
 #if defined(CONF_VIDEORECORDER)
 #include "video.h"

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -3,6 +3,9 @@
 #ifndef ENGINE_CLIENT_CLIENT_H
 #define ENGINE_CLIENT_CLIENT_H
 
+#include "graph.h"
+#include "smooth_time.h"
+
 #include <base/hash.h>
 #include <base/types.h>
 
@@ -21,9 +24,6 @@
 #include <engine/shared/network.h>
 #include <engine/textrender.h>
 #include <engine/warning.h>
-
-#include "graph.h"
-#include "smooth_time.h"
 
 #include <chrono>
 #include <deque>

--- a/src/engine/client/discord.cpp
+++ b/src/engine/client/discord.cpp
@@ -1,4 +1,5 @@
 #include <base/system.h>
+
 #include <engine/client.h>
 #include <engine/discord.h>
 

--- a/src/engine/client/favorites.cpp
+++ b/src/engine/client/favorites.cpp
@@ -1,5 +1,6 @@
 #include <base/log.h>
 #include <base/system.h>
+
 #include <engine/favorites.h>
 #include <engine/shared/config.h>
 #include <engine/shared/protocol.h>

--- a/src/engine/client/friends.cpp
+++ b/src/engine/client/friends.cpp
@@ -1,13 +1,13 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "friends.h"
+
 #include <base/math.h>
 #include <base/system.h>
 
 #include <engine/config.h>
 #include <engine/console.h>
 #include <engine/shared/config.h>
-
-#include "friends.h"
 
 CFriends::CFriends()
 {

--- a/src/engine/client/graphics_threaded_sprites.cpp
+++ b/src/engine/client/graphics_threaded_sprites.cpp
@@ -1,4 +1,5 @@
 #include "graphics_threaded.h"
+
 #include <engine/graphics.h>
 
 #include <generated/client_data.h>

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -1,16 +1,18 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#include <SDL.h>
+#include "input.h"
+
+#include "keynames.h"
 
 #include <base/system.h>
+
 #include <engine/console.h>
 #include <engine/graphics.h>
 #include <engine/input.h>
 #include <engine/keys.h>
 #include <engine/shared/config.h>
 
-#include "input.h"
-#include "keynames.h"
+#include <SDL.h>
 
 // support older SDL version (pre 2.0.6)
 #ifndef SDL_JOYSTICK_AXIS_MIN

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -3,12 +3,12 @@
 #ifndef ENGINE_CLIENT_INPUT_H
 #define ENGINE_CLIENT_INPUT_H
 
-#include <SDL_events.h>
-#include <SDL_joystick.h>
 #include <engine/console.h>
-
 #include <engine/input.h>
 #include <engine/keys.h>
+
+#include <SDL_events.h>
+#include <SDL_joystick.h>
 
 #include <string>
 #include <vector>

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -5,15 +5,15 @@
 #include "serverbrowser_http.h"
 #include "serverbrowser_ping_cache.h"
 
-#include <algorithm>
-#include <map>
-#include <set>
-#include <vector>
-
 #include <base/hash_ctxt.h>
 #include <base/log.h>
 #include <base/system.h>
 
+#include <engine/console.h>
+#include <engine/engine.h>
+#include <engine/favorites.h>
+#include <engine/friends.h>
+#include <engine/http.h>
 #include <engine/shared/config.h>
 #include <engine/shared/json.h>
 #include <engine/shared/masterserver.h>
@@ -21,13 +21,12 @@
 #include <engine/shared/packer.h>
 #include <engine/shared/protocol.h>
 #include <engine/shared/serverinfo.h>
-
-#include <engine/console.h>
-#include <engine/engine.h>
-#include <engine/favorites.h>
-#include <engine/friends.h>
-#include <engine/http.h>
 #include <engine/storage.h>
+
+#include <algorithm>
+#include <map>
+#include <set>
+#include <vector>
 
 class CSortWrap
 {

--- a/src/engine/client/serverbrowser_http.cpp
+++ b/src/engine/client/serverbrowser_http.cpp
@@ -1,5 +1,9 @@
 #include "serverbrowser_http.h"
 
+#include <base/lock.h>
+#include <base/log.h>
+#include <base/system.h>
+
 #include <engine/console.h>
 #include <engine/engine.h>
 #include <engine/external/json-parser/json.h>
@@ -10,14 +14,9 @@
 #include <engine/shared/serverinfo.h>
 #include <engine/storage.h>
 
-#include <base/lock.h>
-#include <base/log.h>
-#include <base/system.h>
-
+#include <chrono>
 #include <memory>
 #include <vector>
-
-#include <chrono>
 
 using namespace std::chrono_literals;
 

--- a/src/engine/client/serverbrowser_ping_cache.cpp
+++ b/src/engine/client/serverbrowser_ping_cache.cpp
@@ -1,6 +1,7 @@
 #include "serverbrowser_ping_cache.h"
 
 #include <base/system.h>
+
 #include <engine/console.h>
 #include <engine/sqlite.h>
 

--- a/src/engine/client/smooth_time.cpp
+++ b/src/engine/client/smooth_time.cpp
@@ -1,11 +1,12 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
-#include <base/math.h>
-#include <base/system.h>
+#include "smooth_time.h"
 
 #include "graph.h"
-#include "smooth_time.h"
+
+#include <base/math.h>
+#include <base/system.h>
 
 void CSmoothTime::Init(int64_t Target)
 {

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -1,6 +1,6 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#include <SDL.h>
+#include "sound.h"
 
 #include <base/math.h>
 #include <base/system.h>
@@ -9,7 +9,7 @@
 #include <engine/shared/config.h>
 #include <engine/storage.h>
 
-#include "sound.h"
+#include <SDL.h>
 
 #if defined(CONF_VIDEORECORDER)
 #include <engine/shared/video.h>

--- a/src/engine/client/sqlite.cpp
+++ b/src/engine/client/sqlite.cpp
@@ -1,4 +1,5 @@
 #include <base/system.h>
+
 #include <engine/console.h>
 #include <engine/sqlite.h>
 

--- a/src/engine/client/steam.cpp
+++ b/src/engine/client/steam.cpp
@@ -1,7 +1,7 @@
-#include <engine/steam.h>
-
 #include <base/system.h>
+
 #include <engine/shared/config.h>
+#include <engine/steam.h>
 
 #include <steam/steam_api_flat.h>
 

--- a/src/engine/client/updater.cpp
+++ b/src/engine/client/updater.cpp
@@ -1,6 +1,7 @@
+#include "updater.h"
+
 #include <base/system.h>
 
-#include "updater.h"
 #include <engine/client.h>
 #include <engine/engine.h>
 #include <engine/external/json-parser/json.h>

--- a/src/engine/client/warning.cpp
+++ b/src/engine/client/warning.cpp
@@ -1,6 +1,6 @@
-#include <engine/warning.h>
-
 #include <base/system.h>
+
+#include <engine/warning.h>
 
 SWarning::SWarning(const SWarning &Other)
 {

--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -4,7 +4,9 @@
 #define ENGINE_CONSOLE_H
 
 #include "kernel.h"
+
 #include <base/color.h>
+
 #include <engine/storage.h>
 
 #include <memory>

--- a/src/engine/demo.h
+++ b/src/engine/demo.h
@@ -4,7 +4,9 @@
 #define ENGINE_DEMO_H
 
 #include "kernel.h"
+
 #include <base/hash.h>
+
 #include <engine/map.h>
 #include <engine/shared/uuid_manager.h>
 

--- a/src/engine/discord.h
+++ b/src/engine/discord.h
@@ -2,7 +2,9 @@
 #define ENGINE_DISCORD_H
 
 #include "kernel.h"
+
 #include <base/types.h>
+
 #include <engine/serverbrowser.h>
 
 class IDiscord : public IInterface

--- a/src/engine/favorites.h
+++ b/src/engine/favorites.h
@@ -1,12 +1,13 @@
 #ifndef ENGINE_FAVORITES_H
 #define ENGINE_FAVORITES_H
 
-#include <memory>
+#include "kernel.h"
 
 #include <base/types.h>
+
 #include <engine/shared/protocol.h>
 
-#include "kernel.h"
+#include <memory>
 
 class IConfigManager;
 

--- a/src/engine/friends.h
+++ b/src/engine/friends.h
@@ -3,9 +3,9 @@
 #ifndef ENGINE_FRIENDS_H
 #define ENGINE_FRIENDS_H
 
-#include <engine/shared/protocol.h>
-
 #include "kernel.h"
+
+#include <engine/shared/protocol.h>
 
 struct CFriendInfo
 {

--- a/src/engine/gfx/image_loader.cpp
+++ b/src/engine/gfx/image_loader.cpp
@@ -3,10 +3,10 @@
 #include <base/log.h>
 #include <base/system.h>
 
+#include <png.h>
+
 #include <csetjmp>
 #include <cstdlib>
-
-#include <png.h>
 
 bool CByteBufferReader::Read(void *pData, size_t Size)
 {

--- a/src/engine/ghost.h
+++ b/src/engine/ghost.h
@@ -1,10 +1,11 @@
 #ifndef ENGINE_GHOST_H
 #define ENGINE_GHOST_H
 
-#include <base/hash.h>
-#include <engine/shared/protocol.h>
-
 #include "kernel.h"
+
+#include <base/hash.h>
+
+#include <engine/shared/protocol.h>
 
 class CGhostInfo
 {

--- a/src/engine/http.h
+++ b/src/engine/http.h
@@ -2,6 +2,7 @@
 #define ENGINE_HTTP_H
 
 #include "kernel.h"
+
 #include <memory>
 
 class IHttpRequest

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -1,9 +1,9 @@
 #ifndef ENGINE_IMAGE_H
 #define ENGINE_IMAGE_H
 
-#include <cstdint>
-
 #include <base/color.h>
+
+#include <cstdint>
 
 /**
  * Represents an image that has been loaded into main memory.

--- a/src/engine/map.h
+++ b/src/engine/map.h
@@ -4,6 +4,7 @@
 #define ENGINE_MAP_H
 
 #include "kernel.h"
+
 #include <base/hash.h>
 #include <base/types.h>
 

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -3,21 +3,23 @@
 #ifndef ENGINE_SERVER_H
 #define ENGINE_SERVER_H
 
-#include <array>
-#include <optional>
-#include <type_traits>
+#include "kernel.h"
+#include "message.h"
 
 #include <base/hash.h>
 #include <base/math.h>
 #include <base/system.h>
 
-#include "kernel.h"
-#include "message.h"
 #include <engine/shared/jsonwriter.h>
 #include <engine/shared/protocol.h>
+
 #include <generated/protocol.h>
 #include <generated/protocol7.h>
 #include <generated/protocolglue.h>
+
+#include <array>
+#include <optional>
+#include <type_traits>
 
 struct CAntibotRoundData;
 

--- a/src/engine/server/antibot.h
+++ b/src/engine/server/antibot.h
@@ -2,6 +2,7 @@
 #define ENGINE_SERVER_ANTIBOT_H
 
 #include <antibot/antibot_data.h>
+
 #include <engine/antibot.h>
 
 class CAntibot : public IEngineAntibot

--- a/src/engine/server/authmanager.cpp
+++ b/src/engine/server/authmanager.cpp
@@ -1,7 +1,10 @@
 #include "authmanager.h"
+
 #include <base/hash_ctxt.h>
 #include <base/system.h>
+
 #include <engine/shared/config.h>
+
 #include <generated/protocol.h>
 
 #define ADMIN_IDENT "default_admin"

--- a/src/engine/server/authmanager.h
+++ b/src/engine/server/authmanager.h
@@ -1,9 +1,9 @@
 #ifndef ENGINE_SERVER_AUTHMANAGER_H
 #define ENGINE_SERVER_AUTHMANAGER_H
 
-#include <vector>
-
 #include <base/hash.h>
+
+#include <vector>
 
 #define SALT_BYTES 8
 

--- a/src/engine/server/databases/connection.h
+++ b/src/engine/server/databases/connection.h
@@ -4,6 +4,7 @@
 #include "connection_pool.h"
 
 #include <engine/shared/protocol.h>
+
 #include <memory>
 
 enum

--- a/src/engine/server/databases/connection_pool.cpp
+++ b/src/engine/server/databases/connection_pool.cpp
@@ -1,12 +1,14 @@
 #include "connection_pool.h"
+
 #include "connection.h"
-#include <engine/shared/config.h>
 
 #include <base/system.h>
-#include <cstring>
+
 #include <engine/console.h>
+#include <engine/shared/config.h>
 
 #include <chrono>
+#include <cstring>
 #include <iterator>
 #include <memory>
 #include <thread>

--- a/src/engine/server/databases/connection_pool.h
+++ b/src/engine/server/databases/connection_pool.h
@@ -1,8 +1,9 @@
 #ifndef ENGINE_SERVER_DATABASES_CONNECTION_POOL_H
 #define ENGINE_SERVER_DATABASES_CONNECTION_POOL_H
 
-#include <atomic>
 #include <base/tl/threading.h>
+
+#include <atomic>
 #include <memory>
 #include <vector>
 

--- a/src/engine/server/databases/mysql.cpp
+++ b/src/engine/server/databases/mysql.cpp
@@ -3,10 +3,11 @@
 #include <engine/server/databases/connection_pool.h>
 
 #if defined(CONF_MYSQL)
-#include <mysql.h>
-
 #include <base/tl/threading.h>
+
 #include <engine/console.h>
+
+#include <mysql.h>
 
 #include <atomic>
 #include <memory>

--- a/src/engine/server/databases/sqlite.cpp
+++ b/src/engine/server/databases/sqlite.cpp
@@ -1,9 +1,10 @@
 #include "connection.h"
 
-#include <sqlite3.h>
-
 #include <base/math.h>
+
 #include <engine/console.h>
+
+#include <sqlite3.h>
 
 #include <atomic>
 

--- a/src/engine/server/main.cpp
+++ b/src/engine/server/main.cpp
@@ -5,15 +5,13 @@
 #include <engine/engine.h>
 #include <engine/map.h>
 #include <engine/server.h>
-#include <engine/storage.h>
-
 #include <engine/server/antibot.h>
 #include <engine/server/databases/connection.h>
 #include <engine/server/server.h>
 #include <engine/server/server_logger.h>
-
 #include <engine/shared/assertion_logger.h>
 #include <engine/shared/config.h>
+#include <engine/storage.h>
 
 #include <game/version.h>
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3,6 +3,10 @@
 
 #include "server.h"
 
+#include "databases/connection.h"
+#include "databases/connection_pool.h"
+#include "register.h"
+
 #include <base/logger.h>
 #include <base/math.h>
 #include <base/system.h>
@@ -12,8 +16,6 @@
 #include <engine/engine.h>
 #include <engine/map.h>
 #include <engine/server.h>
-#include <engine/storage.h>
-
 #include <engine/shared/compression.h>
 #include <engine/shared/config.h>
 #include <engine/shared/console.h>
@@ -25,6 +27,7 @@
 #include <engine/shared/http.h>
 #include <engine/shared/json.h>
 #include <engine/shared/jsonwriter.h>
+#include <engine/shared/linereader.h>
 #include <engine/shared/masterserver.h>
 #include <engine/shared/netban.h>
 #include <engine/shared/network.h>
@@ -34,18 +37,14 @@
 #include <engine/shared/protocol_ex.h>
 #include <engine/shared/rust_version.h>
 #include <engine/shared/snapshot.h>
+#include <engine/storage.h>
 
 #include <game/version.h>
 
-#include <engine/shared/linereader.h>
-#include <vector>
 #include <zlib.h>
 
-#include "databases/connection.h"
-#include "databases/connection_pool.h"
-#include "register.h"
-
 #include <chrono>
+#include <vector>
 
 using namespace std::chrono_literals;
 

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -3,11 +3,15 @@
 #ifndef ENGINE_SERVER_SERVER_H
 #define ENGINE_SERVER_SERVER_H
 
+#include "antibot.h"
+#include "authmanager.h"
+#include "name_ban.h"
+#include "snap_id_pool.h"
+
 #include <base/hash.h>
 
 #include <engine/console.h>
 #include <engine/server.h>
-
 #include <engine/shared/demo.h>
 #include <engine/shared/econ.h>
 #include <engine/shared/fifo.h>
@@ -21,11 +25,6 @@
 #include <memory>
 #include <optional>
 #include <vector>
-
-#include "antibot.h"
-#include "authmanager.h"
-#include "name_ban.h"
-#include "snap_id_pool.h"
 
 #if defined(CONF_UPNP)
 #include "upnp.h"

--- a/src/engine/server/sql_string_helpers.cpp
+++ b/src/engine/server/sql_string_helpers.cpp
@@ -1,6 +1,7 @@
 #include "sql_string_helpers.h"
 
 #include <base/system.h>
+
 #include <cmath>
 
 void sqlstr::FuzzyString(char *pString, int Size)

--- a/src/engine/server/upnp.cpp
+++ b/src/engine/server/upnp.cpp
@@ -1,9 +1,13 @@
 #ifdef CONF_UPNP
 
 #include "upnp.h"
+
 #include <base/system.h>
+
 #include <engine/shared/config.h>
+
 #include <game/version.h>
+
 #include <miniupnpc/miniupnpc.h>
 #include <miniupnpc/upnpcommands.h>
 #include <miniupnpc/upnperrors.h>

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -3,6 +3,8 @@
 #ifndef ENGINE_SERVERBROWSER_H
 #define ENGINE_SERVERBROWSER_H
 
+#include "kernel.h"
+
 #include <base/hash.h>
 #include <base/system.h>
 
@@ -10,8 +12,6 @@
 #include <engine/shared/protocol.h>
 
 #include <generated/protocol7.h>
-
-#include "kernel.h"
 
 #include <unordered_set>
 #include <vector>

--- a/src/engine/shared/compression.cpp
+++ b/src/engine/shared/compression.cpp
@@ -1,8 +1,8 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#include <base/system.h>
-
 #include "compression.h"
+
+#include <base/system.h>
 
 #include <iterator> // std::size
 

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -1,6 +1,11 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
+#include "console.h"
+
+#include "config.h"
+#include "linereader.h"
+
 #include <base/color.h>
 #include <base/log.h>
 #include <base/math.h>
@@ -10,10 +15,6 @@
 #include <engine/console.h>
 #include <engine/shared/protocol.h>
 #include <engine/storage.h>
-
-#include "config.h"
-#include "console.h"
-#include "linereader.h"
 
 #include <algorithm>
 #include <iterator> // std::size

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -3,6 +3,8 @@
 
 #include "datafile.h"
 
+#include "uuid_manager.h"
+
 #include <base/hash_ctxt.h>
 #include <base/log.h>
 #include <base/math.h>
@@ -10,13 +12,11 @@
 
 #include <engine/storage.h>
 
-#include "uuid_manager.h"
+#include <zlib.h>
 
 #include <cstdlib>
 #include <limits>
 #include <unordered_set>
-
-#include <zlib.h>
 
 static constexpr int MAX_ITEM_TYPE = 0xFFFF;
 static constexpr int MAX_ITEM_ID = 0xFFFF;

--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -3,12 +3,12 @@
 #ifndef ENGINE_SHARED_DATAFILE_H
 #define ENGINE_SHARED_DATAFILE_H
 
-#include <engine/storage.h>
+#include "uuid_manager.h"
 
 #include <base/hash.h>
 #include <base/types.h>
 
-#include "uuid_manager.h"
+#include <engine/storage.h>
 
 #include <cstdint>
 #include <map>

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -5,9 +5,8 @@
 #include <base/system.h>
 
 #include <engine/console.h>
-#include <engine/storage.h>
-
 #include <engine/shared/config.h>
+#include <engine/storage.h>
 
 #if defined(CONF_VIDEORECORDER)
 #include <engine/shared/video.h>

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -3,6 +3,8 @@
 #ifndef ENGINE_SHARED_DEMO_H
 #define ENGINE_SHARED_DEMO_H
 
+#include "snapshot.h"
+
 #include <base/hash.h>
 
 #include <engine/demo.h>
@@ -10,8 +12,6 @@
 
 #include <functional>
 #include <vector>
-
-#include "snapshot.h"
 
 typedef std::function<void()> TUpdateIntraTimesFunc;
 

--- a/src/engine/shared/econ.cpp
+++ b/src/engine/shared/econ.cpp
@@ -1,8 +1,9 @@
+#include "econ.h"
+
+#include "netban.h"
+
 #include <engine/console.h>
 #include <engine/shared/config.h>
-
-#include "econ.h"
-#include "netban.h"
 
 CEcon::CEcon() :
 	m_Ready(false)

--- a/src/engine/shared/fifo.cpp
+++ b/src/engine/shared/fifo.cpp
@@ -3,11 +3,12 @@
 #include <base/system.h>
 #if defined(CONF_FAMILY_UNIX)
 
-#include <cstdlib>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+
+#include <cstdlib>
 
 void CFifo::Init(IConsole *pConsole, const char *pFifoFile, int Flag)
 {

--- a/src/engine/shared/fifo.h
+++ b/src/engine/shared/fifo.h
@@ -2,6 +2,7 @@
 #define ENGINE_SHARED_FIFO_H
 
 #include <base/detect.h>
+
 #include <engine/console.h>
 
 class CFifo

--- a/src/engine/shared/filecollection.cpp
+++ b/src/engine/shared/filecollection.cpp
@@ -1,12 +1,13 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
-#include <algorithm>
+#include "filecollection.h"
+
 #include <base/math.h>
 
 #include <engine/storage.h>
 
-#include "filecollection.h"
+#include <algorithm>
 
 void CFileCollection::Init(IStorage *pStorage, const char *pPath, const char *pFileDesc, const char *pFileExt, int MaxEntries)
 {

--- a/src/engine/shared/http.cpp
+++ b/src/engine/shared/http.cpp
@@ -3,9 +3,11 @@
 #include <base/log.h>
 #include <base/math.h>
 #include <base/system.h>
+
 #include <engine/external/json-parser/json.h>
 #include <engine/shared/config.h>
 #include <engine/storage.h>
+
 #include <game/version.h>
 
 #include <limits>

--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -4,6 +4,7 @@
 #include <base/hash_ctxt.h>
 #include <base/system.h>
 
+#include <engine/http.h>
 #include <engine/shared/jobs.h>
 
 #include <algorithm>
@@ -13,8 +14,6 @@
 #include <mutex>
 #include <optional>
 #include <unordered_map>
-
-#include <engine/http.h>
 
 typedef struct _json_value json_value;
 class IStorage;

--- a/src/engine/shared/huffman.cpp
+++ b/src/engine/shared/huffman.cpp
@@ -1,8 +1,10 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "huffman.h"
-#include <algorithm>
+
 #include <base/system.h>
+
+#include <algorithm>
 
 const unsigned CHuffman::ms_aFreqTable[HUFFMAN_MAX_SYMBOLS] = {
 	1 << 30, 4545, 2657, 431, 1950, 919, 444, 482, 2244, 617, 838, 542, 715, 1814, 304, 240, 754, 212, 647, 186,

--- a/src/engine/shared/jobs.cpp
+++ b/src/engine/shared/jobs.cpp
@@ -1,6 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "jobs.h"
+
 #include <algorithm>
 
 IJob::IJob() :

--- a/src/engine/shared/json.cpp
+++ b/src/engine/shared/json.cpp
@@ -1,4 +1,5 @@
 #include <base/system.h>
+
 #include <engine/shared/json.h>
 
 const struct _json_value *json_object_get(const json_value *pObject, const char *pIndex)

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -3,9 +3,10 @@
 #ifndef ENGINE_SHARED_MAP_H
 #define ENGINE_SHARED_MAP_H
 
+#include "datafile.h"
+
 #include <base/types.h>
 
-#include "datafile.h"
 #include <engine/map.h>
 
 class CMap : public IEngineMap

--- a/src/engine/shared/netban.cpp
+++ b/src/engine/shared/netban.cpp
@@ -1,10 +1,10 @@
+#include "netban.h"
+
 #include <base/math.h>
 
 #include <engine/console.h>
 #include <engine/shared/config.h>
 #include <engine/storage.h>
-
-#include "netban.h"
 
 CNetBan::CNetHash::CNetHash(const NETADDR *pAddr)
 {

--- a/src/engine/shared/netban.h
+++ b/src/engine/shared/netban.h
@@ -2,6 +2,7 @@
 #define ENGINE_SHARED_NETBAN_H
 
 #include <base/system.h>
+
 #include <engine/console.h>
 
 inline int NetComp(const NETADDR *pAddr1, const NETADDR *pAddr2)

--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -1,13 +1,14 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "network.h"
+
+#include "config.h"
+#include "huffman.h"
+
 #include <base/system.h>
 #include <base/types.h>
 
 #include <engine/shared/protocolglue.h>
-
-#include "config.h"
-#include "huffman.h"
-#include "network.h"
 
 const unsigned char SECURITY_TOKEN_MAGIC[4] = {'T', 'K', 'E', 'N'};
 

--- a/src/engine/shared/network_client.cpp
+++ b/src/engine/shared/network_client.cpp
@@ -1,8 +1,10 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "network.h"
+
 #include <base/system.h>
 #include <base/types.h>
+
 #include <engine/shared/protocol7.h>
 
 bool CNetClient::Open(NETADDR BindAddr)

--- a/src/engine/shared/network_console.cpp
+++ b/src/engine/shared/network_console.cpp
@@ -1,9 +1,9 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#include <base/system.h>
-
 #include "netban.h"
 #include "network.h"
+
+#include <base/system.h>
 
 bool CNetConsole::Open(NETADDR BindAddr, CNetBan *pNetBan)
 {

--- a/src/engine/shared/network_console_conn.cpp
+++ b/src/engine/shared/network_console_conn.cpp
@@ -1,6 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "network.h"
+
 #include <base/system.h>
 
 void CConsoleNetConnection::Reset()

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -1,12 +1,13 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "config.h"
+#include "netban.h"
+#include "network.h"
+
 #include <base/hash_ctxt.h>
 #include <base/math.h>
 #include <base/system.h>
 
-#include "config.h"
-#include "netban.h"
-#include "network.h"
 #include <engine/shared/compression.h>
 #include <engine/shared/packer.h>
 #include <engine/shared/protocol.h>

--- a/src/engine/shared/packer.cpp
+++ b/src/engine/shared/packer.cpp
@@ -1,9 +1,10 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#include <base/system.h>
+#include "packer.h"
 
 #include "compression.h"
-#include "packer.h"
+
+#include <base/system.h>
 
 CAbstractPacker::CAbstractPacker(unsigned char *pBuffer, size_t Size) :
 	m_pBuffer(pBuffer),

--- a/src/engine/shared/protocol.h
+++ b/src/engine/shared/protocol.h
@@ -3,8 +3,9 @@
 #ifndef ENGINE_SHARED_PROTOCOL_H
 #define ENGINE_SHARED_PROTOCOL_H
 
-#include <bitset>
 #include <engine/shared/protocol7.h>
+
+#include <bitset>
 
 /*
 	Connection diagram - How the initialization works.

--- a/src/engine/shared/protocol_ex.cpp
+++ b/src/engine/shared/protocol_ex.cpp
@@ -4,6 +4,7 @@
 #include "uuid_manager.h"
 
 #include <base/system.h>
+
 #include <engine/message.h>
 
 #include <new>

--- a/src/engine/shared/protocolglue.cpp
+++ b/src/engine/shared/protocolglue.cpp
@@ -1,10 +1,10 @@
+#include "protocolglue.h"
+
 #include <engine/shared/network.h>
 
 #include <generated/protocol.h>
 #include <generated/protocol7.h>
 #include <generated/protocolglue.h>
-
-#include "protocolglue.h"
 
 namespace protocol7
 {

--- a/src/engine/shared/serverinfo.cpp
+++ b/src/engine/shared/serverinfo.cpp
@@ -1,8 +1,10 @@
 #include "serverinfo.h"
 
 #include "json.h"
+
 #include <base/math.h>
 #include <base/system.h>
+
 #include <engine/external/json-parser/json.h>
 
 #include <cstdio>

--- a/src/engine/shared/sixup_translate_snapshot.cpp
+++ b/src/engine/shared/sixup_translate_snapshot.cpp
@@ -1,6 +1,6 @@
-#include <base/system.h>
-
 #include "snapshot.h"
+
+#include <base/system.h>
 
 void CSnapshotBuilder::Init7(const CSnapshot *pSnapshot)
 {

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -1,17 +1,18 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "snapshot.h"
+
 #include "compression.h"
 #include "uuid_manager.h"
-
-#include <cstdlib>
-#include <limits>
 
 #include <base/math.h>
 #include <base/system.h>
 
 #include <generated/protocol7.h>
 #include <generated/protocolglue.h>
+
+#include <cstdlib>
+#include <limits>
 
 // CSnapshot
 

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -3,11 +3,11 @@
 #ifndef ENGINE_SHARED_SNAPSHOT_H
 #define ENGINE_SHARED_SNAPSHOT_H
 
-#include <cstddef>
-#include <cstdint>
-
 #include <generated/protocol.h>
 #include <generated/protocol7.h>
+
+#include <cstddef>
+#include <cstdint>
 
 // CSnapshot
 

--- a/src/engine/shared/translation_context.cpp
+++ b/src/engine/shared/translation_context.cpp
@@ -1,6 +1,6 @@
-#include <base/system.h>
-
 #include "translation_context.h"
+
+#include <base/system.h>
 
 void CTranslationContext::Reset()
 {

--- a/src/engine/shared/translation_context.h
+++ b/src/engine/shared/translation_context.h
@@ -1,10 +1,10 @@
 #ifndef ENGINE_SHARED_TRANSLATION_CONTEXT_H
 #define ENGINE_SHARED_TRANSLATION_CONTEXT_H
 
-#include <engine/shared/protocol.h>
-#include <generated/protocol7.h>
-
 #include <engine/client/enums.h>
+#include <engine/shared/protocol.h>
+
+#include <generated/protocol7.h>
 
 class CTranslationContext
 {

--- a/src/engine/shared/uuid_manager.cpp
+++ b/src/engine/shared/uuid_manager.cpp
@@ -2,6 +2,7 @@
 
 #include <base/hash_ctxt.h>
 #include <base/system.h>
+
 #include <engine/shared/packer.h>
 
 #include <algorithm>

--- a/src/engine/sound.h
+++ b/src/engine/sound.h
@@ -3,10 +3,10 @@
 #ifndef ENGINE_SOUND_H
 #define ENGINE_SOUND_H
 
+#include <base/vmath.h>
+
 #include <engine/kernel.h>
 #include <engine/storage.h>
-
-#include <base/vmath.h>
 
 class ISound : public IInterface
 {

--- a/src/engine/steam.h
+++ b/src/engine/steam.h
@@ -1,9 +1,9 @@
 #ifndef ENGINE_STEAM_H
 #define ENGINE_STEAM_H
 
-#include <base/types.h>
-
 #include "kernel.h"
+
+#include <base/types.h>
 
 class ISteam : public IInterface
 {

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -3,10 +3,10 @@
 #ifndef ENGINE_STORAGE_H
 #define ENGINE_STORAGE_H
 
+#include "kernel.h"
+
 #include <base/hash.h>
 #include <base/types.h>
-
-#include "kernel.h"
 
 #include <memory>
 #include <set>

--- a/src/game/alloc.h
+++ b/src/game/alloc.h
@@ -3,9 +3,9 @@
 #ifndef GAME_ALLOC_H
 #define GAME_ALLOC_H
 
-#include <new>
-
 #include <base/system.h>
+
+#include <new>
 
 #ifndef __has_feature
 #define __has_feature(x) 0

--- a/src/game/client/animstate.cpp
+++ b/src/game/client/animstate.cpp
@@ -1,10 +1,11 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
-#include <base/math.h>
-#include <generated/client_data.h>
-
 #include "animstate.h"
+
+#include <base/math.h>
+
+#include <generated/client_data.h>
 
 static void AnimSeqEval(const CAnimSequence *pSeq, float Time, CAnimKeyframe *pFrame)
 {

--- a/src/game/client/components/background.cpp
+++ b/src/game/client/components/background.cpp
@@ -1,3 +1,5 @@
+#include "background.h"
+
 #include <base/system.h>
 
 #include <engine/map.h>
@@ -5,12 +7,9 @@
 
 #include <game/client/components/mapimages.h>
 #include <game/client/components/maplayers.h>
-
 #include <game/client/gameclient.h>
 #include <game/layers.h>
 #include <game/localization.h>
-
-#include "background.h"
 
 CBackground::CBackground(ERenderType MapType, bool OnlineOnly) :
 	CMapLayers(MapType, OnlineOnly)

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -1,8 +1,10 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "binds.h"
+
 #include <base/log.h>
 #include <base/system.h>
+
 #include <engine/config.h>
 #include <engine/shared/config.h>
 

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -1,17 +1,16 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "broadcast.h"
+
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 
 #include <generated/protocol.h>
 
-#include <game/client/gameclient.h>
-
 #include <game/client/components/motd.h>
 #include <game/client/components/scoreboard.h>
-
-#include "broadcast.h"
+#include <game/client/gameclient.h>
 
 void CBroadcast::OnReset()
 {

--- a/src/game/client/components/broadcast.h
+++ b/src/game/client/components/broadcast.h
@@ -4,6 +4,7 @@
 #define GAME_CLIENT_COMPONENTS_BROADCAST_H
 
 #include <engine/textrender.h>
+
 #include <generated/protocol.h>
 
 #include <game/client/component.h>

--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -1,18 +1,20 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
-#include <engine/shared/config.h>
+#include "camera.h"
+
+#include "controls.h"
 
 #include <base/log.h>
 #include <base/math.h>
 #include <base/vmath.h>
+
+#include <engine/shared/config.h>
+
 #include <game/client/gameclient.h>
 #include <game/collision.h>
 #include <game/localization.h>
 #include <game/mapitems.h>
-
-#include "camera.h"
-#include "controls.h"
 
 #include <limits>
 

--- a/src/game/client/components/censor.cpp
+++ b/src/game/client/components/censor.cpp
@@ -1,12 +1,13 @@
+#include "censor.h"
+
 #include <base/log.h>
+
 #include <engine/engine.h>
 #include <engine/external/json-parser/json.h>
 #include <engine/shared/config.h>
 
 #include <optional>
 #include <utility>
-
-#include "censor.h"
 
 static void ReplaceWords(char *pBuffer, const std::vector<std::string> &vWords, char Replacement)
 {

--- a/src/game/client/components/censor.h
+++ b/src/game/client/components/censor.h
@@ -1,10 +1,5 @@
 #ifndef GAME_CLIENT_COMPONENTS_CENSOR_H
 #define GAME_CLIENT_COMPONENTS_CENSOR_H
-#include <memory>
-#include <optional>
-#include <string>
-#include <vector>
-
 #include <base/lock.h>
 
 #include <engine/console.h>
@@ -13,6 +8,11 @@
 #include <engine/shared/jobs.h>
 
 #include <game/client/component.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
 
 class CCensor : public CComponent
 {

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1,6 +1,8 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
+#include "chat.h"
+
 #include <engine/editor.h>
 #include <engine/graphics.h>
 #include <engine/keys.h>
@@ -18,8 +20,6 @@
 #include <game/client/components/sounds.h>
 #include <game/client/gameclient.h>
 #include <game/localization.h>
-
-#include "chat.h"
 
 char CChat::ms_aDisplayText[MAX_LINE_LENGTH] = "";
 

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -2,17 +2,18 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef GAME_CLIENT_COMPONENTS_CHAT_H
 #define GAME_CLIENT_COMPONENTS_CHAT_H
-#include <vector>
-
 #include <engine/console.h>
 #include <engine/shared/config.h>
 #include <engine/shared/protocol.h>
 #include <engine/shared/ringbuffer.h>
 
+#include <generated/protocol7.h>
+
 #include <game/client/component.h>
 #include <game/client/lineinput.h>
 #include <game/client/render.h>
-#include <generated/protocol7.h>
+
+#include <vector>
 
 constexpr auto SAVES_FILE = "ddnet-saves.txt";
 

--- a/src/game/client/components/community_icons.cpp
+++ b/src/game/client/components/community_icons.cpp
@@ -1,10 +1,10 @@
+#include "community_icons.h"
+
 #include <base/log.h>
 
 #include <engine/engine.h>
 #include <engine/gfx/image_manipulation.h>
 #include <engine/storage.h>
-
-#include "community_icons.h"
 
 CCommunityIcons::CAbstractCommunityIconJob::CAbstractCommunityIconJob(CCommunityIcons *pCommunityIcons, const char *pCommunityId, int StorageType) :
 	m_pCommunityIcons(pCommunityIcons),

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -1,12 +1,12 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
+#include "console.h"
+
 #include <base/lock.h>
 #include <base/logger.h>
 #include <base/math.h>
 #include <base/system.h>
-
-#include <generated/client_data.h>
 
 #include <engine/console.h>
 #include <engine/engine.h>
@@ -17,15 +17,14 @@
 #include <engine/storage.h>
 #include <engine/textrender.h>
 
-#include <game/localization.h>
-#include <game/version.h>
+#include <generated/client_data.h>
 
 #include <game/client/gameclient.h>
 #include <game/client/ui.h>
+#include <game/localization.h>
+#include <game/version.h>
 
 #include <iterator>
-
-#include "console.h"
 
 static constexpr float FONT_SIZE = 10.0f;
 static constexpr float LINE_SPACING = 1.0f;

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -1,6 +1,9 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "controls.h"
+
 #include <base/math.h>
+#include <base/vmath.h>
 
 #include <engine/client.h>
 #include <engine/shared/config.h>
@@ -11,10 +14,6 @@
 #include <game/client/components/scoreboard.h>
 #include <game/client/gameclient.h>
 #include <game/collision.h>
-
-#include <base/vmath.h>
-
-#include "controls.h"
 
 CControls::CControls()
 {

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -8,8 +8,9 @@
 #include <engine/client.h>
 #include <engine/console.h>
 
-#include <game/client/component.h>
 #include <generated/protocol.h>
+
+#include <game/client/component.h>
 
 class CControls : public CComponent
 {

--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -1,5 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "countryflags.h"
+
 #include <base/math.h>
 #include <base/system.h>
 
@@ -8,8 +10,6 @@
 #include <engine/shared/config.h>
 #include <engine/shared/linereader.h>
 #include <engine/storage.h>
-
-#include "countryflags.h"
 
 void CCountryFlags::LoadCountryflagsIndexfile()
 {

--- a/src/game/client/components/countryflags.h
+++ b/src/game/client/components/countryflags.h
@@ -4,7 +4,9 @@
 #define GAME_CLIENT_COMPONENTS_COUNTRYFLAGS_H
 
 #include <engine/graphics.h>
+
 #include <game/client/component.h>
+
 #include <vector>
 
 class CCountryFlags : public CComponent

--- a/src/game/client/components/damageind.cpp
+++ b/src/game/client/components/damageind.cpp
@@ -1,6 +1,9 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "damageind.h"
+
 #include <base/color.h>
+
 #include <engine/demo.h>
 #include <engine/graphics.h>
 
@@ -8,8 +11,6 @@
 #include <generated/protocol.h>
 
 #include <game/client/gameclient.h>
-
-#include "damageind.h"
 
 CDamageInd::CDamageInd()
 {

--- a/src/game/client/components/damageind.h
+++ b/src/game/client/components/damageind.h
@@ -4,6 +4,7 @@
 #define GAME_CLIENT_COMPONENTS_DAMAGEIND_H
 #include <base/color.h>
 #include <base/vmath.h>
+
 #include <game/client/component.h>
 
 class CDamageInd : public CComponent

--- a/src/game/client/components/debughud.cpp
+++ b/src/game/client/components/debughud.cpp
@@ -1,5 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "debughud.h"
+
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
@@ -9,8 +11,6 @@
 #include <game/client/gameclient.h>
 #include <game/client/prediction/entities/character.h>
 #include <game/localization.h>
-
-#include "debughud.h"
 
 static constexpr int64_t GRAPH_MAX_VALUES = 128;
 

--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -1,8 +1,9 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
-#include <engine/demo.h>
+#include "effects.h"
 
+#include <engine/demo.h>
 #include <engine/shared/config.h>
 
 #include <generated/client_data.h>
@@ -12,8 +13,6 @@
 #include <game/client/components/particles.h>
 #include <game/client/components/sounds.h>
 #include <game/client/gameclient.h>
-
-#include "effects.h"
 
 CEffects::CEffects()
 {

--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -1,16 +1,17 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "emoticon.h"
+
+#include "chat.h"
+
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
 
 #include <generated/protocol.h>
 
-#include "chat.h"
-#include "emoticon.h"
 #include <game/client/animstate.h>
-#include <game/client/ui.h>
-
 #include <game/client/gameclient.h>
+#include <game/client/ui.h>
 
 CEmoticon::CEmoticon()
 {

--- a/src/game/client/components/emoticon.h
+++ b/src/game/client/components/emoticon.h
@@ -3,6 +3,7 @@
 #ifndef GAME_CLIENT_COMPONENTS_EMOTICON_H
 #define GAME_CLIENT_COMPONENTS_EMOTICON_H
 #include <base/vmath.h>
+
 #include <engine/console.h>
 
 #include <game/client/component.h>

--- a/src/game/client/components/flow.cpp
+++ b/src/game/client/components/flow.cpp
@@ -1,7 +1,9 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "flow.h"
+
 #include <engine/graphics.h>
+
 #include <game/layers.h>
 #include <game/mapitems.h>
 

--- a/src/game/client/components/flow.h
+++ b/src/game/client/components/flow.h
@@ -3,6 +3,7 @@
 #ifndef GAME_CLIENT_COMPONENTS_FLOW_H
 #define GAME_CLIENT_COMPONENTS_FLOW_H
 #include <base/vmath.h>
+
 #include <game/client/component.h>
 
 class CFlow : public CComponent

--- a/src/game/client/components/freezebars.cpp
+++ b/src/game/client/components/freezebars.cpp
@@ -1,6 +1,6 @@
-#include <game/client/gameclient.h>
-
 #include "freezebars.h"
+
+#include <game/client/gameclient.h>
 
 void CFreezeBars::RenderFreezeBar(const int ClientId)
 {

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1,6 +1,14 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "hud.h"
+
+#include "binds.h"
+#include "camera.h"
+#include "controls.h"
+#include "voting.h"
+
 #include <base/color.h>
+
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
@@ -12,17 +20,10 @@
 #include <game/client/components/scoreboard.h>
 #include <game/client/gameclient.h>
 #include <game/client/prediction/entities/character.h>
-
 #include <game/layers.h>
 #include <game/localization.h>
 
 #include <cmath>
-
-#include "binds.h"
-#include "camera.h"
-#include "controls.h"
-#include "hud.h"
-#include "voting.h"
 
 CHud::CHud()
 {

--- a/src/game/client/components/infomessages.cpp
+++ b/src/game/client/components/infomessages.cpp
@@ -1,5 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "infomessages.h"
+
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
 #include <engine/shared/protocol.h>
@@ -8,13 +10,11 @@
 #include <generated/client_data.h>
 #include <generated/protocol.h>
 
-#include <game/localization.h>
-
-#include "infomessages.h"
 #include <game/client/animstate.h>
 #include <game/client/gameclient.h>
 #include <game/client/prediction/entities/character.h>
 #include <game/client/prediction/gameworld.h>
+#include <game/localization.h>
 
 static constexpr float ROW_HEIGHT = 46.0f;
 static constexpr float FONT_SIZE = 36.0f;

--- a/src/game/client/components/infomessages.h
+++ b/src/game/client/components/infomessages.h
@@ -3,8 +3,8 @@
 #ifndef GAME_CLIENT_COMPONENTS_INFOMESSAGES_H
 #define GAME_CLIENT_COMPONENTS_INFOMESSAGES_H
 #include <engine/textrender.h>
-#include <game/client/component.h>
 
+#include <game/client/component.h>
 #include <game/client/render.h>
 class CInfoMessages : public CComponent
 {

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -1,5 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "items.h"
+
 #include <engine/demo.h>
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
@@ -7,20 +9,15 @@
 #include <generated/client_data.h>
 #include <generated/protocol.h>
 
-#include <game/mapitems.h>
-
+#include <game/client/components/effects.h>
 #include <game/client/gameclient.h>
 #include <game/client/laser_data.h>
 #include <game/client/pickup_data.h>
-#include <game/client/projectile_data.h>
-
 #include <game/client/prediction/entities/laser.h>
 #include <game/client/prediction/entities/pickup.h>
 #include <game/client/prediction/entities/projectile.h>
-
-#include <game/client/components/effects.h>
-
-#include "items.h"
+#include <game/client/projectile_data.h>
+#include <game/mapitems.h>
 
 void CItems::RenderProjectile(const CProjectileData *pCurrent, int ItemId)
 {

--- a/src/game/client/components/local_server.cpp
+++ b/src/game/client/components/local_server.cpp
@@ -1,8 +1,7 @@
-#include <game/client/gameclient.h>
-
-#include <game/localization.h>
-
 #include "local_server.h"
+
+#include <game/client/gameclient.h>
+#include <game/localization.h>
 
 #if defined(CONF_PLATFORM_ANDROID)
 #include <android/android_main.h>

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -1,9 +1,9 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "maplayers.h"
+
 #include <game/client/gameclient.h>
 #include <game/localization.h>
-
-#include "maplayers.h"
 
 #include <chrono>
 

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -1,6 +1,6 @@
-#include <base/system.h>
+#include "menu_background.h"
 
-#include <algorithm>
+#include <base/system.h>
 
 #include <engine/graphics.h>
 #include <engine/map.h>
@@ -10,13 +10,11 @@
 #include <game/client/components/mapimages.h>
 #include <game/client/components/maplayers.h>
 #include <game/client/gameclient.h>
-
 #include <game/layers.h>
 #include <game/localization.h>
 #include <game/mapitems.h>
 
-#include "menu_background.h"
-
+#include <algorithm>
 #include <chrono>
 
 using namespace std::chrono_literals;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1,10 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
-#include <algorithm>
-#include <chrono>
-#include <cmath>
-#include <vector>
+#include "menus.h"
 
 #include <base/log.h>
 #include <base/math.h>
@@ -36,7 +33,10 @@
 #include <game/client/ui_listbox.h>
 #include <game/localization.h>
 
-#include "menus.h"
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <vector>
 
 using namespace FontIcons;
 using namespace std::chrono_literals;

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -6,11 +6,6 @@
 #include <base/types.h>
 #include <base/vmath.h>
 
-#include <chrono>
-#include <deque>
-#include <optional>
-#include <vector>
-
 #include <engine/console.h>
 #include <engine/demo.h>
 #include <engine/friends.h>
@@ -19,15 +14,19 @@
 #include <engine/textrender.h>
 
 #include <game/client/component.h>
+#include <game/client/components/community_icons.h>
 #include <game/client/components/mapimages.h>
 #include <game/client/components/menus_ingame_touch_controls.h>
+#include <game/client/components/menus_start.h>
+#include <game/client/components/skins7.h>
 #include <game/client/lineinput.h>
 #include <game/client/ui.h>
 #include <game/voting.h>
 
-#include <game/client/components/community_icons.h>
-#include <game/client/components/menus_start.h>
-#include <game/client/components/skins7.h>
+#include <chrono>
+#include <deque>
+#include <optional>
+#include <vector>
 
 // component to fetch keypresses, override all other input
 class CMenusKeyBinder : public CComponent

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1,5 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "menus.h"
+
 #include <base/log.h>
 
 #include <engine/engine.h>
@@ -18,8 +20,6 @@
 #include <game/client/ui.h>
 #include <game/client/ui_listbox.h>
 #include <game/localization.h>
-
-#include "menus.h"
 
 using namespace FontIcons;
 

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -1,6 +1,9 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
+#include "maplayers.h"
+#include "menus.h"
+
 #include <base/hash.h>
 #include <base/math.h>
 #include <base/system.h>
@@ -19,9 +22,6 @@
 #include <game/client/ui.h>
 #include <game/client/ui_listbox.h>
 #include <game/localization.h>
-
-#include "maplayers.h"
-#include "menus.h"
 
 #include <chrono>
 

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -1,5 +1,10 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "ghost.h"
+#include "menus.h"
+#include "motd.h"
+#include "voting.h"
+
 #include <base/color.h>
 #include <base/math.h>
 #include <base/system.h>
@@ -9,9 +14,11 @@
 #include <engine/friends.h>
 #include <engine/ghost.h>
 #include <engine/graphics.h>
+#include <engine/keys.h>
 #include <engine/serverbrowser.h>
 #include <engine/shared/config.h>
 #include <engine/shared/localization.h>
+#include <engine/storage.h>
 #include <engine/textrender.h>
 
 #include <generated/client_data.h>
@@ -25,14 +32,6 @@
 #include <game/client/ui_listbox.h>
 #include <game/client/ui_scrollregion.h>
 #include <game/localization.h>
-
-#include "menus.h"
-#include "motd.h"
-#include "voting.h"
-
-#include "ghost.h"
-#include <engine/keys.h>
-#include <engine/storage.h>
 
 #include <chrono>
 

--- a/src/game/client/components/menus_ingame_touch_controls.cpp
+++ b/src/game/client/components/menus_ingame_touch_controls.cpp
@@ -4,12 +4,11 @@
 #include <base/math.h>
 #include <base/system.h>
 
+#include <engine/external/json-parser/json.h>
 #include <engine/graphics.h>
+#include <engine/shared/jsonwriter.h>
 #include <engine/shared/localization.h>
 #include <engine/textrender.h>
-
-#include <engine/external/json-parser/json.h>
-#include <engine/shared/jsonwriter.h>
 
 #include <game/client/components/touch_controls.h>
 #include <game/client/gameclient.h>

--- a/src/game/client/components/menus_ingame_touch_controls.h
+++ b/src/game/client/components/menus_ingame_touch_controls.h
@@ -3,6 +3,7 @@
 #include <game/client/component.h>
 #include <game/client/components/touch_controls.h>
 #include <game/client/ui.h>
+
 #include <memory>
 
 class CMenusIngameTouchControls : public CComponentInterfaces

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1,5 +1,10 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "binds.h"
+#include "countryflags.h"
+#include "menus.h"
+#include "skins.h"
+
 #include <base/log.h>
 #include <base/math.h>
 #include <base/system.h>
@@ -25,11 +30,6 @@
 #include <game/client/ui_listbox.h>
 #include <game/client/ui_scrollregion.h>
 #include <game/localization.h>
-
-#include "binds.h"
-#include "countryflags.h"
-#include "menus.h"
-#include "skins.h"
 
 #include <array>
 #include <chrono>

--- a/src/game/client/components/menus_settings7.cpp
+++ b/src/game/client/components/menus_settings7.cpp
@@ -1,5 +1,8 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "menus.h"
+#include "skins7.h"
+
 #include <base/math.h>
 #include <base/system.h>
 
@@ -24,9 +27,6 @@
 #include <game/client/ui_listbox.h>
 #include <game/client/ui_scrollregion.h>
 #include <game/localization.h>
-
-#include "menus.h"
-#include "skins7.h"
 
 #include <vector>
 

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -1,3 +1,5 @@
+#include "menus.h"
+
 #include <base/system.h>
 
 #include <engine/shared/config.h>
@@ -7,8 +9,6 @@
 #include <game/client/gameclient.h>
 #include <game/client/ui_listbox.h>
 #include <game/localization.h>
-
-#include "menus.h"
 
 #include <chrono>
 

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -1,12 +1,13 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "menus_start.h"
+
+#include <engine/client/updater.h>
 #include <engine/graphics.h>
 #include <engine/keys.h>
 #include <engine/serverbrowser.h>
-#include <engine/textrender.h>
-
-#include <engine/client/updater.h>
 #include <engine/shared/config.h>
+#include <engine/textrender.h>
 
 #include <generated/client_data.h>
 
@@ -14,8 +15,6 @@
 #include <game/client/ui.h>
 #include <game/localization.h>
 #include <game/version.h>
-
-#include "menus_start.h"
 
 #if defined(CONF_PLATFORM_ANDROID)
 #include <android/android_main.h>

--- a/src/game/client/components/motd.cpp
+++ b/src/game/client/components/motd.cpp
@@ -1,5 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "motd.h"
+
 #include <engine/graphics.h>
 #include <engine/keys.h>
 #include <engine/shared/config.h>
@@ -8,8 +10,6 @@
 #include <generated/protocol.h>
 
 #include <game/client/gameclient.h>
-
-#include "motd.h"
 
 CMotd::CMotd()
 {

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -1,8 +1,9 @@
+#include "nameplates.h"
+
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
-#include <engine/textrender.h>
-
 #include <engine/shared/protocol7.h>
+#include <engine/textrender.h>
 
 #include <generated/client_data.h>
 
@@ -12,8 +13,6 @@
 
 #include <memory>
 #include <vector>
-
-#include "nameplates.h"
 
 static constexpr float DEFAULT_PADDING = 5.0f;
 

--- a/src/game/client/components/particles.cpp
+++ b/src/game/client/components/particles.cpp
@@ -1,12 +1,13 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "particles.h"
+
 #include <base/math.h>
+
 #include <engine/demo.h>
 #include <engine/graphics.h>
 
 #include <generated/client_data.h>
-
-#include "particles.h"
 
 #include <game/client/gameclient.h>
 

--- a/src/game/client/components/particles.h
+++ b/src/game/client/components/particles.h
@@ -4,6 +4,7 @@
 #define GAME_CLIENT_COMPONENTS_PARTICLES_H
 #include <base/color.h>
 #include <base/vmath.h>
+
 #include <game/client/component.h>
 
 // particles

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -1,31 +1,29 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
+#include "players.h"
+
+#include <base/color.h>
+#include <base/math.h>
+
 #include <engine/client/enums.h>
 #include <engine/demo.h>
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
-#include <game/gamecore.h>
 
 #include <generated/client_data.h>
 #include <generated/client_data7.h>
 #include <generated/protocol.h>
 
-#include <game/mapitems.h>
-
 #include <game/client/animstate.h>
-#include <game/client/gameclient.h>
-
 #include <game/client/components/controls.h>
 #include <game/client/components/effects.h>
 #include <game/client/components/flow.h>
 #include <game/client/components/skins.h>
 #include <game/client/components/sounds.h>
-
-#include "players.h"
-
-#include <base/color.h>
-#include <base/math.h>
+#include <game/client/gameclient.h>
+#include <game/gamecore.h>
+#include <game/mapitems.h>
 
 static float CalculateHandAngle(vec2 Dir, float AngleOffset)
 {

--- a/src/game/client/components/players.h
+++ b/src/game/client/components/players.h
@@ -2,10 +2,9 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef GAME_CLIENT_COMPONENTS_PLAYERS_H
 #define GAME_CLIENT_COMPONENTS_PLAYERS_H
-#include <game/client/component.h>
-
 #include <generated/protocol.h>
 
+#include <game/client/component.h>
 #include <game/client/render.h>
 
 class CPlayers : public CComponent

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -1,18 +1,17 @@
 /* (c) Redix and Sushi */
 
-#include <cctype>
+#include "race_demo.h"
 
 #include <base/system.h>
+
 #include <engine/shared/config.h>
 #include <engine/storage.h>
 
+#include <game/client/gameclient.h>
 #include <game/client/race.h>
 #include <game/localization.h>
 
-#include "race_demo.h"
-
-#include <game/client/gameclient.h>
-
+#include <cctype>
 #include <chrono>
 
 using namespace std::chrono_literals;

--- a/src/game/client/components/race_demo.h
+++ b/src/game/client/components/race_demo.h
@@ -3,8 +3,9 @@
 #ifndef GAME_CLIENT_COMPONENTS_RACE_DEMO_H
 #define GAME_CLIENT_COMPONENTS_RACE_DEMO_H
 
-#include <chrono>
 #include <game/client/component.h>
+
+#include <chrono>
 
 class CRaceDemo : public CComponent
 {

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -7,14 +7,14 @@
 #include <base/math.h>
 #include <base/system.h>
 
-#include <generated/client_data.h>
-
 #include <engine/engine.h>
 #include <engine/gfx/image_manipulation.h>
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
 #include <engine/shared/http.h>
 #include <engine/storage.h>
+
+#include <generated/client_data.h>
 
 #include <game/client/gameclient.h>
 #include <game/localization.h>

--- a/src/game/client/components/skins7.cpp
+++ b/src/game/client/components/skins7.cpp
@@ -1,5 +1,9 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "skins7.h"
+
+#include "menus.h"
+
 #include <base/color.h>
 #include <base/log.h>
 #include <base/math.h>
@@ -16,9 +20,6 @@
 
 #include <game/client/gameclient.h>
 #include <game/localization.h>
-
-#include "menus.h"
-#include "skins7.h"
 
 const char *const CSkins7::ms_apSkinPartNames[protocol7::NUM_SKINPARTS] = {"body", "marking", "decoration", "hands", "feet", "eyes"};
 const char *const CSkins7::ms_apSkinPartNamesLocalized[protocol7::NUM_SKINPARTS] = {Localizable("Body", "skins"), Localizable("Marking", "skins"), Localizable("Decoration", "skins"), Localizable("Hands", "skins"), Localizable("Feet", "skins"), Localizable("Eyes", "skins")};

--- a/src/game/client/components/sounds.h
+++ b/src/game/client/components/sounds.h
@@ -4,8 +4,10 @@
 #define GAME_CLIENT_COMPONENTS_SOUNDS_H
 
 #include <base/vmath.h>
+
 #include <engine/shared/jobs.h>
 #include <engine/sound.h>
+
 #include <game/client/component.h>
 
 class CSoundLoading : public IJob

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -1,7 +1,9 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
-#include <limits>
+#include "spectator.h"
+
+#include "camera.h"
 
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
@@ -10,12 +12,10 @@
 #include <generated/protocol.h>
 
 #include <game/client/animstate.h>
+#include <game/client/gameclient.h>
 #include <game/localization.h>
 
-#include "camera.h"
-#include "spectator.h"
-
-#include <game/client/gameclient.h>
+#include <limits>
 
 bool CSpectator::CanChangeSpectatorId()
 {

--- a/src/game/client/components/spectator.h
+++ b/src/game/client/components/spectator.h
@@ -3,6 +3,7 @@
 #ifndef GAME_CLIENT_COMPONENTS_SPECTATOR_H
 #define GAME_CLIENT_COMPONENTS_SPECTATOR_H
 #include <base/vmath.h>
+
 #include <engine/console.h>
 
 #include <game/client/component.h>

--- a/src/game/client/components/statboard.h
+++ b/src/game/client/components/statboard.h
@@ -4,6 +4,7 @@
 #include <engine/console.h>
 
 #include <game/client/component.h>
+
 #include <string>
 
 class CStatboard : public CComponent

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1,46 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
-#include <chrono>
-#include <limits>
-
-#include <engine/client/checksum.h>
-#include <engine/client/enums.h>
-#include <engine/demo.h>
-#include <engine/discord.h>
-#include <engine/editor.h>
-#include <engine/engine.h>
-#include <engine/favorites.h>
-#include <engine/friends.h>
-#include <engine/graphics.h>
-#include <engine/map.h>
-#include <engine/serverbrowser.h>
-#include <engine/shared/config.h>
-#include <engine/sound.h>
-#include <engine/storage.h>
-#include <engine/textrender.h>
-#include <engine/updater.h>
-
-#include <generated/client_data.h>
-#include <generated/client_data7.h>
-#include <generated/protocol.h>
-#include <generated/protocol7.h>
-#include <generated/protocolglue.h>
-
-#include <base/log.h>
-#include <base/math.h>
-#include <base/system.h>
-#include <base/vmath.h>
-
 #include "gameclient.h"
-#include "lineinput.h"
-#include "race.h"
-#include "render.h"
-
-#include <game/client/projectile_data.h>
-#include <game/localization.h>
-#include <game/mapitems.h>
-#include <game/version.h>
 
 #include "components/background.h"
 #include "components/binds.h"
@@ -76,8 +37,47 @@
 #include "components/spectator.h"
 #include "components/statboard.h"
 #include "components/voting.h"
+#include "lineinput.h"
 #include "prediction/entities/character.h"
 #include "prediction/entities/projectile.h"
+#include "race.h"
+#include "render.h"
+
+#include <base/log.h>
+#include <base/math.h>
+#include <base/system.h>
+#include <base/vmath.h>
+
+#include <engine/client/checksum.h>
+#include <engine/client/enums.h>
+#include <engine/demo.h>
+#include <engine/discord.h>
+#include <engine/editor.h>
+#include <engine/engine.h>
+#include <engine/favorites.h>
+#include <engine/friends.h>
+#include <engine/graphics.h>
+#include <engine/map.h>
+#include <engine/serverbrowser.h>
+#include <engine/shared/config.h>
+#include <engine/sound.h>
+#include <engine/storage.h>
+#include <engine/textrender.h>
+#include <engine/updater.h>
+
+#include <generated/client_data.h>
+#include <generated/client_data7.h>
+#include <generated/protocol.h>
+#include <generated/protocol7.h>
+#include <generated/protocolglue.h>
+
+#include <game/client/projectile_data.h>
+#include <game/localization.h>
+#include <game/mapitems.h>
+#include <game/version.h>
+
+#include <chrono>
+#include <limits>
 
 using namespace std::chrono_literals;
 

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -4,26 +4,27 @@
 #define GAME_CLIENT_GAMECLIENT_H
 
 #include "render.h"
+
 #include <base/color.h>
 #include <base/vmath.h>
+
 #include <engine/client.h>
 #include <engine/client/enums.h>
 #include <engine/console.h>
 #include <engine/shared/config.h>
 #include <engine/shared/snapshot.h>
 
+#include <generated/protocol7.h>
+#include <generated/protocolglue.h>
+
+#include <game/client/prediction/gameworld.h>
+#include <game/client/race.h>
 #include <game/collision.h>
 #include <game/gamecore.h>
 #include <game/layers.h>
 #include <game/map/render_map.h>
 #include <game/mapbugs.h>
 #include <game/teamscore.h>
-
-#include <game/client/prediction/gameworld.h>
-#include <game/client/race.h>
-
-#include <generated/protocol7.h>
-#include <generated/protocolglue.h>
 
 // components
 #include "components/background.h"

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -1,10 +1,11 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "lineinput.h"
+
+#include "ui.h"
+
 #include <engine/keys.h>
 #include <engine/shared/config.h>
-
-#include "lineinput.h"
-#include "ui.h"
 
 IInput *CLineInput::ms_pInput = nullptr;
 ITextRender *CLineInput::ms_pTextRender = nullptr;

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1,15 +1,16 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "character.h"
+
+#include "laser.h"
+#include "projectile.h"
+
 #include <engine/shared/config.h>
 
 #include <generated/client_data.h>
 
 #include <game/collision.h>
 #include <game/mapitems.h>
-
-#include "character.h"
-#include "laser.h"
-#include "projectile.h"
 
 // Character, "physical" player's part
 

--- a/src/game/client/prediction/entities/door.cpp
+++ b/src/game/client/prediction/entities/door.cpp
@@ -1,6 +1,8 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 #include "door.h"
+
 #include "character.h"
+
 #include <game/client/laser_data.h>
 #include <game/collision.h>
 #include <game/mapitems.h>

--- a/src/game/client/prediction/entities/dragger.cpp
+++ b/src/game/client/prediction/entities/dragger.cpp
@@ -1,5 +1,6 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 #include "dragger.h"
+
 #include "character.h"
 
 #include <engine/shared/config.h>

--- a/src/game/client/prediction/entities/laser.cpp
+++ b/src/game/client/prediction/entities/laser.cpp
@@ -2,14 +2,15 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "laser.h"
 
+#include "character.h"
+
+#include <engine/shared/config.h>
+
 #include <generated/protocol.h>
 
-#include "character.h"
 #include <game/client/laser_data.h>
 #include <game/collision.h>
 #include <game/mapitems.h>
-
-#include <engine/shared/config.h>
 
 CLaser::CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEnergy, int Owner, int Type) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_LASER)

--- a/src/game/client/prediction/entities/pickup.cpp
+++ b/src/game/client/prediction/entities/pickup.cpp
@@ -2,9 +2,10 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "pickup.h"
 
+#include "character.h"
+
 #include <generated/protocol.h>
 
-#include "character.h"
 #include <game/client/pickup_data.h>
 #include <game/collision.h>
 #include <game/mapitems.h>

--- a/src/game/client/prediction/entities/plasma.cpp
+++ b/src/game/client/prediction/entities/plasma.cpp
@@ -1,5 +1,6 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 #include "plasma.h"
+
 #include "character.h"
 
 #include <game/client/laser_data.h>

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -1,5 +1,9 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "projectile.h"
+
+#include "character.h"
+
 #include <engine/shared/config.h>
 
 #include <generated/protocol.h>
@@ -7,9 +11,6 @@
 #include <game/client/projectile_data.h>
 #include <game/collision.h>
 #include <game/mapitems.h>
-
-#include "character.h"
-#include "projectile.h"
 
 CProjectile::CProjectile(
 	CGameWorld *pGameWorld,

--- a/src/game/client/prediction/entity.h
+++ b/src/game/client/prediction/entity.h
@@ -3,11 +3,11 @@
 #ifndef GAME_CLIENT_PREDICTION_ENTITY_H
 #define GAME_CLIENT_PREDICTION_ENTITY_H
 
+#include "gameworld.h"
+
 #include <base/vmath.h>
 
 #include <game/alloc.h>
-
-#include "gameworld.h"
 
 class CEntity
 {

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -2,6 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
 #include "gameworld.h"
+
 #include "entities/character.h"
 #include "entities/door.h"
 #include "entities/dragger.h"
@@ -10,7 +11,9 @@
 #include "entities/plasma.h"
 #include "entities/projectile.h"
 #include "entity.h"
+
 #include <engine/shared/config.h>
+
 #include <game/client/laser_data.h>
 #include <game/client/pickup_data.h>
 #include <game/client/projectile_data.h>

--- a/src/game/client/race.cpp
+++ b/src/game/client/race.cpp
@@ -1,11 +1,11 @@
-#include <cctype>
-#include <vector>
+#include "race.h"
 
 #include <game/client/gameclient.h>
 #include <game/collision.h>
 #include <game/mapitems.h>
 
-#include "race.h"
+#include <cctype>
+#include <vector>
 
 void CRaceHelper::Init(const CGameClient *pGameClient)
 {

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -1,11 +1,10 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#include <cmath>
-
-#include <base/math.h>
+#include "render.h"
 
 #include "animstate.h"
-#include "render.h"
+
+#include <base/math.h>
 
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
@@ -16,6 +15,8 @@
 #include <generated/protocol7.h>
 
 #include <game/mapitems.h>
+
+#include <cmath>
 
 CSkinDescriptor::CSkinDescriptor()
 {

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -3,10 +3,10 @@
 #ifndef GAME_CLIENT_RENDER_H
 #define GAME_CLIENT_RENDER_H
 
-#include <engine/client/enums.h>
-
 #include <base/color.h>
 #include <base/vmath.h>
+
+#include <engine/client/enums.h>
 
 #include <generated/protocol.h>
 #include <generated/protocol7.h>

--- a/src/game/client/sixup_translate_connless.cpp
+++ b/src/game/client/sixup_translate_connless.cpp
@@ -1,4 +1,5 @@
 #include <engine/shared/masterserver.h>
+
 #include <game/client/gameclient.h>
 
 void CClient::PreprocessConnlessPacket7(CNetChunk *pPacket)

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -1,6 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "ui.h"
+
 #include "ui_scrollregion.h"
 
 #include <base/math.h>

--- a/src/game/client/ui_listbox.cpp
+++ b/src/game/client/ui_listbox.cpp
@@ -1,5 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "ui_listbox.h"
+
 #include <base/system.h>
 #include <base/vmath.h>
 
@@ -7,8 +9,6 @@
 #include <engine/shared/config.h>
 
 #include <game/localization.h>
-
-#include "ui_listbox.h"
 
 CListBox::CListBox()
 {

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -1,13 +1,13 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "ui_scrollregion.h"
+
 #include <base/system.h>
 #include <base/vmath.h>
 
 #include <engine/client.h>
 #include <engine/keys.h>
 #include <engine/shared/config.h>
-
-#include "ui_scrollregion.h"
 
 CScrollRegion::CScrollRegion()
 {

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -1,19 +1,19 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include <antibot/antibot_data.h>
+
 #include <base/math.h>
 #include <base/system.h>
 #include <base/vmath.h>
 
-#include <antibot/antibot_data.h>
-
-#include <cmath>
 #include <engine/map.h>
+#include <engine/shared/config.h>
 
 #include <game/collision.h>
 #include <game/layers.h>
 #include <game/mapitems.h>
 
-#include <engine/shared/config.h>
+#include <cmath>
 
 vec2 ClampVel(int MoveRestriction, vec2 Vel)
 {

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -4,6 +4,7 @@
 #define GAME_COLLISION_H
 
 #include <base/vmath.h>
+
 #include <engine/shared/protocol.h>
 
 #include <map>

--- a/src/game/editor/auto_map.h
+++ b/src/game/editor/auto_map.h
@@ -1,9 +1,9 @@
 #ifndef GAME_EDITOR_AUTO_MAP_H
 #define GAME_EDITOR_AUTO_MAP_H
 
-#include <vector>
-
 #include "component.h"
+
+#include <vector>
 
 class CAutoMapper : public CEditorComponent
 {

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1,7 +1,10 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
-#include <algorithm>
+#include "editor.h"
+
+#include "auto_map.h"
+#include "editor_actions.h"
 
 #include <base/color.h>
 #include <base/log.h>
@@ -27,17 +30,13 @@
 #include <game/client/ui.h>
 #include <game/client/ui_listbox.h>
 #include <game/client/ui_scrollregion.h>
-#include <game/editor/explanations.h>
-#include <game/localization.h>
-
 #include <game/editor/editor_history.h>
+#include <game/editor/explanations.h>
 #include <game/editor/mapitems/image.h>
 #include <game/editor/mapitems/sound.h>
+#include <game/localization.h>
 
-#include "auto_map.h"
-#include "editor.h"
-#include "editor_actions.h"
-
+#include <algorithm>
 #include <chrono>
 #include <iterator>
 #include <limits>

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -3,13 +3,28 @@
 #ifndef GAME_EDITOR_EDITOR_H
 #define GAME_EDITOR_EDITOR_H
 
+#include "editor_history.h"
+#include "editor_server_settings.h"
+#include "editor_trackers.h"
+#include "editor_ui.h"
+#include "font_typer.h"
+#include "layer_selector.h"
+#include "map_view.h"
+#include "quadart.h"
+#include "smooth_value.h"
+
 #include <base/bezier.h>
 #include <base/system.h>
 
+#include <engine/console.h>
+#include <engine/editor.h>
+#include <engine/engine.h>
+#include <engine/graphics.h>
+#include <engine/shared/datafile.h>
+#include <engine/shared/jobs.h>
+
 #include <game/client/ui.h>
 #include <game/client/ui_listbox.h>
-#include <game/mapitems.h>
-
 #include <game/editor/enums.h>
 #include <game/editor/file_browser.h>
 #include <game/editor/mapitems/envelope.h>
@@ -25,27 +40,10 @@
 #include <game/editor/mapitems/layer_tiles.h>
 #include <game/editor/mapitems/layer_tune.h>
 #include <game/editor/mapitems/map.h>
-
-#include <game/map/render_interfaces.h>
-
-#include <engine/console.h>
-#include <engine/editor.h>
-#include <engine/engine.h>
-#include <engine/graphics.h>
-#include <engine/shared/datafile.h>
-#include <engine/shared/jobs.h>
-
-#include "editor_history.h"
-#include "editor_server_settings.h"
-#include "editor_trackers.h"
-#include "editor_ui.h"
-#include "font_typer.h"
-#include "layer_selector.h"
-#include "map_view.h"
-#include "quadart.h"
-#include "smooth_value.h"
 #include <game/editor/prompt.h>
 #include <game/editor/quick_action.h>
+#include <game/map/render_interfaces.h>
+#include <game/mapitems.h>
 
 #include <deque>
 #include <functional>

--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -1,4 +1,5 @@
 #include "editor_actions.h"
+
 #include <game/editor/mapitems/image.h>
 
 CEditorBrushDrawAction::CEditorBrushDrawAction(CEditor *pEditor, int Group) :

--- a/src/game/editor/editor_actions.h
+++ b/src/game/editor/editor_actions.h
@@ -3,6 +3,7 @@
 
 #include "editor.h"
 #include "editor_action.h"
+
 #include <game/editor/references.h>
 
 class CEditorActionLayerBase : public IEditorAction

--- a/src/game/editor/editor_history.cpp
+++ b/src/game/editor/editor_history.cpp
@@ -1,8 +1,9 @@
-#include <engine/shared/config.h>
+#include "editor_history.h"
 
 #include "editor.h"
 #include "editor_actions.h"
-#include "editor_history.h"
+
+#include <engine/shared/config.h>
 
 void CEditorHistory::RecordAction(const std::shared_ptr<IEditorAction> &pAction)
 {

--- a/src/game/editor/editor_server_settings.cpp
+++ b/src/game/editor/editor_server_settings.cpp
@@ -1,6 +1,9 @@
 ﻿#include "editor_server_settings.h"
 #include "editor.h"
 
+#include <base/color.h>
+#include <base/system.h>
+
 #include <engine/keys.h>
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
@@ -11,9 +14,6 @@
 #include <game/client/ui_listbox.h>
 #include <game/editor/editor_actions.h>
 #include <game/editor/editor_history.h>
-
-#include <base/color.h>
-#include <base/system.h>
 
 #include <iterator>
 

--- a/src/game/editor/editor_trackers.cpp
+++ b/src/game/editor/editor_trackers.cpp
@@ -1,10 +1,10 @@
 #include "editor_trackers.h"
 
-#include <game/editor/mapitems/layer_group.h>
-#include <game/editor/mapitems/layer_tiles.h>
-
 #include "editor.h"
 #include "editor_actions.h"
+
+#include <game/editor/mapitems/layer_group.h>
+#include <game/editor/mapitems/layer_tiles.h>
 
 CQuadEditTracker::CQuadEditTracker() :
 	m_pEditor(nullptr), m_TrackedProp(EQuadProp::PROP_NONE) {}

--- a/src/game/editor/font_typer.cpp
+++ b/src/game/editor/font_typer.cpp
@@ -1,12 +1,15 @@
+#include "font_typer.h"
+
+#include "editor.h"
+
 #include <base/log.h>
 #include <base/system.h>
+
 #include <engine/keys.h>
+
 #include <game/editor/editor_actions.h>
 
 #include <algorithm>
-
-#include "editor.h"
-#include "font_typer.h"
 
 using namespace std::chrono_literals;
 

--- a/src/game/editor/font_typer.h
+++ b/src/game/editor/font_typer.h
@@ -1,14 +1,16 @@
 #ifndef GAME_EDITOR_FONT_TYPER_H
 #define GAME_EDITOR_FONT_TYPER_H
 
+#include "component.h"
+
 #include <base/vmath.h>
+
 #include <engine/graphics.h>
+
 #include <game/editor/mapitems/layer_tiles.h>
 
 #include <chrono>
 #include <memory>
-
-#include "component.h"
 
 class CFontTyper : public CEditorComponent
 {

--- a/src/game/editor/layer_selector.cpp
+++ b/src/game/editor/layer_selector.cpp
@@ -1,8 +1,8 @@
-#include <engine/shared/config.h>
+#include "layer_selector.h"
 
 #include "editor.h"
 
-#include "layer_selector.h"
+#include <engine/shared/config.h>
 
 void CLayerSelector::OnInit(CEditor *pEditor)
 {

--- a/src/game/editor/map_grid.cpp
+++ b/src/game/editor/map_grid.cpp
@@ -1,8 +1,8 @@
 #include "map_grid.h"
 
-#include <engine/keys.h>
-
 #include "editor.h"
+
+#include <engine/keys.h>
 
 static constexpr int MIN_GRID_FACTOR = 1;
 static constexpr int MAX_GRID_FACTOR = 15;

--- a/src/game/editor/map_view.cpp
+++ b/src/game/editor/map_view.cpp
@@ -1,11 +1,11 @@
 #include "map_view.h"
 
+#include "editor.h"
+
 #include <engine/keys.h>
 #include <engine/shared/config.h>
 
 #include <game/client/ui.h>
-
-#include "editor.h"
 
 void CMapView::OnInit(CEditor *pEditor)
 {

--- a/src/game/editor/map_view.h
+++ b/src/game/editor/map_view.h
@@ -1,12 +1,12 @@
 #ifndef GAME_EDITOR_MAP_VIEW_H
 #define GAME_EDITOR_MAP_VIEW_H
 
-#include <base/vmath.h>
-
 #include "component.h"
 #include "map_grid.h"
 #include "proof_mode.h"
 #include "smooth_value.h"
+
+#include <base/vmath.h>
 
 class CLayerGroup;
 

--- a/src/game/editor/mapitems/layer.h
+++ b/src/game/editor/mapitems/layer.h
@@ -2,6 +2,7 @@
 #define GAME_EDITOR_MAPITEMS_LAYER_H
 
 #include <base/system.h>
+
 #include <game/client/ui.h>
 #include <game/client/ui_rect.h>
 #include <game/mapitems.h>

--- a/src/game/editor/mapitems/layer_group.cpp
+++ b/src/game/editor/mapitems/layer_group.cpp
@@ -1,7 +1,9 @@
 #include "layer_group.h"
 
 #include <base/math.h>
+
 #include <engine/shared/config.h>
+
 #include <game/editor/editor.h>
 
 CLayerGroup::CLayerGroup()

--- a/src/game/editor/mapitems/layer_quads.cpp
+++ b/src/game/editor/mapitems/layer_quads.cpp
@@ -2,10 +2,10 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "layer_quads.h"
 
+#include "image.h"
+
 #include <game/editor/editor.h>
 #include <game/editor/editor_actions.h>
-
-#include "image.h"
 
 CLayerQuads::CLayerQuads(CEditor *pEditor) :
 	CLayer(pEditor)

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -2,17 +2,18 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "layer_tiles.h"
 
+#include "image.h"
+
 #include <engine/keys.h>
 #include <engine/shared/config.h>
 #include <engine/shared/map.h>
+
 #include <game/editor/editor.h>
 #include <game/editor/editor_actions.h>
 #include <game/editor/enums.h>
 
 #include <iterator>
 #include <numeric>
-
-#include "image.h"
 
 CLayerTiles::CLayerTiles(CEditor *pEditor, int w, int h) :
 	CLayer(pEditor)

--- a/src/game/editor/mapitems/layer_tiles.h
+++ b/src/game/editor/mapitems/layer_tiles.h
@@ -1,11 +1,12 @@
 #ifndef GAME_EDITOR_MAPITEMS_LAYER_TILES_H
 #define GAME_EDITOR_MAPITEMS_LAYER_TILES_H
 
+#include "layer.h"
+
 #include <game/editor/editor_trackers.h>
 #include <game/editor/enums.h>
-#include <map>
 
-#include "layer.h"
+#include <map>
 
 struct STileStateChange
 {

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -1,4 +1,5 @@
-#include <game/editor/editor.h>
+#include "image.h"
+#include "sound.h"
 
 #include <engine/client.h>
 #include <engine/console.h>
@@ -9,11 +10,9 @@
 #include <engine/sound.h>
 #include <engine/storage.h>
 
+#include <game/editor/editor.h>
 #include <game/gamecore.h>
 #include <game/mapitems_ex.h>
-
-#include "image.h"
-#include "sound.h"
 
 // compatibility with old sound layers
 class CSoundSourceDeprecated

--- a/src/game/editor/mapitems/sound.h
+++ b/src/game/editor/mapitems/sound.h
@@ -2,6 +2,7 @@
 #define GAME_EDITOR_MAPITEMS_SOUND_H
 
 #include <base/types.h>
+
 #include <game/editor/component.h>
 
 class CEditorSound : public CEditorComponent

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1,6 +1,9 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
+#include "editor.h"
+#include "editor_actions.h"
+
 #include <base/color.h>
 
 #include <engine/console.h>
@@ -10,15 +13,13 @@
 #include <engine/shared/config.h>
 #include <engine/storage.h>
 #include <engine/textrender.h>
-#include <limits>
 
 #include <game/client/gameclient.h>
 #include <game/client/ui_scrollregion.h>
 #include <game/editor/mapitems/image.h>
 #include <game/editor/mapitems/sound.h>
 
-#include "editor.h"
-#include "editor_actions.h"
+#include <limits>
 
 using namespace FontIcons;
 

--- a/src/game/editor/prompt.cpp
+++ b/src/game/editor/prompt.cpp
@@ -1,10 +1,11 @@
-#include <engine/keys.h>
-#include <game/client/ui_listbox.h>
-#include <game/editor/quick_action.h>
+#include "prompt.h"
 
 #include "editor.h"
 
-#include "prompt.h"
+#include <engine/keys.h>
+
+#include <game/client/ui_listbox.h>
+#include <game/editor/quick_action.h>
 
 static bool FuzzyMatch(const char *pHaystack, const char *pNeedle)
 {

--- a/src/game/editor/prompt.h
+++ b/src/game/editor/prompt.h
@@ -1,11 +1,11 @@
 #ifndef GAME_EDITOR_PROMPT_H
 #define GAME_EDITOR_PROMPT_H
 
+#include "component.h"
+
 #include <game/client/lineinput.h>
 #include <game/client/ui_rect.h>
 #include <game/editor/quick_action.h>
-
-#include "component.h"
 
 class CPrompt : public CEditorComponent
 {

--- a/src/game/editor/proof_mode.cpp
+++ b/src/game/editor/proof_mode.cpp
@@ -1,8 +1,8 @@
 #include "proof_mode.h"
 
-#include <game/client/components/menu_background.h>
-
 #include "editor.h"
+
+#include <game/client/components/menu_background.h>
 
 void CProofMode::OnInit(CEditor *pEditor)
 {

--- a/src/game/editor/quadart.cpp
+++ b/src/game/editor/quadart.cpp
@@ -1,4 +1,5 @@
 #include "quadart.h"
+
 #include "editor.h"
 #include "editor_actions.h"
 

--- a/src/game/editor/quadart.h
+++ b/src/game/editor/quadart.h
@@ -2,9 +2,12 @@
 #define GAME_EDITOR_QUADART_H
 
 #include <base/types.h>
+
 #include <engine/image.h>
+
 #include <game/editor/mapitems/layer_quads.h>
 #include <game/mapitems.h>
+
 #include <memory>
 #include <optional>
 

--- a/src/game/editor/quick_actions.cpp
+++ b/src/game/editor/quick_actions.cpp
@@ -1,10 +1,10 @@
+#include "editor.h"
+#include "editor_actions.h"
+
 #include <engine/keys.h>
+
 #include <game/client/gameclient.h>
 #include <game/mapitems.h>
-
-#include "editor.h"
-
-#include "editor_actions.h"
 
 void CEditor::FillGameTiles(EGameTileOp FillTile) const
 {

--- a/src/game/editor/smooth_value.h
+++ b/src/game/editor/smooth_value.h
@@ -1,9 +1,9 @@
 #ifndef GAME_EDITOR_SMOOTH_VALUE_H
 #define GAME_EDITOR_SMOOTH_VALUE_H
 
-#include <base/bezier.h>
-
 #include "component.h"
+
+#include <base/bezier.h>
 
 /**
  * A value that is changed smoothly over time.

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -7,6 +7,7 @@
 #include "teamscore.h"
 
 #include <base/system.h>
+
 #include <engine/shared/config.h>
 
 #include <limits>

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -3,10 +3,9 @@
 #ifndef GAME_GAMECORE_H
 #define GAME_GAMECORE_H
 
-#include <base/vmath.h>
+#include "prng.h"
 
-#include <set>
-#include <vector>
+#include <base/vmath.h>
 
 #include <engine/shared/protocol.h>
 
@@ -14,7 +13,8 @@
 
 #include <game/teamscore.h>
 
-#include "prng.h"
+#include <set>
+#include <vector>
 
 class CCollision;
 class CTeamsCore;

--- a/src/game/map/envelope_extrema.h
+++ b/src/game/map/envelope_extrema.h
@@ -2,6 +2,7 @@
 #define GAME_MAP_ENVELOPE_EXTREMA_H
 
 #include <engine/map.h>
+
 #include <game/map/render_map.h>
 
 #include <vector>

--- a/src/game/map/envelope_manager.h
+++ b/src/game/map/envelope_manager.h
@@ -2,6 +2,7 @@
 #define GAME_MAP_ENVELOPE_MANAGER_H
 
 #include <engine/map.h>
+
 #include <game/map/envelope_extrema.h>
 #include <game/map/render_interfaces.h>
 

--- a/src/game/map/map_renderer.cpp
+++ b/src/game/map/map_renderer.cpp
@@ -1,8 +1,8 @@
+#include "map_renderer.h"
+
 #include <base/log.h>
 
 #include <game/map/envelope_manager.h>
-
-#include "map_renderer.h"
 
 const int LAYER_DEFAULT_TILESET = -1;
 

--- a/src/game/map/map_renderer.h
+++ b/src/game/map/map_renderer.h
@@ -2,6 +2,7 @@
 #define GAME_MAP_MAP_RENDERER_H
 
 #include <engine/map.h>
+
 #include <game/layers.h>
 #include <game/map/render_component.h>
 #include <game/map/render_layer.h>

--- a/src/game/map/render_component.cpp
+++ b/src/game/map/render_component.cpp
@@ -1,7 +1,7 @@
+#include "render_component.h"
+
 #include <engine/graphics.h>
 #include <engine/textrender.h>
-
-#include "render_component.h"
 
 void CRenderComponent::OnInit(IGraphics *pGraphics, ITextRender *pTextRender, CRenderMap *pRenderMap)
 {

--- a/src/game/map/render_layer.h
+++ b/src/game/map/render_layer.h
@@ -7,11 +7,8 @@ using offset_ptr_size = char *;
 using offset_ptr = uintptr_t;
 using offset_ptr32 = unsigned int;
 
-#include <memory>
-#include <optional>
-#include <vector>
-
 #include <base/color.h>
+
 #include <engine/graphics.h>
 
 #include <game/map/envelope_manager.h>
@@ -19,6 +16,10 @@ using offset_ptr32 = unsigned int;
 #include <game/map/render_map.h>
 #include <game/mapitems.h>
 #include <game/mapitems_ex.h>
+
+#include <memory>
+#include <optional>
+#include <vector>
 
 class CMapLayers;
 class CMapItemLayerTilemap;

--- a/src/game/map/render_map.cpp
+++ b/src/game/map/render_map.cpp
@@ -1,16 +1,15 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "render_map.h"
+
 #include <base/math.h>
 
 #include <engine/graphics.h>
 #include <engine/map.h>
-#include <engine/textrender.h>
-
 #include <engine/shared/config.h>
 #include <engine/shared/datafile.h>
 #include <engine/shared/map.h>
-
-#include "render_map.h"
+#include <engine/textrender.h>
 
 #include <generated/client_data.h>
 

--- a/src/game/map/render_map.h
+++ b/src/game/map/render_map.h
@@ -2,6 +2,7 @@
 #define GAME_MAP_RENDER_MAP_H
 
 #include <base/color.h>
+
 #include <game/map/render_interfaces.h>
 #include <game/mapitems.h>
 

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1,7 +1,13 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
+#include "gamecontext.h"
+#include "player.h"
+#include "score.h"
+
 #include <base/log.h>
+
 #include <engine/shared/config.h>
 #include <engine/shared/protocol.h>
+
 #include <game/mapitems.h>
 #include <game/server/entities/character.h>
 #include <game/server/gamemodes/DDRace.h>
@@ -9,10 +15,6 @@
 #include <game/team_state.h>
 #include <game/teamscore.h>
 #include <game/version.h>
-
-#include "gamecontext.h"
-#include "player.h"
-#include "score.h"
 
 void CGameContext::ConCredits(IConsole::IResult *pResult, void *pUserData)
 {

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -2,8 +2,8 @@
 #include "gamecontext.h"
 
 #include <engine/antibot.h>
-
 #include <engine/shared/config.h>
+
 #include <game/server/entities/character.h>
 #include <game/server/gamemodes/DDRace.h>
 #include <game/server/player.h>

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1,11 +1,13 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "character.h"
+
 #include "laser.h"
 #include "pickup.h"
 #include "projectile.h"
 
 #include <antibot/antibot_data.h>
+
 #include <base/log.h>
 
 #include <engine/antibot.h>
@@ -15,13 +17,12 @@
 #include <generated/server_data.h>
 
 #include <game/mapitems.h>
-#include <game/team_state.h>
-
 #include <game/server/gamecontext.h>
 #include <game/server/gamecontroller.h>
 #include <game/server/player.h>
 #include <game/server/score.h>
 #include <game/server/teams.h>
+#include <game/team_state.h>
 
 MACRO_ALLOC_POOL_ID_IMPL(CCharacter, MAX_CLIENTS)
 

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -3,9 +3,8 @@
 #ifndef GAME_SERVER_ENTITIES_CHARACTER_H
 #define GAME_SERVER_ENTITIES_CHARACTER_H
 
-#include <game/server/entity.h>
-
 #include <game/race_state.h>
+#include <game/server/entity.h>
 #include <game/server/save.h>
 
 class CGameTeams;

--- a/src/game/server/entities/door.cpp
+++ b/src/game/server/entities/door.cpp
@@ -1,5 +1,6 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 #include "door.h"
+
 #include "character.h"
 
 #include <generated/protocol.h>

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -1,5 +1,6 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 #include "dragger.h"
+
 #include "character.h"
 #include "dragger_beam.h"
 

--- a/src/game/server/entities/dragger_beam.cpp
+++ b/src/game/server/entities/dragger_beam.cpp
@@ -1,5 +1,6 @@
 /* See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 #include "dragger_beam.h"
+
 #include "character.h"
 #include "dragger.h"
 

--- a/src/game/server/entities/gun.cpp
+++ b/src/game/server/entities/gun.cpp
@@ -1,5 +1,6 @@
 /* copyright (c) 2007 magnus auvinen, see licence.txt for more info */
 #include "gun.h"
+
 #include "character.h"
 #include "plasma.h"
 

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -1,6 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "laser.h"
+
 #include "character.h"
 
 #include <engine/shared/config.h>

--- a/src/game/server/entities/light.cpp
+++ b/src/game/server/entities/light.cpp
@@ -1,5 +1,6 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 #include "light.h"
+
 #include "character.h"
 
 #include <engine/server.h>

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -1,6 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "pickup.h"
+
 #include "character.h"
 
 #include <generated/protocol.h>

--- a/src/game/server/entities/plasma.cpp
+++ b/src/game/server/entities/plasma.cpp
@@ -1,5 +1,6 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 #include "plasma.h"
+
 #include "character.h"
 
 #include <engine/server.h>

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -1,6 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "projectile.h"
+
 #include "character.h"
 
 #include <engine/shared/config.h>
@@ -8,7 +9,6 @@
 #include <generated/protocol.h>
 
 #include <game/mapitems.h>
-
 #include <game/server/gamecontext.h>
 #include <game/server/gamemodes/DDRace.h>
 

--- a/src/game/server/entity.cpp
+++ b/src/game/server/entity.cpp
@@ -2,6 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
 #include "entity.h"
+
 #include "gamecontext.h"
 #include "player.h"
 

--- a/src/game/server/entity.h
+++ b/src/game/server/entity.h
@@ -3,12 +3,12 @@
 #ifndef GAME_SERVER_ENTITY_H
 #define GAME_SERVER_ENTITY_H
 
+#include "gameworld.h"
+#include "save.h"
+
 #include <base/vmath.h>
 
 #include <game/alloc.h>
-
-#include "gameworld.h"
-#include "save.h"
 
 class CCollision;
 class CGameContext;

--- a/src/game/server/eventhandler.h
+++ b/src/game/server/eventhandler.h
@@ -3,9 +3,9 @@
 #ifndef GAME_SERVER_EVENTHANDLER_H
 #define GAME_SERVER_EVENTHANDLER_H
 
-#include <cstdint>
-
 #include <engine/shared/protocol.h>
+
+#include <cstdint>
 
 class CEventHandler
 {

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2,13 +2,19 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "gamecontext.h"
 
-#include <vector>
-
+#include "entities/character.h"
+#include "gamemodes/DDRace.h"
+#include "gamemodes/mod.h"
+#include "player.h"
+#include "score.h"
 #include "teeinfo.h"
+
 #include <antibot/antibot_data.h>
+
 #include <base/logger.h>
 #include <base/math.h>
 #include <base/system.h>
+
 #include <engine/console.h>
 #include <engine/engine.h>
 #include <engine/map.h>
@@ -21,19 +27,15 @@
 #include <engine/shared/protocolglue.h>
 #include <engine/storage.h>
 
+#include <generated/protocol7.h>
+#include <generated/protocolglue.h>
+
 #include <game/collision.h>
 #include <game/gamecore.h>
 #include <game/mapitems.h>
 #include <game/version.h>
 
-#include <generated/protocol7.h>
-#include <generated/protocolglue.h>
-
-#include "entities/character.h"
-#include "gamemodes/DDRace.h"
-#include "gamemodes/mod.h"
-#include "player.h"
-#include "score.h"
+#include <vector>
 
 // Not thread-safe!
 class CClientChatLogger : public ILogger

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -3,6 +3,10 @@
 #ifndef GAME_SERVER_GAMECONTEXT_H
 #define GAME_SERVER_GAMECONTEXT_H
 
+#include "eventhandler.h"
+#include "gameworld.h"
+#include "teehistorian.h"
+
 #include <engine/console.h>
 #include <engine/server.h>
 
@@ -12,10 +16,6 @@
 #include <game/layers.h>
 #include <game/mapbugs.h>
 #include <game/voting.h>
-
-#include "eventhandler.h"
-#include "gameworld.h"
-#include "teehistorian.h"
 
 #include <map>
 #include <memory>

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -1,18 +1,6 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#include <engine/shared/config.h>
-
-#include <engine/shared/protocolglue.h>
-
-#include <generated/protocol.h>
-
-#include <game/mapitems.h>
-#include <game/server/score.h>
-#include <game/teamscore.h>
-
-#include "gamecontext.h"
 #include "gamecontroller.h"
-#include "player.h"
 
 #include "entities/character.h"
 #include "entities/door.h"
@@ -21,6 +9,17 @@
 #include "entities/light.h"
 #include "entities/pickup.h"
 #include "entities/projectile.h"
+#include "gamecontext.h"
+#include "player.h"
+
+#include <engine/shared/config.h>
+#include <engine/shared/protocolglue.h>
+
+#include <generated/protocol.h>
+
+#include <game/mapitems.h>
+#include <game/server/score.h>
+#include <game/teamscore.h>
 
 IGameController::IGameController(class CGameContext *pGameServer) :
 	m_Teams(pGameServer), m_pLoadBestTimeResult(nullptr)

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -4,8 +4,10 @@
 #define GAME_SERVER_GAMECONTROLLER_H
 
 #include <base/vmath.h>
+
 #include <engine/map.h>
 #include <engine/shared/protocol.h>
+
 #include <game/server/teams.h>
 
 struct CScoreLoadBestTimeResult;

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -4,6 +4,7 @@
 
 #include <engine/server.h>
 #include <engine/shared/config.h>
+
 #include <game/mapitems.h>
 #include <game/server/entities/character.h>
 #include <game/server/gamecontext.h>

--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -1,6 +1,6 @@
-#include <engine/shared/config.h>
-
 #include "mod.h"
+
+#include <engine/shared/config.h>
 
 // Exchange this to a string that identifies your game mode.
 // DM, TDM and CTF are reserved for teeworlds original modes.

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -2,6 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
 #include "gameworld.h"
+
 #include "entities/character.h"
 #include "entity.h"
 #include "gamecontext.h"

--- a/src/game/server/gameworld.h
+++ b/src/game/server/gameworld.h
@@ -3,9 +3,9 @@
 #ifndef GAME_SERVER_GAMEWORLD_H
 #define GAME_SERVER_GAMEWORLD_H
 
-#include <game/gamecore.h>
-
 #include "save.h"
+
+#include <game/gamecore.h>
 
 #include <vector>
 

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -1,6 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "player.h"
+
 #include "entities/character.h"
 #include "gamecontext.h"
 #include "gamecontroller.h"

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -3,12 +3,14 @@
 #ifndef GAME_SERVER_PLAYER_H
 #define GAME_SERVER_PLAYER_H
 
+#include "teeinfo.h"
+
 #include <base/vmath.h>
+
 #include <engine/shared/protocol.h>
+
 #include <game/alloc.h>
 #include <game/server/save.h>
-
-#include "teeinfo.h"
 
 #include <memory>
 #include <optional>

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -1,14 +1,16 @@
+#include "save.h"
+
+#include "player.h"
+#include "teams.h"
+
 #include <engine/shared/config.h>
 #include <engine/shared/protocol.h>
+
 #include <game/server/entities/character.h>
 #include <game/server/gamemodes/DDRace.h>
 #include <game/team_state.h>
 
 #include <cstdio> // sscanf
-
-#include "player.h"
-#include "save.h"
-#include "teams.h"
 
 CSaveTee::CSaveTee() = default;
 

--- a/src/game/server/save.h
+++ b/src/game/server/save.h
@@ -2,6 +2,7 @@
 #define GAME_SERVER_SAVE_H
 
 #include <base/vmath.h>
+
 #include <engine/shared/protocol.h>
 
 #include <generated/protocol.h>

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -1,4 +1,11 @@
+#include "score.h"
+
+#include "player.h"
+#include "save.h"
+#include "scoreworker.h"
+
 #include <base/system.h>
+
 #include <engine/server/databases/connection_pool.h>
 #include <engine/shared/config.h>
 #include <engine/shared/console.h>
@@ -11,11 +18,6 @@
 #include <game/team_state.h>
 
 #include <memory>
-
-#include "player.h"
-#include "save.h"
-#include "score.h"
-#include "scoreworker.h"
 
 class IDbConnection;
 

--- a/src/game/server/score.h
+++ b/src/game/server/score.h
@@ -1,9 +1,9 @@
 #ifndef GAME_SERVER_SCORE_H
 #define GAME_SERVER_SCORE_H
 
-#include <game/prng.h>
-
 #include "scoreworker.h"
+
+#include <game/prng.h>
 
 class CDbConnectionPool;
 class CGameContext;

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -2,6 +2,7 @@
 
 #include <base/log.h>
 #include <base/system.h>
+
 #include <engine/server/databases/connection.h>
 #include <engine/server/databases/connection_pool.h>
 #include <engine/server/sql_string_helpers.h>

--- a/src/game/server/scoreworker.h
+++ b/src/game/server/scoreworker.h
@@ -1,18 +1,19 @@
 #ifndef GAME_SERVER_SCOREWORKER_H
 #define GAME_SERVER_SCOREWORKER_H
 
+#include <engine/map.h>
+#include <engine/server/databases/connection_pool.h>
+#include <engine/shared/protocol.h>
+#include <engine/shared/uuid_manager.h>
+
+#include <game/server/save.h>
+#include <game/voting.h>
+
 #include <memory>
 #include <optional>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <engine/map.h>
-#include <engine/server/databases/connection_pool.h>
-#include <engine/shared/protocol.h>
-#include <engine/shared/uuid_manager.h>
-#include <game/server/save.h>
-#include <game/voting.h>
 
 class IDbConnection;
 class IGameController;

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -1,15 +1,18 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
-#include <base/system.h>
-#include <engine/shared/config.h>
-#include <game/mapitems.h>
-#include <game/server/entities/character.h>
-#include <game/team_state.h>
+#include "teams.h"
 
 #include "gamecontroller.h"
 #include "player.h"
 #include "score.h"
-#include "teams.h"
 #include "teehistorian.h"
+
+#include <base/system.h>
+
+#include <engine/shared/config.h>
+
+#include <game/mapitems.h>
+#include <game/server/entities/character.h>
+#include <game/team_state.h>
 
 CGameTeams::CGameTeams(CGameContext *pGameContext) :
 	m_pGameContext(pGameContext)

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -3,6 +3,7 @@
 #define GAME_SERVER_TEAMS_H
 
 #include <engine/shared/protocol.h>
+
 #include <game/race_state.h>
 #include <game/server/gamecontext.h>
 #include <game/team_state.h>

--- a/src/game/server/teehistorian.h
+++ b/src/game/server/teehistorian.h
@@ -2,8 +2,10 @@
 #define GAME_SERVER_TEEHISTORIAN_H
 
 #include <base/hash.h>
+
 #include <engine/console.h>
 #include <engine/shared/protocol.h>
+
 #include <generated/protocol.h>
 
 #include <ctime>

--- a/src/game/teamscore.cpp
+++ b/src/game/teamscore.cpp
@@ -1,6 +1,8 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 #include "teamscore.h"
+
 #include <base/system.h>
+
 #include <engine/shared/config.h>
 
 CTeamsCore::CTeamsCore()

--- a/src/test/aio.cpp
+++ b/src/test/aio.cpp
@@ -1,7 +1,8 @@
 #include "test.h"
-#include <gtest/gtest.h>
 
 #include <base/system.h>
+
+#include <gtest/gtest.h>
 
 static const int BUF_SIZE = 64 * 1024;
 

--- a/src/test/bezier.cpp
+++ b/src/test/bezier.cpp
@@ -1,7 +1,8 @@
 #include "test.h"
-#include <gtest/gtest.h>
 
 #include <base/bezier.h>
+
+#include <gtest/gtest.h>
 
 // Due to the implementation, derivatives must be divisible by 3 to be exactly
 // represented.

--- a/src/test/blocklist_driver.cpp
+++ b/src/test/blocklist_driver.cpp
@@ -1,8 +1,8 @@
-#include <gtest/gtest.h>
-
 #include <base/detect.h>
 
 #include <engine/client/blocklist_driver.h>
+
+#include <gtest/gtest.h>
 
 TEST(BlocklistDriver, Valid1)
 {

--- a/src/test/bytes_be.cpp
+++ b/src/test/bytes_be.cpp
@@ -1,8 +1,8 @@
 #include "test.h"
 
-#include <gtest/gtest.h>
-
 #include <base/system.h>
+
+#include <gtest/gtest.h>
 
 static const int32_t INT_DATA[] = {0, 1, -1, 32, 64, 256, -512, 12345, -123456, 1234567, 12345678, 123456789, 2147483647, (-2147483647 - 1)};
 static const uint32_t UINT_DATA[] = {0u, 1u, 2u, 32u, 64u, 256u, 512u, 12345u, 123456u, 1234567u, 12345678u, 123456789u, 2147483647u, 2147483648u, 4294967295u};

--- a/src/test/chunk_header.cpp
+++ b/src/test/chunk_header.cpp
@@ -1,8 +1,10 @@
 #include "test.h"
-#include <gtest/gtest.h>
 
 #include <base/system.h>
+
 #include <engine/shared/network.h>
+
+#include <gtest/gtest.h>
 
 template<size_t PackedSize>
 static void AssertHeader(const CNetChunkHeader &Header, unsigned char aPacked[PackedSize])

--- a/src/test/color.cpp
+++ b/src/test/color.cpp
@@ -1,8 +1,8 @@
 #include "test.h"
 
-#include <gtest/gtest.h>
-
 #include <base/color.h>
+
+#include <gtest/gtest.h>
 
 TEST(Color, HslToRgbToHslConv)
 {

--- a/src/test/compression.cpp
+++ b/src/test/compression.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include <engine/shared/compression.h>
+
+#include <gtest/gtest.h>
 
 static const int DATA[] = {0, 1, -1, 32, 64, 256, -512, 12345, -123456, 1234567, 12345678, 123456789, 2147483647, (-2147483647 - 1)};
 static const int NUM = std::size(DATA);

--- a/src/test/csv.cpp
+++ b/src/test/csv.cpp
@@ -1,8 +1,10 @@
 #include "test.h"
-#include <gtest/gtest.h>
 
 #include <base/system.h>
+
 #include <engine/shared/csv.h>
+
+#include <gtest/gtest.h>
 
 static void Expect(int NumColumns, const char *const *ppColumns, const char *pExpected)
 {

--- a/src/test/datafile.cpp
+++ b/src/test/datafile.cpp
@@ -1,10 +1,13 @@
 #include "test.h"
-#include <gtest/gtest.h>
-#include <memory>
 
 #include <engine/shared/datafile.h>
 #include <engine/storage.h>
+
 #include <game/mapitems_ex.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
 
 TEST(Datafile, ExtendedType)
 {

--- a/src/test/editor.cpp
+++ b/src/test/editor.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include <base/system.h>
+
+#include <gtest/gtest.h>
 
 bool is_letter(char c) { return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'); }
 

--- a/src/test/fs.cpp
+++ b/src/test/fs.cpp
@@ -1,7 +1,8 @@
 #include "test.h"
-#include <gtest/gtest.h>
 
 #include <base/system.h>
+
+#include <gtest/gtest.h>
 
 TEST(Filesystem, Filename)
 {

--- a/src/test/gameworld.cpp
+++ b/src/test/gameworld.cpp
@@ -1,11 +1,9 @@
 #include "test.h"
-#include <game/server/gamecontroller.h>
-#include <game/server/player.h>
-#include <gtest/gtest.h>
 
 #include <base/logger.h>
 #include <base/system.h>
 #include <base/types.h>
+
 #include <engine/engine.h>
 #include <engine/kernel.h>
 #include <engine/server/databases/connection.h>
@@ -20,8 +18,12 @@
 
 #include <game/server/entities/character.h>
 #include <game/server/gamecontext.h>
+#include <game/server/gamecontroller.h>
 #include <game/server/gameworld.h>
+#include <game/server/player.h>
 #include <game/version.h>
+
+#include <gtest/gtest.h>
 
 #include <memory>
 #include <thread>

--- a/src/test/git_revision.cpp
+++ b/src/test/git_revision.cpp
@@ -1,7 +1,8 @@
-#include <gtest/gtest.h>
-
 #include <base/system.h>
+
 #include <game/version.h>
+
+#include <gtest/gtest.h>
 
 TEST(GitRevision, ExistsOrNull)
 {

--- a/src/test/hash.cpp
+++ b/src/test/hash.cpp
@@ -1,7 +1,7 @@
-#include <gtest/gtest.h>
-
 #include <base/hash_ctxt.h>
 #include <base/system.h>
+
+#include <gtest/gtest.h>
 
 template<size_t BufferSize = SHA256_MAXSTRSIZE>
 static void ExpectSha256(SHA256_DIGEST Actual, const char *pWanted)

--- a/src/test/huffman.cpp
+++ b/src/test/huffman.cpp
@@ -1,7 +1,8 @@
-#include <gtest/gtest.h>
-
 #include <base/system.h>
+
 #include <engine/shared/huffman.h>
+
+#include <gtest/gtest.h>
 
 TEST(Huffman, CompressionShouldNotChangeData)
 {

--- a/src/test/io.cpp
+++ b/src/test/io.cpp
@@ -1,7 +1,8 @@
 #include "test.h"
-#include <gtest/gtest.h>
 
 #include <base/system.h>
+
+#include <gtest/gtest.h>
 
 static void TestFileRead(const char *pWritten)
 {

--- a/src/test/jobs.cpp
+++ b/src/test/jobs.cpp
@@ -1,10 +1,11 @@
 #include "test.h"
-#include <gtest/gtest.h>
 
 #include <base/system.h>
 
 #include <engine/shared/host_lookup.h>
 #include <engine/shared/jobs.h>
+
+#include <gtest/gtest.h>
 
 #include <functional>
 

--- a/src/test/json.cpp
+++ b/src/test/json.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include <engine/shared/json.h>
+
+#include <gtest/gtest.h>
 
 TEST(Json, Escape)
 {

--- a/src/test/jsonwriter.cpp
+++ b/src/test/jsonwriter.cpp
@@ -1,10 +1,12 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "test.h"
-#include <gtest/gtest.h>
 
 #include <base/system.h>
+
 #include <engine/shared/jsonwriter.h>
+
+#include <gtest/gtest.h>
 
 #include <limits>
 

--- a/src/test/linereader.cpp
+++ b/src/test/linereader.cpp
@@ -1,8 +1,10 @@
 #include "test.h"
-#include <gtest/gtest.h>
 
 #include <base/system.h>
+
 #include <engine/shared/linereader.h>
+
+#include <gtest/gtest.h>
 
 void TestFileLineReaderRaw(const char *pWritten, unsigned WrittenLength, std::initializer_list<const char *> pReads, bool ExpectSuccess, bool WriteBom)
 {

--- a/src/test/mapbugs.cpp
+++ b/src/test/mapbugs.cpp
@@ -1,7 +1,8 @@
-#include <gtest/gtest.h>
-
 #include <base/system.h>
+
 #include <game/mapbugs.h>
+
+#include <gtest/gtest.h>
 
 static const char *BINARY_SHA256 = "65b410e197fd2298ec270e89a84b762f6739d1d18089529f8ef6cf2104d3d600";
 static const char *DM1_SHA256 = "0b0c481d77519c32fbe85624ef16ec0fa9991aec7367ad538bd280f28d8c26cf";

--- a/src/test/mapitems.cpp
+++ b/src/test/mapitems.cpp
@@ -1,7 +1,7 @@
+#include <game/mapitems.h>
+
 #include <gtest/gtest-printers.h>
 #include <gtest/gtest.h>
-
-#include <game/mapitems.h>
 
 namespace testing::internal
 {

--- a/src/test/math.cpp
+++ b/src/test/math.cpp
@@ -1,7 +1,8 @@
 #include "test.h"
-#include <gtest/gtest.h>
 
 #include <base/math.h>
+
+#include <gtest/gtest.h>
 
 TEST(Math, FixedPointRoundtrip)
 {

--- a/src/test/memory.cpp
+++ b/src/test/memory.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include <base/system.h>
+
+#include <gtest/gtest.h>
 
 static bool mem_is_null(const void *block, size_t size)
 {

--- a/src/test/name_ban.cpp
+++ b/src/test/name_ban.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include <engine/server/name_ban.h>
+
+#include <gtest/gtest.h>
 
 TEST(NameBan, Empty)
 {

--- a/src/test/net.cpp
+++ b/src/test/net.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include <base/system.h>
+
+#include <gtest/gtest.h>
 
 #include <chrono>
 

--- a/src/test/netaddr.cpp
+++ b/src/test/netaddr.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include <base/system.h>
+
+#include <gtest/gtest.h>
 
 TEST(NetAddr, FromUrlStringInvalid)
 {

--- a/src/test/os.cpp
+++ b/src/test/os.cpp
@@ -1,7 +1,8 @@
 #include "test.h"
-#include <gtest/gtest.h>
 
 #include <base/system.h>
+
+#include <gtest/gtest.h>
 
 TEST(Os, VersionStr)
 {

--- a/src/test/packer.cpp
+++ b/src/test/packer.cpp
@@ -1,8 +1,10 @@
 #include "test.h"
-#include <gtest/gtest.h>
 
 #include <base/system.h>
+
 #include <engine/shared/packer.h>
+
+#include <gtest/gtest.h>
 
 // pExpected is NULL if an error is expected
 static void ExpectAddString5(const char *pString, int Limit, bool AllowTruncation, const char *pExpected)

--- a/src/test/prng.cpp
+++ b/src/test/prng.cpp
@@ -1,7 +1,8 @@
 #include "test.h"
-#include <gtest/gtest.h>
 
 #include <game/prng.h>
+
+#include <gtest/gtest.h>
 
 // https://www.pcg-random.org/using-pcg-c-basic.html, retrieved 2020-05-25
 // suggests to use `pcg-32-global.demo.c`:

--- a/src/test/score.cpp
+++ b/src/test/score.cpp
@@ -1,12 +1,13 @@
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
-
 #include <base/detect.h>
+
 #include <engine/server/databases/connection.h>
 #include <engine/server/databases/connection_pool.h>
 #include <engine/shared/config.h>
+
 #include <game/server/scoreworker.h>
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include <sqlite3.h>
 
 #if defined(CONF_TEST_MYSQL)

--- a/src/test/secure_random.cpp
+++ b/src/test/secure_random.cpp
@@ -1,7 +1,8 @@
 #include "test.h"
-#include <gtest/gtest.h>
 
 #include <base/system.h>
+
+#include <gtest/gtest.h>
 
 TEST(SecureRandom, Fill)
 {

--- a/src/test/serverbrowser.cpp
+++ b/src/test/serverbrowser.cpp
@@ -1,6 +1,4 @@
 #include "test.h"
-#include <gtest/gtest.h>
-#include <memory>
 
 #include <base/system.h>
 
@@ -9,6 +7,10 @@
 #include <engine/engine.h>
 #include <engine/shared/config.h>
 #include <engine/storage.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
 
 TEST(ServerBrowser, PingCache)
 {

--- a/src/test/serverinfo.cpp
+++ b/src/test/serverinfo.cpp
@@ -1,9 +1,8 @@
-#include <gtest/gtest.h>
-
+#include <engine/external/json-parser/json.h>
 #include <engine/serverbrowser.h>
 #include <engine/shared/serverinfo.h>
 
-#include <engine/external/json-parser/json.h>
+#include <gtest/gtest.h>
 
 TEST(ServerInfo, ParseLocation)
 {

--- a/src/test/shell_execute.cpp
+++ b/src/test/shell_execute.cpp
@@ -1,7 +1,8 @@
 #include "test.h"
-#include <gtest/gtest.h>
 
 #include <base/system.h>
+
+#include <gtest/gtest.h>
 
 #if defined(CONF_FAMILY_WINDOWS)
 

--- a/src/test/snapshot.cpp
+++ b/src/test/snapshot.cpp
@@ -1,10 +1,10 @@
-#include <gtest/gtest.h>
-
 #include <base/system.h>
 
 #include <engine/shared/snapshot.h>
 
 #include <generated/protocol.h>
+
+#include <gtest/gtest.h>
 
 TEST(Snapshot, CrcOneInt)
 {

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -1,8 +1,8 @@
-#include <gtest/gtest.h>
-
 #include <base/system.h>
 
 #include <game/gamecore.h>
+
+#include <gtest/gtest.h>
 
 #include <limits>
 

--- a/src/test/strip_path_and_extension.cpp
+++ b/src/test/strip_path_and_extension.cpp
@@ -1,7 +1,8 @@
-#include <gtest/gtest.h>
-
 #include <base/system.h>
+
 #include <engine/storage.h>
+
+#include <gtest/gtest.h>
 
 class StripPathAndExtension : public ::testing::Test
 {

--- a/src/test/swap_endian.cpp
+++ b/src/test/swap_endian.cpp
@@ -1,7 +1,8 @@
 #include "test.h"
-#include <gtest/gtest.h>
 
 #include <base/system.h>
+
+#include <gtest/gtest.h>
 
 #include <array>
 

--- a/src/test/teehistorian.cpp
+++ b/src/test/teehistorian.cpp
@@ -1,11 +1,13 @@
-#include <gtest/gtest.h>
-
 #include <base/detect.h>
+
 #include <engine/external/json-parser/json.h>
 #include <engine/server.h>
 #include <engine/shared/config.h>
+
 #include <game/gamecore.h>
 #include <game/server/teehistorian.h>
+
+#include <gtest/gtest.h>
 
 #include <vector>
 

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -1,9 +1,11 @@
 #include "test.h"
-#include <gtest/gtest.h>
 
 #include <base/logger.h>
 #include <base/system.h>
+
 #include <engine/storage.h>
+
+#include <gtest/gtest.h>
 
 #include <algorithm>
 

--- a/src/test/thread.cpp
+++ b/src/test/thread.cpp
@@ -1,8 +1,8 @@
-#include <gtest/gtest.h>
-
 #include <base/lock.h>
 #include <base/system.h>
 #include <base/tl/threading.h>
+
+#include <gtest/gtest.h>
 
 static void Nothing(void *pUser)
 {

--- a/src/test/time.cpp
+++ b/src/test/time.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include <base/system.h>
+
+#include <gtest/gtest.h>
 
 #include <thread>
 

--- a/src/test/timestamp.cpp
+++ b/src/test/timestamp.cpp
@@ -1,6 +1,7 @@
+#include <base/system.h>
+
 #include <gtest/gtest.h>
 
-#include <base/system.h>
 #include <cstdlib>
 
 class TimestampTest : public testing::Test

--- a/src/test/unix.cpp
+++ b/src/test/unix.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include <base/system.h>
+
+#include <gtest/gtest.h>
 
 #if defined(CONF_FAMILY_UNIX)
 TEST(Unix, Create)

--- a/src/test/uuid.cpp
+++ b/src/test/uuid.cpp
@@ -1,6 +1,6 @@
-#include <gtest/gtest.h>
-
 #include <engine/shared/uuid_manager.h>
+
+#include <gtest/gtest.h>
 
 TEST(Uuid, FromToString)
 {

--- a/src/tools/config_common.h
+++ b/src/tools/config_common.h
@@ -1,5 +1,6 @@
 #include <base/logger.h>
 #include <base/system.h>
+
 #include <engine/storage.h>
 
 struct SListDirectoryContext

--- a/src/tools/config_retrieve.cpp
+++ b/src/tools/config_retrieve.cpp
@@ -1,6 +1,8 @@
 #include <base/system.h>
+
 #include <engine/shared/datafile.h>
 #include <engine/storage.h>
+
 #include <game/mapitems.h>
 
 static void Process(IStorage *pStorage, const char *pMapName, const char *pConfigName)

--- a/src/tools/crapnet.cpp
+++ b/src/tools/crapnet.cpp
@@ -5,7 +5,6 @@
 
 #include <cstdlib>
 #include <iterator> // std::size
-
 #include <thread>
 
 struct SPacket

--- a/src/tools/map_diff.cpp
+++ b/src/tools/map_diff.cpp
@@ -1,7 +1,9 @@
 #include <base/logger.h>
 #include <base/system.h>
+
 #include <engine/shared/datafile.h>
 #include <engine/storage.h>
+
 #include <game/gamecore.h>
 #include <game/mapitems.h>
 

--- a/src/tools/map_find_env.cpp
+++ b/src/tools/map_find_env.cpp
@@ -1,7 +1,9 @@
 #include <base/logger.h>
 #include <base/system.h>
+
 #include <engine/shared/datafile.h>
 #include <engine/storage.h>
+
 #include <game/mapitems.h>
 
 class CEnvelopedQuad

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -1,11 +1,14 @@
-#include <algorithm>
 #include <base/logger.h>
 #include <base/system.h>
-#include <cstdint>
+
 #include <engine/gfx/image_manipulation.h>
 #include <engine/shared/datafile.h>
 #include <engine/storage.h>
+
 #include <game/mapitems.h>
+
+#include <algorithm>
+#include <cstdint>
 #include <vector>
 
 static void ClearTransparentPixels(uint8_t *pImg, int Width, int Height)

--- a/src/tools/map_replace_area.cpp
+++ b/src/tools/map_replace_area.cpp
@@ -1,7 +1,9 @@
 #include <base/logger.h>
 #include <base/system.h>
+
 #include <engine/shared/datafile.h>
 #include <engine/storage.h>
+
 #include <game/mapitems.h>
 
 // global new layers data (set by ReplaceAreaTiles and ReplaceAreaQuads)

--- a/src/tools/stun.cpp
+++ b/src/tools/stun.cpp
@@ -1,5 +1,6 @@
 #include <base/logger.h>
 #include <base/system.h>
+
 #include <engine/shared/stun.h>
 
 #include <chrono>

--- a/src/tools/uuid.cpp
+++ b/src/tools/uuid.cpp
@@ -1,5 +1,6 @@
 #include <base/logger.h>
 #include <base/system.h>
+
 #include <engine/shared/uuid_manager.h>
 int main(int argc, const char **argv)
 {


### PR DESCRIPTION
Specify the precise order of the include groups in the clang format configuration. Use the setting `IncludeBlocks: Regroup` to force includes to be regrouped.

Group system library includes (`cstdio` etc.) separately from other libraries (SDL etc.).

Only the file `.clang-format` was changed manually in the commit a64bc97e418ffbc73875852a17ef5af22f3bafb7, all other files were updated by running `python scripts/fix_style.py`.

Closes #10694.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
