### PR TITLE
Fix client assertion crash on 0.7 servers with high ping

### DIFF
--- a/src/engine/shared/translation_context.h
+++ b/src/engine/shared/translation_context.h
@@ -61,28 +61,18 @@ public:
 		{
 			m_Active = false;
 
-			m_UseCustomColor = 0;
-			m_ColorBody = 0;
-			m_ColorFeet = 0;
-
 			m_aName[0] = '\0';
 			m_aClan[0] = '\0';
 			m_Country = 0;
-			m_aSkinName[0] = '\0';
 			m_Team = 0;
 			m_PlayerFlags7 = 0;
 		}
 
 		bool m_Active;
 
-		int m_UseCustomColor;
-		int m_ColorBody;
-		int m_ColorFeet;
-
 		char m_aName[MAX_NAME_LENGTH];
 		char m_aClan[MAX_CLAN_LENGTH];
 		int m_Country;
-		char m_aSkinName[protocol7::MAX_SKIN_LENGTH];
 		int m_Team;
 		int m_PlayerFlags7;
 	};

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2799,7 +2799,7 @@ void CGameClient::CClientData::Reset()
 	m_aName[0] = '\0';
 	m_aClan[0] = '\0';
 	m_Country = -1;
-	m_aSkinName[0] = '\0';
+	str_copy(m_aSkinName, "default");
 
 	m_Team = 0;
 	m_Emoticon = 0;

--- a/src/game/client/sixup_translate_snapshot.cpp
+++ b/src/game/client/sixup_translate_snapshot.cpp
@@ -151,10 +151,10 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 		StrToInts(Info6.m_aName, std::size(Info6.m_aName), Client.m_aName);
 		StrToInts(Info6.m_aClan, std::size(Info6.m_aClan), Client.m_aClan);
 		Info6.m_Country = Client.m_Country;
-		StrToInts(Info6.m_aSkin, std::size(Info6.m_aSkin), Client.m_aSkinName);
-		Info6.m_UseCustomColor = Client.m_UseCustomColor;
-		Info6.m_ColorBody = Client.m_ColorBody;
-		Info6.m_ColorFeet = Client.m_ColorFeet;
+		StrToInts(Info6.m_aSkin, std::size(Info6.m_aSkin), "default");
+		Info6.m_UseCustomColor = 0;
+		Info6.m_ColorBody = 0;
+		Info6.m_ColorFeet = 0;
 		mem_copy(pObj, &Info6, sizeof(CNetObj_ClientInfo));
 	}
 


### PR DESCRIPTION
On 0.7 servers with higher ping, it takes a moment until the 0.7 skin info is available, which was previously causing the client to crash with an assertion because the 0.6 skin info was used as fallback but not initialized.

Now, the 0.6 skin is always initialized to `default` as fallback.

The skin info variables in the translation context are removed because they are unused.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
