### PR TITLE
Remove use of `vec3`/`vec4` math from color classes

### DIFF
--- a/src/base/color.h
+++ b/src/base/color.h
@@ -3,7 +3,6 @@
 #define BASE_COLOR_H
 
 #include <base/math.h>
-#include <base/vmath.h>
 
 #include <optional>
 #include <type_traits>
@@ -62,16 +61,6 @@ public:
 	{
 	}
 
-	constexpr color4_base(const vec4 &v4) :
-		x(v4.x), y(v4.y), z(v4.z), a(v4.w)
-	{
-	}
-
-	constexpr color4_base(const vec3 &v3) :
-		x(v3.x), y(v3.y), z(v3.z), a(1.0f)
-	{
-	}
-
 	constexpr color4_base(float nx, float ny, float nz, float na) :
 		x(nx), y(ny), z(nz), a(na)
 	{
@@ -96,8 +85,6 @@ public:
 	requires(!std::is_same_v<DerivedT, OtherDerivedT>)
 		color4_base(const color4_base<OtherDerivedT> &Other) = delete;
 
-	constexpr vec4 v4() const { return vec4(x, y, z, a); }
-	constexpr operator vec4() const { return vec4(x, y, z, a); }
 	constexpr float &operator[](int index)
 	{
 		return ((float *)this)[index];
@@ -239,43 +226,44 @@ constexpr ColorHSLA color_cast(const ColorRGBA &rgb)
 template<>
 constexpr ColorRGBA color_cast(const ColorHSLA &hsl)
 {
-	vec3 rgb = vec3(0, 0, 0);
-
 	float h1 = hsl.h * 6;
 	float c = (1.f - absolute(2 * hsl.l - 1)) * hsl.s;
 	float x = c * (1.f - absolute(std::fmod(h1, 2) - 1.f));
 
+	float r = 0.0f;
+	float g = 0.0f;
+	float b = 0.0f;
 	switch(round_truncate(h1))
 	{
 	case 0:
-		rgb.r = c;
-		rgb.g = x;
+		r = c;
+		g = x;
 		break;
 	case 1:
-		rgb.r = x;
-		rgb.g = c;
+		r = x;
+		g = c;
 		break;
 	case 2:
-		rgb.g = c;
-		rgb.b = x;
+		g = c;
+		b = x;
 		break;
 	case 3:
-		rgb.g = x;
-		rgb.b = c;
+		g = x;
+		b = c;
 		break;
 	case 4:
-		rgb.r = x;
-		rgb.b = c;
+		r = x;
+		b = c;
 		break;
 	case 5:
 	case 6:
-		rgb.r = c;
-		rgb.b = x;
+		r = c;
+		b = x;
 		break;
 	}
 
 	float m = hsl.l - (c / 2);
-	return ColorRGBA(rgb.r + m, rgb.g + m, rgb.b + m, hsl.a);
+	return ColorRGBA(r + m, g + m, b + m, hsl.a);
 }
 
 template<>

--- a/src/engine/client/backend/opengl/backend_opengl3.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl3.cpp
@@ -1167,7 +1167,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderQuadLayer(const CCommandBuff
 
 	if(!Grouped)
 	{
-		vec4 aColors[ms_MaxQuadsPossible];
+		ColorRGBA aColors[ms_MaxQuadsPossible];
 		vec2 aOffsets[ms_MaxQuadsPossible];
 		float aRotations[ms_MaxQuadsPossible];
 
@@ -1193,7 +1193,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderQuadLayer(const CCommandBuff
 	}
 	else
 	{
-		vec4 Colors = pCommand->m_pQuadInfo[0].m_Color;
+		ColorRGBA Colors = pCommand->m_pQuadInfo[0].m_Color;
 		vec2 Offsets = pCommand->m_pQuadInfo[0].m_Offsets;
 		float Rotations = pCommand->m_pQuadInfo[0].m_Rotation;
 

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -806,7 +806,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 
 	struct SUniformQuadPushGBufferObject
 	{
-		vec4 m_VertColor;
+		ColorRGBA m_VertColor;
 		vec2 m_Offset;
 		float m_Rotation;
 		float m_Padding;

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -9,6 +9,7 @@
 
 #include <base/color.h>
 #include <base/system.h>
+#include <base/vmath.h>
 
 #include <cstddef>
 #include <cstdint>

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -363,7 +363,8 @@ bool CSkins::LoadSkinData(const char *pName, CSkinLoadData &Data) const
 				}
 			}
 		}
-		Data.m_BloodColor = ColorRGBA(normalize(vec3(aColors[0], aColors[1], aColors[2])));
+		const vec3 NormalizedColor = normalize(vec3(aColors[0], aColors[1], aColors[2]));
+		Data.m_BloodColor = ColorRGBA(NormalizedColor.x, NormalizedColor.y, NormalizedColor.z);
 	}
 
 	CheckMetrics(Data.m_Metrics.m_Body, Data.m_Info.m_pData, Pitch, 0, 0, BodyWidth, BodyHeight);

--- a/src/game/client/components/skins7.cpp
+++ b/src/game/client/components/skins7.cpp
@@ -113,7 +113,8 @@ static ColorRGBA DetermineBloodColor(int PartType, const CImageInfo &Info)
 		}
 	}
 
-	return ColorRGBA(normalize(vec3(aColors[0], aColors[1], aColors[2])));
+	const vec3 NormalizedColor = normalize(vec3(aColors[0], aColors[1], aColors[2]));
+	return ColorRGBA(NormalizedColor.x, NormalizedColor.y, NormalizedColor.z);
 }
 
 bool CSkins7::LoadSkinPart(int PartType, const char *pName, int DirType)

--- a/src/game/client/ui_rect.h
+++ b/src/game/client/ui_rect.h
@@ -4,6 +4,7 @@
 #define GAME_CLIENT_UI_RECT_H
 
 #include <base/color.h>
+#include <base/vmath.h>
 
 class IGraphics;
 


### PR DESCRIPTION
Colors should not be implicitly converted to numeric vectors and vice versa.

Avoid including `vmath.h` in `color.h`. Add `vmath.h` include in other files where it was previously only included through `color.h`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
