### PR TITLE
Fix out-of-bounds write in rcon log line censoring

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1411,8 +1411,8 @@ void CServer::SendRconLogLine(int ClientId, const CLogMessage *pMessage)
 	const char *pStart = str_find(pLine, "<{");
 	const char *pEnd = pStart == nullptr ? nullptr : str_find(pStart + 2, "}>");
 	const char *pLineWithoutIps;
-	char aLine[512];
-	char aLineWithoutIps[512];
+	char aLine[sizeof(CLogMessage().m_aLine)];
+	char aLineWithoutIps[sizeof(CLogMessage().m_aLine)];
 	aLine[0] = '\0';
 	aLineWithoutIps[0] = '\0';
 
@@ -1422,11 +1422,11 @@ void CServer::SendRconLogLine(int ClientId, const CLogMessage *pMessage)
 	}
 	else
 	{
-		str_append(aLine, pLine, pStart - pLine + 1);
-		str_append(aLine, pStart + 2, pStart - pLine + pEnd - pStart - 1);
+		str_append(aLine, pLine, minimum<size_t>(pStart - pLine + 1, sizeof(aLine)));
+		str_append(aLine, pStart + 2, minimum<size_t>(pStart - pLine + pEnd - pStart - 1, sizeof(aLine)));
 		str_append(aLine, pEnd + 2);
 
-		str_append(aLineWithoutIps, pLine, pStart - pLine + 1);
+		str_append(aLineWithoutIps, pLine, minimum<size_t>(pStart - pLine + 1, sizeof(aLine)));
 		str_append(aLineWithoutIps, "XXX");
 		str_append(aLineWithoutIps, pEnd + 2);
 


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
