### PR TITLE
Fix doxygen documentation warnings and ensure correct documentation style in CI

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Prepare Linux
       run: |
         sudo apt-get update -y
-        sudo apt-get install ddnet-tools shellcheck tidy pkg-config cmake ninja-build libfreetype6-dev libnotify-dev libsdl2-dev libsqlite3-dev libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev libx264-dev python3-clang libvulkan-dev glslang-tools spirv-tools libglew-dev -y
+        sudo apt-get install ddnet-tools shellcheck tidy pkg-config cmake doxygen graphviz ninja-build libfreetype6-dev libnotify-dev libsdl2-dev libsqlite3-dev libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev libx264-dev python3-clang libvulkan-dev glslang-tools spirv-tools libglew-dev -y
         rustup default stable
         pip3 install pylint
         wget https://github.com/muttleyxd/clang-tools-static-binaries/releases/download/master-46b8640/clang-format-10_linux-amd64
@@ -39,6 +39,19 @@ jobs:
       run: |
         clang-format -version
         scripts/fix_style.py --dry-run
+
+    - name: Check documentation style (Doxygen)
+      run: |
+        doxygen
+        # TODO: Files included for macro-based lists like config variables and editor actions cannot be found by Doxygen version 1.9.8 used in the CI.
+        #       Remove this ignored warning when the version is upgraded to one where this is fixed.
+        sed -i -E '/warning: include file .* not found, perhaps you forgot to add its directory to INCLUDE_PATH/d' docs/warn.log
+        if [ -s docs/warn.log ]; then
+          echo "--------------------------------------------------"
+          echo "Doxygen warnings:"
+          cat docs/warn.log
+          exit 1
+        fi
 
     - name: Shellcheck
       run: find . -type f -name '*.sh' -print0 | xargs -0 shellcheck

--- a/Doxyfile
+++ b/Doxyfile
@@ -365,7 +365,7 @@ AUTOLINK_SUPPORT       = YES
 # diagrams that involve STL classes more complete and accurate.
 # The default value is: NO.
 
-BUILTIN_STL_SUPPORT    = NO
+BUILTIN_STL_SUPPORT    = YES
 
 # If you use Microsoft's C++/CLI language, you should set this option to YES to
 # enable parsing support.

--- a/src/android/android_main.h
+++ b/src/android/android_main.h
@@ -7,7 +7,7 @@
 #endif
 
 /**
- * @defgroup Android
+ * @defgroup Android Android
  *
  * Android-specific functions to interact with the ClientActivity.
  *

--- a/src/base/lock.h
+++ b/src/base/lock.h
@@ -74,7 +74,7 @@
 	THREAD_ANNOTATION_ATTRIBUTE__(no_thread_safety_analysis)
 
 /**
- * @defgroup Locks
+ * @defgroup Locks Locks
  * @see Threads
  */
 

--- a/src/base/log.h
+++ b/src/base/log.h
@@ -33,7 +33,7 @@ struct LOG_COLOR
 #define log_trace_color(color, sys, ...) log_log_color(LEVEL_TRACE, color, sys, __VA_ARGS__)
 
 /**
- * @defgroup Log
+ * @defgroup Log Logging
  *
  * Methods for outputting log messages and way of handling them.
  */

--- a/src/base/str.h
+++ b/src/base/str.h
@@ -460,7 +460,7 @@ int str_in_list(const char *list, const char *delim, const char *needle);
  *
  * @remark The strings are treated as null-terminated strings.
  */
-bool str_delimiters_around_offset(const char *haystay, const char *delim, int offset, int *start, int *end);
+bool str_delimiters_around_offset(const char *haystack, const char *delim, int offset, int *start, int *end);
 
 /**
  * Finds the last occurrence of a character
@@ -533,7 +533,7 @@ void str_hex_cstyle(char *dst, int dst_size, const void *data, int data_size, in
  *
  * @param dst Buffer for the byte array.
  * @param dst_size size of the buffer.
- * @param data String to decode.
+ * @param src String to decode.
  *
  * @return `2` if string doesn't exactly fit the buffer.
  * @return `1` if invalid character in string.
@@ -551,7 +551,7 @@ int str_hex_decode(void *dst, int dst_size, const char *src);
  * @param dst Buffer to fill with base64 data.
  * @param dst_size Size of the buffer.
  * @param data Data to turn into base64.
- * @param data Size of the data.
+ * @param data_size Size of the data.
  *
  * @remark The destination buffer will be null-terminated
  */
