### PR TITLE
Fix potentially negative animation time for scrollregions

### DIFF
--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -140,6 +140,10 @@ void CScrollRegion::End()
 	if(m_AnimTime > 0.0f)
 	{
 		m_AnimTime -= Client()->RenderFrameTime();
+		if(m_AnimTime < 0.0f)
+		{
+			m_AnimTime = 0.0f;
+		}
 		float AnimProgress = (1.0f - std::pow(m_AnimTime / m_AnimTimeMax, 3.0f)); // cubic ease out
 		m_ScrollY = m_AnimInitScrollY + (m_AnimTargetScrollY - m_AnimInitScrollY) * AnimProgress;
 	}


### PR DESCRIPTION
The current render frame time can be larger than the remaining `m_AnimTime` for smooth scrolling of scrollregions, resulting in the time becoming negative and the animation progress being incorrect for one frame.

## Checklist

- [X] Tested the change ingame: could not notice any difference
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
