### PR TITLE
Ignore typos in icon files

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -6,6 +6,7 @@ extend-exclude = [
 	"data/languages",
 	"data/skins",
 	"ddnet-libs",
+	"other/icons/*.icns",
 	"memcheck.supp",
 	"scripts/android/files/res",
 	"src/engine/external",


### PR DESCRIPTION
I need this downstream:

```
error: `UE` should be `USE`, `DUE`
     ╭▸ other/icons/chillerbot-ux.icns:5148:34
     │
5148 │ QN!#qiNTZ&#`q*GXNm`16UaCV)UZG[B!2UEMbTlYmZ9,D0iAl!3*iiHVFqU3((Um
     ╰╴                                 ━━
```

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
