### PR TITLE
Remove a couple of unnecessary clang-format exceptions

### DIFF
--- a/src/test/netaddr.cpp
+++ b/src/test/netaddr.cpp
@@ -134,15 +134,12 @@ TEST(NetAddr, FromStrInvalid)
 	EXPECT_TRUE(net_addr_from_str(&Addr, "[::]:c"));
 }
 
-// clang-format off
 TEST(NetAddrDeathTest, StrInvalid1)
 {
 	ASSERT_DEATH({
 		NETADDR Addr = {0};
 		char aBuf[NETADDR_MAXSTRSIZE];
-		net_addr_str(&Addr, aBuf, sizeof(aBuf), true);
-	},
-		"");
+		net_addr_str(&Addr, aBuf, sizeof(aBuf), true); }, "");
 }
 
 TEST(NetAddrDeathTest, StrInvalid2)
@@ -150,11 +147,8 @@ TEST(NetAddrDeathTest, StrInvalid2)
 	ASSERT_DEATH({
 		NETADDR Addr = {0};
 		char aBuf[NETADDR_MAXSTRSIZE];
-		net_addr_str(&Addr, aBuf, sizeof(aBuf), false);
-	},
-		"");
+		net_addr_str(&Addr, aBuf, sizeof(aBuf), false); }, "");
 }
-// clang-format on
 
 TEST(NetAddr, IsLocal)
 {

--- a/src/test/score.cpp
+++ b/src/test/score.cpp
@@ -639,16 +639,12 @@ CMysqlConfig gMysqlConfig{
 auto g_pMysqlConn = CreateMysqlConnection(gMysqlConfig);
 #endif
 
-// clang-format off
-auto g_TestValues
-{
+auto g_TestValues{
 	testing::Values(
 #if defined(CONF_TEST_MYSQL)
 		g_pMysqlConn.get(),
 #endif
-		g_pSqliteConn.get())
-};
-// clang-format on
+		g_pSqliteConn.get())};
 
 #define INSTANTIATE(SUITE) \
 	INSTANTIATE_TEST_SUITE_P(Sql, SUITE, g_TestValues, \


### PR DESCRIPTION
## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
