### PR TITLE
Add stateless CanJoinTeam check

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1196,6 +1196,7 @@ void CGameContext::AttemptJoinTeam(int ClientId, int Team)
 			Team = EmptyTeam.value();
 		}
 
+		char aError[512];
 		if(pPlayer->m_LastDDRaceTeamChange + (int64_t)Server()->TickSpeed() * g_Config.m_SvTeamChangeDelay > Server()->Tick())
 		{
 			Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp",
@@ -1214,9 +1215,9 @@ void CGameContext::AttemptJoinTeam(int ClientId, int Team)
 			str_format(aBuf, sizeof(aBuf), "This team already has the maximum allowed size of %d players", g_Config.m_SvMaxTeamSize);
 			Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", aBuf);
 		}
-		else if(const char *pError = m_pController->Teams().SetCharacterTeam(pPlayer->GetCid(), Team))
+		else if(!m_pController->Teams().SetCharacterTeam(pPlayer->GetCid(), Team, aError, sizeof(aError)))
 		{
-			Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", pError);
+			Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", aError);
 		}
 		else
 		{

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -187,7 +187,9 @@ void CCharacter::SetSuper(bool Super)
 	if(Super && !WasSuper)
 	{
 		m_TeamBeforeSuper = Team();
-		Teams()->SetCharacterTeam(GetPlayer()->GetCid(), TEAM_SUPER);
+		char aError[512];
+		if(!Teams()->SetCharacterTeam(GetPlayer()->GetCid(), TEAM_SUPER, aError, sizeof(aError)))
+			log_error("character", "failed to set super: %s", aError);
 		m_DDRaceState = ERaceState::CHEATED;
 	}
 	else if(!Super && WasSuper)

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -217,7 +217,14 @@ CNetObj_PlayerInput CGameContext::GetLastPlayerInput(int ClientId) const
 	return m_aLastPlayerInput[ClientId];
 }
 
-class CCharacter *CGameContext::GetPlayerChar(int ClientId)
+CCharacter *CGameContext::GetPlayerChar(int ClientId)
+{
+	if(ClientId < 0 || ClientId >= MAX_CLIENTS || !m_apPlayers[ClientId])
+		return nullptr;
+	return m_apPlayers[ClientId]->GetCharacter();
+}
+
+const CCharacter *CGameContext::GetPlayerChar(int ClientId) const
 {
 	if(ClientId < 0 || ClientId >= MAX_CLIENTS || !m_apPlayers[ClientId])
 		return nullptr;

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -225,7 +225,8 @@ public:
 	CGameWorld m_World;
 
 	// helper functions
-	class CCharacter *GetPlayerChar(int ClientId);
+	CCharacter *GetPlayerChar(int ClientId);
+	const CCharacter *GetPlayerChar(int ClientId) const;
 	bool EmulateBug(int Bug) const;
 	std::vector<SSwitchers> &Switchers() { return m_World.m_Core.m_vSwitchers; }
 

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -40,7 +40,7 @@ class CGameTeams
 	// the message from playing for a long time in an unfinishable team.
 	int m_aTeamUnfinishableKillTick[NUM_DDRACE_TEAMS];
 
-	class CGameContext *m_pGameContext;
+	CGameContext *m_pGameContext;
 
 	/**
 	* Kill the whole team.
@@ -60,8 +60,10 @@ public:
 
 	// helper methods
 	CCharacter *Character(int ClientId);
+	const CCharacter *Character(int ClientId) const;
 	CPlayer *GetPlayer(int ClientId);
-	class CGameContext *GameServer();
+	CGameContext *GameServer();
+	const CGameContext *GameServer() const;
 	class IServer *Server();
 
 	void OnCharacterStart(int ClientId);
@@ -70,8 +72,12 @@ public:
 	void OnCharacterDeath(int ClientId, int Weapon);
 	void Tick();
 
-	// returns nullptr if successful, error string if failed
-	const char *SetCharacterTeam(int ClientId, int Team);
+	// sets pError to an empty string on success (true)
+	// and sets pError if it returns false
+	bool CanJoinTeam(int ClientId, int Team, char *pError, int ErrorSize) const;
+
+	// returns true if successful. Writes error into pError on failure
+	bool SetCharacterTeam(int ClientId, int Team, char *pError, int ErrorSize);
 	void CheckTeamFinished(int Team);
 
 	void ChangeTeamState(int Team, ETeamState State);


### PR DESCRIPTION
This cleanly separates the check from the team join state change. So the `CanJoinTeam` check could be reused in other places without having to attempt a real team join.

This read only check comes in handy downstream for me.
And I need it for a follow up pr that continues #10468

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
