### PR TITLE
Print some of the variable values that failed an assert

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -261,7 +261,7 @@ IOHANDLE io_open(const char *filename, int flags)
 	}
 	else
 	{
-		dbg_assert_failed("logic error");
+		dbg_assert_failed("Invalid flags: %d", flags);
 	}
 	return fopen(filename, open_mode);
 #endif
@@ -365,7 +365,7 @@ int io_seek(IOHANDLE io, int64_t offset, ESeekOrigin origin)
 		real_origin = SEEK_END;
 		break;
 	default:
-		dbg_assert_failed("origin invalid");
+		dbg_assert_failed("Invalid origin: %d", origin);
 	}
 #if defined(CONF_FAMILY_WINDOWS)
 	return _fseeki64((FILE *)io, offset, real_origin);
@@ -2957,7 +2957,7 @@ ETimeSeason time_season()
 	case 10:
 		return SEASON_AUTUMN;
 	default:
-		dbg_assert_failed("Invalid month");
+		dbg_assert_failed("Invalid month: %d", time_info->tm_mon);
 	}
 }
 
@@ -3327,7 +3327,7 @@ PROCESS shell_execute(const char *file, EShellExecuteWindowState window_state, c
 		info.nShow = SW_SHOWMINNOACTIVE;
 		break;
 	default:
-		dbg_assert_failed("window_state invalid");
+		dbg_assert_failed("Invalid window_state: %d", static_cast<int>(window_state));
 	}
 	info.fMask = SEE_MASK_NOCLOSEPROCESS;
 	// Save and restore the FPU control word because ShellExecute might change it

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -307,7 +307,7 @@ const char *CServer::DnsblStateStr(EDnsblState State)
 		return "white";
 	}
 
-	dbg_assert_failed("unreachable");
+	dbg_assert_failed("Invalid dnsbl State: %d", static_cast<int>(State));
 }
 
 IConsole::EAccessLevel CServer::ConsoleAccessLevel(int ClientId) const
@@ -323,7 +323,7 @@ IConsole::EAccessLevel CServer::ConsoleAccessLevel(int ClientId) const
 		return IConsole::EAccessLevel::HELPER;
 	};
 
-	dbg_assert_failed("invalid auth level: %d", AuthLevel);
+	dbg_assert_failed("Invalid AuthLevel: %d", AuthLevel);
 }
 
 bool CServer::IsClientNameAvailable(int ClientId, const char *pNameRequest)
