### PR TITLE
Fix: Tile layer clip hides tiles with undrawn overlay

### DIFF
--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -726,18 +726,23 @@ void CRenderLayerTile::UploadTileData(std::optional<CTileLayerVisuals> &VisualsO
 	}
 
 	// shrink clip region
-	if(DrawLeft > DrawRight || DrawTop > DrawBottom)
+	// we only apply the clip once for the first overlay type (tile visuals). Physic layers can have multiple layers for text, e.g. speedup force
+	// the first overlay is always the largest and you will never find an overlay, where the text is written over AIR
+	if(CurOverlay == 0)
 	{
-		// we are drawing nothing, layer is empty
-		m_LayerClip->m_Height = 0.0f;
-		m_LayerClip->m_Width = 0.0f;
-	}
-	else
-	{
-		m_LayerClip->m_X = DrawLeft * 32.0f;
-		m_LayerClip->m_Y = DrawTop * 32.0f;
-		m_LayerClip->m_Width = (DrawRight - DrawLeft + 1) * 32.0f;
-		m_LayerClip->m_Height = (DrawBottom - DrawTop + 1) * 32.0f;
+		if(DrawLeft > DrawRight || DrawTop > DrawBottom)
+		{
+			// we are drawing nothing, layer is empty
+			m_LayerClip->m_Height = 0.0f;
+			m_LayerClip->m_Width = 0.0f;
+		}
+		else
+		{
+			m_LayerClip->m_X = DrawLeft * 32.0f;
+			m_LayerClip->m_Y = DrawTop * 32.0f;
+			m_LayerClip->m_Width = (DrawRight - DrawLeft + 1) * 32.0f;
+			m_LayerClip->m_Height = (DrawBottom - DrawTop + 1) * 32.0f;
+		}
 	}
 
 	// append one kill tile to the gamelayer


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Original Description

https://github.com/ddnet/ddnet/pull/11174 introduced a bug, where the last overlay may shrink the clip region, because it doesn't render every tile of a visual. This PR now fixes this by only adjusting the clip region for the tiles themselfes, e.g. when CurOverlay == 0. Previously the same clip was set multiple times as well for physics overlays, which was also not desirable.

This was hard to find, since you need a map with the right properties

## Extra Description

It was reported on discord, that the overlay rendering of speedtiles and switch tiles was not properly working, see https://discord.com/channels/252358080522747904/757720336274948198/1438495576386965559

(I can't upload the video, it's too big)

We shrink tilelayer-clips to the drawn size, why is it breaking?

The [`UploadTileData` function](https://github.com/ddnet/ddnet/blob/4d1b6e955ec3624a7a4e957ad53b81219be4e7b9/src/game/map/render_layer.cpp#L594) is called 3 times for each type of overlay, see [Speedtiles](https://github.com/ddnet/ddnet/blob/4d1b6e955ec3624a7a4e957ad53b81219be4e7b9/src/game/map/render_layer.cpp#L1524) and [Switchtiles](https://github.com/ddnet/ddnet/blob/4d1b6e955ec3624a7a4e957ad53b81219be4e7b9/src/game/map/render_layer.cpp#L1604), where Overlay type 0 equals just the tile data. All of this calls change the member variable `m_LayerClip`. But if the last overlay contains no data that is drawn, the clip regions gets shrinked and the actual data doesn't get rendered.

This is why we are only setting the clip region in overlay type 0, instead of overwriting it with every overlay

closes #11233

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
