### PR TITLE
Move selected editor image and sound handling to `CEditorMap`

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4351,48 +4351,6 @@ bool CEditor::ReplaceSoundCallback(const char *pFileName, int StorageType, void 
 	return static_cast<CEditor *>(pUser)->ReplaceSound(pFileName, StorageType, true);
 }
 
-bool CEditor::IsAssetUsed(CFileBrowser::EFileType FileType, int Index, void *pUser)
-{
-	CEditor *pEditor = (CEditor *)pUser;
-	for(const auto &pGroup : pEditor->m_Map.m_vpGroups)
-	{
-		for(const auto &pLayer : pGroup->m_vpLayers)
-		{
-			if(FileType == CFileBrowser::EFileType::IMAGE)
-			{
-				if(pLayer->m_Type == LAYERTYPE_TILES)
-				{
-					std::shared_ptr<CLayerTiles> pTiles = std::static_pointer_cast<CLayerTiles>(pLayer);
-					if(pTiles->m_Image == Index)
-					{
-						return true;
-					}
-				}
-				else if(pLayer->m_Type == LAYERTYPE_QUADS)
-				{
-					std::shared_ptr<CLayerQuads> pQuads = std::static_pointer_cast<CLayerQuads>(pLayer);
-					if(pQuads->m_Image == Index)
-					{
-						return true;
-					}
-				}
-			}
-			else if(FileType == CFileBrowser::EFileType::SOUND)
-			{
-				if(pLayer->m_Type == LAYERTYPE_SOUNDS)
-				{
-					std::shared_ptr<CLayerSounds> pSounds = std::static_pointer_cast<CLayerSounds>(pLayer);
-					if(pSounds->m_Sound == Index)
-					{
-						return true;
-					}
-				}
-			}
-		}
-	}
-	return false;
-}
-
 void CEditor::SelectGameLayer()
 {
 	for(size_t g = 0; g < m_Map.m_vpGroups.size(); g++)

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -540,7 +540,6 @@ public:
 	std::vector<std::pair<int, int>> m_vSelectedEnvelopePoints;
 	int m_SelectedQuadEnvelope;
 	int m_CurrentQuadIndex;
-	int m_SelectedImage;
 	int m_SelectedSound;
 	int m_SelectedSource;
 	std::pair<int, int> m_SelectedTangentInPoint;
@@ -765,7 +764,7 @@ public:
 
 	void RenderLayers(CUIRect LayersBox);
 	void RenderImagesList(CUIRect Toolbox);
-	void RenderSelectedImage(CUIRect View);
+	void RenderSelectedImage(CUIRect View) const;
 	void RenderSounds(CUIRect Toolbox);
 	void RenderModebar(CUIRect View);
 	void RenderStatusbar(CUIRect View, CUIRect *pTooltipRect);

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -540,7 +540,6 @@ public:
 	std::vector<std::pair<int, int>> m_vSelectedEnvelopePoints;
 	int m_SelectedQuadEnvelope;
 	int m_CurrentQuadIndex;
-	int m_SelectedSound;
 	int m_SelectedSource;
 	std::pair<int, int> m_SelectedTangentInPoint;
 	std::pair<int, int> m_SelectedTangentOutPoint;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -757,7 +757,6 @@ public:
 	static bool ReplaceSoundCallback(const char *pFileName, int StorageType, void *pUser);
 	static bool AddImage(const char *pFilename, int StorageType, void *pUser);
 	static bool AddSound(const char *pFileName, int StorageType, void *pUser);
-	static bool IsAssetUsed(CFileBrowser::EFileType FileType, int Index, void *pUser);
 
 	bool IsEnvelopeUsed(int EnvelopeIndex) const;
 	void RemoveUnusedEnvelopes();

--- a/src/game/editor/mapitems/map.cpp
+++ b/src/game/editor/mapitems/map.cpp
@@ -312,3 +312,49 @@ void CEditorMap::MakeTuneLayer(const std::shared_ptr<CLayer> &pLayer)
 	m_pTuneLayer = std::static_pointer_cast<CLayerTune>(pLayer);
 	m_pTuneLayer->m_pEditor = m_pEditor;
 }
