### PR TITLE
Fix: Tile layer clip hides tiles without overlay

### DIFF
--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -726,18 +726,21 @@ void CRenderLayerTile::UploadTileData(std::optional<CTileLayerVisuals> &VisualsO
 	}
 
 	// shrink clip region
-	if(DrawLeft > DrawRight || DrawTop > DrawBottom)
+	if(CurOverlay == 0)
 	{
-		// we are drawing nothing, layer is empty
-		m_LayerClip->m_Height = 0.0f;
-		m_LayerClip->m_Width = 0.0f;
-	}
-	else
-	{
-		m_LayerClip->m_X = DrawLeft * 32.0f;
-		m_LayerClip->m_Y = DrawTop * 32.0f;
-		m_LayerClip->m_Width = (DrawRight - DrawLeft + 1) * 32.0f;
-		m_LayerClip->m_Height = (DrawBottom - DrawTop + 1) * 32.0f;
+		if(DrawLeft > DrawRight || DrawTop > DrawBottom)
+		{
+			// we are drawing nothing, layer is empty
+			m_LayerClip->m_Height = 0.0f;
+			m_LayerClip->m_Width = 0.0f;
+		}
+		else
+		{
+			m_LayerClip->m_X = DrawLeft * 32.0f;
+			m_LayerClip->m_Y = DrawTop * 32.0f;
+			m_LayerClip->m_Width = (DrawRight - DrawLeft + 1) * 32.0f;
+			m_LayerClip->m_Height = (DrawBottom - DrawTop + 1) * 32.0f;
+		}
 	}
 
 	// append one kill tile to the gamelayer


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

#11174 introduced a bug, where the last overlay may shrink the clip region, because it doesn't render every tile of a visual. This PR now fixes this by only adjusting the clip region for the tiles themselfes, e.g. when CurOverlay == 0. Previously the same clip was set multiple times as well for physics overlays, which was also not desirable.

This was hard to find, since you need a map with the right properties

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
