### PR TITLE
Revert skin name normalization

### DIFF
--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -25,11 +25,6 @@ class CSkins : public CComponent
 {
 private:
 	/**
-	 * Maximum length of normalized skin names. Normalization may increase the length.
-	 */
-	static constexpr size_t NORMALIZED_SKIN_NAME_LENGTH = 2 * MAX_SKIN_LENGTH;
-
-	/**
 	 * The data of a skin that can be loaded in a separate thread.
 	 */
 	class CSkinLoadData
@@ -109,14 +104,13 @@ public:
 		};
 
 		CSkinContainer(CSkinContainer &&Other) = default;
-		CSkinContainer(CSkins *pSkins, const char *pName, const char *pNormalizedName, EType Type, int StorageType);
+		CSkinContainer(CSkins *pSkins, const char *pName, EType Type, int StorageType);
 		~CSkinContainer();
 
 		bool operator<(const CSkinContainer &Other) const;
 		CSkinContainer &operator=(CSkinContainer &&Other) = default;
 
 		const char *Name() const { return m_aName; }
-		const char *NormalizedName() const { return m_aNormalizedName; }
 		EType Type() const { return m_Type; }
 		int StorageType() const { return m_StorageType; }
 		bool IsVanilla() const { return m_Vanilla; }
@@ -133,7 +127,6 @@ public:
 	private:
 		CSkins *m_pSkins;
 		char m_aName[MAX_SKIN_LENGTH];
-		char m_aNormalizedName[NORMALIZED_SKIN_NAME_LENGTH];
 		EType m_Type;
 		int m_StorageType;
 		bool m_Vanilla;
@@ -260,8 +253,7 @@ public:
 	static bool IsSpecialSkin(const char *pName);
 
 private:
-	static bool IsVanillaSkinNormalized(const char *pNormalizedName);
-	static bool IsSpecialSkinNormalized(const char *pNormalizedName);
+	static bool IsVanillaSkin(const char *pName);
 
 	/**
 	 * Names of all vanilla and special skins.

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -4372,7 +4372,7 @@ void CGameClient::OnSkinUpdate(const char *pSkinName)
 	const int SkinPrefixLength = str_length(pSkinPrefix);
 	char aSkinNameWithoutPrefix[MAX_SKIN_LENGTH];
 	if(SkinPrefixLength > 0 &&
-		str_utf8_comp_nocase_num(pSkinName, pSkinPrefix, SkinPrefixLength) == 0 &&
+		str_comp_num(pSkinName, pSkinPrefix, SkinPrefixLength) == 0 &&
 		pSkinName[SkinPrefixLength] == '_' &&
 		pSkinName[SkinPrefixLength + 1] != '\0')
 	{
@@ -4383,12 +4383,12 @@ void CGameClient::OnSkinUpdate(const char *pSkinName)
 		aSkinNameWithoutPrefix[0] = '\0';
 	}
 	const auto &&NameMatches = [&](const char *pCheckName) {
-		if(str_utf8_comp_nocase(pCheckName, pSkinName) == 0)
+		if(str_comp(pCheckName, pSkinName) == 0)
 		{
 			return true;
 		}
 		if(aSkinNameWithoutPrefix[0] != '\0' &&
-			str_utf8_comp_nocase(pCheckName, aSkinNameWithoutPrefix) == 0)
+			str_comp(pCheckName, aSkinNameWithoutPrefix) == 0)
 		{
 			return true;
 		}


### PR DESCRIPTION
Fix skins not being loaded and favorite skins not working on case-sensitive file systems, if the name used to load the skin for the first time does not have the same capitalization as the actual file in `downloadedskins`. For example, with `add_favorite_skin bub` in the config file, this would cause the skin loading to use the name `bub`, but the actual name of the skin is `Bub`. On a case-insensitive file system, the client would successfully load the skin from `Bub.png`, but on case-sensitive file systems it would only accept `bub.png`. Either way, the skin download server would also respond with 404 Not Found if `bub.png` is requested instead of `Bub.png`.

Reintroduces that the same skins can be loaded multiple times for different capitalizations on case-insensitive file systems.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
