### PR TITLE
Remove `DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE` from cmake flags

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -45,6 +45,5 @@ jobs:
           -DCMAKE_CXX_CLANG_TIDY="clang-tidy-20;-warnings-as-errors=*" \
           -DCMAKE_C_CLANG_TIDY="clang-tidy-20;-warnings-as-errors=*" \
           -DCMAKE_BUILD_TYPE=Debug \
-          -Werror=dev \
-          -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=. ..
+          -Werror=dev ..
         cmake --build . --config Debug --target everything -- -k 0


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
It wasn't used and there was a warning about it.

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
