### PR TITLE
Separate history, actions and property trackers for each editor map

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -240,7 +240,7 @@ void CEditor::DeleteSelectedQuads()
 		i--;
 	}
 
-	m_EditorHistory.RecordAction(std::make_shared<CEditorActionDeleteQuad>(this, m_SelectedGroup, m_vSelectedLayers[0], vSelectedQuads, vDeletedQuads));
+	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionDeleteQuad>(&m_Map, m_SelectedGroup, m_vSelectedLayers[0], vSelectedQuads, vDeletedQuads));
 }
 
 bool CEditor::IsQuadSelected(int Index) const
@@ -843,16 +843,16 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 		// undo/redo group
 		ToolbarTop.VSplitLeft(25.0f, &Button, &ToolbarTop);
 		static int s_UndoButton = 0;
-		if(DoButton_FontIcon(&s_UndoButton, FONT_ICON_UNDO, m_EditorHistory.CanUndo() - 1, &Button, BUTTONFLAG_LEFT, "[Ctrl+Z] Undo the last action.", IGraphics::CORNER_L))
+		if(DoButton_FontIcon(&s_UndoButton, FONT_ICON_UNDO, m_Map.m_EditorHistory.CanUndo() - 1, &Button, BUTTONFLAG_LEFT, "[Ctrl+Z] Undo the last action.", IGraphics::CORNER_L))
 		{
-			m_EditorHistory.Undo();
+			m_Map.m_EditorHistory.Undo();
 		}
 
 		ToolbarTop.VSplitLeft(25.0f, &Button, &ToolbarTop);
 		static int s_RedoButton = 0;
-		if(DoButton_FontIcon(&s_RedoButton, FONT_ICON_REDO, m_EditorHistory.CanRedo() - 1, &Button, BUTTONFLAG_LEFT, "[Ctrl+Y] Redo the last action.", IGraphics::CORNER_R))
+		if(DoButton_FontIcon(&s_RedoButton, FONT_ICON_REDO, m_Map.m_EditorHistory.CanRedo() - 1, &Button, BUTTONFLAG_LEFT, "[Ctrl+Y] Redo the last action.", IGraphics::CORNER_R))
 		{
-			m_EditorHistory.Redo();
+			m_Map.m_EditorHistory.Redo();
 		}
 
 		ToolbarTop.VSplitLeft(5.0f, nullptr, &ToolbarTop);
@@ -1107,19 +1107,18 @@ void CEditor::DoSoundSource(int LayerIndex, CSoundSource *pSource, int Index)
 	float CenterY = fx2f(pSource->m_Position.y);
 
 	const bool IgnoreGrid = Input()->AltIsPressed();
-	static CSoundSourceOperationTracker s_Tracker(this);
 
 	if(s_Operation == ESoundSourceOp::OP_NONE)
 	{
 		if(!Ui()->MouseButton(0))
-			s_Tracker.End();
+			m_Map.m_SoundSourceOperationTracker.End();
 	}
 
 	if(Ui()->CheckActiveItem(pSource))
 	{
 		if(s_Operation != ESoundSourceOp::OP_NONE)
 		{
-			s_Tracker.Begin(pSource, s_Operation, LayerIndex);
+			m_Map.m_SoundSourceOperationTracker.Begin(pSource, s_Operation, LayerIndex);
 		}
 
 		if(m_MouseDeltaWorld != vec2(0.0f, 0.0f))
@@ -1764,7 +1763,7 @@ void CEditor::DoQuad(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer,
 			// check if we only should move pivot
 			if(s_Operation == OP_MOVE_PIVOT)
 			{
-				m_QuadTracker.BeginQuadTrack(pLayer, m_vSelectedQuads, -1, LayerIndex);
+				m_Map.m_QuadTracker.BeginQuadTrack(pLayer, m_vSelectedQuads, -1, LayerIndex);
 
 				s_LastOffset = GetDragOffset(); // Update offset
 				ApplyAxisAlignment(s_LastOffset); // Apply axis alignment to the offset
@@ -1780,7 +1779,7 @@ void CEditor::DoQuad(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer,
 			}
 			else if(s_Operation == OP_MOVE_ALL)
 			{
-				m_QuadTracker.BeginQuadTrack(pLayer, m_vSelectedQuads, -1, LayerIndex);
+				m_Map.m_QuadTracker.BeginQuadTrack(pLayer, m_vSelectedQuads, -1, LayerIndex);
 
 				// Compute drag offset
 				s_LastOffset = GetDragOffset();
@@ -1800,7 +1799,7 @@ void CEditor::DoQuad(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer,
 			}
 			else if(s_Operation == OP_ROTATE)
 			{
-				m_QuadTracker.BeginQuadTrack(pLayer, m_vSelectedQuads, -1, LayerIndex);
+				m_Map.m_QuadTracker.BeginQuadTrack(pLayer, m_vSelectedQuads, -1, LayerIndex);
 
 				for(size_t i = 0; i < m_vSelectedQuads.size(); ++i)
 				{
@@ -1873,7 +1872,7 @@ void CEditor::DoQuad(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer,
 				Ui()->DisableMouseLock();
 				s_Operation = OP_NONE;
 				Ui()->SetActiveItem(nullptr);
-				m_QuadTracker.EndQuadTrack();
+				m_Map.m_QuadTracker.EndQuadTrack();
 			}
 			else if(Ui()->MouseButton(1))
 			{
@@ -1903,7 +1902,7 @@ void CEditor::DoQuad(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer,
 				}
 				else if(s_Operation == OP_MOVE_PIVOT || s_Operation == OP_MOVE_ALL)
 				{
-					m_QuadTracker.EndQuadTrack();
+					m_Map.m_QuadTracker.EndQuadTrack();
 				}
 
 				Ui()->DisableMouseLock();
@@ -2053,7 +2052,7 @@ void CEditor::DoQuadPoint(int LayerIndex, const std::shared_ptr<CLayerQuads> &pL
 
 			if(s_Operation == OP_MOVEPOINT)
 			{
-				m_QuadTracker.BeginQuadTrack(pLayer, m_vSelectedQuads, -1, LayerIndex);
+				m_Map.m_QuadTracker.BeginQuadTrack(pLayer, m_vSelectedQuads, -1, LayerIndex);
 
 				s_LastOffset = GetDragOffset(); // Update offset
 				ApplyAxisAlignment(s_LastOffset); // Apply axis alignment to offset
@@ -2076,9 +2075,9 @@ void CEditor::DoQuadPoint(int LayerIndex, const std::shared_ptr<CLayerQuads> &pL
 			{
 				int SelectedPoints = (1 << 0) | (1 << 1) | (1 << 2) | (1 << 3);
 
-				m_QuadTracker.BeginQuadPointPropTrack(pLayer, m_vSelectedQuads, SelectedPoints, -1, LayerIndex);
-				m_QuadTracker.AddQuadPointPropTrack(EQuadPointProp::PROP_TEX_U);
-				m_QuadTracker.AddQuadPointPropTrack(EQuadPointProp::PROP_TEX_V);
+				m_Map.m_QuadTracker.BeginQuadPointPropTrack(pLayer, m_vSelectedQuads, SelectedPoints, -1, LayerIndex);
+				m_Map.m_QuadTracker.AddQuadPointPropTrack(EQuadPointProp::PROP_TEX_U);
+				m_Map.m_QuadTracker.AddQuadPointPropTrack(EQuadPointProp::PROP_TEX_V);
 
 				for(int Selected : m_vSelectedQuads)
 				{
@@ -2148,11 +2147,11 @@ void CEditor::DoQuadPoint(int LayerIndex, const std::shared_ptr<CLayerQuads> &pL
 
 				if(s_Operation == OP_MOVEPOINT)
 				{
-					m_QuadTracker.EndQuadTrack();
+					m_Map.m_QuadTracker.EndQuadTrack();
 				}
 				else if(s_Operation == OP_MOVEUV)
 				{
-					m_QuadTracker.EndQuadPointPropTrackAll();
+					m_Map.m_QuadTracker.EndQuadPointPropTrackAll();
 				}
 
 				Ui()->DisableMouseLock();
@@ -2382,7 +2381,7 @@ void CEditor::DoQuadKnife(int QuadIndex)
 		pResult->m_aPoints[4].y = ((pResult->m_aPoints[0].y + pResult->m_aPoints[3].y) / 2 + (pResult->m_aPoints[1].y + pResult->m_aPoints[2].y) / 2) / 2;
 
 		m_QuadKnifeCount = 0;
-		m_EditorHistory.RecordAction(std::make_shared<CEditorActionNewQuad>(this, m_SelectedGroup, m_vSelectedLayers[0]));
+		m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionNewQuad>(&m_Map, m_SelectedGroup, m_vSelectedLayers[0]));
 	}
 
 	// Render
@@ -2998,8 +2997,8 @@ void CEditor::DoMapEditor(CUIRect View)
 							std::shared_ptr<CLayer> pBrush = m_pBrush->IsEmpty() ? nullptr : m_pBrush->m_vpLayers[BrushIndex];
 							apEditLayers[k].second->FillSelection(m_pBrush->IsEmpty(), pBrush.get(), r);
 						}
-						std::shared_ptr<IEditorAction> Action = std::make_shared<CEditorBrushDrawAction>(this, m_SelectedGroup);
-						m_EditorHistory.RecordAction(Action);
+						std::shared_ptr<IEditorAction> Action = std::make_shared<CEditorBrushDrawAction>(&m_Map, m_SelectedGroup);
+						m_Map.m_EditorHistory.RecordAction(Action);
 					}
 					else
 					{
@@ -3222,10 +3221,10 @@ void CEditor::DoMapEditor(CUIRect View)
 		{
 			if(s_Operation == OP_BRUSH_DRAW)
 			{
-				std::shared_ptr<IEditorAction> pAction = std::make_shared<CEditorBrushDrawAction>(this, m_SelectedGroup);
+				std::shared_ptr<IEditorAction> pAction = std::make_shared<CEditorBrushDrawAction>(&m_Map, m_SelectedGroup);
 
 				if(!pAction->IsEmpty()) // Avoid recording tile draw action when placing quads only
-					m_EditorHistory.RecordAction(pAction);
+					m_Map.m_EditorHistory.RecordAction(pAction);
 			}
 
 			s_Operation = OP_NONE;
@@ -4044,13 +4043,13 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 		if(s_PreviousOperation == OP_GROUP_DRAG)
 		{
 			s_PreviousOperation = OP_NONE;
-			m_EditorHistory.RecordAction(std::make_shared<CEditorActionEditGroupProp>(this, m_SelectedGroup, EGroupProp::PROP_ORDER, s_InitialGroupIndex, m_SelectedGroup));
+			m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionEditGroupProp>(&m_Map, m_SelectedGroup, EGroupProp::PROP_ORDER, s_InitialGroupIndex, m_SelectedGroup));
 		}
 		else if(s_PreviousOperation == OP_LAYER_DRAG)
 		{
 			if(s_InitialGroupIndex != m_SelectedGroup)
 			{
-				m_EditorHistory.RecordAction(std::make_shared<CEditorActionEditLayersGroupAndOrder>(this, s_InitialGroupIndex, s_vInitialLayerIndices, m_SelectedGroup, m_vSelectedLayers));
+				m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionEditLayersGroupAndOrder>(&m_Map, s_InitialGroupIndex, s_vInitialLayerIndices, m_SelectedGroup, m_vSelectedLayers));
 			}
 			else
 			{
@@ -4061,9 +4060,9 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 				for(int k = 0; k < (int)vLayerIndices.size(); k++)
 				{
 					int LayerIndex = vLayerIndices[k];
-					vpActions.push_back(std::make_shared<CEditorActionEditLayerProp>(this, m_SelectedGroup, LayerIndex, ELayerProp::PROP_ORDER, s_vInitialLayerIndices[k], LayerIndex));
+					vpActions.push_back(std::make_shared<CEditorActionEditLayerProp>(&m_Map, m_SelectedGroup, LayerIndex, ELayerProp::PROP_ORDER, s_vInitialLayerIndices[k], LayerIndex));
 				}
-				m_EditorHistory.RecordAction(std::make_shared<CEditorActionBulk>(this, vpActions, nullptr, true));
+				m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionBulk>(&m_Map, vpActions, nullptr, true));
 			}
 			s_PreviousOperation = OP_NONE;
 		}
@@ -4710,7 +4709,7 @@ bool CEditor::IsEnvelopeUsed(int EnvelopeIndex) const
 
 void CEditor::RemoveUnusedEnvelopes()
 {
-	m_EnvelopeEditorHistory.BeginBulk();
+	m_Map.m_EnvelopeEditorHistory.BeginBulk();
 	int DeletedCount = 0;
 	for(size_t EnvelopeIndex = 0; EnvelopeIndex < m_Map.m_vpEnvelopes.size();)
 	{
@@ -4723,13 +4722,13 @@ void CEditor::RemoveUnusedEnvelopes()
 			// deleting removes the shared ptr from the map
 			std::shared_ptr<CEnvelope> pEnvelope = m_Map.m_vpEnvelopes[EnvelopeIndex];
 			auto vpObjectReferences = m_Map.DeleteEnvelope(EnvelopeIndex);
-			m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeDelete>(this, EnvelopeIndex, vpObjectReferences, pEnvelope));
+			m_Map.m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeDelete>(&m_Map, EnvelopeIndex, vpObjectReferences, pEnvelope));
 			DeletedCount++;
 		}
 	}
 	char aDisplay[256];
 	str_format(aDisplay, sizeof(aDisplay), "Tool 'Remove unused envelopes': delete %d envelopes", DeletedCount);
-	m_EnvelopeEditorHistory.EndBulk(aDisplay);
+	m_Map.m_EnvelopeEditorHistory.EndBulk(aDisplay);
 }
 
 void CEditor::ZoomAdaptOffsetX(float ZoomFactor, const CUIRect &View)
@@ -5024,25 +5023,25 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 		// redo button
 		ToolBar.VSplitRight(25.0f, &ToolBar, &Button);
 		static int s_RedoButton = 0;
-		if(DoButton_FontIcon(&s_RedoButton, FONT_ICON_REDO, m_EnvelopeEditorHistory.CanRedo() ? 0 : -1, &Button, BUTTONFLAG_LEFT, "[Ctrl+Y] Redo the last action.", IGraphics::CORNER_R, 11.0f) == 1)
+		if(DoButton_FontIcon(&s_RedoButton, FONT_ICON_REDO, m_Map.m_EnvelopeEditorHistory.CanRedo() ? 0 : -1, &Button, BUTTONFLAG_LEFT, "[Ctrl+Y] Redo the last action.", IGraphics::CORNER_R, 11.0f) == 1)
 		{
-			m_EnvelopeEditorHistory.Redo();
+			m_Map.m_EnvelopeEditorHistory.Redo();
 		}
 
 		// undo button
 		ToolBar.VSplitRight(25.0f, &ToolBar, &Button);
 		ToolBar.VSplitRight(10.0f, &ToolBar, nullptr);
 		static int s_UndoButton = 0;
-		if(DoButton_FontIcon(&s_UndoButton, FONT_ICON_UNDO, m_EnvelopeEditorHistory.CanUndo() ? 0 : -1, &Button, BUTTONFLAG_LEFT, "[Ctrl+Z] Undo the last action.", IGraphics::CORNER_L, 11.0f) == 1)
+		if(DoButton_FontIcon(&s_UndoButton, FONT_ICON_UNDO, m_Map.m_EnvelopeEditorHistory.CanUndo() ? 0 : -1, &Button, BUTTONFLAG_LEFT, "[Ctrl+Z] Undo the last action.", IGraphics::CORNER_L, 11.0f) == 1)
 		{
-			m_EnvelopeEditorHistory.Undo();
+			m_Map.m_EnvelopeEditorHistory.Undo();
 		}
 
 		ToolBar.VSplitRight(50.0f, &ToolBar, &Button);
 		static int s_NewSoundButton = 0;
 		if(DoButton_Editor(&s_NewSoundButton, "Sound+", 0, &Button, BUTTONFLAG_LEFT, "Create a new sound envelope."))
 		{
-			m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionEnvelopeAdd>(this, CEnvelope::EType::SOUND));
+			m_Map.m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionEnvelopeAdd>(&m_Map, CEnvelope::EType::SOUND));
 			pEnvelope = m_Map.m_vpEnvelopes[m_SelectedEnvelope];
 		}
 
@@ -5051,7 +5050,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 		static int s_New4dButton = 0;
 		if(DoButton_Editor(&s_New4dButton, "Color+", 0, &Button, BUTTONFLAG_LEFT, "Create a new color envelope."))
 		{
-			m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionEnvelopeAdd>(this, CEnvelope::EType::COLOR));
+			m_Map.m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionEnvelopeAdd>(&m_Map, CEnvelope::EType::COLOR));
 			pEnvelope = m_Map.m_vpEnvelopes[m_SelectedEnvelope];
 		}
 
@@ -5060,7 +5059,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 		static int s_New2dButton = 0;
 		if(DoButton_Editor(&s_New2dButton, "Pos.+", 0, &Button, BUTTONFLAG_LEFT, "Create a new position envelope."))
 		{
-			m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionEnvelopeAdd>(this, CEnvelope::EType::POSITION));
+			m_Map.m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionEnvelopeAdd>(&m_Map, CEnvelope::EType::POSITION));
 			pEnvelope = m_Map.m_vpEnvelopes[m_SelectedEnvelope];
 		}
 
@@ -5073,7 +5072,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			if(DoButton_Editor(&s_DeleteButton, "✗", 0, &Button, BUTTONFLAG_LEFT, "Delete this envelope."))
 			{
 				auto vpObjectReferences = m_Map.DeleteEnvelope(m_SelectedEnvelope);
-				m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeDelete>(this, m_SelectedEnvelope, vpObjectReferences, pEnvelope));
+				m_Map.m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeDelete>(&m_Map, m_SelectedEnvelope, vpObjectReferences, pEnvelope));
 
 				m_SelectedEnvelope = m_Map.m_vpEnvelopes.empty() ? -1 : std::clamp(m_SelectedEnvelope, 0, (int)m_Map.m_vpEnvelopes.size() - 1);
 				pEnvelope = m_Map.m_vpEnvelopes.empty() ? nullptr : m_Map.m_vpEnvelopes[m_SelectedEnvelope];
@@ -5095,7 +5094,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				m_SelectedEnvelope = m_Map.MoveEnvelope(MoveFrom, MoveTo);
 				if(m_SelectedEnvelope != MoveFrom)
 				{
-					m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeEdit>(this, m_SelectedEnvelope, CEditorActionEnvelopeEdit::EEditType::ORDER, MoveFrom, m_SelectedEnvelope));
+					m_Map.m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeEdit>(&m_Map, m_SelectedEnvelope, CEditorActionEnvelopeEdit::EEditType::ORDER, MoveFrom, m_SelectedEnvelope));
 					pEnvelope = m_Map.m_vpEnvelopes[m_SelectedEnvelope];
 					m_Map.OnModify();
 				}
@@ -5111,7 +5110,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				m_SelectedEnvelope = m_Map.MoveEnvelope(MoveFrom, MoveTo);
 				if(m_SelectedEnvelope != MoveFrom)
 				{
-					m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeEdit>(this, m_SelectedEnvelope, CEditorActionEnvelopeEdit::EEditType::ORDER, MoveFrom, m_SelectedEnvelope));
+					m_Map.m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeEdit>(&m_Map, m_SelectedEnvelope, CEditorActionEnvelopeEdit::EEditType::ORDER, MoveFrom, m_SelectedEnvelope));
 					pEnvelope = m_Map.m_vpEnvelopes[m_SelectedEnvelope];
 					m_Map.OnModify();
 				}
@@ -5346,7 +5345,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 					}
 
 					if(!TimeFound)
-						m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionAddEnvelopePoint>(this, m_SelectedEnvelope, FixedTime, Channels));
+						m_Map.m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionAddEnvelopePoint>(&m_Map, m_SelectedEnvelope, FixedTime, Channels));
 
 					if(FixedTime < CFixedTime(0))
 						RemoveTimeOffsetEnvelope(pEnvelope);
@@ -5582,7 +5581,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 						const int Direction = Input()->ShiftIsPressed() ? -1 : 1;
 						pEnvelope->m_vPoints[i].m_Curvetype = (pEnvelope->m_vPoints[i].m_Curvetype + Direction + NUM_CURVETYPES) % NUM_CURVETYPES;
 
-						m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeEditPoint>(this,
+						m_Map.m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeEditPoint>(&m_Map,
 							m_SelectedEnvelope, i, 0, CEditorActionEnvelopeEditPoint::EEditType::CURVE_TYPE, PrevCurve, pEnvelope->m_vPoints[i].m_Curvetype));
 						m_Map.OnModify();
 					}
@@ -5619,11 +5618,11 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			{
 				UpdateHotEnvelopePoint(View, pEnvelope.get(), s_ActiveChannels);
 				if(!Ui()->MouseButton(0))
-					m_EnvOpTracker.Stop(false);
+					m_Map.m_EnvOpTracker.Stop(false);
 			}
 			else
 			{
-				m_EnvOpTracker.Begin(s_Operation);
+				m_Map.m_EnvOpTracker.Begin(s_Operation);
 			}
 
 			Ui()->ClipEnable(&View);
@@ -5811,7 +5810,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 							{
 								if(Input()->ShiftIsPressed())
 								{
-									m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionDeleteEnvelopePoint>(this, m_SelectedEnvelope, i));
+									m_Map.m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionDeleteEnvelopePoint>(&m_Map, m_SelectedEnvelope, i));
 								}
 								else
 								{
@@ -6224,7 +6223,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			if(Ui()->MouseButton(0))
 			{
 				s_Operation = EEnvelopeEditorOp::OP_NONE;
-				m_EnvOpTracker.Stop(false);
+				m_Map.m_EnvOpTracker.Stop(false);
 			}
 			else if(Ui()->MouseButton(1) || Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 			{
@@ -6452,11 +6451,11 @@ void CEditor::RenderEditorHistory(CUIRect View)
 
 	CEditorHistory *pCurrentHistory;
 	if(s_HistoryType == EDITOR_HISTORY)
-		pCurrentHistory = &m_EditorHistory;
+		pCurrentHistory = &m_Map.m_EditorHistory;
 	else if(s_HistoryType == ENVELOPE_HISTORY)
-		pCurrentHistory = &m_EnvelopeEditorHistory;
+		pCurrentHistory = &m_Map.m_EnvelopeEditorHistory;
 	else if(s_HistoryType == SERVER_SETTINGS_HISTORY)
-		pCurrentHistory = &m_ServerSettingsHistory;
+		pCurrentHistory = &m_Map.m_ServerSettingsHistory;
 	else
 		return;
 
@@ -7416,16 +7415,6 @@ void CEditor::Reset(bool CreateDefault)
 
 	m_ResetZoomEnvelope = true;
 	m_SettingsCommandInput.Clear();
-
-	m_EditorHistory.Clear();
-	m_EnvelopeEditorHistory.Clear();
-	m_ServerSettingsHistory.Clear();
-
-	m_QuadTracker.m_pEditor = this;
-
-	m_EnvOpTracker.m_pEditor = this;
-	m_EnvOpTracker.Reset();
-
 	m_MapSettingsCommandContext.Reset();
 }
 
@@ -7541,7 +7530,7 @@ void CEditor::PlaceBorderTiles()
 	}
 
 	int GameGroupIndex = std::find(m_Map.m_vpGroups.begin(), m_Map.m_vpGroups.end(), m_Map.m_pGameGroup) - m_Map.m_vpGroups.begin();
-	m_EditorHistory.RecordAction(std::make_shared<CEditorBrushDrawAction>(this, GameGroupIndex), "Tool 'Make borders'");
+	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorBrushDrawAction>(&m_Map, GameGroupIndex), "Tool 'Make borders'");
 
 	m_Map.OnModify();
 }
@@ -8121,7 +8110,7 @@ bool CEditor::Append(const char *pFilename, int StorageType, bool IgnoreHistory)
 	auto IndexMap = m_Map.SortImages();
 
 	if(!IgnoreHistory)
-		m_EditorHistory.RecordAction(std::make_shared<CEditorActionAppendMap>(this, pFilename, Info, IndexMap));
+		m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionAppendMap>(&m_Map, pFilename, Info, IndexMap));
 
 	m_Map.CheckIntegrity();
 
@@ -8133,15 +8122,15 @@ CEditorHistory &CEditor::ActiveHistory()
 {
 	if(m_ActiveExtraEditor == EXTRAEDITOR_SERVER_SETTINGS)
 	{
-		return m_ServerSettingsHistory;
+		return m_Map.m_ServerSettingsHistory;
 	}
 	else if(m_ActiveExtraEditor == EXTRAEDITOR_ENVELOPES)
 	{
-		return m_EnvelopeEditorHistory;
+		return m_Map.m_EnvelopeEditorHistory;
 	}
 	else
 	{
-		return m_EditorHistory;
+		return m_Map.m_EditorHistory;
 	}
 }
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -845,13 +845,6 @@ public:
 
 	void AdjustBrushSpecialTiles(bool UseNextFree, int Adjust = 0);
 
-	// Undo/Redo
-	CEditorHistory m_EditorHistory;
-	CEditorHistory m_ServerSettingsHistory;
-	CEditorHistory m_EnvelopeEditorHistory;
-	CQuadEditTracker m_QuadTracker;
-	CEnvelopeEditorOperationTracker m_EnvOpTracker;
-
 private:
 	CEditorHistory &ActiveHistory();
 

--- a/src/game/editor/editor_action.h
+++ b/src/game/editor/editor_action.h
@@ -1,19 +1,13 @@
 #ifndef GAME_EDITOR_EDITOR_ACTION_H
 #define GAME_EDITOR_EDITOR_ACTION_H
 
-#include <string>
+#include <game/editor/map_object.h>
 
-class CEditor;
-
-class IEditorAction
+class IEditorAction : public CMapObject
 {
 public:
-	IEditorAction(CEditor *pEditor) :
-		m_pEditor(pEditor) {}
-
-	IEditorAction() = default;
-
-	virtual ~IEditorAction() = default;
+	IEditorAction(CEditorMap *pMap) :
+		CMapObject(pMap) {}
 
 	virtual void Undo() = 0;
 	virtual void Redo() = 0;
@@ -23,7 +17,6 @@ public:
 	const char *DisplayText() const { return m_aDisplayText; }
 
 protected:
-	CEditor *m_pEditor;
 	char m_aDisplayText[256];
 };
 

--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -2,48 +2,47 @@
 
 #include <game/editor/mapitems/image.h>
 
