### PR TITLE
Fix header include in color.cpp

### DIFF
--- a/src/base/color.cpp
+++ b/src/base/color.cpp
@@ -1,6 +1,6 @@
 #include "color.h"
 
-#include "system.h"
+#include "str.h"
 
 template<typename T>
 std::optional<T> color_parse(const char *pStr)


### PR DESCRIPTION
Should I include `optional`, since the type is only used by the implementation whose definition along with optional is included by `color.h`

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
