### PR TITLE
Fix hook collision line quantization

### DIFF
--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -207,12 +207,7 @@ void CPlayers::RenderHookCollLine(
 	if(HookLength < HOOK_START_DISTANCE || HookFireSpeed <= 0.0f)
 		return;
 
-	// pre calculate quantization
-	vec2 QuantizedPos = Position + Direction * HookFireSpeed;
-	QuantizedPos.x = round_to_int(QuantizedPos.x);
-	QuantizedPos.y = round_to_int(QuantizedPos.y);
-	vec2 QuantizedDirection = normalize(QuantizedPos - Position);
-
+	vec2 QuantizedDirection = Direction;
 	vec2 StartOffset = Direction * HOOK_START_DISTANCE;
 	vec2 BasePos = Position;
 	vec2 LineStartPos = BasePos + StartOffset;
@@ -256,6 +251,13 @@ void CPlayers::RenderHookCollLine(
 			SegmentStartPos = SegmentEndPos;
 			SegmentStartPos.x = round_to_int(SegmentStartPos.x);
 			SegmentStartPos.y = round_to_int(SegmentStartPos.y);
+
+			// direction is always the same after the first tick quantization
+			if(HookTick == 0)
+			{
+				QuantizedDirection.x = round_to_int(QuantizedDirection.x * 256.0f) / 256.0f;
+				QuantizedDirection.y = round_to_int(QuantizedDirection.y * 256.0f) / 256.0f;
+			}
 			continue;
 		}
 
@@ -289,7 +291,16 @@ void CPlayers::RenderHookCollLine(
 		// go through one teleout, update positions and continue
 		BasePos = vTeleOuts[0];
 		LineStartPos = BasePos; // make the line start in the teleporter to prevent a gap
-		SegmentStartPos = BasePos + QuantizedDirection * HOOK_START_DISTANCE;
+		SegmentStartPos = BasePos + Direction * HOOK_START_DISTANCE;
+		SegmentStartPos.x = round_to_int(SegmentStartPos.x);
+		SegmentStartPos.y = round_to_int(SegmentStartPos.y);
+
+		// direction is always the same after the first tick quantization
+		if(HookTick == 0)
+		{
+			QuantizedDirection.x = round_to_int(QuantizedDirection.x * 256.0f) / 256.0f;
+			QuantizedDirection.y = round_to_int(QuantizedDirection.y * 256.0f) / 256.0f;
+		}
 	}
 
 	// The hook line is too expensive to calculate and didn't hit anything before, just set a straight line


### PR DESCRIPTION
Follow up to #10951
The direction and position quantization can't be pre-calculated, as it's done after every tick @AssassinTee 

https://github.com/ddnet/ddnet/blob/00bac294e21d7d40c21d6452189400c90e6aa340/src/game/server/entities/character.cpp#L836-L838
https://github.com/ddnet/ddnet/blob/00bac294e21d7d40c21d6452189400c90e6aa340/src/game/gamecore.cpp#L695-L699


Fixes this, tested same setup with hook tele and works too:

<img width="975" height="656" alt="image" src="https://github.com/user-attachments/assets/f79ec463-31c8-4a33-b08d-c428bce9d31b" />
<img width="975" height="656" alt="image" src="https://github.com/user-attachments/assets/b09f1d85-0ef9-4374-908c-f72af991b67b" />


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