-CEditorBrushDrawAction::CEditorBrushDrawAction(CEditor *pEditor, int Group) :
-	IEditorAction(pEditor), m_Group(Group)
+CEditorBrushDrawAction::CEditorBrushDrawAction(CEditorMap *pMap, int Group) :
+	IEditorAction(pMap), m_Group(Group)
 {
-	auto &Map = pEditor->m_Map;
-	for(size_t k = 0; k < Map.m_vpGroups[Group]->m_vpLayers.size(); k++)
+	for(size_t k = 0; k < Map()->m_vpGroups[Group]->m_vpLayers.size(); k++)
 	{
-		auto pLayer = Map.m_vpGroups[Group]->m_vpLayers[k];
+		auto pLayer = Map()->m_vpGroups[Group]->m_vpLayers[k];
 
 		if(pLayer->m_Type == LAYERTYPE_TILES)
 		{
 			auto pLayerTiles = std::static_pointer_cast<CLayerTiles>(pLayer);
 
-			if(pLayer == Map.m_pTeleLayer)
+			if(pLayer == Map()->m_pTeleLayer)
 			{
-				if(!Map.m_pTeleLayer->m_History.empty())
+				if(!Map()->m_pTeleLayer->m_History.empty())
 				{
-					m_TeleTileChanges = std::map(Map.m_pTeleLayer->m_History);
-					Map.m_pTeleLayer->ClearHistory();
+					m_TeleTileChanges = std::map(Map()->m_pTeleLayer->m_History);
+					Map()->m_pTeleLayer->ClearHistory();
 				}
 			}
-			else if(pLayer == Map.m_pTuneLayer)
+			else if(pLayer == Map()->m_pTuneLayer)
 			{
-				if(!Map.m_pTuneLayer->m_History.empty())
+				if(!Map()->m_pTuneLayer->m_History.empty())
 				{
-					m_TuneTileChanges = std::map(Map.m_pTuneLayer->m_History);
-					Map.m_pTuneLayer->ClearHistory();
+					m_TuneTileChanges = std::map(Map()->m_pTuneLayer->m_History);
+					Map()->m_pTuneLayer->ClearHistory();
 				}
 			}
-			else if(pLayer == Map.m_pSwitchLayer)
+			else if(pLayer == Map()->m_pSwitchLayer)
 			{
-				if(!Map.m_pSwitchLayer->m_History.empty())
+				if(!Map()->m_pSwitchLayer->m_History.empty())
 				{
-					m_SwitchTileChanges = std::map(Map.m_pSwitchLayer->m_History);
-					Map.m_pSwitchLayer->ClearHistory();
+					m_SwitchTileChanges = std::map(Map()->m_pSwitchLayer->m_History);
+					Map()->m_pSwitchLayer->ClearHistory();
 				}
 			}
-			else if(pLayer == Map.m_pSpeedupLayer)
+			else if(pLayer == Map()->m_pSpeedupLayer)
 			{
-				if(!Map.m_pSpeedupLayer->m_History.empty())
+				if(!Map()->m_pSpeedupLayer->m_History.empty())
 				{
-					m_SpeedupTileChanges = std::map(Map.m_pSpeedupLayer->m_History);
-					Map.m_pSpeedupLayer->ClearHistory();
+					m_SpeedupTileChanges = std::map(Map()->m_pSpeedupLayer->m_History);
+					Map()->m_pSpeedupLayer->ClearHistory();
 				}
 			}
 
@@ -68,7 +67,7 @@ void CEditorBrushDrawAction::SetInfos()
 	for(auto const &Pair : m_vTileChanges)
 	{
 		int Layer = Pair.first;
-		std::shared_ptr<CLayer> pLayer = m_pEditor->m_Map.m_vpGroups[m_Group]->m_vpLayers[Layer];
+		std::shared_ptr<CLayer> pLayer = Map()->m_vpGroups[m_Group]->m_vpLayers[Layer];
 		m_TotalLayers++;
 
 		if(pLayer->m_Type == LAYERTYPE_TILES)
@@ -129,13 +128,11 @@ void CEditorBrushDrawAction::Redo()
 
 void CEditorBrushDrawAction::Apply(bool Undo)
 {
-	auto &Map = m_pEditor->m_Map;
-
 	// Process normal tiles
 	for(auto const &Pair : m_vTileChanges)
 	{
 		int Layer = Pair.first;
-		std::shared_ptr<CLayer> pLayer = Map.m_vpGroups[m_Group]->m_vpLayers[Layer];
+		std::shared_ptr<CLayer> pLayer = Map()->m_vpGroups[m_Group]->m_vpLayers[Layer];
 
 		if(pLayer->m_Type == LAYERTYPE_TILES)
 		{
@@ -163,15 +160,15 @@ void CEditorBrushDrawAction::Apply(bool Undo)
 		for(auto &Tile : Line)
 		{
 			int x = Tile.first;
-			int Index = y * Map.m_pSpeedupLayer->m_Width + x;
+			int Index = y * Map()->m_pSpeedupLayer->m_Width + x;
 			SSpeedupTileStateChange State = Tile.second;
 			SSpeedupTileStateChange::SData Data = Undo ? State.m_Previous : State.m_Current;
 
-			Map.m_pSpeedupLayer->m_pSpeedupTile[Index].m_Force = Data.m_Force;
-			Map.m_pSpeedupLayer->m_pSpeedupTile[Index].m_MaxSpeed = Data.m_MaxSpeed;
-			Map.m_pSpeedupLayer->m_pSpeedupTile[Index].m_Angle = Data.m_Angle;
-			Map.m_pSpeedupLayer->m_pSpeedupTile[Index].m_Type = Data.m_Type;
-			Map.m_pSpeedupLayer->m_pTiles[Index].m_Index = Data.m_Index;
+			Map()->m_pSpeedupLayer->m_pSpeedupTile[Index].m_Force = Data.m_Force;
+			Map()->m_pSpeedupLayer->m_pSpeedupTile[Index].m_MaxSpeed = Data.m_MaxSpeed;
+			Map()->m_pSpeedupLayer->m_pSpeedupTile[Index].m_Angle = Data.m_Angle;
+			Map()->m_pSpeedupLayer->m_pSpeedupTile[Index].m_Type = Data.m_Type;
+			Map()->m_pSpeedupLayer->m_pTiles[Index].m_Index = Data.m_Index;
 		}
 	}
 
@@ -183,13 +180,13 @@ void CEditorBrushDrawAction::Apply(bool Undo)
 		for(auto &Tile : Line)
 		{
 			int x = Tile.first;
-			int Index = y * Map.m_pTeleLayer->m_Width + x;
+			int Index = y * Map()->m_pTeleLayer->m_Width + x;
 			STeleTileStateChange State = Tile.second;
 			STeleTileStateChange::SData Data = Undo ? State.m_Previous : State.m_Current;
 
-			Map.m_pTeleLayer->m_pTeleTile[Index].m_Number = Data.m_Number;
-			Map.m_pTeleLayer->m_pTeleTile[Index].m_Type = Data.m_Type;
-			Map.m_pTeleLayer->m_pTiles[Index].m_Index = Data.m_Index;
+			Map()->m_pTeleLayer->m_pTeleTile[Index].m_Number = Data.m_Number;
+			Map()->m_pTeleLayer->m_pTeleTile[Index].m_Type = Data.m_Type;
+			Map()->m_pTeleLayer->m_pTiles[Index].m_Index = Data.m_Index;
 		}
 	}
 
@@ -201,15 +198,15 @@ void CEditorBrushDrawAction::Apply(bool Undo)
 		for(auto &Tile : Line)
 		{
 			int x = Tile.first;
-			int Index = y * Map.m_pSwitchLayer->m_Width + x;
+			int Index = y * Map()->m_pSwitchLayer->m_Width + x;
 			SSwitchTileStateChange State = Tile.second;
 			SSwitchTileStateChange::SData Data = Undo ? State.m_Previous : State.m_Current;
 
-			Map.m_pSwitchLayer->m_pSwitchTile[Index].m_Number = Data.m_Number;
-			Map.m_pSwitchLayer->m_pSwitchTile[Index].m_Type = Data.m_Type;
-			Map.m_pSwitchLayer->m_pSwitchTile[Index].m_Flags = Data.m_Flags;
-			Map.m_pSwitchLayer->m_pSwitchTile[Index].m_Delay = Data.m_Delay;
-			Map.m_pSwitchLayer->m_pTiles[Index].m_Index = Data.m_Index;
+			Map()->m_pSwitchLayer->m_pSwitchTile[Index].m_Number = Data.m_Number;
+			Map()->m_pSwitchLayer->m_pSwitchTile[Index].m_Type = Data.m_Type;
+			Map()->m_pSwitchLayer->m_pSwitchTile[Index].m_Flags = Data.m_Flags;
+			Map()->m_pSwitchLayer->m_pSwitchTile[Index].m_Delay = Data.m_Delay;
+			Map()->m_pSwitchLayer->m_pTiles[Index].m_Index = Data.m_Index;
 		}
 	}
 
@@ -221,21 +218,21 @@ void CEditorBrushDrawAction::Apply(bool Undo)
 		for(auto &Tile : Line)
 		{
 			int x = Tile.first;
-			int Index = y * Map.m_pTuneLayer->m_Width + x;
+			int Index = y * Map()->m_pTuneLayer->m_Width + x;
 			STuneTileStateChange State = Tile.second;
 			STuneTileStateChange::SData Data = Undo ? State.m_Previous : State.m_Current;
 
-			Map.m_pTuneLayer->m_pTuneTile[Index].m_Number = Data.m_Number;
-			Map.m_pTuneLayer->m_pTuneTile[Index].m_Type = Data.m_Type;
-			Map.m_pTuneLayer->m_pTiles[Index].m_Index = Data.m_Index;
+			Map()->m_pTuneLayer->m_pTuneTile[Index].m_Number = Data.m_Number;
+			Map()->m_pTuneLayer->m_pTuneTile[Index].m_Type = Data.m_Type;
+			Map()->m_pTuneLayer->m_pTiles[Index].m_Index = Data.m_Index;
 		}
 	}
 }
 
 // -------------------------------------------
 
-CEditorActionQuadPlace::CEditorActionQuadPlace(CEditor *pEditor, int GroupIndex, int LayerIndex, std::vector<CQuad> &vBrush) :
-	CEditorActionLayerBase(pEditor, GroupIndex, LayerIndex), m_vBrush(vBrush)
+CEditorActionQuadPlace::CEditorActionQuadPlace(CEditorMap *pMap, int GroupIndex, int LayerIndex, std::vector<CQuad> &vBrush) :
+	CEditorActionLayerBase(pMap, GroupIndex, LayerIndex), m_vBrush(vBrush)
 {
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Quad place (x%d)", (int)m_vBrush.size());
 }
@@ -246,7 +243,7 @@ void CEditorActionQuadPlace::Undo()
 	for(size_t k = 0; k < m_vBrush.size(); k++)
 		pLayerQuads->m_vQuads.pop_back();
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 void CEditorActionQuadPlace::Redo()
 {
@@ -254,11 +251,11 @@ void CEditorActionQuadPlace::Redo()
 	for(auto &Brush : m_vBrush)
 		pLayerQuads->m_vQuads.push_back(Brush);
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
-CEditorActionSoundPlace::CEditorActionSoundPlace(CEditor *pEditor, int GroupIndex, int LayerIndex, std::vector<CSoundSource> &vBrush) :
-	CEditorActionLayerBase(pEditor, GroupIndex, LayerIndex), m_vBrush(vBrush)
+CEditorActionSoundPlace::CEditorActionSoundPlace(CEditorMap *pMap, int GroupIndex, int LayerIndex, std::vector<CSoundSource> &vBrush) :
+	CEditorActionLayerBase(pMap, GroupIndex, LayerIndex), m_vBrush(vBrush)
 {
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Sound place (x%d)", (int)m_vBrush.size());
 }
@@ -269,7 +266,7 @@ void CEditorActionSoundPlace::Undo()
 	for(size_t k = 0; k < m_vBrush.size(); k++)
 		pLayerSounds->m_vSources.pop_back();
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 void CEditorActionSoundPlace::Redo()
@@ -278,13 +275,13 @@ void CEditorActionSoundPlace::Redo()
 	for(auto &Brush : m_vBrush)
 		pLayerSounds->m_vSources.push_back(Brush);
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 // ---------------------------------------------------------------------------------------
 
-CEditorActionDeleteQuad::CEditorActionDeleteQuad(CEditor *pEditor, int GroupIndex, int LayerIndex, std::vector<int> const &vQuadsIndices, std::vector<CQuad> const &vDeletedQuads) :
-	CEditorActionLayerBase(pEditor, GroupIndex, LayerIndex), m_vQuadsIndices(vQuadsIndices), m_vDeletedQuads(vDeletedQuads)
+CEditorActionDeleteQuad::CEditorActionDeleteQuad(CEditorMap *pMap, int GroupIndex, int LayerIndex, std::vector<int> const &vQuadsIndices, std::vector<CQuad> const &vDeletedQuads) :
+	CEditorActionLayerBase(pMap, GroupIndex, LayerIndex), m_vQuadsIndices(vQuadsIndices), m_vDeletedQuads(vDeletedQuads)
 {
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Delete quad (x%d)", (int)m_vDeletedQuads.size());
 }
@@ -318,8 +315,8 @@ void CEditorActionDeleteQuad::Redo()
 
 // ---------------------------------------------------------------------------------------
 
-CEditorActionEditQuadPoint::CEditorActionEditQuadPoint(CEditor *pEditor, int GroupIndex, int LayerIndex, int QuadIndex, std::vector<CPoint> const &vPreviousPoints, std::vector<CPoint> const &vCurrentPoints) :
-	CEditorActionLayerBase(pEditor, GroupIndex, LayerIndex), m_QuadIndex(QuadIndex), m_vPreviousPoints(vPreviousPoints), m_vCurrentPoints(vCurrentPoints)
+CEditorActionEditQuadPoint::CEditorActionEditQuadPoint(CEditorMap *pMap, int GroupIndex, int LayerIndex, int QuadIndex, std::vector<CPoint> const &vPreviousPoints, std::vector<CPoint> const &vCurrentPoints) :
+	CEditorActionLayerBase(pMap, GroupIndex, LayerIndex), m_QuadIndex(QuadIndex), m_vPreviousPoints(vPreviousPoints), m_vCurrentPoints(vCurrentPoints)
 {
 	str_copy(m_aDisplayText, "Edit quad points");
 }
@@ -340,8 +337,8 @@ void CEditorActionEditQuadPoint::Redo()
 		Quad.m_aPoints[k] = m_vCurrentPoints[k];
 }
 
-CEditorActionEditQuadProp::CEditorActionEditQuadProp(CEditor *pEditor, int GroupIndex, int LayerIndex, int QuadIndex, EQuadProp Prop, int Previous, int Current) :
-	CEditorActionLayerBase(pEditor, GroupIndex, LayerIndex), m_QuadIndex(QuadIndex), m_Prop(Prop), m_Previous(Previous), m_Current(Current)
+CEditorActionEditQuadProp::CEditorActionEditQuadProp(CEditorMap *pMap, int GroupIndex, int LayerIndex, int QuadIndex, EQuadProp Prop, int Previous, int Current) :
+	CEditorActionLayerBase(pMap, GroupIndex, LayerIndex), m_QuadIndex(QuadIndex), m_Prop(Prop), m_Previous(Previous), m_Current(Current)
 {
 	static const char *s_apNames[] = {
 		"order",
@@ -379,8 +376,8 @@ void CEditorActionEditQuadProp::Apply(int Value)
 		Quad.m_ColorEnvOffset = Value;
 }
 
-CEditorActionEditQuadPointProp::CEditorActionEditQuadPointProp(CEditor *pEditor, int GroupIndex, int LayerIndex, int QuadIndex, int PointIndex, EQuadPointProp Prop, int Previous, int Current) :
-	CEditorActionLayerBase(pEditor, GroupIndex, LayerIndex), m_QuadIndex(QuadIndex), m_PointIndex(PointIndex), m_Prop(Prop), m_Previous(Previous), m_Current(Current)
+CEditorActionEditQuadPointProp::CEditorActionEditQuadPointProp(CEditorMap *pMap, int GroupIndex, int LayerIndex, int QuadIndex, int PointIndex, EQuadPointProp Prop, int Previous, int Current) :
+	CEditorActionLayerBase(pMap, GroupIndex, LayerIndex), m_QuadIndex(QuadIndex), m_PointIndex(PointIndex), m_Prop(Prop), m_Previous(Previous), m_Current(Current)
 {
 	static const char *s_apNames[] = {
 		"pos X",
@@ -416,9 +413,9 @@ void CEditorActionEditQuadPointProp::Apply(int Value)
 		Quad.m_aColors[m_PointIndex].b = ColorPick.b * 255.0f;
 		Quad.m_aColors[m_PointIndex].a = ColorPick.a * 255.0f;
 
-		m_pEditor->m_ColorPickerPopupContext.m_RgbaColor = ColorPick;
-		m_pEditor->m_ColorPickerPopupContext.m_HslaColor = color_cast<ColorHSLA>(ColorPick);
-		m_pEditor->m_ColorPickerPopupContext.m_HsvaColor = color_cast<ColorHSVA>(m_pEditor->m_ColorPickerPopupContext.m_HslaColor);
+		Editor()->m_ColorPickerPopupContext.m_RgbaColor = ColorPick;
+		Editor()->m_ColorPickerPopupContext.m_HslaColor = color_cast<ColorHSLA>(ColorPick);
+		Editor()->m_ColorPickerPopupContext.m_HsvaColor = color_cast<ColorHSVA>(Editor()->m_ColorPickerPopupContext.m_HslaColor);
 	}
 	else if(m_Prop == EQuadPointProp::PROP_TEX_U)
 	{
@@ -432,8 +429,8 @@ void CEditorActionEditQuadPointProp::Apply(int Value)
 
 // ---------------------------------------------------------------------------------------
 
-CEditorActionBulk::CEditorActionBulk(CEditor *pEditor, const std::vector<std::shared_ptr<IEditorAction>> &vpActions, const char *pDisplay, bool Reverse) :
-	IEditorAction(pEditor), m_vpActions(vpActions), m_Reverse(Reverse)
+CEditorActionBulk::CEditorActionBulk(CEditorMap *pMap, const std::vector<std::shared_ptr<IEditorAction>> &vpActions, const char *pDisplay, bool Reverse) :
+	IEditorAction(pMap), m_vpActions(vpActions), m_Reverse(Reverse)
 {
 	// Assuming we only use bulk for actions of same type, if no display was provided
 	if(!pDisplay)
@@ -480,8 +477,8 @@ void CEditorActionBulk::Redo()
 
 // ---------
 
-CEditorActionTileChanges::CEditorActionTileChanges(CEditor *pEditor, int GroupIndex, int LayerIndex, const char *pAction, const EditorTileStateChangeHistory<STileStateChange> &Changes) :
-	CEditorActionLayerBase(pEditor, GroupIndex, LayerIndex), m_Changes(Changes)
+CEditorActionTileChanges::CEditorActionTileChanges(CEditorMap *pMap, int GroupIndex, int LayerIndex, const char *pAction, const EditorTileStateChangeHistory<STileStateChange> &Changes) :
+	CEditorActionLayerBase(pMap, GroupIndex, LayerIndex), m_Changes(Changes)
 {
 	ComputeInfos();
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "%s (x%d)", pAction, m_TotalChanges);
@@ -499,7 +496,6 @@ void CEditorActionTileChanges::Redo()
 
 void CEditorActionTileChanges::Apply(bool Undo)
 {
-	auto &Map = m_pEditor->m_Map;
 	std::shared_ptr<CLayerTiles> pLayerTiles = std::static_pointer_cast<CLayerTiles>(m_pLayer);
 	for(auto &Change : m_Changes)
 	{
@@ -513,7 +509,7 @@ void CEditorActionTileChanges::Apply(bool Undo)
 		}
 	}
 
-	Map.OnModify();
+	Map()->OnModify();
 }
 
 void CEditorActionTileChanges::ComputeInfos()
@@ -525,16 +521,16 @@ void CEditorActionTileChanges::ComputeInfos()
 
 // ---------
 
-CEditorActionLayerBase::CEditorActionLayerBase(CEditor *pEditor, int GroupIndex, int LayerIndex) :
-	IEditorAction(pEditor), m_GroupIndex(GroupIndex), m_LayerIndex(LayerIndex)
+CEditorActionLayerBase::CEditorActionLayerBase(CEditorMap *pMap, int GroupIndex, int LayerIndex) :
+	IEditorAction(pMap), m_GroupIndex(GroupIndex), m_LayerIndex(LayerIndex)
 {
-	m_pLayer = pEditor->m_Map.m_vpGroups[GroupIndex]->m_vpLayers[LayerIndex];
+	m_pLayer = Map()->m_vpGroups[GroupIndex]->m_vpLayers[LayerIndex];
 }
 
 // ----------
 
-CEditorActionAddLayer::CEditorActionAddLayer(CEditor *pEditor, int GroupIndex, int LayerIndex, bool Duplicate) :
-	CEditorActionLayerBase(pEditor, GroupIndex, LayerIndex), m_Duplicate(Duplicate)
+CEditorActionAddLayer::CEditorActionAddLayer(CEditorMap *pMap, int GroupIndex, int LayerIndex, bool Duplicate) :
+	CEditorActionLayerBase(pMap, GroupIndex, LayerIndex), m_Duplicate(Duplicate)
 {
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "%s %s layer in group %d", m_Duplicate ? "Duplicate" : "New", m_pLayer->TypeName(), m_GroupIndex);
 }
@@ -542,61 +538,61 @@ CEditorActionAddLayer::CEditorActionAddLayer(CEditor *pEditor, int GroupIndex, i
 void CEditorActionAddLayer::Undo()
 {
 	// Undo: remove layer from vector but keep it in case we want to add it back
-	auto &vLayers = m_pEditor->m_Map.m_vpGroups[m_GroupIndex]->m_vpLayers;
+	auto &vLayers = Map()->m_vpGroups[m_GroupIndex]->m_vpLayers;
 
 	if(m_pLayer->m_Type == LAYERTYPE_TILES)
 	{
 		std::shared_ptr<CLayerTiles> pLayerTiles = std::static_pointer_cast<CLayerTiles>(m_pLayer);
 		if(pLayerTiles->m_HasFront)
-			m_pEditor->m_Map.m_pFrontLayer = nullptr;
+			Map()->m_pFrontLayer = nullptr;
 		else if(pLayerTiles->m_HasTele)
-			m_pEditor->m_Map.m_pTeleLayer = nullptr;
+			Map()->m_pTeleLayer = nullptr;
 		else if(pLayerTiles->m_HasSpeedup)
-			m_pEditor->m_Map.m_pSpeedupLayer = nullptr;
+			Map()->m_pSpeedupLayer = nullptr;
 		else if(pLayerTiles->m_HasSwitch)
-			m_pEditor->m_Map.m_pSwitchLayer = nullptr;
+			Map()->m_pSwitchLayer = nullptr;
 		else if(pLayerTiles->m_HasTune)
-			m_pEditor->m_Map.m_pTuneLayer = nullptr;
+			Map()->m_pTuneLayer = nullptr;
 	}
 
 	vLayers.erase(vLayers.begin() + m_LayerIndex);
 
-	m_pEditor->m_Map.m_vpGroups[m_GroupIndex]->m_Collapse = false;
+	Map()->m_vpGroups[m_GroupIndex]->m_Collapse = false;
 	if(m_LayerIndex >= (int)vLayers.size())
-		m_pEditor->SelectLayer(vLayers.size() - 1, m_GroupIndex);
+		Editor()->SelectLayer(vLayers.size() - 1, m_GroupIndex);
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 void CEditorActionAddLayer::Redo()
 {
 	// Redo: add back the removed layer contained in this class
-	auto &vLayers = m_pEditor->m_Map.m_vpGroups[m_GroupIndex]->m_vpLayers;
+	auto &vLayers = Map()->m_vpGroups[m_GroupIndex]->m_vpLayers;
 
 	if(m_pLayer->m_Type == LAYERTYPE_TILES)
 	{
 		std::shared_ptr<CLayerTiles> pLayerTiles = std::static_pointer_cast<CLayerTiles>(m_pLayer);
 		if(pLayerTiles->m_HasFront)
-			m_pEditor->m_Map.m_pFrontLayer = std::static_pointer_cast<CLayerFront>(m_pLayer);
+			Map()->m_pFrontLayer = std::static_pointer_cast<CLayerFront>(m_pLayer);
 		else if(pLayerTiles->m_HasTele)
-			m_pEditor->m_Map.m_pTeleLayer = std::static_pointer_cast<CLayerTele>(m_pLayer);
+			Map()->m_pTeleLayer = std::static_pointer_cast<CLayerTele>(m_pLayer);
 		else if(pLayerTiles->m_HasSpeedup)
-			m_pEditor->m_Map.m_pSpeedupLayer = std::static_pointer_cast<CLayerSpeedup>(m_pLayer);
+			Map()->m_pSpeedupLayer = std::static_pointer_cast<CLayerSpeedup>(m_pLayer);
 		else if(pLayerTiles->m_HasSwitch)
-			m_pEditor->m_Map.m_pSwitchLayer = std::static_pointer_cast<CLayerSwitch>(m_pLayer);
+			Map()->m_pSwitchLayer = std::static_pointer_cast<CLayerSwitch>(m_pLayer);
 		else if(pLayerTiles->m_HasTune)
-			m_pEditor->m_Map.m_pTuneLayer = std::static_pointer_cast<CLayerTune>(m_pLayer);
+			Map()->m_pTuneLayer = std::static_pointer_cast<CLayerTune>(m_pLayer);
 	}
 
 	vLayers.insert(vLayers.begin() + m_LayerIndex, m_pLayer);
 
-	m_pEditor->m_Map.m_vpGroups[m_GroupIndex]->m_Collapse = false;
-	m_pEditor->SelectLayer(m_LayerIndex, m_GroupIndex);
-	m_pEditor->m_Map.OnModify();
+	Map()->m_vpGroups[m_GroupIndex]->m_Collapse = false;
+	Editor()->SelectLayer(m_LayerIndex, m_GroupIndex);
+	Map()->OnModify();
 }
 
-CEditorActionDeleteLayer::CEditorActionDeleteLayer(CEditor *pEditor, int GroupIndex, int LayerIndex) :
-	CEditorActionLayerBase(pEditor, GroupIndex, LayerIndex)
+CEditorActionDeleteLayer::CEditorActionDeleteLayer(CEditorMap *pMap, int GroupIndex, int LayerIndex) :
+	CEditorActionLayerBase(pMap, GroupIndex, LayerIndex)
 {
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Delete %s layer of group %d", m_pLayer->TypeName(), m_GroupIndex);
 }
@@ -604,63 +600,63 @@ CEditorActionDeleteLayer::CEditorActionDeleteLayer(CEditor *pEditor, int GroupIn
 void CEditorActionDeleteLayer::Redo()
 {
 	// Redo: remove layer from vector but keep it in case we want to add it back
-	auto &vLayers = m_pEditor->m_Map.m_vpGroups[m_GroupIndex]->m_vpLayers;
+	auto &vLayers = Map()->m_vpGroups[m_GroupIndex]->m_vpLayers;
 
 	if(m_pLayer->m_Type == LAYERTYPE_TILES)
 	{
 		std::shared_ptr<CLayerTiles> pLayerTiles = std::static_pointer_cast<CLayerTiles>(m_pLayer);
 		if(pLayerTiles->m_HasFront)
-			m_pEditor->m_Map.m_pFrontLayer = nullptr;
+			Map()->m_pFrontLayer = nullptr;
 		else if(pLayerTiles->m_HasTele)
-			m_pEditor->m_Map.m_pTeleLayer = nullptr;
+			Map()->m_pTeleLayer = nullptr;
 		else if(pLayerTiles->m_HasSpeedup)
-			m_pEditor->m_Map.m_pSpeedupLayer = nullptr;
+			Map()->m_pSpeedupLayer = nullptr;
 		else if(pLayerTiles->m_HasSwitch)
-			m_pEditor->m_Map.m_pSwitchLayer = nullptr;
+			Map()->m_pSwitchLayer = nullptr;
 		else if(pLayerTiles->m_HasTune)
-			m_pEditor->m_Map.m_pTuneLayer = nullptr;
+			Map()->m_pTuneLayer = nullptr;
 	}
 
-	m_pEditor->m_Map.m_vpGroups[m_GroupIndex]->DeleteLayer(m_LayerIndex);
+	Map()->m_vpGroups[m_GroupIndex]->DeleteLayer(m_LayerIndex);
 
-	m_pEditor->m_Map.m_vpGroups[m_GroupIndex]->m_Collapse = false;
+	Map()->m_vpGroups[m_GroupIndex]->m_Collapse = false;
 	if(m_LayerIndex >= (int)vLayers.size())
-		m_pEditor->SelectLayer(vLayers.size() - 1, m_GroupIndex);
+		Editor()->SelectLayer(vLayers.size() - 1, m_GroupIndex);
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 void CEditorActionDeleteLayer::Undo()
 {
 	// Undo: add back the removed layer contained in this class
-	auto &vLayers = m_pEditor->m_Map.m_vpGroups[m_GroupIndex]->m_vpLayers;
+	auto &vLayers = Map()->m_vpGroups[m_GroupIndex]->m_vpLayers;
 
 	if(m_pLayer->m_Type == LAYERTYPE_TILES)
 	{
 		std::shared_ptr<CLayerTiles> pLayerTiles = std::static_pointer_cast<CLayerTiles>(m_pLayer);
 		if(pLayerTiles->m_HasFront)
-			m_pEditor->m_Map.m_pFrontLayer = std::static_pointer_cast<CLayerFront>(m_pLayer);
+			Map()->m_pFrontLayer = std::static_pointer_cast<CLayerFront>(m_pLayer);
 		else if(pLayerTiles->m_HasTele)
-			m_pEditor->m_Map.m_pTeleLayer = std::static_pointer_cast<CLayerTele>(m_pLayer);
+			Map()->m_pTeleLayer = std::static_pointer_cast<CLayerTele>(m_pLayer);
 		else if(pLayerTiles->m_HasSpeedup)
-			m_pEditor->m_Map.m_pSpeedupLayer = std::static_pointer_cast<CLayerSpeedup>(m_pLayer);
+			Map()->m_pSpeedupLayer = std::static_pointer_cast<CLayerSpeedup>(m_pLayer);
 		else if(pLayerTiles->m_HasSwitch)
-			m_pEditor->m_Map.m_pSwitchLayer = std::static_pointer_cast<CLayerSwitch>(m_pLayer);
+			Map()->m_pSwitchLayer = std::static_pointer_cast<CLayerSwitch>(m_pLayer);
 		else if(pLayerTiles->m_HasTune)
-			m_pEditor->m_Map.m_pTuneLayer = std::static_pointer_cast<CLayerTune>(m_pLayer);
+			Map()->m_pTuneLayer = std::static_pointer_cast<CLayerTune>(m_pLayer);
 	}
 
 	vLayers.insert(vLayers.begin() + m_LayerIndex, m_pLayer);
 
-	m_pEditor->m_Map.m_vpGroups[m_GroupIndex]->m_Collapse = false;
-	m_pEditor->SelectLayer(m_LayerIndex, m_GroupIndex);
-	m_pEditor->m_Map.OnModify();
+	Map()->m_vpGroups[m_GroupIndex]->m_Collapse = false;
+	Editor()->SelectLayer(m_LayerIndex, m_GroupIndex);
+	Map()->OnModify();
 }
 
-CEditorActionGroup::CEditorActionGroup(CEditor *pEditor, int GroupIndex, bool Delete) :
-	IEditorAction(pEditor), m_GroupIndex(GroupIndex), m_Delete(Delete)
+CEditorActionGroup::CEditorActionGroup(CEditorMap *pMap, int GroupIndex, bool Delete) :
+	IEditorAction(pMap), m_GroupIndex(GroupIndex), m_Delete(Delete)
 {
-	m_pGroup = pEditor->m_Map.m_vpGroups[GroupIndex];
+	m_pGroup = Map()->m_vpGroups[GroupIndex];
 	if(m_Delete)
 		str_format(m_aDisplayText, sizeof(m_aDisplayText), "Delete group %d", m_GroupIndex);
 	else
@@ -672,18 +668,18 @@ void CEditorActionGroup::Undo()
 	if(m_Delete)
 	{
 		// Undo: add back the group
-		m_pEditor->m_Map.m_vpGroups.insert(m_pEditor->m_Map.m_vpGroups.begin() + m_GroupIndex, m_pGroup);
-		m_pEditor->m_SelectedGroup = m_GroupIndex;
-		m_pEditor->m_Map.OnModify();
+		Map()->m_vpGroups.insert(Map()->m_vpGroups.begin() + m_GroupIndex, m_pGroup);
+		Editor()->m_SelectedGroup = m_GroupIndex;
+		Map()->OnModify();
 	}
 	else
 	{
 		// Undo: delete the group
-		m_pEditor->m_Map.DeleteGroup(m_GroupIndex);
-		m_pEditor->m_SelectedGroup = maximum(0, m_GroupIndex - 1);
+		Map()->DeleteGroup(m_GroupIndex);
+		Editor()->m_SelectedGroup = maximum(0, m_GroupIndex - 1);
 	}
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 void CEditorActionGroup::Redo()
@@ -691,21 +687,21 @@ void CEditorActionGroup::Redo()
 	if(!m_Delete)
 	{
 		// Redo: add back the group
-		m_pEditor->m_Map.m_vpGroups.insert(m_pEditor->m_Map.m_vpGroups.begin() + m_GroupIndex, m_pGroup);
-		m_pEditor->m_SelectedGroup = m_GroupIndex;
+		Map()->m_vpGroups.insert(Map()->m_vpGroups.begin() + m_GroupIndex, m_pGroup);
+		Editor()->m_SelectedGroup = m_GroupIndex;
 	}
 	else
 	{
 		// Redo: delete the group
-		m_pEditor->m_Map.DeleteGroup(m_GroupIndex);
-		m_pEditor->m_SelectedGroup = maximum(0, m_GroupIndex - 1);
+		Map()->DeleteGroup(m_GroupIndex);
+		Editor()->m_SelectedGroup = maximum(0, m_GroupIndex - 1);
 	}
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
-CEditorActionEditGroupProp::CEditorActionEditGroupProp(CEditor *pEditor, int GroupIndex, EGroupProp Prop, int Previous, int Current) :
-	IEditorAction(pEditor), m_GroupIndex(GroupIndex), m_Prop(Prop), m_Previous(Previous), m_Current(Current)
+CEditorActionEditGroupProp::CEditorActionEditGroupProp(CEditorMap *pMap, int GroupIndex, EGroupProp Prop, int Previous, int Current) :
+	IEditorAction(pMap), m_GroupIndex(GroupIndex), m_Prop(Prop), m_Previous(Previous), m_Current(Current)
 {
 	static const char *s_apNames[] = {
 		"order",
@@ -725,11 +721,11 @@ CEditorActionEditGroupProp::CEditorActionEditGroupProp(CEditor *pEditor, int Gro
 
 void CEditorActionEditGroupProp::Undo()
 {
-	auto pGroup = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
+	auto pGroup = Map()->m_vpGroups[m_GroupIndex];
 
 	if(m_Prop == EGroupProp::PROP_ORDER)
 	{
-		m_pEditor->m_SelectedGroup = m_pEditor->m_Map.MoveGroup(m_Current, m_Previous);
+		Editor()->m_SelectedGroup = Map()->MoveGroup(m_Current, m_Previous);
 	}
 	else
 		Apply(m_Previous);
@@ -737,11 +733,11 @@ void CEditorActionEditGroupProp::Undo()
 
 void CEditorActionEditGroupProp::Redo()
 {
-	auto pGroup = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
+	auto pGroup = Map()->m_vpGroups[m_GroupIndex];
 
 	if(m_Prop == EGroupProp::PROP_ORDER)
 	{
-		m_pEditor->m_SelectedGroup = m_pEditor->m_Map.MoveGroup(m_Previous, m_Current);
+		Editor()->m_SelectedGroup = Map()->MoveGroup(m_Previous, m_Current);
 	}
 	else
 		Apply(m_Current);
@@ -749,7 +745,7 @@ void CEditorActionEditGroupProp::Redo()
 
 void CEditorActionEditGroupProp::Apply(int Value)
 {
-	auto pGroup = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
+	auto pGroup = Map()->m_vpGroups[m_GroupIndex];
 
 	if(m_Prop == EGroupProp::PROP_POS_X)
 		pGroup->m_OffsetX = Value;
@@ -770,17 +766,17 @@ void CEditorActionEditGroupProp::Apply(int Value)
 	if(m_Prop == EGroupProp::PROP_CLIP_H)
 		pGroup->m_ClipH = Value;
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 template<typename E>
-CEditorActionEditLayerPropBase<E>::CEditorActionEditLayerPropBase(CEditor *pEditor, int GroupIndex, int LayerIndex, E Prop, int Previous, int Current) :
-	CEditorActionLayerBase(pEditor, GroupIndex, LayerIndex), m_Prop(Prop), m_Previous(Previous), m_Current(Current)
+CEditorActionEditLayerPropBase<E>::CEditorActionEditLayerPropBase(CEditorMap *pMap, int GroupIndex, int LayerIndex, E Prop, int Previous, int Current) :
+	CEditorActionLayerBase(pMap, GroupIndex, LayerIndex), m_Prop(Prop), m_Previous(Previous), m_Current(Current)
 {
 }
 
-CEditorActionEditLayerProp::CEditorActionEditLayerProp(CEditor *pEditor, int GroupIndex, int LayerIndex, ELayerProp Prop, int Previous, int Current) :
-	CEditorActionEditLayerPropBase(pEditor, GroupIndex, LayerIndex, Prop, Previous, Current)
+CEditorActionEditLayerProp::CEditorActionEditLayerProp(CEditorMap *pMap, int GroupIndex, int LayerIndex, ELayerProp Prop, int Previous, int Current) :
+	CEditorActionEditLayerPropBase(pMap, GroupIndex, LayerIndex, Prop, Previous, Current)
 {
 	static const char *s_apNames[] = {
 		"group",
@@ -793,11 +789,11 @@ CEditorActionEditLayerProp::CEditorActionEditLayerProp(CEditor *pEditor, int Gro
 
 void CEditorActionEditLayerProp::Undo()
 {
-	auto pCurrentGroup = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
+	auto pCurrentGroup = Map()->m_vpGroups[m_GroupIndex];
 
 	if(m_Prop == ELayerProp::PROP_ORDER)
 	{
-		m_pEditor->SelectLayer(pCurrentGroup->MoveLayer(m_Current, m_Previous));
+		Editor()->SelectLayer(pCurrentGroup->MoveLayer(m_Current, m_Previous));
 	}
 	else
 		Apply(m_Previous);
@@ -805,11 +801,11 @@ void CEditorActionEditLayerProp::Undo()
 
 void CEditorActionEditLayerProp::Redo()
 {
-	auto pCurrentGroup = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
+	auto pCurrentGroup = Map()->m_vpGroups[m_GroupIndex];
 
 	if(m_Prop == ELayerProp::PROP_ORDER)
 	{
-		m_pEditor->SelectLayer(pCurrentGroup->MoveLayer(m_Previous, m_Current));
+		Editor()->SelectLayer(pCurrentGroup->MoveLayer(m_Previous, m_Current));
 	}
 	else
 		Apply(m_Current);
@@ -819,26 +815,26 @@ void CEditorActionEditLayerProp::Apply(int Value)
 {
 	if(m_Prop == ELayerProp::PROP_GROUP)
 	{
-		auto pCurrentGroup = m_pEditor->m_Map.m_vpGroups[Value == m_Previous ? m_Current : m_Previous];
-		auto pPreviousGroup = m_pEditor->m_Map.m_vpGroups[Value];
+		auto pCurrentGroup = Map()->m_vpGroups[Value == m_Previous ? m_Current : m_Previous];
+		auto pPreviousGroup = Map()->m_vpGroups[Value];
 		pCurrentGroup->m_vpLayers.erase(pCurrentGroup->m_vpLayers.begin() + pCurrentGroup->m_vpLayers.size() - 1);
 		if(Value == m_Previous)
 			pPreviousGroup->m_vpLayers.insert(pPreviousGroup->m_vpLayers.begin() + m_LayerIndex, m_pLayer);
 		else
 			pPreviousGroup->m_vpLayers.push_back(m_pLayer);
-		m_pEditor->m_SelectedGroup = Value;
-		m_pEditor->SelectLayer(m_LayerIndex);
+		Editor()->m_SelectedGroup = Value;
+		Editor()->SelectLayer(m_LayerIndex);
 	}
 	else if(m_Prop == ELayerProp::PROP_HQ)
 	{
 		m_pLayer->m_Flags = Value;
 	}
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
-CEditorActionEditLayerTilesProp::CEditorActionEditLayerTilesProp(CEditor *pEditor, int GroupIndex, int LayerIndex, ETilesProp Prop, int Previous, int Current) :
-	CEditorActionEditLayerPropBase(pEditor, GroupIndex, LayerIndex, Prop, Previous, Current)
+CEditorActionEditLayerTilesProp::CEditorActionEditLayerTilesProp(CEditorMap *pMap, int GroupIndex, int LayerIndex, ETilesProp Prop, int Previous, int Current) :
+	CEditorActionEditLayerPropBase(pMap, GroupIndex, LayerIndex, Prop, Previous, Current)
 {
 	static const char *s_apNames[] = {
 		"width",
@@ -878,18 +874,18 @@ void CEditorActionEditLayerTilesProp::Undo()
 		RestoreLayer(LAYERTYPE_TILES, pLayerTiles);
 		if(pLayerTiles->m_HasGame || pLayerTiles->m_HasFront || pLayerTiles->m_HasSwitch || pLayerTiles->m_HasSpeedup || pLayerTiles->m_HasTune)
 		{
-			if(m_pEditor->m_Map.m_pFrontLayer && !pLayerTiles->m_HasFront)
-				RestoreLayer(LAYERTYPE_FRONT, m_pEditor->m_Map.m_pFrontLayer);
-			if(m_pEditor->m_Map.m_pTeleLayer && !pLayerTiles->m_HasTele)
-				RestoreLayer(LAYERTYPE_TELE, m_pEditor->m_Map.m_pTeleLayer);
-			if(m_pEditor->m_Map.m_pSwitchLayer && !pLayerTiles->m_HasSwitch)
-				RestoreLayer(LAYERTYPE_SWITCH, m_pEditor->m_Map.m_pSwitchLayer);
-			if(m_pEditor->m_Map.m_pSpeedupLayer && !pLayerTiles->m_HasSpeedup)
-				RestoreLayer(LAYERTYPE_SPEEDUP, m_pEditor->m_Map.m_pSpeedupLayer);
-			if(m_pEditor->m_Map.m_pTuneLayer && !pLayerTiles->m_HasTune)
-				RestoreLayer(LAYERTYPE_TUNE, m_pEditor->m_Map.m_pTuneLayer);
+			if(Map()->m_pFrontLayer && !pLayerTiles->m_HasFront)
+				RestoreLayer(LAYERTYPE_FRONT, Map()->m_pFrontLayer);
+			if(Map()->m_pTeleLayer && !pLayerTiles->m_HasTele)
+				RestoreLayer(LAYERTYPE_TELE, Map()->m_pTeleLayer);
+			if(Map()->m_pSwitchLayer && !pLayerTiles->m_HasSwitch)
+				RestoreLayer(LAYERTYPE_SWITCH, Map()->m_pSwitchLayer);
+			if(Map()->m_pSpeedupLayer && !pLayerTiles->m_HasSpeedup)
+				RestoreLayer(LAYERTYPE_SPEEDUP, Map()->m_pSpeedupLayer);
+			if(Map()->m_pTuneLayer && !pLayerTiles->m_HasTune)
+				RestoreLayer(LAYERTYPE_TUNE, Map()->m_pTuneLayer);
 			if(!pLayerTiles->m_HasGame)
-				RestoreLayer(LAYERTYPE_GAME, m_pEditor->m_Map.m_pGameLayer);
+				RestoreLayer(LAYERTYPE_GAME, Map()->m_pGameLayer);
 		}
 	}
 	else if(m_Prop == ETilesProp::PROP_SHIFT)
@@ -898,17 +894,17 @@ void CEditorActionEditLayerTilesProp::Undo()
 	}
 	else if(m_Prop == ETilesProp::PROP_SHIFT_BY)
 	{
-		m_pEditor->m_ShiftBy = m_Previous;
+		Editor()->m_ShiftBy = m_Previous;
 	}
 	else if(m_Prop == ETilesProp::PROP_IMAGE)
 	{
-		if(m_Previous == -1 || m_pEditor->m_Map.m_vpImages.empty())
+		if(m_Previous == -1 || Map()->m_vpImages.empty())
 		{
 			pLayerTiles->m_Image = -1;
 		}
 		else
 		{
-			pLayerTiles->m_Image = m_Previous % m_pEditor->m_Map.m_vpImages.size();
+			pLayerTiles->m_Image = m_Previous % Map()->m_vpImages.size();
 			pLayerTiles->m_AutoMapperConfig = -1;
 		}
 	}
@@ -921,9 +917,9 @@ void CEditorActionEditLayerTilesProp::Undo()
 		pLayerTiles->m_Color.b = ColorPick.b * 255.0f;
 		pLayerTiles->m_Color.a = ColorPick.a * 255.0f;
 
-		m_pEditor->m_ColorPickerPopupContext.m_RgbaColor = ColorPick;
-		m_pEditor->m_ColorPickerPopupContext.m_HslaColor = color_cast<ColorHSLA>(ColorPick);
-		m_pEditor->m_ColorPickerPopupContext.m_HsvaColor = color_cast<ColorHSVA>(m_pEditor->m_ColorPickerPopupContext.m_HslaColor);
+		Editor()->m_ColorPickerPopupContext.m_RgbaColor = ColorPick;
+		Editor()->m_ColorPickerPopupContext.m_HslaColor = color_cast<ColorHSLA>(ColorPick);
+		Editor()->m_ColorPickerPopupContext.m_HsvaColor = color_cast<ColorHSVA>(Editor()->m_ColorPickerPopupContext.m_HslaColor);
 	}
 	else if(m_Prop == ETilesProp::PROP_COLOR_ENV)
 	{
@@ -946,7 +942,7 @@ void CEditorActionEditLayerTilesProp::Undo()
 		pLayerTiles->m_Seed = m_Previous;
 	}
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 void CEditorActionEditLayerTilesProp::Redo()
@@ -962,18 +958,18 @@ void CEditorActionEditLayerTilesProp::Redo()
 
 		if(pLayerTiles->m_HasGame || pLayerTiles->m_HasFront || pLayerTiles->m_HasSwitch || pLayerTiles->m_HasSpeedup || pLayerTiles->m_HasTune)
 		{
-			if(m_pEditor->m_Map.m_pFrontLayer && !pLayerTiles->m_HasFront)
-				m_pEditor->m_Map.m_pFrontLayer->Resize(pLayerTiles->m_Width, pLayerTiles->m_Height);
-			if(m_pEditor->m_Map.m_pTeleLayer && !pLayerTiles->m_HasTele)
-				m_pEditor->m_Map.m_pTeleLayer->Resize(pLayerTiles->m_Width, pLayerTiles->m_Height);
-			if(m_pEditor->m_Map.m_pSwitchLayer && !pLayerTiles->m_HasSwitch)
-				m_pEditor->m_Map.m_pSwitchLayer->Resize(pLayerTiles->m_Width, pLayerTiles->m_Height);
-			if(m_pEditor->m_Map.m_pSpeedupLayer && !pLayerTiles->m_HasSpeedup)
-				m_pEditor->m_Map.m_pSpeedupLayer->Resize(pLayerTiles->m_Width, pLayerTiles->m_Height);
-			if(m_pEditor->m_Map.m_pTuneLayer && !pLayerTiles->m_HasTune)
-				m_pEditor->m_Map.m_pTuneLayer->Resize(pLayerTiles->m_Width, pLayerTiles->m_Height);
+			if(Map()->m_pFrontLayer && !pLayerTiles->m_HasFront)
+				Map()->m_pFrontLayer->Resize(pLayerTiles->m_Width, pLayerTiles->m_Height);
+			if(Map()->m_pTeleLayer && !pLayerTiles->m_HasTele)
+				Map()->m_pTeleLayer->Resize(pLayerTiles->m_Width, pLayerTiles->m_Height);
+			if(Map()->m_pSwitchLayer && !pLayerTiles->m_HasSwitch)
+				Map()->m_pSwitchLayer->Resize(pLayerTiles->m_Width, pLayerTiles->m_Height);
+			if(Map()->m_pSpeedupLayer && !pLayerTiles->m_HasSpeedup)
+				Map()->m_pSpeedupLayer->Resize(pLayerTiles->m_Width, pLayerTiles->m_Height);
+			if(Map()->m_pTuneLayer && !pLayerTiles->m_HasTune)
+				Map()->m_pTuneLayer->Resize(pLayerTiles->m_Width, pLayerTiles->m_Height);
 			if(!pLayerTiles->m_HasGame)
-				m_pEditor->m_Map.m_pGameLayer->Resize(pLayerTiles->m_Width, pLayerTiles->m_Height);
+				Map()->m_pGameLayer->Resize(pLayerTiles->m_Width, pLayerTiles->m_Height);
 		}
 	}
 	else if(m_Prop == ETilesProp::PROP_SHIFT)
@@ -982,17 +978,17 @@ void CEditorActionEditLayerTilesProp::Redo()
 	}
 	else if(m_Prop == ETilesProp::PROP_SHIFT_BY)
 	{
-		m_pEditor->m_ShiftBy = m_Current;
+		Editor()->m_ShiftBy = m_Current;
 	}
 	else if(m_Prop == ETilesProp::PROP_IMAGE)
 	{
-		if(m_Current == -1 || m_pEditor->m_Map.m_vpImages.empty())
+		if(m_Current == -1 || Map()->m_vpImages.empty())
 		{
 			pLayerTiles->m_Image = -1;
 		}
 		else
 		{
-			pLayerTiles->m_Image = m_Current % m_pEditor->m_Map.m_vpImages.size();
+			pLayerTiles->m_Image = m_Current % Map()->m_vpImages.size();
 			pLayerTiles->m_AutoMapperConfig = -1;
 		}
 	}
@@ -1005,9 +1001,9 @@ void CEditorActionEditLayerTilesProp::Redo()
 		pLayerTiles->m_Color.b = ColorPick.b * 255.0f;
 		pLayerTiles->m_Color.a = ColorPick.a * 255.0f;
 
-		m_pEditor->m_ColorPickerPopupContext.m_RgbaColor = ColorPick;
-		m_pEditor->m_ColorPickerPopupContext.m_HslaColor = color_cast<ColorHSLA>(ColorPick);
-		m_pEditor->m_ColorPickerPopupContext.m_HsvaColor = color_cast<ColorHSVA>(m_pEditor->m_ColorPickerPopupContext.m_HslaColor);
+		Editor()->m_ColorPickerPopupContext.m_RgbaColor = ColorPick;
+		Editor()->m_ColorPickerPopupContext.m_HslaColor = color_cast<ColorHSLA>(ColorPick);
+		Editor()->m_ColorPickerPopupContext.m_HsvaColor = color_cast<ColorHSVA>(Editor()->m_ColorPickerPopupContext.m_HslaColor);
 	}
 	else if(m_Prop == ETilesProp::PROP_COLOR_ENV)
 	{
@@ -1030,7 +1026,7 @@ void CEditorActionEditLayerTilesProp::Redo()
 		pLayerTiles->m_Seed = m_Current;
 	}
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 void CEditorActionEditLayerTilesProp::RestoreLayer(int Layer, const std::shared_ptr<CLayerTiles> &pLayerTiles)
@@ -1067,8 +1063,8 @@ void CEditorActionEditLayerTilesProp::RestoreLayer(int Layer, const std::shared_
 	}
 }
 
-CEditorActionEditLayerQuadsProp::CEditorActionEditLayerQuadsProp(CEditor *pEditor, int GroupIndex, int LayerIndex, ELayerQuadsProp Prop, int Previous, int Current) :
-	CEditorActionEditLayerPropBase(pEditor, GroupIndex, LayerIndex, Prop, Previous, Current)
+CEditorActionEditLayerQuadsProp::CEditorActionEditLayerQuadsProp(CEditorMap *pMap, int GroupIndex, int LayerIndex, ELayerQuadsProp Prop, int Previous, int Current) :
+	CEditorActionEditLayerPropBase(pMap, GroupIndex, LayerIndex, Prop, Previous, Current)
 {
 	static const char *s_apNames[] = {
 		"image"};
@@ -1091,19 +1087,19 @@ void CEditorActionEditLayerQuadsProp::Apply(int Value)
 	std::shared_ptr<CLayerQuads> pLayerQuads = std::static_pointer_cast<CLayerQuads>(m_pLayer);
 	if(m_Prop == ELayerQuadsProp::PROP_IMAGE)
 	{
-		if(Value >= 0 && !m_pEditor->m_Map.m_vpImages.empty())
-			pLayerQuads->m_Image = Value % m_pEditor->m_Map.m_vpImages.size();
+		if(Value >= 0 && !Map()->m_vpImages.empty())
+			pLayerQuads->m_Image = Value % Map()->m_vpImages.size();
 		else
 			pLayerQuads->m_Image = -1;
 	}
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 // --------------------------------------------------------------
 
-CEditorActionEditLayersGroupAndOrder::CEditorActionEditLayersGroupAndOrder(CEditor *pEditor, int GroupIndex, const std::vector<int> &LayerIndices, int NewGroupIndex, const std::vector<int> &NewLayerIndices) :
-	IEditorAction(pEditor), m_GroupIndex(GroupIndex), m_LayerIndices(LayerIndices), m_NewGroupIndex(NewGroupIndex), m_NewLayerIndices(NewLayerIndices)
+CEditorActionEditLayersGroupAndOrder::CEditorActionEditLayersGroupAndOrder(CEditorMap *pMap, int GroupIndex, const std::vector<int> &LayerIndices, int NewGroupIndex, const std::vector<int> &NewLayerIndices) :
+	IEditorAction(pMap), m_GroupIndex(GroupIndex), m_LayerIndices(LayerIndices), m_NewGroupIndex(NewGroupIndex), m_NewLayerIndices(NewLayerIndices)
 {
 	std::sort(m_LayerIndices.begin(), m_LayerIndices.end());
 	std::sort(m_NewLayerIndices.begin(), m_NewLayerIndices.end());
@@ -1114,9 +1110,8 @@ CEditorActionEditLayersGroupAndOrder::CEditorActionEditLayersGroupAndOrder(CEdit
 void CEditorActionEditLayersGroupAndOrder::Undo()
 {
 	// Undo : restore group and order
-	auto &Map = m_pEditor->m_Map;
-	auto &pCurrentGroup = Map.m_vpGroups[m_NewGroupIndex];
-	auto &pPreviousGroup = Map.m_vpGroups[m_GroupIndex];
+	auto &pCurrentGroup = Map()->m_vpGroups[m_NewGroupIndex];
+	auto &pPreviousGroup = Map()->m_vpGroups[m_GroupIndex];
 	std::vector<std::shared_ptr<CLayer>> vpLayers;
 	vpLayers.reserve(m_NewLayerIndices.size());
 	for(auto &LayerIndex : m_NewLayerIndices)
@@ -1129,16 +1124,15 @@ void CEditorActionEditLayersGroupAndOrder::Undo()
 		pPreviousGroup->m_vpLayers.insert(pPreviousGroup->m_vpLayers.begin() + m_LayerIndices[k++], pLayer);
 	}
 
-	m_pEditor->m_vSelectedLayers = m_LayerIndices;
-	m_pEditor->m_SelectedGroup = m_GroupIndex;
+	Editor()->m_vSelectedLayers = m_LayerIndices;
+	Editor()->m_SelectedGroup = m_GroupIndex;
 }
 
 void CEditorActionEditLayersGroupAndOrder::Redo()
 {
 	// Redo : move layers
-	auto &Map = m_pEditor->m_Map;
-	auto &pCurrentGroup = Map.m_vpGroups[m_GroupIndex];
-	auto &pPreviousGroup = Map.m_vpGroups[m_NewGroupIndex];
+	auto &pCurrentGroup = Map()->m_vpGroups[m_GroupIndex];
+	auto &pPreviousGroup = Map()->m_vpGroups[m_NewGroupIndex];
 	std::vector<std::shared_ptr<CLayer>> vpLayers;
 	vpLayers.reserve(m_LayerIndices.size());
 	for(auto &LayerIndex : m_LayerIndices)
@@ -1151,14 +1145,14 @@ void CEditorActionEditLayersGroupAndOrder::Redo()
 		pPreviousGroup->m_vpLayers.insert(pPreviousGroup->m_vpLayers.begin() + m_NewLayerIndices[k++], pLayer);
 	}
 
-	m_pEditor->m_vSelectedLayers = m_NewLayerIndices;
-	m_pEditor->m_SelectedGroup = m_NewGroupIndex;
+	Editor()->m_vSelectedLayers = m_NewLayerIndices;
+	Editor()->m_SelectedGroup = m_NewGroupIndex;
 }
 
 // -----------------------------------
 
-CEditorActionAppendMap::CEditorActionAppendMap(CEditor *pEditor, const char *pMapName, const SPrevInfo &PrevInfo, std::vector<int> &vImageIndexMap) :
-	IEditorAction(pEditor), m_PrevInfo(PrevInfo), m_vImageIndexMap(vImageIndexMap)
+CEditorActionAppendMap::CEditorActionAppendMap(CEditorMap *pMap, const char *pMapName, const SPrevInfo &PrevInfo, std::vector<int> &vImageIndexMap) :
+	IEditorAction(pMap), m_PrevInfo(PrevInfo), m_vImageIndexMap(vImageIndexMap)
 {
 	str_copy(m_aMapName, pMapName);
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Append %s", m_aMapName);
@@ -1166,7 +1160,6 @@ CEditorActionAppendMap::CEditorActionAppendMap(CEditor *pEditor, const char *pMa
 
 void CEditorActionAppendMap::Undo()
 {
-	auto &Map = m_pEditor->m_Map;
 	// Undo append:
 	// - delete added groups
 	// - delete added envelopes
@@ -1174,21 +1167,21 @@ void CEditorActionAppendMap::Undo()
 	// - delete added sounds
 
 	// Delete added groups
-	while((int)Map.m_vpGroups.size() != m_PrevInfo.m_Groups)
+	while((int)Map()->m_vpGroups.size() != m_PrevInfo.m_Groups)
 	{
-		Map.m_vpGroups.pop_back();
+		Map()->m_vpGroups.pop_back();
 	}
 
 	// Delete added envelopes
-	while((int)Map.m_vpEnvelopes.size() != m_PrevInfo.m_Envelopes)
+	while((int)Map()->m_vpEnvelopes.size() != m_PrevInfo.m_Envelopes)
 	{
-		Map.m_vpEnvelopes.pop_back();
+		Map()->m_vpEnvelopes.pop_back();
 	}
 
 	// Delete added sounds
-	while((int)Map.m_vpSounds.size() != m_PrevInfo.m_Sounds)
+	while((int)Map()->m_vpSounds.size() != m_PrevInfo.m_Sounds)
 	{
-		Map.m_vpSounds.pop_back();
+		Map()->m_vpSounds.pop_back();
 	}
 
 	// Delete added images
@@ -1202,15 +1195,15 @@ void CEditorActionAppendMap::Undo()
 			vReverseIndexMap[m_vImageIndexMap[k]] = k;
 
 		std::vector<std::shared_ptr<CEditorImage>> vpRevertedImages;
-		vpRevertedImages.resize(Map.m_vpImages.size());
+		vpRevertedImages.resize(Map()->m_vpImages.size());
 
 		for(int k = 0; k < (int)vReverseIndexMap.size(); k++)
 		{
-			vpRevertedImages[vReverseIndexMap[k]] = Map.m_vpImages[k];
+			vpRevertedImages[vReverseIndexMap[k]] = Map()->m_vpImages[k];
 		}
-		Map.m_vpImages = vpRevertedImages;
+		Map()->m_vpImages = vpRevertedImages;
 
-		Map.ModifyImageIndex([vReverseIndexMap](int *pIndex) {
+		Map()->ModifyImageIndex([vReverseIndexMap](int *pIndex) {
 			if(*pIndex >= 0)
 			{
 				*pIndex = vReverseIndexMap[*pIndex];
@@ -1218,22 +1211,22 @@ void CEditorActionAppendMap::Undo()
 		});
 	}
 
-	while((int)Map.m_vpImages.size() != m_PrevInfo.m_Images)
+	while((int)Map()->m_vpImages.size() != m_PrevInfo.m_Images)
 	{
-		Map.m_vpImages.pop_back();
+		Map()->m_vpImages.pop_back();
 	}
 }
 
 void CEditorActionAppendMap::Redo()
 {
 	// Redo is just re-appending the same map
-	m_pEditor->Append(m_aMapName, IStorage::TYPE_ALL, true);
+	Editor()->Append(m_aMapName, IStorage::TYPE_ALL, true);
 }
 
 // ---------------------------
 
-CEditorActionTileArt::CEditorActionTileArt(CEditor *pEditor, int PreviousImageCount, const char *pTileArtFile, std::vector<int> &vImageIndexMap) :
-	IEditorAction(pEditor), m_PreviousImageCount(PreviousImageCount), m_vImageIndexMap(vImageIndexMap)
+CEditorActionTileArt::CEditorActionTileArt(CEditorMap *pMap, int PreviousImageCount, const char *pTileArtFile, std::vector<int> &vImageIndexMap) :
+	IEditorAction(pMap), m_PreviousImageCount(PreviousImageCount), m_vImageIndexMap(vImageIndexMap)
 {
 	str_copy(m_aTileArtFile, pTileArtFile);
 	str_copy(m_aDisplayText, "Tile art");
@@ -1241,10 +1234,8 @@ CEditorActionTileArt::CEditorActionTileArt(CEditor *pEditor, int PreviousImageCo
 
 void CEditorActionTileArt::Undo()
 {
-	auto &Map = m_pEditor->m_Map;
-
 	// Delete added group
-	Map.m_vpGroups.pop_back();
+	Map()->m_vpGroups.pop_back();
 
 	// Delete added images
 	// Images are sorted when appending, so we need to revert sorting before deleting the images
@@ -1257,15 +1248,15 @@ void CEditorActionTileArt::Undo()
 			vReverseIndexMap[m_vImageIndexMap[k]] = k;
 
 		std::vector<std::shared_ptr<CEditorImage>> vpRevertedImages;
-		vpRevertedImages.resize(Map.m_vpImages.size());
+		vpRevertedImages.resize(Map()->m_vpImages.size());
 
 		for(int k = 0; k < (int)vReverseIndexMap.size(); k++)
 		{
-			vpRevertedImages[vReverseIndexMap[k]] = Map.m_vpImages[k];
+			vpRevertedImages[vReverseIndexMap[k]] = Map()->m_vpImages[k];
 		}
-		Map.m_vpImages = vpRevertedImages;
+		Map()->m_vpImages = vpRevertedImages;
 
-		Map.ModifyImageIndex([vReverseIndexMap](int *pIndex) {
+		Map()->ModifyImageIndex([vReverseIndexMap](int *pIndex) {
 			if(*pIndex >= 0)
 			{
 				*pIndex = vReverseIndexMap[*pIndex];
@@ -1273,57 +1264,55 @@ void CEditorActionTileArt::Undo()
 		});
 	}
 
-	while((int)Map.m_vpImages.size() != m_PreviousImageCount)
+	while((int)Map()->m_vpImages.size() != m_PreviousImageCount)
 	{
-		Map.m_vpImages.pop_back();
+		Map()->m_vpImages.pop_back();
 	}
 }
 
 void CEditorActionTileArt::Redo()
 {
-	if(!m_pEditor->Graphics()->LoadPng(m_pEditor->m_TileartImageInfo, m_aTileArtFile, IStorage::TYPE_ALL))
+	if(!Graphics()->LoadPng(Editor()->m_TileartImageInfo, m_aTileArtFile, IStorage::TYPE_ALL))
 	{
-		m_pEditor->ShowFileDialogError("Failed to load image from file '%s'.", m_aTileArtFile);
+		Editor()->ShowFileDialogError("Failed to load image from file '%s'.", m_aTileArtFile);
 		return;
 	}
 
-	IStorage::StripPathAndExtension(m_aTileArtFile, m_pEditor->m_aTileartFilename, sizeof(m_pEditor->m_aTileartFilename));
-	m_pEditor->AddTileart(true);
+	IStorage::StripPathAndExtension(m_aTileArtFile, Editor()->m_aTileartFilename, sizeof(Editor()->m_aTileartFilename));
+	Editor()->AddTileart(true);
 }
 
 // ---------------------------
 
-CEditorActionQuadArt::CEditorActionQuadArt(CEditor *pEditor, CQuadArtParameters Parameters) :
-	IEditorAction(pEditor), m_Parameters(Parameters)
+CEditorActionQuadArt::CEditorActionQuadArt(CEditorMap *pMap, CQuadArtParameters Parameters) :
+	IEditorAction(pMap), m_Parameters(Parameters)
 {
 	str_copy(m_aDisplayText, "Create Quadart");
 }
 
 void CEditorActionQuadArt::Undo()
 {
-	auto &Map = m_pEditor->m_Map;
-
 	// Delete added group
-	Map.m_vpGroups.pop_back();
+	Map()->m_vpGroups.pop_back();
 }
 
 void CEditorActionQuadArt::Redo()
 {
-	m_pEditor->m_QuadArtParameters = m_Parameters;
-	str_copy(m_pEditor->m_QuadArtParameters.m_aFilename, m_Parameters.m_aFilename, sizeof(m_pEditor->m_QuadArtParameters.m_aFilename));
+	Editor()->m_QuadArtParameters = m_Parameters;
+	str_copy(Editor()->m_QuadArtParameters.m_aFilename, m_Parameters.m_aFilename, sizeof(Editor()->m_QuadArtParameters.m_aFilename));
 
-	if(!m_pEditor->Graphics()->LoadPng(m_pEditor->m_QuadArtImageInfo, m_pEditor->m_QuadArtParameters.m_aFilename, IStorage::TYPE_ALL))
+	if(!Graphics()->LoadPng(Editor()->m_QuadArtImageInfo, Editor()->m_QuadArtParameters.m_aFilename, IStorage::TYPE_ALL))
 	{
-		m_pEditor->ShowFileDialogError("Failed to load image from file '%s'.", m_pEditor->m_QuadArtParameters.m_aFilename);
+		Editor()->ShowFileDialogError("Failed to load image from file '%s'.", Editor()->m_QuadArtParameters.m_aFilename);
 		return;
 	}
-	m_pEditor->AddQuadArt(true);
+	Editor()->AddQuadArt(true);
 }
 
 // ---------------------------------
 
-CEditorCommandAction::CEditorCommandAction(CEditor *pEditor, EType Type, int *pSelectedCommandIndex, int CommandIndex, const char *pPreviousCommand, const char *pCurrentCommand) :
-	IEditorAction(pEditor), m_Type(Type), m_pSelectedCommandIndex(pSelectedCommandIndex), m_CommandIndex(CommandIndex)
+CEditorCommandAction::CEditorCommandAction(CEditorMap *pMap, EType Type, int *pSelectedCommandIndex, int CommandIndex, const char *pPreviousCommand, const char *pCurrentCommand) :
+	IEditorAction(pMap), m_Type(Type), m_pSelectedCommandIndex(pSelectedCommandIndex), m_CommandIndex(CommandIndex)
 {
 	if(pPreviousCommand != nullptr)
 		m_PreviousCommand = std::string(pPreviousCommand);
@@ -1355,36 +1344,35 @@ CEditorCommandAction::CEditorCommandAction(CEditor *pEditor, EType Type, int *pS
 
 void CEditorCommandAction::Undo()
 {
-	auto &Map = m_pEditor->m_Map;
 	switch(m_Type)
 	{
 	case EType::DELETE:
 	{
-		Map.m_vSettings.insert(Map.m_vSettings.begin() + m_CommandIndex, m_PreviousCommand.c_str());
+		Map()->m_vSettings.insert(Map()->m_vSettings.begin() + m_CommandIndex, m_PreviousCommand.c_str());
 		*m_pSelectedCommandIndex = m_CommandIndex;
 		break;
 	}
 	case EType::ADD:
 	{
-		Map.m_vSettings.erase(Map.m_vSettings.begin() + m_CommandIndex);
-		*m_pSelectedCommandIndex = Map.m_vSettings.size() - 1;
+		Map()->m_vSettings.erase(Map()->m_vSettings.begin() + m_CommandIndex);
+		*m_pSelectedCommandIndex = Map()->m_vSettings.size() - 1;
 		break;
 	}
 	case EType::EDIT:
 	{
-		str_copy(Map.m_vSettings[m_CommandIndex].m_aCommand, m_PreviousCommand.c_str());
+		str_copy(Map()->m_vSettings[m_CommandIndex].m_aCommand, m_PreviousCommand.c_str());
 		*m_pSelectedCommandIndex = m_CommandIndex;
 		break;
 	}
 	case EType::MOVE_DOWN:
 	{
-		std::swap(Map.m_vSettings[m_CommandIndex], Map.m_vSettings[m_CommandIndex + 1]);
+		std::swap(Map()->m_vSettings[m_CommandIndex], Map()->m_vSettings[m_CommandIndex + 1]);
 		*m_pSelectedCommandIndex = m_CommandIndex;
 		break;
 	}
 	case EType::MOVE_UP:
 	{
-		std::swap(Map.m_vSettings[m_CommandIndex], Map.m_vSettings[m_CommandIndex - 1]);
+		std::swap(Map()->m_vSettings[m_CommandIndex], Map()->m_vSettings[m_CommandIndex - 1]);
 		*m_pSelectedCommandIndex = m_CommandIndex;
 		break;
 	}
@@ -1393,36 +1381,35 @@ void CEditorCommandAction::Undo()
 
 void CEditorCommandAction::Redo()
 {
-	auto &Map = m_pEditor->m_Map;
 	switch(m_Type)
 	{
 	case EType::DELETE:
 	{
-		Map.m_vSettings.erase(Map.m_vSettings.begin() + m_CommandIndex);
-		*m_pSelectedCommandIndex = Map.m_vSettings.size() - 1;
+		Map()->m_vSettings.erase(Map()->m_vSettings.begin() + m_CommandIndex);
+		*m_pSelectedCommandIndex = Map()->m_vSettings.size() - 1;
 		break;
 	}
 	case EType::ADD:
 	{
-		Map.m_vSettings.insert(Map.m_vSettings.begin() + m_CommandIndex, m_PreviousCommand.c_str());
+		Map()->m_vSettings.insert(Map()->m_vSettings.begin() + m_CommandIndex, m_PreviousCommand.c_str());
 		*m_pSelectedCommandIndex = m_CommandIndex;
 		break;
 	}
 	case EType::EDIT:
 	{
-		str_copy(Map.m_vSettings[m_CommandIndex].m_aCommand, m_CurrentCommand.c_str());
+		str_copy(Map()->m_vSettings[m_CommandIndex].m_aCommand, m_CurrentCommand.c_str());
 		*m_pSelectedCommandIndex = m_CommandIndex;
 		break;
 	}
 	case EType::MOVE_DOWN:
 	{
-		std::swap(Map.m_vSettings[m_CommandIndex], Map.m_vSettings[m_CommandIndex + 1]);
+		std::swap(Map()->m_vSettings[m_CommandIndex], Map()->m_vSettings[m_CommandIndex + 1]);
 		*m_pSelectedCommandIndex = m_CommandIndex;
 		break;
 	}
 	case EType::MOVE_UP:
 	{
-		std::swap(Map.m_vSettings[m_CommandIndex], Map.m_vSettings[m_CommandIndex - 1]);
+		std::swap(Map()->m_vSettings[m_CommandIndex], Map()->m_vSettings[m_CommandIndex - 1]);
 		*m_pSelectedCommandIndex = m_CommandIndex;
 		break;
 	}
@@ -1431,31 +1418,31 @@ void CEditorCommandAction::Redo()
 
 // ------------------------------------------------
 
-CEditorActionEnvelopeAdd::CEditorActionEnvelopeAdd(CEditor *pEditor, CEnvelope::EType EnvelopeType) :
-	IEditorAction(pEditor),
+CEditorActionEnvelopeAdd::CEditorActionEnvelopeAdd(CEditorMap *pMap, CEnvelope::EType EnvelopeType) :
+	IEditorAction(pMap),
 	m_EnvelopeType(EnvelopeType)
 {
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Add new %s envelope", EnvelopeType == CEnvelope::EType::COLOR ? "color" : (EnvelopeType == CEnvelope::EType::POSITION ? "position" : "sound"));
-	m_PreviousSelectedEnvelope = m_pEditor->m_SelectedEnvelope;
+	m_PreviousSelectedEnvelope = Editor()->m_SelectedEnvelope;
 }
 
 void CEditorActionEnvelopeAdd::Undo()
 {
 	// Undo is removing the envelope, which was added at the back of the list
-	m_pEditor->m_Map.m_vpEnvelopes.pop_back();
-	m_pEditor->m_Map.OnModify();
-	m_pEditor->m_SelectedEnvelope = m_PreviousSelectedEnvelope;
+	Map()->m_vpEnvelopes.pop_back();
+	Map()->OnModify();
+	Editor()->m_SelectedEnvelope = m_PreviousSelectedEnvelope;
 }
 
 void CEditorActionEnvelopeAdd::Redo()
 {
 	// Redo is adding a new envelope at the back of the list
-	m_pEditor->m_Map.NewEnvelope(m_EnvelopeType);
-	m_pEditor->m_SelectedEnvelope = m_pEditor->m_Map.m_vpEnvelopes.size() - 1;
+	Map()->NewEnvelope(m_EnvelopeType);
+	Editor()->m_SelectedEnvelope = Map()->m_vpEnvelopes.size() - 1;
 }
 
-CEditorActionEnvelopeDelete::CEditorActionEnvelopeDelete(CEditor *pEditor, int EnvelopeIndex, std::vector<std::shared_ptr<IEditorEnvelopeReference>> &vpObjectReferences, std::shared_ptr<CEnvelope> &pEnvelope) :
-	IEditorAction(pEditor), m_EnvelopeIndex(EnvelopeIndex), m_pEnv(pEnvelope), m_vpObjectReferences(vpObjectReferences)
+CEditorActionEnvelopeDelete::CEditorActionEnvelopeDelete(CEditorMap *pMap, int EnvelopeIndex, std::vector<std::shared_ptr<IEditorEnvelopeReference>> &vpObjectReferences, std::shared_ptr<CEnvelope> &pEnvelope) :
+	IEditorAction(pMap), m_EnvelopeIndex(EnvelopeIndex), m_pEnv(pEnvelope), m_vpObjectReferences(vpObjectReferences)
 {
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Delete envelope %d", m_EnvelopeIndex);
 }
@@ -1463,18 +1450,18 @@ CEditorActionEnvelopeDelete::CEditorActionEnvelopeDelete(CEditor *pEditor, int E
 void CEditorActionEnvelopeDelete::Undo()
 {
 	// Undo is adding back the envelope
-	m_pEditor->m_Map.InsertEnvelope(m_EnvelopeIndex, m_pEnv);
-	m_pEditor->m_Map.UpdateEnvelopeReferences(m_EnvelopeIndex, m_pEnv, m_vpObjectReferences);
+	Map()->InsertEnvelope(m_EnvelopeIndex, m_pEnv);
+	Map()->UpdateEnvelopeReferences(m_EnvelopeIndex, m_pEnv, m_vpObjectReferences);
 }
 
 void CEditorActionEnvelopeDelete::Redo()
 {
 	// Redo is erasing the same envelope index
-	m_pEditor->m_Map.DeleteEnvelope(m_EnvelopeIndex);
+	Map()->DeleteEnvelope(m_EnvelopeIndex);
 }
 
-CEditorActionEnvelopeEdit::CEditorActionEnvelopeEdit(CEditor *pEditor, int EnvelopeIndex, EEditType EditType, int Previous, int Current) :
-	IEditorAction(pEditor), m_EnvelopeIndex(EnvelopeIndex), m_EditType(EditType), m_Previous(Previous), m_Current(Current), m_pEnv(pEditor->m_Map.m_vpEnvelopes[EnvelopeIndex])
+CEditorActionEnvelopeEdit::CEditorActionEnvelopeEdit(CEditorMap *pMap, int EnvelopeIndex, EEditType EditType, int Previous, int Current) :
+	IEditorAction(pMap), m_EnvelopeIndex(EnvelopeIndex), m_EditType(EditType), m_Previous(Previous), m_Current(Current), m_pEnv(Map()->m_vpEnvelopes[EnvelopeIndex])
 {
 	static const char *s_apNames[] = {
 		"sync",
@@ -1488,7 +1475,7 @@ void CEditorActionEnvelopeEdit::Undo()
 	{
 	case EEditType::ORDER:
 	{
-		m_pEditor->m_Map.MoveEnvelope(m_Current, m_Previous);
+		Map()->MoveEnvelope(m_Current, m_Previous);
 		break;
 	}
 	case EEditType::SYNC:
@@ -1497,8 +1484,8 @@ void CEditorActionEnvelopeEdit::Undo()
 		break;
 	}
 	}
-	m_pEditor->m_Map.OnModify();
-	m_pEditor->m_SelectedEnvelope = m_EnvelopeIndex;
+	Map()->OnModify();
+	Editor()->m_SelectedEnvelope = m_EnvelopeIndex;
 }
 
 void CEditorActionEnvelopeEdit::Redo()
@@ -1507,7 +1494,7 @@ void CEditorActionEnvelopeEdit::Redo()
 	{
 	case EEditType::ORDER:
 	{
-		m_pEditor->m_Map.MoveEnvelope(m_Previous, m_Current);
+		Map()->MoveEnvelope(m_Previous, m_Current);
 		break;
 	}
 	case EEditType::SYNC:
@@ -1516,12 +1503,12 @@ void CEditorActionEnvelopeEdit::Redo()
 		break;
 	}
 	}
-	m_pEditor->m_Map.OnModify();
-	m_pEditor->m_SelectedEnvelope = m_EnvelopeIndex;
+	Map()->OnModify();
+	Editor()->m_SelectedEnvelope = m_EnvelopeIndex;
 }
 
-CEditorActionEnvelopeEditPointTime::CEditorActionEnvelopeEditPointTime(CEditor *pEditor, int EnvelopeIndex, int PointIndex, CFixedTime Previous, CFixedTime Current) :
-	IEditorAction(pEditor), m_EnvelopeIndex(EnvelopeIndex), m_PointIndex(PointIndex), m_Previous(Previous), m_Current(Current), m_pEnv(pEditor->m_Map.m_vpEnvelopes[EnvelopeIndex])
+CEditorActionEnvelopeEditPointTime::CEditorActionEnvelopeEditPointTime(CEditorMap *pMap, int EnvelopeIndex, int PointIndex, CFixedTime Previous, CFixedTime Current) :
+	IEditorAction(pMap), m_EnvelopeIndex(EnvelopeIndex), m_PointIndex(PointIndex), m_Previous(Previous), m_Current(Current), m_pEnv(Map()->m_vpEnvelopes[EnvelopeIndex])
 {
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Edit time of point %d of env %d", m_PointIndex, m_EnvelopeIndex);
 }
@@ -1539,11 +1526,11 @@ void CEditorActionEnvelopeEditPointTime::Redo()
 void CEditorActionEnvelopeEditPointTime::Apply(CFixedTime Value)
 {
 	m_pEnv->m_vPoints[m_PointIndex].m_Time = Value;
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
-CEditorActionEnvelopeEditPoint::CEditorActionEnvelopeEditPoint(CEditor *pEditor, int EnvelopeIndex, int PointIndex, int Channel, EEditType EditType, int Previous, int Current) :
-	IEditorAction(pEditor), m_EnvelopeIndex(EnvelopeIndex), m_PointIndex(PointIndex), m_Channel(Channel), m_EditType(EditType), m_Previous(Previous), m_Current(Current), m_pEnv(pEditor->m_Map.m_vpEnvelopes[EnvelopeIndex])
+CEditorActionEnvelopeEditPoint::CEditorActionEnvelopeEditPoint(CEditorMap *pMap, int EnvelopeIndex, int PointIndex, int Channel, EEditType EditType, int Previous, int Current) :
+	IEditorAction(pMap), m_EnvelopeIndex(EnvelopeIndex), m_PointIndex(PointIndex), m_Channel(Channel), m_EditType(EditType), m_Previous(Previous), m_Current(Current), m_pEnv(Map()->m_vpEnvelopes[EnvelopeIndex])
 {
 	static const char *s_apNames[] = {
 		"value",
@@ -1569,9 +1556,9 @@ void CEditorActionEnvelopeEditPoint::Apply(int Value)
 
 		if(m_pEnv->GetChannels() == 4)
 		{
-			m_pEditor->m_ColorPickerPopupContext.m_RgbaColor = m_pEnv->m_vPoints[m_PointIndex].ColorValue();
-			m_pEditor->m_ColorPickerPopupContext.m_HslaColor = color_cast<ColorHSLA>(m_pEditor->m_ColorPickerPopupContext.m_RgbaColor);
-			m_pEditor->m_ColorPickerPopupContext.m_HsvaColor = color_cast<ColorHSVA>(m_pEditor->m_ColorPickerPopupContext.m_HslaColor);
+			Editor()->m_ColorPickerPopupContext.m_RgbaColor = m_pEnv->m_vPoints[m_PointIndex].ColorValue();
+			Editor()->m_ColorPickerPopupContext.m_HslaColor = color_cast<ColorHSLA>(Editor()->m_ColorPickerPopupContext.m_RgbaColor);
+			Editor()->m_ColorPickerPopupContext.m_HsvaColor = color_cast<ColorHSVA>(Editor()->m_ColorPickerPopupContext.m_HslaColor);
 		}
 	}
 	else if(m_EditType == EEditType::CURVE_TYPE)
@@ -1579,13 +1566,13 @@ void CEditorActionEnvelopeEditPoint::Apply(int Value)
 		m_pEnv->m_vPoints[m_PointIndex].m_Curvetype = Value;
 	}
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 // ----
 
-CEditorActionEditEnvelopePointValue::CEditorActionEditEnvelopePointValue(CEditor *pEditor, int EnvIndex, int PointIndex, int Channel, EType Type, CFixedTime OldTime, int OldValue, CFixedTime NewTime, int NewValue) :
-	IEditorAction(pEditor), m_EnvIndex(EnvIndex), m_PtIndex(PointIndex), m_Channel(Channel), m_Type(Type), m_OldTime(OldTime), m_OldValue(OldValue), m_NewTime(NewTime), m_NewValue(NewValue)
+CEditorActionEditEnvelopePointValue::CEditorActionEditEnvelopePointValue(CEditorMap *pMap, int EnvIndex, int PointIndex, int Channel, EType Type, CFixedTime OldTime, int OldValue, CFixedTime NewTime, int NewValue) :
+	IEditorAction(pMap), m_EnvIndex(EnvIndex), m_PtIndex(PointIndex), m_Channel(Channel), m_Type(Type), m_OldTime(OldTime), m_OldValue(OldValue), m_NewTime(NewTime), m_NewValue(NewValue)
 {
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Edit point %d%s value (envelope %d, channel %d)", PointIndex, m_Type == EType::TANGENT_IN ? "tangent in" : (m_Type == EType::TANGENT_OUT ? "tangent out" : ""), m_EnvIndex, m_Channel);
 }
@@ -1605,7 +1592,7 @@ void CEditorActionEditEnvelopePointValue::Apply(bool Undo)
 	float CurrentValue = fx2f(Undo ? m_OldValue : m_NewValue);
 	CFixedTime CurrentTime = (Undo ? m_OldTime : m_NewTime);
 
-	std::shared_ptr<CEnvelope> pEnvelope = m_pEditor->m_Map.m_vpEnvelopes[m_EnvIndex];
+	std::shared_ptr<CEnvelope> pEnvelope = Map()->m_vpEnvelopes[m_EnvIndex];
 	if(m_Type == EType::TANGENT_IN)
 	{
 		pEnvelope->m_vPoints[m_PtIndex].m_Bezier.m_aInTangentDeltaX[m_Channel] = std::min(CurrentTime - pEnvelope->m_vPoints[m_PtIndex].m_Time, CFixedTime(0));
@@ -1637,16 +1624,16 @@ void CEditorActionEditEnvelopePointValue::Apply(bool Undo)
 		}
 	}
 
-	m_pEditor->m_Map.OnModify();
-	m_pEditor->m_UpdateEnvPointInfo = true;
+	Map()->OnModify();
+	Editor()->m_UpdateEnvPointInfo = true;
 }
 
 // ---------------------
 
-CEditorActionResetEnvelopePointTangent::CEditorActionResetEnvelopePointTangent(CEditor *pEditor, int EnvIndex, int PointIndex, int Channel, bool In) :
-	IEditorAction(pEditor), m_EnvIndex(EnvIndex), m_PointIndex(PointIndex), m_Channel(Channel), m_In(In)
+CEditorActionResetEnvelopePointTangent::CEditorActionResetEnvelopePointTangent(CEditorMap *pMap, int EnvIndex, int PointIndex, int Channel, bool In) :
+	IEditorAction(pMap), m_EnvIndex(EnvIndex), m_PointIndex(PointIndex), m_Channel(Channel), m_In(In)
 {
-	std::shared_ptr<CEnvelope> pEnvelope = pEditor->m_Map.m_vpEnvelopes[EnvIndex];
+	std::shared_ptr<CEnvelope> pEnvelope = Map()->m_vpEnvelopes[EnvIndex];
 	if(In)
 	{
 		m_OldTime = pEnvelope->m_vPoints[PointIndex].m_Bezier.m_aInTangentDeltaX[Channel];
@@ -1663,7 +1650,7 @@ CEditorActionResetEnvelopePointTangent::CEditorActionResetEnvelopePointTangent(C
 
 void CEditorActionResetEnvelopePointTangent::Undo()
 {
-	std::shared_ptr<CEnvelope> pEnvelope = m_pEditor->m_Map.m_vpEnvelopes[m_EnvIndex];
+	std::shared_ptr<CEnvelope> pEnvelope = Map()->m_vpEnvelopes[m_EnvIndex];
 	if(m_In)
 	{
 		pEnvelope->m_vPoints[m_PointIndex].m_Bezier.m_aInTangentDeltaX[m_Channel] = m_OldTime;
@@ -1674,12 +1661,12 @@ void CEditorActionResetEnvelopePointTangent::Undo()
 		pEnvelope->m_vPoints[m_PointIndex].m_Bezier.m_aOutTangentDeltaX[m_Channel] = m_OldTime;
 		pEnvelope->m_vPoints[m_PointIndex].m_Bezier.m_aOutTangentDeltaY[m_Channel] = m_OldValue;
 	}
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 void CEditorActionResetEnvelopePointTangent::Redo()
 {
-	std::shared_ptr<CEnvelope> pEnvelope = m_pEditor->m_Map.m_vpEnvelopes[m_EnvIndex];
+	std::shared_ptr<CEnvelope> pEnvelope = Map()->m_vpEnvelopes[m_EnvIndex];
 	if(m_In)
 	{
 		pEnvelope->m_vPoints[m_PointIndex].m_Bezier.m_aInTangentDeltaX[m_Channel] = CFixedTime(0);
@@ -1690,13 +1677,13 @@ void CEditorActionResetEnvelopePointTangent::Redo()
 		pEnvelope->m_vPoints[m_PointIndex].m_Bezier.m_aOutTangentDeltaX[m_Channel] = CFixedTime(0);
 		pEnvelope->m_vPoints[m_PointIndex].m_Bezier.m_aOutTangentDeltaY[m_Channel] = 0.0f;
 	}
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 // ------------------
 
-CEditorActionAddEnvelopePoint::CEditorActionAddEnvelopePoint(CEditor *pEditor, int EnvIndex, CFixedTime Time, ColorRGBA Channels) :
-	IEditorAction(pEditor), m_EnvIndex(EnvIndex), m_Time(Time), m_Channels(Channels)
+CEditorActionAddEnvelopePoint::CEditorActionAddEnvelopePoint(CEditorMap *pMap, int EnvIndex, CFixedTime Time, ColorRGBA Channels) :
+	IEditorAction(pMap), m_EnvIndex(EnvIndex), m_Time(Time), m_Channels(Channels)
 {
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Add new point in envelope %d at time %f", m_EnvIndex, Time.AsSeconds());
 }
@@ -1704,7 +1691,7 @@ CEditorActionAddEnvelopePoint::CEditorActionAddEnvelopePoint(CEditor *pEditor, i
 void CEditorActionAddEnvelopePoint::Undo()
 {
 	// Delete added point
-	auto pEnvelope = m_pEditor->m_Map.m_vpEnvelopes[m_EnvIndex];
+	auto pEnvelope = Map()->m_vpEnvelopes[m_EnvIndex];
 	auto pIt = std::find_if(pEnvelope->m_vPoints.begin(), pEnvelope->m_vPoints.end(), [this](const CEnvPoint_runtime &Point) {
 		return Point.m_Time == m_Time;
 	});
@@ -1713,50 +1700,50 @@ void CEditorActionAddEnvelopePoint::Undo()
 		pEnvelope->m_vPoints.erase(pIt);
 	}
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 void CEditorActionAddEnvelopePoint::Redo()
 {
-	auto pEnvelope = m_pEditor->m_Map.m_vpEnvelopes[m_EnvIndex];
+	auto pEnvelope = Map()->m_vpEnvelopes[m_EnvIndex];
 	pEnvelope->AddPoint(m_Time, {f2fx(m_Channels.r), f2fx(m_Channels.g), f2fx(m_Channels.b), f2fx(m_Channels.a)});
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
-CEditorActionDeleteEnvelopePoint::CEditorActionDeleteEnvelopePoint(CEditor *pEditor, int EnvIndex, int PointIndex) :
-	IEditorAction(pEditor), m_EnvIndex(EnvIndex), m_PointIndex(PointIndex), m_Point(pEditor->m_Map.m_vpEnvelopes[EnvIndex]->m_vPoints[PointIndex])
+CEditorActionDeleteEnvelopePoint::CEditorActionDeleteEnvelopePoint(CEditorMap *pMap, int EnvIndex, int PointIndex) :
+	IEditorAction(pMap), m_EnvIndex(EnvIndex), m_PointIndex(PointIndex), m_Point(Map()->m_vpEnvelopes[EnvIndex]->m_vPoints[PointIndex])
 {
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Delete point %d of envelope %d", m_PointIndex, m_EnvIndex);
 }
 
 void CEditorActionDeleteEnvelopePoint::Undo()
 {
-	std::shared_ptr<CEnvelope> pEnvelope = m_pEditor->m_Map.m_vpEnvelopes[m_EnvIndex];
+	std::shared_ptr<CEnvelope> pEnvelope = Map()->m_vpEnvelopes[m_EnvIndex];
 	pEnvelope->m_vPoints.insert(pEnvelope->m_vPoints.begin() + m_PointIndex, m_Point);
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 void CEditorActionDeleteEnvelopePoint::Redo()
 {
-	std::shared_ptr<CEnvelope> pEnvelope = m_pEditor->m_Map.m_vpEnvelopes[m_EnvIndex];
+	std::shared_ptr<CEnvelope> pEnvelope = Map()->m_vpEnvelopes[m_EnvIndex];
 	pEnvelope->m_vPoints.erase(pEnvelope->m_vPoints.begin() + m_PointIndex);
 
-	auto pSelectedPointIt = std::find_if(m_pEditor->m_vSelectedEnvelopePoints.begin(), m_pEditor->m_vSelectedEnvelopePoints.end(), [this](const std::pair<int, int> Pair) {
+	auto pSelectedPointIt = std::find_if(Editor()->m_vSelectedEnvelopePoints.begin(), Editor()->m_vSelectedEnvelopePoints.end(), [this](const std::pair<int, int> Pair) {
 		return Pair.first == m_PointIndex;
 	});
 
-	if(pSelectedPointIt != m_pEditor->m_vSelectedEnvelopePoints.end())
-		m_pEditor->m_vSelectedEnvelopePoints.erase(pSelectedPointIt);
+	if(pSelectedPointIt != Editor()->m_vSelectedEnvelopePoints.end())
+		Editor()->m_vSelectedEnvelopePoints.erase(pSelectedPointIt);
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 // -------------------------------
 
-CEditorActionEditLayerSoundsProp::CEditorActionEditLayerSoundsProp(CEditor *pEditor, int GroupIndex, int LayerIndex, ELayerSoundsProp Prop, int Previous, int Current) :
-	CEditorActionEditLayerPropBase(pEditor, GroupIndex, LayerIndex, Prop, Previous, Current)
+CEditorActionEditLayerSoundsProp::CEditorActionEditLayerSoundsProp(CEditorMap *pMap, int GroupIndex, int LayerIndex, ELayerSoundsProp Prop, int Previous, int Current) :
+	CEditorActionEditLayerPropBase(pMap, GroupIndex, LayerIndex, Prop, Previous, Current)
 {
 	static const char *s_apNames[] = {
 		"sound"};
@@ -1779,19 +1766,19 @@ void CEditorActionEditLayerSoundsProp::Apply(int Value)
 	std::shared_ptr<CLayerSounds> pLayerSounds = std::static_pointer_cast<CLayerSounds>(m_pLayer);
 	if(m_Prop == ELayerSoundsProp::PROP_SOUND)
 	{
-		if(Value >= 0 && !m_pEditor->m_Map.m_vpSounds.empty())
-			pLayerSounds->m_Sound = Value % m_pEditor->m_Map.m_vpSounds.size();
+		if(Value >= 0 && !Map()->m_vpSounds.empty())
+			pLayerSounds->m_Sound = Value % Map()->m_vpSounds.size();
 		else
 			pLayerSounds->m_Sound = -1;
 	}
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 // ---
 
-CEditorActionDeleteSoundSource::CEditorActionDeleteSoundSource(CEditor *pEditor, int GroupIndex, int LayerIndex, int SourceIndex) :
-	CEditorActionLayerBase(pEditor, GroupIndex, LayerIndex), m_SourceIndex(SourceIndex)
+CEditorActionDeleteSoundSource::CEditorActionDeleteSoundSource(CEditorMap *pMap, int GroupIndex, int LayerIndex, int SourceIndex) :
+	CEditorActionLayerBase(pMap, GroupIndex, LayerIndex), m_SourceIndex(SourceIndex)
 {
 	std::shared_ptr<CLayerSounds> pLayerSounds = std::static_pointer_cast<CLayerSounds>(m_pLayer);
 	m_Source = pLayerSounds->m_vSources[SourceIndex];
@@ -1803,22 +1790,22 @@ void CEditorActionDeleteSoundSource::Undo()
 {
 	std::shared_ptr<CLayerSounds> pLayerSounds = std::static_pointer_cast<CLayerSounds>(m_pLayer);
 	pLayerSounds->m_vSources.insert(pLayerSounds->m_vSources.begin() + m_SourceIndex, m_Source);
-	m_pEditor->m_SelectedSource = m_SourceIndex;
-	m_pEditor->m_Map.OnModify();
+	Editor()->m_SelectedSource = m_SourceIndex;
+	Map()->OnModify();
 }
 
 void CEditorActionDeleteSoundSource::Redo()
 {
 	std::shared_ptr<CLayerSounds> pLayerSounds = std::static_pointer_cast<CLayerSounds>(m_pLayer);
 	pLayerSounds->m_vSources.erase(pLayerSounds->m_vSources.begin() + m_SourceIndex);
-	m_pEditor->m_SelectedSource--;
-	m_pEditor->m_Map.OnModify();
+	Editor()->m_SelectedSource--;
+	Map()->OnModify();
 }
 
 // ---------------
 
-CEditorActionEditSoundSourceShape::CEditorActionEditSoundSourceShape(CEditor *pEditor, int GroupIndex, int LayerIndex, int SourceIndex, int Value) :
-	CEditorActionLayerBase(pEditor, GroupIndex, LayerIndex), m_SourceIndex(SourceIndex), m_CurrentValue(Value)
+CEditorActionEditSoundSourceShape::CEditorActionEditSoundSourceShape(CEditorMap *pMap, int GroupIndex, int LayerIndex, int SourceIndex, int Value) :
+	CEditorActionLayerBase(pMap, GroupIndex, LayerIndex), m_SourceIndex(SourceIndex), m_CurrentValue(Value)
 {
 	Save();
 
@@ -1839,7 +1826,7 @@ void CEditorActionEditSoundSourceShape::Undo()
 
 	pSource->m_Shape = m_SavedShape;
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 void CEditorActionEditSoundSourceShape::Redo()
@@ -1865,7 +1852,7 @@ void CEditorActionEditSoundSourceShape::Redo()
 	}
 	}
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 void CEditorActionEditSoundSourceShape::Save()
@@ -1876,8 +1863,8 @@ void CEditorActionEditSoundSourceShape::Save()
 
 // -----
 
-CEditorActionEditSoundSourceProp::CEditorActionEditSoundSourceProp(CEditor *pEditor, int GroupIndex, int LayerIndex, int SourceIndex, ESoundProp Prop, int Previous, int Current) :
-	CEditorActionEditLayerPropBase(pEditor, GroupIndex, LayerIndex, Prop, Previous, Current), m_SourceIndex(SourceIndex)
+CEditorActionEditSoundSourceProp::CEditorActionEditSoundSourceProp(CEditorMap *pMap, int GroupIndex, int LayerIndex, int SourceIndex, ESoundProp Prop, int Previous, int Current) :
+	CEditorActionEditLayerPropBase(pMap, GroupIndex, LayerIndex, Prop, Previous, Current), m_SourceIndex(SourceIndex)
 {
 	static const char *s_apNames[] = {
 		"pos X",
@@ -1950,11 +1937,11 @@ void CEditorActionEditSoundSourceProp::Apply(int Value)
 		pSource->m_SoundEnvOffset = Value;
 	}
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
-CEditorActionEditRectSoundSourceShapeProp::CEditorActionEditRectSoundSourceShapeProp(CEditor *pEditor, int GroupIndex, int LayerIndex, int SourceIndex, ERectangleShapeProp Prop, int Previous, int Current) :
-	CEditorActionEditLayerPropBase(pEditor, GroupIndex, LayerIndex, Prop, Previous, Current), m_SourceIndex(SourceIndex)
+CEditorActionEditRectSoundSourceShapeProp::CEditorActionEditRectSoundSourceShapeProp(CEditorMap *pMap, int GroupIndex, int LayerIndex, int SourceIndex, ERectangleShapeProp Prop, int Previous, int Current) :
+	CEditorActionEditLayerPropBase(pMap, GroupIndex, LayerIndex, Prop, Previous, Current), m_SourceIndex(SourceIndex)
 {
 	static const char *s_apNames[] = {
 		"width",
@@ -1987,11 +1974,11 @@ void CEditorActionEditRectSoundSourceShapeProp::Apply(int Value)
 		pSource->m_Shape.m_Rectangle.m_Height = Value;
 	}
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
-CEditorActionEditCircleSoundSourceShapeProp::CEditorActionEditCircleSoundSourceShapeProp(CEditor *pEditor, int GroupIndex, int LayerIndex, int SourceIndex, ECircleShapeProp Prop, int Previous, int Current) :
-	CEditorActionEditLayerPropBase(pEditor, GroupIndex, LayerIndex, Prop, Previous, Current), m_SourceIndex(SourceIndex)
+CEditorActionEditCircleSoundSourceShapeProp::CEditorActionEditCircleSoundSourceShapeProp(CEditorMap *pMap, int GroupIndex, int LayerIndex, int SourceIndex, ECircleShapeProp Prop, int Previous, int Current) :
+	CEditorActionEditLayerPropBase(pMap, GroupIndex, LayerIndex, Prop, Previous, Current), m_SourceIndex(SourceIndex)
 {
 	static const char *s_apNames[] = {
 		"radius"};
@@ -2019,13 +2006,13 @@ void CEditorActionEditCircleSoundSourceShapeProp::Apply(int Value)
 		pSource->m_Shape.m_Circle.m_Radius = Value;
 	}
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 // --------------------------
 
-CEditorActionNewEmptySound::CEditorActionNewEmptySound(CEditor *pEditor, int GroupIndex, int LayerIndex, int x, int y) :
-	CEditorActionLayerBase(pEditor, GroupIndex, LayerIndex), m_X(x), m_Y(y)
+CEditorActionNewEmptySound::CEditorActionNewEmptySound(CEditorMap *pMap, int GroupIndex, int LayerIndex, int x, int y) :
+	CEditorActionLayerBase(pMap, GroupIndex, LayerIndex), m_X(x), m_Y(y)
 {
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "New sound in layer %d of group %d", LayerIndex, GroupIndex);
 }
@@ -2036,20 +2023,19 @@ void CEditorActionNewEmptySound::Undo()
 	std::shared_ptr<CLayerSounds> pLayerSounds = std::static_pointer_cast<CLayerSounds>(m_pLayer);
 	pLayerSounds->m_vSources.pop_back();
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 void CEditorActionNewEmptySound::Redo()
 {
-	auto &Map = m_pEditor->m_Map;
 	std::shared_ptr<CLayerSounds> pLayerSounds = std::static_pointer_cast<CLayerSounds>(m_pLayer);
 	pLayerSounds->NewSource(m_X, m_Y);
 
-	Map.OnModify();
+	Map()->OnModify();
 }
 
-CEditorActionNewEmptyQuad::CEditorActionNewEmptyQuad(CEditor *pEditor, int GroupIndex, int LayerIndex, int x, int y) :
-	CEditorActionLayerBase(pEditor, GroupIndex, LayerIndex), m_X(x), m_Y(y)
+CEditorActionNewEmptyQuad::CEditorActionNewEmptyQuad(CEditorMap *pMap, int GroupIndex, int LayerIndex, int x, int y) :
+	CEditorActionLayerBase(pMap, GroupIndex, LayerIndex), m_X(x), m_Y(y)
 {
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "New quad in layer %d of group %d", LayerIndex, GroupIndex);
 }
@@ -2060,31 +2046,30 @@ void CEditorActionNewEmptyQuad::Undo()
 	std::shared_ptr<CLayerQuads> pLayerQuads = std::static_pointer_cast<CLayerQuads>(m_pLayer);
 	pLayerQuads->m_vQuads.pop_back();
 
-	m_pEditor->m_Map.OnModify();
+	Map()->OnModify();
 }
 
 void CEditorActionNewEmptyQuad::Redo()
 {
-	auto &Map = m_pEditor->m_Map;
 	std::shared_ptr<CLayerQuads> pLayerQuads = std::static_pointer_cast<CLayerQuads>(m_pLayer);
 
 	int Width = 64;
 	int Height = 64;
 	if(pLayerQuads->m_Image >= 0)
 	{
-		Width = Map.m_vpImages[pLayerQuads->m_Image]->m_Width;
-		Height = Map.m_vpImages[pLayerQuads->m_Image]->m_Height;
+		Width = Map()->m_vpImages[pLayerQuads->m_Image]->m_Width;
+		Height = Map()->m_vpImages[pLayerQuads->m_Image]->m_Height;
 	}
 
 	pLayerQuads->NewQuad(m_X, m_Y, Width, Height);
 
-	Map.OnModify();
+	Map()->OnModify();
 }
 
 // -------------
 
-CEditorActionNewQuad::CEditorActionNewQuad(CEditor *pEditor, int GroupIndex, int LayerIndex) :
-	CEditorActionLayerBase(pEditor, GroupIndex, LayerIndex)
+CEditorActionNewQuad::CEditorActionNewQuad(CEditorMap *pMap, int GroupIndex, int LayerIndex) :
+	CEditorActionLayerBase(pMap, GroupIndex, LayerIndex)
 {
 	std::shared_ptr<CLayerQuads> pLayerQuads = std::static_pointer_cast<CLayerQuads>(m_pLayer);
 	m_Quad = pLayerQuads->m_vQuads[pLayerQuads->m_vQuads.size() - 1];
@@ -2106,8 +2091,8 @@ void CEditorActionNewQuad::Redo()
 
 // --------------
 
-CEditorActionMoveSoundSource::CEditorActionMoveSoundSource(CEditor *pEditor, int GroupIndex, int LayerIndex, int SourceIndex, CPoint OriginalPosition, CPoint CurrentPosition) :
-	CEditorActionLayerBase(pEditor, GroupIndex, LayerIndex), m_SourceIndex(SourceIndex), m_OriginalPosition(OriginalPosition), m_CurrentPosition(CurrentPosition)
+CEditorActionMoveSoundSource::CEditorActionMoveSoundSource(CEditorMap *pMap, int GroupIndex, int LayerIndex, int SourceIndex, CPoint OriginalPosition, CPoint CurrentPosition) :
+	CEditorActionLayerBase(pMap, GroupIndex, LayerIndex), m_SourceIndex(SourceIndex), m_OriginalPosition(OriginalPosition), m_CurrentPosition(CurrentPosition)
 {
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Move sound source %d of layer %d in group %d", SourceIndex, LayerIndex, GroupIndex);
 }

--- a/src/game/editor/editor_actions.h
+++ b/src/game/editor/editor_actions.h
@@ -9,7 +9,7 @@
 class CEditorActionLayerBase : public IEditorAction
 {
 public:
-	CEditorActionLayerBase(CEditor *pEditor, int GroupIndex, int LayerIndex);
+	CEditorActionLayerBase(CEditorMap *pMap, int GroupIndex, int LayerIndex);
 
 protected:
 	int m_GroupIndex;
@@ -20,7 +20,7 @@ protected:
 class CEditorBrushDrawAction : public IEditorAction
 {
 public:
-	CEditorBrushDrawAction(CEditor *pEditor, int Group);
+	CEditorBrushDrawAction(CEditorMap *pMap, int Group);
 
 	void Undo() override;
 	void Redo() override;
@@ -49,7 +49,7 @@ private:
 class CEditorActionQuadPlace : public CEditorActionLayerBase
 {
 public:
-	CEditorActionQuadPlace(CEditor *pEditor, int GroupIndex, int LayerIndex, std::vector<CQuad> &vBrush);
+	CEditorActionQuadPlace(CEditorMap *pMap, int GroupIndex, int LayerIndex, std::vector<CQuad> &vBrush);
 
 	void Undo() override;
 	void Redo() override;
@@ -61,7 +61,7 @@ private:
 class CEditorActionSoundPlace : public CEditorActionLayerBase
 {
 public:
-	CEditorActionSoundPlace(CEditor *pEditor, int GroupIndex, int LayerIndex, std::vector<CSoundSource> &vBrush);
+	CEditorActionSoundPlace(CEditorMap *pMap, int GroupIndex, int LayerIndex, std::vector<CSoundSource> &vBrush);
 
 	void Undo() override;
 	void Redo() override;
@@ -75,7 +75,7 @@ private:
 class CEditorActionDeleteQuad : public CEditorActionLayerBase
 {
 public:
-	CEditorActionDeleteQuad(CEditor *pEditor, int GroupIndex, int LayerIndex, std::vector<int> const &vQuadsIndices, std::vector<CQuad> const &vDeletedQuads);
+	CEditorActionDeleteQuad(CEditorMap *pMap, int GroupIndex, int LayerIndex, std::vector<int> const &vQuadsIndices, std::vector<CQuad> const &vDeletedQuads);
 
 	void Undo() override;
 	void Redo() override;
@@ -90,7 +90,7 @@ private:
 class CEditorActionEditQuadPoint : public CEditorActionLayerBase
 {
 public:
-	CEditorActionEditQuadPoint(CEditor *pEditor, int GroupIndex, int LayerIndex, int QuadIndex, std::vector<CPoint> const &vPreviousPoints, std::vector<CPoint> const &vCurrentPoints);
+	CEditorActionEditQuadPoint(CEditorMap *pMap, int GroupIndex, int LayerIndex, int QuadIndex, std::vector<CPoint> const &vPreviousPoints, std::vector<CPoint> const &vCurrentPoints);
 
 	void Undo() override;
 	void Redo() override;
@@ -104,7 +104,7 @@ private:
 class CEditorActionEditQuadProp : public CEditorActionLayerBase
 {
 public:
-	CEditorActionEditQuadProp(CEditor *pEditor, int GroupIndex, int LayerIndex, int QuadIndex, EQuadProp Prop, int Previous, int Current);
+	CEditorActionEditQuadProp(CEditorMap *pMap, int GroupIndex, int LayerIndex, int QuadIndex, EQuadProp Prop, int Previous, int Current);
 
 	void Undo() override;
 	void Redo() override;
@@ -121,7 +121,7 @@ private:
 class CEditorActionEditQuadPointProp : public CEditorActionLayerBase
 {
 public:
-	CEditorActionEditQuadPointProp(CEditor *pEditor, int GroupIndex, int LayerIndex, int QuadIndex, int PointIndex, EQuadPointProp Prop, int Previous, int Current);
+	CEditorActionEditQuadPointProp(CEditorMap *pMap, int GroupIndex, int LayerIndex, int QuadIndex, int PointIndex, EQuadPointProp Prop, int Previous, int Current);
 
 	void Undo() override;
 	void Redo() override;
@@ -141,7 +141,7 @@ private:
 class CEditorActionBulk : public IEditorAction
 {
 public:
-	CEditorActionBulk(CEditor *pEditor, const std::vector<std::shared_ptr<IEditorAction>> &vpActions, const char *pDisplay = nullptr, bool Reverse = false);
+	CEditorActionBulk(CEditorMap *pMap, const std::vector<std::shared_ptr<IEditorAction>> &vpActions, const char *pDisplay = nullptr, bool Reverse = false);
 
 	void Undo() override;
 	void Redo() override;
@@ -157,7 +157,7 @@ private:
 class CEditorActionTileChanges : public CEditorActionLayerBase
 {
 public:
-	CEditorActionTileChanges(CEditor *pEditor, int GroupIndex, int LayerIndex, const char *pAction, const EditorTileStateChangeHistory<STileStateChange> &Changes);
+	CEditorActionTileChanges(CEditorMap *pMap, int GroupIndex, int LayerIndex, const char *pAction, const EditorTileStateChangeHistory<STileStateChange> &Changes);
 
 	void Undo() override;
 	void Redo() override;
@@ -175,7 +175,7 @@ private:
 class CEditorActionAddLayer : public CEditorActionLayerBase
 {
 public:
-	CEditorActionAddLayer(CEditor *pEditor, int GroupIndex, int LayerIndex, bool Duplicate = false);
+	CEditorActionAddLayer(CEditorMap *pMap, int GroupIndex, int LayerIndex, bool Duplicate = false);
 
 	void Undo() override;
 	void Redo() override;
@@ -187,7 +187,7 @@ private:
 class CEditorActionDeleteLayer : public CEditorActionLayerBase
 {
 public:
-	CEditorActionDeleteLayer(CEditor *pEditor, int GroupIndex, int LayerIndex);
+	CEditorActionDeleteLayer(CEditorMap *pMap, int GroupIndex, int LayerIndex);
 
 	void Undo() override;
 	void Redo() override;
@@ -196,7 +196,7 @@ public:
 class CEditorActionGroup : public IEditorAction
 {
 public:
-	CEditorActionGroup(CEditor *pEditor, int GroupIndex, bool Delete);
+	CEditorActionGroup(CEditorMap *pMap, int GroupIndex, bool Delete);
 
 	void Undo() override;
 	void Redo() override;
@@ -210,7 +210,7 @@ private:
 class CEditorActionEditGroupProp : public IEditorAction
 {
 public:
-	CEditorActionEditGroupProp(CEditor *pEditor, int GroupIndex, EGroupProp Prop, int Previous, int Current);
+	CEditorActionEditGroupProp(CEditorMap *pMap, int GroupIndex, EGroupProp Prop, int Previous, int Current);
 
 	void Undo() override;
 	void Redo() override;
@@ -228,7 +228,7 @@ template<typename E>
 class CEditorActionEditLayerPropBase : public CEditorActionLayerBase
 {
 public:
-	CEditorActionEditLayerPropBase(CEditor *pEditor, int GroupIndex, int LayerIndex, E Prop, int Previous, int Current);
+	CEditorActionEditLayerPropBase(CEditorMap *pMap, int GroupIndex, int LayerIndex, E Prop, int Previous, int Current);
 
 protected:
 	E m_Prop;
@@ -239,7 +239,7 @@ protected:
 class CEditorActionEditLayerProp : public CEditorActionEditLayerPropBase<ELayerProp>
 {
 public:
-	CEditorActionEditLayerProp(CEditor *pEditor, int GroupIndex, int LayerIndex, ELayerProp Prop, int Previous, int Current);
+	CEditorActionEditLayerProp(CEditorMap *pMap, int GroupIndex, int LayerIndex, ELayerProp Prop, int Previous, int Current);
 
 	void Undo() override;
 	void Redo() override;
@@ -251,7 +251,7 @@ private:
 class CEditorActionEditLayerTilesProp : public CEditorActionEditLayerPropBase<ETilesProp>
 {
 public:
-	CEditorActionEditLayerTilesProp(CEditor *pEditor, int GroupIndex, int LayerIndex, ETilesProp Prop, int Previous, int Current);
+	CEditorActionEditLayerTilesProp(CEditorMap *pMap, int GroupIndex, int LayerIndex, ETilesProp Prop, int Previous, int Current);
 
 	void Undo() override;
 	void Redo() override;
@@ -267,7 +267,7 @@ private:
 class CEditorActionEditLayerQuadsProp : public CEditorActionEditLayerPropBase<ELayerQuadsProp>
 {
 public:
-	CEditorActionEditLayerQuadsProp(CEditor *pEditor, int GroupIndex, int LayerIndex, ELayerQuadsProp Prop, int Previous, int Current);
+	CEditorActionEditLayerQuadsProp(CEditorMap *pMap, int GroupIndex, int LayerIndex, ELayerQuadsProp Prop, int Previous, int Current);
 
 	void Undo() override;
 	void Redo() override;
@@ -279,7 +279,7 @@ private:
 class CEditorActionEditLayersGroupAndOrder : public IEditorAction
 {
 public:
-	CEditorActionEditLayersGroupAndOrder(CEditor *pEditor, int GroupIndex, const std::vector<int> &LayerIndices, int NewGroupIndex, const std::vector<int> &NewLayerIndices);
+	CEditorActionEditLayersGroupAndOrder(CEditorMap *pMap, int GroupIndex, const std::vector<int> &LayerIndices, int NewGroupIndex, const std::vector<int> &NewLayerIndices);
 
 	void Undo() override;
 	void Redo() override;
@@ -304,7 +304,7 @@ public:
 		int m_Envelopes;
 	};
 
-	CEditorActionAppendMap(CEditor *pEditor, const char *pMapName, const SPrevInfo &PrevInfo, std::vector<int> &vImageIndexMap);
+	CEditorActionAppendMap(CEditorMap *pMap, const char *pMapName, const SPrevInfo &PrevInfo, std::vector<int> &vImageIndexMap);
 
 	void Undo() override;
 	void Redo() override;
@@ -320,7 +320,7 @@ private:
 class CEditorActionTileArt : public IEditorAction
 {
 public:
-	CEditorActionTileArt(CEditor *pEditor, int PreviousImageCount, const char *pTileArtFile, std::vector<int> &vImageIndexMap);
+	CEditorActionTileArt(CEditorMap *pMap, int PreviousImageCount, const char *pTileArtFile, std::vector<int> &vImageIndexMap);
 
 	void Undo() override;
 	void Redo() override;
@@ -336,7 +336,7 @@ private:
 class CEditorActionQuadArt : public IEditorAction
 {
 public:
-	CEditorActionQuadArt(CEditor *pEditor, CQuadArtParameters Parameters);
+	CEditorActionQuadArt(CEditorMap *pMap, CQuadArtParameters Parameters);
 
 	void Undo() override;
 	void Redo() override;
@@ -359,7 +359,7 @@ public:
 		MOVE_DOWN
 	};
 
-	CEditorCommandAction(CEditor *pEditor, EType Type, int *pSelectedCommandIndex, int CommandIndex, const char *pPreviousCommand = nullptr, const char *pCurrentCommand = nullptr);
+	CEditorCommandAction(CEditorMap *pMap, EType Type, int *pSelectedCommandIndex, int CommandIndex, const char *pPreviousCommand = nullptr, const char *pCurrentCommand = nullptr);
 
 	void Undo() override;
 	void Redo() override;
@@ -377,7 +377,7 @@ private:
 class CEditorActionEnvelopeAdd : public IEditorAction
 {
 public:
-	CEditorActionEnvelopeAdd(CEditor *pEditor, CEnvelope::EType EnvelopeType);
+	CEditorActionEnvelopeAdd(CEditorMap *pMap, CEnvelope::EType EnvelopeType);
 
 	void Undo() override;
 	void Redo() override;
@@ -390,7 +390,7 @@ private:
 class CEditorActionEnvelopeDelete : public IEditorAction
 {
 public:
-	CEditorActionEnvelopeDelete(CEditor *pEditor, int EnvelopeIndex, std::vector<std::shared_ptr<IEditorEnvelopeReference>> &vpObjectReferences, std::shared_ptr<CEnvelope> &pEnvelope);
+	CEditorActionEnvelopeDelete(CEditorMap *pMap, int EnvelopeIndex, std::vector<std::shared_ptr<IEditorEnvelopeReference>> &vpObjectReferences, std::shared_ptr<CEnvelope> &pEnvelope);
 
 	void Undo() override;
 	void Redo() override;
@@ -410,7 +410,7 @@ public:
 		ORDER
 	};
 
-	CEditorActionEnvelopeEdit(CEditor *pEditor, int EnvelopeIndex, EEditType EditType, int Previous, int Current);
+	CEditorActionEnvelopeEdit(CEditorMap *pMap, int EnvelopeIndex, EEditType EditType, int Previous, int Current);
 
 	void Undo() override;
 	void Redo() override;
@@ -426,7 +426,7 @@ private:
 class CEditorActionEnvelopeEditPointTime : public IEditorAction
 {
 public:
-	CEditorActionEnvelopeEditPointTime(CEditor *pEditor, int EnvelopeIndex, int PointIndex, CFixedTime Previous, CFixedTime Current);
+	CEditorActionEnvelopeEditPointTime(CEditorMap *pMap, int EnvelopeIndex, int PointIndex, CFixedTime Previous, CFixedTime Current);
 
 	void Undo() override;
 	void Redo() override;
@@ -450,7 +450,7 @@ public:
 		CURVE_TYPE,
 	};
 
-	CEditorActionEnvelopeEditPoint(CEditor *pEditor, int EnvelopeIndex, int PointIndex, int Channel, EEditType EditType, int Previous, int Current);
+	CEditorActionEnvelopeEditPoint(CEditorMap *pMap, int EnvelopeIndex, int PointIndex, int Channel, EEditType EditType, int Previous, int Current);
 
 	void Undo() override;
 	void Redo() override;
@@ -470,7 +470,7 @@ private:
 class CEditorActionAddEnvelopePoint : public IEditorAction
 {
 public:
-	CEditorActionAddEnvelopePoint(CEditor *pEditor, int EnvIndex, CFixedTime Time, ColorRGBA Channels);
+	CEditorActionAddEnvelopePoint(CEditorMap *pMap, int EnvIndex, CFixedTime Time, ColorRGBA Channels);
 
 	void Undo() override;
 	void Redo() override;
@@ -484,7 +484,7 @@ private:
 class CEditorActionDeleteEnvelopePoint : public IEditorAction
 {
 public:
-	CEditorActionDeleteEnvelopePoint(CEditor *pEditor, int EnvIndex, int PointIndex);
+	CEditorActionDeleteEnvelopePoint(CEditorMap *pMap, int EnvIndex, int PointIndex);
 
 	void Undo() override;
 	void Redo() override;
@@ -505,7 +505,7 @@ public:
 		POINT
 	};
 
-	CEditorActionEditEnvelopePointValue(CEditor *pEditor, int EnvIndex, int PointIndex, int Channel, EType Type, CFixedTime OldTime, int OldValue, CFixedTime NewTime, int NewValue);
+	CEditorActionEditEnvelopePointValue(CEditorMap *pMap, int EnvIndex, int PointIndex, int Channel, EType Type, CFixedTime OldTime, int OldValue, CFixedTime NewTime, int NewValue);
 
 	void Undo() override;
 	void Redo() override;
@@ -526,7 +526,7 @@ private:
 class CEditorActionResetEnvelopePointTangent : public IEditorAction
 {
 public:
-	CEditorActionResetEnvelopePointTangent(CEditor *pEditor, int EnvIndex, int PointIndex, int Channel, bool In);
+	CEditorActionResetEnvelopePointTangent(CEditorMap *pMap, int EnvIndex, int PointIndex, int Channel, bool In);
 
 	void Undo() override;
 	void Redo() override;
@@ -543,7 +543,7 @@ private:
 class CEditorActionEditLayerSoundsProp : public CEditorActionEditLayerPropBase<ELayerSoundsProp>
 {
 public:
-	CEditorActionEditLayerSoundsProp(CEditor *pEditor, int GroupIndex, int LayerIndex, ELayerSoundsProp Prop, int Previous, int Current);
+	CEditorActionEditLayerSoundsProp(CEditorMap *pMap, int GroupIndex, int LayerIndex, ELayerSoundsProp Prop, int Previous, int Current);
 
 	void Undo() override;
 	void Redo() override;
@@ -555,7 +555,7 @@ private:
 class CEditorActionDeleteSoundSource : public CEditorActionLayerBase
 {
 public:
-	CEditorActionDeleteSoundSource(CEditor *pEditor, int GroupIndex, int LayerIndex, int SourceIndex);
+	CEditorActionDeleteSoundSource(CEditorMap *pMap, int GroupIndex, int LayerIndex, int SourceIndex);
 
 	void Undo() override;
 	void Redo() override;
@@ -568,7 +568,7 @@ private:
 class CEditorActionEditSoundSourceShape : public CEditorActionLayerBase
 {
 public:
-	CEditorActionEditSoundSourceShape(CEditor *pEditor, int GroupIndex, int LayerIndex, int SourceIndex, int Value);
+	CEditorActionEditSoundSourceShape(CEditorMap *pMap, int GroupIndex, int LayerIndex, int SourceIndex, int Value);
 
 	void Undo() override;
 	void Redo() override;
@@ -586,7 +586,7 @@ private:
 class CEditorActionEditSoundSourceProp : public CEditorActionEditLayerPropBase<ESoundProp>
 {
 public:
-	CEditorActionEditSoundSourceProp(CEditor *pEditor, int GroupIndex, int LayerIndex, int SourceIndex, ESoundProp Prop, int Previous, int Current);
+	CEditorActionEditSoundSourceProp(CEditorMap *pMap, int GroupIndex, int LayerIndex, int SourceIndex, ESoundProp Prop, int Previous, int Current);
 
 	void Undo() override;
 	void Redo() override;
@@ -600,7 +600,7 @@ private:
 class CEditorActionEditRectSoundSourceShapeProp : public CEditorActionEditLayerPropBase<ERectangleShapeProp>
 {
 public:
-	CEditorActionEditRectSoundSourceShapeProp(CEditor *pEditor, int GroupIndex, int LayerIndex, int SourceIndex, ERectangleShapeProp Prop, int Previous, int Current);
+	CEditorActionEditRectSoundSourceShapeProp(CEditorMap *pMap, int GroupIndex, int LayerIndex, int SourceIndex, ERectangleShapeProp Prop, int Previous, int Current);
 
 	void Undo() override;
 	void Redo() override;
@@ -614,7 +614,7 @@ private:
 class CEditorActionEditCircleSoundSourceShapeProp : public CEditorActionEditLayerPropBase<ECircleShapeProp>
 {
 public:
-	CEditorActionEditCircleSoundSourceShapeProp(CEditor *pEditor, int GroupIndex, int LayerIndex, int SourceIndex, ECircleShapeProp Prop, int Previous, int Current);
+	CEditorActionEditCircleSoundSourceShapeProp(CEditorMap *pMap, int GroupIndex, int LayerIndex, int SourceIndex, ECircleShapeProp Prop, int Previous, int Current);
 
 	void Undo() override;
 	void Redo() override;
@@ -628,7 +628,7 @@ private:
 class CEditorActionNewEmptySound : public CEditorActionLayerBase
 {
 public:
-	CEditorActionNewEmptySound(CEditor *pEditor, int GroupIndex, int LayerIndex, int x, int y);
+	CEditorActionNewEmptySound(CEditorMap *pMap, int GroupIndex, int LayerIndex, int x, int y);
 
 	void Undo() override;
 	void Redo() override;
@@ -641,7 +641,7 @@ private:
 class CEditorActionNewEmptyQuad : public CEditorActionLayerBase
 {
 public:
-	CEditorActionNewEmptyQuad(CEditor *pEditor, int GroupIndex, int LayerIndex, int x, int y);
+	CEditorActionNewEmptyQuad(CEditorMap *pMap, int GroupIndex, int LayerIndex, int x, int y);
 
 	void Undo() override;
 	void Redo() override;
@@ -654,7 +654,7 @@ private:
 class CEditorActionNewQuad : public CEditorActionLayerBase
 {
 public:
-	CEditorActionNewQuad(CEditor *pEditor, int GroupIndex, int LayerIndex);
+	CEditorActionNewQuad(CEditorMap *pMap, int GroupIndex, int LayerIndex);
 
 	void Undo() override;
 	void Redo() override;
@@ -666,7 +666,7 @@ private:
 class CEditorActionMoveSoundSource : public CEditorActionLayerBase
 {
 public:
-	CEditorActionMoveSoundSource(CEditor *pEditor, int GroupIndex, int LayerIndex, int SourceIndex, CPoint OriginalPosition, CPoint CurrentPosition);
+	CEditorActionMoveSoundSource(CEditorMap *pMap, int GroupIndex, int LayerIndex, int SourceIndex, CPoint OriginalPosition, CPoint CurrentPosition);
 
 	void Undo() override;
 	void Redo() override;

--- a/src/game/editor/editor_history.cpp
+++ b/src/game/editor/editor_history.cpp
@@ -34,7 +34,7 @@ void CEditorHistory::RecordAction(const std::shared_ptr<IEditorAction> &pAction,
 	if(pDisplay == nullptr)
 		m_vpUndoActions.emplace_back(pAction);
 	else
-		m_vpUndoActions.emplace_back(std::make_shared<CEditorActionBulk>(m_pEditor, std::vector<std::shared_ptr<IEditorAction>>{pAction}, pDisplay));
+		m_vpUndoActions.emplace_back(std::make_shared<CEditorActionBulk>(Map(), std::vector<std::shared_ptr<IEditorAction>>{pAction}, pDisplay));
 }
 
 bool CEditorHistory::Undo()
@@ -85,7 +85,7 @@ void CEditorHistory::EndBulk(const char *pDisplay)
 
 	// Record bulk action
 	if(!m_vpBulkActions.empty())
-		RecordAction(std::make_shared<CEditorActionBulk>(m_pEditor, m_vpBulkActions, pDisplay, true));
+		RecordAction(std::make_shared<CEditorActionBulk>(Map(), m_vpBulkActions, pDisplay, true));
 
 	m_vpBulkActions.clear();
 }

--- a/src/game/editor/editor_history.h
+++ b/src/game/editor/editor_history.h
@@ -3,20 +3,21 @@
 
 #include "editor_action.h"
 
+#include <game/editor/map_object.h>
+
 #include <deque>
 #include <memory>
 #include <vector>
 
-class CEditorHistory
+class CEditorHistory : public CMapObject
 {
 public:
-	CEditorHistory()
+	explicit CEditorHistory(CEditorMap *pMap) :
+		CMapObject(pMap)
 	{
-		m_pEditor = nullptr;
-		m_IsBulk = false;
 	}
 
-	~CEditorHistory()
+	~CEditorHistory() override
 	{
 		Clear();
 	}
@@ -36,13 +37,12 @@ public:
 	void EndBulk(const char *pDisplay = nullptr);
 	void EndBulk(int DisplayToUse);
 
-	CEditor *m_pEditor;
 	std::deque<std::shared_ptr<IEditorAction>> m_vpUndoActions;
 	std::deque<std::shared_ptr<IEditorAction>> m_vpRedoActions;
 
 private:
 	std::vector<std::shared_ptr<IEditorAction>> m_vpBulkActions;
-	bool m_IsBulk;
+	bool m_IsBulk = false;
 };
 
 #endif

--- a/src/game/editor/editor_server_settings.cpp
+++ b/src/game/editor/editor_server_settings.cpp
@@ -78,7 +78,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 	static int s_DeleteButton = 0;
 	if(DoButton_FontIcon(&s_DeleteButton, FONT_ICON_TRASH, GotSelection ? 0 : -1, &Button, BUTTONFLAG_LEFT, "[Delete] Delete the selected command from the command list.", IGraphics::CORNER_ALL, 9.0f) || (GotSelection && CLineInput::GetActiveInput() == nullptr && m_Dialog == DIALOG_NONE && Ui()->ConsumeHotkey(CUi::HOTKEY_DELETE)))
 	{
-		m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(this, CEditorCommandAction::EType::DELETE, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand));
+		m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::DELETE, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand));
 
 		m_Map.m_vSettings.erase(m_Map.m_vSettings.begin() + s_CommandSelectedIndex);
 		if(s_CommandSelectedIndex >= (int)m_Map.m_vSettings.size())
@@ -98,7 +98,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 	static int s_DownButton = 0;
 	if(DoButton_FontIcon(&s_DownButton, FONT_ICON_SORT_DOWN, CanMoveDown ? 0 : -1, &Button, BUTTONFLAG_LEFT, "[Alt+Down] Move the selected command down.", IGraphics::CORNER_R, 11.0f) || (CanMoveDown && Input()->AltIsPressed() && Ui()->ConsumeHotkey(CUi::HOTKEY_DOWN)))
 	{
-		m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(this, CEditorCommandAction::EType::MOVE_DOWN, &s_CommandSelectedIndex, s_CommandSelectedIndex));
+		m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::MOVE_DOWN, &s_CommandSelectedIndex, s_CommandSelectedIndex));
 
 		std::swap(m_Map.m_vSettings[s_CommandSelectedIndex], m_Map.m_vSettings[s_CommandSelectedIndex + 1]);
 		s_CommandSelectedIndex++;
@@ -113,7 +113,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 	static int s_UpButton = 0;
 	if(DoButton_FontIcon(&s_UpButton, FONT_ICON_SORT_UP, CanMoveUp ? 0 : -1, &Button, BUTTONFLAG_LEFT, "[Alt+Up] Move the selected command up.", IGraphics::CORNER_L, 11.0f) || (CanMoveUp && Input()->AltIsPressed() && Ui()->ConsumeHotkey(CUi::HOTKEY_UP)))
 	{
-		m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(this, CEditorCommandAction::EType::MOVE_UP, &s_CommandSelectedIndex, s_CommandSelectedIndex));
+		m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::MOVE_UP, &s_CommandSelectedIndex, s_CommandSelectedIndex));
 
 		std::swap(m_Map.m_vSettings[s_CommandSelectedIndex], m_Map.m_vSettings[s_CommandSelectedIndex - 1]);
 		s_CommandSelectedIndex--;
@@ -124,18 +124,18 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 	// redo button
 	ToolBar.VSplitRight(25.0f, &ToolBar, &Button);
 	static int s_RedoButton = 0;
-	if(DoButton_FontIcon(&s_RedoButton, FONT_ICON_REDO, m_ServerSettingsHistory.CanRedo() ? 0 : -1, &Button, BUTTONFLAG_LEFT, "[Ctrl+Y] Redo the last command edit.", IGraphics::CORNER_R, 11.0f))
+	if(DoButton_FontIcon(&s_RedoButton, FONT_ICON_REDO, m_Map.m_ServerSettingsHistory.CanRedo() ? 0 : -1, &Button, BUTTONFLAG_LEFT, "[Ctrl+Y] Redo the last command edit.", IGraphics::CORNER_R, 11.0f))
 	{
-		m_ServerSettingsHistory.Redo();
+		m_Map.m_ServerSettingsHistory.Redo();
 	}
 
 	// undo button
 	ToolBar.VSplitRight(25.0f, &ToolBar, &Button);
 	ToolBar.VSplitRight(5.0f, &ToolBar, nullptr);
 	static int s_UndoButton = 0;
-	if(DoButton_FontIcon(&s_UndoButton, FONT_ICON_UNDO, m_ServerSettingsHistory.CanUndo() ? 0 : -1, &Button, BUTTONFLAG_LEFT, "[Ctrl+Z] Undo the last command edit.", IGraphics::CORNER_L, 11.0f))
+	if(DoButton_FontIcon(&s_UndoButton, FONT_ICON_UNDO, m_Map.m_ServerSettingsHistory.CanUndo() ? 0 : -1, &Button, BUTTONFLAG_LEFT, "[Ctrl+Z] Undo the last command edit.", IGraphics::CORNER_L, 11.0f))
 	{
-		m_ServerSettingsHistory.Undo();
+		m_Map.m_ServerSettingsHistory.Undo();
 	}
 
 	GotSelection = s_ListBox.Active() && s_CommandSelectedIndex >= 0 && (size_t)s_CommandSelectedIndex < m_Map.m_vSettings.size();
@@ -169,14 +169,14 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 			}
 			if(Found)
 			{
-				m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(this, CEditorCommandAction::EType::DELETE, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand));
+				m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::DELETE, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand));
 				m_Map.m_vSettings.erase(m_Map.m_vSettings.begin() + s_CommandSelectedIndex);
 				s_CommandSelectedIndex = i > s_CommandSelectedIndex ? i - 1 : i;
 			}
 			else
 			{
 				const char *pStr = m_SettingsCommandInput.GetString();
-				m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(this, CEditorCommandAction::EType::EDIT, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr));
+				m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::EDIT, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr));
 				str_copy(m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr);
 			}
 		}
@@ -185,7 +185,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 			if(s_CommandSelectedIndex == CollidingCommandIndex)
 			{ // If we are editing the currently collinding line, then we can just call EDIT on it
 				const char *pStr = m_SettingsCommandInput.GetString();
-				m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(this, CEditorCommandAction::EType::EDIT, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr));
+				m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::EDIT, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr));
 				str_copy(m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr);
 			}
 			else
@@ -195,16 +195,16 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 				char aBuf[256];
 				str_format(aBuf, sizeof(aBuf), "Delete command %d; Edit command %d", CollidingCommandIndex, s_CommandSelectedIndex);
 
-				m_ServerSettingsHistory.BeginBulk();
+				m_Map.m_ServerSettingsHistory.BeginBulk();
 				// Delete the colliding command
-				m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(this, CEditorCommandAction::EType::DELETE, &s_CommandSelectedIndex, CollidingCommandIndex, m_Map.m_vSettings[CollidingCommandIndex].m_aCommand));
+				m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::DELETE, &s_CommandSelectedIndex, CollidingCommandIndex, m_Map.m_vSettings[CollidingCommandIndex].m_aCommand));
 				m_Map.m_vSettings.erase(m_Map.m_vSettings.begin() + CollidingCommandIndex);
 				// Edit the selected command
 				s_CommandSelectedIndex = s_CommandSelectedIndex > CollidingCommandIndex ? s_CommandSelectedIndex - 1 : s_CommandSelectedIndex;
-				m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(this, CEditorCommandAction::EType::EDIT, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr));
+				m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::EDIT, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr));
 				str_copy(m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr);
 
-				m_ServerSettingsHistory.EndBulk(aBuf);
+				m_Map.m_ServerSettingsHistory.EndBulk(aBuf);
 			}
 		}
 
@@ -228,14 +228,14 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 			s_CommandSelectedIndex = CollidingCommandIndex;
 
 			const char *pStr = m_SettingsCommandInput.GetString();
-			m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(this, CEditorCommandAction::EType::EDIT, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr));
+			m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::EDIT, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr));
 			str_copy(m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr);
 		}
 		else if(CanAdd)
 		{
 			m_Map.m_vSettings.emplace_back(m_SettingsCommandInput.GetString());
 			s_CommandSelectedIndex = m_Map.m_vSettings.size() - 1;
-			m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(this, CEditorCommandAction::EType::ADD, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand));
+			m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::ADD, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand));
 		}
 
 		m_Map.OnModify();

--- a/src/game/editor/font_typer.cpp
+++ b/src/game/editor/font_typer.cpp
@@ -181,7 +181,7 @@ void CFontTyper::TextModeOff()
 	if(Editor()->m_Dialog == DIALOG_PSEUDO_FONT_TYPER)
 		Editor()->m_Dialog = DIALOG_NONE;
 	if(m_TilesPlacedSinceActivate)
-		Editor()->m_EditorHistory.RecordAction(std::make_shared<CEditorBrushDrawAction>(Editor(), Editor()->m_SelectedGroup), "Font typer");
+		Editor()->m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorBrushDrawAction>(&Editor()->m_Map, Editor()->m_SelectedGroup), "Font typer");
 	m_TilesPlacedSinceActivate = 0;
 	m_Active = false;
 	m_pLastLayer = nullptr;

--- a/src/game/editor/mapitems/layer_game.cpp
+++ b/src/game/editor/mapitems/layer_game.cpp
@@ -37,7 +37,7 @@ void CLayerGame::SetTile(int x, int y, CTile Tile)
 			Map()->m_pGameGroup->AddLayer(pLayerFront);
 			int GameGroupIndex = std::find(Map()->m_vpGroups.begin(), Map()->m_vpGroups.end(), Map()->m_pGameGroup) - Map()->m_vpGroups.begin();
 			int LayerIndex = Map()->m_vpGroups[GameGroupIndex]->m_vpLayers.size() - 1;
-			Editor()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Editor(), GameGroupIndex, LayerIndex));
+			Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), GameGroupIndex, LayerIndex));
 		}
 		CLayerTiles::SetTile(x, y, CTile{TILE_NOHOOK});
 		Map()->m_pFrontLayer->CLayerTiles::SetTile(x, y, CTile{TILE_THROUGH_CUT}); // NOLINT(bugprone-parent-virtual-call)

--- a/src/game/editor/mapitems/layer_quads.cpp
+++ b/src/game/editor/mapitems/layer_quads.cpp
@@ -130,7 +130,7 @@ void CLayerQuads::BrushPlace(CLayer *pBrush, vec2 WorldPos)
 		m_vQuads.push_back(NewQuad);
 		vAddedQuads.push_back(NewQuad);
 	}
-	Editor()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionQuadPlace>(Editor(), Editor()->m_SelectedGroup, Editor()->m_vSelectedLayers[0], vAddedQuads));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionQuadPlace>(Map(), Editor()->m_SelectedGroup, Editor()->m_vSelectedLayers[0], vAddedQuads));
 	Map()->OnModify();
 }
 
@@ -211,8 +211,7 @@ CUi::EPopupMenuFunctionResult CLayerQuads::RenderProperties(CUIRect *pToolBox)
 		Map()->OnModify();
 	}
 
-	static CLayerQuadsPropTracker s_Tracker(Editor());
-	s_Tracker.Begin(this, Prop, State);
+	Map()->m_LayerQuadPropTracker.Begin(this, Prop, State);
 
 	if(Prop == ELayerQuadsProp::PROP_IMAGE)
 	{
@@ -222,7 +221,7 @@ CUi::EPopupMenuFunctionResult CLayerQuads::RenderProperties(CUIRect *pToolBox)
 			m_Image = -1;
 	}
 
-	s_Tracker.End(Prop, State);
+	Map()->m_LayerQuadPropTracker.End(Prop, State);
 
 	return CUi::POPUP_KEEP_OPEN;
 }

--- a/src/game/editor/mapitems/layer_sounds.cpp
+++ b/src/game/editor/mapitems/layer_sounds.cpp
@@ -153,7 +153,7 @@ void CLayerSounds::BrushPlace(CLayer *pBrush, vec2 WorldPos)
 		m_vSources.push_back(NewSource);
 		vAddedSources.push_back(NewSource);
 	}
-	Editor()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionSoundPlace>(Editor(), Editor()->m_SelectedGroup, Editor()->m_vSelectedLayers[0], vAddedSources));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionSoundPlace>(Map(), Editor()->m_SelectedGroup, Editor()->m_vSelectedLayers[0], vAddedSources));
 	Map()->OnModify();
 }
 
@@ -172,8 +172,7 @@ CUi::EPopupMenuFunctionResult CLayerSounds::RenderProperties(CUIRect *pToolBox)
 		Map()->OnModify();
 	}
 
-	static CLayerSoundsPropTracker s_Tracker(Editor());
-	s_Tracker.Begin(this, Prop, State);
+	Map()->m_LayerSoundsPropTracker.Begin(this, Prop, State);
 
 	if(Prop == ELayerSoundsProp::PROP_SOUND)
 	{
@@ -183,7 +182,7 @@ CUi::EPopupMenuFunctionResult CLayerSounds::RenderProperties(CUIRect *pToolBox)
 			m_Sound = -1;
 	}
 
-	s_Tracker.End(Prop, State);
+	Map()->m_LayerSoundsPropTracker.End(Prop, State);
 
 	return CUi::POPUP_KEEP_OPEN;
 }

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -99,7 +99,7 @@ void CLayerTiles::SetTile(int x, int y, CTile Tile)
 				Map()->m_pGameGroup->AddLayer(pLayerTele);
 				int GameGroupIndex = std::find(Map()->m_vpGroups.begin(), Map()->m_vpGroups.end(), Map()->m_pGameGroup) - Map()->m_vpGroups.begin();
 				int LayerIndex = Map()->m_vpGroups[GameGroupIndex]->m_vpLayers.size() - 1;
-				Editor()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Editor(), GameGroupIndex, LayerIndex));
+				Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), GameGroupIndex, LayerIndex));
 			}
 
 			pLayer = Map()->m_pTeleLayer;
@@ -806,9 +806,9 @@ void CLayerTiles::FillGameTiles(EGameTileOp Fill)
 				const int NewW = pGLayer->m_Width < m_Width + OffsetX ? m_Width + OffsetX : pGLayer->m_Width;
 				const int NewH = pGLayer->m_Height < m_Height + OffsetY ? m_Height + OffsetY : pGLayer->m_Height;
 				pGLayer->Resize(NewW, NewH);
-				vpActions.push_back(std::make_shared<CEditorActionEditLayerTilesProp>(Editor(), GameGroupIndex, GameLayerIndex, ETilesProp::PROP_WIDTH, PrevW, NewW));
+				vpActions.push_back(std::make_shared<CEditorActionEditLayerTilesProp>(Map(), GameGroupIndex, GameLayerIndex, ETilesProp::PROP_WIDTH, PrevW, NewW));
 				const std::shared_ptr<CEditorActionEditLayerTilesProp> &Action1 = std::static_pointer_cast<CEditorActionEditLayerTilesProp>(vpActions[vpActions.size() - 1]);
-				vpActions.push_back(std::make_shared<CEditorActionEditLayerTilesProp>(Editor(), GameGroupIndex, GameLayerIndex, ETilesProp::PROP_HEIGHT, PrevH, NewH));
+				vpActions.push_back(std::make_shared<CEditorActionEditLayerTilesProp>(Map(), GameGroupIndex, GameLayerIndex, ETilesProp::PROP_HEIGHT, PrevH, NewH));
 				const std::shared_ptr<CEditorActionEditLayerTilesProp> &Action2 = std::static_pointer_cast<CEditorActionEditLayerTilesProp>(vpActions[vpActions.size() - 1]);
 
 				Action1->SetSavedLayers(SavedLayers);
@@ -828,10 +828,10 @@ void CLayerTiles::FillGameTiles(EGameTileOp Fill)
 				}
 			}
 
-			vpActions.push_back(std::make_shared<CEditorBrushDrawAction>(Editor(), GameGroupIndex));
+			vpActions.push_back(std::make_shared<CEditorBrushDrawAction>(Map(), GameGroupIndex));
 			char aDisplay[256];
 			str_format(aDisplay, sizeof(aDisplay), "Construct '%s' game tiles (x%d)", GAME_TILE_OP_NAMES[(int)Fill], Changes);
-			Editor()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionBulk>(Editor(), vpActions, aDisplay, true));
+			Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionBulk>(Map(), vpActions, aDisplay, true));
 		}
 		else
 		{
@@ -841,7 +841,7 @@ void CLayerTiles::FillGameTiles(EGameTileOp Fill)
 				Map()->MakeTeleLayer(pLayer);
 				Map()->m_pGameGroup->AddLayer(pLayer);
 
-				vpActions.push_back(std::make_shared<CEditorActionAddLayer>(Editor(), GameGroupIndex, Map()->m_pGameGroup->m_vpLayers.size() - 1));
+				vpActions.push_back(std::make_shared<CEditorActionAddLayer>(Map(), GameGroupIndex, Map()->m_pGameGroup->m_vpLayers.size() - 1));
 
 				if(m_Width != pGLayer->m_Width || m_Height > pGLayer->m_Height)
 				{
@@ -863,9 +863,9 @@ void CLayerTiles::FillGameTiles(EGameTileOp Fill)
 					int PrevW = pGLayer->m_Width;
 					int PrevH = pGLayer->m_Height;
 					pLayer->Resize(NewW, NewH);
-					vpActions.push_back(std::make_shared<CEditorActionEditLayerTilesProp>(Editor(), GameGroupIndex, GameLayerIndex, ETilesProp::PROP_WIDTH, PrevW, NewW));
+					vpActions.push_back(std::make_shared<CEditorActionEditLayerTilesProp>(Map(), GameGroupIndex, GameLayerIndex, ETilesProp::PROP_WIDTH, PrevW, NewW));
 					const std::shared_ptr<CEditorActionEditLayerTilesProp> &Action1 = std::static_pointer_cast<CEditorActionEditLayerTilesProp>(vpActions[vpActions.size() - 1]);
-					vpActions.push_back(std::make_shared<CEditorActionEditLayerTilesProp>(Editor(), GameGroupIndex, GameLayerIndex, ETilesProp::PROP_HEIGHT, PrevH, NewH));
+					vpActions.push_back(std::make_shared<CEditorActionEditLayerTilesProp>(Map(), GameGroupIndex, GameLayerIndex, ETilesProp::PROP_HEIGHT, PrevH, NewH));
 					const std::shared_ptr<CEditorActionEditLayerTilesProp> &Action2 = std::static_pointer_cast<CEditorActionEditLayerTilesProp>(vpActions[vpActions.size() - 1]);
 
 					Action1->SetSavedLayers(SavedLayers);
@@ -888,8 +888,8 @@ void CLayerTiles::FillGameTiles(EGameTileOp Fill)
 				int NewH = pTLayer->m_Height < m_Height + OffsetY ? m_Height + OffsetY : pTLayer->m_Height;
 				pTLayer->Resize(NewW, NewH);
 				std::shared_ptr<CEditorActionEditLayerTilesProp> Action1, Action2;
-				vpActions.push_back(Action1 = std::make_shared<CEditorActionEditLayerTilesProp>(Editor(), GameGroupIndex, TeleLayerIndex, ETilesProp::PROP_WIDTH, PrevW, NewW));
-				vpActions.push_back(Action2 = std::make_shared<CEditorActionEditLayerTilesProp>(Editor(), GameGroupIndex, TeleLayerIndex, ETilesProp::PROP_HEIGHT, PrevH, NewH));
+				vpActions.push_back(Action1 = std::make_shared<CEditorActionEditLayerTilesProp>(Map(), GameGroupIndex, TeleLayerIndex, ETilesProp::PROP_WIDTH, PrevW, NewW));
+				vpActions.push_back(Action2 = std::make_shared<CEditorActionEditLayerTilesProp>(Map(), GameGroupIndex, TeleLayerIndex, ETilesProp::PROP_HEIGHT, PrevH, NewH));
 
 				Action1->SetSavedLayers(SavedLayers);
 				Action2->SetSavedLayers(SavedLayers);
@@ -924,10 +924,10 @@ void CLayerTiles::FillGameTiles(EGameTileOp Fill)
 				}
 			}
 
-			vpActions.push_back(std::make_shared<CEditorBrushDrawAction>(Editor(), GameGroupIndex));
+			vpActions.push_back(std::make_shared<CEditorBrushDrawAction>(Map(), GameGroupIndex));
 			char aDisplay[256];
 			str_format(aDisplay, sizeof(aDisplay), "Construct 'tele' game tiles (x%d)", Changes);
-			Editor()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionBulk>(Editor(), vpActions, aDisplay, true));
+			Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionBulk>(Map(), vpActions, aDisplay, true));
 		}
 	}
 }
@@ -1007,7 +1007,7 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 					if(!m_TilesHistory.empty()) // Sometimes pressing that button causes the automap to run so we should be able to undo that
 					{
 						// record undo
-						Editor()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Editor(), Editor()->m_SelectedGroup, Editor()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
+						Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Map(), Editor()->m_SelectedGroup, Editor()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
 						ClearHistory();
 					}
 				}
@@ -1018,7 +1018,7 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 			{
 				Map()->m_vpImages[m_Image]->m_AutoMapper.Proceed(this, Map()->m_pGameLayer.get(), m_AutoMapperReference, m_AutoMapperConfig, m_Seed);
 				// record undo
-				Editor()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Editor(), Editor()->m_SelectedGroup, Editor()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
+				Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Map(), Editor()->m_SelectedGroup, Editor()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
 				ClearHistory();
 				return CUi::POPUP_CLOSE_CURRENT;
 			}
@@ -1059,9 +1059,8 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 	int NewVal = 0;
 	auto [State, Prop] = Editor()->DoPropertiesWithState<ETilesProp>(pToolBox, aProps, s_aIds, &NewVal);
 
-	static CLayerTilesPropTracker s_Tracker(Editor());
-	s_Tracker.Begin(this, Prop, State);
-	Editor()->m_EditorHistory.BeginBulk();
+	Map()->m_LayerTilesPropTracker.Begin(this, Prop, State);
+	Map()->m_EditorHistory.BeginBulk();
 
 	if(Prop == ETilesProp::PROP_WIDTH && NewVal > 1)
 	{
@@ -1155,7 +1154,7 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 		m_LiveGameTiles = NewVal != 0;
 	}
 
-	s_Tracker.End(Prop, State);
+	Map()->m_LayerTilesPropTracker.End(Prop, State);
 
 	// Check if modified property could have an effect on automapper
 	if((State == EEditState::END || State == EEditState::ONE_GO) && HasAutomapEffect(Prop))
@@ -1165,7 +1164,7 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 		// Record undo if automapper was ran
 		if(m_AutoAutoMap && !m_TilesHistory.empty())
 		{
-			Editor()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Editor(), Editor()->m_SelectedGroup, Editor()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
+			Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Map(), Editor()->m_SelectedGroup, Editor()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
 			ClearHistory();
 		}
 	}
@@ -1173,13 +1172,14 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 	// End undo bulk, taking the first action display as the displayed text in the history
 	// This is usually the resulting text of the edit layer tiles prop action
 	// Since we may also squeeze a tile changes action, we want both to appear as one, thus using a bulk
-	Editor()->m_EditorHistory.EndBulk(0);
+	Map()->m_EditorHistory.EndBulk(0);
 
 	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUi::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditor *pEditor, CUIRect *pToolbox, std::vector<std::shared_ptr<CLayerTiles>> &vpLayers, std::vector<int> &vLayerIndices)
+CUi::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditorMap *pEditorMap, CUIRect *pToolbox, std::vector<std::shared_ptr<CLayerTiles>> &vpLayers, std::vector<int> &vLayerIndices)
 {
+	CEditor *pEditor = pEditorMap->Editor();
 	if(State.m_Modified)
 	{
 		CUIRect Commit;
@@ -1202,18 +1202,18 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropSta
 					SavedLayers[LAYERTYPE_TILES] = pLayer->Duplicate();
 					if(pLayer->m_HasGame || pLayer->m_HasFront || pLayer->m_HasSwitch || pLayer->m_HasSpeedup || pLayer->m_HasTune || pLayer->m_HasTele)
 					{ // Need to save all entities layers when any entity layer
-						if(pEditor->m_Map.m_pFrontLayer && !pLayer->m_HasFront)
-							SavedLayers[LAYERTYPE_FRONT] = pEditor->m_Map.m_pFrontLayer->Duplicate();
-						if(pEditor->m_Map.m_pTeleLayer && !pLayer->m_HasTele)
-							SavedLayers[LAYERTYPE_TELE] = pEditor->m_Map.m_pTeleLayer->Duplicate();
-						if(pEditor->m_Map.m_pSwitchLayer && !pLayer->m_HasSwitch)
-							SavedLayers[LAYERTYPE_SWITCH] = pEditor->m_Map.m_pSwitchLayer->Duplicate();
-						if(pEditor->m_Map.m_pSpeedupLayer && !pLayer->m_HasSpeedup)
-							SavedLayers[LAYERTYPE_SPEEDUP] = pEditor->m_Map.m_pSpeedupLayer->Duplicate();
-						if(pEditor->m_Map.m_pTuneLayer && !pLayer->m_HasTune)
-							SavedLayers[LAYERTYPE_TUNE] = pEditor->m_Map.m_pTuneLayer->Duplicate();
+						if(pEditorMap->m_pFrontLayer && !pLayer->m_HasFront)
+							SavedLayers[LAYERTYPE_FRONT] = pEditorMap->m_pFrontLayer->Duplicate();
+						if(pEditorMap->m_pTeleLayer && !pLayer->m_HasTele)
+							SavedLayers[LAYERTYPE_TELE] = pEditorMap->m_pTeleLayer->Duplicate();
+						if(pEditorMap->m_pSwitchLayer && !pLayer->m_HasSwitch)
+							SavedLayers[LAYERTYPE_SWITCH] = pEditorMap->m_pSwitchLayer->Duplicate();
+						if(pEditorMap->m_pSpeedupLayer && !pLayer->m_HasSpeedup)
+							SavedLayers[LAYERTYPE_SPEEDUP] = pEditorMap->m_pSpeedupLayer->Duplicate();
+						if(pEditorMap->m_pTuneLayer && !pLayer->m_HasTune)
+							SavedLayers[LAYERTYPE_TUNE] = pEditorMap->m_pTuneLayer->Duplicate();
 						if(!pLayer->m_HasGame)
-							SavedLayers[LAYERTYPE_GAME] = pEditor->m_Map.m_pGameLayer->Duplicate();
+							SavedLayers[LAYERTYPE_GAME] = pEditorMap->m_pGameLayer->Duplicate();
 					}
 
 					int PrevW = pLayer->m_Width;
@@ -1223,14 +1223,14 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropSta
 					if(PrevW != State.m_Width)
 					{
 						std::shared_ptr<CEditorActionEditLayerTilesProp> pAction;
-						vpActions.push_back(pAction = std::make_shared<CEditorActionEditLayerTilesProp>(pEditor, GroupIndex, LayerIndex, ETilesProp::PROP_WIDTH, PrevW, State.m_Width));
+						vpActions.push_back(pAction = std::make_shared<CEditorActionEditLayerTilesProp>(pEditorMap, GroupIndex, LayerIndex, ETilesProp::PROP_WIDTH, PrevW, State.m_Width));
 						pAction->SetSavedLayers(SavedLayers);
 					}
 
 					if(PrevH != State.m_Height)
 					{
 						std::shared_ptr<CEditorActionEditLayerTilesProp> pAction;
-						vpActions.push_back(pAction = std::make_shared<CEditorActionEditLayerTilesProp>(pEditor, GroupIndex, LayerIndex, ETilesProp::PROP_HEIGHT, PrevH, State.m_Height));
+						vpActions.push_back(pAction = std::make_shared<CEditorActionEditLayerTilesProp>(pEditorMap, GroupIndex, LayerIndex, ETilesProp::PROP_HEIGHT, PrevH, State.m_Height));
 						pAction->SetSavedLayers(SavedLayers);
 					}
 				}
@@ -1239,7 +1239,7 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropSta
 				{
 					const int PackedColor = PackColor(pLayer->m_Color);
 					pLayer->m_Color = UnpackColor(State.m_Color);
-					vpActions.push_back(std::make_shared<CEditorActionEditLayerTilesProp>(pEditor, GroupIndex, LayerIndex, ETilesProp::PROP_COLOR, PackedColor, State.m_Color));
+					vpActions.push_back(std::make_shared<CEditorActionEditLayerTilesProp>(pEditorMap, GroupIndex, LayerIndex, ETilesProp::PROP_COLOR, PackedColor, State.m_Color));
 				}
 
 				pLayer->FlagModified(0, 0, pLayer->m_Width, pLayer->m_Height);
@@ -1248,7 +1248,7 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropSta
 
 			char aDisplay[256];
 			str_format(aDisplay, sizeof(aDisplay), "Edit %d layers common properties: %s", (int)vpLayers.size(), HasModifiedColor && HasModifiedSize ? "color, size" : (HasModifiedColor ? "color" : "size"));
-			pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionBulk>(pEditor, vpActions, aDisplay));
+			pEditorMap->m_EditorHistory.RecordAction(std::make_shared<CEditorActionBulk>(pEditorMap, vpActions, aDisplay));
 		}
 	}
 	else
