### PR TITLE
Add missing backcompat save success messages

### DIFF
--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -1720,39 +1720,11 @@ bool CScoreWorker::SaveTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 		if(NumInserted == 1)
 		{
 			pResult->m_Status = CScoreSaveResult::SAVE_SUCCESS;
-			if(w == Write::NORMAL)
+			if(w != Write::NORMAL)
 			{
-				pResult->m_aBroadcast[0] = '\0';
 				if(str_comp(pData->m_aServer, g_Config.m_SvSqlServerName) == 0)
 				{
-					str_format(pResult->m_aMessage, sizeof(pResult->m_aMessage),
-						"Team successfully saved by %s. Use '/load %s' to continue",
-						pData->m_aClientName, aCode);
-				}
-				else
-				{
-					str_format(pResult->m_aMessage, sizeof(pResult->m_aMessage),
-						"Team successfully saved by %s. Use '/load %s' on %s to continue",
-						pData->m_aClientName, aCode, pData->m_aServer);
-				}
-			}
-			else
-			{
-				str_copy(pResult->m_aBroadcast,
-					"Database connection failed, teamsave written to a file instead. On official DDNet servers this will automatically be inserted into the database every full hour.",
-					sizeof(pResult->m_aBroadcast));
-				if(str_comp(pData->m_aServer, g_Config.m_SvSqlServerName) == 0)
-				{
-					str_format(pResult->m_aMessage, sizeof(pResult->m_aMessage),
-						"Team successfully saved by %s. The database connection failed, using generated save code instead to avoid collisions. Use '/load %s' to continue",
-						pData->m_aClientName, aCode);
 					pResult->m_aServer[0] = '\0';
-				}
-				else
-				{
-					str_format(pResult->m_aMessage, sizeof(pResult->m_aMessage),
-						"Team successfully saved by %s. The database connection failed, using generated save code instead to avoid collisions. Use '/load %s' on %s to continue",
-						pData->m_aClientName, aCode, pData->m_aServer);
 				}
 				pResult->m_Status = CScoreSaveResult::SAVE_FALLBACKFILE;
 			}


### PR DESCRIPTION
The worker thread would set the messages but the main thread would never send them.
Now the messages are move fully to the main thread to keep it simpler.

Closed #11084

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
