### PR TITLE
Move linked list iterator `NextCommandInfo` to `CConsole`

### DIFF
--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -75,6 +75,12 @@ public:
 		virtual int GetVictim() const = 0;
 	};
 
+	typedef void (*FTeeHistorianCommandCallback)(int ClientId, int FlagMask, const char *pCmd, IResult *pResult, void *pUser);
+	typedef void (*FPossibleCallback)(int Index, const char *pCmd, void *pUser);
+	typedef void (*FCommandCallback)(IResult *pResult, void *pUserData);
+	typedef void (*FChainCommandCallback)(IResult *pResult, void *pUserData, FCommandCallback pfnCallback, void *pCallbackUserData);
+	typedef bool (*FUnknownCommandCallback)(const char *pCommand, void *pUser); // returns true if the callback has handled the argument
+
 	class ICommandInfo
 	{
 	public:
@@ -82,21 +88,30 @@ public:
 		virtual const char *Name() const = 0;
 		virtual const char *Help() const = 0;
 		virtual const char *Params() const = 0;
-		virtual const ICommandInfo *NextCommandInfo(EAccessLevel AccessLevel, int FlagMask) const = 0;
 		virtual EAccessLevel GetAccessLevel() const = 0;
+		virtual void SetAccessLevel(EAccessLevel AccessLevel) = 0;
+		virtual void SetName(const char *pName) = 0;
+		virtual void SetHelp(const char *pHelp) = 0;
+		virtual void SetParams(const char *pParams) = 0;
+		virtual const ICommandInfo *Next() const = 0;
+		virtual ICommandInfo *Next() = 0;
+		virtual void SetNext(ICommandInfo *pNext) = 0;
+		virtual int Flags() const = 0;
+		virtual void SetFlags(int Flags) = 0;
+		virtual bool IsTemp() const = 0;
+		virtual void SetTemp(bool Temp) = 0;
+		virtual void *CallbackUserData() const = 0;
+		virtual FCommandCallback Callback() const = 0;
+		virtual void SetCallback(FCommandCallback pfnCallback, void *pUserData) = 0;
+		virtual void ExecCallback(IResult *pResult) = 0;
 	};
-
-	typedef void (*FTeeHistorianCommandCallback)(int ClientId, int FlagMask, const char *pCmd, IResult *pResult, void *pUser);
-	typedef void (*FPossibleCallback)(int Index, const char *pCmd, void *pUser);
-	typedef void (*FCommandCallback)(IResult *pResult, void *pUserData);
-	typedef void (*FChainCommandCallback)(IResult *pResult, void *pUserData, FCommandCallback pfnCallback, void *pCallbackUserData);
-	typedef bool (*FUnknownCommandCallback)(const char *pCommand, void *pUser); // returns true if the callback has handled the argument
 
 	static void EmptyPossibleCommandCallback(int Index, const char *pCmd, void *pUser) {}
 	static bool EmptyUnknownCommandCallback(const char *pCommand, void *pUser) { return false; }
 
 	virtual void Init() = 0;
 	virtual const ICommandInfo *FirstCommandInfo(EAccessLevel AccessLevel, int FlagMask) const = 0;
+	virtual const ICommandInfo *NextCommandInfo(const IConsole::ICommandInfo *pInfo, EAccessLevel AccessLevel, int FlagMask) const = 0;
 	virtual const ICommandInfo *GetCommandInfo(const char *pName, int FlagMask, bool Temp) = 0;
 	virtual int PossibleCommands(const char *pStr, int FlagMask, bool Temp, FPossibleCallback pfnCallback = EmptyPossibleCommandCallback, void *pUser = nullptr) = 0;
 	virtual void ParseArguments(int NumArgs, const char **ppArguments) = 0;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1483,7 +1483,7 @@ int CServer::NumRconCommands(int ClientId)
 	int Num = 0;
 	const IConsole::EAccessLevel AccessLevel = ConsoleAccessLevel(ClientId);
 	for(const IConsole::ICommandInfo *pCmd = Console()->FirstCommandInfo(AccessLevel, CFGFLAG_SERVER);
-		pCmd; pCmd = pCmd->NextCommandInfo(AccessLevel, CFGFLAG_SERVER))
+		pCmd; pCmd = Console()->NextCommandInfo(pCmd, AccessLevel, CFGFLAG_SERVER))
 	{
 		Num++;
 	}
