### PR TITLE
Feature: Add crying eyes emote

### DIFF
--- a/datasrc/content.py
+++ b/datasrc/content.py
@@ -383,7 +383,7 @@ container.sprites.Add(Sprite("tee_eye_normal", set_tee, 2,3,1,1))
 container.sprites.Add(Sprite("tee_eye_angry", set_tee, 3,3,1,1))
 container.sprites.Add(Sprite("tee_eye_pain", set_tee, 4,3,1,1))
 container.sprites.Add(Sprite("tee_eye_happy", set_tee, 5,3,1,1))
-container.sprites.Add(Sprite("tee_eye_dead", set_tee, 6,3,1,1))
+container.sprites.Add(Sprite("tee_eye_crying", set_tee, 6,3,1,1))
 container.sprites.Add(Sprite("tee_eye_surprise", set_tee, 7,3,1,1))
 
 container.sprites.Add(Sprite("oop", set_emoticons, 0, 0, 1, 1))

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -4,7 +4,7 @@
 from datatypes import Enum, Flags, NetArray, NetBool, NetEvent, NetEventEx, NetIntAny, NetTwIntString, NetIntRange
 from datatypes import NetMessage, NetMessageEx, NetObject, NetObjectEx, NetString, NetStringHalfStrict, NetStringStrict, NetTick
 
-Emotes = ["NORMAL", "PAIN", "HAPPY", "SURPRISE", "ANGRY", "BLINK"]
+Emotes = ["NORMAL", "PAIN", "HAPPY", "SURPRISE", "ANGRY", "BLINK", "CRYING"]
 PlayerFlags = ["PLAYING", "IN_MENU", "CHATTING", "SCOREBOARD", "AIM", "SPEC_CAM", "INPUT_ABSOLUTE", "INPUT_MANUAL"]
 GameFlags = ["TEAMS", "FLAGS"]
 GameStateFlags = ["GAMEOVER", "SUDDENDEATH", "PAUSED", "RACETIME"]

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -521,6 +521,7 @@ void CClient::OnPostConnect(int Conn)
 				"surprise",
 				"angry",
 				"blink",
+				"crying",
 			};
 			static_assert(std::size(s_EMOTE_NAMES) == NUM_EMOTES - 1, "The size of EMOTE_NAMES must match NUM_EMOTES - 1");
 

--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -238,6 +238,9 @@ void CEmoticon::EyeEmote(int Emote)
 	case EMOTE_BLINK:
 		str_format(aBuf, sizeof(aBuf), "/emote blink %d", g_Config.m_ClEyeDuration);
 		break;
+	case EMOTE_CRYING:
+		str_format(aBuf, sizeof(aBuf), "/emote crying %d", g_Config.m_ClEyeDuration);
+		break;
 	}
 	GameClient()->m_Chat.SendChat(0, aBuf);
 }

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -425,7 +425,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 		pEmote = &g_Config.m_ClDummyDefaultEyes;
 	}
 
