### PR TITLE
Remove team super, rename invincible to super

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -527,7 +527,6 @@ MACRO_CONFIG_INT(SvEndlessDrag, sv_endless_drag, 0, 0, 1, CFGFLAG_SERVER | CFGFL
 MACRO_CONFIG_INT(SvTestingCommands, sv_test_cmds, 0, 0, 1, CFGFLAG_SERVER, "Turns testing commands aka cheats on/off (setting only works in initial config)")
 MACRO_CONFIG_INT(SvFreezeDelay, sv_freeze_delay, 3, 1, 30, CFGFLAG_SERVER | CFGFLAG_GAME, "How many seconds the players will remain frozen (applies to all except delayed freeze in switch layer & deepfreeze)")
 MACRO_CONFIG_INT(ClDDRaceBindsSet, cl_race_binds_set, 0, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "What level the DDRace binds are set to (this is automated, you don't need to use this)")
-MACRO_CONFIG_INT(SvEndlessSuperHook, sv_endless_super_hook, 0, 0, 1, CFGFLAG_SERVER, "Endless hook for super players on/off")
 MACRO_CONFIG_INT(SvHideScore, sv_hide_score, 0, 0, 1, CFGFLAG_SERVER, "Whether players scores will be announced or not")
 MACRO_CONFIG_INT(SvSaveWorseScores, sv_save_worse_scores, 1, 0, 1, CFGFLAG_SERVER | CFGFLAG_GAME, "Whether to save worse scores when you already have a better one")
 MACRO_CONFIG_INT(SvPauseable, sv_pauseable, 0, 0, 1, CFGFLAG_SERVER | CFGFLAG_GAME, "Whether players can pause their char or not")

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -468,7 +468,6 @@ void CItems::OnRender()
 	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 		return;
 
-	bool IsSuper = GameClient()->IsLocalCharSuper();
 	int Ticks = Client()->GameTick(g_Config.m_ClDummy) % Client()->GameTickSpeed();
 	bool BlinkingPickup = (Ticks % 22) < 4;
 	bool BlinkingGun = (Ticks % 22) < 4;
@@ -486,7 +485,7 @@ void CItems::OnRender()
 	{
 		for(auto *pProj = (CProjectile *)GameClient()->m_PrevPredictedWorld.FindFirst(CGameWorld::ENTTYPE_PROJECTILE); pProj; pProj = (CProjectile *)pProj->NextEntity())
 		{
-			if(!IsSuper && pProj->m_Number > 0 && pProj->m_Number < (int)aSwitchers.size() && !aSwitchers[pProj->m_Number].m_aStatus[SwitcherTeam] && (pProj->m_Explosive ? BlinkingProjEx : BlinkingProj))
+			if(pProj->m_Number > 0 && pProj->m_Number < (int)aSwitchers.size() && !aSwitchers[pProj->m_Number].m_aStatus[SwitcherTeam] && (pProj->m_Explosive ? BlinkingProjEx : BlinkingProj))
 				continue;
 
 			CProjectileData Data = pProj->GetData();
@@ -502,7 +501,7 @@ void CItems::OnRender()
 		}
 		for(auto *pPickup = (CPickup *)GameClient()->m_PrevPredictedWorld.FindFirst(CGameWorld::ENTTYPE_PICKUP); pPickup; pPickup = (CPickup *)pPickup->NextEntity())
 		{
-			if(!IsSuper && pPickup->m_Layer == LAYER_SWITCH && pPickup->m_Number > 0 && pPickup->m_Number < (int)aSwitchers.size() && !aSwitchers[pPickup->m_Number].m_aStatus[SwitcherTeam] && BlinkingPickup)
+			if(pPickup->m_Layer == LAYER_SWITCH && pPickup->m_Number > 0 && pPickup->m_Number < (int)aSwitchers.size() && !aSwitchers[pPickup->m_Number].m_aStatus[SwitcherTeam] && BlinkingPickup)
 				continue;
 
 			if(pPickup->InDDNetTile())
@@ -527,7 +526,7 @@ void CItems::OnRender()
 		if(Item.m_Type == NETOBJTYPE_PROJECTILE || Item.m_Type == NETOBJTYPE_DDRACEPROJECTILE || Item.m_Type == NETOBJTYPE_DDNETPROJECTILE)
 		{
 			CProjectileData Data = ExtractProjectileInfo(Item.m_Type, pData, &GameClient()->m_GameWorld, pEntEx);
-			bool Inactive = !IsSuper && Data.m_SwitchNumber > 0 && Data.m_SwitchNumber < (int)aSwitchers.size() && !aSwitchers[Data.m_SwitchNumber].m_aStatus[SwitcherTeam];
+			bool Inactive = Data.m_SwitchNumber > 0 && Data.m_SwitchNumber < (int)aSwitchers.size() && !aSwitchers[Data.m_SwitchNumber].m_aStatus[SwitcherTeam];
 			if(Inactive && (Data.m_Explosive ? BlinkingProjEx : BlinkingProj))
 				continue;
 			if(UsePredicted)
@@ -553,7 +552,7 @@ void CItems::OnRender()
 		else if(Item.m_Type == NETOBJTYPE_PICKUP || Item.m_Type == NETOBJTYPE_DDNETPICKUP)
 		{
 			CPickupData Data = ExtractPickupInfo(Item.m_Type, pData, pEntEx);
-			bool Inactive = !IsSuper && Data.m_SwitchNumber > 0 && Data.m_SwitchNumber < (int)aSwitchers.size() && !aSwitchers[Data.m_SwitchNumber].m_aStatus[SwitcherTeam];
+			bool Inactive = Data.m_SwitchNumber > 0 && Data.m_SwitchNumber < (int)aSwitchers.size() && !aSwitchers[Data.m_SwitchNumber].m_aStatus[SwitcherTeam];
 
 			if(Inactive && BlinkingPickup)
 				continue;
@@ -577,7 +576,7 @@ void CItems::OnRender()
 			}
 
 			CLaserData Data = ExtractLaserInfo(Item.m_Type, pData, &GameClient()->m_GameWorld, pEntEx);
-			bool Inactive = !IsSuper && Data.m_SwitchNumber > 0 && Data.m_SwitchNumber < (int)aSwitchers.size() && !aSwitchers[Data.m_SwitchNumber].m_aStatus[SwitcherTeam];
+			bool Inactive = Data.m_SwitchNumber > 0 && Data.m_SwitchNumber < (int)aSwitchers.size() && !aSwitchers[Data.m_SwitchNumber].m_aStatus[SwitcherTeam];
 
 			bool IsEntBlink = false;
 			int EntStartTick = -1;
@@ -598,7 +597,7 @@ void CItems::OnRender()
 			}
 			else if(Data.m_Type == LASERTYPE_DOOR)
 			{
-				if(Data.m_Predict && (Inactive || IsSuper))
+				if(Data.m_Predict && Inactive)
 				{
 					Data.m_From.x = Data.m_To.x;
 					Data.m_From.y = Data.m_To.y;

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -617,9 +617,7 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 
 					if(NumPlayers > 8)
 					{
-						if(DDTeam == TEAM_SUPER)
-							str_copy(aBuf, Localize("Super"));
-						else if(CurrentDDTeamSize <= 1)
+						if(CurrentDDTeamSize <= 1)
 							str_format(aBuf, sizeof(aBuf), "%d", DDTeam);
 						else
 							str_format(aBuf, sizeof(aBuf), Localize("%d\n(%d/%d)", "Team and size"), DDTeam, CurrentDDTeamSize, MaxTeamSize);
@@ -627,9 +625,7 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 					}
 					else
 					{
-						if(DDTeam == TEAM_SUPER)
-							str_copy(aBuf, Localize("Super"));
-						else if(CurrentDDTeamSize > 1)
+						if(CurrentDDTeamSize > 1)
 							str_format(aBuf, sizeof(aBuf), Localize("Team %d (%d/%d)"), DDTeam, CurrentDDTeamSize, MaxTeamSize);
 						else
 							str_format(aBuf, sizeof(aBuf), Localize("Team %d"), DDTeam);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -3946,13 +3946,6 @@ int CGameClient::SwitchStateTeam() const
 	return m_Teams.Team(m_Snap.m_LocalClientId);
 }
 
-bool CGameClient::IsLocalCharSuper() const
-{
-	if(m_Snap.m_LocalClientId < 0)
-		return false;
-	return m_aClients[m_Snap.m_LocalClientId].m_Super;
-}
-
 void CGameClient::LoadGameSkin(const char *pPath, bool AsDir)
 {
 	if(m_GameSkinLoaded)

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1996,8 +1996,7 @@ void CGameClient::OnNewSnapshot()
 					continue;
 				}
 				const CNetObj_SwitchState *pSwitchStateData = (const CNetObj_SwitchState *)Item.m_pData;
-				// TODO: use NUM_DDRACE_TEAMS instead of hardcoding 64
-				int Team = std::clamp(Item.m_Id, (int)TEAM_FLOCK, 64);
+				int Team = std::clamp(Item.m_Id, (int)TEAM_FLOCK, (int)NUM_DDRACE_TEAMS - 1);
 
 				int HighestSwitchNumber = std::clamp(pSwitchStateData->m_HighestSwitchNumber, 0, 255);
 				if(HighestSwitchNumber != maximum(0, (int)Switchers().size() - 1))
@@ -3924,15 +3923,10 @@ bool CGameClient::IsOtherTeam(int ClientId) const
 		return false;
 	else if(m_Snap.m_SpecInfo.m_Active && m_Snap.m_SpecInfo.m_SpectatorId != SPEC_FREEVIEW)
 	{
-		if(m_Teams.Team(ClientId) == TEAM_SUPER || m_Teams.Team(m_Snap.m_SpecInfo.m_SpectatorId) == TEAM_SUPER)
-			return false;
 		return m_Teams.Team(ClientId) != m_Teams.Team(m_Snap.m_SpecInfo.m_SpectatorId);
 	}
 	else if((m_aClients[m_Snap.m_LocalClientId].m_Solo || m_aClients[ClientId].m_Solo) && !Local)
 		return true;
-
-	if(m_Teams.Team(ClientId) == TEAM_SUPER || m_Teams.Team(m_Snap.m_LocalClientId) == TEAM_SUPER)
-		return false;
 
 	return m_Teams.Team(ClientId) != m_Teams.Team(m_Snap.m_LocalClientId);
 }

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -75,6 +75,7 @@
 #include <game/client/projectile_data.h>
 #include <game/localization.h>
 #include <game/mapitems.h>
+#include <game/teamscore.h>
 #include <game/version.h>
 
 #include <chrono>
@@ -1124,7 +1125,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 		for(i = 0; i < MAX_CLIENTS; i++)
 		{
 			const int Team = pUnpacker->GetInt();
-			if(!pUnpacker->Error() && Team >= TEAM_FLOCK && Team <= TEAM_SUPER)
+			if(!pUnpacker->Error() && Team >= TEAM_FLOCK && Team < NUM_DDRACE_TEAMS)
 				m_Teams.Team(i, Team);
 			else
 			{
@@ -1995,7 +1996,8 @@ void CGameClient::OnNewSnapshot()
 					continue;
 				}
 				const CNetObj_SwitchState *pSwitchStateData = (const CNetObj_SwitchState *)Item.m_pData;
-				int Team = std::clamp(Item.m_Id, (int)TEAM_FLOCK, (int)TEAM_SUPER - 1);
+				// TODO: use NUM_DDRACE_TEAMS instead of hardcoding 64
+				int Team = std::clamp(Item.m_Id, (int)TEAM_FLOCK, 64);
 
 				int HighestSwitchNumber = std::clamp(pSwitchStateData->m_HighestSwitchNumber, 0, 255);
 				if(HighestSwitchNumber != maximum(0, (int)Switchers().size() - 1))
@@ -2154,7 +2156,7 @@ void CGameClient::OnNewSnapshot()
 
 	// sort player infos by DDRace Team (and score between)
 	int Index = 0;
-	for(int Team = TEAM_FLOCK; Team <= TEAM_SUPER; ++Team)
+	for(int Team = TEAM_FLOCK; Team < NUM_DDRACE_TEAMS; ++Team)
 	{
 		for(int i = 0; i < MAX_CLIENTS && Index < MAX_CLIENTS; ++i)
 		{
@@ -2165,7 +2167,7 @@ void CGameClient::OnNewSnapshot()
 
 	// sort player infos by DDRace Team (and name between)
 	Index = 0;
-	for(int Team = TEAM_FLOCK; Team <= TEAM_SUPER; ++Team)
+	for(int Team = TEAM_FLOCK; Team < NUM_DDRACE_TEAMS; ++Team)
 	{
 		for(int i = 0; i < MAX_CLIENTS && Index < MAX_CLIENTS; ++i)
 		{

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -703,7 +703,6 @@ public:
 	void Echo(const char *pString) override;
 	bool IsOtherTeam(int ClientId) const;
 	int SwitchStateTeam() const;
-	bool IsLocalCharSuper() const;
 	bool CanDisplayWarning() const override;
 
 	IMap *Map() override { return m_pMap.get(); }

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -35,8 +35,6 @@ void CCharacter::SetSolo(bool Solo)
 void CCharacter::SetSuper(bool Super)
 {
 	m_Core.m_Super = Super;
-	if(m_Core.m_Super && TeamsCore()->m_IsDDRace16)
-		TeamsCore()->Team(GetCid(), VANILLA_TEAM_SUPER);
 }
 
 bool CCharacter::IsGrounded()

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -35,8 +35,8 @@ void CCharacter::SetSolo(bool Solo)
 void CCharacter::SetSuper(bool Super)
 {
 	m_Core.m_Super = Super;
-	if(m_Core.m_Super)
-		TeamsCore()->Team(GetCid(), TeamsCore()->m_IsDDRace16 ? VANILLA_TEAM_SUPER : TEAM_SUPER);
+	if(m_Core.m_Super && TeamsCore()->m_IsDDRace16)
+		TeamsCore()->Team(GetCid(), VANILLA_TEAM_SUPER);
 }
 
 bool CCharacter::IsGrounded()
@@ -1136,9 +1136,9 @@ void CCharacter::DDRacePostCoreTick()
 		m_Core.m_Jumped = 1;
 	}
 
-	if((m_Core.m_Super || m_Core.m_EndlessJump) && m_Core.m_Jumped > 1)
+	if(m_Core.m_EndlessJump && m_Core.m_Jumped > 1)
 	{
-		// Super players and players with infinite jumps always have light feet
+		// players with infinite jumps always have light feet
 		m_Core.m_Jumped = 1;
 	}
 

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -750,7 +750,7 @@ bool CCharacter::IsSwitchActiveCb(int Number, void *pUser)
 {
 	CCharacter *pThis = (CCharacter *)pUser;
 	auto &aSwitchers = pThis->Switchers();
-	return !aSwitchers.empty() && pThis->Team() != TEAM_SUPER && aSwitchers[Number].m_aStatus[pThis->Team()];
+	return !aSwitchers.empty() && aSwitchers[Number].m_aStatus[pThis->Team()];
 }
 
 void CCharacter::HandleTiles(int Index)
@@ -939,59 +939,59 @@ void CCharacter::HandleTiles(int Index)
 	m_Core.m_Vel = ClampVel(m_MoveRestrictions, m_Core.m_Vel);
 
 	// handle switch tiles
-	if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHOPEN && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
+	if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHOPEN && Collision()->GetSwitchNumber(MapIndex) > 0)
 	{
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aStatus[Team()] = true;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aEndTick[Team()] = 0;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aType[Team()] = TILE_SWITCHOPEN;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aLastUpdateTick[Team()] = GameWorld()->GameTick();
 	}
-	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHTIMEDOPEN && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHTIMEDOPEN && Collision()->GetSwitchNumber(MapIndex) > 0)
 	{
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aStatus[Team()] = true;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aEndTick[Team()] = GameWorld()->GameTick() + 1 + Collision()->GetSwitchDelay(MapIndex) * GameWorld()->GameTickSpeed();
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aType[Team()] = TILE_SWITCHTIMEDOPEN;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aLastUpdateTick[Team()] = GameWorld()->GameTick();
 	}
-	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHTIMEDCLOSE && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHTIMEDCLOSE && Collision()->GetSwitchNumber(MapIndex) > 0)
 	{
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aStatus[Team()] = false;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aEndTick[Team()] = GameWorld()->GameTick() + 1 + Collision()->GetSwitchDelay(MapIndex) * GameWorld()->GameTickSpeed();
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aType[Team()] = TILE_SWITCHTIMEDCLOSE;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aLastUpdateTick[Team()] = GameWorld()->GameTick();
 	}
-	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHCLOSE && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHCLOSE && Collision()->GetSwitchNumber(MapIndex) > 0)
 	{
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aStatus[Team()] = false;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aEndTick[Team()] = 0;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aType[Team()] = TILE_SWITCHCLOSE;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aLastUpdateTick[Team()] = GameWorld()->GameTick();
 	}
-	else if(Collision()->GetSwitchType(MapIndex) == TILE_FREEZE && Team() != TEAM_SUPER && !m_Core.m_Invincible)
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_FREEZE && !m_Core.m_Invincible)
 	{
 		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aStatus[Team()])
 		{
 			Freeze(Collision()->GetSwitchDelay(MapIndex));
 		}
 	}
-	else if(Collision()->GetSwitchType(MapIndex) == TILE_DFREEZE && Team() != TEAM_SUPER && !m_Core.m_Invincible)
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_DFREEZE && !m_Core.m_Invincible)
 	{
 		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aStatus[Team()])
 			m_Core.m_DeepFrozen = true;
 	}