@@ -599,6 +599,7 @@ unsigned str_quickhash(const char *str);
  * @ingroup Strings
  *
  * @param ptr Pointer to a buffer that should receive the data. Should be able to hold at least 4 bytes.
+ * @param chr Unicode codepoint to encode.
  *
  * @return Number of bytes put into the buffer.
  *
@@ -628,7 +629,7 @@ int str_utf8_decode(const char **ptr);
  *
  * @param dst Pointer to a buffer that shall receive the string.
  * @param dst_size Size of the buffer dst.
- * @param str String to be truncated.
+ * @param src String to be truncated.
  * @param truncation_len Maximum codepoints in the returned string.
  *
  * @remark The strings are treated as utf8-encoded null-terminated strings.
@@ -666,7 +667,7 @@ void str_utf8_trim_right(char *param);
  *
  * @ingroup Strings
  *
- * @param str String to convert to lowercase.
+ * @param input String to convert to lowercase.
  * @param output Buffer that will receive the lowercase string.
  * @param size Size of the output buffer.
  *

--- a/src/base/str.h
+++ b/src/base/str.h
@@ -112,7 +112,7 @@ int str_isallnum_hex(const char *str);
  *
  * @return `1` if the character is whitespace, `0` otherwise.
  *
- * @remark The following characters are considered whitespace: ' ', '\n', '\r', '\t'.
+ * @remark The following characters are considered whitespace: ` `, `\n`, `\r`, `\t`.
  */
 int str_isspace(char c);
 
@@ -157,7 +157,7 @@ void str_sanitize_cc(char *str);
 
 /**
  * Replaces all characters below 32 with whitespace with
- * exception to \t, \n and \r.
+ * exception to `\t`, `\n` and `\n`.
  *
  * @ingroup Strings
  *

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -48,7 +48,7 @@
 /**
  * Utilities for debugging.
  *
- * @defgroup Debug
+ * @defgroup Debug Debugging
  */
 
 /**
@@ -123,7 +123,7 @@ void dbg_assert_set_handler(DBG_ASSERT_HANDLER handler);
 /**
  * Memory management utilities.
  *
- * @defgroup Memory
+ * @defgroup Memory Memory
  */
 
 /**
@@ -199,9 +199,9 @@ int mem_comp(const void *a, const void *b, size_t size);
 bool mem_has_null(const void *block, size_t size);
 
 /**
- * I/O related operations.
+ * File I/O related operations.
  *
- * @defgroup File-IO
+ * @defgroup File-IO File I/O
  */
 
 /**
@@ -599,7 +599,7 @@ void aio_free(ASYNCIO *aio);
 /**
  * Threading related functions.
  *
- * @defgroup Threads
+ * @defgroup Threads Threading
  *
  * @see Locks
  * @see Semaphore
@@ -657,7 +657,7 @@ void thread_detach(void *thread);
 void thread_init_and_detach(void (*threadfunc)(void *), void *user, const char *name);
 
 /**
- * @defgroup Semaphore
+ * @defgroup Semaphore Semaphores
  *
  * @see Threads
  */
@@ -694,7 +694,13 @@ void sphore_destroy(SEMAPHORE *sem);
 /**
  * Time utilities.
  *
- * @defgroup Time
+ * @defgroup Time Time
+ */
+
+/**
+ * Timestamp related functions.
+ *
+ * @defgroup Timestamp Timestamps
  */
 
 /**
@@ -739,7 +745,7 @@ int64_t time_freq();
 /**
  * Retrieves the current time as a UNIX timestamp.
  *
- * @ingroup Time
+ * @ingroup Timestamp
  *
  * @return The time as a UNIX timestamp.
  */
