### PR TITLE
Correctly center entities text (tele numbers)

### DIFF
--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -458,7 +458,7 @@ void CMapImages::InitOverlayTextures()
 {
 	int TextureSize = 64 * m_TextureScale / 100;
 	TextureSize = std::clamp(TextureSize, 2, 64);
-	int TextureToVerticalCenterOffset = (64 - TextureSize) / 2; // should be used to move texture to the center of 64 pixels area
+	int TextureToVerticalCenterOffset = (64 - TextureSize) / 2 + TextureSize * 0.1f; // should be used to move texture to the center of 64 pixels area
 
 	if(!m_OverlayBottomTexture.IsValid())
 	{


### PR DESCRIPTION
Texts were already centered in editor, not sure why they weren't in game

<img width="479" height="348" alt="image" src="https://github.com/user-attachments/assets/29ddc46c-f4c0-42d9-9133-29e6982c61cd" />

With outdated entities:
<img width="513" height="349" alt="image" src="https://github.com/user-attachments/assets/4a854cbc-e63e-47df-a14d-39e4c662aeae" />


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
