### PR TITLE
Remove unneeded check on direction in CPlayers::GetPlayerTargetAngle

### DIFF
--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -103,10 +103,6 @@ float CPlayers::GetPlayerTargetAngle(
 		// calculate what would be sent to the server from our current input
 		vec2 Direction = normalize(vec2((int)GameClient()->m_Controls.m_aMousePos[g_Config.m_ClDummy].x, (int)GameClient()->m_Controls.m_aMousePos[g_Config.m_ClDummy].y));
 
-		// fix direction if mouse is exactly in the center
-		if(Direction == vec2(0.0f, 0.0f))
-			Direction = vec2(1.0f, 0.0f);
-
 		return angle(Direction);
 	}
 


### PR DESCRIPTION
The check is done in angle()

Is there any reason angle() isn't just atan2, as far as I can tell it has the same behaviour

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
