### PR TITLE
Fix performance regression due to very frequent skin updating

### DIFF
--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -541,7 +541,7 @@ void CSkins::OnUpdate()
 {
 	// Only update skins periodically to reduce FPS impact
 	const std::chrono::nanoseconds StartTime = time_get_nanoseconds();
-	const std::chrono::nanoseconds MaxTime = std::chrono::microseconds(maximum(round_to_int(Client()->RenderFrameTime() / 8.0f), 25));
+	const std::chrono::nanoseconds MaxTime = std::chrono::milliseconds(std::clamp(round_to_int(Client()->RenderFrameTime() * 50000.0f), 25, 500));
 	if(m_ContainerUpdateTime.has_value() && StartTime - m_ContainerUpdateTime.value() < MaxTime)
 	{
 		return;


### PR DESCRIPTION
Skins were only supposed to be updated every 25 milliseconds or slower depending on the FPS. However, due to the incorrect type `std::chrono::microseconds` being used and the `IClient::RenderFrameTime` function actually returning the average frame time in seconds, the update duration was reduced to only 25 microseconds.

Adjusting the skin updating to a more realistic frequency reduces average frametimes from 895 us to 622 us (1117 to 1607 FPS). Profiling shows that the CPU time spent in the `CSkins::OnUpdate` function is reduced from 22.81% to 0.87%.

Profiling:
- Before: <img src="https://github.com/user-attachments/assets/36c97d69-c8e1-4ae3-85a1-449a8a21859e" />
- After: <img src="https://github.com/user-attachments/assets/5996fc91-acf0-44e5-877b-81da44b5e7b3" />

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
