### PR TITLE
Add command net_reset and reset on netaddr change

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -12,6 +12,7 @@
 #include <base/log.h>
 #include <base/logger.h>
 #include <base/math.h>
+#include <base/str.h>
 #include <base/system.h>
 
 #include <engine/config.h>
@@ -1069,6 +1070,26 @@ void CClient::Quit()
 	SetState(IClient::STATE_QUITTING);
 }
 
+void CClient::ResetSocket()
+{
+	NETADDR BindAddr;
+	if(g_Config.m_Bindaddr[0] == '\0')
+	{
+		mem_zero(&BindAddr, sizeof(BindAddr));
+	}
+	else if(net_host_lookup(g_Config.m_Bindaddr, &BindAddr, NETTYPE_ALL) != 0)
+	{
+		log_error("client", "The configured bindaddr '%s' cannot be resolved.", g_Config.m_Bindaddr);
+		return;
+	}
+	BindAddr.type = NETTYPE_ALL;
+	for(size_t Conn = 0; Conn < std::size(m_aNetClient); Conn++)
+	{
+		char aError[256];
+		if(!InitNetworkClientImpl(BindAddr, Conn, aError, sizeof(aError)))
+			log_error("client", "%s", aError);
+	}
+}
 const char *CClient::PlayerName() const
 {
 	if(g_Config.m_PlayerName[0])
@@ -3410,31 +3431,60 @@ bool CClient::InitNetworkClient(char *pError, size_t ErrorSize)
 		return false;
 	}
 	BindAddr.type = NETTYPE_ALL;
-	for(unsigned int i = 0; i < std::size(m_aNetClient); i++)
+	for(size_t i = 0; i < std::size(m_aNetClient); i++)
 	{
-		int &PortRef = i == CONN_MAIN ? g_Config.m_ClPort : (i == CONN_DUMMY ? g_Config.m_ClDummyPort : g_Config.m_ClContactPort);
-		if(PortRef < 1024) // Reject users setting ports that we don't want to use
+		if(!InitNetworkClientImpl(BindAddr, i, pError, ErrorSize))
 		{
-			PortRef = 0;
+			return false;
 		}
-		BindAddr.port = PortRef;
-		unsigned RemainingAttempts = 25;
-		while(!m_aNetClient[i].Open(BindAddr))
+	}
+	return true;
+}
+
+bool CClient::InitNetworkClientImpl(NETADDR BindAddr, int Conn, char *pError, size_t ErrorSize)
+{
+	int *pPort;
+	const char *pName;
+	switch(Conn)
+	{
+	case CONN_MAIN:
+		pPort = &g_Config.m_ClPort;
+		pName = "main";
+		break;
+	case CONN_DUMMY:
+		pPort = &g_Config.m_ClDummyPort;
+		pName = "dummy";
+		break;
+	case CONN_CONTACT:
+		pPort = &g_Config.m_ClContactPort;
+		pName = "contact";
+		break;
+	default:
+		dbg_assert_failed("unreachable");
+	}
+	if(m_aNetClient[Conn].State() != NETSTATE_OFFLINE)
+	{
+		str_format(pError, ErrorSize, "Could not open network client %s while already connected.", pName);
+		return false;
+	}
+	if(*pPort < 1024) // Reject users setting ports that we don't want to use
+		*pPort = 0;
+	BindAddr.port = *pPort;
+
+	unsigned RemainingAttempts = 25;
+	while(!m_aNetClient[Conn].Open(BindAddr))
+	{
+		--RemainingAttempts;
+		if(RemainingAttempts == 0)
 		{
-			--RemainingAttempts;
-			if(RemainingAttempts == 0)
-			{
-				if(g_Config.m_Bindaddr[0])
-					str_format(pError, ErrorSize, "Could not open the network client, try changing or unsetting the bindaddr '%s'.", g_Config.m_Bindaddr);
-				else
-					str_copy(pError, "Could not open the network client.", ErrorSize);
-				return false;
-			}
-			if(BindAddr.port != 0)
-			{
-				BindAddr.port = 0;
-			}
+			if(g_Config.m_Bindaddr[0])
+				str_format(pError, ErrorSize, "Could not open network client %s, try changing or unsetting the bindaddr '%s'.", pName, g_Config.m_Bindaddr);
+			else
+				str_format(pError, ErrorSize, "Could not open network client %s.", pName);
+			return false;
 		}
+		if(BindAddr.port != 0)
+			BindAddr.port = 0;
 	}
 	return true;
 }
@@ -3507,6 +3557,12 @@ void CClient::Con_Ping(IConsole::IResult *pResult, void *pUserData)
 	CMsgPacker Msg(NETMSG_PING, true);
 	pSelf->SendMsg(CONN_MAIN, &Msg, MSGFLAG_FLUSH);
 	pSelf->m_PingStartTime = time_get();
+}
+
+void CClient::ConNetReset(IConsole::IResult *pResult, void *pUserData)
+{
+	CClient *pSelf = (CClient *)pUserData;
+	pSelf->ResetSocket();
 }
 
 void CClient::AutoScreenshot_Start()
@@ -4371,6 +4427,14 @@ void CClient::ConchainInputFifo(IConsole::IResult *pResult, void *pUserData, ICo
 	}
 }
 
