### PR TITLE
Remove most clang-tidy variable/constant/parameter name exclusions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -146,13 +146,13 @@ CheckOptions:
   - key:             readability-identifier-naming.ParameterCase
     value:           CamelCase
   - key:             readability-identifier-naming.ParameterIgnoredRegexp
-    value:           '^(p|a|v|[a-z]$|[xy][0123]$).*'
+    value:           '^((a|v|p|pfn)+[A-Z][a-zA-Z0-9]*|[a-z]|[pxy][0-3]|p[xy])$'
   - key:             readability-identifier-naming.ClassMethodIgnoredRegexp
     value:           '^(Con_).*'
   - key:             readability-identifier-naming.ClassMemberIgnoredRegexp
     value:           '^(ms?_(a|v|p|pfn)*[A-Z][a-zA-Z0-9]*|[abfghlrsuvwxyz])$'
   - key:             readability-identifier-naming.LocalConstantIgnoredRegexp
-    value:           '^(p|a|v|MAX_ANIM_SPEED$|DATA_OFFSET$|HEADER_LEN$|MIN_ANIM_SPEED$|[hwdcbqstf]$|[xt][0123]$|result$|sub$|it$|len$|d[xy]$).*'
+    value:           '^((a|v|p|pfn)+[A-Z][a-zA-Z0-9]*|[abcdfhpqstvw]|[aptvx][0-3]|d[xy])$'
   - key:             readability-identifier-naming.LocalVariableIgnoredRegexp
-    value:           '^(p|a|FT_|TB_|ul_|v|[xy]i$|[zijklxyhmrgbacwestnduvqf]$|[dmpwsitcf][xy]$|(ch|skel)[0-2]?$|it$|tw$|dt$|th$|ls$|func$|res$|shader$|len$|maxLength$|length$|offset$|offpos$|result$|bg$|sp$|url$|index$|ctxt$|key$|null$|logger$|LAST_MODIFIED$|teleNr$|target$|id$|hit$|hsl[0-2]?$|rgb[0-2]?$|dir$|tmp$|sub$|ret$|rendered$|size$|isWeaponCollide$|zerochar$|dist$|sound$|matches$|nohook$|btn$|savedLayers$|l[hw]$|evilz$|sec$|min$|to2$|delay$|[xy]Fract$|[xy]Int$|imgg[xy]$|skip$|localPlayer$|fdratio$|[rgbat][0-2]$|[xy][0-3]$|x[rl]$).*'
+    value:           '^((a|v|p|pfn)+[A-Z][a-zA-Z0-9]*|[abcdefghijklmnpqrstuvwxyz]|[aptvxy][0-3]|[cdfimpstw][xy])$'
 

--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -855,7 +855,7 @@ void CCommandProcessorFragment_OpenGL::TextureCreate(int Slot, int Width, int He
 				glBindSampler(0, 0);
 			}
 
-			uint8_t *p3DImageData = static_cast<uint8_t *>(malloc((size_t)Width * Height * PixelSize));
+			uint8_t *pImageData3D = static_cast<uint8_t *>(malloc((size_t)Width * Height * PixelSize));
 			int Image3DWidth, Image3DHeight;
 
 			int ConvertWidth = Width;
@@ -875,12 +875,12 @@ void CCommandProcessorFragment_OpenGL::TextureCreate(int Slot, int Width, int He
 				pTexData = pNewTexData;
 			}
 
-			if(Texture2DTo3D(pTexData, ConvertWidth, ConvertHeight, PixelSize, 16, 16, p3DImageData, Image3DWidth, Image3DHeight))
+			if(Texture2DTo3D(pTexData, ConvertWidth, ConvertHeight, PixelSize, 16, 16, pImageData3D, Image3DWidth, Image3DHeight))
 			{
-				glTexImage3D(Target, 0, GLStoreFormat, Image3DWidth, Image3DHeight, 256, 0, GLFormat, GL_UNSIGNED_BYTE, p3DImageData);
+				glTexImage3D(Target, 0, GLStoreFormat, Image3DWidth, Image3DHeight, 256, 0, GLFormat, GL_UNSIGNED_BYTE, pImageData3D);
 			}
 
-			free(p3DImageData);
+			free(pImageData3D);
 		}
 	}
 

--- a/src/engine/client/backend/opengl/backend_opengl3.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl3.cpp
@@ -654,7 +654,7 @@ void CCommandProcessorFragment_OpenGL3_3::TextureCreate(int Slot, int Width, int
 				glSamplerParameterf(m_vTextures[Slot].m_Sampler2DArray, GL_TEXTURE_LOD_BIAS, ((GLfloat)m_OpenGLTextureLodBIAS / 1000.0f));
 #endif
 
-			uint8_t *p3DImageData = static_cast<uint8_t *>(malloc((size_t)Width * Height * PixelSize));
+			uint8_t *pImageData3D = static_cast<uint8_t *>(malloc((size_t)Width * Height * PixelSize));
 			int Image3DWidth, Image3DHeight;
 
 			int ConvertWidth = Width;
@@ -674,13 +674,13 @@ void CCommandProcessorFragment_OpenGL3_3::TextureCreate(int Slot, int Width, int
 				pTexData = pNewTexData;
 			}
 
-			if(Texture2DTo3D(pTexData, ConvertWidth, ConvertHeight, PixelSize, 16, 16, p3DImageData, Image3DWidth, Image3DHeight))
+			if(Texture2DTo3D(pTexData, ConvertWidth, ConvertHeight, PixelSize, 16, 16, pImageData3D, Image3DWidth, Image3DHeight))
 			{
-				glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GLStoreFormat, Image3DWidth, Image3DHeight, 256, 0, GLFormat, GL_UNSIGNED_BYTE, p3DImageData);
+				glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GLStoreFormat, Image3DWidth, Image3DHeight, 256, 0, GLFormat, GL_UNSIGNED_BYTE, pImageData3D);
 				glGenerateMipmap(GL_TEXTURE_2D_ARRAY);
 			}
 
-			free(p3DImageData);
+			free(pImageData3D);
 		}
 	}
 
@@ -875,10 +875,10 @@ void CCommandProcessorFragment_OpenGL3_3::AppendIndices(unsigned int NewIndicesC
 	GLuint NewIndexBufferId;
 	glGenBuffers(1, &NewIndexBufferId);
 	glBindBuffer(BUFFER_INIT_INDEX_TARGET, NewIndexBufferId);
-	GLsizeiptr size = sizeof(unsigned int);
-	glBufferData(BUFFER_INIT_INDEX_TARGET, (GLsizeiptr)NewIndicesCount * size, NULL, GL_STATIC_DRAW);
-	glCopyBufferSubData(GL_COPY_READ_BUFFER, BUFFER_INIT_INDEX_TARGET, 0, 0, (GLsizeiptr)m_CurrentIndicesInBuffer * size);
-	glBufferSubData(BUFFER_INIT_INDEX_TARGET, (GLsizeiptr)m_CurrentIndicesInBuffer * size, (GLsizeiptr)AddCount * size, pIndices);
+	constexpr GLsizeiptr Size = sizeof(unsigned int);
+	glBufferData(BUFFER_INIT_INDEX_TARGET, (GLsizeiptr)NewIndicesCount * Size, NULL, GL_STATIC_DRAW);
+	glCopyBufferSubData(GL_COPY_READ_BUFFER, BUFFER_INIT_INDEX_TARGET, 0, 0, (GLsizeiptr)m_CurrentIndicesInBuffer * Size);
+	glBufferSubData(BUFFER_INIT_INDEX_TARGET, (GLsizeiptr)m_CurrentIndicesInBuffer * Size, (GLsizeiptr)AddCount * Size, pIndices);
 	glBindBuffer(BUFFER_INIT_INDEX_TARGET, 0);
 	glBindBuffer(GL_COPY_READ_BUFFER, 0);
 

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -380,9 +380,9 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 
 		void Destroy(VkDevice &Device)
 		{
-			for(auto it = m_MemoryCaches.m_vpMemoryHeaps.begin(); it != m_MemoryCaches.m_vpMemoryHeaps.end();)
+			for(auto HeapIterator = m_MemoryCaches.m_vpMemoryHeaps.begin(); HeapIterator != m_MemoryCaches.m_vpMemoryHeaps.end();)
 			{
-				auto *pHeap = *it;
+				auto *pHeap = *HeapIterator;
 				if(pHeap->m_pMappedBuffer != nullptr)
 					vkUnmapMemory(Device, pHeap->m_BufferMem.m_Mem);
 				if(pHeap->m_Buffer != VK_NULL_HANDLE)
@@ -390,7 +390,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 				vkFreeMemory(Device, pHeap->m_BufferMem.m_Mem, nullptr);
 
 				delete pHeap;
-				it = m_MemoryCaches.m_vpMemoryHeaps.erase(it);
+				HeapIterator = m_MemoryCaches.m_vpMemoryHeaps.erase(HeapIterator);
 			}
 
 			m_MemoryCaches.m_vpMemoryHeaps.clear();
@@ -423,9 +423,9 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 				m_CanShrink = false;
 				if(m_MemoryCaches.m_vpMemoryHeaps.size() > 1)
 				{
-					for(auto it = m_MemoryCaches.m_vpMemoryHeaps.begin(); it != m_MemoryCaches.m_vpMemoryHeaps.end();)
+					for(auto HeapIterator = m_MemoryCaches.m_vpMemoryHeaps.begin(); HeapIterator != m_MemoryCaches.m_vpMemoryHeaps.end();)
 					{
-						auto *pHeap = *it;
+						auto *pHeap = *HeapIterator;
 						if(pHeap->m_Heap.IsUnused())
 						{
 							if(pHeap->m_pMappedBuffer != nullptr)
@@ -436,12 +436,12 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 							FreeedMemory += pHeap->m_BufferMem.m_Size;
 
 							delete pHeap;
-							it = m_MemoryCaches.m_vpMemoryHeaps.erase(it);
+							HeapIterator = m_MemoryCaches.m_vpMemoryHeaps.erase(HeapIterator);
 							if(m_MemoryCaches.m_vpMemoryHeaps.size() == 1)
 								break;
 						}
 						else
-							++it;
+							++HeapIterator;
 					}
 				}
 			}
@@ -1889,14 +1889,14 @@ protected:
 
 	[[nodiscard]] bool GetImageMemory(SMemoryImageBlock<IMAGE_BUFFER_CACHE_ID> &RetBlock, VkDeviceSize RequiredSize, VkDeviceSize RequiredAlignment, uint32_t RequiredMemoryTypeBits)
 	{
-		auto it = m_ImageBufferCaches.find(RequiredMemoryTypeBits);
-		if(it == m_ImageBufferCaches.end())
+		auto BufferCacheIterator = m_ImageBufferCaches.find(RequiredMemoryTypeBits);
+		if(BufferCacheIterator == m_ImageBufferCaches.end())
 		{
-			it = m_ImageBufferCaches.insert({RequiredMemoryTypeBits, {}}).first;
+			BufferCacheIterator = m_ImageBufferCaches.insert({RequiredMemoryTypeBits, {}}).first;
 
-			it->second.Init(m_SwapChainImageCount);
+			BufferCacheIterator->second.Init(m_SwapChainImageCount);
 		}
-		return GetImageMemoryBlockImpl<IMAGE_BUFFER_CACHE_ID, IMAGE_SIZE_1024X1024_APPROXIMATION, 2>(RetBlock, it->second, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, RequiredSize, RequiredAlignment, RequiredMemoryTypeBits);
+		return GetImageMemoryBlockImpl<IMAGE_BUFFER_CACHE_ID, IMAGE_SIZE_1024X1024_APPROXIMATION, 2>(RetBlock, BufferCacheIterator->second, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, RequiredSize, RequiredAlignment, RequiredMemoryTypeBits);
 	}
 
 	void FreeImageMemBlock(SMemoryImageBlock<IMAGE_BUFFER_CACHE_ID> &Block)
@@ -2635,15 +2635,15 @@ protected:
 			}
 
 			bool Needs3DTexDel = false;
-			uint8_t *p3DTexData = static_cast<uint8_t *>(malloc((size_t)PixelSize * ConvertWidth * ConvertHeight));
-			if(!Texture2DTo3D(pData, ConvertWidth, ConvertHeight, PixelSize, 16, 16, p3DTexData, Image3DWidth, Image3DHeight))
+			uint8_t *pTexData3D = static_cast<uint8_t *>(malloc((size_t)PixelSize * ConvertWidth * ConvertHeight));
+			if(!Texture2DTo3D(pData, ConvertWidth, ConvertHeight, PixelSize, 16, 16, pTexData3D, Image3DWidth, Image3DHeight))
 			{
-				free(p3DTexData);
-				p3DTexData = nullptr;
+				free(pTexData3D);
+				pTexData3D = nullptr;
 			}
 			Needs3DTexDel = true;
 
-			if(p3DTexData != nullptr)
+			if(pTexData3D != nullptr)
 			{
 				const size_t ImageDepth2DArray = (size_t)16 * 16;
 				VkExtent3D ImgSize{(uint32_t)Image3DWidth, (uint32_t)Image3DHeight, 1};
@@ -2654,7 +2654,7 @@ protected:
 						MipMapLevelCount = 1;
 				}
 
-				if(!CreateTextureImage(ImageIndex, Texture.m_Img3D, Texture.m_Img3DMem, p3DTexData, Format, Image3DWidth, Image3DHeight, ImageDepth2DArray, PixelSize, MipMapLevelCount))
+				if(!CreateTextureImage(ImageIndex, Texture.m_Img3D, Texture.m_Img3DMem, pTexData3D, Format, Image3DWidth, Image3DHeight, ImageDepth2DArray, PixelSize, MipMapLevelCount))
 					return false;
 				VkFormat ImgFormat = Format;
 				VkImageView ImgView = CreateTextureImageView(Texture.m_Img3D, ImgFormat, VK_IMAGE_VIEW_TYPE_2D_ARRAY, ImageDepth2DArray, MipMapLevelCount);
@@ -2666,7 +2666,7 @@ protected:
 					return false;
 
 				if(Needs3DTexDel)
-					free(p3DTexData);
+					free(pTexData3D);
 			}
 		}
 		return true;
@@ -3949,8 +3949,7 @@ public:
 		VKCreateInfo.pEnabledFeatures = NULL;
 		VKCreateInfo.flags = 0;
 
