### PR TITLE
Indent `namespace`s so migrated `enum`s look nicer

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,7 +20,7 @@ BraceWrapping:
   AfterEnum: true
   AfterExternBlock: false
   AfterFunction: true
-  AfterNamespace: false
+  AfterNamespace: true
   AfterStruct: true
   AfterUnion: true
   BeforeCatch: true
@@ -44,6 +44,7 @@ IncludeCategories:
 IncludeIsMainRegex: '$'
 IndentWidth: 8
 KeepEmptyLinesAtTheStartOfBlocks: false
+NamespaceIndentation: All
 PointerAlignment: Right
 ReflowComments: true
 SpaceBeforeParens: Never

--- a/src/engine/server/sql_string_helpers.h
+++ b/src/engine/server/sql_string_helpers.h
@@ -1,14 +1,14 @@
 #ifndef ENGINE_SERVER_SQL_STRING_HELPERS_H
 #define ENGINE_SERVER_SQL_STRING_HELPERS_H
 
-namespace sqlstr {
+namespace sqlstr
+{
+	void FuzzyString(char *pString, int Size);
 
-void FuzzyString(char *pString, int Size);
+	// written number of added bytes
+	int EscapeLike(char *pDst, const char *pSrc, int DstSize);
 
-// written number of added bytes
-int EscapeLike(char *pDst, const char *pSrc, int DstSize);
-
-void AgoTimeToString(int AgoTime, char *pAgoString, int Size);
+	void AgoTimeToString(int AgoTime, char *pAgoString, int Size);
 
 } // namespace sqlstr
 

--- a/src/engine/shared/protocol7.h
+++ b/src/engine/shared/protocol7.h
@@ -5,75 +5,74 @@
 
 #include <base/types.h>
 
-namespace protocol7 {
-
-enum
+namespace protocol7
 {
-	NETMSG_NULL = 0,
+	enum
+	{
+		NETMSG_NULL = 0,
 
-	// the first thing sent by the client
-	// contains the version info for the client
-	NETMSG_INFO,
+		// the first thing sent by the client
+		// contains the version info for the client
+		NETMSG_INFO,
 
-	// sent by server
-	NETMSG_MAP_CHANGE, // sent when client should switch map
-	NETMSG_MAP_DATA, // map transfer, contains a chunk of the map file
-	NETMSG_SERVERINFO,
-	NETMSG_CON_READY, // connection is ready, client should send start info
-	NETMSG_SNAP, // normal snapshot, multiple parts
-	NETMSG_SNAPEMPTY, // empty snapshot
-	NETMSG_SNAPSINGLE, // ?
-	NETMSG_SNAPSMALL, //
-	NETMSG_INPUTTIMING, // reports how off the input was
-	NETMSG_RCON_AUTH_ON, // rcon authentication enabled
-	NETMSG_RCON_AUTH_OFF, // rcon authentication disabled
-	NETMSG_RCON_LINE, // line that should be printed to the remote console
-	NETMSG_RCON_CMD_ADD,
-	NETMSG_RCON_CMD_REM,
+		// sent by server
+		NETMSG_MAP_CHANGE, // sent when client should switch map
+		NETMSG_MAP_DATA, // map transfer, contains a chunk of the map file
+		NETMSG_SERVERINFO,
+		NETMSG_CON_READY, // connection is ready, client should send start info
+		NETMSG_SNAP, // normal snapshot, multiple parts
+		NETMSG_SNAPEMPTY, // empty snapshot
+		NETMSG_SNAPSINGLE, // ?
+		NETMSG_SNAPSMALL, //
+		NETMSG_INPUTTIMING, // reports how off the input was
+		NETMSG_RCON_AUTH_ON, // rcon authentication enabled
+		NETMSG_RCON_AUTH_OFF, // rcon authentication disabled
+		NETMSG_RCON_LINE, // line that should be printed to the remote console
+		NETMSG_RCON_CMD_ADD,
+		NETMSG_RCON_CMD_REM,
 
-	NETMSG_UNUSED1,
-	NETMSG_UNUSED2,
+		NETMSG_UNUSED1,
+		NETMSG_UNUSED2,
 
-	// sent by client
-	NETMSG_READY, //
-	NETMSG_ENTERGAME,
-	NETMSG_INPUT, // contains the inputdata from the client
-	NETMSG_RCON_CMD, //
-	NETMSG_RCON_AUTH, //
-	NETMSG_REQUEST_MAP_DATA, //
+		// sent by client
+		NETMSG_READY, //
+		NETMSG_ENTERGAME,
+		NETMSG_INPUT, // contains the inputdata from the client
+		NETMSG_RCON_CMD, //
+		NETMSG_RCON_AUTH, //
+		NETMSG_REQUEST_MAP_DATA, //
 
-	NETMSG_UNUSED3,
-	NETMSG_UNUSED4,
+		NETMSG_UNUSED3,
+		NETMSG_UNUSED4,
 
-	// sent by both
-	NETMSG_PING,
-	NETMSG_PING_REPLY,
-	NETMSG_UNUSED5,
+		// sent by both
+		NETMSG_PING,
+		NETMSG_PING_REPLY,
+		NETMSG_UNUSED5,
 
-	NETMSG_MAPLIST_ENTRY_ADD, // todo 0.8: move up
-	NETMSG_MAPLIST_ENTRY_REM,
-};
+		NETMSG_MAPLIST_ENTRY_ADD, // todo 0.8: move up
+		NETMSG_MAPLIST_ENTRY_REM,
+	};
 
-enum
-{
-	NET_CTRLMSG_KEEPALIVE = 0,
-	NET_CTRLMSG_CONNECT,
-	NET_CTRLMSG_ACCEPT,
-	NET_CTRLMSG_UNUSED,
-	NET_CTRLMSG_CLOSE,
-	NET_CTRLMSG_TOKEN,
-};
+	enum
+	{
+		NET_CTRLMSG_KEEPALIVE = 0,
+		NET_CTRLMSG_CONNECT,
+		NET_CTRLMSG_ACCEPT,
+		NET_CTRLMSG_UNUSED,
+		NET_CTRLMSG_CLOSE,
+		NET_CTRLMSG_TOKEN,
+	};
 
-enum
-{
-	MAX_NAME_LENGTH = 16,
-	MAX_NAME_ARRAY_SIZE = MAX_NAME_LENGTH * UTF8_BYTE_LENGTH + 1,
-	MAX_CLAN_LENGTH = 12,
-	MAX_CLAN_ARRAY_SIZE = MAX_CLAN_LENGTH * UTF8_BYTE_LENGTH + 1,
-	MAX_SKIN_LENGTH = 24,
-	MAX_SKIN_ARRAY_SIZE = MAX_SKIN_LENGTH * UTF8_BYTE_LENGTH + 1,
-};
-
+	enum
+	{
+		MAX_NAME_LENGTH = 16,
+		MAX_NAME_ARRAY_SIZE = MAX_NAME_LENGTH * UTF8_BYTE_LENGTH + 1,
+		MAX_CLAN_LENGTH = 12,
+		MAX_CLAN_ARRAY_SIZE = MAX_CLAN_LENGTH * UTF8_BYTE_LENGTH + 1,
+		MAX_SKIN_LENGTH = 24,
+		MAX_SKIN_ARRAY_SIZE = MAX_SKIN_LENGTH * UTF8_BYTE_LENGTH + 1,
+	};
 } // namespace protocol7
 
 #endif

--- a/src/engine/shared/protocolglue.cpp
+++ b/src/engine/shared/protocolglue.cpp
@@ -6,14 +6,14 @@
 
 #include "protocolglue.h"
 
-namespace protocol7 {
-
-enum
+namespace protocol7
 {
-	NET_PACKETFLAG_CONTROL = 1 << 0,
-	NET_PACKETFLAG_RESEND = 1 << 1,
-	NET_PACKETFLAG_COMPRESSION = 1 << 2,
-};
+	enum
+	{
+		NET_PACKETFLAG_CONTROL = 1 << 0,
+		NET_PACKETFLAG_RESEND = 1 << 1,
+		NET_PACKETFLAG_COMPRESSION = 1 << 2,
+	};
 
 }
 

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -63,96 +63,97 @@ enum class EFontPreset
 	ICON_FONT,
 };
 
