### PR TITLE
Disallow casting between different `color4_base` template types

### DIFF
--- a/src/base/color.h
+++ b/src/base/color.h
@@ -6,6 +6,7 @@
 #include <base/vmath.h>
 
 #include <optional>
+#include <type_traits>
 
 /*
 	Title: Color handling
@@ -88,6 +89,12 @@ public:
 		y = ((col >> 8) & 0xFF) / 255.0f;
 		z = ((col >> 0) & 0xFF) / 255.0f;
 	}
+
+	// Disallow casting between different instantiations of the color4_base template.
+	// The color_cast functions below should be used to convert between colors.
+	template<typename OtherDerivedT>
+	requires(!std::is_same_v<DerivedT, OtherDerivedT>)
+		color4_base(const color4_base<OtherDerivedT> &Other) = delete;
 
 	constexpr vec4 v4() const { return vec4(x, y, z, a); }
 	constexpr operator vec4() const { return vec4(x, y, z, a); }

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2479,7 +2479,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 		}
 
 		static CButtonContainer s_BackgroundColor;
-		DoLine_ColorPicker(&s_BackgroundColor, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &LeftView, Localize("Chat background color"), &g_Config.m_ClChatBackgroundColor, static_cast<ColorRGBA>(ColorHSLA(CConfig::ms_ClChatBackgroundColor, true)), false, nullptr, true);
+		DoLine_ColorPicker(&s_BackgroundColor, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &LeftView, Localize("Chat background color"), &g_Config.m_ClChatBackgroundColor, color_cast<ColorRGBA>(ColorHSLA(CConfig::ms_ClChatBackgroundColor, true)), false, nullptr, true);
 
 		// ***** Messages ***** //
 		Ui()->DoLabel_AutoLineSize(Localize("Messages"), HeadlineFontSize,


### PR DESCRIPTION
Casts between different `color4_base` template instantiations (`ColorHSLA`, `ColorHSVA`, `ColorRGBA`) do not work correctly and instead cause the color values to be reinterpreted.

Prevent this by deleting the copy-constructors for `color4_base` with non-matching types.

Replace an incorrect `static_cast` of the chat background color from `ColorHSLA` to `ColorRGBA` with `color_cast`, which was only working because the affected color value only had a non-zero alpha component that was reinterpreted correctly.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
