### PR TITLE
Always exit demo player to demo browser

### DIFF
--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -707,6 +707,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	if(Ui()->DoButton_FontIcon(&s_ExitButton, FONT_ICON_XMARK, 0, &Button, BUTTONFLAG_LEFT) || (Input()->KeyPress(KEY_C) && !GameClient()->m_GameConsole.IsActive() && m_DemoPlayerState == DEMOPLAYER_NONE))
 	{
 		Client()->Disconnect();
+		SetMenuPage(PAGE_DEMOS);
 		DemolistOnUpdate(false);
 	}
 	GameClient()->m_Tooltips.DoToolTip(&s_ExitButton, &Button, Localize("Close the demo player"));


### PR DESCRIPTION
The page for the menu page and the in game menu page are sep**e**rate
The demo player will always put you in the normal menu as it disconnects you so uses the menu page (which is always the demo browser)
With the demo browser now accessable in game the demo player exit button will put you in the page you last accessed in menu (most often server list, but using `connect` you can be in others)
This forces that you end up in demo browser

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
