### PR TITLE
Feature: Add hundreths to scoreboard and hud

### DIFF
--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -345,8 +345,19 @@ void CHud::RenderScoreHud()
 						str_time((int64_t)absolute(apPlayerInfo[t]->m_Score) / 10, TIME_MINS_CENTISECS, aScore[t], sizeof(aScore[t]));
 					else if(GameClient()->m_GameInfo.m_TimeScore)
 					{
-						if(apPlayerInfo[t]->m_Score != FinishTime::NOT_FINISHED_TIMESCORE)
+						CGameClient::CClientData &ClientData = GameClient()->m_aClients[apPlayerInfo[t]->m_ClientId];
+						if(GameClient()->m_ReceivedDDNetPlayerFinishTimes && ClientData.m_FinishTimeSeconds != FinishTime::NOT_FINISHED_MILLIS)
+						{
+							int64_t TimeSeconds = static_cast<int64_t>(absolute(ClientData.m_FinishTimeSeconds));
+							int64_t TimeMillis = TimeSeconds * 1000 + (absolute(ClientData.m_FinishTimeMillis) % 1000);
+
+							// show centiseconds if we are under an hour
+							str_time(TimeMillis / 10, TimeSeconds < 60 * 60 ? TIME_MINS_CENTISECS : TIME_HOURS, aScore[t], sizeof(aScore[t]));
+						}
+						else if(apPlayerInfo[t]->m_Score != FinishTime::NOT_FINISHED_TIMESCORE)
+						{
 							str_time((int64_t)absolute(apPlayerInfo[t]->m_Score) * 100, TIME_HOURS, aScore[t], sizeof(aScore[t]));
+						}
 						else
 							aScore[t][0] = 0;
 					}

--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -22,7 +22,9 @@ class CScoreboard : public CComponent
 			m_TeamStartX(0), m_TeamStartY(0), m_CurrentDDTeamSize(0) {}
 	};
 
-	void RenderTitle(CUIRect TitleBar, int Team, const char *pTitle);
+	void RenderTitleScore(CUIRect ScoreLabel, int Team, float TitleFontSize);
+	void RenderTitle(CUIRect TitleLabel, int Team, const char *pTitle, float TitleFontSize);
+	void RenderTitleBar(CUIRect TitleBar, int Team, const char *pTitle);
 	void RenderGoals(CUIRect Goals);
 	void RenderSpectators(CUIRect Spectators);
 	void RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart, int CountEnd, CScoreboardRenderState &State);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -674,6 +674,7 @@ void CGameClient::OnReset()
 	m_DummyFire = 0;
 	m_ReceivedDDNetPlayer = false;
 	m_ReceivedDDNetPlayerFinishTimes = false;
+	m_ReceivedDDNetPlayerFinishTimesMillis = false;
 
 	m_Teams.Reset();
 	m_GameWorld.Clear();
@@ -1669,6 +1670,7 @@ void CGameClient::OnNewSnapshot()
 	bool FoundGameInfoEx = false;
 	bool GotSwitchStateTeam = false;
 	bool HasUnsetDDNetFinishTimes = false;
+	bool HasTrueMillisecondFinishTimes = false;
 	m_aSwitchStateTeam[g_Config.m_ClDummy] = -1;
 
 	for(auto &Client : m_aClients)
@@ -1763,6 +1765,8 @@ void CGameClient::OnNewSnapshot()
 
 					if(m_aClients[Item.m_Id].m_FinishTimeSeconds == FinishTime::UNSET)
 						HasUnsetDDNetFinishTimes = true;
+					else if(m_aClients[Item.m_Id].m_FinishTimeMillis % 10 != 0)
+						HasTrueMillisecondFinishTimes = true;
 
 					if(Item.m_Id == m_Snap.m_LocalClientId && (m_aClients[Item.m_Id].m_Paused || m_aClients[Item.m_Id].m_Spec))
 					{
@@ -2085,6 +2089,7 @@ void CGameClient::OnNewSnapshot()
 
 	// check if we received all finish times
 	m_ReceivedDDNetPlayerFinishTimes = m_ReceivedDDNetPlayer && !HasUnsetDDNetFinishTimes;
+	m_ReceivedDDNetPlayerFinishTimesMillis = m_ReceivedDDNetPlayer && HasTrueMillisecondFinishTimes;
 
 	// sort player infos by name
 	mem_copy(m_Snap.m_apInfoByName, m_Snap.m_apPlayerInfos, sizeof(m_Snap.m_apInfoByName));

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -666,6 +666,7 @@ public:
 	unsigned int m_DummyFire;
 	bool m_ReceivedDDNetPlayer;
 	bool m_ReceivedDDNetPlayerFinishTimes;
+	bool m_ReceivedDDNetPlayerFinishTimesMillis;
 
 	class CTeamsCore m_Teams;
 

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -671,6 +671,9 @@ public:
 	// progress bar
 	void RenderProgressBar(CUIRect ProgressBar, float Progress);
 
+	// render time with hundredths or thousands aligned to the right of the UIRect
+	void RenderTime(CUIRect TimeRect, float FontSize, int Seconds, bool NotFinished, int Millis, bool TrueMilliseconds) const;
+
 	// progress spinner
 	void RenderProgressSpinner(vec2 Center, float OuterRadius, const SProgressSpinnerProperties &Props = {}) const;
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Players don't stop hunting for if they reached the best possible second. We have a lot of maps, which are short enough that they're hunted to the centisecond and I always found it odd, that we are not displaying more precise times, if the server is collecting them. We need to manually check with `/rank x` in order to see which more precise time a player has, which also causes additional load on the database.

This PR allows a servers to send times in milliseconds and allows for the player scoreboard to show centiseconds. Due to scoreboard size limitations, a centisecond time is only displayed if your time is under an hour. If it's longer, it will automatically switch representation. DDNet itself doesn't support centisecond times, but other servers might, so this is only limiting the scoreboard, but not the netcode.

- With a gameflag this is fully backwards compatible. You can still play on older servers and have the time displayed the usual way.
- Fixes a bug, where the time returned by a server is off by 1 second if your time is exactly 9999 seconds.
- Does not affect sixup at all

### Screenshots

New Client: correct sorting, hundreths in the scoreboard and ranks up to an hour

<img width="2560" height="1440" alt="screenshot_2025-10-30_16-49-46" src="https://github.com/user-attachments/assets/71a8fcae-3be5-4867-9667-f4444016f3b9" />

New Client on old server: displays the time as before

<img width="2560" height="1440" alt="screenshot_2025-10-28_16-39-10" src="https://github.com/user-attachments/assets/d2040c9c-c63c-4a0a-a022-528bc9b618b5" />

Old Client: Still displays time as usual, as the server knows it's an old client

<img width="2560" height="1440" alt="screenshot_2025-10-28_15-50-22" src="https://github.com/user-attachments/assets/18c1f872-6138-49b1-ac4e-1a2bba221870" />

@Robyt3 suggested adding a new NetMessage instead. I need some help/guidance doing it like this

Alternative: If you find this times too hard to read if you have both combined, we can also precalculate which representation we choose for the hole server based on the worst time. On the other side you'll have < 1 hour and > 1 hour times grouped together

### Related issues

closes #8223, #11137

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