-	else if(Collision()->GetSwitchType(MapIndex) == TILE_DUNFREEZE && Team() != TEAM_SUPER && !m_Core.m_Invincible)
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_DUNFREEZE && !m_Core.m_Invincible)
 	{
 		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aStatus[Team()])
 			m_Core.m_DeepFrozen = false;
 	}
-	else if(Collision()->GetSwitchType(MapIndex) == TILE_LFREEZE && Team() != TEAM_SUPER && !m_Core.m_Invincible)
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_LFREEZE && !m_Core.m_Invincible)
 	{
 		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aStatus[Team()])
 		{
 			m_Core.m_LiveFrozen = true;
 		}
 	}
-	else if(Collision()->GetSwitchType(MapIndex) == TILE_LUNFREEZE && Team() != TEAM_SUPER && !m_Core.m_Invincible)
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_LUNFREEZE && !m_Core.m_Invincible)
 	{
 		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aStatus[Team()])
 		{

--- a/src/game/client/prediction/entities/dragger.cpp
+++ b/src/game/client/prediction/entities/dragger.cpp
@@ -44,11 +44,6 @@ void CDragger::LookForPlayersToDrag()
 		CCharacter *pTarget = static_cast<CCharacter *>(apPlayersInRange[i]);
 		const int &TargetTeam = pTarget->Team();
 
-		// Do not create a dragger beam for super player
-		if(TargetTeam == TEAM_SUPER)
-		{
-			continue;
-		}
 		// If the dragger is disabled for the target's team, no dragger beam will be generated
 		if(m_Layer == LAYER_SWITCH && m_Number > 0 &&
 			!Switchers()[m_Number].m_aStatus[TargetTeam])

--- a/src/game/client/prediction/entities/pickup.cpp
+++ b/src/game/client/prediction/entities/pickup.cpp
@@ -67,8 +67,6 @@ void CPickup::Tick()
 			case POWERUP_ARMOR_SHOTGUN:
 				if(!GameWorld()->m_WorldConfig.m_IsDDRace || !GameWorld()->m_WorldConfig.m_PredictDDRace)
 					continue;
-				if(pChr->Team() == TEAM_SUPER)
-					continue;
 				if(pChr->GetWeaponGot(WEAPON_SHOTGUN))
 				{
 					pChr->SetWeaponGot(WEAPON_SHOTGUN, false);
@@ -82,8 +80,6 @@ void CPickup::Tick()
 
 			case POWERUP_ARMOR_GRENADE:
 				if(!GameWorld()->m_WorldConfig.m_IsDDRace || !GameWorld()->m_WorldConfig.m_PredictDDRace)
-					continue;
-				if(pChr->Team() == TEAM_SUPER)
 					continue;
 				if(pChr->GetWeaponGot(WEAPON_GRENADE))
 				{
@@ -99,8 +95,6 @@ void CPickup::Tick()
 			case POWERUP_ARMOR_NINJA:
 				if(!GameWorld()->m_WorldConfig.m_IsDDRace || !GameWorld()->m_WorldConfig.m_PredictDDRace)
 					continue;
-				if(pChr->Team() == TEAM_SUPER)
-					continue;
 				pChr->SetNinjaActivationDir(vec2(0, 0));
 				pChr->SetNinjaActivationTick(-500);
 				pChr->SetNinjaCurrentMoveTime(0);
@@ -108,8 +102,6 @@ void CPickup::Tick()
 
 			case POWERUP_ARMOR_LASER:
 				if(!GameWorld()->m_WorldConfig.m_IsDDRace || !GameWorld()->m_WorldConfig.m_PredictDDRace)
-					continue;
-				if(pChr->Team() == TEAM_SUPER)
 					continue;
 				if(pChr->GetWeaponGot(WEAPON_LASER))
 				{

--- a/src/game/client/prediction/entities/plasma.cpp
+++ b/src/game/client/prediction/entities/plasma.cpp
@@ -94,12 +94,6 @@ bool CPlasma::HitCharacter(CCharacter *pTarget)
 		return false;
 	}
 
-	// Super player should not be able to stop the plasma bullets
-	if(pHitPlayer->Team() == TEAM_SUPER)
-	{
-		return false;
-	}
-
 	m_Freeze ? pHitPlayer->Freeze() : pHitPlayer->Unfreeze();
 	if(m_Explosive)
 	{

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -349,7 +349,7 @@ void CCharacterCore::Tick(bool UseInput, bool DoDeferredTick)
 			for(int i = 0; i < MAX_CLIENTS; i++)
 			{
 				CCharacterCore *pCharCore = m_pWorld->m_apCharacters[i];
-				if(!pCharCore || pCharCore == this || (!(m_Super || pCharCore->m_Super) && ((m_Id != -1 && !m_pTeams->CanCollide(i, m_Id)) || pCharCore->m_Solo || m_Solo)))
+				if(!pCharCore || pCharCore == this || ((m_Id != -1 && !m_pTeams->CanCollide(i, m_Id)) || pCharCore->m_Solo || m_Solo))
 					continue;
 
 				vec2 ClosestPoint;
@@ -468,7 +468,7 @@ void CCharacterCore::TickDeferred()
 			if(pCharCore == this || (m_Id != -1 && !m_pTeams->CanCollide(m_Id, i)))
 				continue; // make sure that we don't nudge our self
 
-			if(!(m_Super || pCharCore->m_Super) && (m_Solo || pCharCore->m_Solo))
+			if(m_Solo || pCharCore->m_Solo)
 				continue;
 
 			// handle player <-> player collision
@@ -477,7 +477,7 @@ void CCharacterCore::TickDeferred()
 			{
 				vec2 Dir = normalize(m_Pos - pCharCore->m_Pos);
 
-				bool CanCollide = (m_Super || pCharCore->m_Super) || (!m_CollisionDisabled && !pCharCore->m_CollisionDisabled && m_Tuning.m_PlayerCollision);
+				bool CanCollide = !m_CollisionDisabled && !pCharCore->m_CollisionDisabled && m_Tuning.m_PlayerCollision;
 
 				if(CanCollide && Distance < PhysicalSize() * 1.25f)
 				{
@@ -560,7 +560,7 @@ void CCharacterCore::Move()
 
 	m_Vel.x = m_Vel.x * (1.0f / RampValue);
 
-	if(m_pWorld && (m_Super || (m_Tuning.m_PlayerCollision && !m_CollisionDisabled && !m_Solo)))
+	if(m_pWorld && (m_Tuning.m_PlayerCollision && !m_CollisionDisabled && !m_Solo))
 	{
 		// check player collision
 		float Distance = distance(m_Pos, NewPos);
@@ -577,7 +577,7 @@ void CCharacterCore::Move()
 					CCharacterCore *pCharCore = m_pWorld->m_apCharacters[p];
 					if(!pCharCore || pCharCore == this)
 						continue;
-					if((!(pCharCore->m_Super || m_Super) && (m_Solo || pCharCore->m_Solo || pCharCore->m_CollisionDisabled || (m_Id != -1 && !m_pTeams->CanCollide(m_Id, p)))))
+					if((m_Solo || pCharCore->m_Solo || pCharCore->m_CollisionDisabled || (m_Id != -1 && !m_pTeams->CanCollide(m_Id, p))))
 						continue;
 					float D = distance(Pos, pCharCore->m_Pos);
 					if(D < PhysicalSize())

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -732,7 +732,7 @@ bool CCharacterCore::IsSwitchActiveCb(int Number, void *pUser)
 {
 	CCharacterCore *pThis = (CCharacterCore *)pUser;
 	if(pThis->m_pWorld && !pThis->m_pWorld->m_vSwitchers.empty())
-		if(pThis->m_Id != -1 && pThis->m_pTeams->Team(pThis->m_Id) != (pThis->m_pTeams->m_IsDDRace16 ? VANILLA_TEAM_SUPER : TEAM_SUPER))
+		if(pThis->m_Id != -1)
 			return pThis->m_pWorld->m_vSwitchers[Number].m_aStatus[pThis->m_pTeams->Team(pThis->m_Id)];
 	return false;
 }

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -910,7 +910,7 @@ void CGameContext::ConCancelSwap(IConsole::IResult *pResult, void *pUserData)
 
 	int Team = Teams.m_Core.Team(pResult->m_ClientId);
 
-	if(!pSelf->m_pController->Teams().IsValidTeamNumber(Team))
+	if(!Teams.IsValidTeamNumber(Team))
 	{
 		log_info("chatresp", "You aren't in a valid team.");
 		return;
@@ -2293,11 +2293,11 @@ void CGameContext::ConPracticeSetSwitch(IConsole::IResult *pResult, void *pUserD
 		ConSetSwitch(pResult, pUserData);
 }
 
-void CGameContext::ConPracticeToggleInvincible(IConsole::IResult *pResult, void *pUserData)
+void CGameContext::ConPracticeToggleSuper(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	if(pSelf->GetPracticeCharacter(pResult))
-		ConToggleInvincible(pResult, pUserData);
+		ConToggleSuper(pResult, pUserData);
 }
 
 void CGameContext::ConPracticeToggleCollision(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -143,6 +143,31 @@ void CGameContext::ConUnEndlessHook(IConsole::IResult *pResult, void *pUserData)
 	}
 }
 
+void CGameContext::ConSuper(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(!CheckClientId(pResult->m_ClientId))
+		return;
+	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
+	if(pChr && !pChr->IsSuper())
+	{
+		pChr->SetSuper(true);
+		pChr->Unfreeze();
+	}
+}
+
+void CGameContext::ConUnSuper(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(!CheckClientId(pResult->m_ClientId))
+		return;
+	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
+	if(pChr && pChr->IsSuper())
+	{
+		pChr->SetSuper(false);
+	}
+}
+
 void CGameContext::ConToggleSuper(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -143,39 +143,14 @@ void CGameContext::ConUnEndlessHook(IConsole::IResult *pResult, void *pUserData)
 	}
 }
 
-void CGameContext::ConSuper(IConsole::IResult *pResult, void *pUserData)
-{
-	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientId(pResult->m_ClientId))
-		return;
-	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
-	if(pChr && !pChr->IsSuper())
-	{
-		pChr->SetSuper(true);
-		pChr->Unfreeze();
-	}
-}
-
-void CGameContext::ConUnSuper(IConsole::IResult *pResult, void *pUserData)
-{
-	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientId(pResult->m_ClientId))
-		return;
-	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
-	if(pChr && pChr->IsSuper())
-	{
-		pChr->SetSuper(false);
-	}
-}
-
-void CGameContext::ConToggleInvincible(IConsole::IResult *pResult, void *pUserData)
+void CGameContext::ConToggleSuper(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	if(!CheckClientId(pResult->m_ClientId))
 		return;
 	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 	if(pChr)
-		pChr->SetInvincible(pResult->NumArguments() == 0 ? !pChr->Core()->m_Invincible : pResult->GetInteger(0));
+		pChr->SetSuper(pResult->NumArguments() == 0 ? !pChr->IsSuper() : pResult->GetInteger(0));
 }
 
 void CGameContext::ConSolo(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -178,37 +178,12 @@ void CCharacter::SetSolo(bool Solo)
 
 void CCharacter::SetSuper(bool Super)
 {
-	// Disable invincible mode before activating super mode. Both modes active at the same time wouldn't necessarily break anything but it's not useful.
-	if(Super)
-		SetInvincible(false);
-
-	bool WasSuper = m_Core.m_Super;
+	m_Core.m_Invincible = Super;
 	m_Core.m_Super = Super;
-	if(Super && !WasSuper)
-	{
-		m_TeamBeforeSuper = Team();
-		char aError[512];
-		if(!Teams()->SetCharacterTeam(GetPlayer()->GetCid(), TEAM_SUPER, aError, sizeof(aError)))
-			log_error("character", "failed to set super: %s", aError);
-		m_DDRaceState = ERaceState::CHEATED;
-	}
-	else if(!Super && WasSuper)
-	{
-		Teams()->SetForceCharacterTeam(GetPlayer()->GetCid(), m_TeamBeforeSuper);
-	}
-}
-
-void CCharacter::SetInvincible(bool Invincible)
-{
-	// Disable super mode before activating invincible mode. Both modes active at the same time wouldn't necessarily break anything but it's not useful.
-	if(Invincible)
-		SetSuper(false);
-
-	m_Core.m_Invincible = Invincible;
-	if(Invincible)
+	if(Super)
 		Unfreeze();
 
-	SetEndlessJump(Invincible);
+	SetEndlessJump(Super);
 }
 
 void CCharacter::SetCollisionDisabled(bool CollisionDisabled)
@@ -1206,7 +1181,7 @@ bool CCharacter::CanSnapCharacter(int SnappingClient)
 		else if(pSnapPlayer->SpectatorId() == SPEC_FREEVIEW && !CanCollide(SnappingClient) && pSnapPlayer->m_SpecTeam && !SameTeam(SnappingClient))
 			return false;
 	}
-	else if(pSnapChar && !pSnapChar->m_Core.m_Super && !CanCollide(SnappingClient) && (pSnapPlayer->m_ShowOthers == SHOW_OTHERS_OFF || (pSnapPlayer->m_ShowOthers == SHOW_OTHERS_ONLY_TEAM && !SameTeam(SnappingClient))))
+	else if(pSnapChar && !pSnapChar->IsSuper() && !CanCollide(SnappingClient) && (pSnapPlayer->m_ShowOthers == SHOW_OTHERS_OFF || (pSnapPlayer->m_ShowOthers == SHOW_OTHERS_ONLY_TEAM && !SameTeam(SnappingClient))))
 		return false;
 
 	return true;
@@ -1266,10 +1241,8 @@ void CCharacter::Snap(int SnappingClient)
 	pDDNetCharacter->m_Flags = 0;
 	if(m_Core.m_Solo)
 		pDDNetCharacter->m_Flags |= CHARACTERFLAG_SOLO;
-	if(m_Core.m_Super)
-		pDDNetCharacter->m_Flags |= CHARACTERFLAG_SUPER;
-	if(m_Core.m_Invincible)
-		pDDNetCharacter->m_Flags |= CHARACTERFLAG_INVINCIBLE;
+	if(IsSuper())
+		pDDNetCharacter->m_Flags |= CHARACTERFLAG_INVINCIBLE | CHARACTERFLAG_SUPER;
 	if(m_Core.m_EndlessHook)
 		pDDNetCharacter->m_Flags |= CHARACTERFLAG_ENDLESS_HOOK;
 	if(m_Core.m_CollisionDisabled || !GetTuning(m_TuneZone)->m_PlayerCollision)
@@ -1445,7 +1418,7 @@ void CCharacter::HandleSkippableTiles(int Index)
 		   Collision()->GetFrontCollisionAt(m_Pos.x + GetProximityRadius() / 3.f, m_Pos.y + GetProximityRadius() / 3.f) == TILE_DEATH ||
 		   Collision()->GetFrontCollisionAt(m_Pos.x - GetProximityRadius() / 3.f, m_Pos.y - GetProximityRadius() / 3.f) == TILE_DEATH ||
 		   Collision()->GetFrontCollisionAt(m_Pos.x - GetProximityRadius() / 3.f, m_Pos.y + GetProximityRadius() / 3.f) == TILE_DEATH) &&
-		!m_Core.m_Super && !m_Core.m_Invincible && !(Team() && Teams()->TeeFinished(m_pPlayer->GetCid())))
+		!IsSuper() && !(Team() && Teams()->TeeFinished(m_pPlayer->GetCid())))
 	{
 		if(Teams()->IsPractice(Team()))
 		{
@@ -1561,7 +1534,7 @@ bool CCharacter::IsSwitchActiveCb(int Number, void *pUser)
 {
 	CCharacter *pThis = (CCharacter *)pUser;
 	auto &aSwitchers = pThis->Switchers();
-	return !aSwitchers.empty() && pThis->Team() != TEAM_SUPER && aSwitchers[Number].m_aStatus[pThis->Team()];
+	return !aSwitchers.empty() && aSwitchers[Number].m_aStatus[pThis->Team()];
 }
 
 void CCharacter::SetTimeCheckpoint(int TimeCheckpoint)
@@ -1621,7 +1594,7 @@ void CCharacter::HandleTiles(int Index)
 		return;
 
 	// freeze
-	if(((m_TileIndex == TILE_FREEZE) || (m_TileFIndex == TILE_FREEZE)) && !m_Core.m_Super && !m_Core.m_Invincible && !m_Core.m_DeepFrozen)
+	if(((m_TileIndex == TILE_FREEZE) || (m_TileFIndex == TILE_FREEZE)) && !IsSuper() && !m_Core.m_DeepFrozen)
 	{
 		Freeze();
 	}
@@ -1629,17 +1602,17 @@ void CCharacter::HandleTiles(int Index)
 		Unfreeze();
 
 	// deep freeze
-	if(((m_TileIndex == TILE_DFREEZE) || (m_TileFIndex == TILE_DFREEZE)) && !m_Core.m_Super && !m_Core.m_Invincible && !m_Core.m_DeepFrozen)
+	if(((m_TileIndex == TILE_DFREEZE) || (m_TileFIndex == TILE_DFREEZE)) && !IsSuper() && !m_Core.m_DeepFrozen)
 		m_Core.m_DeepFrozen = true;
-	else if(((m_TileIndex == TILE_DUNFREEZE) || (m_TileFIndex == TILE_DUNFREEZE)) && !m_Core.m_Super && !m_Core.m_Invincible && m_Core.m_DeepFrozen)
+	else if(((m_TileIndex == TILE_DUNFREEZE) || (m_TileFIndex == TILE_DUNFREEZE)) && !IsSuper() && m_Core.m_DeepFrozen)
 		m_Core.m_DeepFrozen = false;
 
 	// live freeze
-	if(((m_TileIndex == TILE_LFREEZE) || (m_TileFIndex == TILE_LFREEZE)) && !m_Core.m_Super && !m_Core.m_Invincible)
+	if(((m_TileIndex == TILE_LFREEZE) || (m_TileFIndex == TILE_LFREEZE)) && !IsSuper())
 	{
 		m_Core.m_LiveFrozen = true;
 	}
-	else if(((m_TileIndex == TILE_LUNFREEZE) || (m_TileFIndex == TILE_LUNFREEZE)) && !m_Core.m_Super && !m_Core.m_Invincible)
+	else if(((m_TileIndex == TILE_LUNFREEZE) || (m_TileFIndex == TILE_LUNFREEZE)) && !IsSuper())
 	{
 		m_Core.m_LiveFrozen = false;
 	}
@@ -1792,59 +1765,59 @@ void CCharacter::HandleTiles(int Index)
 	ApplyMoveRestrictions();
 
 	// handle switch tiles
-	if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHOPEN && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
+	if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHOPEN && Collision()->GetSwitchNumber(MapIndex) > 0)
 	{
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aStatus[Team()] = true;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aEndTick[Team()] = 0;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aType[Team()] = TILE_SWITCHOPEN;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aLastUpdateTick[Team()] = Server()->Tick();
 	}
-	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHTIMEDOPEN && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHTIMEDOPEN && Collision()->GetSwitchNumber(MapIndex) > 0)
 	{
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aStatus[Team()] = true;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aEndTick[Team()] = Server()->Tick() + 1 + Collision()->GetSwitchDelay(MapIndex) * Server()->TickSpeed();
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aType[Team()] = TILE_SWITCHTIMEDOPEN;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aLastUpdateTick[Team()] = Server()->Tick();
 	}
-	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHTIMEDCLOSE && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHTIMEDCLOSE && Collision()->GetSwitchNumber(MapIndex) > 0)
 	{
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aStatus[Team()] = false;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aEndTick[Team()] = Server()->Tick() + 1 + Collision()->GetSwitchDelay(MapIndex) * Server()->TickSpeed();
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aType[Team()] = TILE_SWITCHTIMEDCLOSE;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aLastUpdateTick[Team()] = Server()->Tick();
 	}
-	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHCLOSE && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHCLOSE && Collision()->GetSwitchNumber(MapIndex) > 0)
 	{
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aStatus[Team()] = false;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aEndTick[Team()] = 0;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aType[Team()] = TILE_SWITCHCLOSE;
 		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aLastUpdateTick[Team()] = Server()->Tick();
 	}
