### PR TITLE
Check header and source function order in CI

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -40,6 +40,26 @@ jobs:
         clang-format -version
         scripts/fix_style.py --dry-run
 
+    - name: Install Clang 20
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y wget gnupg lsb-release
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 20 all
+        rm llvm.sh
+
+    - name: Check source and header order
+      run: |
+        git clone https://github.com/ChillerDragon/ddnet-lint ~/ddnet-lint
+        pushd ~/ddnet-lint
+        mkdir build
+        pushd build
+        cmake .. && make
+        popd
+        popd
+        ~/ddnet-lint/build/ddnet_lint
+
     - name: Shellcheck
       run: find . -type f -name '*.sh' -print0 | xargs -0 shellcheck
 

--- a/src/base/str.cpp
+++ b/src/base/str.cpp
@@ -1,4 +1,4 @@
-#include "str.h"
+#include <base/str.h>
 
 #include <cstring>
 


### PR DESCRIPTION
Adds an external script only run in the CI that checks
for now only those source files:

	src/base/fs.cpp
	src/base/fs.h
	src/base/str.cpp
	src/base/str.h

The CI will fail if the order of functions is not the same
in the header and source file.

This helps to keep the newly sorted files from regressing again.


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
