### PR TITLE
Refactor: Improve hook collision line logic

### DIFF
--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -363,7 +363,6 @@ void CGhost::OnRender()
 		}
 
 		GameClient()->m_Players.RenderHook(&Prev, &Player, pRenderInfo, -2, IntraTick);
-		GameClient()->m_Players.RenderHookCollLine(&Prev, &Player, -2, IntraTick);
 		GameClient()->m_Players.RenderPlayer(&Prev, &Player, pRenderInfo, -2, IntraTick);
 	}
 }

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -148,27 +148,22 @@ float CPlayers::GetPlayerTargetAngle(
 void CPlayers::RenderHookCollLine(
 	const CNetObj_Character *pPrevChar,
 	const CNetObj_Character *pPlayerChar,
-	int ClientId,
-	float Intra)
+	int ClientId)
 {
 	CNetObj_Character Prev;
 	CNetObj_Character Player;
 	Prev = *pPrevChar;
 	Player = *pPlayerChar;
 
+	dbg_assert(in_range(ClientId, MAX_CLIENTS - 1), "invalid client id (%d)", ClientId);
+
 	bool Local = GameClient()->m_Snap.m_LocalClientId == ClientId;
 
-	if(ClientId >= 0)
-		Intra = GameClient()->m_aClients[ClientId].m_IsPredicted ? Client()->PredIntraGameTick(g_Config.m_ClDummy) : Client()->IntraGameTick(g_Config.m_ClDummy);
-
+	float Intra = GameClient()->m_aClients[ClientId].m_IsPredicted ? Client()->PredIntraGameTick(g_Config.m_ClDummy) : Client()->IntraGameTick(g_Config.m_ClDummy);
 	float Angle = GetPlayerTargetAngle(&Prev, &Player, ClientId, Intra);
 
 	vec2 Direction = direction(Angle);
-	vec2 Position;
-	if(in_range(ClientId, MAX_CLIENTS - 1))
-		Position = GameClient()->m_aClients[ClientId].m_RenderPos;
-	else
-		Position = mix(vec2(Prev.m_X, Prev.m_Y), vec2(Player.m_X, Player.m_Y), Intra);
+	vec2 Position = GameClient()->m_aClients[ClientId].m_RenderPos;
 
 	bool Aim = (Player.m_PlayerFlags & PLAYERFLAG_AIM);
 	if(!Client()->ServerCapAnyPlayerFlag())
@@ -189,7 +184,7 @@ void CPlayers::RenderHookCollLine(
 #endif
 
 	bool AlwaysRenderHookColl = GameClient()->m_GameInfo.m_AllowHookColl && (Local ? g_Config.m_ClShowHookCollOwn : g_Config.m_ClShowHookCollOther) == 2;
-	bool RenderHookCollPlayer = ClientId >= 0 && Aim && (Local ? g_Config.m_ClShowHookCollOwn : g_Config.m_ClShowHookCollOther) > 0;
+	bool RenderHookCollPlayer = Aim && (Local ? g_Config.m_ClShowHookCollOwn : g_Config.m_ClShowHookCollOther) > 0;
 	if(Local && GameClient()->m_GameInfo.m_AllowHookColl && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 		RenderHookCollPlayer = GameClient()->m_Controls.m_aShowHookColl[g_Config.m_ClDummy] && g_Config.m_ClShowHookCollOwn > 0;
 	if(!AlwaysRenderHookColl && !RenderHookCollPlayer)
@@ -204,79 +199,109 @@ void CPlayers::RenderHookCollLine(
 			Direction = vec2(1.0f, 0.0f);
 	}
 
-	// Calculate hook coll line position
-	int HookSpeed = GameClient()->m_aClients[ClientId].m_Predicted.m_Tuning.m_HookFireSpeed;
-	if(HookSpeed <= 0)
+	static constexpr float HOOK_START_DISTANCE = CCharacterCore::PhysicalSize() * 1.5f;
+	float HookLength = (float)GameClient()->m_aClients[ClientId].m_Predicted.m_Tuning.m_HookLength;
+	float HookFireSpeed = (float)GameClient()->m_aClients[ClientId].m_Predicted.m_Tuning.m_HookFireSpeed;
+
+	// janky physics
+	if(HookLength < HOOK_START_DISTANCE || HookFireSpeed <= 0.0f)
 		return;
 
-	int HookLength = GameClient()->m_aClients[ClientId].m_Predicted.m_Tuning.m_HookLength;
+	// pre calculate quantization
+	vec2 QuantizedPos = Position + Direction * HookFireSpeed;
+	QuantizedPos.x = round_to_int(QuantizedPos.x);
+	QuantizedPos.y = round_to_int(QuantizedPos.y);
+	vec2 QuantizedDirection = normalize(QuantizedPos - Position);
 
-	const float LineOffset = CCharacterCore::PhysicalSize() * 1.5f;
-	vec2 InitPos = Position;
-	vec2 FinishPos = InitPos + Direction * (HookLength - LineOffset);
+	vec2 StartOffset = Direction * HOOK_START_DISTANCE;
+	vec2 BasePos = Position;
+	vec2 LineStartPos = BasePos + StartOffset;
+	vec2 SegmentStartPos = LineStartPos;
 
 	ColorRGBA HookCollColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClHookCollColorNoColl));
-
-	vec2 OldPos = InitPos + Direction * LineOffset;
-	vec2 NewPos = OldPos;
-
-	bool DoBreak = false;
 	std::vector<IGraphics::CLineItem> vLineSegments;
-	do
-	{
-		OldPos = NewPos;
-		NewPos = OldPos + Direction * HookSpeed;
 
-		if(distance(InitPos, NewPos) > HookLength)
+	const int MaxHookTicks = 5 * Client()->GameTickSpeed(); // calculating above 5 seconds is very expensive and unlikely to happen
+
+	// simulate the hook into the future
+	int HookTick;
+	for(HookTick = 0; HookTick < MaxHookTicks; ++HookTick)
+	{
+		int Tele;
+		vec2 HitPos;
+		vec2 SegmentEndPos = SegmentStartPos + QuantizedDirection * HookFireSpeed;
+
+		// check if a hook would enter retracting state in this tick
+		if(distance(BasePos, SegmentEndPos) > HookLength)
 		{
-			NewPos = InitPos + normalize(NewPos - InitPos) * HookLength;
-			DoBreak = true;
+			// the line is too long here, and the hook starts to retract, use old position
+			vLineSegments.emplace_back(LineStartPos, SegmentStartPos);
+			break;
 		}
 
-		int Tele;
-		int Hit = Collision()->IntersectLineTeleHook(OldPos, NewPos, &FinishPos, nullptr, &Tele);
+		// check for map collisions
+		int Hit = Collision()->IntersectLineTeleHook(SegmentStartPos, SegmentEndPos, &HitPos, nullptr, &Tele);
 
-		if(ClientId >= 0 && GameClient()->IntersectCharacter(OldPos, FinishPos, FinishPos, ClientId) != -1)
+		// check if we intersect a player
+		if(GameClient()->IntersectCharacter(SegmentStartPos, HitPos, SegmentEndPos, ClientId) != -1)
 		{
 			HookCollColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClHookCollColorTeeColl));
+			vLineSegments.emplace_back(LineStartPos, SegmentEndPos);
 			break;
 		}
 
-		if(!DoBreak && Hit == TILE_TELEINHOOK)
+		// we hit nothing, continue calculating segments
+		if(!Hit)
 		{
-			if(Collision()->TeleOuts(Tele - 1).size() != 1)
-			{
-				Hit = Collision()->IntersectLineTeleHook(OldPos, NewPos, &FinishPos, nullptr);
-			}
-			else
-			{
-				vLineSegments.emplace_back(InitPos, FinishPos);
-				InitPos = NewPos = Collision()->TeleOuts(Tele - 1)[0];
-			}
+			SegmentStartPos = SegmentEndPos;
+			SegmentStartPos.x = round_to_int(SegmentStartPos.x);
+			SegmentStartPos.y = round_to_int(SegmentStartPos.y);
+			continue;
 		}
 
-		if(!DoBreak && Hit && Hit != TILE_TELEINHOOK)
+		// we hit a solid / hook stopper
+		if(Hit != TILE_TELEINHOOK)
 		{
 			if(Hit != TILE_NOHOOK)
-			{
 				HookCollColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClHookCollColorHookableColl));
-			}
+			vLineSegments.emplace_back(LineStartPos, HitPos);
+			break;
 		}
 
