### PR TITLE
Minor refactoring of `CEnvelope::AddPoint` function

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5318,13 +5318,13 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 		{
 			if(pNewEnv->GetChannels() == 4)
 			{
-				pNewEnv->AddPoint(CFixedTime::FromSeconds(0.0f), f2fx(1.0f), f2fx(1.0f), f2fx(1.0f), f2fx(1.0f));
-				pNewEnv->AddPoint(CFixedTime::FromSeconds(1.0f), f2fx(1.0f), f2fx(1.0f), f2fx(1.0f), f2fx(1.0f));
+				pNewEnv->AddPoint(CFixedTime::FromSeconds(0.0f), {f2fx(1.0f), f2fx(1.0f), f2fx(1.0f), f2fx(1.0f)});
+				pNewEnv->AddPoint(CFixedTime::FromSeconds(1.0f), {f2fx(1.0f), f2fx(1.0f), f2fx(1.0f), f2fx(1.0f)});
 			}
 			else
 			{
-				pNewEnv->AddPoint(CFixedTime::FromSeconds(0.0f), 0);
-				pNewEnv->AddPoint(CFixedTime::FromSeconds(1.0f), 0);
+				pNewEnv->AddPoint(CFixedTime::FromSeconds(0.0f), {0, 0, 0, 0});
+				pNewEnv->AddPoint(CFixedTime::FromSeconds(1.0f), {0, 0, 0, 0});
 			}
 
 			m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeAdd>(this, pNewEnv));

--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -1715,9 +1715,7 @@ void CEditorActionAddEnvelopePoint::Undo()
 void CEditorActionAddEnvelopePoint::Redo()
 {
 	auto pEnvelope = m_pEditor->m_Map.m_vpEnvelopes[m_EnvIndex];
-	pEnvelope->AddPoint(m_Time,
-		f2fx(m_Channels.r), f2fx(m_Channels.g),
-		f2fx(m_Channels.b), f2fx(m_Channels.a));
+	pEnvelope->AddPoint(m_Time, {f2fx(m_Channels.r), f2fx(m_Channels.g), f2fx(m_Channels.b), f2fx(m_Channels.a)});
 
 	m_pEditor->m_Map.OnModify();
 }

--- a/src/game/editor/mapitems/envelope.cpp
+++ b/src/game/editor/mapitems/envelope.cpp
@@ -104,23 +104,17 @@ void CEnvelope::Eval(float Time, ColorRGBA &Result, size_t Channels)
 	CRenderMap::RenderEvalEnvelope(&m_PointsAccess, std::chrono::nanoseconds((int64_t)((double)Time * (double)std::chrono::nanoseconds(1s).count())), Result, Channels);
 }
 
-void CEnvelope::AddPoint(CFixedTime Time, int v0, int v1, int v2, int v3)
+void CEnvelope::AddPoint(CFixedTime Time, std::array<int, CEnvPoint::MAX_CHANNELS> aValues)
 {
-	CEnvPoint_runtime p;
-	p.m_Time = Time;
-	p.m_aValues[0] = v0;
-	p.m_aValues[1] = v1;
-	p.m_aValues[2] = v2;
-	p.m_aValues[3] = v3;
-	p.m_Curvetype = CURVETYPE_LINEAR;
-	for(int c = 0; c < CEnvPoint::MAX_CHANNELS; c++)
-	{
-		p.m_Bezier.m_aInTangentDeltaX[c] = CFixedTime(0);
-		p.m_Bezier.m_aInTangentDeltaY[c] = 0;
-		p.m_Bezier.m_aOutTangentDeltaX[c] = CFixedTime(0);
-		p.m_Bezier.m_aOutTangentDeltaY[c] = 0;
-	}
-	m_vPoints.push_back(p);
+	CEnvPoint_runtime Point;
+	Point.m_Time = Time;
+	Point.m_Curvetype = CURVETYPE_LINEAR;
+	std::copy_n(aValues.begin(), std::size(Point.m_aValues), Point.m_aValues);
+	std::fill(std::begin(Point.m_Bezier.m_aInTangentDeltaX), std::end(Point.m_Bezier.m_aInTangentDeltaX), CFixedTime(0));
+	std::fill(std::begin(Point.m_Bezier.m_aInTangentDeltaY), std::end(Point.m_Bezier.m_aInTangentDeltaY), 0);
+	std::fill(std::begin(Point.m_Bezier.m_aOutTangentDeltaX), std::end(Point.m_Bezier.m_aOutTangentDeltaX), CFixedTime(0));
+	std::fill(std::begin(Point.m_Bezier.m_aOutTangentDeltaY), std::end(Point.m_Bezier.m_aOutTangentDeltaY), 0);
+	m_vPoints.emplace_back(Point);
 	Resort();
 }
 

--- a/src/game/editor/mapitems/envelope.h
+++ b/src/game/editor/mapitems/envelope.h
@@ -3,6 +3,8 @@
 
 #include <game/map/render_map.h>
 #include <game/mapitems.h>
+
+#include <array>
 #include <vector>
 
 class CEnvelope
@@ -23,7 +25,7 @@ public:
 
 	std::pair<float, float> GetValueRange(int ChannelMask);
 	void Eval(float Time, ColorRGBA &Result, size_t Channels);
-	void AddPoint(CFixedTime Time, int v0, int v1 = 0, int v2 = 0, int v3 = 0);
+	void AddPoint(CFixedTime Time, std::array<int, CEnvPoint::MAX_CHANNELS> aValues);
 	float EndTime() const;
 	int FindPointIndex(CFixedTime Time) const;
 	int GetChannels() const;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1641,8 +1641,8 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEnvPointCurveType(void *pContext, CU
 				CEnvPoint LastPoint = pEnvelope->m_vPoints[LastSelectedIndex];
 
 				CEnvelope HelperEnvelope(1);
-				HelperEnvelope.AddPoint(FirstPoint.m_Time, FirstPoint.m_aValues[c]);
-				HelperEnvelope.AddPoint(LastPoint.m_Time, LastPoint.m_aValues[c]);
+				HelperEnvelope.AddPoint(FirstPoint.m_Time, {FirstPoint.m_aValues[c], 0, 0, 0});
+				HelperEnvelope.AddPoint(LastPoint.m_Time, {LastPoint.m_aValues[c], 0, 0, 0});
 				HelperEnvelope.m_vPoints[0].m_Curvetype = CurveType;
 
 				for(auto [SelectedIndex, SelectedChannel] : pEditor->m_vSelectedEnvelopePoints)


### PR DESCRIPTION
- Use `std::array` to pass point values instead of 4 separate parameters. (Also fixes the parameter names `v0`-`v3`.)
- Use `std::fill` to set default bezier tangent values.
- Rename variable `p` to `Point`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