@@ -352,7 +352,7 @@ bool CServer::IsClientNameAvailable(int ClientId, const char *pNameRequest)
 
 bool CServer::SetClientNameImpl(int ClientId, const char *pNameRequest, bool Set)
 {
-	dbg_assert(0 <= ClientId && ClientId < MAX_CLIENTS, "invalid client id");
+	dbg_assert(0 <= ClientId && ClientId < MAX_CLIENTS, "Invalid ClientId: %d", ClientId);
 	if(m_aClients[ClientId].m_State < CClient::STATE_READY)
 		return false;
 
@@ -408,7 +408,7 @@ bool CServer::SetClientNameImpl(int ClientId, const char *pNameRequest, bool Set
 
 bool CServer::SetClientClanImpl(int ClientId, const char *pClanRequest, bool Set)
 {
-	dbg_assert(0 <= ClientId && ClientId < MAX_CLIENTS, "invalid client id");
+	dbg_assert(0 <= ClientId && ClientId < MAX_CLIENTS, "Invalid ClientId: %d", ClientId);
 	if(m_aClients[ClientId].m_State < CClient::STATE_READY)
 		return false;
 
@@ -522,7 +522,7 @@ void CServer::Ban(int ClientId, int Seconds, const char *pReason, bool VerbatimR
 
 void CServer::ReconnectClient(int ClientId)
 {
-	dbg_assert(0 <= ClientId && ClientId < MAX_CLIENTS, "invalid client id");
+	dbg_assert(0 <= ClientId && ClientId < MAX_CLIENTS, "Invalid ClientId: %d", ClientId);
 
 	if(GetClientVersion(ClientId) < VERSION_DDNET_RECONNECT)
 	{
@@ -545,7 +545,7 @@ void CServer::ReconnectClient(int ClientId)
 
 void CServer::RedirectClient(int ClientId, int Port)
 {
-	dbg_assert(0 <= ClientId && ClientId < MAX_CLIENTS, "invalid client id");
+	dbg_assert(0 <= ClientId && ClientId < MAX_CLIENTS, "Invalid ClientId: %d", ClientId);
 
 	bool SupportsRedirect = GetClientVersion(ClientId) >= VERSION_DDNET_REDIRECT;
 
@@ -624,7 +624,7 @@ void CServer::SetRconCid(int ClientId)
 
 int CServer::GetAuthedState(int ClientId) const
 {
-	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "ClientId is not valid");
+	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "Invalid ClientId: %d", ClientId);
 	dbg_assert(m_aClients[ClientId].m_State != CServer::CClient::STATE_EMPTY, "Client slot is empty");
 	return m_AuthManager.KeyLevel(m_aClients[ClientId].m_AuthKey);
 }
@@ -641,8 +641,8 @@ bool CServer::IsRconAuthedAdmin(int ClientId) const
 
 const char *CServer::GetAuthName(int ClientId) const
 {
-	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "ClientId is not valid");
-	dbg_assert(m_aClients[ClientId].m_State != CServer::CClient::STATE_EMPTY, "Client slot is empty");
+	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "Invalid ClientId: %d", ClientId);
+	dbg_assert(m_aClients[ClientId].m_State != CServer::CClient::STATE_EMPTY, "Client slot %d is empty", ClientId);
 	int Key = m_aClients[ClientId].m_AuthKey;
 	dbg_assert(Key != -1, "Client not authed");
 	return m_AuthManager.KeyIdent(Key);
@@ -650,13 +650,13 @@ const char *CServer::GetAuthName(int ClientId) const
 
 bool CServer::HasAuthHidden(int ClientId) const
 {
-	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "ClientId is not valid");
+	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "Invalid ClientId: %d", ClientId);
 	return m_aClients[ClientId].m_AuthHidden;
 }
 
 bool CServer::GetClientInfo(int ClientId, CClientInfo *pInfo) const
 {
-	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "ClientId is not valid");
+	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "Invalid ClientId: %d", ClientId);
 	dbg_assert(pInfo != nullptr, "pInfo cannot be null");
 
 	if(m_aClients[ClientId].m_State == CClient::STATE_INGAME)
@@ -682,7 +682,7 @@ bool CServer::GetClientInfo(int ClientId, CClientInfo *pInfo) const
 
 void CServer::SetClientDDNetVersion(int ClientId, int DDNetVersion)
 {
-	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "ClientId is not valid");
+	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "Invalid ClientId: %d", ClientId);
 
 	if(m_aClients[ClientId].m_State == CClient::STATE_INGAME)
 	{
@@ -693,8 +693,8 @@ void CServer::SetClientDDNetVersion(int ClientId, int DDNetVersion)
 
 const NETADDR *CServer::ClientAddr(int ClientId) const
 {
-	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "ClientId is not valid");
-	dbg_assert(m_aClients[ClientId].m_State != CServer::CClient::STATE_EMPTY, "Client slot is empty");
+	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "Invalid ClientId: %d", ClientId);
+	dbg_assert(m_aClients[ClientId].m_State != CServer::CClient::STATE_EMPTY, "Client slot %d is empty", ClientId);
 #ifdef CONF_DEBUG
 	if(m_aClients[ClientId].m_DebugDummy)
 	{
@@ -706,8 +706,8 @@ const NETADDR *CServer::ClientAddr(int ClientId) const
 
 const std::array<char, NETADDR_MAXSTRSIZE> &CServer::ClientAddrStringImpl(int ClientId, bool IncludePort) const
 {
-	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "ClientId is not valid");
-	dbg_assert(m_aClients[ClientId].m_State != CServer::CClient::STATE_EMPTY, "Client slot is empty");
+	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "Invalid ClientId: %d", ClientId);
+	dbg_assert(m_aClients[ClientId].m_State != CServer::CClient::STATE_EMPTY, "Client slot %d is empty", ClientId);
 #ifdef CONF_DEBUG
 	if(m_aClients[ClientId].m_DebugDummy)
 	{
@@ -2323,7 +2323,7 @@ void CServer::CacheServerInfo(CCache *pCache, int Type, bool SendClients)
 	case SERVERINFO_64_LEGACY: Remaining = 24; break;
 	case SERVERINFO_VANILLA: Remaining = VANILLA_MAX_CLIENTS; break;
 	case SERVERINFO_INGAME: Remaining = VANILLA_MAX_CLIENTS; break;
-	default: dbg_assert_failed("unreachable");
+	default: dbg_assert_failed("Invalid Type: %d", Type);
 	}
 
 	// Use the following strategy for sending:
