### PR TITLE
Use num teams as max instead of super

### DIFF
--- a/src/game/teamscore.cpp
+++ b/src/game/teamscore.cpp
@@ -22,7 +22,7 @@ int CTeamsCore::Team(int ClientId) const
 
 void CTeamsCore::Team(int ClientId, int Team)
 {
-	dbg_assert(Team >= TEAM_FLOCK && Team <= TEAM_SUPER, "invalid team");
+	dbg_assert(Team >= TEAM_FLOCK && Team < NUM_DDRACE_TEAMS, "invalid team %d", Team);
 	m_aTeam[ClientId] = Team;
 }
 


### PR DESCRIPTION
Requested by @SollyBunny here https://github.com/ddnet/ddnet/pull/10581#discussion_r2347298027

Context:

https://github.com/ddnet/ddnet/blob/364a494d0c5b78272e78c12b8338aeff64f82b2d/src/game/teamscore.h#L7-L13

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
