### PR TITLE
Add missing `engine/console.h` include in `controls.h`

### DIFF
--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -6,6 +6,7 @@
 #include <base/vmath.h>
 
 #include <engine/client.h>
+#include <engine/console.h>
 
 #include <game/client/component.h>
 #include <generated/protocol.h>


### PR DESCRIPTION
This was only working because other includes where transitively including `engine/console.h` before `controls.h`, so the required definition for `IConsole::IResult` was always available in `controls.h`.

This would break when main includes are moved to the top of source files. See #10902.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
