### PR TITLE
Fix HadokenAngle affecting eyes

### DIFF
--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -603,26 +603,26 @@ void CPlayers::RenderPlayer(
 					}
 					if(g_pData->m_Weapons.m_aId[CurrentWeapon].m_aSpriteMuzzles[IteX])
 					{
+						vec2 HadokenDirection;
 						if(PredictLocalWeapons || ClientId < 0)
-							Direction = vec2(pPlayerChar->m_X, pPlayerChar->m_Y) - vec2(pPrevChar->m_X, pPrevChar->m_Y);
+							HadokenDirection = vec2(pPlayerChar->m_X, pPlayerChar->m_Y) - vec2(pPrevChar->m_X, pPrevChar->m_Y);
 						else
-							Direction = vec2(GameClient()->m_Snap.m_aCharacters[ClientId].m_Cur.m_X, GameClient()->m_Snap.m_aCharacters[ClientId].m_Cur.m_Y) - vec2(GameClient()->m_Snap.m_aCharacters[ClientId].m_Prev.m_X, GameClient()->m_Snap.m_aCharacters[ClientId].m_Prev.m_Y);
-						float HadOkenAngle = 0.0f;
-						if(absolute(Direction.x) > 0.0001f || absolute(Direction.y) > 0.0001f)
+							HadokenDirection = vec2(GameClient()->m_Snap.m_aCharacters[ClientId].m_Cur.m_X, GameClient()->m_Snap.m_aCharacters[ClientId].m_Cur.m_Y) - vec2(GameClient()->m_Snap.m_aCharacters[ClientId].m_Prev.m_X, GameClient()->m_Snap.m_aCharacters[ClientId].m_Prev.m_Y);
+						float HadokenAngle = 0.0f;
+						if(absolute(HadokenDirection.x) > 0.0001f || absolute(HadokenDirection.y) > 0.0001f)
 						{
-							Direction = normalize(Direction);
-							HadOkenAngle = angle(Direction);
+							HadokenDirection = normalize(HadokenDirection);
+							HadokenAngle = angle(HadokenDirection);
 						}
 						else
 						{
-							Direction = vec2(1.0f, 0.0f);
+							HadokenDirection = vec2(1.0f, 0.0f);
 						}
-						Graphics()->QuadsSetRotation(HadOkenAngle);
+						Graphics()->QuadsSetRotation(HadokenAngle);
 						QuadOffset = IteX * 2;
-						vec2 DirectionY(-Direction.y, Direction.x);
 						WeaponPosition = Position;
 						float OffsetX = g_pData->m_Weapons.m_aId[CurrentWeapon].m_Muzzleoffsetx;
-						WeaponPosition -= Direction * OffsetX;
+						WeaponPosition -= HadokenDirection * OffsetX;
 						Graphics()->TextureSet(GameClient()->m_GameSkin.m_aaSpriteWeaponsMuzzles[CurrentWeapon][IteX]);
 						Graphics()->RenderQuadContainerAsSprite(m_aWeaponSpriteMuzzleQuadContainerIndex[CurrentWeapon], QuadOffset, WeaponPosition.x, WeaponPosition.y);
 					}


### PR DESCRIPTION
https://github.com/user-attachments/assets/5bfcf458-6868-41d5-beac-3a0d120fcbf0

Eyes go in the Hadoken direction, this was an unintended change... by someone

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
