### PR TITLE
mastersrv: Disallow port 0

### DIFF
--- a/src/mastersrv/src/addr.rs
+++ b/src/mastersrv/src/addr.rs
@@ -132,6 +132,9 @@ impl FromStr for Addr {
         )
         .unwrap();
         let sock_addr: SocketAddr = ip_port.parse().map_err(|_| InvalidAddr)?;
+        if sock_addr.port() == 0 {
+            return Err(InvalidAddr);
+        }
         Ok(Addr {
             ip: sock_addr.ip(),
             port: sock_addr.port(),


### PR DESCRIPTION
It's not a valid port number, this catches it very early in the registration process.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
