### PR TITLE
Fix client crash when community removed while on browser tab

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -1365,6 +1365,7 @@ const json_value *CServerBrowser::LoadDDNetInfo()
 		UpdateServerCommunity(&m_ppServerlist[i]->m_Info);
 		UpdateServerRank(&m_ppServerlist[i]->m_Info);
 	}
+	ValidateServerlistType();
 	return m_pDDNetInfo;
 }
 
@@ -1666,6 +1667,21 @@ void CServerBrowser::UpdateServerRank(CServerInfo *pInfo) const
 {
 	const CCommunity *pCommunity = Community(pInfo->m_aCommunityId);
 	pInfo->m_HasRank = pCommunity == nullptr ? CServerInfo::RANK_UNAVAILABLE : pCommunity->HasRank(pInfo->m_aMap);
+}
+
+void CServerBrowser::ValidateServerlistType()
+{
+	if(m_ServerlistType >= IServerBrowser::TYPE_FAVORITE_COMMUNITY_1 &&
+		m_ServerlistType <= IServerBrowser::TYPE_FAVORITE_COMMUNITY_5)
+	{
+		const size_t CommunityIndex = m_ServerlistType - IServerBrowser::TYPE_FAVORITE_COMMUNITY_1;
+		if(CommunityIndex >= FavoriteCommunities().size())
+		{
+			// Reset to internet type if there is no favorite community for the current browser type,
+			// in case communities have been removed.
+			m_ServerlistType = IServerBrowser::TYPE_INTERNET;
+		}
+	}
 }
 
 const char *CServerBrowser::GetTutorialServer()

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -275,6 +275,7 @@ public:
 	void UpdateServerFriends(CServerInfo *pInfo) const;
 	void UpdateServerCommunity(CServerInfo *pInfo) const;
 	void UpdateServerRank(CServerInfo *pInfo) const;
+	void ValidateServerlistType();
 	const char *GetTutorialServer() override;
 
 	const std::vector<CCommunity> &Communities() const override;


### PR DESCRIPTION
Immediately after refreshing the communities from the DDNet info, the serverlist type of the engine serverbrowser needs to be reset if a favorite community tab is selected but not enough communities are available anymore, as the engine serverbrowser will subsequently use the serverlist type to refresh the filtered serverlist.

Closes #11153.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
