### PR TITLE
Optimization: Add option to cull details when zooming out

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -433,6 +433,7 @@ MACRO_CONFIG_INT(GfxBackgroundRender, gfx_backgroundrender, 1, 0, 1, CFGFLAG_SAV
 MACRO_CONFIG_INT(GfxTextOverlay, gfx_text_overlay, 10, 1, 100, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Stop rendering textoverlay in editor or with entities: high value = less details = more speed")
 MACRO_CONFIG_INT(GfxAsyncRenderOld, gfx_asyncrender_old, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "During an update cycle, skip the render cycle, if the render cycle would need to wait for the previous render cycle to finish")
 MACRO_CONFIG_INT(GfxQuadAsTriangle, gfx_quad_as_triangle, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Render quads as triangles (fixes quad coloring on some GPUs)")
+MACRO_CONFIG_INT(GfxZoomHideDetail, gfx_zoom_hide_detail, 2, 0, 64, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Pixel size at which the client starts hiding details when zooming out");
 
 MACRO_CONFIG_INT(InpMousesens, inp_mousesens, 200, 1, 100000, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Mouse sensitivity")
 MACRO_CONFIG_INT(InpTranslatedKeys, inp_translated_keys, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Translate keys before interpreting them, respects keyboard layouts")

--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -200,20 +200,29 @@ void CRenderLayer::RenderLoading() const
 		(*m_RenderUploadCallback)(pLoadingTitle, pLoadingMessage, 0);
 }
 
-bool CRenderLayer::IsVisibleInClipRegion(const std::optional<CClipRegion> &ClipRegion) const
+bool CRenderLayer::IsVisibleInClipRegion(const std::optional<CClipRegion> &ClipRegion, const CRenderLayerParams &Params)
 {
 	// always show unclipped regions
 	if(!ClipRegion.has_value())
 		return true;
 
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
 	float Left = ClipRegion->m_X;
 	float Top = ClipRegion->m_Y;
 	float Right = ClipRegion->m_X + ClipRegion->m_Width;
 	float Bottom = ClipRegion->m_Y + ClipRegion->m_Height;
 
-	return Right >= ScreenX0 && Left <= ScreenX1 && Bottom >= ScreenY0 && Top <= ScreenY1;
+	if(Right < m_Screen.m_TopLeft.x || Left > m_Screen.m_BottomRight.x || Bottom < m_Screen.m_TopLeft.y || Top > m_Screen.m_BottomRight.y)
+		return false;
+
+	// ignore a clip region if it's too small
+	if(m_Flags & LAYERFLAG_DETAIL && Params.m_RenderType != ERenderType::RENDERTYPE_FULL_DESIGN && Params.m_Zoom > 2.0f)
+	{
+		bool IsWideEnough = ClipRegion->m_Width * Graphics()->ScreenWidth() / (m_Screen.m_BottomRight.x - m_Screen.m_TopLeft.x) > g_Config.m_GfxZoomHideDetail;
+		bool IsHighEnough = ClipRegion->m_Height * Graphics()->ScreenHeight() / (m_Screen.m_BottomRight.y - m_Screen.m_TopLeft.y) > g_Config.m_GfxZoomHideDetail;
+		if(!IsHighEnough || !IsWideEnough)
+			return false;
+	}
+	return true;
 }
 
 /**************
@@ -293,15 +302,23 @@ void CRenderLayerTile::RenderTileLayer(const ColorRGBA &Color, const CRenderLaye
 	if(Visuals.m_BufferContainerIndex == -1)
 		return; // no visuals were created
 
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreen CurrentScreen;
+	Graphics()->GetScreen(&CurrentScreen.m_TopLeft.x, &CurrentScreen.m_TopLeft.y, &CurrentScreen.m_BottomRight.x, &CurrentScreen.m_BottomRight.y);
 
-	int ScreenRectY0 = std::floor(ScreenY0 / 32);
-	int ScreenRectX0 = std::floor(ScreenX0 / 32);
-	int ScreenRectY1 = std::ceil(ScreenY1 / 32);
-	int ScreenRectX1 = std::ceil(ScreenX1 / 32);
+	int ScreenRectY0 = std::floor(CurrentScreen.m_TopLeft.y / 32);
+	int ScreenRectX0 = std::floor(CurrentScreen.m_TopLeft.x / 32);
+	int ScreenRectY1 = std::ceil(CurrentScreen.m_BottomRight.y / 32);
+	int ScreenRectX1 = std::ceil(CurrentScreen.m_BottomRight.x / 32);
 
-	if(IsVisibleInClipRegion(m_LayerClip))
+	// update cached visibility check
+	if(CurrentScreen != m_Screen)
+	{
+		m_Screen = CurrentScreen;
+		if(m_LayerClip.has_value())
+			m_LayerClip.value().m_IsVisible = IsVisibleInClipRegion(m_LayerClip, Params);
+	}
+
+	if(!m_LayerClip.has_value() || m_LayerClip.value().m_IsVisible)
 	{
 		// create the indice buffers we want to draw -- reuse them
 		std::vector<char *> vpIndexOffsets;
@@ -939,7 +956,7 @@ void CRenderLayerQuads::RenderQuadLayer(float Alpha, const CRenderLayerParams &P
 
 	for(auto &QuadCluster : m_vQuadClusters)
 	{
-		if(!IsVisibleInClipRegion(QuadCluster.m_ClipRegion))
+		if(QuadCluster.m_ClipRegion.has_value() && !QuadCluster.m_ClipRegion.value().m_IsVisible)
 			continue;
 
 		if(!QuadCluster.m_Grouped)
@@ -1007,7 +1024,7 @@ void CRenderLayerQuads::RenderQuadLayer(float Alpha, const CRenderLayerParams &P
 	{
 		for(auto &QuadCluster : m_vQuadClusters)
 		{
-			if(!IsVisibleInClipRegion(QuadCluster.m_ClipRegion) || !QuadCluster.m_ClipRegion.has_value())
+			if(QuadCluster.m_ClipRegion.has_value() && !QuadCluster.m_ClipRegion.value().m_IsVisible)
 				continue;
 
 			char aDebugText[64];
@@ -1382,7 +1399,26 @@ bool CRenderLayerQuads::DoRender(const CRenderLayerParams &Params)
 			return false;
 	}
 
-	return IsVisibleInClipRegion(m_LayerClip);
+	// update cached visibility check
+	CScreen CurrentScreen;
+	Graphics()->GetScreen(&CurrentScreen.m_TopLeft.x, &CurrentScreen.m_TopLeft.y, &CurrentScreen.m_BottomRight.x, &CurrentScreen.m_BottomRight.y);
+	if(CurrentScreen != m_Screen)
+	{
+		m_Screen = CurrentScreen;
+		if(m_LayerClip.has_value())
+			m_LayerClip.value().m_IsVisible = IsVisibleInClipRegion(m_LayerClip, Params);
+
+		// update quad cluster visibility if the layer is visible
+		if(!m_LayerClip.has_value() || m_LayerClip.value().m_IsVisible)
+		{
+			for(auto &QuadCluster : m_vQuadClusters)
+			{
+				if(QuadCluster.m_ClipRegion.has_value())
+					QuadCluster.m_ClipRegion.value().m_IsVisible = IsVisibleInClipRegion(QuadCluster.m_ClipRegion, Params);
+			}
+		}
+	}
+	return !m_LayerClip.has_value() || m_LayerClip.value().m_IsVisible;
 }
 
 /****************

--- a/src/game/map/render_layer.h
+++ b/src/game/map/render_layer.h
@@ -36,12 +36,27 @@ class CClipRegion
 public:
 	CClipRegion() = default;
 	CClipRegion(float X, float Y, float Width, float Height) :
-		m_X(X), m_Y(Y), m_Width(Width), m_Height(Height) {}
+		m_X(X), m_Y(Y), m_Width(Width), m_Height(Height), m_IsVisible(true) {}
 
 	float m_X;
 	float m_Y;
 	float m_Width;
 	float m_Height;
+	bool m_IsVisible;
+};
+
+class CScreen
+{
+public:
+	vec2 m_TopLeft;
+	vec2 m_BottomRight;
+
+	CScreen() :
+		m_TopLeft(), m_BottomRight() {}
+	bool operator!=(const CScreen &Other) const
+	{
+		return m_TopLeft != Other.m_TopLeft || m_BottomRight != Other.m_BottomRight;
+	}
 };
 
 class CRenderLayerParams
@@ -74,7 +89,7 @@ public:
 	virtual bool IsGroup() const { return false; }
 	virtual void Unload() = 0;
 
-	bool IsVisibleInClipRegion(const std::optional<CClipRegion> &ClipRegion) const;
+	bool IsVisibleInClipRegion(const std::optional<CClipRegion> &ClipRegion, const CRenderLayerParams &Params);
 	int GetGroup() const { return m_GroupId; }
 
 protected:
@@ -91,6 +106,7 @@ protected:
 	std::shared_ptr<CEnvelopeManager> m_pEnvelopeManager;
 	std::optional<FRenderUploadCallback> m_RenderUploadCallback;
 	std::optional<CClipRegion> m_LayerClip;
+	CScreen m_Screen;
 };
 
 class CRenderLayerGroup : public CRenderLayer


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Add an option to cull details when zooming out. If you zoom out a lot, the client renders **everything** which can lead to some serious performance issues on some maps bringing normal computers to their knees. I don't understand why we allow zooming out so far in the first place, but if we keep allowing it, we should make sure your computer doesn't explode.

Culling works best on maps with lots of quads, since their clustering has likely smaller clip regions.

Unfortunately, this will not improve the situation on every map, because it requires details in the first place to be hidden.

### Map Mud:

Before:
<img width="2560" height="1440" alt="screenshot_2025-11-23_11-57-37" src="https://github.com/user-attachments/assets/5a273547-4f6c-4ec9-946d-5942b7044fcf" />

After:
<img width="2560" height="1440" alt="screenshot_2025-11-23_11-57-31" src="https://github.com/user-attachments/assets/c8b592ea-43f3-4735-84c9-d510796583d3" />

### Map KingsLeap

Before:
<img width="2560" height="1440" alt="screenshot_2025-11-23_11-47-32" src="https://github.com/user-attachments/assets/c4ffe2db-aacc-43fe-9e1a-5a929521a4bc" />

After:
<img width="2560" height="1440" alt="screenshot_2025-11-23_11-47-41" src="https://github.com/user-attachments/assets/6fe7e932-459e-4175-9c2f-f89f3ad999f9" />

I believe I don't need real benchmarks, as the FPS increase in the top right is sufficient enough.

closes #11079

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
