### PR TITLE
Fix Tees getting stuck in corners

### DIFF
--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -519,7 +519,7 @@ bool CCollision::TestBox(vec2 Pos, vec2 Size) const
 	return false;
 }
 
-void CCollision::MoveBox(vec2 *pInoutPos, vec2 *pInoutVel, vec2 Size, vec2 Elasticity, bool *pGrounded) const
+void CCollision::MoveBox(vec2 *pInoutPos, vec2 *pInoutVel, vec2 Size, vec2 Elasticity, bool *pGrounded, const std::function<bool(vec2)> &ShouldStop) const
 {
 	// do the move
 	vec2 Pos = *pInoutPos;
@@ -584,6 +584,12 @@ void CCollision::MoveBox(vec2 *pInoutPos, vec2 *pInoutVel, vec2 Size, vec2 Elast
 					NewPos.x = Pos.x;
 					Vel.x *= -ElasticityX;
 				}
+			}
+			if(ShouldStop && ShouldStop(NewPos))
+			{
+				// we have a collision with a Tee
+				// don't cancel velocity, just stop going further
+				break;
 			}
 
 			Pos = NewPos;

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -50,7 +50,7 @@ public:
 	int IntersectLineTeleWeapon(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision, int *pTeleNr = nullptr) const;
 	int IntersectLineTeleHook(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision, int *pTeleNr = nullptr) const;
 	void MovePoint(vec2 *pInoutPos, vec2 *pInoutVel, float Elasticity, int *pBounces) const;
-	void MoveBox(vec2 *pInoutPos, vec2 *pInoutVel, vec2 Size, vec2 Elasticity, bool *pGrounded = nullptr) const;
+	void MoveBox(vec2 *pInoutPos, vec2 *pInoutVel, vec2 Size, vec2 Elasticity, bool *pGrounded = nullptr, const std::function<bool(vec2)> &ShouldStop = nullptr) const;
 	bool TestBox(vec2 Pos, vec2 Size) const;
 
 	// DDRace

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -604,15 +604,15 @@ void CCharacterCore::Move()
 							NewPos = m_Pos;
 							// check player collision
 							auto Collide = [this](vec2 CurPos) {
-								for(int p = 0; p < MAX_CLIENTS; p++)
+								for(int pId = 0; pId < MAX_CLIENTS; pId++)
 								{
-									CCharacterCore *pCharCore = m_pWorld->m_apCharacters[p];
-									if(!pCharCore || pCharCore == this)
+									CCharacterCore *pCore = m_pWorld->m_apCharacters[pId];
+									if(!pCore || pCore == this)
 										continue;
-									if((!(pCharCore->m_Super || m_Super) && (m_Solo || pCharCore->m_Solo || pCharCore->m_CollisionDisabled || (m_Id != -1 && !m_pTeams->CanCollide(m_Id, p)))))
+									if((!(pCore->m_Super || m_Super) && (m_Solo || pCore->m_Solo || pCore->m_CollisionDisabled || (m_Id != -1 && !m_pTeams->CanCollide(m_Id, pId)))))
 										continue;
-									float D = distance(CurPos, pCharCore->m_Pos);
-									if(D < PhysicalSize())
+									float Dist = distance(CurPos, pCore->m_Pos);
+									if(Dist < PhysicalSize())
 									{
 										return true;
 									}


### PR DESCRIPTION
Fixes #1738 with slightest physics change possible as far as I can tell.

Thanks to Aoe for providing me a test map with which I could investigate Tees getting stuck: [EdgeBug2.map.zip](https://github.com/user-attachments/files/22696949/EdgeBug2.zip). Just holding d makes the Tee get stuck.

https://github.com/user-attachments/assets/1fa160f0-f56d-444a-81ed-ad5ff03e194a

What is happening is visualized in the following diagram. This visualizes the `CCharacterCore::Move` functions with all tee positions for collision checks. All points that were checked are the blue dots in the diagram.
First we check collision against the wall. We move diagonally first. We then hit the wall and move straight up.
Then we check for Tee collision until the newly calculated end point. We stop right before we hit the tee. This is depicted as orange points in the diagram. Note that the orange points don't guarantee that there is no wall collision, because the blue and the orange lines differ.
The end point in this case is above the wall and the tee gets stuck indefinite.

<img width="959" height="971" alt="tee_stuck" src="https://github.com/user-attachments/assets/36db70e2-d01c-4065-8ef2-6eb1e04fa9de" />

The proposed fix is when we detect that the end position is stuck above the wall, to do the blue point calculations again, but this time also consider tee collision and stop moving further right before hitting the first tee.

I think this also explains the stuck videos of #4474 due to even if start/end points are the same, due to floating point inaccuracies and different way of computing blue/orange points, . However, I can't tell for sure, because I didn't have a reproducible case of it.

This is how it would look like with the current fix applied:

https://github.com/user-attachments/assets/38c48ead-a733-4567-85fa-6065822b7040

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] **~~Changed no physics that affect existing maps~~: This is a physics change**
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
