### PR TITLE
Improve moving client window between screens

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1605,11 +1605,13 @@ void CGraphicsBackend_SDL_GL::Maximize()
 
 void CGraphicsBackend_SDL_GL::SetWindowParams(int FullscreenMode, bool IsBorderless)
 {
+	// The flags have to be kept consistent with flags set in the CGraphics_Threaded::IssueInit function!
+
 	if(FullscreenMode > 0)
 	{
 		bool IsDesktopFullscreen = FullscreenMode == 2;
 #ifndef CONF_FAMILY_WINDOWS
-		//  special mode for windows only
+		//  Windowed fullscreen is only available on Windows, use desktop fullscreen on other platforms
 		IsDesktopFullscreen |= FullscreenMode == 3;
 #endif
 		if(FullscreenMode == 1)
@@ -1627,10 +1629,10 @@ void CGraphicsBackend_SDL_GL::SetWindowParams(int FullscreenMode, bool IsBorderl
 			SDL_SetWindowFullscreen(m_pWindow, SDL_WINDOW_FULLSCREEN_DESKTOP);
 			SDL_SetWindowResizable(m_pWindow, SDL_FALSE);
 		}
-		else
+		else // Windowed fullscreen
 		{
 			SDL_SetWindowFullscreen(m_pWindow, 0);
-			SDL_SetWindowBordered(m_pWindow, SDL_TRUE);
+			SDL_SetWindowBordered(m_pWindow, SDL_FALSE);
 			SDL_SetWindowResizable(m_pWindow, SDL_FALSE);
 			SDL_DisplayMode DpMode;
 			if(SDL_GetDesktopDisplayMode(g_Config.m_GfxScreen, &DpMode) < 0)
@@ -1644,7 +1646,7 @@ void CGraphicsBackend_SDL_GL::SetWindowParams(int FullscreenMode, bool IsBorderl
 			}
 		}
 	}
-	else
+	else // Windowed
 	{
 		SDL_SetWindowFullscreen(m_pWindow, 0);
 		SDL_SetWindowBordered(m_pWindow, SDL_bool(!IsBorderless));
@@ -1652,24 +1654,33 @@ void CGraphicsBackend_SDL_GL::SetWindowParams(int FullscreenMode, bool IsBorderl
 	}
 }
 
-bool CGraphicsBackend_SDL_GL::SetWindowScreen(int Index)
+bool CGraphicsBackend_SDL_GL::SetWindowScreen(int Index, bool MoveToCenter)
 {
 	if(Index < 0 || Index >= m_NumScreens)
 	{
+		log_error("gfx", "Invalid screen number: %d (min: 0, max: %d)", Index, m_NumScreens);
 		return false;
 	}
 
 	SDL_Rect ScreenPos;
 	if(SDL_GetDisplayBounds(Index, &ScreenPos) != 0)
 	{
+		log_error("gfx", "Unable to get bounds of screen %d: %s", Index, SDL_GetError());
 		return false;
 	}
-	// Todo SDL: remove this when fixed (changing screen when in fullscreen is bugged)
-	SDL_SetWindowBordered(m_pWindow, SDL_TRUE); //fixing primary monitor goes black when switch screen (borderless OpenGL)
 
-	SDL_SetWindowPosition(m_pWindow,
-		SDL_WINDOWPOS_CENTERED_DISPLAY(Index),
-		SDL_WINDOWPOS_CENTERED_DISPLAY(Index));
+	if(MoveToCenter)
+	{
+		SDL_SetWindowPosition(m_pWindow,
+			SDL_WINDOWPOS_CENTERED_DISPLAY(Index),
+			SDL_WINDOWPOS_CENTERED_DISPLAY(Index));
+	}
+	else
+	{
+		SDL_SetWindowPosition(m_pWindow,
+			SDL_WINDOWPOS_UNDEFINED_DISPLAY(Index),
+			SDL_WINDOWPOS_UNDEFINED_DISPLAY(Index));
+	}
 
 	return UpdateDisplayMode(Index);
 }

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -249,7 +249,7 @@ public:
 	void Minimize() override;
 	void Maximize() override;
 	void SetWindowParams(int FullscreenMode, bool IsBorderless) override;
-	bool SetWindowScreen(int Index) override;
+	bool SetWindowScreen(int Index, bool MoveToCenter) override;
 	bool UpdateDisplayMode(int Index) override;
 	int GetWindowScreen() override;
 	int WindowActive() override;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4275,7 +4275,7 @@ void CClient::ConchainWindowScreen(IConsole::IResult *pResult, void *pUserData, 
 	if(pSelf->Graphics() && pResult->NumArguments())
 	{
 		if(g_Config.m_GfxScreen != pResult->GetInteger(0))
-			pSelf->Graphics()->SwitchWindowScreen(pResult->GetInteger(0));
+			pSelf->Graphics()->SwitchWindowScreen(pResult->GetInteger(0), true);
 	}
 	else
 		pfnCallback(pResult, pCallbackUserData);

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -689,7 +689,7 @@ public:
 	virtual void Minimize() = 0;
 	virtual void Maximize() = 0;
 	virtual void SetWindowParams(int FullscreenMode, bool IsBorderless) = 0;
-	virtual bool SetWindowScreen(int Index) = 0;
+	virtual bool SetWindowScreen(int Index, bool MoveToCenter) = 0;
 	virtual bool UpdateDisplayMode(int Index) = 0;
 	virtual int GetWindowScreen() = 0;
 	virtual int WindowActive() = 0;
@@ -1207,8 +1207,8 @@ public:
 	void Maximize() override;
 	void WarnPngliteIncompatibleImages(bool Warn) override;
 	void SetWindowParams(int FullscreenMode, bool IsBorderless) override;
-	bool SetWindowScreen(int Index) override;
-	bool SwitchWindowScreen(int Index) override;
+	bool SetWindowScreen(int Index, bool MoveToCenter) override;
+	bool SwitchWindowScreen(int Index, bool MoveToCenter) override;
 	void Move(int x, int y) override;
 	bool Resize(int w, int h, int RefreshRate) override;
 	void ResizeToScreen() override;

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -793,6 +793,11 @@ int CInput::Update()
 			// shortcuts
 			switch(Event.window.event)
 			{
+#if SDL_VERSION_ATLEAST(2, 0, 18)
+			case SDL_WINDOWEVENT_DISPLAY_CHANGED:
+				Graphics()->SwitchWindowScreen(Event.display.data1, false);
+				break;
+#endif
 			case SDL_WINDOWEVENT_MOVED:
 				Graphics()->Move(Event.window.data1, Event.window.data2);
 				break;

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -228,8 +228,8 @@ public:
 
 	virtual void WarnPngliteIncompatibleImages(bool Warn) = 0;
 	virtual void SetWindowParams(int FullscreenMode, bool IsBorderless) = 0;
-	virtual bool SetWindowScreen(int Index) = 0;
-	virtual bool SwitchWindowScreen(int Index) = 0;
+	virtual bool SetWindowScreen(int Index, bool MoveToCenter) = 0;
+	virtual bool SwitchWindowScreen(int Index, bool MoveToCenter) = 0;
 	virtual bool SetVSync(bool State) = 0;
 	virtual bool SetMultiSampling(uint32_t ReqMultiSamplingCount, uint32_t &MultiSamplingCountBackend) = 0;
 	virtual int GetWindowScreen() = 0;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -975,7 +975,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 		s_ScreenDropDownState.m_SelectionPopupContext.m_pScrollRegion = &s_ScreenDropDownScrollRegion;
 		const int NewScreen = Ui()->DoDropDown(&ScreenDropDown, g_Config.m_GfxScreen, s_vpScreenNames.data(), s_vpScreenNames.size(), s_ScreenDropDownState);
 		if(NewScreen != g_Config.m_GfxScreen)
-			Graphics()->SwitchWindowScreen(NewScreen);
+			Graphics()->SwitchWindowScreen(NewScreen, true);
 	}
 
 	MainView.HSplitTop(2.0f, nullptr, &MainView);


### PR DESCRIPTION
Support moving the client window between screens using the window manager, e.g. with Windows+Shift+Left/Right on Windows, by handling `SDL_WINDOWEVENT_DISPLAY_CHANGED`. On Windows 10, this works in all fullscreen modes except in windowed mode when in the special state where the window is using the entire screen size without the decoration/border being shown, which e.g. happens when switching to windowed fullscreen and then back to windowed mode.

Do not resize the window to the screen size when changing the screen in windowed mode, because windowed mode is supposed to use the user-defined size of the window and the window manager may resize the window automatically when moving it between screens.

Remove obsolete SDL TODO/workaround for setting the window to bordered when changing the screen, which does not appear to be necessary for any fullscreen mode. Instead, consistently set the borderless flag for all fullscreen modes in both the `CGraphics_Threaded::IssueInit` and `CGraphicsBackend_SDL_GL::SetWindowParams` functions to avoid discrepancy in window behavior between initial launch of client and after changing the fullscreen mode.

Add more error messages to `CGraphicsBackend_SDL_GL::SetWindowScreen` function when the screen could not be changed.

Closes #8191.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options:
    - Graphics backends: Vulkan, OpenGL 3, OpenGL 1
    - OS: Windows 10
    - Fullscreen modes: all
    - Client states: first launch with each fullscreen mode, after changing to each fullscreen mode in settings
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
