### PR TITLE
Refactor: Generalize render layer clipping

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -508,6 +508,7 @@ MACRO_CONFIG_INT(DbgGfx, dbg_gfx, 0, 0, 4, CFGFLAG_CLIENT, "Show graphic library
 MACRO_CONFIG_INT(DbgRenderGroupClips, dbg_render_group_clips, 0, 0, 1, CFGFLAG_CLIENT, "Debug group clipping")
 MACRO_CONFIG_INT(DbgRenderQuadClips, dbg_render_quad_clips, 0, 0, 1, CFGFLAG_CLIENT, "Debug quad layer clipping")
 MACRO_CONFIG_INT(DbgRenderClusterClips, dbg_render_cluster_clips, 0, 0, 1, CFGFLAG_CLIENT, "Debug quad layer cluster clipping")
+MACRO_CONFIG_INT(DbgRenderTileClips, dbg_render_tile_clips, 0, 0, 1, CFGFLAG_CLIENT, "Debug tile layer clipping")
 #ifdef CONF_DEBUG
 MACRO_CONFIG_INT(DbgStress, dbg_stress, 0, 0, 1, CFGFLAG_CLIENT, "Stress systems (Debug build only)")
 MACRO_CONFIG_STR(DbgStressServer, dbg_stress_server, 32, "localhost", CFGFLAG_CLIENT, "Server to stress (Debug build only)")

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -110,6 +110,7 @@ void CMapLayers::OnRender()
 	m_Params.m_DebugRenderGroupClips = g_Config.m_DbgRenderGroupClips;
 	m_Params.m_DebugRenderQuadClips = g_Config.m_DbgRenderQuadClips;
 	m_Params.m_DebugRenderClusterClips = g_Config.m_DbgRenderClusterClips;
+	m_Params.m_DebugRenderTileClips = g_Config.m_DbgRenderTileClips;
 
 	m_MapRenderer.Render(m_Params);
 }

--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -178,9 +178,9 @@ bool CRenderLayerTile::CTileLayerVisuals::Init(unsigned int Width, unsigned int 
 	return true;
 }
 
-/*************
-* Base Layer *
-**************/
+/**************
+ * Base Layer *
+ **************/
 
 CRenderLayer::CRenderLayer(int GroupId, int LayerId, int Flags) :
 	m_GroupId(GroupId), m_LayerId(LayerId), m_Flags(Flags) {}
@@ -208,6 +208,22 @@ void CRenderLayer::RenderLoading() const
 	const char *pLoadingMessage = Localize("Uploading map data to GPU");
 	if(m_RenderUploadCallback.has_value())
 		(*m_RenderUploadCallback)(pLoadingTitle, pLoadingMessage, 0);