+
+bool CEditorMap::IsImageUsed(int ImageIndex) const
+{
+	for(const auto &pGroup : m_vpGroups)
+	{
+		for(const auto &pLayer : pGroup->m_vpLayers)
+		{
+			if(pLayer->m_Type == LAYERTYPE_TILES)
+			{
+				const std::shared_ptr<CLayerTiles> pTiles = std::static_pointer_cast<CLayerTiles>(pLayer);
+				if(pTiles->m_Image == ImageIndex)
+				{
+					return true;
+				}
+			}
+			else if(pLayer->m_Type == LAYERTYPE_QUADS)
+			{
+				const std::shared_ptr<CLayerQuads> pQuads = std::static_pointer_cast<CLayerQuads>(pLayer);
+				if(pQuads->m_Image == ImageIndex)
+				{
+					return true;
+				}
+			}
+		}
+	}
+	return false;
+}
+
+bool CEditorMap::IsSoundUsed(int SoundIndex) const
+{
+	for(const auto &pGroup : m_vpGroups)
+	{
+		for(const auto &pLayer : pGroup->m_vpLayers)
+		{
+			if(pLayer->m_Type == LAYERTYPE_SOUNDS)
+			{
+				std::shared_ptr<CLayerSounds> pSounds = std::static_pointer_cast<CLayerSounds>(pLayer);
+				if(pSounds->m_Sound == SoundIndex)
+				{
+					return true;
+				}
+			}
+		}
+	}
+	return false;
+}

--- a/src/game/editor/mapitems/map.cpp
+++ b/src/game/editor/mapitems/map.cpp
@@ -3,6 +3,7 @@
 #include <base/system.h>
 
 #include <game/editor/editor.h>
+#include <game/editor/mapitems/image.h>
 #include <game/editor/mapitems/layer_front.h>
 #include <game/editor/mapitems/layer_game.h>
 #include <game/editor/mapitems/layer_group.h>
@@ -244,6 +245,8 @@ void CEditorMap::Clean()
 
 	m_MapInfo.Reset();
 	m_MapInfoTmp.Reset();
+
+	m_SelectedImage = 0;
 }
 
 void CEditorMap::CreateDefault()
@@ -311,6 +314,77 @@ void CEditorMap::MakeTuneLayer(const std::shared_ptr<CLayer> &pLayer)
 {
 	m_pTuneLayer = std::static_pointer_cast<CLayerTune>(pLayer);
 	m_pTuneLayer->m_pEditor = m_pEditor;
+}
+
+std::shared_ptr<CEditorImage> CEditorMap::SelectedImage() const
+{
+	if(m_SelectedImage < 0 || (size_t)m_SelectedImage >= m_vpImages.size())
+	{
+		return nullptr;
+	}
+	return m_vpImages[m_SelectedImage];
+}
+
+void CEditorMap::SelectImage(const std::shared_ptr<CEditorImage> &pImage)
+{
+	for(size_t i = 0; i < m_vpImages.size(); ++i)
+	{
+		if(m_vpImages[i] == pImage)
+		{
+			m_SelectedImage = i;
+			break;
+		}
+	}
+}
+
+void CEditorMap::SelectNextImage()
+{
+	const int OldImage = m_SelectedImage;
+	m_SelectedImage = std::clamp(m_SelectedImage, 0, (int)m_vpImages.size() - 1);
+	for(size_t i = m_SelectedImage + 1; i < m_vpImages.size(); i++)
+	{
+		if(m_vpImages[i]->m_External == m_vpImages[m_SelectedImage]->m_External)
+		{
+			m_SelectedImage = i;
+			break;
+		}
+	}
+	if(m_SelectedImage == OldImage && !m_vpImages[m_SelectedImage]->m_External)
+	{
+		for(size_t i = 0; i < m_vpImages.size(); i++)
+		{
+			if(m_vpImages[i]->m_External)
+			{
+				m_SelectedImage = i;
+				break;
+			}
+		}
+	}
+}
+
+void CEditorMap::SelectPreviousImage()
+{
+	const int OldImage = m_SelectedImage;
+	m_SelectedImage = std::clamp(m_SelectedImage, 0, (int)m_vpImages.size() - 1);
+	for(int i = m_SelectedImage - 1; i >= 0; i--)
+	{
+		if(m_vpImages[i]->m_External == m_vpImages[m_SelectedImage]->m_External)
+		{
+			m_SelectedImage = i;
+			break;
+		}
+	}
+	if(m_SelectedImage == OldImage && m_vpImages[m_SelectedImage]->m_External)
+	{
+		for(int i = (int)m_vpImages.size() - 1; i >= 0; i--)
+		{
+			if(!m_vpImages[i]->m_External)
+			{
+				m_SelectedImage = i;
+				break;
+			}
+		}
+	}
 }
 
 bool CEditorMap::IsImageUsed(int ImageIndex) const

