### PR TITLE
Silence doxygens verbose success log in the CI

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -42,7 +42,8 @@ jobs:
 
     - name: Check documentation style (Doxygen)
       run: |
-        doxygen
+        doxygen --version
+        doxygen -q
         # TODO: Files included for macro-based lists like config variables and editor actions cannot be found by Doxygen version 1.9.8 used in the CI.
         #       Remove this ignored warning when the version is upgraded to one where this is fixed.
         sed -i -E '/warning: include file .* not found, perhaps you forgot to add its directory to INCLUDE_PATH/d' docs/warn.log


### PR DESCRIPTION
This still prints the warnings. Even the ones we ignore.

It reduces the CI log that has to be loaded and scrolled through to see the errors from 11k success and warning lines to only 22 ignored warnings.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
