### PR TITLE
Fix: Background not beeing removed with 100% entities

### DIFF
--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -558,8 +558,8 @@ bool CRenderLayerTile::DoRender(const CRenderLayerParams &Params)
 	if(!g_Config.m_ClBackgroundShowTilesLayers && Params.m_RenderType == ERenderType::RENDERTYPE_BACKGROUND_FORCE)
 		return false;
 
-	// skip rendering anything but entities if we only want to render entities
-	if(Params.m_EntityOverlayVal == 100 && Params.m_RenderType != ERenderType::RENDERTYPE_BACKGROUND_FORCE)
+	// skip rendering any tilelayer
+	if(Params.m_EntityOverlayVal == 100)
 		return false;
 
 	// skip rendering if detail layers if not wanted
@@ -1352,7 +1352,7 @@ void CRenderLayerQuads::Render(const CRenderLayerParams &Params)
 bool CRenderLayerQuads::DoRender(const CRenderLayerParams &Params)
 {
 	// skip rendering anything but entities if we only want to render entities
-	if(Params.m_EntityOverlayVal == 100 && Params.m_RenderType != ERenderType::RENDERTYPE_BACKGROUND_FORCE)
+	if(Params.m_EntityOverlayVal == 100)
 		return false;
 
 	// skip rendering if detail layers if not wanted


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

I don't know how nobody reported that (ever).

Entities have their own check and are not using the tilelayer check: https://github.com/ddnet/ddnet/blob/a451c5e63d00e2ed51e608ebca4346c2422d1f8d/src/game/map/render_layer.cpp#L1379

### New behavior:

0% entities:
<img width="2560" height="1440" alt="screenshot_2025-11-18_18-47-09" src="https://github.com/user-attachments/assets/a9420a17-3a8f-49b8-b15f-1993888a1df8" />

50% entities:
<img width="2560" height="1440" alt="screenshot_2025-11-18_18-47-11" src="https://github.com/user-attachments/assets/4eb45e0c-cecf-43d0-baf3-32b696532304" />

100% entities
<img width="2560" height="1440" alt="screenshot_2025-11-18_18-47-17" src="https://github.com/user-attachments/assets/738e855f-5d43-4e51-8df0-782d83dec17a" />

### Old behavior:

100% entities:
<img width="2560" height="1440" alt="screenshot_2025-11-18_18-47-48" src="https://github.com/user-attachments/assets/e1788879-6275-47a4-b686-feb1d8c0ca40" />


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
