### PR TITLE
Give loggers names

### DIFF
--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -185,6 +185,7 @@ public:
 	{
 		m_Filter.m_MaxLevel.store(LEVEL_TRACE, std::memory_order_relaxed);
 	}
+	const char *Name() override { return typeid(this).name(); }
 	void Log(const CLogMessage *pMessage) override
 	{
 		if(m_Filter.Filters(pMessage))
@@ -223,6 +224,7 @@ public:
 		m_Close(Close)
 	{
 	}
+	const char *Name() override { return typeid(this).name(); }
 	void Log(const CLogMessage *pMessage) override
 	{
 		if(m_Filter.Filters(pMessage))
@@ -481,6 +483,7 @@ std::unique_ptr<ILogger> log_logger_windows_debugger()
 class CLoggerNoOp : public ILogger
 {
 public:
+	const char *Name() override { return typeid(this).name(); }
 	void Log(const CLogMessage *pMessage) override
 	{
 		// no-op

--- a/src/base/logger.h
+++ b/src/base/logger.h
@@ -81,7 +81,10 @@ public:
 		m_Filter.m_MaxLevel.store(Filter.m_MaxLevel.load(std::memory_order_relaxed), std::memory_order_relaxed);
 		OnFilterChange();
 	}
-
+	/**
+	 * Name of the logger class. Only used for debugging.
+	 */
+	virtual const char *Name() = 0;
 	/**
 	 * Send the specified message to the logging backend.
 	 *
@@ -238,6 +241,7 @@ private:
 	CLock m_PendingLock;
 
 public:
+	const char *Name() override { return typeid(this).name(); }
 	/**
 	 * Replace the `CFutureLogger` instance with the given logger. It'll
 	 * receive all log messages sent to the `CFutureLogger` so far.
@@ -266,6 +270,7 @@ class CMemoryLogger : public ILogger
 	CLock m_MessagesMutex;
 
 public:
+	const char *Name() override { return typeid(this).name(); }
 	void SetParent(ILogger *pParentLogger) { m_pParentLogger = pParentLogger; }
 	void Log(const CLogMessage *pMessage) override REQUIRES(!m_MessagesMutex);
 	std::vector<CLogMessage> Lines() REQUIRES(!m_MessagesMutex);

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -195,6 +195,7 @@ public:
 		m_ClientId(ClientId)
 	{
 	}
+	const char *Name() override { return typeid(this).name(); }
 	void Log(const CLogMessage *pMessage) override;
 };
 

--- a/src/engine/server/server_logger.h
+++ b/src/engine/server/server_logger.h
@@ -15,6 +15,7 @@ class CServerLogger : public ILogger
 
 public:
 	CServerLogger(CServer *pServer);
+	const char *Name() override { return typeid(this).name(); }
 	void Log(const CLogMessage *pMessage) override REQUIRES(!m_PendingLock);
 	// Must be called from the main thread!
 	void OnServerDeletion();

--- a/src/engine/shared/assertion_logger.cpp
+++ b/src/engine/shared/assertion_logger.cpp
@@ -24,6 +24,7 @@ class CAssertionLogger : public ILogger
 
 public:
 	CAssertionLogger(const char *pAssertLogPath, const char *pGameName);
+	const char *Name() override { return typeid(this).name(); }
 	void Log(const CLogMessage *pMessage) override REQUIRES(!m_DbgMessageMutex);
 	void GlobalFinish() override REQUIRES(!m_DbgMessageMutex);
 };

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -41,6 +41,7 @@ public:
 		dbg_assert(pConsole != nullptr, "console pointer must not be null");
 	}
 
+	const char *Name() override { return typeid(this).name(); }
 	void Log(const CLogMessage *pMessage) override REQUIRES(!m_ConsoleMutex);
 	void OnConsoleDeletion() REQUIRES(!m_ConsoleMutex);
 };

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -52,6 +52,7 @@ public:
 		m_pOuterLogger(pOuterLogger)
 	{
 	}
+	const char *Name() override { return typeid(this).name(); }
 	void Log(const CLogMessage *pMessage) override;
 };
 


### PR DESCRIPTION
This can be used for debugging. When we have a ILogger instance we can now ask it for its name to understand which logger is active.

While investigating #11095 I wanted to printf which logger is currently active. So this helped a lot. Could also hardcode strings instead of the compiler dependent C++ class name typeid thing. 

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