+}
+
+bool CRenderLayer::IsVisibleInClipRegion(const std::optional<CClipRegion> &ClipRegion) const
+{
+	// always show unclipped regions
+	if(!ClipRegion.has_value())
+		return true;
+
+	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
+	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	float Left = ClipRegion->m_X;
+	float Top = ClipRegion->m_Y;
+	float Right = ClipRegion->m_X + ClipRegion->m_Width;
+	float Bottom = ClipRegion->m_Y + ClipRegion->m_Height;
+
+	return Right >= ScreenX0 && Left <= ScreenX1 && Bottom >= ScreenY0 && Top <= ScreenY1;
 }
 
 /**************
@@ -295,7 +311,7 @@ void CRenderLayerTile::RenderTileLayer(const ColorRGBA &Color, const CRenderLaye
 	int ScreenRectY1 = std::ceil(ScreenY1 / 32);
 	int ScreenRectX1 = std::ceil(ScreenX1 / 32);
 
-	if(ScreenRectX1 > 0 && ScreenRectY1 > 0 && ScreenRectX0 < (int)Visuals.m_Width && ScreenRectY0 < (int)Visuals.m_Height)
+	if(IsVisibleInClipRegion(m_LayerClip))
 	{
 		// create the indice buffers we want to draw -- reuse them
 		std::vector<char *> vpIndexOffsets;
@@ -338,6 +354,14 @@ void CRenderLayerTile::RenderTileLayer(const ColorRGBA &Color, const CRenderLaye
 	if(Params.m_RenderTileBorder && (ScreenRectX1 > (int)Visuals.m_Width || ScreenRectY1 > (int)Visuals.m_Height || ScreenRectX0 < 0 || ScreenRectY0 < 0))
 	{
 		RenderTileBorder(Color, ScreenRectX0, ScreenRectY0, ScreenRectX1, ScreenRectY1, &Visuals);
+	}
+
+	if(Params.m_DebugRenderTileClips && m_LayerClip.has_value())
+	{
+		const CClipRegion &Clip = m_LayerClip.value();
+		char aDebugText[32];
+		str_format(aDebugText, sizeof(aDebugText), "Group %d LayerId %d", m_GroupId, m_LayerId);
+		RenderMap()->RenderDebugClip(Clip.m_X, Clip.m_Y, Clip.m_Width, Clip.m_Height, ColorRGBA(1.0f, 0.5f, 0.0f, 1.0f), Params.m_Zoom, aDebugText);
 	}
 }
 
@@ -827,6 +851,7 @@ void CRenderLayerTile::OnInit(IGraphics *pGraphics, ITextRender *pTextRender, CR
 {
 	CRenderLayer::OnInit(pGraphics, pTextRender, pRenderMap, pEnvelopeManager, pMap, pMapImages, FRenderUploadCallbackOptional);
 	InitTileData();
+	m_LayerClip = CClipRegion(0.0f, 0.0f, m_pLayerTilemap->m_Width * 32.0f, m_pLayerTilemap->m_Height * 32.0f);
 }
 
 void CRenderLayerTile::InitTileData()
@@ -1287,22 +1312,6 @@ void CRenderLayerQuads::Render(const CRenderLayerParams &Params)
 		str_format(aDebugText, sizeof(aDebugText), "Group %d, quad layer %d", m_GroupId, m_LayerId);
 		RenderMap()->RenderDebugClip(m_LayerClip->m_X, m_LayerClip->m_Y, m_LayerClip->m_Width, m_LayerClip->m_Height, ColorRGBA(1.0f, 0.0f, 0.5f, 1.0f), Params.m_Zoom, aDebugText);
 	}
-}
-
-bool CRenderLayerQuads::IsVisibleInClipRegion(const std::optional<CClipRegion> &ClipRegion) const
-{
-	// always show unclipped regions
-	if(!ClipRegion.has_value())
-		return true;
-
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
-	float Left = ClipRegion->m_X;
-	float Top = ClipRegion->m_Y;
-	float Right = ClipRegion->m_X + ClipRegion->m_Width;
-	float Bottom = ClipRegion->m_Y + ClipRegion->m_Height;
-
-	return Right >= ScreenX0 && Left <= ScreenX1 && Bottom >= ScreenY0 && Top <= ScreenY1;
 }
 
 bool CRenderLayerQuads::DoRender(const CRenderLayerParams &Params)

--- a/src/game/map/render_layer.h
+++ b/src/game/map/render_layer.h
@@ -31,6 +31,19 @@ typedef std::function<void(const char *pCaption, const char *pContent, int Incre
 
 constexpr int BorderRenderDistance = 201;
 
+class CClipRegion
+{
+public:
+	CClipRegion() = default;
+	CClipRegion(float X, float Y, float Width, float Height) :
+		m_X(X), m_Y(Y), m_Width(Width), m_Height(Height) {}
+
+	float m_X;
+	float m_Y;
+	float m_Width;
+	float m_Height;
+};
+
 class CRenderLayerParams
 {
 public:
@@ -45,6 +58,7 @@ public:
 	bool m_DebugRenderGroupClips;
 	bool m_DebugRenderQuadClips;
 	bool m_DebugRenderClusterClips;
+	bool m_DebugRenderTileClips;
 };
 
 class CRenderLayer : public CRenderComponent
@@ -60,6 +74,7 @@ public:
 	virtual bool IsGroup() const { return false; }
 	virtual void Unload() = 0;
 
+	bool IsVisibleInClipRegion(const std::optional<CClipRegion> &ClipRegion) const;
 	int GetGroup() const { return m_GroupId; }
 
 protected:
@@ -75,6 +90,7 @@ protected:
 	IMapImages *m_pMapImages = nullptr;
 	std::shared_ptr<CEnvelopeManager> m_pEnvelopeManager;
 	std::optional<FRenderUploadCallback> m_RenderUploadCallback;
+	std::optional<CClipRegion> m_LayerClip;
 };
 
 class CRenderLayerGroup : public CRenderLayer
@@ -238,15 +254,6 @@ protected:
 	std::optional<CRenderLayerQuads::CQuadLayerVisuals> m_VisualQuad;
 	CMapItemLayerQuads *m_pLayerQuads;
 
-	class CClipRegion
-	{
-	public:
-		float m_X;
-		float m_Y;
-		float m_Width;
-		float m_Height;
-	};
-
 	class CQuadCluster
 	{
 	public:
@@ -262,14 +269,10 @@ protected:
 		std::vector<SQuadRenderInfo> m_vQuadRenderInfo;
 		std::optional<CClipRegion> m_ClipRegion;
 	};
-
-	bool IsVisibleInClipRegion(const std::optional<CClipRegion> &ClipRegion) const;
 	void CalculateClipping(CQuadCluster &QuadCluster);
 	bool CalculateQuadClipping(const CQuadCluster &QuadCluster, int aQuadOffsetMin[2], int aQuadOffsetMax[2]) const;
 
-	std::optional<CClipRegion> m_LayerClip;
 	std::vector<CQuadCluster> m_vQuadClusters;
-
 	CQuad *m_pQuads;
 
 private:


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Currently render layer clipping is only limited to quad layers. We can easily generalize it to tilelayers as well. Tilelayers already have a clip check in place, this is just replacing (and thus generalizing) it.

You can debug it with `dbg_render_layer_tile_clip 1`, which then looks like this:

<img width="2560" height="1440" alt="screenshot_2025-10-31_11-01-02" src="https://github.com/user-attachments/assets/61184db5-bd2e-46c3-a022-493e8a454c6f" />
<img width="2560" height="1440" alt="screenshot_2025-10-31_11-01-05" src="https://github.com/user-attachments/assets/43e2a0d6-fe14-45a6-812a-dbb6f4b0b4cd" />

Some additional notes:
- You can not put this check into `DoRender`, because this would skip border rendering
- I plan to follow up border rendering in another PR
- I plan to do a clip region optimization in a followup. You can clearly see, that the clip region is not yet alligned with the tile layer region. The best thing is we can do this on setup time quite easily

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