+void CClient::ConchainNetReset(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
+{
+	CClient *pSelf = (CClient *)pUserData;
+	pfnCallback(pResult, pCallbackUserData);
+	if(pResult->NumArguments())
+		pSelf->ResetSocket();
+}
+
 void CClient::ConchainLoglevel(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
 {
 	CClient *pSelf = (CClient *)pUserData;
@@ -4407,6 +4471,7 @@ void CClient::RegisterCommands()
 	m_pConsole->Register("disconnect", "", CFGFLAG_CLIENT, Con_Disconnect, this, "Disconnect from the server");
 	m_pConsole->Register("ping", "", CFGFLAG_CLIENT, Con_Ping, this, "Ping the current server");
 	m_pConsole->Register("screenshot", "", CFGFLAG_CLIENT | CFGFLAG_STORE, Con_Screenshot, this, "Take a screenshot");
+	m_pConsole->Register("net_reset", "", CFGFLAG_CLIENT, ConNetReset, this, "Rebinds the client's listening address and port");
 
 #if defined(CONF_VIDEORECORDER)
 	m_pConsole->Register("start_video", "?r[file]", CFGFLAG_CLIENT, Con_StartVideo, this, "Start recording a video");
@@ -4437,6 +4502,10 @@ void CClient::RegisterCommands()
 	m_pConsole->Chain("cl_timeout_seed", ConchainTimeoutSeed, this);
 	m_pConsole->Chain("cl_replays", ConchainReplays, this);
 	m_pConsole->Chain("cl_input_fifo", ConchainInputFifo, this);
+	m_pConsole->Chain("cl_port", ConchainNetReset, this);
+	m_pConsole->Chain("cl_dummy_port", ConchainNetReset, this);
+	m_pConsole->Chain("cl_contact_port", ConchainNetReset, this);
+	m_pConsole->Chain("bindaddr", ConchainNetReset, this);
 
 	m_pConsole->Chain("password", ConchainPassword, this);
 

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -364,6 +364,7 @@ public:
 
 	void Restart() override;
 	void Quit() override;
+	void ResetSocket();
 
 	const char *PlayerName() const override;
 	const char *DummyName() override;
@@ -411,6 +412,7 @@ public:
 	void Run();
 
 	bool InitNetworkClient(char *pError, size_t ErrorSize);
+	bool InitNetworkClientImpl(NETADDR BindAddr, int Conn, char *pError, size_t ErrorSize);
 	bool CtrlShiftKey(int Key, bool &Last);
 
 	static void Con_Connect(IConsole::IResult *pResult, void *pUserData);
@@ -426,6 +428,7 @@ public:
 	static void Con_DemoSpeed(IConsole::IResult *pResult, void *pUserData);
 	static void Con_Minimize(IConsole::IResult *pResult, void *pUserData);
 	static void Con_Ping(IConsole::IResult *pResult, void *pUserData);
+	static void ConNetReset(IConsole::IResult *pResult, void *pUserData);
 	static void Con_Screenshot(IConsole::IResult *pResult, void *pUserData);
 
 #if defined(CONF_VIDEORECORDER)
@@ -457,6 +460,7 @@ public:
 	static void ConchainPassword(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainReplays(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainInputFifo(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+	static void ConchainNetReset(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainLoglevel(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainStdoutOutputLevel(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -448,9 +448,9 @@ MACRO_CONFIG_INT(InpControllerX, inp_controller_x, 0, 0, 12, CFGFLAG_SAVE | CFGF
 MACRO_CONFIG_INT(InpControllerY, inp_controller_y, 1, 0, 12, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Controller axis that controls Y axis of cursor")
 MACRO_CONFIG_INT(InpControllerTolerance, inp_controller_tolerance, 5, 0, 50, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Controller axis tolerance to account for jitter")
 
-MACRO_CONFIG_INT(ClPort, cl_port, 0, 0, 65535, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Port to use for client connections to server (0 to choose a random port, 1024 or higher to set a manual port, requires a restart)")
-MACRO_CONFIG_INT(ClDummyPort, cl_dummy_port, 0, 0, 65535, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Port to use for dummy connections to server (0 to choose a random port, 1024 or higher to set a manual port, requires a restart)")
-MACRO_CONFIG_INT(ClContactPort, cl_contact_port, 0, 0, 65535, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Port to use for serverinfo connections to server (0 to choose a random port, 1024 or higher to set a manual port, requires a restart)")
+MACRO_CONFIG_INT(ClPort, cl_port, 0, 0, 65535, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Port to use for client connections to server (0 to choose a random port, 1024 or higher to set a manual port)")
+MACRO_CONFIG_INT(ClDummyPort, cl_dummy_port, 0, 0, 65535, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Port to use for dummy connections to server (0 to choose a random port, 1024 or higher to set a manual port)")
+MACRO_CONFIG_INT(ClContactPort, cl_contact_port, 0, 0, 65535, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Port to use for serverinfo connections to server (0 to choose a random port, 1024 or higher to set a manual port)")
 
 MACRO_CONFIG_STR(SvName, sv_name, 128, "unnamed server", CFGFLAG_SERVER, "Server name")
 MACRO_CONFIG_STR(Bindaddr, bindaddr, 128, "", CFGFLAG_CLIENT | CFGFLAG_SERVER | CFGFLAG_MASTER, "Address to bind the client/server to")

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -572,7 +572,7 @@ class CNetClient
 	CStun *m_pStun = nullptr;
 
 public:
-	NETSOCKET m_Socket;
+	NETSOCKET m_Socket = nullptr;
 	// openness
 	bool Open(NETADDR BindAddr);
 	void Close();

--- a/src/engine/shared/network_client.cpp
+++ b/src/engine/shared/network_client.cpp
@@ -14,7 +14,7 @@ bool CNetClient::Open(NETADDR BindAddr)
 	Socket = net_udp_create(BindAddr);
 	if(!Socket)
 		return false;
-
+	Close();
 	// clean it
 	*this = CNetClient{};
 


### PR DESCRIPTION
Motivation is because the great firewall constantly dropping udp packets from/to my specific port so this can reset it without having restart my game or open a second client. Only tested on windows

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