-		VkResult res = vkCreateDevice(m_VKGPU, &VKCreateInfo, nullptr, &m_VKDevice);
-		if(res != VK_SUCCESS)
+		if(vkCreateDevice(m_VKGPU, &VKCreateInfo, nullptr, &m_VKDevice) != VK_SUCCESS)
 		{
 			SetError(EGfxErrorType::GFX_ERROR_TYPE_INIT, "Logical device could not be created.");
 			return false;
@@ -4227,8 +4226,7 @@ public:
 	[[nodiscard]] bool GetSwapChainImageHandles()
 	{
 		uint32_t ImgCount = 0;
-		VkResult res = vkGetSwapchainImagesKHR(m_VKDevice, m_VKSwapChain, &ImgCount, nullptr);
-		if(res != VK_SUCCESS)
+		if(vkGetSwapchainImagesKHR(m_VKDevice, m_VKSwapChain, &ImgCount, nullptr) != VK_SUCCESS)
 		{
 			SetError(EGfxErrorType::GFX_ERROR_TYPE_INIT, "Could not get swap chain images.");
 			return false;
@@ -4274,10 +4272,10 @@ public:
 
 	VkResult CreateDebugUtilsMessengerEXT(const VkDebugUtilsMessengerCreateInfoEXT *pCreateInfo, const VkAllocationCallbacks *pAllocator, VkDebugUtilsMessengerEXT *pDebugMessenger)
 	{
-		auto func = (PFN_vkCreateDebugUtilsMessengerEXT)vkGetInstanceProcAddr(m_VKInstance, "vkCreateDebugUtilsMessengerEXT");
-		if(func != nullptr)
+		auto pfnVulkanCreateDebugUtilsFunction = (PFN_vkCreateDebugUtilsMessengerEXT)vkGetInstanceProcAddr(m_VKInstance, "vkCreateDebugUtilsMessengerEXT");
+		if(pfnVulkanCreateDebugUtilsFunction != nullptr)
 		{
-			return func(m_VKInstance, pCreateInfo, pAllocator, pDebugMessenger);
+			return pfnVulkanCreateDebugUtilsFunction(m_VKInstance, pCreateInfo, pAllocator, pDebugMessenger);
 		}
 		else
 		{
@@ -4287,10 +4285,10 @@ public:
 
 	void DestroyDebugUtilsMessengerEXT(VkDebugUtilsMessengerEXT &DebugMessenger)
 	{
-		auto func = (PFN_vkDestroyDebugUtilsMessengerEXT)vkGetInstanceProcAddr(m_VKInstance, "vkDestroyDebugUtilsMessengerEXT");
-		if(func != nullptr)
+		auto pfnVulkanDestroyDebugUtilsFunction = (PFN_vkDestroyDebugUtilsMessengerEXT)vkGetInstanceProcAddr(m_VKInstance, "vkDestroyDebugUtilsMessengerEXT");
+		if(pfnVulkanDestroyDebugUtilsFunction != nullptr)
 		{
-			func(m_VKInstance, DebugMessenger, nullptr);
+			pfnVulkanDestroyDebugUtilsFunction(m_VKInstance, DebugMessenger, nullptr);
 		}
 	}
 #endif
@@ -4562,8 +4560,8 @@ public:
 
 	[[nodiscard]] bool LoadShader(const char *pFilename, std::vector<uint8_t> *&pvShaderData)
 	{
-		auto it = m_ShaderFiles.find(pFilename);
-		if(it == m_ShaderFiles.end())
+		auto ShaderFileIterator = m_ShaderFiles.find(pFilename);
+		if(ShaderFileIterator == m_ShaderFiles.end())
 		{
 			void *pShaderBuff;
 			unsigned FileSize;
@@ -4575,10 +4573,10 @@ public:
 			mem_copy(vShaderBuff.data(), pShaderBuff, FileSize);
 			free(pShaderBuff);
 
-			it = m_ShaderFiles.insert({pFilename, {std::move(vShaderBuff)}}).first;
+			ShaderFileIterator = m_ShaderFiles.insert({pFilename, {std::move(vShaderBuff)}}).first;
 		}
 
-		pvShaderData = &it->second.m_vBinary;
+		pvShaderData = &ShaderFileIterator->second.m_vBinary;
 
 		return true;
 	}
@@ -6301,12 +6299,12 @@ public:
 
 		uint8_t *pMem = nullptr;
 
-		size_t it = 0;
+		size_t BufferCountOffset = 0;
 		if(UsesCurrentCountOffset)
-			it = StreamUniformBuffer.GetUsedCount(m_CurImageIndex);
-		for(; it < StreamUniformBuffer.GetBuffers(m_CurImageIndex).size(); ++it)
+			BufferCountOffset = StreamUniformBuffer.GetUsedCount(m_CurImageIndex);
+		for(; BufferCountOffset < StreamUniformBuffer.GetBuffers(m_CurImageIndex).size(); ++BufferCountOffset)
 		{
-			auto &BufferOfFrame = StreamUniformBuffer.GetBuffers(m_CurImageIndex)[it];
+			auto &BufferOfFrame = StreamUniformBuffer.GetBuffers(m_CurImageIndex)[BufferCountOffset];
 			if(BufferOfFrame.m_Size >= DataSize + BufferOfFrame.m_UsedSize)
 			{
 				if(BufferOfFrame.m_UsedSize == 0)

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -634,9 +634,9 @@ void CClient::Connect(const char *pAddress, const char *pPassword)
 	{
 		NETADDR NextAddr;
 		char aHost[128];
-		int url = net_addr_from_url(&NextAddr, aBuffer, aHost, sizeof(aHost));
+		const int UrlParseResult = net_addr_from_url(&NextAddr, aBuffer, aHost, sizeof(aHost));
 		bool Sixup = NextAddr.type & NETTYPE_TW7;
-		if(url > 0)
+		if(UrlParseResult > 0)
 			str_copy(aHost, aBuffer);
 
 		if(net_host_lookup(aHost, &NextAddr, m_aNetClient[CONN_MAIN].NetType()) != 0)
@@ -4504,9 +4504,9 @@ void CClient::HandleConnectLink(const char *pLink)
 	else
 		str_copy(m_aCmdConnect, pLink);
 	// Edge appends / to the URL
-	const int len = str_length(m_aCmdConnect);
-	if(m_aCmdConnect[len - 1] == '/')
-		m_aCmdConnect[len - 1] = '\0';
+	const int Length = str_length(m_aCmdConnect);
+	if(m_aCmdConnect[Length - 1] == '/')
+		m_aCmdConnect[Length - 1] = '\0';
 }
 
 void CClient::HandleDemoPath(const char *pPath)

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -745,16 +745,16 @@ void CServerBrowser::SetInfo(CServerEntry *pEntry, const CServerInfo &Info) cons
 		{
 		}
 
-		bool operator()(const CServerInfo::CClient &p0, const CServerInfo::CClient &p1) const
+		bool operator()(const CServerInfo::CClient &Client0, const CServerInfo::CClient &Client1) const
 		{
 			// Sort players before non players
-			if(p0.m_Player && !p1.m_Player)
+			if(Client0.m_Player && !Client1.m_Player)
 				return true;
-			if(!p0.m_Player && p1.m_Player)
+			if(!Client0.m_Player && Client1.m_Player)
 				return false;
 
-			int Score0 = p0.m_Score;
-			int Score1 = p1.m_Score;
+			int Score0 = Client0.m_Score;
+			int Score1 = Client1.m_Score;
 
 			if(m_ScoreKind == CServerInfo::CLIENT_SCORE_KIND_TIME || m_ScoreKind == CServerInfo::CLIENT_SCORE_KIND_TIME_BACKCOMPAT)
 			{
@@ -774,7 +774,7 @@ void CServerBrowser::SetInfo(CServerEntry *pEntry, const CServerInfo &Info) cons
 					return Score0 > Score1;
 			}
 
-			return str_comp_nocase(p0.m_aName, p1.m_aName) < 0;
+			return str_comp_nocase(Client0.m_aName, Client1.m_aName) < 0;
 		}
 	};
 

--- a/src/engine/client/serverbrowser_http.cpp
+++ b/src/engine/client/serverbrowser_http.cpp
@@ -170,7 +170,7 @@ bool CChooseMaster::CJob::Abort()
 		return false;
 	}
 
-	CLockScope ls(m_Lock);
+	const CLockScope LockScope(m_Lock);
 	if(m_pHead != nullptr)
 	{
 		m_pHead->Abort();
@@ -216,7 +216,7 @@ void CChooseMaster::CJob::Run()
 		pHead->Timeout(Timeout);
 		pHead->LogProgress(HTTPLOG::FAILURE);
 		{
-			CLockScope ls(m_Lock);
+			const CLockScope LockScope(m_Lock);
 			m_pHead = pHead;
 		}
 
@@ -237,7 +237,7 @@ void CChooseMaster::CJob::Run()
 		pGet->Timeout(Timeout);
 		pGet->LogProgress(HTTPLOG::FAILURE);
 		{
-			CLockScope ls(m_Lock);
+			const CLockScope LockScope(m_Lock);
 			m_pGet = pGet;
 		}
 

--- a/src/engine/client/updater.cpp
+++ b/src/engine/client/updater.cpp
@@ -55,7 +55,7 @@ CUpdaterFetchTask::CUpdaterFetchTask(CUpdater *pUpdater, const char *pFile, cons
 
 void CUpdaterFetchTask::OnProgress()
 {
-	CLockScope ls(m_pUpdater->m_Lock);
+	const CLockScope LockScope(m_pUpdater->m_Lock);
 	m_pUpdater->m_Percent = Progress();
 }
 
@@ -101,31 +101,31 @@ void CUpdater::Init(CHttp *pHttp)
 
 void CUpdater::SetCurrentState(EUpdaterState NewState)
 {
-	CLockScope ls(m_Lock);
+	const CLockScope LockScope(m_Lock);
 	m_State = NewState;
 }
 
 IUpdater::EUpdaterState CUpdater::GetCurrentState()
 {
-	CLockScope ls(m_Lock);
+	const CLockScope LockScope(m_Lock);
 	return m_State;
 }
 
 void CUpdater::GetCurrentFile(char *pBuf, int BufSize)
 {
-	CLockScope ls(m_Lock);
+	const CLockScope LockScope(m_Lock);
 	str_copy(pBuf, m_aStatus, BufSize);
 }
 
 int CUpdater::GetCurrentPercent()
 {
-	CLockScope ls(m_Lock);
+	const CLockScope LockScope(m_Lock);
 	return m_Percent;
 }
 
 void CUpdater::FetchFile(const char *pFile, const char *pDestPath)
 {
-	CLockScope ls(m_Lock);
+	const CLockScope LockScope(m_Lock);
 	m_pCurrentTask = std::make_shared<CUpdaterFetchTask>(this, pFile, pDestPath);
 	str_copy(m_aStatus, m_pCurrentTask->Dest());
 	m_pHttp->Run(m_pCurrentTask);
@@ -134,20 +134,20 @@ void CUpdater::FetchFile(const char *pFile, const char *pDestPath)
 bool CUpdater::MoveFile(const char *pFile)
 {
 	char aBuf[256];
-	size_t len = str_length(pFile);
+	const size_t Length = str_length(pFile);
 	bool Success = true;
 
 #if !defined(CONF_FAMILY_WINDOWS)
-	if(!str_comp_nocase(pFile + len - 4, ".dll"))
+	if(!str_comp_nocase(pFile + Length - 4, ".dll"))
 		return Success;
 #endif
 
 #if !defined(CONF_PLATFORM_LINUX)
-	if(!str_comp_nocase(pFile + len - 3, ".so"))
+	if(!str_comp_nocase(pFile + Length - 3, ".so"))
 		return Success;
 #endif
 
-	if(!str_comp_nocase(pFile + len - 4, ".dll") || !str_comp_nocase(pFile + len - 4, ".ttf") || !str_comp_nocase(pFile + len - 3, ".so"))
+	if(!str_comp_nocase(pFile + Length - 4, ".dll") || !str_comp_nocase(pFile + Length - 4, ".ttf") || !str_comp_nocase(pFile + Length - 3, ".so"))
 	{
 		str_format(aBuf, sizeof(aBuf), "%s.old", pFile);
 		m_pStorage->RenameBinaryFile(pFile, aBuf);
@@ -310,25 +310,25 @@ void CUpdater::RunningUpdate()
 		if(Job.second)
 		{
 			const char *pFile = Job.first.c_str();
-			size_t len = str_length(pFile);
-			if(!str_comp_nocase(pFile + len - 4, ".dll"))
+			const size_t Length = str_length(pFile);
+			if(!str_comp_nocase(pFile + Length - 4, ".dll"))
 			{
 #if defined(CONF_FAMILY_WINDOWS)
 				char aBuf[512];
 				str_copy(aBuf, pFile, sizeof(aBuf)); // SDL
-				str_copy(aBuf + len - 4, "-" PLAT_NAME, sizeof(aBuf) - len + 4); // -win32
-				str_append(aBuf, pFile + len - 4); // .dll
+				str_copy(aBuf + Length - 4, "-" PLAT_NAME, sizeof(aBuf) - Length + 4); // -win32
+				str_append(aBuf, pFile + Length - 4); // .dll
 				FetchFile(aBuf, pFile);
 #endif
 				// Ignore DLL downloads on other platforms
 			}
-			else if(!str_comp_nocase(pFile + len - 3, ".so"))
+			else if(!str_comp_nocase(pFile + Length - 3, ".so"))
 			{
 #if defined(CONF_PLATFORM_LINUX)
 				char aBuf[512];
 				str_copy(aBuf, pFile, sizeof(aBuf)); // libsteam_api
-				str_copy(aBuf + len - 3, "-" PLAT_NAME, sizeof(aBuf) - len + 3); // -linux-x86_64
-				str_append(aBuf, pFile + len - 3); // .so
+				str_copy(aBuf + Length - 3, "-" PLAT_NAME, sizeof(aBuf) - Length + 3); // -linux-x86_64
+				str_append(aBuf, pFile + Length - 3); // .so
 				FetchFile(aBuf, pFile);
 #endif
 				// Ignore DLL downloads on other platforms, on Linux we statically link anyway

--- a/src/engine/client/video.cpp
+++ b/src/engine/client/video.cpp
@@ -510,7 +510,7 @@ void CVideo::RunAudioThread(size_t ParentThreadIndex, size_t ThreadIndex)
 				std::unique_lock<std::mutex> LockAudio(pThreadData->m_AudioFillMutex);
 
 				{
-					CLockScope ls(m_WriteLock);
+					const CLockScope LockScope(m_WriteLock);
 					m_AudioStream.m_vpFrames[ThreadIndex]->pts = av_rescale_q(pThreadData->m_SampleCountStart, AVRational{1, m_AudioStream.m_pCodecContext->sample_rate}, m_AudioStream.m_pCodecContext->time_base);
 					WriteFrame(&m_AudioStream, ThreadIndex);
 				}
@@ -598,7 +598,7 @@ void CVideo::RunVideoThread(size_t ParentThreadIndex, size_t ThreadIndex)
 			{
 				std::unique_lock<std::mutex> LockVideo(pThreadData->m_VideoFillMutex);
 				{
-					CLockScope ls(m_WriteLock);
+					const CLockScope LockScope(m_WriteLock);
 #if LIBAVCODEC_VERSION_MAJOR >= 60
 					m_VideoStream.m_vpFrames[ThreadIndex]->pts = m_VideoStream.m_pCodecContext->frame_num;
 #else

--- a/src/engine/gfx/image_manipulation.cpp
+++ b/src/engine/gfx/image_manipulation.cpp
@@ -227,19 +227,19 @@ static void GetPixelClamped(const uint8_t *pSourceImage, int x, int y, uint32_t 
 static void SampleBicubic(const uint8_t *pSourceImage, float u, float v, uint32_t W, uint32_t H, size_t BPP, uint8_t aSample[4])
 {
 	float X = (u * W) - 0.5f;
-	int xInt = (int)X;
-	float xFract = X - std::floor(X);
+	const int RoundedX = (int)X;
+	const float FractionX = X - std::floor(X);
 
 	float Y = (v * H) - 0.5f;
-	int yInt = (int)Y;
-	float yFract = Y - std::floor(Y);
+	const int RoundedY = (int)Y;
+	const float FractionY = Y - std::floor(Y);
 
 	uint8_t aaaSamples[4][4][4];
 	for(int y = 0; y < 4; ++y)
 	{
 		for(int x = 0; x < 4; ++x)
 		{
-			GetPixelClamped(pSourceImage, xInt + x - 1, yInt + y - 1, W, H, BPP, aaaSamples[x][y]);
+			GetPixelClamped(pSourceImage, RoundedX + x - 1, RoundedY + y - 1, W, H, BPP, aaaSamples[x][y]);
 		}
 	}
 
@@ -248,9 +248,9 @@ static void SampleBicubic(const uint8_t *pSourceImage, float u, float v, uint32_
 		float aRows[4];
 		for(int y = 0; y < 4; ++y)
 		{
-			aRows[y] = CubicHermite(aaaSamples[0][y][i], aaaSamples[1][y][i], aaaSamples[2][y][i], aaaSamples[3][y][i], xFract);
+			aRows[y] = CubicHermite(aaaSamples[0][y][i], aaaSamples[1][y][i], aaaSamples[2][y][i], aaaSamples[3][y][i], FractionX);
 		}
-		aSample[i] = (uint8_t)std::clamp<float>(CubicHermite(aRows[0], aRows[1], aRows[2], aRows[3], yFract), 0.0f, 255.0f);
+		aSample[i] = (uint8_t)std::clamp<float>(CubicHermite(aRows[0], aRows[1], aRows[2], aRows[3], FractionY), 0.0f, 255.0f);
 	}
 }
 

--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -281,7 +281,7 @@ void CRegister::CProtocol::SendRegister()
 	bool SendInfo;
 
 	{
-		CLockScope ls(m_pShared->m_pGlobal->m_Lock);
+		const CLockScope LockScope(m_pShared->m_pGlobal->m_Lock);
 		InfoSerial = m_pShared->m_pGlobal->m_InfoSerial;
 		SendInfo = InfoSerial > m_pShared->m_pGlobal->m_LatestSuccessfulInfoSerial;
 	}
@@ -321,7 +321,7 @@ void CRegister::CProtocol::SendRegister()
 
 	int RequestIndex;
 	{
-		CLockScope ls(m_pShared->m_Lock);
+		const CLockScope LockScope(m_pShared->m_Lock);
 		if(m_pShared->m_LatestResponseStatus != STATUS_OK)
 		{
 			log_info(ProtocolToSystem(m_Protocol), "registering...");
@@ -380,7 +380,7 @@ CRegister::CProtocol::CProtocol(CRegister *pParent, int Protocol) :
 
 void CRegister::CProtocol::CheckChallengeStatus()
 {
-	CLockScope ls(m_pShared->m_Lock);
+	const CLockScope LockScope(m_pShared->m_Lock);
 	// No requests in flight?
 	if(m_pShared->m_LatestResponseIndex == m_pShared->m_NumTotalRequests - 1)
 	{
@@ -474,7 +474,7 @@ void CRegister::CProtocol::CJob::Run()
 		return;
 	}
 	{
-		CLockScope ls(m_pShared->m_Lock);
+		const CLockScope LockScope(m_pShared->m_Lock);
 		if(Status != m_pShared->m_LatestResponseStatus)
 		{
 			if(Status != STATUS_OK)
@@ -500,7 +500,7 @@ void CRegister::CProtocol::CJob::Run()
 	}
 	if(Status == STATUS_OK)
 	{
-		CLockScope ls(m_pShared->m_pGlobal->m_Lock);
+		const CLockScope LockScope(m_pShared->m_pGlobal->m_Lock);
 		if(m_InfoSerial > m_pShared->m_pGlobal->m_LatestSuccessfulInfoSerial)
 		{
 			m_pShared->m_pGlobal->m_LatestSuccessfulInfoSerial = m_InfoSerial;
@@ -508,7 +508,7 @@ void CRegister::CProtocol::CJob::Run()
 	}
 	else if(Status == STATUS_NEEDINFO)
 	{
-		CLockScope ls(m_pShared->m_pGlobal->m_Lock);
+		const CLockScope LockScope(m_pShared->m_pGlobal->m_Lock);
 		if(m_InfoSerial == m_pShared->m_pGlobal->m_LatestSuccessfulInfoSerial)
 		{
 			// Tell other requests that they need to send the info again.
@@ -530,7 +530,7 @@ CRegister::CRegister(CConfig *pConfig, IConsole *pConsole, IEngine *pEngine, IHt
 		CProtocol(this, PROTOCOL_TW7_IPV4),
 	}
 {
-	const int HEADER_LEN = sizeof(SERVERBROWSE_CHALLENGE);
+	static constexpr int HEADER_LEN = sizeof(SERVERBROWSE_CHALLENGE);
 	mem_copy(m_aVerifyPacketPrefix, SERVERBROWSE_CHALLENGE, HEADER_LEN);
 	FormatUuid(m_ChallengeSecret, m_aVerifyPacketPrefix + HEADER_LEN, sizeof(m_aVerifyPacketPrefix) - HEADER_LEN);
 	m_aVerifyPacketPrefix[HEADER_LEN + UUID_MAXSTRSIZE - 1] = ':';
@@ -734,7 +734,7 @@ void CRegister::OnNewInfo(const char *pInfo)
 	m_GotServerInfo = true;
 	str_copy(m_aServerInfo, pInfo);
 	{
-		CLockScope ls(m_pGlobal->m_Lock);
+		const CLockScope LockScope(m_pGlobal->m_Lock);
 		m_pGlobal->m_InfoSerial += 1;
 	}
 

--- a/src/engine/shared/compression.cpp
+++ b/src/engine/shared/compression.cpp
@@ -65,41 +65,41 @@ const unsigned char *CVariableInt::Unpack(const unsigned char *pSrc, int *pInOut
 	return pSrc;
 }
 
-long CVariableInt::Decompress(const void *pSrc_, int SrcSize, void *pDst_, int DstSize)
+long CVariableInt::Decompress(const void *pSrc, int SrcSize, void *pDst, int DstSize)
 {
 	dbg_assert(DstSize % sizeof(int) == 0, "invalid bounds");
 
-	const unsigned char *pSrc = (unsigned char *)pSrc_;
-	const unsigned char *pSrcEnd = pSrc + SrcSize;
-	int *pDst = (int *)pDst_;
-	const int *pDstEnd = pDst + DstSize / sizeof(int); // NOLINT(bugprone-sizeof-expression)
-	while(pSrc < pSrcEnd)
+	const unsigned char *pCharSrc = (unsigned char *)pSrc;
+	const unsigned char *pCharSrcEnd = pCharSrc + SrcSize;
+	int *pIntDst = (int *)pDst;
+	const int *pIntDstEnd = pIntDst + DstSize / sizeof(int); // NOLINT(bugprone-sizeof-expression)
+	while(pCharSrc < pCharSrcEnd)
 	{
-		if(pDst >= pDstEnd)
+		if(pIntDst >= pIntDstEnd)
 			return -1;
-		pSrc = CVariableInt::Unpack(pSrc, pDst, pSrcEnd - pSrc);
-		if(!pSrc)
+		pCharSrc = CVariableInt::Unpack(pCharSrc, pIntDst, pCharSrcEnd - pCharSrc);
+		if(!pCharSrc)
 			return -1;
-		pDst++;
+		pIntDst++;
 	}
-	return (long)((unsigned char *)pDst - (unsigned char *)pDst_);
+	return (long)((unsigned char *)pIntDst - (unsigned char *)pDst);
 }
 
-long CVariableInt::Compress(const void *pSrc_, int SrcSize, void *pDst_, int DstSize)
+long CVariableInt::Compress(const void *pSrc, int SrcSize, void *pDst, int DstSize)
 {
 	dbg_assert(SrcSize % sizeof(int) == 0, "invalid bounds");
 
-	const int *pSrc = (int *)pSrc_;
-	unsigned char *pDst = (unsigned char *)pDst_;
-	const unsigned char *pDstEnd = pDst + DstSize;
+	const int *pIntSrc = (int *)pSrc;
+	unsigned char *pCharDst = (unsigned char *)pDst;
+	const unsigned char *pCharDstEnd = pCharDst + DstSize;
 	SrcSize /= sizeof(int);
 	while(SrcSize)
 	{
-		pDst = CVariableInt::Pack(pDst, *pSrc, pDstEnd - pDst);
-		if(!pDst)
+		pCharDst = CVariableInt::Pack(pCharDst, *pIntSrc, pCharDstEnd - pCharDst);
+		if(!pCharDst)
 			return -1;
 		SrcSize--;
-		pSrc++;
+		pIntSrc++;
 	}
-	return (long)(pDst - (unsigned char *)pDst_);
+	return (long)(pCharDst - (unsigned char *)pDst);
 }

--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -133,7 +133,7 @@ static const unsigned char NET_HEADER_EXTENDED[] = {'x', 'e'};
 void CNetBase::SendPacketConnless(NETSOCKET Socket, NETADDR *pAddr, const void *pData, int DataSize, bool Extended, unsigned char aExtra[NET_CONNLESS_EXTRA_SIZE])
 {
 	unsigned char aBuffer[NET_MAX_PACKETSIZE];
-	const int DATA_OFFSET = sizeof(NET_HEADER_EXTENDED) + NET_CONNLESS_EXTRA_SIZE;
+	static constexpr int DATA_OFFSET = sizeof(NET_HEADER_EXTENDED) + NET_CONNLESS_EXTRA_SIZE;
 	dbg_assert(DataSize <= (int)sizeof(aBuffer) - DATA_OFFSET,
 		"Invalid DataSize for CNetBase::SendPacketConnless: %d > %d", DataSize, (int)sizeof(aBuffer) - DATA_OFFSET);
 
@@ -153,7 +153,7 @@ void CNetBase::SendPacketConnless(NETSOCKET Socket, NETADDR *pAddr, const void *
 void CNetBase::SendPacketConnlessWithToken7(NETSOCKET Socket, NETADDR *pAddr, const void *pData, int DataSize, SECURITY_TOKEN Token, SECURITY_TOKEN ResponseToken)
 {
 	unsigned char aBuffer[NET_MAX_PACKETSIZE];
-	const int DATA_OFFSET = 1 + 2 * sizeof(SECURITY_TOKEN);
+	static constexpr int DATA_OFFSET = 1 + 2 * sizeof(SECURITY_TOKEN);
 	dbg_assert(DataSize <= (int)sizeof(aBuffer) - DATA_OFFSET,
 		"Invalid DataSize for CNetBase::SendPacketConnlessWithToken7: %d > %d", DataSize, (int)sizeof(aBuffer) - DATA_OFFSET);
 

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -312,8 +312,8 @@ bool CChat::OnInput(const IInput::CEvent &Event)
 				}
 			}
 			std::stable_sort(m_aPlayerCompletionList, m_aPlayerCompletionList + m_PlayerCompletionListLength,
-				[](const CRateablePlayer &p1, const CRateablePlayer &p2) -> bool {
-					return p1.m_Score < p2.m_Score;
+				[](const CRateablePlayer &Player1, const CRateablePlayer &Player2) -> bool {
+					return Player1.m_Score < Player2.m_Score;
 				});
 		}
 

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1488,22 +1488,22 @@ void CHud::RenderMovementInformation()
 	const CMovementInformation Info = GetMovementInformation(ClientId, g_Config.m_ClDummy);
 
 	float y = StartY + LineSpacer * 2.0f;
-	float xl = StartX + 2.0f;
-	float xr = m_Width - 2.0f;
+	const float LeftX = StartX + 2.0f;
+	const float RightX = m_Width - 2.0f;
 
 	if(g_Config.m_ClShowhudPlayerPosition)
 	{
-		TextRender()->Text(xl, y, Fontsize, Localize("Position:"), -1.0f);
+		TextRender()->Text(LeftX, y, Fontsize, Localize("Position:"), -1.0f);
 		y += MOVEMENT_INFORMATION_LINE_HEIGHT;
 
-		TextRender()->Text(xl, y, Fontsize, "X:", -1.0f);
+		TextRender()->Text(LeftX, y, Fontsize, "X:", -1.0f);
 		UpdateMovementInformationTextContainer(m_aPlayerPositionContainers[0], Fontsize, Info.m_Pos.x, m_aPlayerPrevPosition[0]);
-		RenderMovementInformationTextContainer(m_aPlayerPositionContainers[0], TextRender()->DefaultTextColor(), xr, y);
+		RenderMovementInformationTextContainer(m_aPlayerPositionContainers[0], TextRender()->DefaultTextColor(), RightX, y);
 		y += MOVEMENT_INFORMATION_LINE_HEIGHT;
 
-		TextRender()->Text(xl, y, Fontsize, "Y:", -1.0f);
+		TextRender()->Text(LeftX, y, Fontsize, "Y:", -1.0f);
 		UpdateMovementInformationTextContainer(m_aPlayerPositionContainers[1], Fontsize, Info.m_Pos.y, m_aPlayerPrevPosition[1]);
-		RenderMovementInformationTextContainer(m_aPlayerPositionContainers[1], TextRender()->DefaultTextColor(), xr, y);
+		RenderMovementInformationTextContainer(m_aPlayerPositionContainers[1], TextRender()->DefaultTextColor(), RightX, y);
 		y += MOVEMENT_INFORMATION_LINE_HEIGHT;
 	}
 
@@ -1512,7 +1512,7 @@ void CHud::RenderMovementInformation()
 
 	if(g_Config.m_ClShowhudPlayerSpeed)
 	{
-		TextRender()->Text(xl, y, Fontsize, Localize("Speed:"), -1.0f);
+		TextRender()->Text(LeftX, y, Fontsize, Localize("Speed:"), -1.0f);
 		y += MOVEMENT_INFORMATION_LINE_HEIGHT;
 
 		const char aaCoordinates[][4] = {"X:", "Y:"};
@@ -1523,9 +1523,9 @@ void CHud::RenderMovementInformation()
 				Color = ColorRGBA(0.0f, 1.0f, 0.0f, 1.0f);
 			if(m_aLastPlayerSpeedChange[i] == ESpeedChange::DECREASE)
 				Color = ColorRGBA(1.0f, 0.5f, 0.5f, 1.0f);
-			TextRender()->Text(xl, y, Fontsize, aaCoordinates[i], -1.0f);
+			TextRender()->Text(LeftX, y, Fontsize, aaCoordinates[i], -1.0f);
 			UpdateMovementInformationTextContainer(m_aPlayerSpeedTextContainers[i], Fontsize, i == 0 ? Info.m_Speed.x : Info.m_Speed.y, m_aPlayerPrevSpeed[i]);
-			RenderMovementInformationTextContainer(m_aPlayerSpeedTextContainers[i], Color, xr, y);
+			RenderMovementInformationTextContainer(m_aPlayerSpeedTextContainers[i], Color, RightX, y);
 			y += MOVEMENT_INFORMATION_LINE_HEIGHT;
 		}
 
@@ -1534,11 +1534,11 @@ void CHud::RenderMovementInformation()
 
 	if(g_Config.m_ClShowhudPlayerAngle)
 	{
-		TextRender()->Text(xl, y, Fontsize, Localize("Angle:"), -1.0f);
+		TextRender()->Text(LeftX, y, Fontsize, Localize("Angle:"), -1.0f);
 		y += MOVEMENT_INFORMATION_LINE_HEIGHT;
 
 		UpdateMovementInformationTextContainer(m_PlayerAngleTextContainerIndex, Fontsize, Info.m_Angle, m_PlayerPrevAngle);
-		RenderMovementInformationTextContainer(m_PlayerAngleTextContainerIndex, TextRender()->DefaultTextColor(), xr, y);
+		RenderMovementInformationTextContainer(m_PlayerAngleTextContainerIndex, TextRender()->DefaultTextColor(), RightX, y);
 	}
 }
 

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -76,24 +76,24 @@ CMenus::CMenus()
 	m_DemoPlayerState = DEMOPLAYER_NONE;
 	m_Dummy = false;
 
-	for(SUIAnimator &animator : m_aAnimatorsSettingsTab)
+	for(SUIAnimator &Animator : m_aAnimatorsSettingsTab)
 	{
-		animator.m_YOffset = -2.5f;
-		animator.m_HOffset = 5.0f;
-		animator.m_WOffset = 5.0f;
-		animator.m_RepositionLabel = true;
+		Animator.m_YOffset = -2.5f;
+		Animator.m_HOffset = 5.0f;
+		Animator.m_WOffset = 5.0f;
+		Animator.m_RepositionLabel = true;
 	}
 
-	for(SUIAnimator &animator : m_aAnimatorsBigPage)
+	for(SUIAnimator &Animator : m_aAnimatorsBigPage)
 	{
-		animator.m_YOffset = -5.0f;
-		animator.m_HOffset = 5.0f;
+		Animator.m_YOffset = -5.0f;
+		Animator.m_HOffset = 5.0f;
 	}
 
-	for(SUIAnimator &animator : m_aAnimatorsSmallPage)
+	for(SUIAnimator &Animator : m_aAnimatorsSmallPage)
 	{
-		animator.m_YOffset = -2.5f;
-		animator.m_HOffset = 2.5f;
+		Animator.m_YOffset = -2.5f;
+		Animator.m_HOffset = 2.5f;
 	}
 
 	m_PasswordInput.SetBuffer(g_Config.m_Password, sizeof(g_Config.m_Password));

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -1416,14 +1416,14 @@ void CMenus::RenderGhost(CUIRect MainView)
 		if(!Item.m_Visible)
 			continue;
 
-		ColorRGBA rgb = ColorRGBA(1.0f, 1.0f, 1.0f);
+		ColorRGBA Color = ColorRGBA(1.0f, 1.0f, 1.0f);
 		if(pGhost->m_Own)
-			rgb = color_cast<ColorRGBA>(ColorHSLA(0.33f, 1.0f, 0.75f));
+			Color = color_cast<ColorRGBA>(ColorHSLA(0.33f, 1.0f, 0.75f));
 
 		if(pGhost->m_Failed)
-			rgb = ColorRGBA(0.6f, 0.6f, 0.6f, 1.0f);
+			Color = ColorRGBA(0.6f, 0.6f, 0.6f, 1.0f);
 
-		TextRender()->TextColor(rgb.WithAlpha(pGhost->HasFile() ? 1.0f : 0.5f));
+		TextRender()->TextColor(Color.WithAlpha(pGhost->HasFile() ? 1.0f : 0.5f));
 
 		for(int c = 0; c < NumCols; c++)
 		{

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -573,8 +573,7 @@ void CSpectator::OnRender()
 
 		if(GameClient()->m_aClients[GameClient()->m_Snap.m_apInfoByDDTeamName[i]->m_ClientId].m_Friend)
 		{
-			ColorRGBA rgb = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageFriendColor));
-			TextRender()->TextColor(rgb.WithAlpha(1.f));
+			TextRender()->TextColor(color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageFriendColor)));
 			TextRender()->Text(Width / 2.0f + x - TeeInfo.m_Size / 2.0f, Height / 2.0f + y + BoxMove + (LineHeight - FontSize) / 2.f, FontSize, "♥", 220.0f);
 			TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 		}

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -213,7 +213,6 @@ void CStatboard::RenderGlobalStats()
 
 	Graphics()->DrawRect(x - 10.f, y - 10.f, StatboardContentWidth, StatboardContentHeight, ColorRGBA(0.0f, 0.0f, 0.0f, 0.5f), IGraphics::CORNER_ALL, 17.0f);
 
-	float tw;
 	int px = 325;
 
 	TextRender()->Text(x + 10, y - 5, 22.0f, Localize("Name"), -1.0f);
@@ -227,8 +226,8 @@ void CStatboard::RenderGlobalStats()
 			px += 10.0f; // Suicides
 		if(i == 8 && !GameWithFlags) // Don't draw "Grabs" in game with no flag
 			continue;
-		tw = TextRender()->TextWidth(22.0f, apHeaders[i], -1, -1.0f);
-		TextRender()->Text(x + px - tw, y - 5, 22.0f, apHeaders[i], -1.0f);
+		const float TextWidth = TextRender()->TextWidth(22.0f, apHeaders[i], -1, -1.0f);
+		TextRender()->Text(x + px - TextWidth, y - 5, 22.0f, apHeaders[i], -1.0f);
 		px += 85;
 	}
 
@@ -315,23 +314,23 @@ void CStatboard::RenderGlobalStats()
 		// FRAGS
 		{
 			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_Frags);
-			tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
-			TextRender()->Text(x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
+			const float TextWidth = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
+			TextRender()->Text(x - TextWidth + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
 			px += 85;
 		}
 		// DEATHS
 		{
 			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_Deaths);
-			tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
-			TextRender()->Text(x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
+			const float TextWidth = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
+			TextRender()->Text(x - TextWidth + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
 			px += 85;
 		}
 		// SUICIDES
 		{
 			px += 10;
 			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_Suicides);
-			tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
-			TextRender()->Text(x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
+			const float TextWidth = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
+			TextRender()->Text(x - TextWidth + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
 			px += 85;
 		}
 		// RATIO
@@ -340,45 +339,45 @@ void CStatboard::RenderGlobalStats()
 				str_copy(aBuf, "--");
 			else
 				str_format(aBuf, sizeof(aBuf), "%.2f", (float)(pStats->m_Frags) / pStats->m_Deaths);
-			tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
-			TextRender()->Text(x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
+			const float TextWidth = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
+			TextRender()->Text(x - TextWidth + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
 			px += 85;
 		}
 		// NET
 		{
 			str_format(aBuf, sizeof(aBuf), "%+d", pStats->m_Frags - pStats->m_Deaths);
-			tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
-			TextRender()->Text(x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
+			const float TextWidth = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
+			TextRender()->Text(x - TextWidth + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
 			px += 85;
 		}
 		// FPM
 		{
 			float Fpm = pStats->GetFPM(Client()->GameTick(g_Config.m_ClDummy), Client()->GameTickSpeed());
 			str_format(aBuf, sizeof(aBuf), "%.1f", Fpm);
-			tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
-			TextRender()->Text(x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
+			const float TextWidth = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
+			TextRender()->Text(x - TextWidth + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
 			px += 85;
 		}
 		// SPREE
 		{
 			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_CurrentSpree);
-			tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
-			TextRender()->Text(x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
+			const float TextWidth = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
+			TextRender()->Text(x - TextWidth + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
 			px += 85;
 		}
 		// BEST SPREE
 		{
 			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_BestSpree);
-			tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
-			TextRender()->Text(x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
+			const float TextWidth = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
+			TextRender()->Text(x - TextWidth + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
 			px += 85;
 		}
 		// GRABS
 		if(GameWithFlags)
 		{
 			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_FlagGrabs);
-			tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
-			TextRender()->Text(x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
+			const float TextWidth = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
+			TextRender()->Text(x - TextWidth + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
 			px += 85;
 		}
 		// WEAPONS
@@ -389,16 +388,16 @@ void CStatboard::RenderGlobalStats()
 				continue;
 
 			str_format(aBuf, sizeof(aBuf), "%d/%d", pStats->m_aFragsWith[i], pStats->m_aDeathsFrom[i]);
-			tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
-			TextRender()->Text(x + px - tw / 2, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
+			const float TextWidth = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
+			TextRender()->Text(x + px - TextWidth / 2, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
 			px += 80;
 		}
 		// FLAGS
 		if(GameWithFlags)
 		{
 			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_FlagCaptures);
-			tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
-			TextRender()->Text(x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
+			const float TextWidth = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
+			TextRender()->Text(x - TextWidth + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
 		}
 		y += LineHeight;
 	}
@@ -437,16 +436,16 @@ std::string CStatboard::ReplaceCommata(char *pStr)
 		return pStr;
 
 	char aOutbuf[256] = "";
-	for(int i = 0, skip = 0; i < 64; i++)
+	for(int i = 0, Skip = 0; i < 64; i++)
 	{
 		if(pStr[i] == ',')
 		{
-			aOutbuf[i + skip++] = '%';
-			aOutbuf[i + skip++] = '2';
-			aOutbuf[i + skip] = 'C';
+			aOutbuf[i + Skip++] = '%';
+			aOutbuf[i + Skip++] = '2';
+			aOutbuf[i + Skip] = 'C';
 		}
 		else
-			aOutbuf[i + skip] = pStr[i];
+			aOutbuf[i + Skip] = pStr[i];
 	}
 	return aOutbuf;
 }
@@ -505,19 +504,19 @@ void CStatboard::FormatStats(char *pDest, size_t DestSize)
 		}
 
 		// Frag/Death ratio
-		float fdratio = 0.0f;
+		float KillRatio = 0.0f;
 		if(pStats->m_Deaths != 0)
-			fdratio = (float)(pStats->m_Frags) / pStats->m_Deaths;
+			KillRatio = (float)(pStats->m_Frags) / pStats->m_Deaths;
 
 		// Local player
-		bool localPlayer = (GameClient()->m_Snap.m_LocalClientId == pInfo->m_ClientId || (GameClient()->m_Snap.m_SpecInfo.m_Active && pInfo->m_ClientId == GameClient()->m_Snap.m_SpecInfo.m_SpectatorId));
+		bool LocalPlayer = (GameClient()->m_Snap.m_LocalClientId == pInfo->m_ClientId || (GameClient()->m_Snap.m_SpecInfo.m_Active && pInfo->m_ClientId == GameClient()->m_Snap.m_SpecInfo.m_SpectatorId));
 
 		// Game with flags
 		bool GameWithFlags = (GameClient()->m_Snap.m_pGameInfoObj && GameClient()->m_Snap.m_pGameInfoObj->m_GameFlags & GAMEFLAG_FLAGS);
 
 		char aBuf[1024];
 		str_format(aBuf, sizeof(aBuf), "%d,%d,%s,%s,%d,%d,%d,%d,%.2f,%i,%.1f,%d,%d,%s,%d,%d,%d\n",
-			localPlayer ? 1 : 0, // Local player
+			LocalPlayer ? 1 : 0, // Local player
 			GameClient()->m_aClients[pInfo->m_ClientId].m_Team, // Team
 			ReplaceCommata(GameClient()->m_aClients[pInfo->m_ClientId].m_aName).c_str(), // Name
 			ReplaceCommata(GameClient()->m_aClients[pInfo->m_ClientId].m_aClan).c_str(), // Clan
@@ -525,7 +524,7 @@ void CStatboard::FormatStats(char *pDest, size_t DestSize)
 			pStats->m_Frags, // Frags
 			pStats->m_Deaths, // Deaths
 			pStats->m_Suicides, // Suicides
-			fdratio, // fdratio
+			KillRatio, // Kill ratio
 			pStats->m_Frags - pStats->m_Deaths, // Net
 			pStats->GetFPM(Client()->GameTick(g_Config.m_ClDummy), Client()->GameTickSpeed()), // FPM
 			pStats->m_CurrentSpree, // CurSpree

--- a/src/game/client/components/tooltips.cpp
+++ b/src/game/client/components/tooltips.cpp
@@ -28,15 +28,15 @@ inline void CTooltips::ClearActiveTooltip()
 void CTooltips::DoToolTip(const void *pId, const CUIRect *pNearRect, const char *pText, float WidthHint)
 {
 	uintptr_t Id = reinterpret_cast<uintptr_t>(pId);
-	const auto result = m_Tooltips.emplace(Id, CTooltip{
-							   pId,
-							   *pNearRect,
-							   pText,
-							   WidthHint,
-							   false});
-	CTooltip &Tooltip = result.first->second;
+	const auto &[Entry, WasInserted] = m_Tooltips.emplace(Id, CTooltip{
+									  pId,
+									  *pNearRect,
+									  pText,
+									  WidthHint,
+									  false});
+	CTooltip &Tooltip = Entry->second;
 
-	if(!result.second)
+	if(!WasInserted)
 	{
 		Tooltip.m_Rect = *pNearRect; // update in case of window resize
 		Tooltip.m_pText = pText; // update in case of language change

--- a/src/game/client/prediction/entities/pickup.cpp
+++ b/src/game/client/prediction/entities/pickup.cpp
@@ -27,7 +27,7 @@ void CPickup::Tick()
 				continue;
 			if(m_Layer == LAYER_SWITCH && m_Number > 0 && m_Number < (int)Switchers().size() && !Switchers()[m_Number].m_aStatus[pChr->Team()])
 				continue;
-			bool sound = false;
+			bool CreateSound = false;
 			// player picked us up, is someone was hooking us, let them go
 			switch(m_Type)
 			{
@@ -48,13 +48,13 @@ void CPickup::Tick()
 					{
 						pChr->SetWeaponGot(j, false);
 						pChr->SetWeaponAmmo(j, 0);
-						sound = true;
+						CreateSound = true;
 					}
 				}
 				pChr->SetNinjaActivationDir(vec2(0, 0));
 				pChr->SetNinjaActivationTick(-500);
 				pChr->SetNinjaCurrentMoveTime(0);
-				if(sound)
+				if(CreateSound)
 					pChr->SetLastWeapon(WEAPON_GUN);
 				if(pChr->GetActiveWeapon() >= WEAPON_SHOTGUN)
 					pChr->SetActiveWeapon(WEAPON_HAMMER);

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -90,16 +90,16 @@ void CProjectile::Tick()
 	if(m_LifeSpan > -1)
 		m_LifeSpan--;
 
-	bool isWeaponCollide = false;
+	bool IsWeaponCollide = false;
 	if(
 		pOwnerChar &&
 		pTargetChr &&
 		!pTargetChr->CanCollide(m_Owner))
 	{
-		isWeaponCollide = true;
+		IsWeaponCollide = true;
 	}
 
-	if(((pTargetChr && (pOwnerChar ? !pOwnerChar->GrenadeHitDisabled() : g_Config.m_SvHit || m_Owner == -1 || pTargetChr == pOwnerChar)) || Collide || GameLayerClipped(CurPos)) && !isWeaponCollide)
+	if(((pTargetChr && (pOwnerChar ? !pOwnerChar->GrenadeHitDisabled() : g_Config.m_SvHit || m_Owner == -1 || pTargetChr == pOwnerChar)) || Collide || GameLayerClipped(CurPos)) && !IsWeaponCollide)
 	{
 		if(m_Explosive && (!pTargetChr || (!m_Freeze || (m_Type == WEAPON_SHOTGUN && Collide))))
 		{

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -319,10 +319,10 @@ int CCollision::GetTile(int x, int y) const
 
 	int Nx = std::clamp(x / 32, 0, m_Width - 1);
 	int Ny = std::clamp(y / 32, 0, m_Height - 1);
-	int pos = Ny * m_Width + Nx;
+	const int Index = Ny * m_Width + Nx;
 
-	if(m_pTiles[pos].m_Index >= TILE_SOLID && m_pTiles[pos].m_Index <= TILE_NOLASER)
-		return m_pTiles[pos].m_Index;
+	if(m_pTiles[Index].m_Index >= TILE_SOLID && m_pTiles[Index].m_Index <= TILE_NOLASER)
+		return m_pTiles[Index].m_Index;
 	return 0;
 }
 
@@ -390,23 +390,23 @@ int CCollision::IntersectLineTeleHook(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision,
 			return TILE_TELEINHOOK;
 		}
 
-		int hit = 0;
+		int Hit = 0;
 		if(CheckPoint(ix, iy))
 		{
 			if(!IsThrough(ix, iy, dx, dy, Pos0, Pos1))
-				hit = GetCollisionAt(ix, iy);
+				Hit = GetCollisionAt(ix, iy);
 		}
 		else if(IsHookBlocker(ix, iy, Pos0, Pos1))
 		{
-			hit = TILE_NOHOOK;
+			Hit = TILE_NOHOOK;
 		}
-		if(hit)
+		if(Hit)
 		{
 			if(pOutCollision)
 				*pOutCollision = Pos;
 			if(pOutBeforeCollision)
 				*pOutBeforeCollision = Last;
-			return hit;
+			return Hit;
 		}
 
 		Last = Pos;
@@ -598,32 +598,32 @@ void CCollision::MoveBox(vec2 *pInoutPos, vec2 *pInoutVel, vec2 Size, vec2 Elast
 
 int CCollision::IsSolid(int x, int y) const
 {
-	int index = GetTile(x, y);
-	return index == TILE_SOLID || index == TILE_NOHOOK;
+	const int Index = GetTile(x, y);
+	return Index == TILE_SOLID || Index == TILE_NOHOOK;
 }
 
 bool CCollision::IsThrough(int x, int y, int OffsetX, int OffsetY, vec2 Pos0, vec2 Pos1) const
 {
-	int pos = GetPureMapIndex(x, y);
-	if(m_pFront && (m_pFront[pos].m_Index == TILE_THROUGH_ALL || m_pFront[pos].m_Index == TILE_THROUGH_CUT))
+	const int Index = GetPureMapIndex(x, y);
+	if(m_pFront && (m_pFront[Index].m_Index == TILE_THROUGH_ALL || m_pFront[Index].m_Index == TILE_THROUGH_CUT))
 		return true;
-	if(m_pFront && m_pFront[pos].m_Index == TILE_THROUGH_DIR && ((m_pFront[pos].m_Flags == ROTATION_0 && Pos0.y > Pos1.y) || (m_pFront[pos].m_Flags == ROTATION_90 && Pos0.x < Pos1.x) || (m_pFront[pos].m_Flags == ROTATION_180 && Pos0.y < Pos1.y) || (m_pFront[pos].m_Flags == ROTATION_270 && Pos0.x > Pos1.x)))
+	if(m_pFront && m_pFront[Index].m_Index == TILE_THROUGH_DIR && ((m_pFront[Index].m_Flags == ROTATION_0 && Pos0.y > Pos1.y) || (m_pFront[Index].m_Flags == ROTATION_90 && Pos0.x < Pos1.x) || (m_pFront[Index].m_Flags == ROTATION_180 && Pos0.y < Pos1.y) || (m_pFront[Index].m_Flags == ROTATION_270 && Pos0.x > Pos1.x)))
 		return true;
-	int offpos = GetPureMapIndex(x + OffsetX, y + OffsetY);
-	return m_pTiles[offpos].m_Index == TILE_THROUGH || (m_pFront && m_pFront[offpos].m_Index == TILE_THROUGH);
+	const int OffsetIndex = GetPureMapIndex(x + OffsetX, y + OffsetY);
+	return m_pTiles[OffsetIndex].m_Index == TILE_THROUGH || (m_pFront && m_pFront[OffsetIndex].m_Index == TILE_THROUGH);
 }
 
 bool CCollision::IsHookBlocker(int x, int y, vec2 Pos0, vec2 Pos1) const
 {
-	int pos = GetPureMapIndex(x, y);
-	if(m_pTiles[pos].m_Index == TILE_THROUGH_ALL || (m_pFront && m_pFront[pos].m_Index == TILE_THROUGH_ALL))
+	const int Index = GetPureMapIndex(x, y);
+	if(m_pTiles[Index].m_Index == TILE_THROUGH_ALL || (m_pFront && m_pFront[Index].m_Index == TILE_THROUGH_ALL))
 		return true;
-	if(m_pTiles[pos].m_Index == TILE_THROUGH_DIR && ((m_pTiles[pos].m_Flags == ROTATION_0 && Pos0.y < Pos1.y) ||
-								(m_pTiles[pos].m_Flags == ROTATION_90 && Pos0.x > Pos1.x) ||
-								(m_pTiles[pos].m_Flags == ROTATION_180 && Pos0.y > Pos1.y) ||
-								(m_pTiles[pos].m_Flags == ROTATION_270 && Pos0.x < Pos1.x)))
+	if(m_pTiles[Index].m_Index == TILE_THROUGH_DIR && ((m_pTiles[Index].m_Flags == ROTATION_0 && Pos0.y < Pos1.y) ||
+								  (m_pTiles[Index].m_Flags == ROTATION_90 && Pos0.x > Pos1.x) ||
+								  (m_pTiles[Index].m_Flags == ROTATION_180 && Pos0.y > Pos1.y) ||
+								  (m_pTiles[Index].m_Flags == ROTATION_270 && Pos0.x < Pos1.x)))
 		return true;
-	if(m_pFront && m_pFront[pos].m_Index == TILE_THROUGH_DIR && ((m_pFront[pos].m_Flags == ROTATION_0 && Pos0.y < Pos1.y) || (m_pFront[pos].m_Flags == ROTATION_90 && Pos0.x > Pos1.x) || (m_pFront[pos].m_Flags == ROTATION_180 && Pos0.y > Pos1.y) || (m_pFront[pos].m_Flags == ROTATION_270 && Pos0.x < Pos1.x)))
+	if(m_pFront && m_pFront[Index].m_Index == TILE_THROUGH_DIR && ((m_pFront[Index].m_Flags == ROTATION_0 && Pos0.y < Pos1.y) || (m_pFront[Index].m_Flags == ROTATION_90 && Pos0.x > Pos1.x) || (m_pFront[Index].m_Flags == ROTATION_180 && Pos0.y > Pos1.y) || (m_pFront[Index].m_Flags == ROTATION_270 && Pos0.x < Pos1.x)))
 		return true;
 	return false;
 }
@@ -1013,7 +1013,8 @@ int CCollision::GetIndex(vec2 PrevPos, vec2 Pos) const
 		}
 	}
 
-	for(int i = 0, id = std::ceil(Distance); i < id; i++)
+	const int DistanceRounded = std::ceil(Distance);
+	for(int i = 0; i < DistanceRounded; i++)
 	{
 		float a = (float)i / Distance;
 		vec2 Tmp = mix(PrevPos, Pos, a);
@@ -1140,12 +1141,13 @@ void ThroughOffset(vec2 Pos0, vec2 Pos1, int *pOffsetX, int *pOffsetY)
 
 int CCollision::IntersectNoLaser(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision) const
 {
-	float d = distance(Pos0, Pos1);
+	float Distance = distance(Pos0, Pos1);
 	vec2 Last = Pos0;
 
-	for(int i = 0, id = std::ceil(d); i < id; i++)
+	const int DistanceRounded = std::ceil(Distance);
+	for(int i = 0; i < DistanceRounded; i++)
 	{
-		float a = i / d;
+		float a = i / Distance;
 		vec2 Pos = mix(Pos0, Pos1, a);
 		int Nx = std::clamp(round_to_int(Pos.x) / 32, 0, m_Width - 1);
 		int Ny = std::clamp(round_to_int(Pos.y) / 32, 0, m_Height - 1);
@@ -1171,12 +1173,13 @@ int CCollision::IntersectNoLaser(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2
 
 int CCollision::IntersectNoLaserNoWalls(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision) const
 {
-	float d = distance(Pos0, Pos1);
+	float Distance = distance(Pos0, Pos1);
 	vec2 Last = Pos0;
 
-	for(int i = 0, id = std::ceil(d); i < id; i++)
+	const int DistanceRounded = std::ceil(Distance);
+	for(int i = 0; i < DistanceRounded; i++)
 	{
-		float a = (float)i / d;
+		float a = (float)i / Distance;
 		vec2 Pos = mix(Pos0, Pos1, a);
 		if(IsNoLaser(round_to_int(Pos.x), round_to_int(Pos.y)) || IsFrontNoLaser(round_to_int(Pos.x), round_to_int(Pos.y)))
 		{
@@ -1200,12 +1203,13 @@ int CCollision::IntersectNoLaserNoWalls(vec2 Pos0, vec2 Pos1, vec2 *pOutCollisio
 
 int CCollision::IntersectAir(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision) const
 {
-	float d = distance(Pos0, Pos1);
+	float Distance = distance(Pos0, Pos1);
 	vec2 Last = Pos0;
 
-	for(int i = 0, id = std::ceil(d); i < id; i++)
+	const int DistanceRounded = std::ceil(Distance);
+	for(int i = 0; i < DistanceRounded; i++)
 	{
-		float a = (float)i / d;
+		float a = (float)i / Distance;
 		vec2 Pos = mix(Pos0, Pos1, a);
 		if(IsSolid(round_to_int(Pos.x), round_to_int(Pos.y)) || (!GetTile(round_to_int(Pos.x), round_to_int(Pos.y)) && !GetFrontTile(round_to_int(Pos.x), round_to_int(Pos.y))))
 		{

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -320,7 +320,7 @@ bool CEditor::IsEnvPointSelected(int Index) const
 	auto Iter = std::find_if(
 		m_vSelectedEnvelopePoints.begin(),
 		m_vSelectedEnvelopePoints.end(),
-		[&](auto pair) { return pair.first == Index; });
+		[&](const auto &Pair) { return Pair.first == Index; });
 
 	return Iter != m_vSelectedEnvelopePoints.end();
 }
@@ -730,15 +730,15 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 		}
 	}
 
-	CUIRect TB_Top, TB_Bottom;
+	CUIRect ToolbarTop, ToolbarBottom;
 	CUIRect Button;
 
-	ToolBar.HSplitMid(&TB_Top, &TB_Bottom, 5.0f);
+	ToolBar.HSplitMid(&ToolbarTop, &ToolbarBottom, 5.0f);
 
 	// top line buttons
 	{
 		// detail button
-		TB_Top.VSplitLeft(40.0f, &Button, &TB_Top);
+		ToolbarTop.VSplitLeft(40.0f, &Button, &ToolbarTop);
 		static int s_HqButton = 0;
 		if(DoButton_Editor(&s_HqButton, "HD", m_ShowDetail, &Button, BUTTONFLAG_LEFT, "[Ctrl+H] Toggle high detail.") ||
 			(m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && Input()->KeyPress(KEY_H) && ModPressed))
@@ -746,10 +746,10 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 			m_ShowDetail = !m_ShowDetail;
 		}
 
-		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
+		ToolbarTop.VSplitLeft(5.0f, nullptr, &ToolbarTop);
 
 		// animation button
-		TB_Top.VSplitLeft(25.0f, &Button, &TB_Top);
+		ToolbarTop.VSplitLeft(25.0f, &Button, &ToolbarTop);
 		static char s_AnimateButton;
 		if(DoButton_FontIcon(&s_AnimateButton, FONT_ICON_CIRCLE_PLAY, m_Animate, &Button, BUTTONFLAG_LEFT, "[Ctrl+M] Toggle animation.", IGraphics::CORNER_L) ||
 			(m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && Input()->KeyPress(KEY_M) && ModPressed))
@@ -759,7 +759,7 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 		}
 
 		// animation settings button
-		TB_Top.VSplitLeft(14.0f, &Button, &TB_Top);
+		ToolbarTop.VSplitLeft(14.0f, &Button, &ToolbarTop);
 		static char s_AnimateSettingsButton;
 		if(DoButton_FontIcon(&s_AnimateSettingsButton, FONT_ICON_CIRCLE_CHEVRON_DOWN, 0, &Button, BUTTONFLAG_LEFT, "Change the animation settings.", IGraphics::CORNER_R, 8.0f))
 		{
@@ -768,16 +768,16 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 			Ui()->DoPopupMenu(&s_PopupAnimateSettingsId, Button.x, Button.y + Button.h, 150.0f, 37.0f, this, PopupAnimateSettings);
 		}
 
-		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
+		ToolbarTop.VSplitLeft(5.0f, nullptr, &ToolbarTop);
 
 		// proof button
-		TB_Top.VSplitLeft(40.0f, &Button, &TB_Top);
+		ToolbarTop.VSplitLeft(40.0f, &Button, &ToolbarTop);
 		if(DoButton_Ex(&m_QuickActionProof, m_QuickActionProof.Label(), m_QuickActionProof.Active(), &Button, BUTTONFLAG_LEFT, m_QuickActionProof.Description(), IGraphics::CORNER_L))
 		{
 			m_QuickActionProof.Call();
 		}
 
-		TB_Top.VSplitLeft(14.0f, &Button, &TB_Top);
+		ToolbarTop.VSplitLeft(14.0f, &Button, &ToolbarTop);
 		static int s_ProofModeButton = 0;
 		if(DoButton_FontIcon(&s_ProofModeButton, FONT_ICON_CIRCLE_CHEVRON_DOWN, 0, &Button, BUTTONFLAG_LEFT, "Select proof mode.", IGraphics::CORNER_R, 8.0f))
 		{
@@ -785,20 +785,20 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 			Ui()->DoPopupMenu(&s_PopupProofModeId, Button.x, Button.y + Button.h, 60.0f, 36.0f, this, PopupProofMode);
 		}
 
-		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
+		ToolbarTop.VSplitLeft(5.0f, nullptr, &ToolbarTop);
 
 		// zoom button
-		TB_Top.VSplitLeft(40.0f, &Button, &TB_Top);
+		ToolbarTop.VSplitLeft(40.0f, &Button, &ToolbarTop);
 		static int s_ZoomButton = 0;
 		if(DoButton_Editor(&s_ZoomButton, "Zoom", m_PreviewZoom, &Button, BUTTONFLAG_LEFT, "Toggle preview of how layers will be zoomed ingame."))
 		{
 			m_PreviewZoom = !m_PreviewZoom;
 		}
 
-		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
+		ToolbarTop.VSplitLeft(5.0f, nullptr, &ToolbarTop);
 
 		// grid button
-		TB_Top.VSplitLeft(25.0f, &Button, &TB_Top);
+		ToolbarTop.VSplitLeft(25.0f, &Button, &ToolbarTop);
 		static int s_GridButton = 0;
 		if(DoButton_FontIcon(&s_GridButton, FONT_ICON_BORDER_ALL, m_QuickActionToggleGrid.Active(), &Button, BUTTONFLAG_LEFT, m_QuickActionToggleGrid.Description(), IGraphics::CORNER_L) ||
 			(m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && Input()->KeyPress(KEY_G) && ModPressed && !ShiftPressed))
@@ -807,62 +807,62 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 		}
 
 		// grid settings button
-		TB_Top.VSplitLeft(14.0f, &Button, &TB_Top);
+		ToolbarTop.VSplitLeft(14.0f, &Button, &ToolbarTop);
 		static char s_GridSettingsButton;
 		if(DoButton_FontIcon(&s_GridSettingsButton, FONT_ICON_CIRCLE_CHEVRON_DOWN, 0, &Button, BUTTONFLAG_LEFT, "Change the grid settings.", IGraphics::CORNER_R, 8.0f))
 		{
 			MapView()->MapGrid()->DoSettingsPopup(vec2(Button.x, Button.y + Button.h));
 		}
 
-		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
+		ToolbarTop.VSplitLeft(5.0f, nullptr, &ToolbarTop);
 
 		// zoom group
-		TB_Top.VSplitLeft(20.0f, &Button, &TB_Top);
+		ToolbarTop.VSplitLeft(20.0f, &Button, &ToolbarTop);
 		static int s_ZoomOutButton = 0;
 		if(DoButton_FontIcon(&s_ZoomOutButton, FONT_ICON_MINUS, 0, &Button, BUTTONFLAG_LEFT, m_QuickActionZoomOut.Description(), IGraphics::CORNER_L))
 		{
 			m_QuickActionZoomOut.Call();
 		}
 
-		TB_Top.VSplitLeft(25.0f, &Button, &TB_Top);
+		ToolbarTop.VSplitLeft(25.0f, &Button, &ToolbarTop);
 		static int s_ZoomNormalButton = 0;
 		if(DoButton_FontIcon(&s_ZoomNormalButton, FONT_ICON_MAGNIFYING_GLASS, 0, &Button, BUTTONFLAG_LEFT, m_QuickActionResetZoom.Description(), IGraphics::CORNER_NONE))
 		{
 			m_QuickActionResetZoom.Call();
 		}
 
-		TB_Top.VSplitLeft(20.0f, &Button, &TB_Top);
+		ToolbarTop.VSplitLeft(20.0f, &Button, &ToolbarTop);
 		static int s_ZoomInButton = 0;
 		if(DoButton_FontIcon(&s_ZoomInButton, FONT_ICON_PLUS, 0, &Button, BUTTONFLAG_LEFT, m_QuickActionZoomIn.Description(), IGraphics::CORNER_R))
 		{
 			m_QuickActionZoomIn.Call();
 		}
 
-		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
+		ToolbarTop.VSplitLeft(5.0f, nullptr, &ToolbarTop);
 
 		// undo/redo group
-		TB_Top.VSplitLeft(25.0f, &Button, &TB_Top);
+		ToolbarTop.VSplitLeft(25.0f, &Button, &ToolbarTop);
 		static int s_UndoButton = 0;
 		if(DoButton_FontIcon(&s_UndoButton, FONT_ICON_UNDO, m_EditorHistory.CanUndo() - 1, &Button, BUTTONFLAG_LEFT, "[Ctrl+Z] Undo the last action.", IGraphics::CORNER_L))
 		{
 			m_EditorHistory.Undo();
 		}
 
-		TB_Top.VSplitLeft(25.0f, &Button, &TB_Top);
+		ToolbarTop.VSplitLeft(25.0f, &Button, &ToolbarTop);
 		static int s_RedoButton = 0;
 		if(DoButton_FontIcon(&s_RedoButton, FONT_ICON_REDO, m_EditorHistory.CanRedo() - 1, &Button, BUTTONFLAG_LEFT, "[Ctrl+Y] Redo the last action.", IGraphics::CORNER_R))
 		{
 			m_EditorHistory.Redo();
 		}
 
-		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
+		ToolbarTop.VSplitLeft(5.0f, nullptr, &ToolbarTop);
 
 		// brush manipulation
 		{
 			int Enabled = m_pBrush->IsEmpty() ? -1 : 0;
 
 			// flip buttons
-			TB_Top.VSplitLeft(25.0f, &Button, &TB_Top);
+			ToolbarTop.VSplitLeft(25.0f, &Button, &ToolbarTop);
 			static int s_FlipXButton = 0;
 			if(DoButton_FontIcon(&s_FlipXButton, FONT_ICON_ARROWS_LEFT_RIGHT, Enabled, &Button, BUTTONFLAG_LEFT, "[N] Flip the brush horizontally.", IGraphics::CORNER_L) || (Input()->KeyPress(KEY_N) && m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && !Ui()->IsPopupOpen()))
 			{
@@ -870,17 +870,17 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 					pLayer->BrushFlipX();
 			}
 
-			TB_Top.VSplitLeft(25.0f, &Button, &TB_Top);
+			ToolbarTop.VSplitLeft(25.0f, &Button, &ToolbarTop);
 			static int s_FlipyButton = 0;
 			if(DoButton_FontIcon(&s_FlipyButton, FONT_ICON_ARROWS_UP_DOWN, Enabled, &Button, BUTTONFLAG_LEFT, "[M] Flip the brush vertically.", IGraphics::CORNER_R) || (Input()->KeyPress(KEY_M) && m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && !Ui()->IsPopupOpen()))
 			{
 				for(auto &pLayer : m_pBrush->m_vpLayers)
 					pLayer->BrushFlipY();
 			}
-			TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
+			ToolbarTop.VSplitLeft(5.0f, nullptr, &ToolbarTop);
 
 			// rotate buttons
-			TB_Top.VSplitLeft(25.0f, &Button, &TB_Top);
+			ToolbarTop.VSplitLeft(25.0f, &Button, &ToolbarTop);
 			static int s_RotationAmount = 90;
 			bool TileLayer = false;
 			// check for tile layers in brush selection
@@ -899,11 +899,11 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 					pLayer->BrushRotate(-s_RotationAmount / 360.0f * pi * 2);
 			}
 
-			TB_Top.VSplitLeft(30.0f, &Button, &TB_Top);
+			ToolbarTop.VSplitLeft(30.0f, &Button, &ToolbarTop);
 			auto RotationAmountRes = UiDoValueSelector(&s_RotationAmount, &Button, "", s_RotationAmount, TileLayer ? 90 : 1, 359, TileLayer ? 90 : 1, TileLayer ? 10.0f : 2.0f, "Rotation of the brush in degrees. Use left mouse button to drag and change the value. Hold shift to be more precise.", true, false, IGraphics::CORNER_NONE);
 			s_RotationAmount = RotationAmountRes.m_Value;
 
-			TB_Top.VSplitLeft(25.0f, &Button, &TB_Top);
+			ToolbarTop.VSplitLeft(25.0f, &Button, &ToolbarTop);
 			static int s_CwButton = 0;
 			if(DoButton_FontIcon(&s_CwButton, FONT_ICON_ARROW_ROTATE_RIGHT, Enabled, &Button, BUTTONFLAG_LEFT, "[T] Rotate the brush clockwise.", IGraphics::CORNER_R) || (Input()->KeyPress(KEY_T) && m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && !Ui()->IsPopupOpen()))
 			{
@@ -917,10 +917,10 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 			const float PipetteButtonWidth = 30.0f;
 			const float ColorPickerButtonWidth = 20.0f;
 			const float Spacing = 2.0f;
-			const size_t NumColorsShown = std::clamp<int>(round_to_int((TB_Top.w - PipetteButtonWidth - 40.0f) / (ColorPickerButtonWidth + Spacing)), 1, std::size(m_aSavedColors));
+			const size_t NumColorsShown = std::clamp<int>(round_to_int((ToolbarTop.w - PipetteButtonWidth - 40.0f) / (ColorPickerButtonWidth + Spacing)), 1, std::size(m_aSavedColors));
 
 			CUIRect ColorPalette;
-			TB_Top.VSplitRight(NumColorsShown * (ColorPickerButtonWidth + Spacing) + PipetteButtonWidth, &TB_Top, &ColorPalette);
+			ToolbarTop.VSplitRight(NumColorsShown * (ColorPickerButtonWidth + Spacing) + PipetteButtonWidth, &ToolbarTop, &ColorPalette);
 
 			// Pipette button
 			static char s_PipetteButton;
@@ -949,11 +949,11 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 	{
 		// refocus button
 		{
-			TB_Bottom.VSplitLeft(50.0f, &Button, &TB_Bottom);
+			ToolbarBottom.VSplitLeft(50.0f, &Button, &ToolbarBottom);
 			int FocusButtonChecked = MapView()->IsFocused() ? -1 : 1;
 			if(DoButton_Editor(&m_QuickActionRefocus, m_QuickActionRefocus.Label(), FocusButtonChecked, &Button, BUTTONFLAG_LEFT, m_QuickActionRefocus.Description()) || (m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && Input()->KeyPress(KEY_HOME)))
 				m_QuickActionRefocus.Call();
-			TB_Bottom.VSplitLeft(5.0f, nullptr, &TB_Bottom);
+			ToolbarBottom.VSplitLeft(5.0f, nullptr, &ToolbarBottom);
 		}
 
 		// tile manipulation
@@ -998,7 +998,7 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 						static char s_aButtonTooltip[64];
 						str_format(s_aButtonTooltip, sizeof(s_aButtonTooltip), "[Ctrl+T] %s", pButtonName);
 
-						TB_Bottom.VSplitLeft(60.0f, &Button, &TB_Bottom);
+						ToolbarBottom.VSplitLeft(60.0f, &Button, &ToolbarBottom);
 						static int s_ModifierButton = 0;
 						if(DoButton_Ex(&s_ModifierButton, pButtonName, 0, &Button, BUTTONFLAG_LEFT, s_aButtonTooltip, IGraphics::CORNER_ALL) || (m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && ModPressed && Input()->KeyPress(KEY_T)))
 						{
@@ -1008,7 +1008,7 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 								Ui()->DoPopupMenu(&s_PopupModifierId, Button.x, Button.y + Button.h, 120 + ExtraWidth, 10.0f + Rows * 13.0f, this, pfnPopupFunc);
 							}
 						}
-						TB_Bottom.VSplitLeft(5.0f, nullptr, &TB_Bottom);
+						ToolbarBottom.VSplitLeft(5.0f, nullptr, &ToolbarBottom);
 					}
 				}
 			}
@@ -1019,7 +1019,7 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 		if(pLayer && (pLayer->m_Type == LAYERTYPE_QUADS || pLayer->m_Type == LAYERTYPE_SOUNDS))
 		{
 			// "Add sound source" button needs more space or the font size will be scaled down
-			TB_Bottom.VSplitLeft((pLayer->m_Type == LAYERTYPE_QUADS) ? 60.0f : 100.0f, &Button, &TB_Bottom);
+			ToolbarBottom.VSplitLeft((pLayer->m_Type == LAYERTYPE_QUADS) ? 60.0f : 100.0f, &Button, &ToolbarBottom);
 
 			if(pLayer->m_Type == LAYERTYPE_QUADS)
 			{
@@ -1038,17 +1038,17 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 				}
 			}
 
-			TB_Bottom.VSplitLeft(5.0f, &Button, &TB_Bottom);
+			ToolbarBottom.VSplitLeft(5.0f, &Button, &ToolbarBottom);
 		}
 
 		// Brush draw mode button
 		{
-			TB_Bottom.VSplitLeft(65.0f, &Button, &TB_Bottom);
+			ToolbarBottom.VSplitLeft(65.0f, &Button, &ToolbarBottom);
 			static int s_BrushDrawModeButton = 0;
 			if(DoButton_Editor(&s_BrushDrawModeButton, "Destructive", m_BrushDrawDestructive, &Button, BUTTONFLAG_LEFT, "[Ctrl+D] Toggle brush draw mode: preserve or override existing tiles.") ||
 				(m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && Input()->KeyPress(KEY_D) && ModPressed && !ShiftPressed))
 				m_BrushDrawDestructive = !m_BrushDrawDestructive;
-			TB_Bottom.VSplitLeft(5.0f, &Button, &TB_Bottom);
+			ToolbarBottom.VSplitLeft(5.0f, &Button, &ToolbarBottom);
 		}
 	}
 }

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -799,9 +799,9 @@ void CLayerTiles::FillGameTiles(EGameTileOp Fill)
 		{
 			if(pGLayer->m_Width < m_Width + OffsetX || pGLayer->m_Height < m_Height + OffsetY)
 			{
-				std::map<int, std::shared_ptr<CLayer>> savedLayers;
-				savedLayers[LAYERTYPE_TILES] = pGLayer->Duplicate();
-				savedLayers[LAYERTYPE_GAME] = savedLayers[LAYERTYPE_TILES];
+				std::map<int, std::shared_ptr<CLayer>> SavedLayers;
+				SavedLayers[LAYERTYPE_TILES] = pGLayer->Duplicate();
+				SavedLayers[LAYERTYPE_GAME] = SavedLayers[LAYERTYPE_TILES];
 
 				int PrevW = pGLayer->m_Width;
 				int PrevH = pGLayer->m_Height;
@@ -813,8 +813,8 @@ void CLayerTiles::FillGameTiles(EGameTileOp Fill)
 				vpActions.push_back(std::make_shared<CEditorActionEditLayerTilesProp>(m_pEditor, GameGroupIndex, GameLayerIndex, ETilesProp::PROP_HEIGHT, PrevH, NewH));
 				const std::shared_ptr<CEditorActionEditLayerTilesProp> &Action2 = std::static_pointer_cast<CEditorActionEditLayerTilesProp>(vpActions[vpActions.size() - 1]);
 
-				Action1->SetSavedLayers(savedLayers);
-				Action2->SetSavedLayers(savedLayers);
+				Action1->SetSavedLayers(SavedLayers);
+				Action2->SetSavedLayers(SavedLayers);
 			}
 
 			int Changes = 0;
@@ -847,9 +847,9 @@ void CLayerTiles::FillGameTiles(EGameTileOp Fill)
 
 				if(m_Width != pGLayer->m_Width || m_Height > pGLayer->m_Height)
 				{
-					std::map<int, std::shared_ptr<CLayer>> savedLayers;
-					savedLayers[LAYERTYPE_TILES] = pGLayer->Duplicate();
-					savedLayers[LAYERTYPE_GAME] = savedLayers[LAYERTYPE_TILES];
+					std::map<int, std::shared_ptr<CLayer>> SavedLayers;
+					SavedLayers[LAYERTYPE_TILES] = pGLayer->Duplicate();
+					SavedLayers[LAYERTYPE_GAME] = SavedLayers[LAYERTYPE_TILES];
 
 					int NewW = pGLayer->m_Width;
 					int NewH = pGLayer->m_Height;
@@ -870,8 +870,8 @@ void CLayerTiles::FillGameTiles(EGameTileOp Fill)
 					vpActions.push_back(std::make_shared<CEditorActionEditLayerTilesProp>(m_pEditor, GameGroupIndex, GameLayerIndex, ETilesProp::PROP_HEIGHT, PrevH, NewH));
 					const std::shared_ptr<CEditorActionEditLayerTilesProp> &Action2 = std::static_pointer_cast<CEditorActionEditLayerTilesProp>(vpActions[vpActions.size() - 1]);
 
-					Action1->SetSavedLayers(savedLayers);
-					Action2->SetSavedLayers(savedLayers);
+					Action1->SetSavedLayers(SavedLayers);
+					Action2->SetSavedLayers(SavedLayers);
 				}
 			}
 
@@ -880,9 +880,9 @@ void CLayerTiles::FillGameTiles(EGameTileOp Fill)
 
 			if(pTLayer->m_Width < m_Width + OffsetX || pTLayer->m_Height < m_Height + OffsetY)
 			{
-				std::map<int, std::shared_ptr<CLayer>> savedLayers;
-				savedLayers[LAYERTYPE_TILES] = pTLayer->Duplicate();
-				savedLayers[LAYERTYPE_TELE] = savedLayers[LAYERTYPE_TILES];
+				std::map<int, std::shared_ptr<CLayer>> SavedLayers;
+				SavedLayers[LAYERTYPE_TILES] = pTLayer->Duplicate();
+				SavedLayers[LAYERTYPE_TELE] = SavedLayers[LAYERTYPE_TILES];
 
 				int PrevW = pTLayer->m_Width;
 				int PrevH = pTLayer->m_Height;
@@ -893,8 +893,8 @@ void CLayerTiles::FillGameTiles(EGameTileOp Fill)
 				vpActions.push_back(Action1 = std::make_shared<CEditorActionEditLayerTilesProp>(m_pEditor, GameGroupIndex, TeleLayerIndex, ETilesProp::PROP_WIDTH, PrevW, NewW));
 				vpActions.push_back(Action2 = std::make_shared<CEditorActionEditLayerTilesProp>(m_pEditor, GameGroupIndex, TeleLayerIndex, ETilesProp::PROP_HEIGHT, PrevH, NewH));
 
-				Action1->SetSavedLayers(savedLayers);
-				Action2->SetSavedLayers(savedLayers);
+				Action1->SetSavedLayers(SavedLayers);
+				Action2->SetSavedLayers(SavedLayers);
 			}
 
 			int Changes = 0;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -3019,8 +3019,8 @@ CUi::EPopupMenuFunctionResult CEditor::PopupAnimateSettings(void *pContext, CUIR
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
-	constexpr float MIN_ANIM_SPEED = 0.001f;
-	constexpr float MAX_ANIM_SPEED = 1000000.0f;
+	static constexpr float MIN_ANIM_SPEED = 0.001f;
+	static constexpr float MAX_ANIM_SPEED = 1000000.0f;
 
 	CUIRect Row, Label, ButtonDecrease, EditBox, ButtonIncrease, ButtonReset;
 	View.HSplitTop(13.0f, &Row, &View);

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -331,8 +331,8 @@ void CCharacterCore::Tick(bool UseInput, bool DoDeferredTick)
 		bool GoingToHitGround = false;
 		bool GoingToRetract = false;
 		bool GoingThroughTele = false;
-		int teleNr = 0;
-		int Hit = m_pCollision->IntersectLineTeleHook(m_HookPos, NewPos, &NewPos, nullptr, &teleNr);
+		int TeleNr = 0;
+		int Hit = m_pCollision->IntersectLineTeleHook(m_HookPos, NewPos, &NewPos, nullptr, &TeleNr);
 
 		if(Hit)
 		{
@@ -386,14 +386,14 @@ void CCharacterCore::Tick(bool UseInput, bool DoDeferredTick)
 				m_HookState = HOOK_RETRACT_START;
 			}
 
-			if(GoingThroughTele && m_pWorld && !m_pCollision->TeleOuts(teleNr - 1).empty())
+			if(GoingThroughTele && m_pWorld && !m_pCollision->TeleOuts(TeleNr - 1).empty())
 			{
 				m_TriggeredEvents = 0;
 				SetHookedPlayer(-1);
 
 				m_NewHook = true;
-				int RandomOut = m_pWorld->RandomOr0(m_pCollision->TeleOuts(teleNr - 1).size());
-				m_HookPos = m_pCollision->TeleOuts(teleNr - 1)[RandomOut] + TargetDirection * PhysicalSize() * 1.5f;
+				int RandomOut = m_pWorld->RandomOr0(m_pCollision->TeleOuts(TeleNr - 1).size());
+				m_HookPos = m_pCollision->TeleOuts(TeleNr - 1)[RandomOut] + TargetDirection * PhysicalSize() * 1.5f;
 				m_HookDir = TargetDirection;
 				m_HookTeleBase = m_HookPos;
 			}

--- a/src/game/map/render_map.cpp
+++ b/src/game/map/render_map.cpp
@@ -198,7 +198,7 @@ static float SolveBezier(float x, float p0, float p1, float p2, float p3)
 		const double c = x0 / x3;
 
 		// substitute t = y - a / 3
-		const double sub = a / 3.0;
+		const double Substitute = a / 3.0;
 
 		// depressed form x^3 + px + q = 0
 		// cardano's method
@@ -211,34 +211,34 @@ static float SolveBezier(float x, float p0, float p1, float p2, float p3)
 		{
 			// only one 'real' solution
 			const double s = std::sqrt(D);
-			return std::cbrt(s - q) - std::cbrt(s + q) - sub;
+			return std::cbrt(s - q) - std::cbrt(s + q) - Substitute;
 		}
 		else if(D == 0.0)
 		{
 			// one single, one double solution or triple solution
 			const double s = std::cbrt(-q);
-			const double t = 2.0 * s - sub;
+			const double t = 2.0 * s - Substitute;
 
 			if(0.0 <= t && t <= 1.0001)
 				return t;
-			return (-s - sub);
+			return (-s - Substitute);
 		}
 		else
 		{
 			// Casus irreducibilis ... ,_,
-			const double phi = std::acos(-q / std::sqrt(-(p * p * p))) / 3.0;
+			const double Phi = std::acos(-q / std::sqrt(-(p * p * p))) / 3.0;
 			const double s = 2.0 * std::sqrt(-p);
 
-			const double t1 = s * std::cos(phi) - sub;
+			const double t1 = s * std::cos(Phi) - Substitute;
 
 			if(0.0 <= t1 && t1 <= 1.0001)
 				return t1;
 
-			const double t2 = -s * std::cos(phi + pi / 3.0) - sub;
+			const double t2 = -s * std::cos(Phi + pi / 3.0) - Substitute;
 
 			if(0.0 <= t2 && t2 <= 1.0001)
 				return t2;
-			return -s * std::cos(phi - pi / 3.0) - sub;
+			return -s * std::cos(Phi - pi / 3.0) - Substitute;
 		}
 	}
 }

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -73,11 +73,10 @@ void CGameContext::ConList(IConsole::IResult *pResult, void *pUserData)
 	if(!CheckClientId(ClientId))
 		return;
 
-	char zerochar = 0;
 	if(pResult->NumArguments() > 0)
 		pSelf->List(ClientId, pResult->GetString(0));
 	else
-		pSelf->List(ClientId, &zerochar);
+		pSelf->List(ClientId, "");
 }
 
 void CGameContext::ConHelp(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1903,11 +1903,11 @@ void CCharacter::HandleTiles(int Index)
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_ADD_TIME && !m_LastPenalty)
 	{
-		int min = Collision()->GetSwitchDelay(MapIndex);
-		int sec = Collision()->GetSwitchNumber(MapIndex);
+		const int Minutes = Collision()->GetSwitchDelay(MapIndex);
+		const int Seconds = Collision()->GetSwitchNumber(MapIndex);
 		int Team = Teams()->m_Core.Team(m_Core.m_Id);
 
-		m_StartTime -= (min * 60 + sec) * Server()->TickSpeed();
+		m_StartTime -= (Minutes * 60 + Seconds) * Server()->TickSpeed();
 
 		if((g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || (Team != TEAM_FLOCK && !Teams()->TeamFlock(Team))) && Team != TEAM_SUPER)
 		{
@@ -1927,11 +1927,11 @@ void CCharacter::HandleTiles(int Index)
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_SUBTRACT_TIME && !m_LastBonus)
 	{
-		int min = Collision()->GetSwitchDelay(MapIndex);
-		int sec = Collision()->GetSwitchNumber(MapIndex);
+		const int Minutes = Collision()->GetSwitchDelay(MapIndex);
+		const int Seconds = Collision()->GetSwitchNumber(MapIndex);
 		int Team = Teams()->m_Core.Team(m_Core.m_Id);
 
-		m_StartTime += (min * 60 + sec) * Server()->TickSpeed();
+		m_StartTime += (Minutes * 60 + Seconds) * Server()->TickSpeed();
 		if(m_StartTime > Server()->Tick())
 			m_StartTime = Server()->Tick();
 
@@ -1977,13 +1977,13 @@ void CCharacter::HandleTiles(int Index)
 			ResetPickups();
 		return;
 	}
-	int evilz = Collision()->IsEvilTeleport(MapIndex);
-	if(evilz && !Collision()->TeleOuts(evilz - 1).empty())
+	const int EvilTeleport = Collision()->IsEvilTeleport(MapIndex);
+	if(EvilTeleport && !Collision()->TeleOuts(EvilTeleport - 1).empty())
 	{
 		if(m_Core.m_Super || m_Core.m_Invincible)
 			return;
-		int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleOuts(evilz - 1).size());
-		m_Core.m_Pos = Collision()->TeleOuts(evilz - 1)[TeleOut];
+		int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleOuts(EvilTeleport - 1).size());
+		m_Core.m_Pos = Collision()->TeleOuts(EvilTeleport - 1)[TeleOut];
 		if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons)
 		{
 			m_Core.m_Vel = vec2(0, 0);

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -240,9 +240,9 @@ void CLaser::DoBounce()
 			{
 				// Delay specifies which weapon the tile should work for.
 				// Delay = 0 means all.
-				int delay = GameServer()->Collision()->GetSwitchDelay(MapIndex);
+				const int Delay = GameServer()->Collision()->GetSwitchDelay(MapIndex);
 
-				if((delay != 3 && delay != 0) && m_Type == WEAPON_LASER)
+				if((Delay != 3 && Delay != 0) && m_Type == WEAPON_LASER)
 				{
 					IsSwitchTeleGun = IsBlueSwitchTeleGun = false;
 				}

--- a/src/game/server/entities/light.cpp
+++ b/src/game/server/entities/light.cpp
@@ -73,9 +73,9 @@ void CLight::Move()
 void CLight::Step()
 {
 	Move();
-	vec2 dir(std::sin(m_Rotation), std::cos(m_Rotation));
-	vec2 to2 = m_Pos + normalize(dir) * m_CurveLength;
-	GameServer()->Collision()->IntersectNoLaser(m_Pos, to2, &m_To, nullptr);
+	const vec2 Direction = vec2(std::sin(m_Rotation), std::cos(m_Rotation));
+	const vec2 NextPosition = m_Pos + normalize(Direction) * m_CurveLength;
+	GameServer()->Collision()->IntersectNoLaser(m_Pos, NextPosition, &m_To, nullptr);
 }
 
 void CLight::Reset()

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -195,13 +195,13 @@ void CProjectile::Tick()
 			{
 				// Delay specifies which weapon the tile should work for.
 				// Delay = 0 means all.
-				int delay = GameServer()->Collision()->GetSwitchDelay(MapIndex);
+				int Delay = GameServer()->Collision()->GetSwitchDelay(MapIndex);
 
-				if(delay == 1 && m_Type != WEAPON_GUN)
+				if(Delay == 1 && m_Type != WEAPON_GUN)
 					IsSwitchTeleGun = IsBlueSwitchTeleGun = false;
-				if(delay == 2 && m_Type != WEAPON_GRENADE)
+				if(Delay == 2 && m_Type != WEAPON_GRENADE)
 					IsSwitchTeleGun = IsBlueSwitchTeleGun = false;
-				if(delay == 3 && m_Type != WEAPON_LASER)
+				if(Delay == 3 && m_Type != WEAPON_LASER)
 					IsSwitchTeleGun = IsBlueSwitchTeleGun = false;
 			}
 

--- a/src/game/server/entity.cpp
+++ b/src/game/server/entity.cpp
@@ -77,9 +77,9 @@ bool CEntity::GetNearestAirPos(vec2 Pos, vec2 PrevPos, vec2 *pOutPos)
 
 bool CEntity::GetNearestAirPosPlayer(vec2 PlayerPos, vec2 *pOutPos)
 {
-	for(int dist = 5; dist >= -1; dist--)
+	for(int Distance = 5; Distance >= -1; Distance--)
 	{
-		*pOutPos = vec2(PlayerPos.x, PlayerPos.y - dist);
+		*pOutPos = vec2(PlayerPos.x, PlayerPos.y - Distance);
 		if(!GameServer()->Collision()->TestBox(*pOutPos, CCharacterCore::PhysicalSizeVec2()))
 		{
 			return true;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -312,11 +312,11 @@ void CPlayer::Snap(int SnappingClient)
 	if(!Server()->ClientIngame(m_ClientId))
 		return;
 
-	int id = m_ClientId;
-	if(!Server()->Translate(id, SnappingClient))
+	int TranslatedId = m_ClientId;
+	if(!Server()->Translate(TranslatedId, SnappingClient))
 		return;
 
-	CNetObj_ClientInfo *pClientInfo = Server()->SnapNewItem<CNetObj_ClientInfo>(id);
+	CNetObj_ClientInfo *pClientInfo = Server()->SnapNewItem<CNetObj_ClientInfo>(TranslatedId);
 	if(!pClientInfo)
 		return;
 
@@ -356,14 +356,14 @@ void CPlayer::Snap(int SnappingClient)
 
 	if(!Server()->IsSixup(SnappingClient))
 	{
-		CNetObj_PlayerInfo *pPlayerInfo = Server()->SnapNewItem<CNetObj_PlayerInfo>(id);
+		CNetObj_PlayerInfo *pPlayerInfo = Server()->SnapNewItem<CNetObj_PlayerInfo>(TranslatedId);
 		if(!pPlayerInfo)
 			return;
 
 		pPlayerInfo->m_Latency = Latency;
 		pPlayerInfo->m_Score = Score;
 		pPlayerInfo->m_Local = (int)(m_ClientId == SnappingClient && (m_Paused != PAUSE_PAUSED || SnappingClientVersion >= VERSION_DDNET_OLD));
-		pPlayerInfo->m_ClientId = id;
+		pPlayerInfo->m_ClientId = TranslatedId;
 		pPlayerInfo->m_Team = m_Team;
 		if(SnappingClientVersion < VERSION_DDNET_INDEPENDENT_SPECTATORS_TEAM)
 		{
@@ -373,7 +373,7 @@ void CPlayer::Snap(int SnappingClient)
 	}
 	else
 	{
-		protocol7::CNetObj_PlayerInfo *pPlayerInfo = Server()->SnapNewItem<protocol7::CNetObj_PlayerInfo>(id);
+		protocol7::CNetObj_PlayerInfo *pPlayerInfo = Server()->SnapNewItem<protocol7::CNetObj_PlayerInfo>(TranslatedId);
 		if(!pPlayerInfo)
 			return;
 
@@ -416,12 +416,12 @@ void CPlayer::Snap(int SnappingClient)
 	if(m_ClientId == SnappingClient)
 	{
 		// send extended spectator info even when playing, this allows demo to record camera settings for local player
-		const int SpectatingClient = ((m_Team != TEAM_SPECTATORS && !m_Paused) || m_SpectatorId < 0 || m_SpectatorId >= MAX_CLIENTS) ? id : m_SpectatorId;
+		const int SpectatingClient = ((m_Team != TEAM_SPECTATORS && !m_Paused) || m_SpectatorId < 0 || m_SpectatorId >= MAX_CLIENTS) ? TranslatedId : m_SpectatorId;
 		const CPlayer *pSpecPlayer = GameServer()->m_apPlayers[SpectatingClient];
 
 		if(pSpecPlayer)
 		{
-			CNetObj_DDNetSpectatorInfo *pDDNetSpectatorInfo = Server()->SnapNewItem<CNetObj_DDNetSpectatorInfo>(id);
+			CNetObj_DDNetSpectatorInfo *pDDNetSpectatorInfo = Server()->SnapNewItem<CNetObj_DDNetSpectatorInfo>(TranslatedId);
 			if(!pDDNetSpectatorInfo)
 				return;
 
@@ -430,25 +430,25 @@ void CPlayer::Snap(int SnappingClient)
 			pDDNetSpectatorInfo->m_Deadzone = pSpecPlayer->m_CameraInfo.m_Deadzone;
 			pDDNetSpectatorInfo->m_FollowFactor = pSpecPlayer->m_CameraInfo.m_FollowFactor;
 
-			if(SpectatingClient == id && SnappingClient != SERVER_DEMO_CLIENT && m_Team != TEAM_SPECTATORS && !m_Paused)
+			if(SpectatingClient == TranslatedId && SnappingClient != SERVER_DEMO_CLIENT && m_Team != TEAM_SPECTATORS && !m_Paused)
 			{
 				int SpectatorCount = 0;
 				for(auto &pPlayer : GameServer()->m_apPlayers)
 				{
-					if(!pPlayer || pPlayer->m_ClientId == id || pPlayer->m_Afk ||
+					if(!pPlayer || pPlayer->m_ClientId == TranslatedId || pPlayer->m_Afk ||
 						(Server()->IsRconAuthed(pPlayer->m_ClientId) && Server()->HasAuthHidden(pPlayer->m_ClientId)) ||
 						!(pPlayer->m_Paused || pPlayer->m_Team == TEAM_SPECTATORS))
 					{
 						continue;
 					}
 
-					if(pPlayer->m_SpectatorId == id)
+					if(pPlayer->m_SpectatorId == TranslatedId)
 					{
 						SpectatorCount++;
 					}
-					else if(GameServer()->m_apPlayers[id]->GetCharacter())
+					else if(GameServer()->m_apPlayers[TranslatedId]->GetCharacter())
 					{
-						vec2 CheckPos = GameServer()->m_apPlayers[id]->GetCharacter()->GetPos();
+						vec2 CheckPos = GameServer()->m_apPlayers[TranslatedId]->GetCharacter()->GetPos();
 						float dx = pPlayer->m_ViewPos.x - CheckPos.x;
 						float dy = pPlayer->m_ViewPos.y - CheckPos.y;
 						if(absolute(dx) < (pPlayer->m_ShowDistance.x / 2.5f) && absolute(dy) < (pPlayer->m_ShowDistance.y / 2.3f))
@@ -460,7 +460,7 @@ void CPlayer::Snap(int SnappingClient)
 		}
 	}
 
-	CNetObj_DDNetPlayer *pDDNetPlayer = Server()->SnapNewItem<CNetObj_DDNetPlayer>(id);
+	CNetObj_DDNetPlayer *pDDNetPlayer = Server()->SnapNewItem<CNetObj_DDNetPlayer>(TranslatedId);
 	if(!pDDNetPlayer)
 		return;
 
@@ -480,7 +480,7 @@ void CPlayer::Snap(int SnappingClient)
 	if(Server()->IsSixup(SnappingClient) && m_pCharacter && m_pCharacter->m_DDRaceState == ERaceState::STARTED &&
 		GameServer()->m_apPlayers[SnappingClient]->m_TimerType == TIMERTYPE_SIXUP)
 	{
-		protocol7::CNetObj_PlayerInfoRace *pRaceInfo = Server()->SnapNewItem<protocol7::CNetObj_PlayerInfoRace>(id);
+		protocol7::CNetObj_PlayerInfoRace *pRaceInfo = Server()->SnapNewItem<protocol7::CNetObj_PlayerInfoRace>(TranslatedId);
 		if(!pRaceInfo)
 			return;
 		pRaceInfo->m_RaceStartTick = m_pCharacter->m_StartTime;
@@ -496,7 +496,7 @@ void CPlayer::Snap(int SnappingClient)
 
 	if(ShowSpec)
 	{
-		CNetObj_SpecChar *pSpecChar = Server()->SnapNewItem<CNetObj_SpecChar>(id);
+		CNetObj_SpecChar *pSpecChar = Server()->SnapNewItem<CNetObj_SpecChar>(TranslatedId);
 		if(!pSpecChar)
 			return;
 

--- a/src/game/server/save.h
+++ b/src/game/server/save.h
@@ -40,8 +40,8 @@ class CSaveTee
 public:
 	CSaveTee();
 	~CSaveTee() = default;
-	void Save(CCharacter *pchr, bool AddPenalty = true);
-	bool Load(CCharacter *pchr, std::optional<int> Team = std::nullopt);
+	void Save(CCharacter *pChr, bool AddPenalty = true);
+	bool Load(CCharacter *pChr, std::optional<int> Team = std::nullopt);
 	char *GetString(const CSaveTeam *pTeam);
 	int FromString(const char *pString);
 	void LoadHookedPlayer(const CSaveTeam *pTeam);

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -352,13 +352,13 @@ void CGameTeams::CheckTeamFinished(int Team)
 			{
 				ChangeTeamState(Team, ETeamState::FINISHED);
 
-				int min = (int)Time / 60;
-				float sec = Time - (min * 60.0f);
+				const int Minutes = (int)Time / 60;
+				const float Seconds = Time - (Minutes * 60.0f);
 
 				char aBuf[256];
 				str_format(aBuf, sizeof(aBuf),
 					"Your team would've finished in: %d minute(s) %5.2f second(s). Since you had practice mode enabled your rank doesn't count.",
-					min, sec);
+					Minutes, Seconds);
 				GameServer()->SendChatTeam(Team, aBuf);
 
 				for(unsigned int i = 0; i < PlayersCount; ++i)

--- a/src/game/server/teehistorian.cpp
+++ b/src/game/server/teehistorian.cpp
@@ -409,12 +409,12 @@ void CTeeHistorian::WriteTick()
 	CTeehistorianPacker TickPacker;
 	TickPacker.Reset();
 
-	int dt = m_Tick - m_LastWrittenTick - 1;
+	const int TickDelta = m_Tick - m_LastWrittenTick - 1;
 	TickPacker.AddInt(-TEEHISTORIAN_TICK_SKIP);
-	TickPacker.AddInt(dt);
+	TickPacker.AddInt(TickDelta);
 	if(m_Debug)
 	{
-		dbg_msg("teehistorian", "skip_ticks dt=%d", dt);
+		dbg_msg("teehistorian", "skip_ticks tick_delta=%d", TickDelta);
 	}
 	Write(TickPacker.Data(), TickPacker.Size());
 

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -47,12 +47,12 @@ static void ClearPixelsTile(uint8_t *pImg, int Width, int Height, int TileIndex)
 {
 	int WTile = Width / 16;
 	int HTile = Height / 16;
-	int xi = (TileIndex % 16) * WTile;
-	int yi = (TileIndex / 16) * HTile;
+	int StartX = (TileIndex % 16) * WTile;
+	int StartY = (TileIndex / 16) * HTile;
 
-	for(int y = yi; y < yi + HTile; ++y)
+	for(int y = StartY; y < StartY + HTile; ++y)
 	{
-		for(int x = xi; x < xi + WTile; ++x)
+		for(int x = StartX; x < StartX + WTile; ++x)
 		{
 			int Index = y * Width * 4 + x * 4;
 			pImg[Index + 0] = 0;
@@ -221,14 +221,14 @@ int main(int argc, const char **argv)
 		bool DeletePtr = false;
 		void *pPtr = Reader.GetData(Index);
 		int Size = Reader.GetDataSize(Index);
-		auto it = std::find_if(vDataFindHelper.begin(), vDataFindHelper.end(), [Index](const SMapOptimizeItem &Other) -> bool { return Other.m_Data == Index || Other.m_Text == Index; });
-		if(it != vDataFindHelper.end())
+		auto MapDataItemIterator = std::find_if(vDataFindHelper.begin(), vDataFindHelper.end(), [Index](const SMapOptimizeItem &Other) -> bool { return Other.m_Data == Index || Other.m_Text == Index; });
+		if(MapDataItemIterator != vDataFindHelper.end())
 		{
-			int Width = it->m_pImage->m_Width;
-			int Height = it->m_pImage->m_Height;
+			int Width = MapDataItemIterator->m_pImage->m_Width;
+			int Height = MapDataItemIterator->m_pImage->m_Height;
 
-			int ImageIndex = it->m_Index;
-			if(it->m_Data == Index)
+			int ImageIndex = MapDataItemIterator->m_Index;
+			if(MapDataItemIterator->m_Data == Index)
 			{
 				DeletePtr = true;
 				// optimize embedded images
@@ -292,11 +292,11 @@ int main(int argc, const char **argv)
 					}
 				}
 			}
-			else if(it->m_Text == Index)
+			else if(MapDataItemIterator->m_Text == Index)
 			{
 				char *pImgName = (char *)pPtr;
-				uint8_t *pImgBuff = (uint8_t *)Reader.GetData(it->m_Data);
-				int ImgSize = Reader.GetDataSize(it->m_Data);
+				uint8_t *pImgBuff = (uint8_t *)Reader.GetData(MapDataItemIterator->m_Data);
+				int ImgSize = Reader.GetDataSize(MapDataItemIterator->m_Data);
 
 				char aSHA256Str[SHA256_MAXSTRSIZE];
 				// This is the important function, that calculates the SHA256 in a special way


### PR DESCRIPTION
Remove most ignored local variable, local constant and parameter names from clang-tidy configuration. The remaining ignored names consist of at most two characters.

More precisely check for type-prefixes followed by camel case instead of only checking for prefixes, which was previously causing any variable name starting with a prefix (e.g. `a`, `p`, `v`) to be ignored entirely.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