@@ -1290,11 +1290,10 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropSta
 	int NewVal = 0;
 	auto [PropState, Prop] = pEditor->DoPropertiesWithState<ETilesCommonProp>(pToolbox, aProps, s_aIds, &NewVal);
 
-	static CLayerTilesCommonPropTracker s_Tracker(pEditor);
-	s_Tracker.m_vpLayers = vpLayers;
-	s_Tracker.m_vLayerIndices = vLayerIndices;
+	pEditorMap->m_LayerTilesCommonPropTracker.m_vpLayers = vpLayers;
+	pEditorMap->m_LayerTilesCommonPropTracker.m_vLayerIndices = vLayerIndices;
 
-	s_Tracker.Begin(nullptr, Prop, PropState);
+	pEditorMap->m_LayerTilesCommonPropTracker.Begin(nullptr, Prop, PropState);
 
 	if(Prop == ETilesCommonProp::PROP_WIDTH && NewVal > 1)
 	{
@@ -1330,7 +1329,7 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropSta
 		State.m_Color = NewVal;
 	}
 
-	s_Tracker.End(Prop, PropState);
+	pEditorMap->m_LayerTilesCommonPropTracker.End(Prop, PropState);
 
 	if(PropState == EEditState::END || PropState == EEditState::ONE_GO)
 	{

--- a/src/game/editor/mapitems/layer_tiles.h
+++ b/src/game/editor/mapitems/layer_tiles.h
@@ -156,7 +156,7 @@ public:
 		int m_Height = -1;
 		int m_Color = 0;
 	};