--- a/src/game/editor/mapitems/map.cpp
+++ b/src/game/editor/mapitems/map.cpp
@@ -10,6 +10,7 @@
 #include <game/editor/mapitems/layer_quads.h>
 #include <game/editor/mapitems/layer_sounds.h>
 #include <game/editor/mapitems/layer_tiles.h>
+#include <game/editor/mapitems/sound.h>
 
 void CEditorMap::CMapInfo::Reset()
 {
@@ -247,6 +248,7 @@ void CEditorMap::Clean()
 	m_MapInfoTmp.Reset();
 
 	m_SelectedImage = 0;
+	m_SelectedSound = 0;
 }
 
 void CEditorMap::CreateDefault()
@@ -412,6 +414,37 @@ bool CEditorMap::IsImageUsed(int ImageIndex) const
 		}
 	}
 	return false;
+}
+
+std::shared_ptr<CEditorSound> CEditorMap::SelectedSound() const
+{
+	if(m_SelectedSound < 0 || (size_t)m_SelectedSound >= m_vpSounds.size())
+	{
+		return nullptr;
+	}
+	return m_vpSounds[m_SelectedSound];
+}
+
+void CEditorMap::SelectSound(const std::shared_ptr<CEditorSound> &pSound)
+{
+	for(size_t i = 0; i < m_vpSounds.size(); ++i)
+	{
+		if(m_vpSounds[i] == pSound)
+		{
+			m_SelectedSound = i;
+			break;
+		}
+	}
+}
+
+void CEditorMap::SelectNextSound()
+{
+	m_SelectedSound = (m_SelectedSound + 1) % m_vpSounds.size();
+}
+
+void CEditorMap::SelectPreviousSound()
+{
+	m_SelectedSound = (m_SelectedSound + m_vpSounds.size() - 1) % m_vpSounds.size();
 }
 
 bool CEditorMap::IsSoundUsed(int SoundIndex) const

--- a/src/game/editor/mapitems/map.h
+++ b/src/game/editor/mapitems/map.h
@@ -98,6 +98,7 @@ public:
 	CMapInfo m_MapInfoTmp;
 
 	int m_SelectedImage;
+	int m_SelectedSound;
 
 	std::shared_ptr<CEnvelope> NewEnvelope(CEnvelope::EType Type);
 	void InsertEnvelope(int Index, std::shared_ptr<CEnvelope> &pEnvelope);
@@ -137,6 +138,10 @@ public:
 	void SelectPreviousImage();
 	bool IsImageUsed(int ImageIndex) const;
 
+	std::shared_ptr<CEditorSound> SelectedSound() const;
+	void SelectSound(const std::shared_ptr<CEditorSound> &pSound);
+	void SelectNextSound();
+	void SelectPreviousSound();
 	bool IsSoundUsed(int SoundIndex) const;
 
 private:

--- a/src/game/editor/mapitems/map.h
+++ b/src/game/editor/mapitems/map.h
@@ -129,6 +129,10 @@ public:
 	void MakeSwitchLayer(const std::shared_ptr<CLayer> &pLayer);
 	void MakeTuneLayer(const std::shared_ptr<CLayer> &pLayer);
 
+	bool IsImageUsed(int ImageIndex) const;
+
+	bool IsSoundUsed(int SoundIndex) const;
+
 private:
 	CEditor *m_pEditor;
 };

--- a/src/game/editor/mapitems/map.h
+++ b/src/game/editor/mapitems/map.h
@@ -97,6 +97,8 @@ public:
 	CMapInfo m_MapInfo;
 	CMapInfo m_MapInfoTmp;
 
