### PR TITLE
Revert "fix tile layer clip to be set by every overlay"

### DIFF
--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -726,21 +726,18 @@ void CRenderLayerTile::UploadTileData(std::optional<CTileLayerVisuals> &VisualsO
 	}
 
 	// shrink clip region
-	if(CurOverlay == 0)
+	if(DrawLeft > DrawRight || DrawTop > DrawBottom)
 	{
-		if(DrawLeft > DrawRight || DrawTop > DrawBottom)
-		{
-			// we are drawing nothing, layer is empty
-			m_LayerClip->m_Height = 0.0f;
-			m_LayerClip->m_Width = 0.0f;
-		}
-		else
-		{
-			m_LayerClip->m_X = DrawLeft * 32.0f;
-			m_LayerClip->m_Y = DrawTop * 32.0f;
-			m_LayerClip->m_Width = (DrawRight - DrawLeft + 1) * 32.0f;
-			m_LayerClip->m_Height = (DrawBottom - DrawTop + 1) * 32.0f;
-		}
+		// we are drawing nothing, layer is empty
+		m_LayerClip->m_Height = 0.0f;
+		m_LayerClip->m_Width = 0.0f;
+	}
+	else
+	{
+		m_LayerClip->m_X = DrawLeft * 32.0f;
+		m_LayerClip->m_Y = DrawTop * 32.0f;
+		m_LayerClip->m_Width = (DrawRight - DrawLeft + 1) * 32.0f;
+		m_LayerClip->m_Height = (DrawBottom - DrawTop + 1) * 32.0f;
 	}
 
 	// append one kill tile to the gamelayer


### PR DESCRIPTION
This reverts commit 0997b87876bb795fc14b310ee7731079c89072c2.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
