### PR TITLE
Remove weird quantization in CPlayers::RenderHookCollLine

### DIFF
--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -274,14 +274,8 @@ void CPlayers::RenderHookCollLine(
 		if(Hit && Hit != TILE_TELEINHOOK)
 			break;
 
-		NewPos.x = round_to_int(NewPos.x);
-		NewPos.y = round_to_int(NewPos.y);
-
 		if(OldPos == NewPos)
 			break;
-
-		Direction.x = round_to_int(Direction.x * 256.0f) / 256.0f;
-		Direction.y = round_to_int(Direction.y * 256.0f) / 256.0f;
 	} while(!DoBreak);
 
 	std::pair<vec2, vec2> NewPair = std::make_pair(InitPos, FinishPos);


### PR DESCRIPTION
* At the end of the loop direction is quantized to the nearest 0.0039, this does pretty much nothing to causes the line to rotate +-0.0019 after the first segment

* NewPos is quantized to the nearest int just before comparing with NewPos, this is in 1/32 blocks so the nearest 1/32 block. This means hook speeds slower than this will not render, this may have been intentional so that you cant have extremley slow hook speed with huge length to lag people out (rendering hook line is already quite expensive), but this should be prevented more explitley (eg by capping the number of calculating segments or capping the configs to reasonable values)

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