+	int m_SelectedImage;
+
 	std::shared_ptr<CEnvelope> NewEnvelope(CEnvelope::EType Type);
 	void InsertEnvelope(int Index, std::shared_ptr<CEnvelope> &pEnvelope);
 	void UpdateEnvelopeReferences(int Index, std::shared_ptr<CEnvelope> &pEnvelope, std::vector<std::shared_ptr<IEditorEnvelopeReference>> &vpEditorObjectReferences);
@@ -129,6 +131,10 @@ public:
 	void MakeSwitchLayer(const std::shared_ptr<CLayer> &pLayer);
 	void MakeTuneLayer(const std::shared_ptr<CLayer> &pLayer);
 
+	std::shared_ptr<CEditorImage> SelectedImage() const;
+	void SelectImage(const std::shared_ptr<CEditorImage> &pImage);
+	void SelectNextImage();
+	void SelectPreviousImage();
 	bool IsImageUsed(int ImageIndex) const;
 
 	bool IsSoundUsed(int SoundIndex) const;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1699,7 +1699,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupImage(void *pContext, CUIRect View, 
 
 	CUIRect Slot;
 	View.HSplitTop(RowHeight, &Slot, &View);
-	std::shared_ptr<CEditorImage> pImg = pEditor->m_Map.m_vpImages[pEditor->m_SelectedImage];
+	std::shared_ptr<CEditorImage> pImg = pEditor->m_Map.SelectedImage();
 
 	if(!pImg->m_External)
 	{
@@ -1793,15 +1793,15 @@ CUi::EPopupMenuFunctionResult CEditor::PopupImage(void *pContext, CUIRect View, 
 	View.HSplitTop(RowHeight, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_RemoveButton, "Remove", 0, &Slot, BUTTONFLAG_LEFT, "Remove the image from the map."))
 	{
-		if(pEditor->m_Map.IsImageUsed(pEditor->m_SelectedImage))
+		if(pEditor->m_Map.IsImageUsed(pEditor->m_Map.m_SelectedImage))
 		{
 			pEditor->m_PopupEventType = POPEVENT_REMOVE_USED_IMAGE;
 			pEditor->m_PopupEventActivated = true;
 		}
 		else
 		{
-			pEditor->m_Map.m_vpImages.erase(pEditor->m_Map.m_vpImages.begin() + pEditor->m_SelectedImage);
-			pEditor->m_Map.ModifyImageIndex(gs_ModifyIndexDeleted(pEditor->m_SelectedImage));
+			pEditor->m_Map.m_vpImages.erase(pEditor->m_Map.m_vpImages.begin() + pEditor->m_Map.m_SelectedImage);
+			pEditor->m_Map.ModifyImageIndex(gs_ModifyIndexDeleted(pEditor->m_Map.m_SelectedImage));
 		}
 		return CUi::POPUP_CLOSE_CURRENT;
 	}
@@ -2204,8 +2204,8 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEvent(void *pContext, CUIRect View, 
 		}
 		else if(pEditor->m_PopupEventType == POPEVENT_REMOVE_USED_IMAGE)
 		{
-			pEditor->m_Map.m_vpImages.erase(pEditor->m_Map.m_vpImages.begin() + pEditor->m_SelectedImage);
-			pEditor->m_Map.ModifyImageIndex(gs_ModifyIndexDeleted(pEditor->m_SelectedImage));
+			pEditor->m_Map.m_vpImages.erase(pEditor->m_Map.m_vpImages.begin() + pEditor->m_Map.m_SelectedImage);
+			pEditor->m_Map.ModifyImageIndex(gs_ModifyIndexDeleted(pEditor->m_Map.m_SelectedImage));
 		}
 		else if(pEditor->m_PopupEventType == POPEVENT_REMOVE_USED_SOUND)
 		{

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1793,7 +1793,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupImage(void *pContext, CUIRect View, 
 	View.HSplitTop(RowHeight, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_RemoveButton, "Remove", 0, &Slot, BUTTONFLAG_LEFT, "Remove the image from the map."))
 	{
-		if(IsAssetUsed(CFileBrowser::EFileType::IMAGE, pEditor->m_SelectedImage, pEditor))
+		if(pEditor->m_Map.IsImageUsed(pEditor->m_SelectedImage))
 		{
 			pEditor->m_PopupEventType = POPEVENT_REMOVE_USED_IMAGE;
 			pEditor->m_PopupEventActivated = true;
@@ -1902,7 +1902,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSound(void *pContext, CUIRect View, 
 	View.HSplitTop(RowHeight, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_RemoveButton, "Remove", 0, &Slot, BUTTONFLAG_LEFT, "Remove the sound from the map."))
 	{
-		if(IsAssetUsed(CFileBrowser::EFileType::SOUND, pEditor->m_SelectedSound, pEditor))
+		if(pEditor->m_Map.IsSoundUsed(pEditor->m_SelectedSound))
 		{
 			pEditor->m_PopupEventType = POPEVENT_REMOVE_USED_SOUND;
 			pEditor->m_PopupEventActivated = true;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1838,7 +1838,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSound(void *pContext, CUIRect View, 
 
 	CUIRect Slot;
 	View.HSplitTop(RowHeight, &Slot, &View);
-	std::shared_ptr<CEditorSound> pSound = pEditor->m_Map.m_vpSounds[pEditor->m_SelectedSound];
+	std::shared_ptr<CEditorSound> pSound = pEditor->m_Map.SelectedSound();
 
 	static CUi::SSelectionPopupContext s_SelectionPopupContext;
 	static CScrollRegion s_SelectionPopupScrollRegion;
@@ -1902,15 +1902,15 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSound(void *pContext, CUIRect View, 
 	View.HSplitTop(RowHeight, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_RemoveButton, "Remove", 0, &Slot, BUTTONFLAG_LEFT, "Remove the sound from the map."))
 	{
-		if(pEditor->m_Map.IsSoundUsed(pEditor->m_SelectedSound))
+		if(pEditor->m_Map.IsSoundUsed(pEditor->m_Map.m_SelectedSound))
 		{
 			pEditor->m_PopupEventType = POPEVENT_REMOVE_USED_SOUND;
 			pEditor->m_PopupEventActivated = true;
 		}
 		else
 		{
-			pEditor->m_Map.m_vpSounds.erase(pEditor->m_Map.m_vpSounds.begin() + pEditor->m_SelectedSound);
-			pEditor->m_Map.ModifySoundIndex(gs_ModifyIndexDeleted(pEditor->m_SelectedSound));
+			pEditor->m_Map.m_vpSounds.erase(pEditor->m_Map.m_vpSounds.begin() + pEditor->m_Map.m_SelectedSound);
+			pEditor->m_Map.ModifySoundIndex(gs_ModifyIndexDeleted(pEditor->m_Map.m_SelectedSound));
 			pEditor->m_ToolbarPreviewSound = -1;
 		}
 		return CUi::POPUP_CLOSE_CURRENT;
@@ -2209,8 +2209,8 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEvent(void *pContext, CUIRect View, 
 		}
 		else if(pEditor->m_PopupEventType == POPEVENT_REMOVE_USED_SOUND)
 		{
-			pEditor->m_Map.m_vpSounds.erase(pEditor->m_Map.m_vpSounds.begin() + pEditor->m_SelectedSound);
-			pEditor->m_Map.ModifySoundIndex(gs_ModifyIndexDeleted(pEditor->m_SelectedSound));
+			pEditor->m_Map.m_vpSounds.erase(pEditor->m_Map.m_vpSounds.begin() + pEditor->m_Map.m_SelectedSound);
+			pEditor->m_Map.ModifySoundIndex(gs_ModifyIndexDeleted(pEditor->m_Map.m_SelectedSound));
 			pEditor->m_ToolbarPreviewSound = -1;
 		}
 		else if(pEditor->m_PopupEventType == POPEVENT_RESTART_SERVER)


### PR DESCRIPTION
The editor selection (image, sound, group, layer etc.) should be tracked separately for each map. This PR moves handling of the selected image and sound. This is part of a larger refactoring to eventually support opening multiple maps in separate tabs in the editor.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
