### PR TITLE
Move `CBinds::MODIFIER_*` constants to `namespace KeyModifier`

### DIFF
--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -44,7 +44,7 @@ CBinds::~CBinds()
 void CBinds::Bind(int KeyId, const char *pStr, bool FreeOnly, int ModifierCombination)
 {
 	dbg_assert(KeyId >= KEY_FIRST && KeyId < KEY_LAST, "KeyId invalid");
-	dbg_assert(ModifierCombination >= MODIFIER_NONE && ModifierCombination < MODIFIER_COMBINATION_COUNT, "ModifierCombination invalid");
+	dbg_assert(ModifierCombination >= KeyModifier::NONE && ModifierCombination < KeyModifier::COMBINATION_COUNT, "ModifierCombination invalid");
 
 	if(FreeOnly && Get(KeyId, ModifierCombination)[0])
 		return;
@@ -97,18 +97,18 @@ int CBinds::GetModifierMaskOfKey(int Key)
 	{
 	case KEY_LSHIFT:
 	case KEY_RSHIFT:
-		return 1 << CBinds::MODIFIER_SHIFT;
+		return 1 << KeyModifier::SHIFT;
 	case KEY_LCTRL:
 	case KEY_RCTRL:
-		return 1 << CBinds::MODIFIER_CTRL;
+		return 1 << KeyModifier::CTRL;
 	case KEY_LALT:
 	case KEY_RALT:
-		return 1 << CBinds::MODIFIER_ALT;
+		return 1 << KeyModifier::ALT;
 	case KEY_LGUI:
 	case KEY_RGUI:
-		return 1 << CBinds::MODIFIER_GUI;
+		return 1 << KeyModifier::GUI;
 	default:
-		return CBinds::MODIFIER_NONE;
+		return KeyModifier::NONE;
 	}
 }
 
@@ -147,11 +147,11 @@ bool CBinds::OnInput(const IInput::CEvent &Event)
 				OnKeyPress(ModifierMask);
 				Handled = true;
 			}
-			else if(m_aapKeyBindings[MODIFIER_NONE][Event.m_Key] &&
-				ModifierMask != ((1 << MODIFIER_CTRL) | (1 << MODIFIER_SHIFT)) &&
-				ModifierMask != ((1 << MODIFIER_GUI) | (1 << MODIFIER_SHIFT)))
+			else if(m_aapKeyBindings[KeyModifier::NONE][Event.m_Key] &&
+				ModifierMask != ((1 << KeyModifier::CTRL) | (1 << KeyModifier::SHIFT)) &&
+				ModifierMask != ((1 << KeyModifier::GUI) | (1 << KeyModifier::SHIFT)))
 			{
-				OnKeyPress(MODIFIER_NONE);
+				OnKeyPress(KeyModifier::NONE);
 				Handled = true;
 			}
 		}
@@ -198,7 +198,7 @@ bool CBinds::OnInput(const IInput::CEvent &Event)
 		}
 
 		// Release all active binds that use this modifier key
