### PR TITLE
Cleanup `CSoundSourceOperationTracker`

### DIFF
--- a/src/game/editor/editor_trackers.cpp
+++ b/src/game/editor/editor_trackers.cpp
@@ -394,7 +394,9 @@ void CSoundSourceOperationTracker::Begin(CSoundSource *pSource, ESoundSourceOp O
 	m_LayerIndex = LayerIndex;
 
 	if(m_TrackedOp == ESoundSourceOp::OP_MOVE)
-		HandlePointMove(EState::STATE_BEGIN);
+	{
+		m_Data.m_OriginalPoint = m_pSource->m_Position;
+	}
 }
 
 void CSoundSourceOperationTracker::End()
@@ -403,22 +405,15 @@ void CSoundSourceOperationTracker::End()
 		return;
 
 	if(m_TrackedOp == ESoundSourceOp::OP_MOVE)
-		HandlePointMove(EState::STATE_END);
-
-	m_TrackedOp = ESoundSourceOp::OP_NONE;
-}
-
-void CSoundSourceOperationTracker::HandlePointMove(EState State)
-{
-	if(State == EState::STATE_BEGIN)
-	{
-		m_Data.m_OriginalPoint = m_pSource->m_Position;
-	}
-	else if(State == EState::STATE_END)
 	{
 		if(m_Data.m_OriginalPoint != m_pSource->m_Position)
-			m_pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionMoveSoundSource>(m_pEditor, m_pEditor->m_SelectedGroup, m_LayerIndex, m_pEditor->m_SelectedSource, m_Data.m_OriginalPoint, m_pSource->m_Position));
+		{
+			m_pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionMoveSoundSource>(
+				m_pEditor, m_pEditor->m_SelectedGroup, m_LayerIndex, m_pEditor->m_SelectedSource, m_Data.m_OriginalPoint, m_pSource->m_Position));
+		}
 	}
+
+	m_TrackedOp = ESoundSourceOp::OP_NONE;
 }
 
 // -----------------------------------------------------------------------

--- a/src/game/editor/editor_trackers.h
+++ b/src/game/editor/editor_trackers.h
@@ -117,14 +117,6 @@ private:
 		CPoint m_OriginalPoint;
 	};
 	SData m_Data;
-
-	enum EState
-	{
-		STATE_BEGIN,
-		STATE_EDITING,
-		STATE_END
-	};
-	void HandlePointMove(EState State);
 };
 
 struct SPropTrackerHelper


### PR DESCRIPTION
Remove unnecessary `enum EState` and `HandlePointMove` function. Inline the cases of the `HandlePointMove` function at the call sites instead of using an enum to differentiate between them.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
