### PR TITLE
Improve and optimize quad envelope preview

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -528,6 +528,14 @@ public:
 		ALL,
 	};
 	EEnvelopePreview m_ActiveEnvelopePreview = EEnvelopePreview::NONE;
+	enum class EQuadEnvelopePointOperation
+	{
+		NONE = 0,
+		MOVE,
+		ROTATE,
+	};
+	EQuadEnvelopePointOperation m_QuadEnvelopePointOperation = EQuadEnvelopePointOperation::NONE;
+
 	bool m_ShowPicker;
 
 	std::vector<int> m_vSelectedLayers;
@@ -682,8 +690,8 @@ public:
 	void PopupSelectAutoMapReferenceInvoke(int Current, float x, float y);
 	int PopupSelectAutoMapReferenceResult();
 
-	void DoQuadEnvelopes(const std::vector<CQuad> &vQuads, IGraphics::CTextureHandle Texture = IGraphics::CTextureHandle());
-	void DoQuadEnvPoint(const CQuad *pQuad, int QuadIndex, int PointIndex);
+	void DoQuadEnvelopes(const CLayerQuads *pLayerQuads);
+	void DoQuadEnvPoint(const CQuad *pQuad, CEnvelope *pEnvelope, int QuadIndex, int PointIndex);
 	void DoQuadPoint(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer, CQuad *pQuad, int QuadIndex, int v);
 	void UpdateHotQuadPoint(const CLayerQuads *pLayer);
 


### PR DESCRIPTION
Change color of quad envelope point handles from green to cyan to better differentiate the handles from regular quad handles.

Also use a brighter cyan color for the envelope preview lines to make them more visible.

Fix wrong color being used for quads at the point locations, as the quad corner colors where not being normalized into the 0-1 range (i.e. the values in 0-255 range from the map were used directly).

Draw preview lines more precisely by considering each segment between quad points separately. This fixes the quad preview lines sometimes not hitting the quad envelope handles at all. This also makes the rendering significantly more efficient, as only a single line needs to be drawn between quad points for all non-bezier envelope segments.

Avoid allocating an array for all quads when only quads with a position envelope will be previewed. Use a vector to store only the relevant quads together with their position envelope.

Add `enum class EQuadEnvelopePointOperation` and avoid `static` variable.

Screenshots:
- ctf2 snow (also note the FPS in the debug menu):
   - Before: <img width="1920" height="1080" alt="ctf2_old" src="https://github.com/user-attachments/assets/1ed10b1a-9e33-4e3d-b1c9-ba4e42760cc2" />
   - After: <img width="1920" height="1080" alt="ctf2_new" src="https://github.com/user-attachments/assets/576fa00b-9f44-4aaf-a1f9-80a4424ebe33" />
- Bezier test (ignore how the actual, red quad is at the wrong position due to a separate bug in the bezier evaluation):
   - Before: <img width="1920" height="1080" alt="bezier_old" src="https://github.com/user-attachments/assets/679490a3-b6f0-42dc-9310-62b2bc5133d0" />
   - After: <img width="1920" height="1080" alt="bezier_new" src="https://github.com/user-attachments/assets/12305e83-63c4-4fed-812d-1347bfe6c81c" />
- Color test
   - Before: <img width="1920" height="1080" alt="color_old" src="https://github.com/user-attachments/assets/2ccd13ad-3725-4b7f-a450-c73d0512ce87" />
   - After: <img width="1920" height="1080" alt="color_new" src="https://github.com/user-attachments/assets/28b604c3-4273-44d1-b9ce-303cc05a55f4" />

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