-	const float EyeButtonSize = 40.0f;
+	const float EyeButtonSize = 32.0f;
 	const bool RenderEyesBelow = MainView.w < 750.0f;
 	CUIRect YourSkin, Checkboxes, SkinPrefix, Eyes, Button, Label;
 	MainView.HSplitTop(90.0f, &YourSkin, &MainView);

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -393,6 +393,8 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 				{
 					switch(Emote)
 					{
+					case EMOTE_CRYING:
+						[[fallthrough]];
 					case EMOTE_PAIN:
 						Graphics()->SelectSprite7(client_data7::SPRITE_TEE_EYES_PAIN);
 						break;
@@ -535,6 +537,10 @@ void CRenderTools::RenderTee6(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 					case EMOTE_ANGRY:
 						EyeQuadOffset = 3;
 						TeeEye = SPRITE_TEE_EYE_ANGRY - SPRITE_TEE_EYE_NORMAL;
+						break;
+					case EMOTE_CRYING:
+						EyeQuadOffset = 2;
+						TeeEye = SPRITE_TEE_EYE_CRYING - SPRITE_TEE_EYE_NORMAL;
 						break;
 					default:
 						EyeQuadOffset = 4;

--- a/src/game/client/skin.h
+++ b/src/game/client/skin.h
@@ -6,6 +6,8 @@
 #include <engine/graphics.h>
 #include <engine/shared/protocol.h>
 
+#include <generated/protocol.h>
+
 // do this better and nicer
 class CSkin
 {
@@ -24,7 +26,7 @@ public:
 		IGraphics::CTextureHandle m_Hands;
 		IGraphics::CTextureHandle m_HandsOutline;
 
-		IGraphics::CTextureHandle m_aEyes[6];
+		IGraphics::CTextureHandle m_aEyes[NUM_EMOTES];
 
 		void Reset();
 		void Unload(IGraphics *pGraphics);

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1553,6 +1553,8 @@ void CGameContext::ConEyeEmote(IConsole::IResult *pResult, void *pUserData)
 			EmoteType = EMOTE_SURPRISE;
 		else if(!str_comp_nocase(pResult->GetString(0), "normal"))
 			EmoteType = EMOTE_NORMAL;
+		else if(!str_comp_nocase(pResult->GetString(0), "crying"))
+			EmoteType = EMOTE_CRYING;
 		else
 		{
 			pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD,

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2923,7 +2923,6 @@ void CGameContext::OnEmoticonNetMessage(const CNetMsg_Cl_Emoticon *pMsg, int Cli
 			EmoteType = EMOTE_SURPRISE;
 			break;
 		case EMOTICON_DOTDOT:
-		case EMOTICON_DROP:
 		case EMOTICON_ZZZ:
 			EmoteType = EMOTE_BLINK;
 			break;
@@ -2941,6 +2940,9 @@ void CGameContext::OnEmoticonNetMessage(const CNetMsg_Cl_Emoticon *pMsg, int Cli
 		case EMOTICON_SPLATTEE:
 		case EMOTICON_ZOMG:
 			EmoteType = EMOTE_ANGRY;
+			break;
+		case EMOTICON_DROP:
+			EmoteType = EMOTE_CRYING;
 			break;
 		default:
 			break;

--- a/src/test/gameworld.cpp
+++ b/src/test/gameworld.cpp
@@ -309,4 +309,8 @@ TEST_F(CTestGameWorld, CharacterEmote)
 	// /emote angry 3 chat command and frozen
 	pChr->Freeze(10);
 	ASSERT_EQ(pChr->DetermineEyeEmote(), EMOTE_ANGRY);
+
+	// /emote crying 3 chat command
+	pChr->SetEmote(EMOTE_CRYING, GameServer()->Server()->Tick() + GameServer()->Server()->TickSpeed() * 3);
+	ASSERT_EQ(pChr->DetermineEyeEmote(), EMOTE_CRYING);
 }


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This PR uses the last slot in the skin location and uses it for crying eyes as explained in #9423

@l-ouis @SoulyVEVO I need from you now reworked default skins with the new eyes (instead of this dead `+` eyes)

Tested ingame and when joining:

<img width="2560" height="1440" alt="screenshot_2025-11-15_17-33-10" src="https://github.com/user-attachments/assets/ec7a347d-3307-489e-8de4-9f16ce7c2a52" />

<img width="2560" height="1440" alt="screenshot_2025-11-15_17-35-35" src="https://github.com/user-attachments/assets/2dc9c3b2-b8d2-4075-8958-91d3aedb8907" />

tested `/emote crying 99999`

**New UI**:

16:9
<img width="2560" height="1440" alt="screenshot_2025-11-15_18-00-08" src="https://github.com/user-attachments/assets/a3eb2b4a-cab5-4dcd-8093-b9931c150585" />

4:3
<img width="1920" height="1440" alt="screenshot_2025-11-15_18-00-30" src="https://github.com/user-attachments/assets/012a8fab-bd74-4808-b416-b3ce8c4ef85c" />

### TODOs

UI breaks here (Solved):

<img width="2560" height="1440" alt="screenshot_2025-11-15_17-33-56" src="https://github.com/user-attachments/assets/59efde97-0095-4c73-b29c-7be90f05917f" />

### TODO list:

- [x] Fix Ui still breaks
- [ ] need new default skins

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
