### PR TITLE
Delete RAII wrapper copy constructors

### DIFF
--- a/src/base/lock.h
+++ b/src/base/lock.h
@@ -130,6 +130,8 @@ public:
 		m_Lock.unlock();
 	}
 
+	CLockScope(const CLockScope &) = delete;
+
 private:
 	CLock &m_Lock;
 };

--- a/src/base/logger.h
+++ b/src/base/logger.h
@@ -296,5 +296,6 @@ public:
 		//dbg_assert(log_get_scope_logger() == new_scope_logger, "loggers weren't properly scoped");
 		log_set_scope_logger(old_scope_logger);
 	}
+	CLogScope(const CLogScope &) = delete;
 };
 #endif // BASE_LOGGER_H

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2130,6 +2130,7 @@ public:
 	{
 		cmdline_free(m_Argc, m_ppArgv);
 	}
+	CCmdlineFix(const CCmdlineFix &) = delete;
 };
 
 #if defined(CONF_FAMILY_WINDOWS)
@@ -2178,6 +2179,7 @@ class CWindowsComLifecycle
 public:
 	CWindowsComLifecycle(bool HasWindow);
 	~CWindowsComLifecycle();
+	CWindowsComLifecycle(const CWindowsComLifecycle &) = delete;
 };
 
 /**


### PR DESCRIPTION
RAII wrappers should not be copied.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
