### PR TITLE
Simplify editor history action to change sound source shape

### DIFF
--- a/src/game/editor/editor_actions.h
+++ b/src/game/editor/editor_actions.h
@@ -565,27 +565,20 @@ private:
 	CSoundSource m_Source;
 };
 
-class CEditorActionEditSoundSource : public CEditorActionLayerBase
+class CEditorActionEditSoundSourceShape : public CEditorActionLayerBase
 {
 public:
-	enum class EEditType
-	{
-		SHAPE
-	};
-
-	CEditorActionEditSoundSource(CEditor *pEditor, int GroupIndex, int LayerIndex, int SourceIndex, EEditType Type, int Value);
-	~CEditorActionEditSoundSource() override;
+	CEditorActionEditSoundSourceShape(CEditor *pEditor, int GroupIndex, int LayerIndex, int SourceIndex, int Value);
 
 	void Undo() override;
 	void Redo() override;
 
 private:
 	int m_SourceIndex;
-	EEditType m_EditType;
 	int m_CurrentValue;
 
 	std::vector<int> m_vOriginalValues;
-	void *m_pSavedObject;
+	CSoundShape m_SavedShape;
 
 	void Save();
 };

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1161,7 +1161,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 	static int s_ShapeTypeButton = 0;
 	if(pEditor->DoButton_Editor(&s_ShapeTypeButton, s_apShapeNames[pSource->m_Shape.m_Type], 0, &ShapeButton, BUTTONFLAG_LEFT, "Change sound source shape."))
 	{
-		pEditor->m_EditorHistory.Execute(std::make_shared<CEditorActionEditSoundSource>(pEditor, pEditor->m_SelectedGroup, pEditor->m_vSelectedLayers[0], pEditor->m_SelectedSource, CEditorActionEditSoundSource::EEditType::SHAPE, (pSource->m_Shape.m_Type + 1) % CSoundShape::NUM_SHAPES));
+		pEditor->m_EditorHistory.Execute(std::make_shared<CEditorActionEditSoundSourceShape>(pEditor, pEditor->m_SelectedGroup, pEditor->m_vSelectedLayers[0], pEditor->m_SelectedSource, (pSource->m_Shape.m_Type + 1) % CSoundShape::NUM_SHAPES));
 	}
 
 	CProperty aProps[] = {


### PR DESCRIPTION
Copy the old sound source shape directly instead of in a roundabout way. Avoid allocating separate heap memory for old sound shape.

Rename `CEditorActionEditSoundSource` to `CEditorActionEditSoundSourceShape` and remove its `EEditType` because the action was only changing one property.

Change display text of the action to include the current value.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
