### PR TITLE
Allow changing game type to "Block"

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -262,7 +262,7 @@ MACRO_CONFIG_INT(ClSkipStartMenu, cl_skip_start_menu, 0, 0, 1, CFGFLAG_CLIENT | 
 // server
 MACRO_CONFIG_INT(SvWarmup, sv_warmup, 0, 0, 0, CFGFLAG_SERVER, "Number of seconds to do warmup before round starts")
 MACRO_CONFIG_STR(SvMotd, sv_motd, 900, "", CFGFLAG_SERVER, "Message of the day to display for the clients")
-MACRO_CONFIG_STR(SvGametype, sv_gametype, 32, "ddnet", CFGFLAG_SERVER, "Game type (ddnet, mod)")
+MACRO_CONFIG_STR(SvGametype, sv_gametype, 32, "ddnet", CFGFLAG_SERVER, "Game type (ddnet, block, mod)")
 MACRO_CONFIG_INT(SvTournamentMode, sv_tournament_mode, 0, 0, 1, CFGFLAG_SERVER, "Tournament mode. When enabled, players joins the server as spectator")
 MACRO_CONFIG_INT(SvSpamprotection, sv_spamprotection, 1, 0, 1, CFGFLAG_SERVER, "Spam protection for: team change, chat, skin change, emotes and votes")
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4079,10 +4079,15 @@ void CGameContext::OnInit(const void *pPersistentData)
 		}
 	}
 
-	if(!str_comp(Config()->m_SvGametype, "mod"))
+	if(str_comp(Config()->m_SvGametype, "mod") == 0)
+	{
 		m_pController = new CGameControllerMod(this);
+	}
 	else
-		m_pController = new CGameControllerDDRace(this);
+	{
+		bool Block = str_comp(Config()->m_SvGametype, "block") == 0;
+		m_pController = new CGameControllerDDRace(this, Block);
+	}
 
 	ReadCensorList();
 

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -15,10 +15,17 @@
 #define GAME_TYPE_NAME "DDraceNetwork"
 #define TEST_TYPE_NAME "TestDDraceNetwork"
 
-CGameControllerDDRace::CGameControllerDDRace(class CGameContext *pGameServer) :
+CGameControllerDDRace::CGameControllerDDRace(class CGameContext *pGameServer, bool Block) :
 	IGameController(pGameServer)
 {
-	m_pGameType = g_Config.m_SvTestingCommands ? TEST_TYPE_NAME : GAME_TYPE_NAME;
+	if(!Block)
+	{
+		m_pGameType = g_Config.m_SvTestingCommands ? TEST_TYPE_NAME : GAME_TYPE_NAME;
+	}
+	else
+	{
+		m_pGameType = g_Config.m_SvTestingCommands ? "TestBlock" : "Block";
+	}
 	m_GameFlags = protocol7::GAMEFLAG_RACE;
 }
 

--- a/src/game/server/gamemodes/DDRace.h
+++ b/src/game/server/gamemodes/DDRace.h
@@ -7,7 +7,7 @@
 class CGameControllerDDRace : public IGameController
 {
 public:
-	CGameControllerDDRace(class CGameContext *pGameServer);
+	CGameControllerDDRace(class CGameContext *pGameServer, bool Block);
 	~CGameControllerDDRace() override;
 
 	CScore *Score();


### PR DESCRIPTION
I think the "Game Type" column should give an indication of what kind of gameplay I can expect from a server. Both racing and blocking currently share the game type "DDraceNetwork". I'm adding an option to change that to "Block" for block servers.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