-namespace FontIcons {
-// Each font icon is named according to its official name in Font Awesome
-[[maybe_unused]] static const char *FONT_ICON_PLUS = "+";
-[[maybe_unused]] static const char *FONT_ICON_MINUS = "-";
-[[maybe_unused]] static const char *FONT_ICON_LOCK = "\xEF\x80\xA3";
-[[maybe_unused]] static const char *FONT_ICON_MAGNIFYING_GLASS = "\xEF\x80\x82";
-[[maybe_unused]] static const char *FONT_ICON_HEART = "\xEF\x80\x84";
-[[maybe_unused]] static const char *FONT_ICON_STAR = "\xEF\x80\x85";
-[[maybe_unused]] static const char *FONT_ICON_XMARK = "\xEF\x80\x8D";
-[[maybe_unused]] static const char *FONT_ICON_CIRCLE = "\xEF\x84\x91";
-[[maybe_unused]] static const char *FONT_ICON_ARROW_ROTATE_LEFT = "\xEF\x83\xA2";
-[[maybe_unused]] static const char *FONT_ICON_ARROW_ROTATE_RIGHT = "\xEF\x80\x9E";
-[[maybe_unused]] static const char *FONT_ICON_FLAG_CHECKERED = "\xEF\x84\x9E";
-[[maybe_unused]] static const char *FONT_ICON_BAN = "\xEF\x81\x9E";
-[[maybe_unused]] static const char *FONT_ICON_CIRCLE_CHEVRON_DOWN = "\xEF\x84\xBA";
-[[maybe_unused]] static const char *FONT_ICON_SQUARE_MINUS = "\xEF\x85\x86";
-[[maybe_unused]] static const char *FONT_ICON_SQUARE_PLUS = "\xEF\x83\xBE";
-[[maybe_unused]] static const char *FONT_ICON_SORT_UP = "\xEF\x83\x9E";
-[[maybe_unused]] static const char *FONT_ICON_SORT_DOWN = "\xEF\x83\x9D";
-[[maybe_unused]] static const char *FONT_ICON_TRIANGLE_EXCLAMATION = "\xEF\x81\xB1";
+namespace FontIcons
+{
+	// Each font icon is named according to its official name in Font Awesome
+	[[maybe_unused]] static const char *FONT_ICON_PLUS = "+";
+	[[maybe_unused]] static const char *FONT_ICON_MINUS = "-";
+	[[maybe_unused]] static const char *FONT_ICON_LOCK = "\xEF\x80\xA3";
+	[[maybe_unused]] static const char *FONT_ICON_MAGNIFYING_GLASS = "\xEF\x80\x82";
+	[[maybe_unused]] static const char *FONT_ICON_HEART = "\xEF\x80\x84";
+	[[maybe_unused]] static const char *FONT_ICON_STAR = "\xEF\x80\x85";
+	[[maybe_unused]] static const char *FONT_ICON_XMARK = "\xEF\x80\x8D";
+	[[maybe_unused]] static const char *FONT_ICON_CIRCLE = "\xEF\x84\x91";
+	[[maybe_unused]] static const char *FONT_ICON_ARROW_ROTATE_LEFT = "\xEF\x83\xA2";
+	[[maybe_unused]] static const char *FONT_ICON_ARROW_ROTATE_RIGHT = "\xEF\x80\x9E";
+	[[maybe_unused]] static const char *FONT_ICON_FLAG_CHECKERED = "\xEF\x84\x9E";
+	[[maybe_unused]] static const char *FONT_ICON_BAN = "\xEF\x81\x9E";
+	[[maybe_unused]] static const char *FONT_ICON_CIRCLE_CHEVRON_DOWN = "\xEF\x84\xBA";
+	[[maybe_unused]] static const char *FONT_ICON_SQUARE_MINUS = "\xEF\x85\x86";
+	[[maybe_unused]] static const char *FONT_ICON_SQUARE_PLUS = "\xEF\x83\xBE";
+	[[maybe_unused]] static const char *FONT_ICON_SORT_UP = "\xEF\x83\x9E";
+	[[maybe_unused]] static const char *FONT_ICON_SORT_DOWN = "\xEF\x83\x9D";
+	[[maybe_unused]] static const char *FONT_ICON_TRIANGLE_EXCLAMATION = "\xEF\x81\xB1";
 
-[[maybe_unused]] static const char *FONT_ICON_HOUSE = "\xEF\x80\x95";
-[[maybe_unused]] static const char *FONT_ICON_BOOKMARK = "\xEF\x80\xAE";
-[[maybe_unused]] static const char *FONT_ICON_NEWSPAPER = "\xEF\x87\xAA";
-[[maybe_unused]] static const char *FONT_ICON_POWER_OFF = "\xEF\x80\x91";
-[[maybe_unused]] static const char *FONT_ICON_GEAR = "\xEF\x80\x93";
-[[maybe_unused]] static const char *FONT_ICON_PEN_TO_SQUARE = "\xEF\x81\x84";
-[[maybe_unused]] static const char *FONT_ICON_CLAPPERBOARD = "\xEE\x84\xB1";
-[[maybe_unused]] static const char *FONT_ICON_EARTH_AMERICAS = "\xEF\x95\xBD";
-[[maybe_unused]] static const char *FONT_ICON_NETWORK_WIRED = "\xEF\x9B\xBF";
-[[maybe_unused]] static const char *FONT_ICON_LIST_UL = "\xEF\x83\x8A";
-[[maybe_unused]] static const char *FONT_ICON_INFO = "\xEF\x84\xA9";
-[[maybe_unused]] static const char *FONT_ICON_TERMINAL = "\xEF\x84\xA0";
+	[[maybe_unused]] static const char *FONT_ICON_HOUSE = "\xEF\x80\x95";
+	[[maybe_unused]] static const char *FONT_ICON_BOOKMARK = "\xEF\x80\xAE";
+	[[maybe_unused]] static const char *FONT_ICON_NEWSPAPER = "\xEF\x87\xAA";
+	[[maybe_unused]] static const char *FONT_ICON_POWER_OFF = "\xEF\x80\x91";
+	[[maybe_unused]] static const char *FONT_ICON_GEAR = "\xEF\x80\x93";
+	[[maybe_unused]] static const char *FONT_ICON_PEN_TO_SQUARE = "\xEF\x81\x84";
+	[[maybe_unused]] static const char *FONT_ICON_CLAPPERBOARD = "\xEE\x84\xB1";
+	[[maybe_unused]] static const char *FONT_ICON_EARTH_AMERICAS = "\xEF\x95\xBD";
+	[[maybe_unused]] static const char *FONT_ICON_NETWORK_WIRED = "\xEF\x9B\xBF";
+	[[maybe_unused]] static const char *FONT_ICON_LIST_UL = "\xEF\x83\x8A";
+	[[maybe_unused]] static const char *FONT_ICON_INFO = "\xEF\x84\xA9";
+	[[maybe_unused]] static const char *FONT_ICON_TERMINAL = "\xEF\x84\xA0";
 
-[[maybe_unused]] static const char *FONT_ICON_SLASH = "\xEF\x9C\x95";
-[[maybe_unused]] static const char *FONT_ICON_PLAY = "\xEF\x81\x8B";
-[[maybe_unused]] static const char *FONT_ICON_PAUSE = "\xEF\x81\x8C";
-[[maybe_unused]] static const char *FONT_ICON_STOP = "\xEF\x81\x8D";
-[[maybe_unused]] static const char *FONT_ICON_CHEVRON_LEFT = "\xEF\x81\x93";
-[[maybe_unused]] static const char *FONT_ICON_CHEVRON_RIGHT = "\xEF\x81\x94";
-[[maybe_unused]] static const char *FONT_ICON_CHEVRON_UP = "\xEF\x81\xB7";
-[[maybe_unused]] static const char *FONT_ICON_CHEVRON_DOWN = "\xEF\x81\xB8";
-[[maybe_unused]] static const char *FONT_ICON_BACKWARD = "\xEF\x81\x8A";
-[[maybe_unused]] static const char *FONT_ICON_FORWARD = "\xEF\x81\x8E";
-[[maybe_unused]] static const char *FONT_ICON_RIGHT_FROM_BRACKET = "\xEF\x8B\xB5";
-[[maybe_unused]] static const char *FONT_ICON_RIGHT_TO_BRACKET = "\xEF\x8B\xB6";
-[[maybe_unused]] static const char *FONT_ICON_ARROW_UP_RIGHT_FROM_SQUARE = "\xEF\x82\x8E";
-[[maybe_unused]] static const char *FONT_ICON_BACKWARD_STEP = "\xEF\x81\x88";
-[[maybe_unused]] static const char *FONT_ICON_FORWARD_STEP = "\xEF\x81\x91";
-[[maybe_unused]] static const char *FONT_ICON_BACKWARD_FAST = "\xEF\x81\x89";
-[[maybe_unused]] static const char *FONT_ICON_FORWARD_FAST = "\xEF\x81\x90";
-[[maybe_unused]] static const char *FONT_ICON_KEYBOARD = "\xE2\x8C\xA8";
-[[maybe_unused]] static const char *FONT_ICON_ELLIPSIS = "\xEF\x85\x81";
+	[[maybe_unused]] static const char *FONT_ICON_SLASH = "\xEF\x9C\x95";
+	[[maybe_unused]] static const char *FONT_ICON_PLAY = "\xEF\x81\x8B";
+	[[maybe_unused]] static const char *FONT_ICON_PAUSE = "\xEF\x81\x8C";
+	[[maybe_unused]] static const char *FONT_ICON_STOP = "\xEF\x81\x8D";
+	[[maybe_unused]] static const char *FONT_ICON_CHEVRON_LEFT = "\xEF\x81\x93";
+	[[maybe_unused]] static const char *FONT_ICON_CHEVRON_RIGHT = "\xEF\x81\x94";
+	[[maybe_unused]] static const char *FONT_ICON_CHEVRON_UP = "\xEF\x81\xB7";
+	[[maybe_unused]] static const char *FONT_ICON_CHEVRON_DOWN = "\xEF\x81\xB8";
+	[[maybe_unused]] static const char *FONT_ICON_BACKWARD = "\xEF\x81\x8A";
+	[[maybe_unused]] static const char *FONT_ICON_FORWARD = "\xEF\x81\x8E";
+	[[maybe_unused]] static const char *FONT_ICON_RIGHT_FROM_BRACKET = "\xEF\x8B\xB5";
+	[[maybe_unused]] static const char *FONT_ICON_RIGHT_TO_BRACKET = "\xEF\x8B\xB6";
+	[[maybe_unused]] static const char *FONT_ICON_ARROW_UP_RIGHT_FROM_SQUARE = "\xEF\x82\x8E";
+	[[maybe_unused]] static const char *FONT_ICON_BACKWARD_STEP = "\xEF\x81\x88";
+	[[maybe_unused]] static const char *FONT_ICON_FORWARD_STEP = "\xEF\x81\x91";
+	[[maybe_unused]] static const char *FONT_ICON_BACKWARD_FAST = "\xEF\x81\x89";
+	[[maybe_unused]] static const char *FONT_ICON_FORWARD_FAST = "\xEF\x81\x90";
+	[[maybe_unused]] static const char *FONT_ICON_KEYBOARD = "\xE2\x8C\xA8";
+	[[maybe_unused]] static const char *FONT_ICON_ELLIPSIS = "\xEF\x85\x81";
 
-[[maybe_unused]] static const char *FONT_ICON_FOLDER = "\xEF\x81\xBB";
-[[maybe_unused]] static const char *FONT_ICON_FOLDER_OPEN = "\xEF\x81\xBC";
-[[maybe_unused]] static const char *FONT_ICON_FOLDER_TREE = "\xEF\xA0\x82";
-[[maybe_unused]] static const char *FONT_ICON_FILM = "\xEF\x80\x88";
-[[maybe_unused]] static const char *FONT_ICON_VIDEO = "\xEF\x80\xBD";
-[[maybe_unused]] static const char *FONT_ICON_MAP = "\xEF\x89\xB9";
-[[maybe_unused]] static const char *FONT_ICON_IMAGE = "\xEF\x80\xBE";
-[[maybe_unused]] static const char *FONT_ICON_MUSIC = "\xEF\x80\x81";
-[[maybe_unused]] static const char *FONT_ICON_FILE = "\xEF\x85\x9B";
+	[[maybe_unused]] static const char *FONT_ICON_FOLDER = "\xEF\x81\xBB";
+	[[maybe_unused]] static const char *FONT_ICON_FOLDER_OPEN = "\xEF\x81\xBC";
+	[[maybe_unused]] static const char *FONT_ICON_FOLDER_TREE = "\xEF\xA0\x82";
+	[[maybe_unused]] static const char *FONT_ICON_FILM = "\xEF\x80\x88";
+	[[maybe_unused]] static const char *FONT_ICON_VIDEO = "\xEF\x80\xBD";
+	[[maybe_unused]] static const char *FONT_ICON_MAP = "\xEF\x89\xB9";
+	[[maybe_unused]] static const char *FONT_ICON_IMAGE = "\xEF\x80\xBE";
+	[[maybe_unused]] static const char *FONT_ICON_MUSIC = "\xEF\x80\x81";
+	[[maybe_unused]] static const char *FONT_ICON_FILE = "\xEF\x85\x9B";
 
-[[maybe_unused]] static const char *FONT_ICON_PENCIL = "\xEF\x8C\x83";
-[[maybe_unused]] static const char *FONT_ICON_TRASH = "\xEF\x87\xB8";
+	[[maybe_unused]] static const char *FONT_ICON_PENCIL = "\xEF\x8C\x83";
+	[[maybe_unused]] static const char *FONT_ICON_TRASH = "\xEF\x87\xB8";
 
-[[maybe_unused]] static const char *FONT_ICON_ARROWS_LEFT_RIGHT = "\xEF\x8C\xB7";
-[[maybe_unused]] static const char *FONT_ICON_ARROWS_UP_DOWN = "\xEF\x81\xBD";
-[[maybe_unused]] static const char *FONT_ICON_CIRCLE_PLAY = "\xEF\x85\x84";
-[[maybe_unused]] static const char *FONT_ICON_BORDER_ALL = "\xEF\xA1\x8C";
-[[maybe_unused]] static const char *FONT_ICON_EYE = "\xEF\x81\xAE";
-[[maybe_unused]] static const char *FONT_ICON_EYE_SLASH = "\xEF\x81\xB0";
-[[maybe_unused]] static const char *FONT_ICON_EYE_DROPPER = "\xEF\x87\xBB";
+	[[maybe_unused]] static const char *FONT_ICON_ARROWS_LEFT_RIGHT = "\xEF\x8C\xB7";
+	[[maybe_unused]] static const char *FONT_ICON_ARROWS_UP_DOWN = "\xEF\x81\xBD";
+	[[maybe_unused]] static const char *FONT_ICON_CIRCLE_PLAY = "\xEF\x85\x84";
+	[[maybe_unused]] static const char *FONT_ICON_BORDER_ALL = "\xEF\xA1\x8C";
+	[[maybe_unused]] static const char *FONT_ICON_EYE = "\xEF\x81\xAE";
+	[[maybe_unused]] static const char *FONT_ICON_EYE_SLASH = "\xEF\x81\xB0";
+	[[maybe_unused]] static const char *FONT_ICON_EYE_DROPPER = "\xEF\x87\xBB";
 
-[[maybe_unused]] static const char *FONT_ICON_DICE_ONE = "\xEF\x94\xA5";
-[[maybe_unused]] static const char *FONT_ICON_DICE_TWO = "\xEF\x94\xA8";
-[[maybe_unused]] static const char *FONT_ICON_DICE_THREE = "\xEF\x94\xA7";
-[[maybe_unused]] static const char *FONT_ICON_DICE_FOUR = "\xEF\x94\xA4";
-[[maybe_unused]] static const char *FONT_ICON_DICE_FIVE = "\xEF\x94\xA3";
-[[maybe_unused]] static const char *FONT_ICON_DICE_SIX = "\xEF\x94\xA6";
+	[[maybe_unused]] static const char *FONT_ICON_DICE_ONE = "\xEF\x94\xA5";
+	[[maybe_unused]] static const char *FONT_ICON_DICE_TWO = "\xEF\x94\xA8";
+	[[maybe_unused]] static const char *FONT_ICON_DICE_THREE = "\xEF\x94\xA7";
+	[[maybe_unused]] static const char *FONT_ICON_DICE_FOUR = "\xEF\x94\xA4";
+	[[maybe_unused]] static const char *FONT_ICON_DICE_FIVE = "\xEF\x94\xA3";
+	[[maybe_unused]] static const char *FONT_ICON_DICE_SIX = "\xEF\x94\xA6";
 
-[[maybe_unused]] static const char *FONT_ICON_LAYER_GROUP = "\xEF\x97\xBD";
-[[maybe_unused]] static const char *FONT_ICON_UNDO = "\xEF\x8B\xAA";
-[[maybe_unused]] static const char *FONT_ICON_REDO = "\xEF\x8B\xB9";
+	[[maybe_unused]] static const char *FONT_ICON_LAYER_GROUP = "\xEF\x97\xBD";
+	[[maybe_unused]] static const char *FONT_ICON_UNDO = "\xEF\x8B\xAA";
+	[[maybe_unused]] static const char *FONT_ICON_REDO = "\xEF\x8B\xB9";
 
-[[maybe_unused]] static const char *FONT_ICON_ARROWS_ROTATE = "\xEF\x80\xA1";
-[[maybe_unused]] static const char *FONT_ICON_QUESTION = "?";
+	[[maybe_unused]] static const char *FONT_ICON_ARROWS_ROTATE = "\xEF\x80\xA1";
+	[[maybe_unused]] static const char *FONT_ICON_QUESTION = "?";
 
-[[maybe_unused]] static const char *FONT_ICON_CAMERA = "\xEF\x80\xB0";
+	[[maybe_unused]] static const char *FONT_ICON_CAMERA = "\xEF\x80\xB0";
 } // end namespace FontIcons
 
 enum ETextCursorSelectionMode

--- a/src/game/editor/editor_ui.h
+++ b/src/game/editor/editor_ui.h
@@ -16,12 +16,14 @@ struct SEditBoxDropdownContext
 };
 
 // TODO: add and use constants for other special Checked-values in CEditor::GetButtonColor
