### PR TITLE
Fix preinputs

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1925,7 +1925,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 						if(!aPreInputClients[Id])
 							continue;
 
-						SendPackMsg(&PreInput, MSGFLAG_FLUSH | MSGFLAG_NORECORD, Id);
+						SendPackMsg(&PreInput, MSGFLAG_VITAL | MSGFLAG_NORECORD, Id);
 					}
 				}
 			}


### PR DESCRIPTION
Wanted to show preinputs to a friend, they didn't work on any server but my own.
Ended up broken 2 days after pr was merged by https://github.com/ddnet/ddnet/commit/3d2c19238ba6dfd42b09e621d4972ec1354a3b73

SendPackMsg(&PreInput, MSGFLAG_VITAL | MSGFLAG_NORECORD, Id);

I replaced MSGFLAG_FLUSH with MSGFLAG_VITAL, seems without MSGFLAG_VITAL it doesn't send the messages at all.
Can't find any instance of SendPackMsg not using MSGFLAG_VITAL that isn't MSGFLAG_NOSEND
Not sure if thats intended behaviour

## Checklist

- [X] Tested the change ingame