-	static CUi::EPopupMenuFunctionResult RenderCommonProperties(SCommonPropState &State, CEditor *pEditor, CUIRect *pToolbox, std::vector<std::shared_ptr<CLayerTiles>> &vpLayers, std::vector<int> &vLayerIndices);
+	static CUi::EPopupMenuFunctionResult RenderCommonProperties(SCommonPropState &State, CEditorMap *pEditorMap, CUIRect *pToolbox, std::vector<std::shared_ptr<CLayerTiles>> &vpLayers, std::vector<int> &vLayerIndices);
 
 	void ModifyImageIndex(const FIndexModifyFunction &IndexModifyFunction) override;
 	void ModifyEnvelopeIndex(const FIndexModifyFunction &IndexModifyFunction) override;

--- a/src/game/editor/mapitems/map.cpp
+++ b/src/game/editor/mapitems/map.cpp
@@ -256,6 +256,11 @@ void CEditorMap::Clean()
 	m_MapInfo.Reset();
 	m_MapInfoTmp.Reset();
 
+	m_EditorHistory.Clear();
+	m_EnvelopeEditorHistory.Clear();
+	m_ServerSettingsHistory.Clear();
+	m_EnvOpTracker.Reset();
+
 	m_SelectedImage = 0;
 	m_SelectedSound = 0;
 }

