### PR TITLE
Improve message flag documentation, remove unused flag

### DIFF
--- a/src/engine/shared/protocol.h
+++ b/src/engine/shared/protocol.h
@@ -101,11 +101,26 @@ enum
 	MAX_SKIN_LENGTH = 24,
 
 	// message packing
-	MSGFLAG_VITAL = 1 << 0, // guaranteed to be delivered, resent on packet loss
-	MSGFLAG_FLUSH = 1 << 1, // makes the msg be sent immediately, without it it's delayed until the next flush
-	MSGFLAG_NORECORD = 1 << 2, // don't write msg to demo recorders
-	MSGFLAG_RECORD = 1 << 3, // write msg to demo recorders
-	MSGFLAG_NOSEND = 1 << 4 // don't send the msg to client/server, useful combined with MSGFLAG_RECORD to record a msg without sending it
+	/**
+	 * Guaranteed to be delivered, resent on packet loss.
+	 */
+	MSGFLAG_VITAL = 1 << 0,
+	/**
+	 * Makes the message be sent immediately. Without this flag the message will be delayed until the next flush.
+	 */
+	MSGFLAG_FLUSH = 1 << 1,
+	/**
+	 * Don't write message to demo recorders. This flag is server-side only, where sent messages are recorded by default.
+	 */
+	MSGFLAG_NORECORD = 1 << 2,
+	/**
+	 * Write message to demo recorders. This flag is client-side only, where sent messages are not recorded by default.
+	 */
+	MSGFLAG_RECORD = 1 << 3,
+	/**
+	 * Don't send the message to client/server. Useful combined with @link MSGFLAG_RECORD @endlink to record a message without sending it.
+	 */
+	MSGFLAG_NOSEND = 1 << 4,
 };
 
 enum

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4496,7 +4496,7 @@ void CGameContext::OnSnap(int ClientId, bool GlobalSnap)
 		int *pParams = (int *)&m_Tuning;
 		for(unsigned i = 0; i < sizeof(m_Tuning) / sizeof(int); i++)
 			Msg.AddInt(pParams[i]);
-		Server()->SendMsg(&Msg, MSGFLAG_RECORD | MSGFLAG_NOSEND, ClientId);
+		Server()->SendMsg(&Msg, MSGFLAG_NOSEND, ClientId);
 	}
 
 	m_pController->Snap(ClientId);


### PR DESCRIPTION
The flag `MSGFLAG_NORECORD` is only used on the server-side, whereas the flag `MSGFLAG_RECORD` is only used on the client-side.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
