### PR TITLE
Fix server crashes in PickupType_SixToSeven

### DIFF
--- a/src/engine/shared/protocolglue.cpp
+++ b/src/engine/shared/protocolglue.cpp
@@ -119,17 +119,24 @@ int PickupType_SixToSeven(int Type6, int SubType6)
 	case POWERUP_WEAPON:
 		switch(SubType6)
 		{
+		case WEAPON_HAMMER: return protocol7::PICKUP_HAMMER;
+		case WEAPON_GUN: return protocol7::PICKUP_GUN;
 		case WEAPON_SHOTGUN: return protocol7::PICKUP_SHOTGUN;
 		case WEAPON_GRENADE: return protocol7::PICKUP_GRENADE;
 		case WEAPON_LASER: return protocol7::PICKUP_LASER;
-		case WEAPON_GUN: return protocol7::PICKUP_GUN;
-		case WEAPON_HAMMER: return protocol7::PICKUP_HAMMER;
+		case WEAPON_NINJA: return protocol7::PICKUP_NINJA;
 		default:
 			dbg_assert(false, "invalid subtype %d", SubType6);
 			dbg_break();
 		}
 	case POWERUP_NINJA: return protocol7::PICKUP_NINJA;
-	case POWERUP_ARMOR: return protocol7::PICKUP_ARMOR;
+	case POWERUP_HEALTH: return protocol7::PICKUP_HEALTH;
+	case POWERUP_ARMOR:
+	case POWERUP_ARMOR_SHOTGUN:
+	case POWERUP_ARMOR_GRENADE:
+	case POWERUP_ARMOR_NINJA:
+	case POWERUP_ARMOR_LASER:
+		return protocol7::PICKUP_ARMOR;
 	default:
 		dbg_assert(false, "invalid type %d", Type6);
 		dbg_break();


### PR DESCRIPTION
Introduced in https://github.com/ddnet/ddnet/pull/11097

Steps to reproduce:

1. Load a map with a health pickup, or DDrace shields
2. Connect to server with 0.7 (`connect tw-0.7+udp://127.0.0.1`)
3. Crash.

Is stuff even tested before getting merged, this seems like an obvious bug

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
