### PR TITLE
Reduce false positives in header check

### DIFF
--- a/scripts/check_standard_headers.sh
+++ b/scripts/check_standard_headers.sh
@@ -15,10 +15,10 @@ error_found=0
 # Check each source file for C headers
 for file in $files; do
 	# First check if the file includes any C headers for more efficiency when no C header is used
-	if grep -E "#include\s+<($c_headers_regex)\.h>" "$file" > /dev/null; then
+	if grep -E "^\s*#include\s+<($c_headers_regex)\.h>" "$file" > /dev/null; then
 		# Check each C header individually to print an error message with the appropriate replacement C++ header
 		for ((i = 0; i < ${#c_headers[@]}; i++)); do
-			if grep -E "#include\s+<${c_headers[i]}\.h>" "$file" > /dev/null; then
+			if grep -E "^\s*#include\s+<${c_headers[i]}\.h>" "$file" > /dev/null; then
 				echo "Error: '$file' includes C header '${c_headers[i]}.h'. Include the C++ header '${c_headers_map[i]}' instead."
 			fi
 		done


### PR DESCRIPTION
If a C++ preprocessor directive is prefixed by anything other than a space it is either a syntax error or more likely a comment like this one:

https://github.com/ddnet/ddnet/blob/d3d25bda65b3bbdacb2af90fb41b30351a0aeaf9/src/engine/external/md5/md5.c#L45

This helps me reduce the diff needed in https://github.com/ddnet-community/ddnet_base to pass the CI

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
