### PR TITLE
Fix: Quad rotation clipping integer overflow

### DIFF
--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -1160,7 +1160,7 @@ bool CRenderLayerQuads::CalculateQuadClipping(int aQuadOffsetMin[2], int aQuadOf
 			for(int QuadIdPoint = 0; QuadIdPoint < 4; ++QuadIdPoint)
 			{
 				const CPoint &QuadPoint = pQuad->m_aPoints[QuadIdPoint];
-				int Distance = (int)std::ceil(std::sqrt(1.0 * (Center.x - QuadPoint.x) * (Center.x - QuadPoint.x) + (Center.y - QuadPoint.y) * (Center.y - QuadPoint.y)));
+				int Distance = (int)std::ceil(length(vec2(Center.x - QuadPoint.x, Center.y - QuadPoint.y)));
 				MaxDistance = std::max(Distance, MaxDistance);
 			}
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

fixes an integer overflow in quad rotation clipping

closes #11018

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
