### PR TITLE
Fix doxygen navigation structure

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,10 +1,8 @@
-# Overview
-
 @mainpage Overview
 
 This is the main page of the documentation of the [DDNet source code](https://github.com/ddnet/ddnet).
 
-## Structure
+# Structure
 
 The `src` folder is structured into several folders as follows:
 
@@ -21,7 +19,7 @@ The `src` folder is structured into several folders as follows:
 - test: Unit tests.
 - tools: Additional tools for utility and testing.
 
-## Documentation
+# Documentation
 
 We use [doxygen](https://www.doxygen.nl/) to generate this code documentation.
 The documentation is updated regularly and available at https://codedoc.ddnet.org/
@@ -29,7 +27,7 @@ The documentation is updated regularly and available at https://codedoc.ddnet.or
 To generate the documentation locally, install doxygen, then run `doxygen` within the project folder.
 The documentation will be written to the `docs` folder.
 
-## Resources
+# Resources
 
 - [Development page on the DDNet Wiki](https://wiki.ddnet.org/wiki/Development)
 - [Extra tools pages on the DDNet Wiki](https://wiki.ddnet.org/wiki/Extra_tools)

--- a/src/mastersrv/README.md
+++ b/src/mastersrv/README.md
@@ -1,4 +1,4 @@
-# @page mastersrv mastersrv
+@page mastersrv mastersrv
 
 The mastersrv maintains a list of all registered DDNet (and Teeworlds) servers.
 Game servers try to register themselves with the mastersrv via an HTTP POST
@@ -16,19 +16,19 @@ the `src/mastersrv` folder. The resulting binary should appear in
 
 Use `--help` to see some of the options of the mastersrv.
 
-## servers.json
+# servers.json
 
 The `servers.json` file produced by the mastersrv is not actually served
 automatically, it needs to be served by another HTTPS server, probably by the
 same as the reverse proxy handling HTTPS for the mastersrv. It is suggested to
 serve the `servers.json` file at the path `/ddnet/15/servers.json`.
 
-## Logs
+# Logs
 
 To enable logs, set the environment variable `RUST_LOG=mastersrv,info`. Logs
 should appear already when just starting the mastersrv.
 
-## Reverse proxy
+# Reverse proxy
 
 In order to run this mastersrv in production, you must put it behind a reverse
 proxy that handles HTTPS, such as nginx, Caddy, or Apache.


### PR DESCRIPTION
The `@mainpage` and `@page` commands already set the top-most page title for Doxygen. The `@page mastersrv mastersrv` was not correctly transformed while inside the `#`-headline with the older Doxygen version 1.9.8 that is used on the server.

The other `##`-headers are changed to `#` so their header level is directly below the page itself, otherwise they are not shown in the navigation menu.

Screenshots (with Doxygen 1.9.8):
- Before: <img src="https://github.com/user-attachments/assets/0f161c86-d500-4923-abcf-f906c06a8cc3" />
- After: <img src="https://github.com/user-attachments/assets/c4ed485d-1558-418e-a5d1-18f390890f10" />

## Checklist

- [X] Tested the change
- [X] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options: also works with Doxygen 1.14.0
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
