### PR TITLE
Simplify CGameContext construction

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -71,7 +71,9 @@ void CClientChatLogger::Log(const CLogMessage *pMessage)
 	}
 }
 
-void CGameContext::Construct(bool Resetting)
+CGameContext::CGameContext(bool Resetting) :
+	m_Mutes("mutes"),
+	m_VoteMutes("votemutes")
 {
 	m_Resetting = false;
 	m_pServer = nullptr;
@@ -125,12 +127,12 @@ void CGameContext::Construct(bool Resetting)
 	m_TeeHistorianActive = false;
 }
 
-void CGameContext::Destruct(bool Resetting)
+CGameContext::~CGameContext()
 {
 	for(auto &pPlayer : m_apPlayers)
 		delete pPlayer;
 
-	if(!Resetting)
+	if(!m_Resetting)
 	{
 		for(auto &pSavedTee : m_apSavedTees)
 			delete pSavedTee;
@@ -143,25 +145,6 @@ void CGameContext::Destruct(bool Resetting)
 
 	delete m_pScore;
 	m_pScore = nullptr;
-}
-
-CGameContext::CGameContext() :
-	m_Mutes("mutes"),
-	m_VoteMutes("votemutes")
-{
-	Construct(false);
-}
-
-CGameContext::CGameContext(bool Reset) :
-	m_Mutes("mutes"),
-	m_VoteMutes("votemutes")
-{
-	Construct(Reset);
-}
-
-CGameContext::~CGameContext()
-{
-	Destruct(m_Resetting);
 }
 
 void CGameContext::Clear()

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -169,8 +169,6 @@ class CGameContext : public IGameServer
 	static void ConchainPracticeByDefaultUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConDumpLog(IConsole::IResult *pResult, void *pUserData);
 
-	void Construct(bool Resetting);
-	void Destruct(bool Resetting);
 	void AddVote(const char *pDescription, const char *pCommand);
 	static int MapScan(const char *pName, int IsDir, int DirType, void *pUserData);
 
@@ -202,8 +200,7 @@ public:
 	CNetObjHandler *GetNetObjHandler() override { return &m_NetObjHandler; }
 	protocol7::CNetObjHandler *GetNetObjHandler7() override { return &m_NetObjHandler7; }
 
-	CGameContext();
-	CGameContext(bool Reset);
+	CGameContext(bool Resetting = false);
 	~CGameContext() override;
 
 	void Clear();


### PR DESCRIPTION
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI ~~to generate more than single-line completions~~

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->

## Tested (that it works without crash)

* Join the server
* Play a bit
* Shutdown the server (ctrl-c and `shutdown`)
* `hot_reload`
* `map`

## Why

~~The only questionable bit is removing the `Clear()` in `OnShutdown(...)`, this is fine as `Clear()` doesn't free anything, the deconstruct after `OnShutdown` actually does freeing. Regardless these resources are owned by `CGameContext` (as they are deleted and allocated there) so it's fine as long as they are eventually freed~~

~~As `Clear()` was only in `OnShutdown`, it isn't called on `hot_reload` or `map` like it's behaviour implies~~ It is!

It would be nice if it was completley RAII (no `OnShutdown`, `OnInit` and whatever `Clear` is, but that's too scary rn)

* Making the enum a bool makes it more readable
* When deleting `nullptr` shouldn't be checked (usually there's a clang warning, but since there's also the side effect of setting nullptr, it is silenced)
* Inline the construct and destruct member fns that just add an indirection for no reason