-		if(Hit && Hit != TILE_TELEINHOOK)
+		// we are hitting TILE_TELEINHOOK
+		vLineSegments.emplace_back(LineStartPos, HitPos);
+
+		// check tele outs
+		const std::vector<vec2> &vTeleOuts = Collision()->TeleOuts(Tele - 1);
+		if(vTeleOuts.empty())
+		{
+			// the hook gets stuck, this is a feature or a bug
+			HookCollColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClHookCollColorHookableColl));
 			break;
-
-		NewPos.x = round_to_int(NewPos.x);
-		NewPos.y = round_to_int(NewPos.y);
-
-		if(OldPos == NewPos)
+		}
+		else if(vTeleOuts.size() > 1)
+		{
+			// we don't know which teleout the hook takes, just invert the color
+			HookCollColor = color_invert(color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClHookCollColorTeeColl)));
 			break;
+		}
 
-		Direction.x = round_to_int(Direction.x * 256.0f) / 256.0f;
-		Direction.y = round_to_int(Direction.y * 256.0f) / 256.0f;
-	} while(!DoBreak);
+		// go through one teleout, update positions and continue
+		BasePos = vTeleOuts[0];
+		LineStartPos = BasePos; // make the line start in the teleporter to prevent a gap
+		SegmentStartPos = BasePos + QuantizedDirection * HOOK_START_DISTANCE;
+	}
 
