### PR TITLE
CI: Make integration test timeouts more generous for the full smoke test

### DIFF
--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -551,7 +551,7 @@ def open_editor(test_env):
 	client.exit()
 	client.wait_for_exit()
 
-@test
+@test(timeout=120)
 def smoke_test(test_env):
 	client1 = test_env.client(["logfile client1.log", "player_name client1"])
 	server = test_env.server(["logfile server.log", "sv_demo_chat 1", "sv_map coverage", "sv_tee_historian 1"])
@@ -578,10 +578,10 @@ def smoke_test(test_env):
 		)
 
 	client1.command("say hello world")
-	server.wait_for_log_exact("chat: 0:-2:client1: hello world")
+	server.wait_for_log_exact("chat: 0:-2:client1: hello world", timeout=10)
 
 	client1.command(f"rcon_auth {server.rcon_password}")
-	server.wait_for_log_exact("server: ClientId=0 authed with key=default_admin (admin)")
+	server.wait_for_log_exact("server: ClientId=0 authed with key=default_admin (admin)", timeout=10)
 
 	client1.command("say \"/mc; {}\"".format("; ".join(l.strip() for l in """
 		top5
@@ -609,7 +609,7 @@ def smoke_test(test_env):
 		rcon unban_all
 		rcon say the end
 	""".strip().split("\n")))
-	client1.wait_for_log_exact("chat/server: *** the end", timeout=3)
+	client1.wait_for_log_exact("chat/server: *** the end", timeout=10)
 
 	server.command("stoprecord")
 	client1.command("stoprecord")


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This PR adds generous timeouts to all smoke_test integration actions.
Timeouts do not mean, that his will run so long. It means, that it'll stop trying after a set amount of time. And even if this check now takes 2 minutes instead of 1, before it fails, this is better than failing randomly without cause. (2 minutes is the absolute maximum for this test, times 10 for valgrind are 20 minutes. It's still far more likely, that you fail at an action with 10 * 10 = 100s instead of the full 20 minutes in this case)

The tests are a bit flakey, as described in #11238 . I noticed that the new timeouts come from different parts of the code. The tests are extra-slow if you are doing them with valgrind or ASAN.

closes #11238

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