--- a/src/game/editor/mapitems/map.h
+++ b/src/game/editor/mapitems/map.h
@@ -8,7 +8,9 @@
 #include <engine/shared/datafile.h>
 #include <engine/shared/jobs.h>
 
+#include <game/editor/editor_history.h>
 #include <game/editor/editor_server_settings.h>
+#include <game/editor/editor_trackers.h>
 #include <game/editor/mapitems/envelope.h>
 #include <game/editor/mapitems/layer.h>
 #include <game/editor/references.h>
@@ -49,6 +51,21 @@ class CEditorMap
 {
 public:
 	explicit CEditorMap(CEditor *pEditor) :
+		m_EditorHistory(this),
+		m_ServerSettingsHistory(this),
+		m_EnvelopeEditorHistory(this),
+		m_QuadTracker(this),
+		m_EnvOpTracker(this),
+		m_LayerGroupPropTracker(this),
+		m_LayerPropTracker(this),
+		m_LayerTilesCommonPropTracker(this),
+		m_LayerTilesPropTracker(this),
+		m_LayerQuadPropTracker(this),
+		m_LayerSoundsPropTracker(this),
+		m_SoundSourceOperationTracker(this),
+		m_SoundSourcePropTracker(this),
+		m_SoundSourceRectShapePropTracker(this),
+		m_SoundSourceCircleShapePropTracker(this),
 		m_pEditor(pEditor)
 	{
 	}
@@ -96,6 +113,23 @@ public:
 	};
 	CMapInfo m_MapInfo;
 	CMapInfo m_MapInfoTmp;