-		if(KeyModifierMask != MODIFIER_NONE)
+		if(KeyModifierMask != KeyModifier::NONE)
 		{
 			while(true)
 			{
@@ -232,14 +232,14 @@ void CBinds::UnbindAll()
 const char *CBinds::Get(int KeyId, int ModifierCombination)
 {
 	dbg_assert(KeyId >= KEY_FIRST && KeyId < KEY_LAST, "KeyId invalid");
-	dbg_assert(ModifierCombination >= MODIFIER_NONE && ModifierCombination < MODIFIER_COMBINATION_COUNT, "ModifierCombination invalid");
+	dbg_assert(ModifierCombination >= KeyModifier::NONE && ModifierCombination < KeyModifier::COMBINATION_COUNT, "ModifierCombination invalid");
 	return m_aapKeyBindings[ModifierCombination][KeyId] ? m_aapKeyBindings[ModifierCombination][KeyId] : "";
 }
 
 void CBinds::GetKey(const char *pBindStr, char *pBuf, size_t BufSize)
 {
 	pBuf[0] = '\0';
-	for(int Modifier = MODIFIER_NONE; Modifier < MODIFIER_COMBINATION_COUNT; Modifier++)
+	for(int Modifier = KeyModifier::NONE; Modifier < KeyModifier::COMBINATION_COUNT; Modifier++)
 	{
 		for(int KeyId = KEY_FIRST; KeyId < KEY_LAST; KeyId++)
 		{
@@ -361,7 +361,7 @@ void CBinds::ConBinds(IConsole::IResult *pResult, void *pUserData)
 	}
 	else
 	{
-		for(int Modifier = MODIFIER_NONE; Modifier < MODIFIER_COMBINATION_COUNT; Modifier++)
+		for(int Modifier = KeyModifier::NONE; Modifier < KeyModifier::COMBINATION_COUNT; Modifier++)
 		{
 			for(int Key = KEY_FIRST; Key < KEY_LAST; Key++)
 			{
@@ -398,42 +398,42 @@ void CBinds::ConUnbindAll(IConsole::IResult *pResult, void *pUserData)
 
 CBinds::CBindSlot CBinds::GetBindSlot(const char *pBindString) const
 {
-	int ModifierMask = MODIFIER_NONE;
+	int ModifierMask = KeyModifier::NONE;
 	char aMod[32];
 	aMod[0] = '\0';
 	const char *pKey = str_next_token(pBindString, "+", aMod, sizeof(aMod));
 	while(aMod[0] && *(pKey))
 	{
 		if(!str_comp_nocase(aMod, "shift"))
-			ModifierMask |= (1 << MODIFIER_SHIFT);
+			ModifierMask |= (1 << KeyModifier::SHIFT);
 		else if(!str_comp_nocase(aMod, "ctrl"))
-			ModifierMask |= (1 << MODIFIER_CTRL);
+			ModifierMask |= (1 << KeyModifier::CTRL);
 		else if(!str_comp_nocase(aMod, "alt"))
-			ModifierMask |= (1 << MODIFIER_ALT);
+			ModifierMask |= (1 << KeyModifier::ALT);
 		else if(!str_comp_nocase(aMod, "gui"))
-			ModifierMask |= (1 << MODIFIER_GUI);
+			ModifierMask |= (1 << KeyModifier::GUI);
 		else
-			return {KEY_UNKNOWN, MODIFIER_NONE};
+			return {KEY_UNKNOWN, KeyModifier::NONE};
 
 		if(str_find(pKey + 1, "+"))
 			pKey = str_next_token(pKey + 1, "+", aMod, sizeof(aMod));
 		else
 			break;
 	}
-	return {Input()->FindKeyByName(ModifierMask == MODIFIER_NONE ? aMod : pKey + 1), ModifierMask};
+	return {Input()->FindKeyByName(ModifierMask == KeyModifier::NONE ? aMod : pKey + 1), ModifierMask};
 }
 
 const char *CBinds::GetModifierName(int Modifier)
 {
 	switch(Modifier)
 	{
-	case MODIFIER_SHIFT:
+	case KeyModifier::SHIFT:
 		return "shift";
-	case MODIFIER_CTRL:
+	case KeyModifier::CTRL:
 		return "ctrl";
-	case MODIFIER_ALT:
+	case KeyModifier::ALT:
 		return "alt";
-	case MODIFIER_GUI:
+	case KeyModifier::GUI:
 		return "gui";
 	default:
 		dbg_assert(false, "Modifier invalid: %d", Modifier);
@@ -444,11 +444,11 @@ const char *CBinds::GetModifierName(int Modifier)
 void CBinds::GetKeyBindName(int Key, int ModifierMask, char *pBuf, size_t BufSize) const
 {
 	pBuf[0] = '\0';
-	for(int k = 1; k < MODIFIER_COUNT; k++)
+	for(int Modifier = KeyModifier::CTRL; Modifier < KeyModifier::COUNT; Modifier++)
 	{
-		if(ModifierMask & (1 << k))
+		if(ModifierMask & (1 << Modifier))
 		{
-			str_append(pBuf, GetModifierName(k), BufSize);
+			str_append(pBuf, GetModifierName(Modifier), BufSize);
 			str_append(pBuf, "+", BufSize);
 		}
 	}
@@ -475,7 +475,7 @@ void CBinds::ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData)
 	CBinds *pSelf = (CBinds *)pUserData;
 
 	pConfigManager->WriteLine("unbindall");
-	for(int Modifier = MODIFIER_NONE; Modifier < MODIFIER_COMBINATION_COUNT; Modifier++)
+	for(int Modifier = KeyModifier::NONE; Modifier < KeyModifier::COMBINATION_COUNT; Modifier++)
 	{
 		for(int Key = KEY_FIRST; Key < KEY_LAST; Key++)
 		{

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -12,6 +12,17 @@
 
 class IConfigManager;
 
+namespace KeyModifier
+{
+	inline constexpr int32_t NONE = 0;
+	inline constexpr int32_t CTRL = 1;
+	inline constexpr int32_t ALT = 2;
+	inline constexpr int32_t SHIFT = 3;
+	inline constexpr int32_t GUI = 4;
+	inline constexpr int32_t COUNT = 5;
+	inline constexpr int32_t COMBINATION_COUNT = 1 << COUNT;
+};
+
 class CBinds : public CComponent
 {
 	static void ConBind(IConsole::IResult *pResult, void *pUserData);
@@ -53,21 +64,9 @@ public:
 
 	bool m_MouseOnAction;
 
-	enum
-	{
-		MODIFIER_NONE = 0,
-		MODIFIER_CTRL,
-		MODIFIER_ALT,
-		MODIFIER_SHIFT,
-		MODIFIER_GUI,
-
-		MODIFIER_COUNT,
-	};
-	static constexpr auto MODIFIER_COMBINATION_COUNT = 1 << MODIFIER_COUNT;
-
 	CBindsSpecial m_SpecialBinds;
 
-	void Bind(int KeyId, const char *pStr, bool FreeOnly = false, int ModifierCombination = MODIFIER_NONE);
+	void Bind(int KeyId, const char *pStr, bool FreeOnly = false, int ModifierCombination = KeyModifier::NONE);
 	void SetDefaults();
 	void UnbindAll();
 	const char *Get(int KeyId, int ModifierCombination);
@@ -85,7 +84,7 @@ public:
 	void SetDDRaceBinds(bool FreeOnly);
 
 private:
-	char *m_aapKeyBindings[MODIFIER_COMBINATION_COUNT][KEY_LAST];
+	char *m_aapKeyBindings[KeyModifier::COMBINATION_COUNT][KEY_LAST];
 	std::vector<CBindSlot> m_vActiveBinds;
 };
 #endif

--- a/src/game/client/components/key_binder.cpp
+++ b/src/game/client/components/key_binder.cpp
@@ -14,7 +14,7 @@ CKeyBinder::CKeyBinder()
 	m_pKeyReaderId = nullptr;
 	m_TakeKey = false;
 	m_GotKey = false;
-	m_ModifierCombination = CBinds::MODIFIER_NONE;
+	m_ModifierCombination = KeyModifier::NONE;
 }
 
 bool CKeyBinder::OnInput(const IInput::CEvent &Event)
@@ -33,7 +33,7 @@ bool CKeyBinder::OnInput(const IInput::CEvent &Event)
 		m_ModifierCombination = CBinds::GetModifierMask(Input());
 		if(m_ModifierCombination == CBinds::GetModifierMaskOfKey(Event.m_Key))
 		{
-			m_ModifierCombination = CBinds::MODIFIER_NONE;
+			m_ModifierCombination = KeyModifier::NONE;
 		}
 	}
 	return true;
@@ -54,7 +54,7 @@ int CKeyBinder::DoKeyReader(const void *pId, const CUIRect *pRect, int Key, int 
 	else if(ButtonResult == 2)
 	{
 		NewKey = 0;
-		*pNewModifierCombination = CBinds::MODIFIER_NONE;
+		*pNewModifierCombination = KeyModifier::NONE;
 	}
 
 	if(m_pKeyReaderId == pId && m_GotKey)

--- a/src/game/client/components/menus_settings_controls.cpp
+++ b/src/game/client/components/menus_settings_controls.cpp
@@ -88,9 +88,9 @@ void CMenusSettingsControls::Render(CUIRect MainView)
 	for(auto &Key : gs_aKeys)
 		Key.m_KeyId = Key.m_ModifierCombination = 0;
 
-	for(int Mod = 0; Mod < CBinds::MODIFIER_COMBINATION_COUNT; Mod++)
+	for(int Mod = KeyModifier::NONE; Mod < KeyModifier::COMBINATION_COUNT; Mod++)
 	{
-		for(int KeyId = 0; KeyId < KEY_LAST; KeyId++)
+		for(int KeyId = KEY_FIRST; KeyId < KEY_LAST; KeyId++)
 		{
 			const char *pBind = GameClient()->m_Binds.Get(KeyId, Mod);
 			if(!pBind[0])


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
