### PR TITLE
Fix invalid label for custom binds when rebinding to same command

### DIFF
--- a/src/game/client/components/menus_settings_controls.cpp
+++ b/src/game/client/components/menus_settings_controls.cpp
@@ -232,7 +232,7 @@ void CMenusSettingsControls::UpdateBindOptions()
 			if(ExistingOption == m_vBindOptions.end())
 			{
 				// Bind option not found for command, add custom bind option.
-				CBindOption NewOption = {EBindOptionGroup::CUSTOM, pBind, pBind};
+				CBindOption NewOption = {EBindOptionGroup::CUSTOM, nullptr, pBind};
 				ExistingOption = m_vBindOptions.insert(
 					std::upper_bound(m_vBindOptions.begin() + m_NumPredefinedBindOptions, m_vBindOptions.end(), NewOption, [&](const CBindOption &Option1, const CBindOption &Option2) {
 						return str_utf8_comp_nocase(Option1.m_Command.c_str(), Option2.m_Command.c_str()) < 0;
@@ -505,7 +505,7 @@ void CMenusSettingsControls::RenderSettingsBinds(EBindOptionGroup Group, CUIRect
 		{
 			LabelProps.SetColor(ColorRGBA(0.4f, 0.4f, 0.9f, 1.0f));
 		}
-		const CLabelResult LabelResult = Ui()->DoLabel(&Label, BindOption.m_Group == EBindOptionGroup::CUSTOM ? BindOption.m_pLabel : Localize(BindOption.m_pLabel),
+		const CLabelResult LabelResult = Ui()->DoLabel(&Label, BindOption.m_Group == EBindOptionGroup::CUSTOM ? BindOption.m_Command.c_str() : Localize(BindOption.m_pLabel),
 			FONT_SIZE, TEXTALIGN_ML, LabelProps);
 		if(BindOption.m_Group != EBindOptionGroup::CUSTOM || LabelResult.m_Truncated)
 		{


### PR DESCRIPTION
The label of custom binds options was a pointer to the command string allocated by `CBinds`, which is freed when the command is unbound. Unused bind options were already removed automatically, but this did not handle the case that the same command is unbound and immediately bound again. Now, the label is not stored separately for custom bind options anymore, as the stored command is identical and already stored as an `std::string` to avoid this issue.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