+
+	// Undo/Redo
+	CEditorHistory m_EditorHistory;
+	CEditorHistory m_ServerSettingsHistory;
+	CEditorHistory m_EnvelopeEditorHistory;
+	CQuadEditTracker m_QuadTracker;
+	CEnvelopeEditorOperationTracker m_EnvOpTracker;
+	CLayerGroupPropTracker m_LayerGroupPropTracker;
+	CLayerPropTracker m_LayerPropTracker;
+	CLayerTilesCommonPropTracker m_LayerTilesCommonPropTracker;
+	CLayerTilesPropTracker m_LayerTilesPropTracker;
+	CLayerQuadsPropTracker m_LayerQuadPropTracker;
+	CLayerSoundsPropTracker m_LayerSoundsPropTracker;
+	CSoundSourceOperationTracker m_SoundSourceOperationTracker;
+	CSoundSourcePropTracker m_SoundSourcePropTracker;
+	CSoundSourceRectShapePropTracker m_SoundSourceRectShapePropTracker;
+	CSoundSourceCircleShapePropTracker m_SoundSourceCircleShapePropTracker;
 
 	int m_SelectedImage;
 	int m_SelectedSound;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -499,7 +499,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 	{
 		if(pEditor->DoButton_Editor(&s_DeleteButton, "Delete group", 0, &Button, BUTTONFLAG_LEFT, "Delete the group."))
 		{
-			pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionGroup>(pEditor, pEditor->m_SelectedGroup, true));
+			pEditor->m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionGroup>(&pEditor->m_Map, pEditor->m_SelectedGroup, true));
 			pEditor->m_Map.DeleteGroup(pEditor->m_SelectedGroup);
 			pEditor->m_SelectedGroup = maximum(0, pEditor->m_SelectedGroup - 1);
 			return CUi::POPUP_CLOSE_CURRENT;
