### PR TITLE
Fix set_team_ddr not working with practice/during a run

### DIFF
--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -532,6 +532,7 @@ void CGameContext::ConSetDDRTeam(IConsole::IResult *pResult, void *pUserData)
 		pSelf->m_apPlayers[Target]->KillCharacter(WEAPON_GAME);
 
 	pController->Teams().SetForceCharacterTeam(Target, Team);
+	pController->Teams().SetTeamLock(Team, true);
 }
 
 void CGameContext::ConUninvite(IConsole::IResult *pResult, void *pUserData)


### PR DESCRIPTION
When a run is started or in practice mode, `set_team_ddr` would kill the character first, then move to a team while the character is still dead

https://github.com/ddnet/ddnet/blob/067a36a0f6c947c58298fd917082d54297e3a98c/src/game/server/ddracecommands.cpp#L531-L534

Then, when spawning `CGameTeams::OnCharacterSpawn` would move the character to team 0, because said team isn't locked
https://github.com/ddnet/ddnet/blob/067a36a0f6c947c58298fd917082d54297e3a98c/src/game/server/teams.cpp#L1099-L1102

This resulted in `set_team_ddr` simply killing the character, without moving to any team
The fix simply locks the team after moving a character to it.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
