### PR TITLE
Ignore vote messages in demo player

### DIFF
--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -248,6 +248,9 @@ void CVoting::OnConsoleInit()
 
 void CVoting::OnMessage(int MsgType, void *pRawMsg)
 {
+	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
+		return;
+
 	if(MsgType == NETMSGTYPE_SV_VOTESET)
 	{
 		CNetMsg_Sv_VoteSet *pMsg = (CNetMsg_Sv_VoteSet *)pRawMsg;
@@ -333,7 +336,7 @@ void CVoting::OnMessage(int MsgType, void *pRawMsg)
 
 void CVoting::Render()
 {
-	if((!g_Config.m_ClShowVotesAfterVoting && !GameClient()->m_Scoreboard.IsActive() && TakenChoice()) || !IsVoting() || Client()->State() == IClient::STATE_DEMOPLAYBACK)
+	if((!g_Config.m_ClShowVotesAfterVoting && !GameClient()->m_Scoreboard.IsActive() && TakenChoice()) || !IsVoting())
 		return;
 	const int Seconds = SecondsLeft();
 	if(Seconds < 0)


### PR DESCRIPTION
The voting HUD is already hidden in the demo player, so handling the voting messages is unnecessary. Ideally, voting messages would not be recorded to demos at all, but that is a separate issue.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