@@ -559,7 +559,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 				else
 				{
 					// record undo
-					pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(pEditor, pEditor->m_SelectedGroup, GameLayerIndex, "Clean up game tiles", pGameLayer->m_TilesHistory));
+					pEditor->m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(&pEditor->m_Map, pEditor->m_SelectedGroup, GameLayerIndex, "Clean up game tiles", pGameLayer->m_TilesHistory));
 				}
 				pGameLayer->ClearHistory();
 			}
@@ -694,8 +694,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 		pEditor->m_Map.OnModify();
 	}
 
-	static CLayerGroupPropTracker s_Tracker(pEditor);
-	s_Tracker.Begin(pEditor->GetSelectedGroup().get(), Prop, State);
+	pEditor->m_Map.m_LayerGroupPropTracker.Begin(pEditor->GetSelectedGroup().get(), Prop, State);
 
 	if(Prop == EGroupProp::PROP_ORDER)
 	{
@@ -743,7 +742,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 		}
 	}
 
-	s_Tracker.End(Prop, State);
+	pEditor->m_Map.m_LayerGroupPropTracker.End(Prop, State);
 
 	return CUi::POPUP_KEEP_OPEN;
 }
@@ -761,7 +760,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 
 	if(pPopup->m_vpLayers.size() > 1)
 	{
-		return CLayerTiles::RenderCommonProperties(pPopup->m_CommonPropState, pEditor, &View, pPopup->m_vpLayers, pPopup->m_vLayerIndices);
+		return CLayerTiles::RenderCommonProperties(pPopup->m_CommonPropState, &pEditor->m_Map, &View, pPopup->m_vpLayers, pPopup->m_vLayerIndices);
 	}
 
 	const bool EntitiesLayer = pCurrentLayer->IsEntitiesLayer();
