### PR TITLE
Refactor: Normalize quad clipping to tile space

### DIFF
--- a/src/game/map/render_layer.h
+++ b/src/game/map/render_layer.h
@@ -265,7 +265,7 @@ protected:
 
 	bool IsVisibleInClipRegion(const std::optional<CClipRegion> &ClipRegion) const;
 	void CalculateClipping(CQuadCluster &QuadCluster);
-	bool CalculateQuadClipping(const CQuadCluster &QuadCluster, int aQuadOffsetMin[2], int aQuadOffsetMax[2]) const;
+	bool CalculateQuadClipping(const CQuadCluster &QuadCluster, float aQuadOffsetMin[2], float aQuadOffsetMax[2]) const;
 
 	std::optional<CClipRegion> m_LayerClip;
 	std::vector<CQuadCluster> m_vQuadClusters;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Normalizes quad clipping to tile space, calculates quad clipping in fixed floating space instead of raw ints

Followup of #11023, see [comment](https://github.com/ddnet/ddnet/pull/11023#pullrequestreview-3298532882)

## Ingame tests

You can debug this with `dbg_render_cluster_clips 1`, tested with and without rotating quads:

<img width="2560" height="1440" alt="screenshot_2025-10-14_22-38-26" src="https://github.com/user-attachments/assets/5ecb7be2-427f-407f-af17-ed479c65d805" />

https://github.com/user-attachments/assets/ca810d0d-3ee0-4e29-8f9f-a680d31ba476

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