-	else if(Collision()->GetSwitchType(MapIndex) == TILE_FREEZE && Team() != TEAM_SUPER && !m_Core.m_Invincible)
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_FREEZE && !IsSuper())
 	{
 		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aStatus[Team()])
 		{
 			Freeze(Collision()->GetSwitchDelay(MapIndex));
 		}
 	}
-	else if(Collision()->GetSwitchType(MapIndex) == TILE_DFREEZE && Team() != TEAM_SUPER && !m_Core.m_Invincible)
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_DFREEZE && !IsSuper())
 	{
 		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aStatus[Team()])
 			m_Core.m_DeepFrozen = true;
 	}
-	else if(Collision()->GetSwitchType(MapIndex) == TILE_DUNFREEZE && Team() != TEAM_SUPER && !m_Core.m_Invincible)
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_DUNFREEZE && !IsSuper())
 	{
 		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aStatus[Team()])
 			m_Core.m_DeepFrozen = false;
 	}
-	else if(Collision()->GetSwitchType(MapIndex) == TILE_LFREEZE && Team() != TEAM_SUPER && !m_Core.m_Invincible)
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_LFREEZE && !IsSuper())
 	{
 		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aStatus[Team()])
 		{
 			m_Core.m_LiveFrozen = true;
 		}
 	}
