### PR TITLE
Fix: Remove hook line reserve

### DIFF
--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -222,7 +222,6 @@ void CPlayers::RenderHookCollLine(
 
 	bool DoBreak = false;
 	std::vector<IGraphics::CLineItem> vLineSegments;
-	vLineSegments.reserve(HookLength / HookSpeed + 1);
 	do
 	{
 		OldPos = NewPos;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Remove this vector reserve, as it may create issues with jank physics and cause huge allocations.
Reported by @SollyBunny 

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
