### PR TITLE
Minor cleanup of `CVoting`

### DIFF
--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -841,7 +841,7 @@ bool CMenus::RenderServerControlServer(CUIRect MainView, bool UpdateScroll)
 	int TotalShown = 0;
 
 	int i = 0;
-	for(CVoteOptionClient *pOption = GameClient()->m_Voting.m_pFirst; pOption; pOption = pOption->m_pNext, i++)
+	for(const CVoteOptionClient *pOption = GameClient()->m_Voting.FirstOption(); pOption; pOption = pOption->m_pNext, i++)
 	{
 		if(!m_FilterInput.IsEmpty() && !str_utf8_find_nocase(pOption->m_aDescription, m_FilterInput.GetString()))
 			continue;
@@ -854,7 +854,7 @@ bool CMenus::RenderServerControlServer(CUIRect MainView, bool UpdateScroll)
 	s_ListBox.DoStart(19.0f, TotalShown, 1, 3, Selected, &List);
 
 	i = 0;
-	for(CVoteOptionClient *pOption = GameClient()->m_Voting.m_pFirst; pOption; pOption = pOption->m_pNext, i++)
+	for(const CVoteOptionClient *pOption = GameClient()->m_Voting.FirstOption(); pOption; pOption = pOption->m_pNext, i++)
 	{
 		if(!m_FilterInput.IsEmpty() && !str_utf8_find_nocase(pOption->m_aDescription, m_FilterInput.GetString()))
 			continue;
@@ -1003,7 +1003,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 	{
 		if(s_ControlPage == EServerControlTab::SETTINGS)
 		{
-			if(0 <= m_CallvoteSelectedOption && m_CallvoteSelectedOption < GameClient()->m_Voting.m_NumVoteOptions)
+			if(0 <= m_CallvoteSelectedOption && m_CallvoteSelectedOption < GameClient()->m_Voting.NumOptions())
 			{
 				GameClient()->m_Voting.CallvoteOption(m_CallvoteSelectedOption, m_CallvoteReasonInput.GetString());
 				if(g_Config.m_UiCloseWindowAfterChangingSetting)

--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -233,8 +233,8 @@ void CVoting::ClearOptions()
 void CVoting::OnReset()
 {
 	m_Opentime = m_Closetime = 0;
-	m_aDescription[0] = 0;
-	m_aReason[0] = 0;
+	m_aDescription[0] = '\0';
+	m_aReason[0] = '\0';
 	m_Yes = m_No = m_Pass = m_Total = 0;
 	m_Voted = 0;
 	m_ReceivingOptions = false;

--- a/src/game/client/components/voting.h
+++ b/src/game/client/components/voting.h
@@ -7,9 +7,8 @@
 #include <engine/shared/memheap.h>
 
 #include <game/client/component.h>
+#include <game/client/ui_rect.h>
 #include <game/voting.h>
-
-class CUIRect;
 
 class CVoting : public CComponent
 {
@@ -26,13 +25,6 @@ class CVoting : public CComponent
 	int m_Yes, m_No, m_Pass, m_Total;
 	bool m_ReceivingOptions;
 
-	void RemoveOption(const char *pDescription);
-	void ClearOptions();
-	void Callvote(const char *pType, const char *pValue, const char *pReason);
-
-	void RenderBars(CUIRect Bars) const;
-
-public:
 	int m_NumVoteOptions;
 	CVoteOptionClient *m_pFirst;
 	CVoteOptionClient *m_pLast;
@@ -40,11 +32,18 @@ public:
 	CVoteOptionClient *m_pRecycleFirst;
 	CVoteOptionClient *m_pRecycleLast;
 
+	void RemoveOption(const char *pDescription);
+	void ClearOptions();
+	void Callvote(const char *pType, const char *pValue, const char *pReason);
+
+	void RenderBars(CUIRect Bars) const;
+
+public:
 	CVoting();
 	int Sizeof() const override { return sizeof(*this); }
 	void OnReset() override;
 	void OnConsoleInit() override;
-	void OnMessage(int Msgtype, void *pRawMsg) override;
+	void OnMessage(int MsgType, void *pRawMsg) override;
 
 	void Render();
 
@@ -63,6 +62,8 @@ public:
 	const char *VoteDescription() const { return m_aDescription; }
 	const char *VoteReason() const { return m_aReason; }
 	bool IsReceivingOptions() const { return m_ReceivingOptions; }
+	int NumOptions() const { return m_NumVoteOptions; }
+	const CVoteOptionClient *FirstOption() const { return m_pFirst; }
 };
 
 #endif


### PR DESCRIPTION
- Encapsulate member variables. Add `NumOptions` and `FirstOption` getters.
- Rename parameter `Msgtype` to `MsgType`.
- Replace incorrect forward declaration of `CUIRect` with required include.
- Use `'\0'` instead of `0`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
