### PR TITLE
Feature: Allow rcon to hide multiple IP addresses per line

### DIFF
--- a/src/engine/shared/netban.h
+++ b/src/engine/shared/netban.h
@@ -56,7 +56,7 @@ protected:
 		char aAddrStr1[NETADDR_MAXSTRSIZE], aAddrStr2[NETADDR_MAXSTRSIZE];
 		net_addr_str(&pData->m_LB, aAddrStr1, sizeof(aAddrStr1), false);
 		net_addr_str(&pData->m_UB, aAddrStr2, sizeof(aAddrStr2), false);
-		str_format(pBuffer, BufferSize, "<{'%s' - '%s'}>", aAddrStr1, aAddrStr2);
+		str_format(pBuffer, BufferSize, "<{'%s'}> - <{'%s'}>", aAddrStr1, aAddrStr2);
 		return pBuffer;
 	}
 

--- a/src/test/server.cpp
+++ b/src/test/server.cpp
@@ -6,56 +6,75 @@ TEST(Server, StrHideIps)
 {
 	char aLine[512];
 	char aLineWithoutIps[512];
+	bool HasHiddenIps = false;
 
-	CServer::StrHideIps("hello world", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
+	HasHiddenIps = CServer::StrHideIps("hello world", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
+	EXPECT_FALSE(HasHiddenIps);
 	EXPECT_STREQ(aLine, "hello world");
 	EXPECT_STREQ(aLineWithoutIps, "hello world");
 
-	CServer::StrHideIps("hello <{127.0.0.1}>", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
+	HasHiddenIps = CServer::StrHideIps("hello <{127.0.0.1}>", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
+	EXPECT_TRUE(HasHiddenIps);
 	EXPECT_STREQ(aLine, "hello 127.0.0.1");
 	EXPECT_STREQ(aLineWithoutIps, "hello XXX");
 
-	CServer::StrHideIps("<{127.0.0.1}> <{127.0.0.1}>", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
-	EXPECT_STREQ(aLine, "127.0.0.1 <{127.0.0.1}>");
-	EXPECT_STREQ(aLineWithoutIps, "XXX <{127.0.0.1}>");
+	HasHiddenIps = CServer::StrHideIps("<{127.0.0.1}> <{127.0.0.1}>", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
+	EXPECT_TRUE(HasHiddenIps);
+	EXPECT_STREQ(aLine, "127.0.0.1 127.0.0.1");
+	EXPECT_STREQ(aLineWithoutIps, "XXX XXX");
 
-	CServer::StrHideIps("o <{127.0.0.1}>", aLine, 8, aLineWithoutIps, 8);
+	HasHiddenIps = CServer::StrHideIps("o <{127.0.0.1}>", aLine, 8, aLineWithoutIps, 8);
+	EXPECT_TRUE(HasHiddenIps);
 	EXPECT_STREQ(aLine, "o 127.0");
 	EXPECT_STREQ(aLineWithoutIps, "o XXX");
 
-	CServer::StrHideIps("o <{127.0.0.1}>", aLine, 4, aLineWithoutIps, 4);
+	HasHiddenIps = CServer::StrHideIps("o <{127.0.0.1}>", aLine, 4, aLineWithoutIps, 4);
+	EXPECT_TRUE(HasHiddenIps);
 	EXPECT_STREQ(aLine, "o 1");
 	EXPECT_STREQ(aLineWithoutIps, "o X");
 
-	CServer::StrHideIps("<{}><{}> hello", aLine, 10, aLineWithoutIps, 10);
-	EXPECT_STREQ(aLine, "<{}> hell");
-	EXPECT_STREQ(aLineWithoutIps, "XXX<{}> h");
+	HasHiddenIps = CServer::StrHideIps("<{}><{}> hello", aLine, 10, aLineWithoutIps, 10);
+	EXPECT_TRUE(HasHiddenIps);
+	EXPECT_STREQ(aLine, " hell");
+	EXPECT_STREQ(aLineWithoutIps, "XXXXXX h");
 
-	CServer::StrHideIps("<{", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
+	HasHiddenIps = CServer::StrHideIps("<{", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
+	EXPECT_FALSE(HasHiddenIps);
 	EXPECT_STREQ(aLine, "<{");
 	EXPECT_STREQ(aLineWithoutIps, "<{");
 
-	CServer::StrHideIps("<{}>", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
+	HasHiddenIps = CServer::StrHideIps("<{}>", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
+	EXPECT_TRUE(HasHiddenIps);
 	EXPECT_STREQ(aLine, "");
 	EXPECT_STREQ(aLineWithoutIps, "XXX");
 
-	CServer::StrHideIps("<{<{<{<{<{<{<{", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
+	HasHiddenIps = CServer::StrHideIps("<{<{<{<{<{<{<{", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
+	EXPECT_FALSE(HasHiddenIps);
 	EXPECT_STREQ(aLine, "<{<{<{<{<{<{<{");
 	EXPECT_STREQ(aLineWithoutIps, "<{<{<{<{<{<{<{");
 
-	CServer::StrHideIps("<{<{<{<{<{<{<{a}>", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
+	HasHiddenIps = CServer::StrHideIps("<{<{<{<{<{<{<{a}>", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
+	EXPECT_TRUE(HasHiddenIps);
 	EXPECT_STREQ(aLine, "<{<{<{<{<{<{a");
 	EXPECT_STREQ(aLineWithoutIps, "XXX");
 
-	CServer::StrHideIps("<{}><{}>", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
-	EXPECT_STREQ(aLine, "<{}>");
-	EXPECT_STREQ(aLineWithoutIps, "XXX<{}>");
+	HasHiddenIps = CServer::StrHideIps("<{}><{}>", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
+	EXPECT_TRUE(HasHiddenIps);
+	EXPECT_STREQ(aLine, "");
+	EXPECT_STREQ(aLineWithoutIps, "XXXXXX");
 
-	CServer::StrHideIps("<{}>}>}>}>}>}>", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
+	HasHiddenIps = CServer::StrHideIps("<{}>}>}>}>}>}>", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
+	EXPECT_TRUE(HasHiddenIps);
 	EXPECT_STREQ(aLine, "}>}>}>}>}>");
 	EXPECT_STREQ(aLineWithoutIps, "XXX}>}>}>}>}>");
 
-	CServer::StrHideIps("<{<{<{a}>}>}>", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
-	EXPECT_STREQ(aLine, "<{<{a}>}>");
+	HasHiddenIps = CServer::StrHideIps("<{<{<{a}>}>}>", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
+	EXPECT_TRUE(HasHiddenIps);
+	EXPECT_STREQ(aLine, "a");
 	EXPECT_STREQ(aLineWithoutIps, "XXX}>}>");
+
+	HasHiddenIps = CServer::StrHideIps("<{127.0.0.1}> <{127.0.0.1}> <{127.0.0.1}>", aLine, sizeof(aLine), aLineWithoutIps, sizeof(aLineWithoutIps));
+	EXPECT_TRUE(HasHiddenIps);
+	EXPECT_STREQ(aLine, "127.0.0.1 127.0.0.1 127.0.0.1");
+	EXPECT_STREQ(aLineWithoutIps, "XXX XXX XXX");
 }


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Allow rcon to hide multiple IP addresses per line. This is limited to 10 IPs per line.

Tested ingame:

```
> say <{127.0.0.1}> <{127.0.0.1}> <{127.0.0.1}>
2025-11-22 16:04:03 I server: ClientId=0 rcon='say XXX XXX XXX'
2025-11-22 16:04:03 I chat: *** XXX XXX XXX
```

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
