### PR TITLE
Add reset quad rotation to countryflag render

### DIFF
--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -143,6 +143,7 @@ void CCountryFlags::Render(const CCountryFlag *pFlag, ColorRGBA Color, float x, 
 	{
 		Graphics()->TextureSet(pFlag->m_Texture);
 		Graphics()->SetColor(Color);
+		Graphics()->QuadsSetRotation(0.0f);
 		Graphics()->RenderQuadContainerEx(m_FlagsQuadContainerIndex, 0, -1, x, y, w, h);
 	}
 }


### PR DESCRIPTION
Isn't required for any country flag related rendering in DDNet but RenderQuadContainerEx doesn't reset rotation

Functions using this don't reset rotation either (eg `void CMenus::RenderServerbrowserCountriesFilter(CUIRect View)` and `void CMenus::RenderSettingsPlayer(CUIRect MainView)`)

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