@@ -781,14 +787,19 @@ enum ETimeSeason
 ETimeSeason time_season();
 
 /**
- * @defgroup Network-General
+ * @defgroup Network Networking
  */
 
-extern const NETADDR NETADDR_ZEROED;
+/**
+ * @defgroup Network-General General networking
+ *
+ * @ingroup Network
+ */
 
 /**
  * @ingroup Network-General
  */
+extern const NETADDR NETADDR_ZEROED;
 
 #ifdef CONF_FAMILY_UNIX
 /**
@@ -975,9 +986,9 @@ int net_would_block();
 int net_socket_read_wait(NETSOCKET sock, std::chrono::nanoseconds nanoseconds);
 
 /**
- * @defgroup Network-UDP
+ * @defgroup Network-UDP UDP Networking
  *
- * @ingroup Network-General
+ * @ingroup Network
  */
 
 /**
@@ -1040,9 +1051,9 @@ int net_udp_recv(NETSOCKET sock, NETADDR *addr, unsigned char **data);
 void net_udp_close(NETSOCKET sock);
 
 /**
- * @defgroup Network-TCP
+ * @defgroup Network-TCP TCP Networking
  *
- * @ingroup Network-General
+ * @ingroup Network
  */
 
 /**
@@ -1144,9 +1155,9 @@ void net_tcp_close(NETSOCKET sock);
 
 #if defined(CONF_FAMILY_UNIX)
 /**
- * @defgroup Network-Unix-Sockets
+ * @defgroup Network-Unix-Sockets UNIX Socket Networking
  *
- * @ingroup Network-General
+ * @ingroup Network
  */
 
 /**
@@ -1207,7 +1218,7 @@ std::string windows_format_system_message(unsigned long error);
 /**
  * String related functions.
  *
- * @defgroup Strings
+ * @defgroup Strings Strings
  */
 
 /**
@@ -1325,7 +1336,7 @@ int str_utf32_dist_buffer(const int *a, int a_len, const int *b, int b_len, int 
 /**
  * Copies a timestamp in the format year-month-day_hour-minute-second to the string.
  *
- * @ingroup Strings
+ * @ingroup Timestamp
  *
  * @param buffer Pointer to a buffer that shall receive the timestamp string.
  * @param buffer_size Size of the buffer.
@@ -1396,7 +1407,7 @@ int str_time_float(float secs, int format, char *buffer, int buffer_size);
 /**
  * Utilities for accessing the file system.
  *
- * @defgroup Filesystem
+ * @defgroup Filesystem Filesystem
  */
 
 /**
@@ -1845,7 +1856,7 @@ void uint_to_bytes_be(unsigned char *bytes, unsigned value);
 /**
  * Shell, process management, OS specific functionality.
  *
- * @defgroup Shell
+ * @defgroup Shell Shell
  */
 
 /**
@@ -1984,7 +1995,7 @@ int open_file(const char *path);
 /**
  * Secure random number generation.
  *
- * @defgroup Secure-Random
+ * @defgroup Secure-Random Secure Random
  */
 
 /**
@@ -2075,14 +2086,14 @@ bool os_version_str(char *version, size_t length);
 void os_locale_str(char *locale, size_t length);
 
 /**
- * @defgroup Crash-dumping
+ * @defgroup Crash-Dumping Crash Dumping
  */
 
 /**
  * Initializes the crash dumper and sets the filename to write the crash dump
  * to, if support for crash logging was compiled in. Otherwise does nothing.
  *
- * @ingroup Crash-dumping
+ * @ingroup Crash-Dumping
  *
  * @param log_file_path Absolute path to which crash log file should be written.
  */

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -57,7 +57,7 @@
  * @ingroup Debug
  *
  * @param test Result of the test.
- * @param msg Message that should be printed if the test fails.
+ * @param fmt A printf styled format message that should be printed if the test fails.
  *
  * @remark Also works in release mode.
  *
