### PR TITLE
Add button to open downloads page with `CONF_INFORM_UPDATE` option

### DIFF
--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -251,10 +251,21 @@ void CMenusStart::RenderStartMenu(CUIRect MainView)
 #elif defined(CONF_INFORM_UPDATE)
 	if(str_comp(Client()->LatestVersion(), "0") != 0)
 	{
+		CUIRect DownloadButton;
+		VersionUpdate.VSplitRight(100.0f, &VersionUpdate, &DownloadButton);
+		VersionUpdate.VSplitRight(10.0f, &VersionUpdate, nullptr);
+
+		static CButtonContainer s_DownloadButton;
+		if(GameClient()->m_Menus.DoButton_Menu(&s_DownloadButton, Localize("Download"), 0, &DownloadButton, BUTTONFLAG_LEFT, 0, IGraphics::CORNER_ALL, 5.0f, 0.0f, ColorRGBA(0.0f, 0.0f, 0.0f, 0.25f)))
+		{
+			Client()->ViewLink("https://ddnet.org/downloads/");
+		}
+
 		char aBuf[64];
 		str_format(aBuf, sizeof(aBuf), Localize("DDNet %s is out!"), Client()->LatestVersion());
-		TextRender()->TextColor(TextRender()->DefaultTextColor());
-		Ui()->DoLabel(&VersionUpdate, aBuf, 14.0f, TEXTALIGN_MC);
+		SLabelProperties UpdateLabelProps;
+		UpdateLabelProps.SetColor(ColorRGBA(1.0f, 0.4f, 0.4f, 1.0f));
+		Ui()->DoLabel(&VersionUpdate, aBuf, 14.0f, TEXTALIGN_ML, UpdateLabelProps);
 	}
 #endif
 


### PR DESCRIPTION
This would be useful especially for the standalone Android version, which can only be compiled with `CONF_INFORM_UPDATE` but not with `CONF_AUTOUPDATE`.

Also change the label alignment and color with `CONF_INFORM_UPDATE` to be consistent with the label with `CONF_AUTOUPDATE`.

Screenshots:
- Before: <img src="https://github.com/user-attachments/assets/85c2ef1d-7e9a-4dc9-9646-f9ba47bf8198" />
- After: <img src="https://github.com/user-attachments/assets/a7cf7bd1-169e-4457-ac28-43741acb79a9" />


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
