### PR TITLE
Visual: Make hookline stop at other players outline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3074,6 +3074,7 @@ if((GTEST_FOUND OR DOWNLOAD_GTEST) AND SERVER)
     timestamp.cpp
     unix.cpp
     uuid.cpp
+    vmath.cpp
   )
   set(TESTS_EXTRA
     src/engine/client/blocklist_driver.cpp

--- a/src/base/vmath.h
+++ b/src/base/vmath.h
@@ -179,6 +179,42 @@ constexpr bool closest_point_on_line(vector2_base<T> line_pointA, vector2_base<T
 		return false;
 }
 
+constexpr int intersect_line_circle(const vec2 LineStart, const vec2 LineEnd, const vec2 CircleCenter, float Radius, vec2 aIntersections[2])
+{
+	vec2 Delta = LineEnd - LineStart;
+	vec2 Offset = LineStart - CircleCenter;
+
+	// A * Time^2 + B * Time + c == 0
+	float A = length_squared(Delta);
+	float B = 2.0f * dot(Offset, Delta);
+	float C = dot(Offset, Offset) - Radius * Radius;
+
+	float Discriminant = B * B - 4.0f * A * C;
+	if(Discriminant < 0.0f || A == 0.0f)
+	{
+		// no intersection
+		return 0;
+	}
+	else if(Discriminant == 0.0f)
+	{
+		// tangent
+		float Time = -B / (2.0f * A);
+		aIntersections[0] = LineStart + Delta * Time;
+		return 1;
+	}
+	else
+	{
+		Discriminant = std::sqrt(Discriminant);
+		float Time1 = (-B - Discriminant) / (2.0f * A);
+		float Time2 = (-B + Discriminant) / (2.0f * A);
+
+		aIntersections[0] = LineStart + Delta * Time1;
+		aIntersections[1] = LineStart + Delta * Time2;
+
+		return 2;
+	}
+}
+
 // ------------------------------------
 template<Numeric T>
 class vector3_base

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -213,13 +213,32 @@ void CPlayers::RenderHookCollLine(
 
 	const int MaxHookTicks = 5 * Client()->GameTickSpeed(); // calculating above 5 seconds is very expensive and unlikely to happen
 
+	auto AddHookPlayerSegment = [&](const vec2 &StartPos, const vec2 &EndPos, const vec2 &HookablePlayerPosition, const vec2 &HitPos) {
+		HookCollColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClHookCollColorTeeColl));
+
+		// stop hookline at player circle so it looks better
+		vec2 aIntersections[2];
+		int NumIntersections = intersect_line_circle(StartPos, EndPos, HookablePlayerPosition, CCharacterCore::PhysicalSize() * 1.45f / 2.0f, aIntersections);
+		if(NumIntersections == 2)
+		{
+			if(distance(Position, aIntersections[0]) < distance(Position, aIntersections[1]))
+				vLineSegments.emplace_back(StartPos, aIntersections[0]);
+			else
+				vLineSegments.emplace_back(StartPos, aIntersections[1]);
+		}
+		else if(NumIntersections == 1)
+			vLineSegments.emplace_back(StartPos, aIntersections[0]);
+		else
+			vLineSegments.emplace_back(StartPos, HitPos);
+	};
+
 	// simulate the hook into the future
 	int HookTick;
 	bool HookEnteredTelehook = false;
 	for(HookTick = 0; HookTick < MaxHookTicks; ++HookTick)
 	{
 		int Tele;
-		vec2 HitPos;
+		vec2 HitPos, IntersectedPlayerPosition;
 		vec2 SegmentEndPos = SegmentStartPos + QuantizedDirection * HookFireSpeed;
 
 		// check if a hook would enter retracting state in this tick
@@ -229,10 +248,9 @@ void CPlayers::RenderHookCollLine(
 			if(!HookEnteredTelehook)
 			{
 				vec2 RetractingHookEndPos = BasePos + normalize(SegmentEndPos - BasePos) * HookLength;
-				if(GameClient()->IntersectCharacter(SegmentStartPos, RetractingHookEndPos, HitPos, ClientId) != -1)
+				if(GameClient()->IntersectCharacter(SegmentStartPos, RetractingHookEndPos, HitPos, ClientId, &IntersectedPlayerPosition) != -1)
 				{
-					HookCollColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClHookCollColorTeeColl));
-					vLineSegments.emplace_back(LineStartPos, HitPos);
+					AddHookPlayerSegment(LineStartPos, SegmentEndPos, IntersectedPlayerPosition, HitPos);
 					break;
 				}
 			}
