### PR TITLE
Disable clang readability-use-concise-preprocessor-directives

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -102,6 +102,7 @@ Checks: >
   -readability-simplify-boolean-expr,
   -readability-suspicious-call-argument,
   -readability-uppercase-literal-suffix,
+  -readability-use-concise-preprocessor-directives,
   -readability-use-std-min-max,
   performance-*,
   -performance-enum-size,


### PR DESCRIPTION
Ignores those clang tidy offenses:

```
src/base/types.h:99:2: warning: preprocessor condition can be written more concisely using '#ifdef' [readability-use-concise-preprocessor-directives]
   99 | #if defined(CONF_FAMILY_WINDOWS)
      |  ^~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |  ifdef CONF_FAMILY_WINDOWS
```

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
