### PR TITLE
Be explicit about the default command access

### DIFF
--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -15,7 +15,7 @@ class CConsole : public IConsole
 {
 	class CCommand : public ICommandInfo
 	{
-		EAccessLevel m_AccessLevel;
+		EAccessLevel m_AccessLevel = EAccessLevel::ADMIN;
 		CCommand *m_pNext;
 
 	public:


### PR DESCRIPTION
It being implicitly 0 almost caused some disaster in #10827

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
