### PR TITLE
Make `CCommand::m_Next` private

### DIFF
--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -15,8 +15,12 @@ class CConsole : public IConsole
 {
 	class CCommand : public CCommandInfo
 	{
-	public:
 		CCommand *m_pNext;
+
+	public:
+		const CCommand *Next() const { return m_pNext; }
+		CCommand *Next() { return m_pNext; }
+		void SetNext(CCommand *pNext) { m_pNext = pNext; }
 		int m_Flags;
 		bool m_Temp;
 		FCommandCallback m_pfnCallback;


### PR DESCRIPTION
Helps with #10836 which is needed for #10681
Allows to swap out `Next()` with a virtual method with a small git diff.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
