### PR TITLE
Fix: Hook line not showing player hooking correctly

### DIFF
--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -215,6 +215,7 @@ void CPlayers::RenderHookCollLine(
 
 	// simulate the hook into the future
 	int HookTick;
+	bool HookEnteredTelehook = false;
 	for(HookTick = 0; HookTick < MaxHookTicks; ++HookTick)
 	{
 		int Tele;
@@ -224,7 +225,19 @@ void CPlayers::RenderHookCollLine(
 		// check if a hook would enter retracting state in this tick
 		if(distance(BasePos, SegmentEndPos) > HookLength)
 		{
-			// the line is too long here, and the hook starts to retract, use old position
+			// check if the retracting hook hits a player
+			if(!HookEnteredTelehook)
+			{
+				vec2 RetractingHookEndPos = BasePos + normalize(SegmentEndPos - BasePos) * HookLength;
+				if(GameClient()->IntersectCharacter(SegmentStartPos, RetractingHookEndPos, HitPos, ClientId) != -1)
+				{
+					HookCollColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClHookCollColorTeeColl));
+					vLineSegments.emplace_back(LineStartPos, HitPos);
+					break;
+				}
+			}
+
+			// the line is too long here, and the hook retracts, use old position
 			vLineSegments.emplace_back(LineStartPos, SegmentStartPos);
 			break;
 		}
@@ -233,10 +246,10 @@ void CPlayers::RenderHookCollLine(
 		int Hit = Collision()->IntersectLineTeleHook(SegmentStartPos, SegmentEndPos, &HitPos, nullptr, &Tele);
 
 		// check if we intersect a player
-		if(GameClient()->IntersectCharacter(SegmentStartPos, HitPos, SegmentEndPos, ClientId) != -1)
+		if(GameClient()->IntersectCharacter(SegmentStartPos, SegmentEndPos, HitPos, ClientId) != -1)
 		{
 			HookCollColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClHookCollColorTeeColl));
-			vLineSegments.emplace_back(LineStartPos, SegmentEndPos);
+			vLineSegments.emplace_back(LineStartPos, HitPos);
 			break;
 		}
 
@@ -267,6 +280,7 @@ void CPlayers::RenderHookCollLine(
 
 		// we are hitting TILE_TELEINHOOK
 		vLineSegments.emplace_back(LineStartPos, HitPos);
+		HookEnteredTelehook = true;
 
 		// check tele outs
 		const std::vector<vec2> &vTeleOuts = Collision()->TeleOuts(Tele - 1);


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Fix the hookline not showing player hooks correctly. This happened, because a retracting hook **can still hook a player**, but only, if it didn't go through a telehook. 
A retracting hook can still hook players, but not hit the ground. This makes it so hard to calculate the hookline properly.

This is the related gamecore line:
https://github.com/ddnet/ddnet/blob/5f1193538f2c46927df1649140be70995a0aed59/src/game/gamecore.cpp#L349

`m_NewHook` is false, as long as the hook doesn't enter a hook teleport, allowing for the hook to still attach to the player. The hook enters state RETRACTING as soon as it **overshoots**, but is still allowing for a player hook

## Tests:

The hook can go much closer to a player if it comes out of a hook teleporter:

<img width="2560" height="1440" alt="screenshot_2025-10-19_14-08-31" src="https://github.com/user-attachments/assets/25495092-2085-4ab3-bbca-2ec391ad1cb4" />
<img width="2560" height="1440" alt="screenshot_2025-10-19_14-09-24" src="https://github.com/user-attachments/assets/0bcc5b76-833a-4b01-9f5b-47a2f0cd12be" />
<img width="2560" height="1440" alt="screenshot_2025-10-19_14-09-27" src="https://github.com/user-attachments/assets/ff79e567-43f4-4a63-8234-b2144583fa45" />
<img width="2560" height="1440" alt="screenshot_2025-10-19_14-09-28" src="https://github.com/user-attachments/assets/1a438163-d3c3-47dd-921a-da47d79da264" />

Video:

https://github.com/user-attachments/assets/8c6dcf91-3b72-412d-8bf1-7181ba95b8ba

## More

@def- a new patch was proposed for this by @Jupeyy. I Invite @Robyt3 and @KebsCS to take a second look.

As a followup I plan to calculate the point on the player radius and prevent the hookline from entering the player.

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
