### PR TITLE
fix (UX): tooltip active only inside a rect

### DIFF
--- a/src/game/client/components/tooltips.cpp
+++ b/src/game/client/components/tooltips.cpp
@@ -56,13 +56,12 @@ void CTooltips::OnRender()
 	{
 		CTooltip &Tooltip = m_ActiveTooltip.value();
 
-		if(Ui()->HotItem() != Tooltip.m_pId)
+		if(Ui()->HotItem() != Tooltip.m_pId || !Tooltip.m_Rect.Inside(Ui()->MousePos()))
 		{
 			Tooltip.m_OnScreen = false;
 			ClearActiveTooltip();
 			return;
 		}
-
 		if(!Tooltip.m_OnScreen)
 			return;
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)

before and after

https://github.com/user-attachments/assets/d09c881d-6625-4070-a40b-ae3f19751ef4


https://github.com/user-attachments/assets/c4e0e1cd-bdd5-4044-8a9c-9d20c82e4a6a



### How to reproduce 
Hold left mouse at any rect with tooltip and move the mouse