@@ -788,7 +787,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 		if(pEditor->DoButton_Editor(&s_DuplicationButton, "Duplicate layer", 0, &DuplicateButton, BUTTONFLAG_LEFT, "Create an identical copy of the selected layer."))
 		{
 			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->DuplicateLayer(pEditor->m_vSelectedLayers[0]);
-			pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(pEditor, pEditor->m_SelectedGroup, pEditor->m_vSelectedLayers[0] + 1, true));
+			pEditor->m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(&pEditor->m_Map, pEditor->m_SelectedGroup, pEditor->m_vSelectedLayers[0] + 1, true));
 			return CUi::POPUP_CLOSE_CURRENT;
 		}
 	}
@@ -833,8 +832,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 		pEditor->m_Map.OnModify();
 	}
 
-	static CLayerPropTracker s_Tracker(pEditor);
-	s_Tracker.Begin(pCurrentLayer.get(), Prop, State);
+	pEditor->m_Map.m_LayerPropTracker.Begin(pCurrentLayer.get(), Prop, State);
 
 	if(Prop == ELayerProp::PROP_ORDER)
 	{
@@ -859,7 +857,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 			pCurrentLayer->m_Flags |= LAYERFLAG_DETAIL;
 	}
 
-	s_Tracker.End(Prop, State);
+	pEditor->m_Map.m_LayerPropTracker.End(Prop, State);
 
 	return pCurrentLayer->RenderProperties(&View);
 }
@@ -896,7 +894,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 		static int s_AspectRatioButton = 0;
 		if(pEditor->DoButton_Editor(&s_AspectRatioButton, "Aspect ratio", 0, &Button, BUTTONFLAG_LEFT, "Resize the current quad based on the aspect ratio of its image."))
 		{
-			pEditor->m_QuadTracker.BeginQuadTrack(pLayer, pEditor->m_vSelectedQuads);
+			pEditor->m_Map.m_QuadTracker.BeginQuadTrack(pLayer, pEditor->m_vSelectedQuads);
 			for(auto &pQuad : vpQuads)
 			{
 				int Top = pQuad->m_aPoints[0].y;
@@ -925,7 +923,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 				pQuad->m_aPoints[3].y = Top + Height;
 				pEditor->m_Map.OnModify();
 			}
-			pEditor->m_QuadTracker.EndQuadTrack();
+			pEditor->m_Map.m_QuadTracker.EndQuadTrack();
 
 			return CUi::POPUP_CLOSE_CURRENT;
 		}
@@ -937,7 +935,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 	static int s_CenterButton = 0;
 	if(pEditor->DoButton_Editor(&s_CenterButton, "Center pivot", 0, &Button, BUTTONFLAG_LEFT, "Center the pivot of the current quad."))
 	{
-		pEditor->m_QuadTracker.BeginQuadTrack(pLayer, pEditor->m_vSelectedQuads);
+		pEditor->m_Map.m_QuadTracker.BeginQuadTrack(pLayer, pEditor->m_vSelectedQuads);
 		int Top = pCurrentQuad->m_aPoints[0].y;
 		int Left = pCurrentQuad->m_aPoints[0].x;
 		int Bottom = pCurrentQuad->m_aPoints[0].y;
@@ -957,7 +955,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 
 		pCurrentQuad->m_aPoints[4].x = Left + (Right - Left) / 2;
 		pCurrentQuad->m_aPoints[4].y = Top + (Bottom - Top) / 2;
-		pEditor->m_QuadTracker.EndQuadTrack();
+		pEditor->m_Map.m_QuadTracker.EndQuadTrack();
 		pEditor->m_Map.OnModify();
 		return CUi::POPUP_CLOSE_CURRENT;
 	}
@@ -968,7 +966,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 	static int s_AlignButton = 0;
 	if(pEditor->DoButton_Editor(&s_AlignButton, "Align", 0, &Button, BUTTONFLAG_LEFT, "Align coordinates of the quad points."))
 	{
-		pEditor->m_QuadTracker.BeginQuadTrack(pLayer, pEditor->m_vSelectedQuads);
+		pEditor->m_Map.m_QuadTracker.BeginQuadTrack(pLayer, pEditor->m_vSelectedQuads);
 		for(auto &pQuad : vpQuads)
 		{
 			for(int k = 1; k < 4; k++)
@@ -978,7 +976,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 			}
 			pEditor->m_Map.OnModify();
 		}
-		pEditor->m_QuadTracker.EndQuadTrack();
+		pEditor->m_Map.m_QuadTracker.EndQuadTrack();
 		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
@@ -988,7 +986,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 	static int s_Button = 0;
 	if(pEditor->DoButton_Editor(&s_Button, "Square", 0, &Button, BUTTONFLAG_LEFT, "Square the current quad."))
 	{
-		pEditor->m_QuadTracker.BeginQuadTrack(pLayer, pEditor->m_vSelectedQuads);
+		pEditor->m_Map.m_QuadTracker.BeginQuadTrack(pLayer, pEditor->m_vSelectedQuads);
 		for(auto &pQuad : vpQuads)
 		{
 			int Top = pQuad->m_aPoints[0].y;
@@ -1018,7 +1016,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 			pQuad->m_aPoints[3].y = Bottom;
 			pEditor->m_Map.OnModify();
 		}
-		pEditor->m_QuadTracker.EndQuadTrack();
+		pEditor->m_Map.m_QuadTracker.EndQuadTrack();
 		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
@@ -1050,7 +1048,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 	auto [State, Prop] = pEditor->DoPropertiesWithState<EQuadProp>(&View, aProps, s_aIds, &NewVal);
 	if(Prop != EQuadProp::PROP_NONE && (State == EEditState::START || State == EEditState::ONE_GO))
 	{
-		pEditor->m_QuadTracker.BeginQuadPropTrack(pLayer, pEditor->m_vSelectedQuads, Prop);
+		pEditor->m_Map.m_QuadTracker.BeginQuadPropTrack(pLayer, pEditor->m_vSelectedQuads, Prop);
 	}
 
 	const float OffsetX = i2fx(NewVal) - pCurrentQuad->m_aPoints[4].x;
@@ -1118,7 +1116,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 
 	if(Prop != EQuadProp::PROP_NONE && (State == EEditState::END || State == EEditState::ONE_GO))
 	{
-		pEditor->m_QuadTracker.EndQuadPropTrack(Prop);
+		pEditor->m_Map.m_QuadTracker.EndQuadPropTrack(Prop);
 		pEditor->m_Map.OnModify();
 	}
 
@@ -1142,7 +1140,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 		std::shared_ptr<CLayerSounds> pLayer = std::static_pointer_cast<CLayerSounds>(pEditor->GetSelectedLayerType(0, LAYERTYPE_SOUNDS));
 		if(pLayer)
 		{
-			pEditor->m_EditorHistory.Execute(std::make_shared<CEditorActionDeleteSoundSource>(pEditor, pEditor->m_SelectedGroup, pEditor->m_vSelectedLayers[0], pEditor->m_SelectedSource));
+			pEditor->m_Map.m_EditorHistory.Execute(std::make_shared<CEditorActionDeleteSoundSource>(&pEditor->m_Map, pEditor->m_SelectedGroup, pEditor->m_vSelectedLayers[0], pEditor->m_SelectedSource));
 		}
 		return CUi::POPUP_CLOSE_CURRENT;
 	}
@@ -1161,7 +1159,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 	static int s_ShapeTypeButton = 0;
 	if(pEditor->DoButton_Editor(&s_ShapeTypeButton, s_apShapeNames[pSource->m_Shape.m_Type], 0, &ShapeButton, BUTTONFLAG_LEFT, "Change sound source shape."))
 	{
-		pEditor->m_EditorHistory.Execute(std::make_shared<CEditorActionEditSoundSourceShape>(pEditor, pEditor->m_SelectedGroup, pEditor->m_vSelectedLayers[0], pEditor->m_SelectedSource, (pSource->m_Shape.m_Type + 1) % CSoundShape::NUM_SHAPES));
+		pEditor->m_Map.m_EditorHistory.Execute(std::make_shared<CEditorActionEditSoundSourceShape>(&pEditor->m_Map, pEditor->m_SelectedGroup, pEditor->m_vSelectedLayers[0], pEditor->m_SelectedSource, (pSource->m_Shape.m_Type + 1) % CSoundShape::NUM_SHAPES));
 	}
 
 	CProperty aProps[] = {
@@ -1186,8 +1184,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 		pEditor->m_Map.OnModify();
 	}
 
-	static CSoundSourcePropTracker s_Tracker(pEditor);
-	s_Tracker.Begin(pSource, Prop, State);
+	pEditor->m_Map.m_SoundSourcePropTracker.Begin(pSource, Prop, State);
 
 	if(Prop == ESoundProp::PROP_POS_X)
 	{
@@ -1248,7 +1245,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 		pSource->m_SoundEnvOffset = NewVal;
 	}
 
-	s_Tracker.End(Prop, State);
+	pEditor->m_Map.m_SoundSourcePropTracker.End(Prop, State);
 
 	// source shape properties
 	switch(pSource->m_Shape.m_Type)
@@ -1268,15 +1265,14 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 			pEditor->m_Map.OnModify();
 		}
 
-		static CSoundSourceCircleShapePropTracker s_ShapeTracker(pEditor);
-		s_ShapeTracker.Begin(pSource, LocalProp, LocalState);
+		pEditor->m_Map.m_SoundSourceCircleShapePropTracker.Begin(pSource, LocalProp, LocalState);
 
 		if(LocalProp == ECircleShapeProp::PROP_CIRCLE_RADIUS)
 		{
 			pSource->m_Shape.m_Circle.m_Radius = NewVal;
 		}
 
-		s_ShapeTracker.End(LocalProp, LocalState);
+		pEditor->m_Map.m_SoundSourceCircleShapePropTracker.End(LocalProp, LocalState);
 		break;
 	}
 
@@ -1296,8 +1292,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 			pEditor->m_Map.OnModify();
 		}
 
-		static CSoundSourceRectShapePropTracker s_ShapeTracker(pEditor);
-		s_ShapeTracker.Begin(pSource, LocalProp, LocalState);
+		pEditor->m_Map.m_SoundSourceRectShapePropTracker.Begin(pSource, LocalProp, LocalState);
 
 		if(LocalProp == ERectangleShapeProp::PROP_RECTANGLE_WIDTH)
 		{
@@ -1308,7 +1303,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 			pSource->m_Shape.m_Rectangle.m_Height = NewVal * 1024;
 		}
 
-		s_ShapeTracker.End(LocalProp, LocalState);
+		pEditor->m_Map.m_SoundSourceRectShapePropTracker.End(LocalProp, LocalState);
 		break;
 	}
 	}
@@ -1344,8 +1339,8 @@ CUi::EPopupMenuFunctionResult CEditor::PopupPoint(void *pContext, CUIRect View, 
 	auto [State, Prop] = pEditor->DoPropertiesWithState<EQuadPointProp>(&View, aProps, s_aIds, &NewVal);
 	if(Prop != EQuadPointProp::PROP_NONE && (State == EEditState::START || State == EEditState::ONE_GO))
 	{
-		pEditor->m_QuadTracker.BeginQuadPointPropTrack(pLayer, pEditor->m_vSelectedQuads, pEditor->m_SelectedQuadPoints);
-		pEditor->m_QuadTracker.AddQuadPointPropTrack(Prop);
+		pEditor->m_Map.m_QuadTracker.BeginQuadPointPropTrack(pLayer, pEditor->m_vSelectedQuads, pEditor->m_SelectedQuadPoints);
+		pEditor->m_Map.m_QuadTracker.AddQuadPointPropTrack(Prop);
 	}
 
 	for(CQuad *pQuad : vpQuads)
@@ -1388,7 +1383,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupPoint(void *pContext, CUIRect View, 
 
 	if(Prop != EQuadPointProp::PROP_NONE && (State == EEditState::END || State == EEditState::ONE_GO))
 	{
-		pEditor->m_QuadTracker.EndQuadPointPropTrack(Prop);
+		pEditor->m_Map.m_QuadTracker.EndQuadPointPropTrack(Prop);
 		pEditor->m_Map.OnModify();
 	}
 
@@ -1440,12 +1435,12 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEnvPoint(void *pContext, CUIRect Vie
 
 				for(int Channel = 0; Channel < 4; ++Channel)
 				{
-					vpActions[Channel] = std::make_shared<CEditorActionEnvelopeEditPoint>(pEditor, pEditor->m_SelectedEnvelope, SelectedIndex, Channel, CEditorActionEnvelopeEditPoint::EEditType::VALUE, s_Values[Channel], f2fx(NewColor[Channel]));
+					vpActions[Channel] = std::make_shared<CEditorActionEnvelopeEditPoint>(&pEditor->m_Map, pEditor->m_SelectedEnvelope, SelectedIndex, Channel, CEditorActionEnvelopeEditPoint::EEditType::VALUE, s_Values[Channel], f2fx(NewColor[Channel]));
 				}
 
 				char aDisplay[256];
 				str_format(aDisplay, sizeof(aDisplay), "Edit color of point %d of envelope %d", SelectedIndex, pEditor->m_SelectedEnvelope);
-				pEditor->m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionBulk>(pEditor, vpActions, aDisplay));
+				pEditor->m_Map.m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionBulk>(&pEditor->m_Map, vpActions, aDisplay));
 			}
 
 			pEditor->m_UpdateEnvPointInfo = true;
@@ -1500,20 +1495,20 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEnvPoint(void *pContext, CUIRect Vie
 			{
 				auto [SelectedIndex, SelectedChannel] = pEditor->m_SelectedTangentInPoint;
 
-				pEditor->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionEditEnvelopePointValue>(pEditor, pEditor->m_SelectedEnvelope, SelectedIndex, SelectedChannel, CEditorActionEditEnvelopePointValue::EType::TANGENT_IN, OldTime, OldValue, CFixedTime::FromSeconds(CurrentTime), f2fx(CurrentValue)));
+				pEditor->m_Map.m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionEditEnvelopePointValue>(&pEditor->m_Map, pEditor->m_SelectedEnvelope, SelectedIndex, SelectedChannel, CEditorActionEditEnvelopePointValue::EType::TANGENT_IN, OldTime, OldValue, CFixedTime::FromSeconds(CurrentTime), f2fx(CurrentValue)));
 				CurrentTime = (pEnvelope->m_vPoints[SelectedIndex].m_Time + pEnvelope->m_vPoints[SelectedIndex].m_Bezier.m_aInTangentDeltaX[SelectedChannel]).AsSeconds();
 			}
 			else if(pEditor->IsTangentOutSelected())
 			{
 				auto [SelectedIndex, SelectedChannel] = pEditor->m_SelectedTangentOutPoint;
 
-				pEditor->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionEditEnvelopePointValue>(pEditor, pEditor->m_SelectedEnvelope, SelectedIndex, SelectedChannel, CEditorActionEditEnvelopePointValue::EType::TANGENT_OUT, OldTime, OldValue, CFixedTime::FromSeconds(CurrentTime), f2fx(CurrentValue)));
+				pEditor->m_Map.m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionEditEnvelopePointValue>(&pEditor->m_Map, pEditor->m_SelectedEnvelope, SelectedIndex, SelectedChannel, CEditorActionEditEnvelopePointValue::EType::TANGENT_OUT, OldTime, OldValue, CFixedTime::FromSeconds(CurrentTime), f2fx(CurrentValue)));
 				CurrentTime = (pEnvelope->m_vPoints[SelectedIndex].m_Time + pEnvelope->m_vPoints[SelectedIndex].m_Bezier.m_aOutTangentDeltaX[SelectedChannel]).AsSeconds();
 			}
 			else
 			{
 				auto [SelectedIndex, SelectedChannel] = pEditor->m_vSelectedEnvelopePoints.front();
-				pEditor->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionEditEnvelopePointValue>(pEditor, pEditor->m_SelectedEnvelope, SelectedIndex, SelectedChannel, CEditorActionEditEnvelopePointValue::EType::POINT, OldTime, OldValue, CFixedTime::FromSeconds(CurrentTime), f2fx(CurrentValue)));
+				pEditor->m_Map.m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionEditEnvelopePointValue>(&pEditor->m_Map, pEditor->m_SelectedEnvelope, SelectedIndex, SelectedChannel, CEditorActionEditEnvelopePointValue::EType::POINT, OldTime, OldValue, CFixedTime::FromSeconds(CurrentTime), f2fx(CurrentValue)));
 
 				if(SelectedIndex != 0)
 				{
@@ -1544,17 +1539,17 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEnvPoint(void *pContext, CUIRect Vie
 		if(pEditor->IsTangentInSelected())
 		{
 			auto [SelectedIndex, SelectedChannel] = pEditor->m_SelectedTangentInPoint;
-			pEditor->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionResetEnvelopePointTangent>(pEditor, pEditor->m_SelectedEnvelope, SelectedIndex, SelectedChannel, true));
+			pEditor->m_Map.m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionResetEnvelopePointTangent>(&pEditor->m_Map, pEditor->m_SelectedEnvelope, SelectedIndex, SelectedChannel, true));
 		}
 		else if(pEditor->IsTangentOutSelected())
 		{
 			auto [SelectedIndex, SelectedChannel] = pEditor->m_SelectedTangentOutPoint;
-			pEditor->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionResetEnvelopePointTangent>(pEditor, pEditor->m_SelectedEnvelope, SelectedIndex, SelectedChannel, false));
+			pEditor->m_Map.m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionResetEnvelopePointTangent>(&pEditor->m_Map, pEditor->m_SelectedEnvelope, SelectedIndex, SelectedChannel, false));
 		}
 		else
 		{
 			auto [SelectedIndex, SelectedChannel] = pEditor->m_vSelectedEnvelopePoints.front();
-			pEditor->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionDeleteEnvelopePoint>(pEditor, pEditor->m_SelectedEnvelope, SelectedIndex));
+			pEditor->m_Map.m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionDeleteEnvelopePoint>(&pEditor->m_Map, pEditor->m_SelectedEnvelope, SelectedIndex));
 		}
 
 		return CUi::POPUP_CLOSE_CURRENT;
@@ -1657,7 +1652,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEnvPointCurveType(void *pContext, CU
 							HelperEnvelope.Eval(CurrentPoint.m_Time.AsSeconds(), Channels, 1);
 							int PrevValue = CurrentPoint.m_aValues[c];
 							CurrentPoint.m_aValues[c] = f2fx(Channels.r);
-							vpActions.push_back(std::make_shared<CEditorActionEnvelopeEditPoint>(pEditor, pEditor->m_SelectedEnvelope, SelectedIndex, SelectedChannel, CEditorActionEnvelopeEditPoint::EEditType::VALUE, PrevValue, CurrentPoint.m_aValues[c]));
+							vpActions.push_back(std::make_shared<CEditorActionEnvelopeEditPoint>(&pEditor->m_Map, pEditor->m_SelectedEnvelope, SelectedIndex, SelectedChannel, CEditorActionEnvelopeEditPoint::EEditType::VALUE, PrevValue, CurrentPoint.m_aValues[c]));
 						}
 					}
 				}
@@ -1666,7 +1661,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEnvPointCurveType(void *pContext, CU
 
 		if(!vpActions.empty())
 		{
-			pEditor->m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionBulk>(pEditor, vpActions, "Project points"));
+			pEditor->m_Map.m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionBulk>(&pEditor->m_Map, vpActions, "Project points"));
 		}
 
 		pEditor->m_Map.OnModify();
@@ -3101,7 +3096,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEnvelopeCurvetype(void *pContext, CU
 			if(PrevCurve != Type)
 			{
 				SelectedPoint.m_Curvetype = Type;
-				pEditor->m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeEditPoint>(pEditor,
+				pEditor->m_Map.m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeEditPoint>(&pEditor->m_Map,
 					pEditor->m_SelectedEnvelope, pEditor->m_PopupEnvelopeSelectedPoint, 0, CEditorActionEnvelopeEditPoint::EEditType::CURVE_TYPE, PrevCurve, SelectedPoint.m_Curvetype));
 				pEditor->m_Map.OnModify();
 				return CUi::POPUP_CLOSE_CURRENT;

--- a/src/game/editor/quadart.cpp
+++ b/src/game/editor/quadart.cpp
@@ -190,7 +190,7 @@ void CEditor::AddQuadArt(bool IgnoreHistory)
 	QuadArt.Create(pLayer);
 
 	if(!IgnoreHistory)
-		m_EditorHistory.RecordAction(std::make_shared<CEditorActionQuadArt>(this, m_QuadArtParameters));
+		m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionQuadArt>(&m_Map, m_QuadArtParameters));
 
 	m_Map.OnModify();
 	OnDialogClose();

--- a/src/game/editor/quick_actions.cpp
+++ b/src/game/editor/quick_actions.cpp
@@ -42,16 +42,16 @@ void CEditor::AddQuadOrSound()
 	}
 
 	if(pLayer->m_Type == LAYERTYPE_QUADS)
-		m_EditorHistory.Execute(std::make_shared<CEditorActionNewEmptyQuad>(this, m_SelectedGroup, m_vSelectedLayers[0], x, y));
+		m_Map.m_EditorHistory.Execute(std::make_shared<CEditorActionNewEmptyQuad>(&m_Map, m_SelectedGroup, m_vSelectedLayers[0], x, y));
 	else if(pLayer->m_Type == LAYERTYPE_SOUNDS)
-		m_EditorHistory.Execute(std::make_shared<CEditorActionNewEmptySound>(this, m_SelectedGroup, m_vSelectedLayers[0], x, y));
+		m_Map.m_EditorHistory.Execute(std::make_shared<CEditorActionNewEmptySound>(&m_Map, m_SelectedGroup, m_vSelectedLayers[0], x, y));
 }
 
 void CEditor::AddGroup()
 {
 	m_Map.NewGroup();
 	m_SelectedGroup = m_Map.m_vpGroups.size() - 1;
-	m_EditorHistory.RecordAction(std::make_shared<CEditorActionGroup>(this, m_SelectedGroup, false));
+	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionGroup>(&m_Map, m_SelectedGroup, false));
 }
 
 void CEditor::AddSoundLayer()
@@ -61,7 +61,7 @@ void CEditor::AddSoundLayer()
 	int LayerIndex = m_Map.m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
 	SelectLayer(LayerIndex);
 	m_Map.m_vpGroups[m_SelectedGroup]->m_Collapse = false;
-	m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(this, m_SelectedGroup, LayerIndex));
+	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(&m_Map, m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddTileLayer()
@@ -71,7 +71,7 @@ void CEditor::AddTileLayer()
 	int LayerIndex = m_Map.m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
 	SelectLayer(LayerIndex);
 	m_Map.m_vpGroups[m_SelectedGroup]->m_Collapse = false;
-	m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(this, m_SelectedGroup, LayerIndex));
+	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(&m_Map, m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddQuadsLayer()
@@ -81,7 +81,7 @@ void CEditor::AddQuadsLayer()
 	int LayerIndex = m_Map.m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
 	SelectLayer(LayerIndex);
 	m_Map.m_vpGroups[m_SelectedGroup]->m_Collapse = false;
-	m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(this, m_SelectedGroup, LayerIndex));
+	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(&m_Map, m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddSwitchLayer()
@@ -92,7 +92,7 @@ void CEditor::AddSwitchLayer()
 	int LayerIndex = m_Map.m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
 	SelectLayer(LayerIndex);
 	m_pBrush->Clear();
-	m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(this, m_SelectedGroup, LayerIndex));
+	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(&m_Map, m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddFrontLayer()
@@ -103,7 +103,7 @@ void CEditor::AddFrontLayer()
 	int LayerIndex = m_Map.m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
 	SelectLayer(LayerIndex);
 	m_pBrush->Clear();
-	m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(this, m_SelectedGroup, LayerIndex));
+	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(&m_Map, m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddTuneLayer()
@@ -114,7 +114,7 @@ void CEditor::AddTuneLayer()
 	int LayerIndex = m_Map.m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
 	SelectLayer(LayerIndex);
 	m_pBrush->Clear();
-	m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(this, m_SelectedGroup, LayerIndex));
+	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(&m_Map, m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddSpeedupLayer()
@@ -125,7 +125,7 @@ void CEditor::AddSpeedupLayer()
 	int LayerIndex = m_Map.m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
 	SelectLayer(LayerIndex);
 	m_pBrush->Clear();
-	m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(this, m_SelectedGroup, LayerIndex));
+	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(&m_Map, m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddTeleLayer()
@@ -136,7 +136,7 @@ void CEditor::AddTeleLayer()
 	int LayerIndex = m_Map.m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
 	SelectLayer(LayerIndex);
 	m_pBrush->Clear();
-	m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(this, m_SelectedGroup, LayerIndex));
+	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(&m_Map, m_SelectedGroup, LayerIndex));
 }
 
 bool CEditor::IsNonGameTileLayerSelected() const
@@ -198,7 +198,7 @@ void CEditor::DeleteSelectedLayer()
 	if(m_Map.m_pGameLayer == pCurrentLayer)
 		return;
 
-	m_EditorHistory.RecordAction(std::make_shared<CEditorActionDeleteLayer>(this, m_SelectedGroup, m_vSelectedLayers[0]));
+	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionDeleteLayer>(&m_Map, m_SelectedGroup, m_vSelectedLayers[0]));
 
 	if(pCurrentLayer == m_Map.m_pFrontLayer)
 		m_Map.m_pFrontLayer = nullptr;

--- a/src/game/editor/tileart.cpp
+++ b/src/game/editor/tileart.cpp
@@ -162,7 +162,7 @@ void CEditor::AddTileart(bool IgnoreHistory)
 
 	if(!IgnoreHistory)
 	{
-		m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileArt>(this, ImageCount, m_aTileartFilename, IndexMap));
+		m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileArt>(&m_Map, ImageCount, m_aTileartFilename, IndexMap));
 	}
 
 	m_TileartImageInfo.Free();


### PR DESCRIPTION
The edit history should be stored separately for each editor map to eventually support opening multiple maps at the same time, each with their own independent history.

Consequently, editor actions are now executed an a specific map instead of the editor's current map.

Property trackers track properties for each map individually to record actions to the respective map's history.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