@@ -2486,7 +2486,7 @@ void CServer::CacheServerInfoSixup(CCache *pCache, bool SendClients, int MaxCons
 				}
 				else
 				{
-					dbg_assert(Packer.Size() <= MaxPacketSize, "Max packet size exceeded while repacking");
+					dbg_assert(Packer.Size() <= MaxPacketSize, "Max packet size exceeded while repacking. Packer.Size()=%d MaxPacketSize=%d", Packer.Size(), MaxPacketSize);
 				}
 			}
 		}
@@ -2539,7 +2539,7 @@ void CServer::SendServerInfo(const NETADDR *pAddr, int Token, int Type, bool Sen
 		}
 		else
 		{
-			dbg_assert_failed("unknown serverinfo type");
+			dbg_assert_failed("Invalid serverinfo Type: %d", Type);
 		}
 
 		p.AddRaw(Chunk.m_vData.data(), Chunk.m_vData.size());
@@ -4387,7 +4387,7 @@ void CServer::SnapFreeId(int Id)
 
 void *CServer::SnapNewItem(int Type, int Id, int Size)
 {
-	dbg_assert(Id >= -1 && Id <= 0xffff, "incorrect id");
+	dbg_assert(Id >= -1 && Id <= 0xffff, "Invalid snap item Id: %d", Id);
 	return Id < 0 ? nullptr : m_SnapshotBuilder.NewItem(Type, Id, Size);
 }
 

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -141,7 +141,7 @@ public:
 
 	int GetFileDataSize(int Index) const
 	{
-		dbg_assert(Index >= 0 && Index < m_Header.m_NumRawData, "Index invalid: %d", Index);
+		dbg_assert(Index >= 0 && Index < m_Header.m_NumRawData, "Invalid Index: %d", Index);
 
 		if(Index == m_Header.m_NumRawData - 1)
 		{
@@ -292,7 +292,7 @@ public:
 
 	int GetFileItemSize(int Index) const
 	{
-		dbg_assert(Index >= 0 && Index < m_Header.m_NumItems, "Index invalid: %d", Index);
+		dbg_assert(Index >= 0 && Index < m_Header.m_NumItems, "Invalid Index: %d", Index);
 
 		if(Index == m_Header.m_NumItems - 1)
 		{
@@ -309,7 +309,7 @@ public:
 
 	CDatafileItem *GetItem(int Index) const
 	{
-		dbg_assert(Index >= 0 && Index < m_Header.m_NumItems, "Index invalid: %d", Index);
+		dbg_assert(Index >= 0 && Index < m_Header.m_NumItems, "Invalid Index: %d", Index);
 
 		return static_cast<CDatafileItem *>(static_cast<void *>(m_Info.m_pItemStart + m_Info.m_pItemOffsets[Index]));
 	}
@@ -993,8 +993,8 @@ int CDataFileWriter::GetExtendedItemTypeIndex(int Type, const CUuid *pUuid)
 
 int CDataFileWriter::AddItem(int Type, int Id, size_t Size, const void *pData, const CUuid *pUuid)
 {
-	dbg_assert((Type >= 0 && Type <= MAX_ITEM_TYPE) || Type >= OFFSET_UUID || (Type == -1 && pUuid != nullptr), "Invalid type: %d", Type);
-	dbg_assert(Id >= 0 && Id <= MAX_ITEM_ID, "Invalid ID: %d", Id);
+	dbg_assert((Type >= 0 && Type <= MAX_ITEM_TYPE) || Type >= OFFSET_UUID || (Type == -1 && pUuid != nullptr), "Invalid Type: %d", Type);
+	dbg_assert(Id >= 0 && Id <= MAX_ITEM_ID, "Invalid Id: %d", Id);
 	dbg_assert(Size == 0 || pData != nullptr, "Data missing"); // Items without data are allowed
 	dbg_assert(Size <= (size_t)std::numeric_limits<int>::max(), "Data too large");
 	dbg_assert(Size % sizeof(int) == 0, "Invalid data boundary");
@@ -1100,7 +1100,7 @@ static int CompressionLevelToZlib(CDataFileWriter::ECompressionLevel Compression
 	case CDataFileWriter::COMPRESSION_BEST:
 		return Z_BEST_COMPRESSION;
 	default:
-		dbg_assert_failed("CompressionLevel invalid");
+		dbg_assert_failed("Invalid CompressionLevel: %d", static_cast<int>(CompressionLevel));
 	}
 }
 
@@ -1170,7 +1170,7 @@ void CDataFileWriter::Finish()
 	int ItemCount = 0;
 	for(const auto &[Type, ItemType] : m_ItemTypes)
 	{
-		dbg_assert(ItemType.m_Num > 0, "Invalid item type entry");
+		dbg_assert(ItemType.m_Num > 0, "Invalid ItemType.m_Num: %d", ItemType.m_Num);
 
 		CDatafileItemType Info;
 		Info.m_Type = Type;

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -698,7 +698,7 @@ int CNetServer::Send(CNetChunk *pChunk)
 		int Flags = 0;
 		dbg_assert(
 			pChunk->m_ClientId >= 0 && pChunk->m_ClientId < MaxClients(),
-			"erroneous client id %d",
+			"Invalid pChunk->m_ClientId: %d",
 			pChunk->m_ClientId);
 
 		if(pChunk->m_Flags & NETSENDFLAG_VITAL)

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -505,7 +505,7 @@ void CMenus::RenderMenubar(CUIRect Box, IClient::EClientState ClientState)
 	}
 	else
 	{
-		dbg_assert_failed("Client state invalid for RenderMenubar");
+		dbg_assert_failed("Client state %d is invalid for RenderMenubar", ClientState);
 	}
 
 	// First render buttons aligned from right side so remaining
@@ -1128,7 +1128,7 @@ void CMenus::Render()
 			}
 			else
 			{
-				dbg_assert_failed("m_MenuPage invalid");
+				dbg_assert_failed("Invalid m_MenuPage: %d", m_MenuPage);
 			}
 
 			RenderMenubar(TabBar, ClientState);
@@ -1180,7 +1180,7 @@ void CMenus::Render()
 			}
 			else
 			{
-				dbg_assert_failed("m_GamePage invalid");
+				dbg_assert_failed("Invalid m_GamePage: %d", m_GamePage);
 			}
 
 			RenderMenubar(TabBar, ClientState);
@@ -2031,7 +2031,7 @@ void CMenus::RenderPopupLoading(CUIRect Screen)
 			str_copy(aLabel1, Localize("Sending initial client info"));
 			break;
 		default:
-			dbg_assert_failed("Invalid loading state for RenderPopupLoading");
+			dbg_assert_failed("Invalid loading state %d for RenderPopupLoading", static_cast<int>(Client()->LoadingStateDetail()));
 		}
 		aLabel2[0] = '\0';
 	}