@@ -1504,7 +1504,7 @@ void CServer::UpdateClientRconCommands(int ClientId)
 	for(int i = 0; i < MAX_RCONCMD_SEND && Client.m_pRconCmdToSend; ++i)
 	{
 		SendRconCmdAdd(Client.m_pRconCmdToSend, ClientId);
-		Client.m_pRconCmdToSend = Client.m_pRconCmdToSend->NextCommandInfo(AccessLevel, CFGFLAG_SERVER);
+		Client.m_pRconCmdToSend = Console()->NextCommandInfo(Client.m_pRconCmdToSend, AccessLevel, CFGFLAG_SERVER);
 		if(Client.m_pRconCmdToSend == nullptr)
 		{
 			SendRconCmdGroupEnd(ClientId);

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -772,11 +772,11 @@ void CGameContext::ConPracticeCmdList(IConsole::IResult *pResult, void *pUserDat
 
 	char aPracticeCommands[256] = "Available practice commands: ";
 	for(const IConsole::ICommandInfo *pCmd = pSelf->Console()->FirstCommandInfo(IConsole::EAccessLevel::USER, CMDFLAG_PRACTICE);
-		pCmd; pCmd = pCmd->NextCommandInfo(IConsole::EAccessLevel::USER, CMDFLAG_PRACTICE))
+		pCmd; pCmd = pSelf->Console()->NextCommandInfo(pCmd, IConsole::EAccessLevel::USER, CMDFLAG_PRACTICE))
 	{
 		char aCommand[64];
 
-		str_format(aCommand, sizeof(aCommand), "/%s%s", pCmd->Name(), pCmd->NextCommandInfo(IConsole::EAccessLevel::USER, CMDFLAG_PRACTICE) ? ", " : "");
+		str_format(aCommand, sizeof(aCommand), "/%s%s", pCmd->Name(), pSelf->Console()->NextCommandInfo(pCmd, IConsole::EAccessLevel::USER, CMDFLAG_PRACTICE) ? ", " : "");
 
 		if(str_length(aCommand) + str_length(aPracticeCommands) > 255)
 		{

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1555,7 +1555,7 @@ void CGameContext::OnClientEnter(int ClientId)
 		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 	}
 	for(const IConsole::ICommandInfo *pCmd = Console()->FirstCommandInfo(IConsole::EAccessLevel::USER, CFGFLAG_CHAT);
-		pCmd; pCmd = pCmd->NextCommandInfo(IConsole::EAccessLevel::USER, CFGFLAG_CHAT))
+		pCmd; pCmd = Console()->NextCommandInfo(pCmd, IConsole::EAccessLevel::USER, CFGFLAG_CHAT))
 	{
 		const char *pName = pCmd->Name();
 


### PR DESCRIPTION
Needed for #10681

Alternative to #10836 suggested by @Robyt3 here https://github.com/ddnet/ddnet/pull/10836#discussion_r2375577452

The method to get the first entry is already defined in the `CConsole` but the next was on the command it self. Which is proper linked list styled code. And it also worked because the command stores the access level so while iterating it has all the information it needs.

But when access levels become more complex this will no longer work. Because it is planned to no longer store that information on the command. Because there will be multiple different roles that can access a command and they are not strictly ordered by access level. So a simple integer comparison will not work.

The alternative would be moving all that context onto the command. That works by passing one callback and one callback context to every command on registration. I tried that approach too. It worked. But I think moving the `NextCommandInfo` one class scope further up is way smoother.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
