### PR TITLE
Recreate swapchain for other OS than macos

### DIFF
--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -6875,6 +6875,9 @@ public:
 			}
 			m_CanvasWidth = (uint32_t)pCommand->m_Width;
 			m_CanvasHeight = (uint32_t)pCommand->m_Height;
+#ifndef CONF_PLATFORM_MACOS
+			m_RecreateSwapChain = true;
+#endif
 		}
 		else
 		{


### PR DESCRIPTION
I did my research and the conclusion is.

Vulkan spec does not enforce that a video driver has to send outdated or suboptimal events (e.g. on resize).
And there are wayland compositors that will break then.

So #10882 for macos only.. Didn't find a better way.. try some stuff like comparing surface props, which are not helpful in all cases :/

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