@@ -2428,7 +2428,7 @@ int CMenus::DoButton_CheckBox_Tristate(const void *pId, const char *pText, TRIST
 	case TRISTATE::ALL:
 		return DoButton_CheckBox_Common(pId, pText, "X", pRect, BUTTONFLAG_LEFT);
 	default:
-		dbg_assert_failed("invalid tristate");
+		dbg_assert_failed("Invalid tristate. Checked: %d", static_cast<int>(Checked));
 	}
 }
 

--- a/src/game/client/components/menus_ingame_touch_controls.cpp
+++ b/src/game/client/components/menus_ingame_touch_controls.cpp
@@ -1301,7 +1301,7 @@ void CMenusIngameTouchControls::SaveCachedSettingsToTarget(CTouchControls::CTouc
 	}
 	else
 	{
-		dbg_assert_failed("Unknown m_EditBehaviorType = %d", (int)m_EditBehaviorType);
+		dbg_assert_failed("Invalid m_EditBehaviorType: %d", static_cast<int>(m_EditBehaviorType));
 	}
 	pTargetButton->UpdatePointers();
 }

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -684,7 +684,7 @@ void CLineInputNumber::SetInteger(int Number, int Base, int HexPrefix)
 		str_format(aBuf, sizeof(aBuf), "%0*X", HexPrefix, Number);
 		break;
 	default:
