### PR TITLE
Move sixup security tokens into the packet class

### DIFF
--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -173,6 +173,15 @@ public:
 	int m_DataSize;
 	unsigned char m_aChunkData[NET_MAX_PAYLOAD];
 	unsigned char m_aExtraData[NET_CONNLESS_EXTRA_SIZE];
+
+	class CSixup
+	{
+	public:
+		SECURITY_TOKEN m_SecurityToken = NET_SECURITY_TOKEN_UNSUPPORTED;
+		SECURITY_TOKEN m_ResponseToken = NET_SECURITY_TOKEN_UNSUPPORTED;
+	};
+	// Only used for connless 0.7 packets.
+	CSixup m_Sixup;
 };
 
 enum class CONNECTIVITY
@@ -299,7 +308,7 @@ public:
 	int Update();
 	int Flush();
 
-	int Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr, SECURITY_TOKEN SecurityToken = NET_SECURITY_TOKEN_UNSUPPORTED, SECURITY_TOKEN ResponseToken = NET_SECURITY_TOKEN_UNSUPPORTED);
+	int Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr);
 	int QueueChunk(int Flags, int DataSize, const void *pData);
 
 	const char *ErrorString();
@@ -435,7 +444,7 @@ class CNetServer
 	CNetRecvUnpacker m_RecvUnpacker;
 
 	void OnTokenCtrlMsg(NETADDR &Addr, int ControlMsg, const CNetPacketConstruct &Packet);
-	int OnSixupCtrlMsg(NETADDR &Addr, CNetChunk *pChunk, int ControlMsg, const CNetPacketConstruct &Packet, SECURITY_TOKEN &ResponseToken, SECURITY_TOKEN Token);
+	int OnSixupCtrlMsg(NETADDR &Addr, CNetChunk *pChunk, int ControlMsg, CNetPacketConstruct *pPacket);
 	void OnPreConnMsg(NETADDR &Addr, CNetPacketConstruct &Packet);
 	void OnConnCtrlMsg(NETADDR &Addr, int ClientId, int ControlMsg, const CNetPacketConstruct &Packet);
 	bool ClientExists(const NETADDR &Addr) { return GetClientSlot(Addr) != -1; }
@@ -628,7 +637,7 @@ public:
 	static void SendPacket(NETSOCKET Socket, NETADDR *pAddr, CNetPacketConstruct *pPacket, SECURITY_TOKEN SecurityToken, bool Sixup = false);
 
 	static std::optional<int> UnpackPacketFlags(unsigned char *pBuffer, int Size);
-	static int UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct *pPacket, bool &Sixup, SECURITY_TOKEN *pSecurityToken = nullptr, SECURITY_TOKEN *pResponseToken = nullptr);
+	static int UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct *pPacket, bool &Sixup);
 
 	// The backroom is ack-NET_MAX_SEQUENCE/2. Used for knowing if we acked a packet or not
 	static bool IsSeqInBackroom(int Seq, int Ack);

--- a/src/engine/shared/network_client.cpp
+++ b/src/engine/shared/network_client.cpp
@@ -93,9 +93,10 @@ int CNetClient::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken, bool Six
 			continue;
 		}
 
-		SECURITY_TOKEN Token;
-		*pResponseToken = NET_SECURITY_TOKEN_UNKNOWN;
-		if(CNetBase::UnpackPacket(pData, Bytes, &m_RecvUnpacker.m_Data, Sixup, &Token, pResponseToken) == 0)
+		bool UnpackSuccess = CNetBase::UnpackPacket(pData, Bytes, &m_RecvUnpacker.m_Data, Sixup) == 0;
+		*pResponseToken = m_RecvUnpacker.m_Data.m_Sixup.m_ResponseToken;
+
+		if(UnpackSuccess)
 		{
 			if(Sixup)
 			{
@@ -122,11 +123,11 @@ int CNetClient::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken, bool Six
 					m_RecvUnpacker.m_Data.m_DataSize >= 1 + (int)sizeof(SECURITY_TOKEN) &&
 					m_RecvUnpacker.m_Data.m_aChunkData[0] == protocol7::NET_CTRLMSG_TOKEN)
 				{
-					m_TokenCache.AddToken(&Addr, *pResponseToken);
+					m_TokenCache.AddToken(&Addr, m_RecvUnpacker.m_Data.m_Sixup.m_ResponseToken);
 				}
 				if(m_Connection.State() != CNetConnection::EState::OFFLINE &&
 					m_Connection.State() != CNetConnection::EState::ERROR &&
-					m_Connection.Feed(&m_RecvUnpacker.m_Data, &Addr, Token, *pResponseToken))
+					m_Connection.Feed(&m_RecvUnpacker.m_Data, &Addr))
 				{
 					m_RecvUnpacker.Start(&Addr, &m_Connection, 0);
 				}


### PR DESCRIPTION
Makes the code cleaner because the tokens are now tied to the packet object which they belong to.

Also gets rid of the need to pass two tokens separately around as arguments.

Makes it clear that these tokens are used for sixup only and are not to be confused with the ddnet security tokens.

## Checklist

- [x] Tested the change ingame
  - [x] connect 0.6 ddnet and 0.7 teeworlds to the server
  - [x] connect the client to 0.6 ddnet and 0.7 teeworlds servers
  - [x] browse local teeworlds 0.7 servers
  - [ ] browse local ddnet server with teeworlds 0.7 client
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
