### PR TITLE
Fix default emote

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -497,7 +497,7 @@ void CClient::EnterGame(int Conn)
 	m_CurrentServerNextPingTime = time_get() + time_freq() / 2;
 }
 
-void CClient::OnPostConnect(int Conn, bool Dummy)
+void CClient::OnPostConnect(int Conn)
 {
 	if(!m_ServerCapabilities.m_ChatTimeoutCode)
 		return;
@@ -510,11 +510,11 @@ void CClient::OnPostConnect(int Conn, bool Dummy)
 
 	if(g_Config.m_ClDummyDefaultEyes || g_Config.m_ClPlayerDefaultEyes)
 	{
-		int Emote = ((g_Config.m_ClDummy) ? !Dummy : Dummy) ? g_Config.m_ClDummyDefaultEyes : g_Config.m_ClPlayerDefaultEyes;
+		int Emote = Conn ? g_Config.m_ClDummyDefaultEyes : g_Config.m_ClPlayerDefaultEyes;
 
 		if(Emote != EMOTE_NORMAL)
 		{
-			char aBuf[16];
+			char aBuf[32];
 			static const char *s_EMOTE_NAMES[] = {
 				"pain",
 				"happy",
@@ -525,7 +525,7 @@ void CClient::OnPostConnect(int Conn, bool Dummy)
 			static_assert(std::size(s_EMOTE_NAMES) == NUM_EMOTES - 1, "The size of EMOTE_NAMES must match NUM_EMOTES - 1");
 
 			str_append(aBufMsg, ";");
-			str_format(aBuf, sizeof(aBuf), "emote %s %d", s_EMOTE_NAMES[Emote], g_Config.m_ClEyeDuration);
+			str_format(aBuf, sizeof(aBuf), "emote %s %d", s_EMOTE_NAMES[Emote - 1], g_Config.m_ClEyeDuration);
 			str_append(aBufMsg, aBuf);
 		}
 	}
@@ -2206,7 +2206,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 
 					if(m_aReceivedSnapshots[Conn] > GameTickSpeed() && !m_aDidPostConnect[Conn])
 					{
-						OnPostConnect(Conn, Dummy);
+						OnPostConnect(Conn);
 						m_aDidPostConnect[Conn] = true;
 					}
 

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -330,7 +330,7 @@ public:
 	void EnterGame(int Conn) override;
 
 	// called once after being ingame for 1 second
-	void OnPostConnect(int Conn, bool Dummy);
+	void OnPostConnect(int Conn);
 
 	void Connect(const char *pAddress, const char *pPassword = nullptr) override;
 	void DisconnectWithReason(const char *pReason);


### PR DESCRIPTION
Default emote is broken by #11067 and this pr fixes it. Guess I'm the only one who uses a non-default eye emote :>

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