-	else if(Collision()->GetSwitchType(MapIndex) == TILE_LUNFREEZE && Team() != TEAM_SUPER && !m_Core.m_Invincible)
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_LUNFREEZE && !IsSuper())
 	{
 		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_aStatus[Team()])
 		{
@@ -1920,7 +1893,7 @@ void CCharacter::HandleTiles(int Index)
 
 		m_StartTime -= (Minutes * 60 + Seconds) * Server()->TickSpeed();
 
-		if((g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || (Team != TEAM_FLOCK && !Teams()->TeamFlock(Team))) && Team != TEAM_SUPER)
+		if(g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || (Team != TEAM_FLOCK && !Teams()->TeamFlock(Team)))
 		{
 			for(int i = 0; i < MAX_CLIENTS; i++)
 			{
@@ -1946,7 +1919,7 @@ void CCharacter::HandleTiles(int Index)
 		if(m_StartTime > Server()->Tick())
 			m_StartTime = Server()->Tick();
 
-		if((g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || (Team != TEAM_FLOCK && !Teams()->TeamFlock(Team))) && Team != TEAM_SUPER)
+		if(g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || (Team != TEAM_FLOCK && !Teams()->TeamFlock(Team)))
 		{
 			for(int i = 0; i < MAX_CLIENTS; i++)
 			{
@@ -1976,7 +1949,7 @@ void CCharacter::HandleTiles(int Index)
 	int z = Collision()->IsTeleport(MapIndex);
 	if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons && z && !Collision()->TeleOuts(z - 1).empty())
 	{
-		if(m_Core.m_Super || m_Core.m_Invincible)
+		if(IsSuper())
 			return;
 		int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleOuts(z - 1).size());
 		m_Core.m_Pos = Collision()->TeleOuts(z - 1)[TeleOut];
@@ -1991,7 +1964,7 @@ void CCharacter::HandleTiles(int Index)
 	const int EvilTeleport = Collision()->IsEvilTeleport(MapIndex);
 	if(EvilTeleport && !Collision()->TeleOuts(EvilTeleport - 1).empty())
 	{
-		if(m_Core.m_Super || m_Core.m_Invincible)
+		if(IsSuper())
 			return;
 		int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleOuts(EvilTeleport - 1).size());
 		m_Core.m_Pos = Collision()->TeleOuts(EvilTeleport - 1)[TeleOut];
@@ -2013,7 +1986,7 @@ void CCharacter::HandleTiles(int Index)
 	}
 	if(Collision()->IsCheckEvilTeleport(MapIndex))
 	{
-		if(m_Core.m_Super || m_Core.m_Invincible)
+		if(IsSuper())
 			return;
 		// first check if there is a TeleCheckOut for the current recorded checkpoint, if not check previous checkpoints
 		for(int k = m_TeleCheckpoint - 1; k >= 0; k--)
@@ -2050,7 +2023,7 @@ void CCharacter::HandleTiles(int Index)
 	}
 	if(Collision()->IsCheckTeleport(MapIndex))
 	{
-		if(m_Core.m_Super || m_Core.m_Invincible)
+		if(IsSuper())
 			return;
 		// first check if there is a TeleCheckOut for the current recorded checkpoint, if not check previous checkpoints
 		for(int k = m_TeleCheckpoint - 1; k >= 0; k--)
@@ -2192,7 +2165,7 @@ void CCharacter::DDRaceTick()
 	if(m_Input.m_Direction != 0 || m_Input.m_Jump != 0)
 		m_LastMove = Server()->Tick();
 
-	if(m_Core.m_LiveFrozen && !m_Core.m_Super && !m_Core.m_Invincible)
+	if(m_Core.m_LiveFrozen && !IsSuper())
 	{
 		m_Input.m_Direction = 0;
 		m_Input.m_Jump = 0;
@@ -2249,12 +2222,12 @@ void CCharacter::DDRacePostCoreTick()
 {
 	m_Time = (float)(Server()->Tick() - m_StartTime) / ((float)Server()->TickSpeed());
 
-	if(m_Core.m_EndlessHook || (m_Core.m_Super && g_Config.m_SvEndlessSuperHook))
+	if(m_Core.m_EndlessHook)
 		m_Core.m_HookTick = 0;
 
 	m_FrozenLastTick = false;
 
-	if(m_Core.m_DeepFrozen && !m_Core.m_Super && !m_Core.m_Invincible)
+	if(m_Core.m_DeepFrozen && !IsSuper())
 		Freeze();
 
 	// following jump rules can be overridden by tiles, like Refill Jumps, Stopper and Wall Jump
@@ -2279,9 +2252,10 @@ void CCharacter::DDRacePostCoreTick()
 		m_Core.m_Jumped = 1;
 	}
 
-	if((m_Core.m_Super || m_Core.m_EndlessJump) && m_Core.m_Jumped > 1)
+	// TODO, endlessjump is split from invincible, what to do here
+	if(m_Core.m_EndlessJump && m_Core.m_Jumped > 1)
 	{
-		// Super players and players with infinite jumps always have light feet
+		// players with infinite jumps always have light feet
 		m_Core.m_Jumped = 1;
 	}
 
@@ -2326,7 +2300,7 @@ void CCharacter::DDRacePostCoreTick()
 
 bool CCharacter::Freeze(int Seconds)
 {
-	if(Seconds <= 0 || m_Core.m_Super || m_Core.m_Invincible || m_FreezeTime > Seconds * Server()->TickSpeed())
+	if(Seconds <= 0 || IsSuper() || m_FreezeTime > Seconds * Server()->TickSpeed())
 		return false;
 	if(m_FreezeTime == 0 || m_Core.m_FreezeStart < Server()->Tick() - Server()->TickSpeed())
 	{
@@ -2452,7 +2426,6 @@ void CCharacter::DDRaceInit()
 	for(bool &Set : m_SetSavePos)
 		Set = false;
 	m_LastBroadcast = 0;
-	m_TeamBeforeSuper = 0;
 	m_Core.m_Id = GetPlayer()->GetCid();
 	m_TeleCheckpoint = 0;
 	m_Core.m_EndlessHook = g_Config.m_SvEndlessDrag;
@@ -2499,7 +2472,7 @@ void CCharacter::DDRaceInit()
 
 void CCharacter::Rescue()
 {
-	if(m_SetSavePos[GetPlayer()->m_RescueMode] && !m_Core.m_Super && !m_Core.m_Invincible)
+	if(m_SetSavePos[GetPlayer()->m_RescueMode] && !IsSuper())
 	{
 		if(m_LastRescue + (int64_t)g_Config.m_SvRescueDelay * Server()->TickSpeed() > Server()->Tick() && !Teams()->IsPractice(Team()))
 		{

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2252,7 +2252,6 @@ void CCharacter::DDRacePostCoreTick()
 		m_Core.m_Jumped = 1;
 	}
 
-	// TODO, endlessjump is split from invincible, what to do here
 	if(m_Core.m_EndlessJump && m_Core.m_Jumped > 1)
 	{
 		// players with infinite jumps always have light feet

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1181,7 +1181,7 @@ bool CCharacter::CanSnapCharacter(int SnappingClient)
 		else if(pSnapPlayer->SpectatorId() == SPEC_FREEVIEW && !CanCollide(SnappingClient) && pSnapPlayer->m_SpecTeam && !SameTeam(SnappingClient))
 			return false;
 	}
-	else if(pSnapChar && !pSnapChar->IsSuper() && !CanCollide(SnappingClient) && (pSnapPlayer->m_ShowOthers == SHOW_OTHERS_OFF || (pSnapPlayer->m_ShowOthers == SHOW_OTHERS_ONLY_TEAM && !SameTeam(SnappingClient))))
+	else if(pSnapChar && !CanCollide(SnappingClient) && (pSnapPlayer->m_ShowOthers == SHOW_OTHERS_OFF || (pSnapPlayer->m_ShowOthers == SHOW_OTHERS_ONLY_TEAM && !SameTeam(SnappingClient))))
 		return false;
 
 	return true;

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -56,7 +56,6 @@ public:
 	void SetJumps(int Jumps);
 	void SetSolo(bool Solo);
 	void SetSuper(bool Super);
-	void SetInvincible(bool Invincible);
 	void SetCollisionDisabled(bool CollisionDisabled);
 	void SetHookHitDisabled(bool HookHitDisabled);
 	void SetLiveFrozen(bool Active);
@@ -206,7 +205,6 @@ public:
 	bool SameTeam(int ClientId);
 	void StopRecording();
 	bool m_NinjaJetpack;
-	int m_TeamBeforeSuper;
 	int m_FreezeTime;
 	bool m_FrozenLastTick;
 	int m_TuneZone;
@@ -273,8 +271,7 @@ public:
 	void SetGrenadeHitDisabled(bool GrenadeHitDisabled) { m_Core.m_GrenadeHitDisabled = GrenadeHitDisabled; }
 	void SetLaserHitDisabled(bool LaserHitDisabled) { m_Core.m_LaserHitDisabled = LaserHitDisabled; }
 
-	bool IsSuper() const { return m_Core.m_Super; }
-
+	bool IsSuper() const { return m_Core.m_Super && m_Core.m_Invincible; }
 	CSaveTee &GetLastRescueTeeRef(int Mode = RESCUEMODE_AUTO) { return m_RescueTee[Mode]; }
 	CTuningParams *GetTuning(int Zone) { return &TuningList()[Zone]; }
 };

--- a/src/game/server/entities/door.cpp
+++ b/src/game/server/entities/door.cpp
@@ -67,7 +67,7 @@ void CDoor::Snap(int SnappingClient)
 		if(SnappingClient != SERVER_DEMO_CLIENT && (GameServer()->m_apPlayers[SnappingClient]->GetTeam() == TEAM_SPECTATORS || GameServer()->m_apPlayers[SnappingClient]->IsPaused()) && GameServer()->m_apPlayers[SnappingClient]->SpectatorId() != SPEC_FREEVIEW)
 			pChr = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->SpectatorId());
 
-		if(pChr && pChr->Team() != TEAM_SUPER && pChr->IsAlive() && !Switchers().empty() && Switchers()[m_Number].m_aStatus[pChr->Team()])
+		if(pChr && pChr->IsAlive() && !Switchers().empty() && Switchers()[m_Number].m_aStatus[pChr->Team()])
 		{
 			From = m_To;
 		}

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -79,11 +79,6 @@ void CDragger::LookForPlayersToDrag()
 		CCharacter *pTarget = static_cast<CCharacter *>(apPlayersInRange[i]);
 		const int &TargetTeam = pTarget->Team();
 
-		// Do not create a dragger beam for super player
-		if(TargetTeam == TEAM_SUPER)
-		{
-			continue;
-		}
 		// If the dragger is disabled for the target's team, no dragger beam will be generated
 		if(m_Layer == LAYER_SWITCH && m_Number > 0 &&
 			!Switchers()[m_Number].m_aStatus[TargetTeam])

--- a/src/game/server/entities/dragger.h
+++ b/src/game/server/entities/dragger.h
@@ -10,7 +10,6 @@ class CDraggerBeam;
  *
  * A dragger will only generate one dragger beam per team for the closest player for whom the following criteria are met:
  * - The player is within the dragger range (sv_dragger_range).
- * - The player is not a super player
  * - The dragger is activated
  * - The dragger beam to be generated is not blocked by laser stoppers (or solid blocks if IgnoreWalls is set to false)
  * With the exception of solo players, for whom a dragger beam is always generated, regardless of the rest of the team,

--- a/src/game/server/entities/gun.cpp
+++ b/src/game/server/entities/gun.cpp
@@ -65,11 +65,6 @@ void CGun::Fire()
 	{
 		CCharacter *pTarget = static_cast<CCharacter *>(apPlayersInRange[i]);
 		const int &TargetTeam = pTarget->Team();
-		// Do not fire at super players
-		if(TargetTeam == TEAM_SUPER)
-		{
-			continue;
-		}
 		// If the turret is disabled for the target's team, the turret will not fire
 		if(m_Layer == LAYER_SWITCH && m_Number > 0 &&
 			!Switchers()[m_Number].m_aStatus[TargetTeam])

--- a/src/game/server/entities/gun.h
+++ b/src/game/server/entities/gun.h
@@ -11,7 +11,6 @@
  * A turret fires plasma bullets with a certain firing rate (sv_plasma_per_sec) at the closest player of a team for whom
  * the following criteria are met:
  * - The player is within the turret range (sv_plasma_range)
- * - The player is not a super player
  * - The turret is activated
  * - The initial trajectory of the plasma bullet to be generated would not be stopped by any solid block
  * With the exception of solo players, for whom plasma bullets will always be fired, regardless of the rest of the team,

--- a/src/game/server/entities/light.cpp
+++ b/src/game/server/entities/light.cpp
@@ -111,11 +111,7 @@ void CLight::Snap(int SnappingClient)
 	vec2 From = m_Pos;
 	int StartTick = -1;
 
-	if(pChr && pChr->Team() == TEAM_SUPER)
-	{
-		From = m_Pos;
-	}
-	else if(pChr && m_Layer == LAYER_SWITCH && m_Number > 0 && Switchers()[m_Number].m_aStatus[pChr->Team()])
+	if(pChr && m_Layer == LAYER_SWITCH && m_Number > 0 && Switchers()[m_Number].m_aStatus[pChr->Team()])
 	{
 		From = m_To;
 	}

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -57,8 +57,6 @@ void CPickup::Tick()
 				break;
 
 			case POWERUP_ARMOR:
-				if(pChr->Team() == TEAM_SUPER)
-					continue;
 				for(int j = WEAPON_SHOTGUN; j < NUM_WEAPONS; j++)
 				{
 					if(pChr->GetWeaponGot(j))
@@ -81,8 +79,6 @@ void CPickup::Tick()
 				break;
 
 			case POWERUP_ARMOR_SHOTGUN:
-				if(pChr->Team() == TEAM_SUPER)
-					continue;
 				if(pChr->GetWeaponGot(WEAPON_SHOTGUN))
 				{
 					pChr->SetWeaponGot(WEAPON_SHOTGUN, false);
@@ -95,8 +91,6 @@ void CPickup::Tick()
 				break;
 
 			case POWERUP_ARMOR_GRENADE:
-				if(pChr->Team() == TEAM_SUPER)
-					continue;
 				if(pChr->GetWeaponGot(WEAPON_GRENADE))
 				{
 					pChr->SetWeaponGot(WEAPON_GRENADE, false);
@@ -109,16 +103,12 @@ void CPickup::Tick()
 				break;
 
 			case POWERUP_ARMOR_NINJA:
-				if(pChr->Team() == TEAM_SUPER)
-					continue;
 				pChr->SetNinjaActivationDir(vec2(0, 0));
 				pChr->SetNinjaActivationTick(-500);
 				pChr->SetNinjaCurrentMoveTime(0);
 				break;
 
 			case POWERUP_ARMOR_LASER:
-				if(pChr->Team() == TEAM_SUPER)
-					continue;
 				if(pChr->GetWeaponGot(WEAPON_LASER))
 				{
 					pChr->SetWeaponGot(WEAPON_LASER, false);

--- a/src/game/server/entities/plasma.cpp
+++ b/src/game/server/entities/plasma.cpp
@@ -65,12 +65,6 @@ bool CPlasma::HitCharacter(CCharacter *pTarget)
 		return false;
 	}
 
-	// Super player should not be able to stop the plasma bullets
-	if(pHitPlayer->Team() == TEAM_SUPER)
-	{
-		return false;
-	}
-
 	m_Freeze ? pHitPlayer->Freeze() : pHitPlayer->Unfreeze();
 	if(m_Explosive)
 	{

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1091,9 +1091,9 @@ void CGameContext::OnPreTickTeehistorian()
 		else
 			m_TeeHistorian.RecordPlayerTeam(i, 0);
 	}
-	for(int i = 0; i < NUM_DDRACE_TEAMS; i++)
+	for(int TeamId = 0; TeamId < NUM_DDRACE_TEAMS; TeamId++)
 	{
-		m_TeeHistorian.RecordTeamPractice(i, m_pController->Teams().IsPractice(i));
+		m_TeeHistorian.RecordTeamPractice(TeamId, m_pController->Teams().IsPractice(TeamId));
 	}
 }
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3954,7 +3954,8 @@ void CGameContext::RegisterDDRaceCommands()
 	Console()->Register("unweapons", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConUnWeapons, this, "Removes all weapons from you");
 	Console()->Register("ninja", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConNinja, this, "Makes you a ninja");
 	Console()->Register("unninja", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConUnNinja, this, "Removes ninja from you");
-	Console()->Register("super", "?i['0'|'1']", CFGFLAG_SERVER | CMDFLAG_TEST, ConToggleSuper, this, "Toggles super mode");
+	Console()->Register("super", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConSuper, this, "Makes you super");
+	Console()->Register("unsuper", "", CFGFLAG_SERVER, ConUnSuper, this, "Removes super from you");
 	Console()->Register("infinite_jump", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConEndlessJump, this, "Gives you infinite jump");
 	Console()->Register("uninfinite_jump", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConUnEndlessJump, this, "Removes infinite jump from you");
 	Console()->Register("endless_hook", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConEndlessHook, this, "Gives you endless hook");

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -347,8 +347,6 @@ void CGameContext::CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamag
 			int PlayerTeam = pChr->Team();
 			if((GetPlayerChar(Owner) ? GetPlayerChar(Owner)->GrenadeHitDisabled() : !g_Config.m_SvHit) || NoDamage)
 			{
-				if(PlayerTeam == TEAM_SUPER)
-					continue;
 				if(!TeamMask.test(PlayerTeam))
 					continue;
 				TeamMask.reset(PlayerTeam);
@@ -443,9 +441,6 @@ void CGameContext::SnapSwitchers(int SnappingClient)
 
 	if(pPlayer && (pPlayer->GetTeam() == TEAM_SPECTATORS || pPlayer->IsPaused()) && pPlayer->SpectatorId() != SPEC_FREEVIEW && m_apPlayers[pPlayer->SpectatorId()] && m_apPlayers[pPlayer->SpectatorId()]->GetCharacter())
 		Team = m_apPlayers[pPlayer->SpectatorId()]->GetCharacter()->Team();
-
-	if(Team == TEAM_SUPER)
-		return;
 
 	int SentTeam = Team;
 	if(g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO)
@@ -1096,7 +1091,7 @@ void CGameContext::OnPreTickTeehistorian()
 		else
 			m_TeeHistorian.RecordPlayerTeam(i, 0);
 	}
-	for(int i = 0; i < TEAM_SUPER; i++)
+	for(int i = 0; i < NUM_DDRACE_TEAMS; i++)
 	{
 		m_TeeHistorian.RecordTeamPractice(i, m_pController->Teams().IsPractice(i));
 	}
@@ -3467,8 +3462,6 @@ void CGameContext::ConHotReload(IConsole::IResult *pResult, void *pUserData)
 
 		// Save the team state
 		pSelf->m_aTeamMapping[i] = pSelf->GetDDRaceTeam(i);
-		if(pSelf->m_aTeamMapping[i] == TEAM_SUPER)
-			pSelf->m_aTeamMapping[i] = pChar->m_TeamBeforeSuper;
 
 		if(pSelf->m_apSavedTeams[pSelf->m_aTeamMapping[i]])
 			continue;
@@ -3961,9 +3954,7 @@ void CGameContext::RegisterDDRaceCommands()
 	Console()->Register("unweapons", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConUnWeapons, this, "Removes all weapons from you");
 	Console()->Register("ninja", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConNinja, this, "Makes you a ninja");
 	Console()->Register("unninja", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConUnNinja, this, "Removes ninja from you");
-	Console()->Register("super", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConSuper, this, "Makes you super");
-	Console()->Register("unsuper", "", CFGFLAG_SERVER, ConUnSuper, this, "Removes super from you");
-	Console()->Register("invincible", "?i['0'|'1']", CFGFLAG_SERVER | CMDFLAG_TEST, ConToggleInvincible, this, "Toggles invincible mode");
+	Console()->Register("super", "?i['0'|'1']", CFGFLAG_SERVER | CMDFLAG_TEST, ConToggleSuper, this, "Toggles super mode");
 	Console()->Register("infinite_jump", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConEndlessJump, this, "Gives you infinite jump");
 	Console()->Register("uninfinite_jump", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConUnEndlessJump, this, "Removes infinite jump from you");
 	Console()->Register("endless_hook", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConEndlessHook, this, "Gives you endless hook");
@@ -4113,11 +4104,10 @@ void CGameContext::RegisterChatCommands()
 	Console()->Register("endless", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeEndlessHook, this, "Gives you endless hook");
 	Console()->Register("unendless", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnEndlessHook, this, "Removes endless hook from you");
 	Console()->Register("setswitch", "i[switch] ?i['0'|'1'] ?i[seconds]", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeSetSwitch, this, "Toggle or set the switch on or off for the specified time (or indefinitely by default)");
-	Console()->Register("invincible", "?i['0'|'1']", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeToggleInvincible, this, "Toggles invincible mode");
 	Console()->Register("collision", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeToggleCollision, this, "Toggles collision");
 	Console()->Register("hookcollision", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeToggleHookCollision, this, "Toggles hook collision");
 	Console()->Register("hitothers", "?s['all'|'hammer'|'shotgun'|'grenade'|'laser']", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeToggleHitOthers, this, "Toggles hit others");
-
+	Console()->Register("super", "?i['0'|'1']", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeToggleSuper, this, "Toggles super mode");
 	Console()->Register("kill", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConProtectedKill, this, "Kill yourself when kill-protected during a long game (use f1, kill for regular kill)");
 }
 

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -443,6 +443,8 @@ private:
 	static void ConUnDeep(IConsole::IResult *pResult, void *pUserData);
 	static void ConLiveFreeze(IConsole::IResult *pResult, void *pUserData);
 	static void ConUnLiveFreeze(IConsole::IResult *pResult, void *pUserData);
+	static void ConSuper(IConsole::IResult *pResult, void *pUserData);
+	static void ConUnSuper(IConsole::IResult *pResult, void *pUserData);
 	static void ConToggleSuper(IConsole::IResult *pResult, void *pUserData);
 	static void ConShotgun(IConsole::IResult *pResult, void *pUserData);
 	static void ConGrenade(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -443,9 +443,7 @@ private:
 	static void ConUnDeep(IConsole::IResult *pResult, void *pUserData);
 	static void ConLiveFreeze(IConsole::IResult *pResult, void *pUserData);
 	static void ConUnLiveFreeze(IConsole::IResult *pResult, void *pUserData);
-	static void ConUnSuper(IConsole::IResult *pResult, void *pUserData);
-	static void ConSuper(IConsole::IResult *pResult, void *pUserData);
-	static void ConToggleInvincible(IConsole::IResult *pResult, void *pUserData);
+	static void ConToggleSuper(IConsole::IResult *pResult, void *pUserData);
 	static void ConShotgun(IConsole::IResult *pResult, void *pUserData);
 	static void ConGrenade(IConsole::IResult *pResult, void *pUserData);
 	static void ConLaser(IConsole::IResult *pResult, void *pUserData);
@@ -561,10 +559,10 @@ private:
 	static void ConPracticeEndlessHook(IConsole::IResult *pResult, void *pUserData);
 	static void ConPracticeUnEndlessHook(IConsole::IResult *pResult, void *pUserData);
 	static void ConPracticeSetSwitch(IConsole::IResult *pResult, void *pUserData);
-	static void ConPracticeToggleInvincible(IConsole::IResult *pResult, void *pUserData);
 	static void ConPracticeToggleCollision(IConsole::IResult *pResult, void *pUserData);
 	static void ConPracticeToggleHookCollision(IConsole::IResult *pResult, void *pUserData);
 	static void ConPracticeToggleHitOthers(IConsole::IResult *pResult, void *pUserData);
+	static void ConPracticeToggleSuper(IConsole::IResult *pResult, void *pUserData);
 
 	static void ConPracticeAddWeapon(IConsole::IResult *pResult, void *pUserData);
 	static void ConPracticeRemoveWeapon(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/server/gamemodes/ddnet.cpp
+++ b/src/game/server/gamemodes/ddnet.cpp
@@ -216,7 +216,7 @@ void CGameControllerDDNet::OnPlayerDisconnect(CPlayer *pPlayer, const char *pRea
 	if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO)
 		Teams().SetForceCharacterTeam(ClientId, TEAM_FLOCK);
 
-	for(int Team = TEAM_FLOCK + 1; Team < TEAM_SUPER; Team++)
+	for(int Team = TEAM_FLOCK + 1; Team < NUM_DDRACE_TEAMS; Team++)
 		if(Teams().IsInvited(Team, ClientId))
 			Teams().SetClientInvited(Team, ClientId, false);
 }

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -490,8 +490,7 @@ bool CSaveTee::IsHooking() const
 void CSaveHotReloadTee::Save(CCharacter *pChr, bool AddPenalty)
 {
 	m_SaveTee.Save(pChr, AddPenalty);
-	m_Super = pChr->m_Core.m_Super;
-	m_Invincible = pChr->m_Core.m_Invincible;
+	m_Super = pChr->IsSuper();
 	m_SavedTeleTee = pChr->GetPlayer()->m_LastTeleTee;
 	m_LastDeath = pChr->GetPlayer()->m_LastDeath;
 }
@@ -499,8 +498,8 @@ void CSaveHotReloadTee::Save(CCharacter *pChr, bool AddPenalty)
 bool CSaveHotReloadTee::Load(CCharacter *pChr, int Team)
 {
 	bool Result = m_SaveTee.Load(pChr, Team);
-	pChr->SetSuper(m_Super);
-	pChr->m_Core.m_Invincible = m_Invincible;
+	pChr->m_Core.m_Invincible = m_Super;
+	pChr->m_Core.m_Super = m_Super; // separate because setter also sets endless jump
 	pChr->GetPlayer()->m_LastTeleTee = m_SavedTeleTee;
 	pChr->GetPlayer()->m_LastDeath = m_LastDeath;
 

--- a/src/game/server/save.h
+++ b/src/game/server/save.h
@@ -165,7 +165,6 @@ public:
 private:
 	CSaveTee m_SaveTee;
 	bool m_Super;
-	bool m_Invincible;
 	CSaveTee m_SavedTeleTee;
 	std::optional<CSaveTee> m_LastDeath;
 };

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -235,21 +235,21 @@ void CGameTeams::Tick()
 		}
 	}
 
-	for(int i = 0; i < NUM_DDRACE_TEAMS; i++)
+	for(int TeamId = 0; TeamId < NUM_DDRACE_TEAMS; TeamId++)
 	{
-		if(m_aTeamUnfinishableKillTick[i] == -1 || m_aTeamState[i] != ETeamState::STARTED_UNFINISHABLE)
+		if(m_aTeamUnfinishableKillTick[TeamId] == -1 || m_aTeamState[TeamId] != ETeamState::STARTED_UNFINISHABLE)
 		{
 			continue;
 		}
-		if(Now >= m_aTeamUnfinishableKillTick[i])
+		if(Now >= m_aTeamUnfinishableKillTick[TeamId])
 		{
-			if(m_aPractice[i])
+			if(m_aPractice[TeamId])
 			{
-				m_aTeamUnfinishableKillTick[i] = -1;
+				m_aTeamUnfinishableKillTick[TeamId] = -1;
 				continue;
 			}
-			GameServer()->SendChatTeam(i, "Your team was killed because it couldn't finish anymore and hasn't entered /practice mode");
-			KillTeam(i, -1);
+			GameServer()->SendChatTeam(TeamId, "Your team was killed because it couldn't finish anymore and hasn't entered /practice mode");
+			KillTeam(TeamId, -1);
 		}
 	}
 
@@ -1334,9 +1334,9 @@ void CGameTeams::ResetSavedTeam(int ClientId, int Team)
 
 std::optional<int> CGameTeams::GetFirstEmptyTeam() const
 {
-	for(int i = 1; i < NUM_DDRACE_TEAMS - 1; i++) // no TEAM_SUPER
-		if(m_aTeamState[i] == ETeamState::EMPTY)
-			return i;
+	for(int TeamId = 1; TeamId < NUM_DDRACE_TEAMS - 1; TeamId++) // no TEAM_SUPER
+		if(m_aTeamState[TeamId] == ETeamState::EMPTY)
+			return TeamId;
 	return std::nullopt;
 }
 

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -1438,5 +1438,5 @@ bool CGameTeams::IsPractice(int Team)
 
 bool CGameTeams::IsValidTeamNumber(int Team) const
 {
-	return Team >= TEAM_FLOCK && Team < NUM_DDRACE_TEAMS - 1; // no TEAM_SUPER
+	return Team >= TEAM_FLOCK && Team < NUM_DDRACE_TEAMS;
 }

--- a/src/game/teamscore.cpp
+++ b/src/game/teamscore.cpp
@@ -28,14 +28,14 @@ void CTeamsCore::Team(int ClientId, int Team)
 
 bool CTeamsCore::CanKeepHook(int ClientId1, int ClientId2) const
 {
-	if(m_aTeam[ClientId1] == (m_IsDDRace16 ? VANILLA_TEAM_SUPER : TEAM_SUPER) || m_aTeam[ClientId2] == (m_IsDDRace16 ? VANILLA_TEAM_SUPER : TEAM_SUPER) || ClientId1 == ClientId2)
+	if(ClientId1 == ClientId2)
 		return true;
 	return m_aTeam[ClientId1] == m_aTeam[ClientId2];
 }
 
 bool CTeamsCore::CanCollide(int ClientId1, int ClientId2) const
 {
-	if(m_aTeam[ClientId1] == (m_IsDDRace16 ? VANILLA_TEAM_SUPER : TEAM_SUPER) || m_aTeam[ClientId2] == (m_IsDDRace16 ? VANILLA_TEAM_SUPER : TEAM_SUPER) || ClientId1 == ClientId2)
+	if(ClientId1 == ClientId2)
 		return true;
 	if(m_aIsSolo[ClientId1] || m_aIsSolo[ClientId2])
 		return false;

--- a/src/game/teamscore.cpp
+++ b/src/game/teamscore.cpp
@@ -12,7 +12,7 @@ CTeamsCore::CTeamsCore()
 
 bool CTeamsCore::SameTeam(int ClientId1, int ClientId2) const
 {
-	return m_aTeam[ClientId1] == TEAM_SUPER || m_aTeam[ClientId2] == TEAM_SUPER || m_aTeam[ClientId1] == m_aTeam[ClientId2];
+	return m_aTeam[ClientId1] == m_aTeam[ClientId2];
 }
 
 int CTeamsCore::Team(int ClientId) const

--- a/src/game/teamscore.h
+++ b/src/game/teamscore.h
@@ -9,7 +9,6 @@ enum
 	TEAM_FLOCK = 0,
 	TEAM_SUPER = 64,
 	NUM_DDRACE_TEAMS = TEAM_SUPER + 1,
-	VANILLA_TEAM_SUPER = VANILLA_MAX_CLIENTS
 };
 
 // do not change the values of the following enum

--- a/src/game/teamscore.h
+++ b/src/game/teamscore.h
@@ -7,8 +7,7 @@
 enum
 {
 	TEAM_FLOCK = 0,
-	TEAM_SUPER = 64,
-	NUM_DDRACE_TEAMS = TEAM_SUPER + 1,
+	NUM_DDRACE_TEAMS = 64,
 };
 
 // do not change the values of the following enum


### PR DESCRIPTION
Fixes https://github.com/ddnet/ddnet/issues/9117
Helps progress [128 player support]( https://github.com/ddnet/ddnet/pull/10581)
Fixes https://github.com/ddnet/ddnet/issues/4799

Draft, only server-side now. Also renamed `NUM_DDRACE_TEAMS` -> `NUM_ALL_TEAMS` and `TEAM_SUPER`  -> `NUM_JOINABLE_TEAMS` to see the changes more clearly.

Server builds fine, and works correctly with the latest master client. Client won't build now because of the renamed variables.
I'll revert the variable names or rename them to something better and fix the build if this PR gets the green light.


**How this PR works:**
`/super` will now send both invincible and super flags. Their logic was the same in most cases, but also sending the invincible flag adds the sparkles particles. 

Prediction is working perfectly fine. That is done by using `CharacterCore` super and invincible variables (now `IsSuper()`) and removing `Team == TEAM_SUPER` checks. (We can keep the checks on client side to predict servers that have super) 

So far from my testing, the only issue is that doors are incorrectly rendered. But that problem is on the client-side prediction incorrectly removing lasers, even though we receive snaps for them. (wrong super detection)

What should be done on the client-side? 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
