### PR TITLE
Feature: Set gpu clips from region clips if we can

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -153,6 +153,15 @@ void CGraphics_Threaded::ClipEnable(int x, int y, int w, int h)
 	m_State.m_ClipH = h;
 }
 
+bool CGraphics_Threaded::ClipFetch(int &x, int &y, int &w, int &h) const
+{
+	x = m_State.m_ClipX;
+	y = ScreenHeight() - m_State.m_ClipY - m_State.m_ClipH; // reverse of ClipEnable
+	w = m_State.m_ClipW;
+	h = m_State.m_ClipH;
+	return m_State.m_ClipEnable;
+}
+
 void CGraphics_Threaded::ClipDisable()
 {
 	m_State.m_ClipEnable = false;

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -899,6 +899,7 @@ public:
 	CGraphics_Threaded();
 
 	void ClipEnable(int x, int y, int w, int h) override;
+	bool ClipFetch(int &x, int &y, int &w, int &h) const override;
 	void ClipDisable() override;
 
 	void BlendNone() override;

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -257,6 +257,7 @@ public:
 	virtual void Clear(float r, float g, float b, bool ForceClearNow = false) = 0;
 
 	virtual void ClipEnable(int x, int y, int w, int h) = 0;
+	virtual bool ClipFetch(int &x, int &y, int &w, int &h) const = 0;
 	virtual void ClipDisable() = 0;
 
 	virtual void MapScreen(float TopLeftX, float TopLeftY, float BottomRightX, float BottomRightY) = 0;

--- a/src/game/map/render_layer.h
+++ b/src/game/map/render_layer.h
@@ -75,6 +75,8 @@ public:
 	virtual void Unload() = 0;
 
 	bool IsVisibleInClipRegion(const std::optional<CClipRegion> &ClipRegion) const;
+	bool SetGraphicsClip(const std::optional<CClipRegion> &ClipRegion, int GroupClip[4]);
+	void ResetGraphicsClip(int GroupClip[4], bool ClipEnabled);
 	int GetGroup() const { return m_GroupId; }
 
 protected:


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This PR sets GPU clips before rendering anything. This should improve performance overall slightly

TODO: Benchmarks

TODO: provide testmap

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