@@ -1126,7 +1126,7 @@ int net_tcp_send(NETSOCKET sock, const void *data, int size);
  *
  * @param sock Socket to recvive data from.
  * @param data Pointer to a buffer to write the data to.
- * @param max_size Maximum of data to write to the buffer.
+ * @param maxsize Maximum of data to write to the buffer.
  *
  * @return Number of bytes recvived. Negative value on failure. When in
  * non-blocking mode, it returns 0 when there is no more data to be fetched.
@@ -1790,7 +1790,7 @@ void str_utf8_stats(const char *str, size_t max_size, size_t max_count, size_t *
  *
  * @ingroup Strings
  *
- * @param text Pointer to the string.
+ * @param str Pointer to the string.
  * @param byte_offset Offset in bytes.
  *
  * @return Offset in UTF-8 characters. Clamped to the maximum length of the string in UTF-8 characters.
@@ -1805,7 +1805,7 @@ size_t str_utf8_offset_bytes_to_chars(const char *str, size_t byte_offset);
  *
  * @ingroup Strings
  *
- * @param text Pointer to the string.
+ * @param str Pointer to the string.
  * @param char_offset Offset in UTF-8 characters.
  *
  * @return Offset in bytes. Clamped to the maximum length of the string in bytes.
@@ -2018,7 +2018,7 @@ void secure_random_password(char *buffer, unsigned length, unsigned pw_length);
  *
  * @ingroup Secure-Random
  *
- * @param buffer Pointer to the start of the buffer.
+ * @param bytes Pointer to the start of the buffer.
  * @param length Length of the buffer.
  */
 void secure_random_fill(void *bytes, unsigned length);

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -737,20 +737,20 @@ int64_t time_get();
 int64_t time_freq();
 
 /**
- * Retrieves the current time as a UNIX timestamp
+ * Retrieves the current time as a UNIX timestamp.
  *
  * @ingroup Time
  *
- * @return The time as a UNIX timestamp
+ * @return The time as a UNIX timestamp.
  */
 int64_t time_timestamp();
 
 /**
- * Retrieves the hours since midnight (0..23)
+ * Retrieves the hours since midnight (0..23).
  *
  * @ingroup Time
  *
- * @return The current hour of the day
+ * @return The current hour of the day.
  */
 int time_houroftheday();
 
@@ -774,7 +774,7 @@ enum ETimeSeason
  *
  * @ingroup Time
  *
- * @return One of the SEASON_* enum literals
+ * @return One of the SEASON_* enum literals.
  *
  * @see SEASON_SPRING
  */
@@ -1120,7 +1120,7 @@ int net_tcp_connect_non_blocking(NETSOCKET sock, NETADDR bindaddr);
 int net_tcp_send(NETSOCKET sock, const void *data, int size);
 
 /**
- * Recvives data from a TCP stream.
+ * Receives data from a TCP stream.
  *
  * @ingroup Network-TCP
  *

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -194,7 +194,7 @@ public:
 	/**
 	 * Converts access level string to access level enum.
 	 *
-	 * @param pAccesssLevel should be either "admin", "mod", "moderator", "helper" or "user".
+	 * @param pAccessLevel should be either "admin", "mod", "moderator", "helper" or "user".
 	 * @return `std::nullopt` on error otherwise one of the auth enums such as `EAccessLevel::ADMIN`.
 	 */
 	static std::optional<EAccessLevel> AccessLevelToEnum(const char *pAccessLevel);

--- a/src/engine/shared/jobs.h
+++ b/src/engine/shared/jobs.h
@@ -147,7 +147,7 @@ public:
 	/**
 	 * Initializes the job pool with the given number of worker threads.
 	 *
-	 * @param NumTheads The number of worker threads.
+	 * @param NumThreads The number of worker threads.
 	 *
 	 * @remark Must be called on the main thread.
 	 */


### PR DESCRIPTION
See commit messages.

I think this closes #4128. The use of doxygen has been documented in CONTRIBUTING.md, the generation is now checked in the CI, and most base/system functions are documented.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
