### PR TITLE
Prediction: Match server's proj vel calculation

### DIFF
--- a/src/game/client/projectile_data.cpp
+++ b/src/game/client/projectile_data.cpp
@@ -74,7 +74,7 @@ CProjectileData ExtractProjectileInfoDDNet(const CNetObj_DDNetProjectile *pProj)
 	CProjectileData Result = {vec2(0, 0)};
 
 	Result.m_StartPos = vec2(pProj->m_X / 100.0f, pProj->m_Y / 100.0f);
-	Result.m_StartVel = vec2(pProj->m_VelX / 1e6f, pProj->m_VelY / 1e6f);
+	Result.m_StartVel = pProj->m_Owner < 0 ? vec2(pProj->m_VelX, pProj->m_VelY) / 1e6f : vec2(pProj->m_VelX, pProj->m_VelY);
 
 	if(pProj->m_Flags & PROJECTILEFLAG_NORMALIZE_VEL)
 	{


### PR DESCRIPTION
Currently this only works by luck, because of the normilization step.

Server code:
https://github.com/ddnet/ddnet/blob/693f1e28cbe90c8daf2cdb11a23c2b8a53435951/src/game/server/entities/projectile.cpp#L415-L425

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