-		dbg_assert_failed("Base unsupported");
+		dbg_assert_failed("Base %d unsupported", Base);
 	}
 	if(str_comp(aBuf, GetString()) != 0)
 		Set(aBuf);
@@ -707,7 +707,7 @@ void CLineInputNumber::SetInteger64(int64_t Number, int Base, int HexPrefix)
 		str_format(aBuf, sizeof(aBuf), "%0*" PRIX64, HexPrefix, Number);
 		break;
 	default:
-		dbg_assert_failed("Base unsupported");
+		dbg_assert_failed("Base %d unsupported", Base);
 	}
 	if(str_comp(aBuf, GetString()) != 0)
 		Set(aBuf);

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -245,7 +245,7 @@ static int GetMoveRestrictionsMask(int Direction)
 	case MR_DIR_DOWN: return CANTMOVE_DOWN;
 	case MR_DIR_LEFT: return CANTMOVE_LEFT;
 	case MR_DIR_UP: return CANTMOVE_UP;
-	default: dbg_assert_failed("invalid dir");
+	default: dbg_assert_failed("Invalid Direction: %d", Direction);
 	}
 }
 
@@ -271,7 +271,7 @@ int CCollision::GetMoveRestrictions(CALLBACK_SWITCHACTIVE pfnSwitchActive, void 
 			vec2(0, 1),
 			vec2(-1, 0),
 			vec2(0, -1)};
-	dbg_assert(0.0f <= Distance && Distance <= 32.0f, "invalid distance");
+	dbg_assert(0.0f <= Distance && Distance <= 32.0f, "Invalid Distance: %f", Distance);
 	int Restrictions = 0;
 	for(int d = 0; d < NUM_MR_DIRS; d++)
 	{
@@ -1069,7 +1069,7 @@ int CCollision::Entity(int x, int y, int Layer) const
 	case LAYER_TUNE:
 		return m_pTune[Index].m_Type - ENTITY_OFFSET;
 	default:
-		dbg_assert_failed("Layer invalid");
+		dbg_assert_failed("Invalid Layer: %d", Layer);
 	}
 }
 

--- a/src/tools/demo_extract_chat.cpp
+++ b/src/tools/demo_extract_chat.cpp
@@ -69,13 +69,13 @@ public:
 
 	int SnapNumItems(int SnapId)
 	{
-		dbg_assert(SnapId >= 0 && SnapId < IClient::NUM_SNAPSHOT_TYPES, "invalid SnapId");
+		dbg_assert(SnapId >= 0 && SnapId < IClient::NUM_SNAPSHOT_TYPES, "Invalid SnapId: %d", SnapId);
 		return m_apAltSnapshots[SnapId]->NumItems();
 	}
 
 	IClient::CSnapItem SnapGetItem(int SnapId, int Index)
 	{
-		dbg_assert(SnapId >= 0 && SnapId < IClient::NUM_SNAPSHOT_TYPES, "invalid SnapId");
+		dbg_assert(SnapId >= 0 && SnapId < IClient::NUM_SNAPSHOT_TYPES, "Invalid SnapId: %d", SnapId);
 		const CSnapshot *pSnapshot = m_apAltSnapshots[SnapId];
 		const CSnapshotItem *pSnapshotItem = m_apAltSnapshots[SnapId]->GetItem(Index);
 		IClient::CSnapItem Item;


### PR DESCRIPTION
This is not going throught ALL occurences of asserts. I just picked a certain type of assert and unified the error message while also enriching the assert information.

The goal of this commit is to establish the new style that was intentionally picked in #11205 so future asserts can copy that. There is no need to enforce this style in the CI or anywhere else.

Another goal of this commit was to have the most useful error message possible. So I did not touch existing asserts where strictly applying the new style would be less descriptive.

Closed #11205

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
