### PR TITLE
Detect player's dummy

### DIFF
--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -196,6 +196,7 @@ public:
 		char m_aDDNetVersionStr[64];
 		CUuid m_ConnectionId;
 		int64_t m_RedirectDropTime;
+		int m_DummyClientId;
 
 		// DNSBL
 		EDnsblState m_DnsblState;


### PR DESCRIPTION
Using uniquely generated for the client `m_ConnectionId` uuid + IP address

Can be later used for all sorts of different things. 

- Hiding mod's auth when connecting dummy: https://github.com/ddnet/ddnet/issues/10381
- Allowing other players to see which dummy is active: https://github.com/ddnet/ddnet/issues/7723 or https://github.com/ddnet/ddnet/issues/9515
- Scoreboard stuff with dummy: https://github.com/ddnet/ddnet/issues/6689
- Disabling dummies on server: https://github.com/ddnet/ddnet/issues/6884
- Antibot stuff? etc

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
