### PR TITLE
Fix `readability-inconsistent-declaration-parameter-name` in `str_format_opt`

### DIFF
--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1280,7 +1280,7 @@ int str_format_opt(char *buffer, int buffer_size, const char *format, Args... ar
 }
 
 template<>
-inline int str_format_opt(char *buffer, int buffer_size, const char *format, int val)
+inline int str_format_opt(char *buffer, int buffer_size, const char *format, int val) // NOLINT(readability-inconsistent-declaration-parameter-name)
 {
 	if(strcmp(format, "%d") == 0)
 	{


### PR DESCRIPTION
Closes #11300

The str_format_opt taking an `int` should be named `args` becuase it is a specialiazation of a template whose equivilant param is named `args`

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] @BlaiZephyr solved it, I just made the PR

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