-	vLineSegments.emplace_back(InitPos, FinishPos);
+	// The hook line is too expensive to calculate and didn't hit anything before, just set a straight line
+	if(HookTick >= MaxHookTicks && vLineSegments.empty())
+	{
+		// we simply don't know if we hit anything or not
+		HookCollColor = color_invert(color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClHookCollColorTeeColl)));
+		vLineSegments.emplace_back(LineStartPos, BasePos + QuantizedDirection * HookLength);
+	}
+
+	// add a line from the player to the start position to prevent a visual gap
+	vLineSegments.emplace_back(Position, Position + StartOffset);
 
 	if(AlwaysRenderHookColl && RenderHookCollPlayer)
 	{
@@ -287,9 +312,10 @@ void CPlayers::RenderHookCollLine(
 	// Render hook coll line
 	const int HookCollSize = Local ? g_Config.m_ClHookCollSize : g_Config.m_ClHookCollSizeOther;
 
-	bool OtherTeam = GameClient()->IsOtherTeam(ClientId);
-	float Alpha = (OtherTeam || ClientId < 0) ? g_Config.m_ClShowOthersAlpha / 100.0f : 1.0f;
+	float Alpha = GameClient()->IsOtherTeam(ClientId) ? g_Config.m_ClShowOthersAlpha / 100.0f : 1.0f;
 	Alpha *= (float)g_Config.m_ClHookCollAlpha / 100;
+	if(Alpha <= 0.0f)
+		return;
 
 	Graphics()->TextureClear();
 	if(HookCollSize > 0)
@@ -323,6 +349,7 @@ void CPlayers::RenderHookCollLine(
 		Graphics()->LinesEnd();
 	}
 }
+
 void CPlayers::RenderHook(
 	const CNetObj_Character *pPrevChar,
 	const CNetObj_Character *pPlayerChar,

--- a/src/game/client/components/players.h
+++ b/src/game/client/components/players.h
@@ -31,8 +31,7 @@ class CPlayers : public CComponent
 	void RenderHookCollLine(
 		const CNetObj_Character *pPrevChar,
 		const CNetObj_Character *pPlayerChar,
-		int ClientId,
-		float Intra = 0.f);
+		int ClientId);
 	bool IsPlayerInfoAvailable(int ClientId) const;
 
 	int m_WeaponEmoteQuadContainerIndex;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Improves the hook collision line algorithm. Instead of creating a line segment for every simulated hook tick, it combines the segments to one.

This PR also adds a calculation limit, as with the right tuning values, e.g. `hook_length 9999` and `hook_fire_speed 1` it will calculate thousands of hook ticks each frame, which is certainly undesirable.

This PR introduces an unknown state, for hook teleporters with multiple exists and if the calculation limit is exceeded.

closes #10943
closes #10486

## bug checklist
- [x] dont skip telehooks with none or invalid telehooks
- [x] invent a new color for multiple teleouts but stop creating new line segments
- [x] improve performance of very very long hook collision lines outside the map
- [x] fix collision line beeing too long
- [x] fix low `hook_fire_speed` causing hook and hook line not to match
- [x] fix teleout start position
- [x] fix the hook collision line trying to support invalid client IDs (like -1) but actually doesn't, by removing it. You don't have enough information to render a collision line properly for a ghost!
- [x] (fix possible overflow in the vector reserve already done by other PR)

## Test screenshots

[TEST OUTDATED, now it's blue and skipped] Test extreme `tune hook_length 99999`, fps are still bad but waaaay better:
<img width="2560" height="1440" alt="screenshot_2025-09-18_18-25-07" src="https://github.com/user-attachments/assets/89740a69-d206-47d4-a898-82e9887e7dc7" />

Test endless hook teleportation shenanigans:
<img width="2560" height="1440" alt="screenshot_2025-09-18_18-26-42" src="https://github.com/user-attachments/assets/fe89ab5e-cd66-46c7-922e-22cdf94f5862" />

Test teleport destination unclear, look it's blue:
<img width="2560" height="1440" alt="screenshot_2025-09-18_18-26-49" src="https://github.com/user-attachments/assets/3a4aa578-6c05-4808-b7f9-0c0896e85512" />

[Hook-Tele output start is outdated] Test normal use case
<img width="2560" height="1440" alt="screenshot_2025-09-18_18-26-57" src="https://github.com/user-attachments/assets/35a6ad42-176b-47c9-b609-2916726697cd" />

Test no teleport destination hook gets stuck
<img width="2560" height="1440" alt="screenshot_2025-09-18_18-27-10" src="https://github.com/user-attachments/assets/173058b2-11f4-4fa5-9956-cc975ba4c181" />

I also tested the precision of solids and players to the pixel.

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
