### PR TITLE
Rename "flag" to "country" in serverinfo

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2627,8 +2627,8 @@ void CServer::UpdateRegisterServerInfo()
 	{
 		if(g_Config.m_SvFlag != -1)
 		{
-			JsonWriter.WriteAttribute("flag");
-			JsonWriter.WriteIntValue(g_Config.m_SvFlag);
+			JsonWriter.WriteAttribute("country");
+			JsonWriter.WriteIntValue(g_Config.m_SvFlag); // ISO 3166-1 numeric
 		}
 	}
 


### PR DESCRIPTION
This mirrors the same field for clients. It's technically not always a country, because we also support the EU flag and others.

CC https://github.com/ddnet/ddnet/pull/11038#issuecomment-3394169974

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
