### PR TITLE
Hide spectators when no one is in spectator team.

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -157,6 +157,17 @@ void CScoreboard::RenderGoals(CUIRect Goals)
 
 void CScoreboard::RenderSpectators(CUIRect Spectators)
 {
+	int RemainingSpectators = 0;
+	for(const CNetObj_PlayerInfo *pInfo : GameClient()->m_Snap.m_apInfoByName)
+	{
+		if(!pInfo || pInfo->m_Team != TEAM_SPECTATORS)
+			continue;
+		++RemainingSpectators;
+	}
+
+	if(RemainingSpectators == 0)
+		return;
+
 	Spectators.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.5f), IGraphics::CORNER_ALL, 15.0f);
 	Spectators.Margin(10.0f, &Spectators);
 
@@ -165,14 +176,6 @@ void CScoreboard::RenderSpectators(CUIRect Spectators)
 	Cursor.m_FontSize = 22.0f;
 	Cursor.m_LineWidth = Spectators.w;
 	Cursor.m_MaxLines = round_truncate(Spectators.h / Cursor.m_FontSize);
-
-	int RemainingSpectators = 0;
-	for(const CNetObj_PlayerInfo *pInfo : GameClient()->m_Snap.m_apInfoByName)
-	{
-		if(!pInfo || pInfo->m_Team != TEAM_SPECTATORS)
-			continue;
-		++RemainingSpectators;
-	}
 
 	TextRender()->TextEx(&Cursor, Localize("Spectators"));
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
Spectators take up space on the scoreboard for no reason when most people dont even go on the spectator team.
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)

Video of the change.
https://wv.acrylix.vip/euX7B3cMVwbtPSg1VDacLA52kaZCEYA4Z6