### PR TITLE
Make map settings read-only

### DIFF
--- a/src/engine/config.h
+++ b/src/engine/config.h
@@ -16,6 +16,7 @@ public:
 	virtual void Reset(const char *pScriptName) = 0;
 	virtual void ResetGameSettings() = 0;
 	virtual void SetReadOnly(const char *pScriptName, bool ReadOnly) = 0;
+	virtual void SetGameSettingsReadOnly(bool ReadOnly) = 0;
 	virtual bool Save() = 0;
 	virtual class CConfig *Values() = 0;
 

--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -365,6 +365,14 @@ void CConfigManager::SetReadOnly(const char *pScriptName, bool ReadOnly)
 	dbg_assert(false, "Invalid command for SetReadOnly: '%s'", pScriptName);
 }
 
+void CConfigManager::SetGameSettingsReadOnly(bool ReadOnly)
+{
+	for(SConfigVariable *pVariable : m_vpGameVariables)
+	{
+		pVariable->m_ReadOnly = ReadOnly;
+	}
+}
+
 bool CConfigManager::Save()
 {
 	if(!m_pStorage || !g_Config.m_ClSaveSettings)

--- a/src/engine/shared/config.h
+++ b/src/engine/shared/config.h
@@ -231,6 +231,7 @@ public:
 	void Reset(const char *pScriptName) override;
 	void ResetGameSettings() override;
 	void SetReadOnly(const char *pScriptName, bool ReadOnly) override;
+	void SetGameSettingsReadOnly(bool ReadOnly) override;
 	bool Save() override;
 	CConfig *Values() override { return &g_Config; }
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4052,9 +4052,13 @@ void CGameContext::OnInit(const void *pPersistentData)
 			Switcher.m_Initial = true;
 	}
 
+	m_pConfigManager->SetGameSettingsReadOnly(false);
+
 	Console()->ExecuteFile(g_Config.m_SvResetFile, -1);
 
 	LoadMapSettings();
+
+	m_pConfigManager->SetGameSettingsReadOnly(true);
 
 	m_MapBugs.Dump();
 


### PR DESCRIPTION
Closes #7589. I did what was suggested in #10907, sorry for not knowing how to use git and github properly.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