-namespace EditorButtonChecked {
-[[maybe_unused]] static constexpr int DANGEROUS_ACTION = 9;
+namespace EditorButtonChecked
+{
+	[[maybe_unused]] static constexpr int DANGEROUS_ACTION = 9;
 }
 
-namespace EditorFontSizes {
-[[maybe_unused]] static constexpr float MENU = 10.0f;
+namespace EditorFontSizes
+{
+	[[maybe_unused]] static constexpr float MENU = 10.0f;
 }
 
 #endif

--- a/src/test/mapitems.cpp
+++ b/src/test/mapitems.cpp
@@ -3,17 +3,17 @@
 
 #include <game/mapitems.h>
 
-namespace testing::internal {
-
-template<>
-class UniversalPrinter<CFixedTime>
+namespace testing::internal
 {
-public:
-	static void Print(const CFixedTime &FixedTime, std::ostream *pOutputStream)
+	template<>
+	class UniversalPrinter<CFixedTime>
 	{
-		*pOutputStream << "CFixedTime with internal value " << FixedTime.GetInternal();
-	}
-};
+	public:
+		static void Print(const CFixedTime &FixedTime, std::ostream *pOutputStream)
+		{
+			*pOutputStream << "CFixedTime with internal value " << FixedTime.GetInternal();
+		}
+	};
 
 } // namespace testing::internal
 


### PR DESCRIPTION
The only question I have viewing this is whether the protocol7.h should be changed like this, since it was probably more or less a direct copy before.

CC https://github.com/ddnet/ddnet/pull/10876#discussion_r2362341503

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