@@ -246,10 +264,9 @@ void CPlayers::RenderHookCollLine(
 		int Hit = Collision()->IntersectLineTeleHook(SegmentStartPos, SegmentEndPos, &HitPos, nullptr, &Tele);
 
 		// check if we intersect a player
-		if(GameClient()->IntersectCharacter(SegmentStartPos, HitPos, SegmentEndPos, ClientId) != -1)
+		if(GameClient()->IntersectCharacter(SegmentStartPos, HitPos, SegmentEndPos, ClientId, &IntersectedPlayerPosition) != -1)
 		{
-			HookCollColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClHookCollColorTeeColl));
-			vLineSegments.emplace_back(LineStartPos, SegmentEndPos);
+			AddHookPlayerSegment(LineStartPos, HitPos, IntersectedPlayerPosition, SegmentEndPos);
 			break;
 		}
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -3164,7 +3164,7 @@ IGameClient *CreateGameClient()
 	return new CGameClient();
 }
 
-int CGameClient::IntersectCharacter(vec2 HookPos, vec2 NewPos, vec2 &NewPos2, int OwnId)
+int CGameClient::IntersectCharacter(vec2 HookPos, vec2 NewPos, vec2 &NewPos2, int OwnId, vec2 *pPlayerPosition)
 {
 	float Distance = 0.0f;
 	int ClosestId = -1;
@@ -3202,6 +3202,8 @@ int CGameClient::IntersectCharacter(vec2 HookPos, vec2 NewPos, vec2 &NewPos2, in
 					NewPos2 = ClosestPoint;
 					ClosestId = i;
 					Distance = distance(HookPos, Position);
+					if(pPlayerPosition)
+						*pPlayerPosition = Position;
 				}
 			}
 		}

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -658,7 +658,7 @@ public:
 
 	class CTeamsCore m_Teams;
 
-	int IntersectCharacter(vec2 HookPos, vec2 NewPos, vec2 &NewPos2, int OwnId);
+	int IntersectCharacter(vec2 HookPos, vec2 NewPos, vec2 &NewPos2, int OwnId, vec2 *pPlayerPosition = nullptr);
 
 	int LastRaceTick() const;
 	int CurrentRaceTime() const;

--- a/src/test/vmath.cpp
+++ b/src/test/vmath.cpp
@@ -1,0 +1,64 @@
+#include "test.h"
+
+#include <base/vmath.h>
+
+#include <gtest/gtest.h>
+
+TEST(VMath, IntersectLineCircleMiss)
+{
+	vec2 Start(0, 0);
+	vec2 End(0, 1);
+	vec2 Circle(2, 0);
+	float Radius = 1.0f;
+
+	vec2 aIntersections[2];
+	int Size = intersect_line_circle(Start, End, Circle, Radius, aIntersections);
+	EXPECT_EQ(Size, 0);
+}
+
+TEST(VMath, IntersectLineCircleTangent)
+{
+	vec2 Start(0, 0);
+	vec2 End(0, 1);
+	vec2 Circle(1, 0);
+	float Radius = 1.0f;
+
+	vec2 aIntersections[2];
+	int Size = intersect_line_circle(Start, End, Circle, Radius, aIntersections);
+	EXPECT_EQ(Size, 1);
+	EXPECT_EQ(aIntersections[0], Start);
+}
+
+TEST(VMath, IntersectLineCircleMultipleIntersections)
+{
+	vec2 Start(0, 0);
+	vec2 End(0, 1);
+	vec2 Circle(0, 0);
+	float Radius = 1.0f;
+
+	vec2 aIntersections[2];
+	int Size = intersect_line_circle(Start, End, Circle, Radius, aIntersections);
+	EXPECT_EQ(Size, 2);
+	EXPECT_EQ(aIntersections[0], -End);
+	EXPECT_EQ(aIntersections[1], End);
+}
+
+TEST(VMath, IntersectLineCircleMultipleIntersectionsOutsideOfLineSegment)
+{
+	vec2 Start(1, 0);
+	vec2 End(1, 1);
+	vec2 Circle(1, 10);
+	float Radius = 1.0f;
+
+	vec2 aIntersections[2];
+	int Size = intersect_line_circle(Start, End, Circle, Radius, aIntersections);
+	EXPECT_EQ(Size, 2);
+	EXPECT_EQ(aIntersections[0], vec2(1, 9));
+	EXPECT_EQ(aIntersections[1], vec2(1, 11));
+
+	vec2 Circle2(1, -10);
+	int Size2 = intersect_line_circle(Start, End, Circle2, Radius, aIntersections);
+	EXPECT_EQ(Size2, 2);
+	EXPECT_EQ(aIntersections[0], vec2(1, -11));
+	EXPECT_EQ(aIntersections[1], vec2(1, -9));
+}


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Previously the hook line was stopping at some random mathematical point, which is the closest point on the line between it and the player position. This however causes it to enter and overdraw the player you want to hook. I find this annoying and ugly. Therefore I propose stopping the hook line before the player "enters" the skin.

This feature is purely visual (as the hookline is also just a purely visual feature).

Previous:

Uploading test-hook-line_2025-10-19_14-17-28.mp4…

Now:

https://github.com/user-attachments/assets/32f5eda5-eef6-424c-9ba1-2ced38444125

@Robyt3 this code contains a generic `Circle<-->(infinite)Line` intersection code, I don't know where to move it

## Checklist

- [x] Tested the change ingame
- [x] Provided ~~screenshots~~ video if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
