### PR TITLE
Cleanup: Remove (some) static variables from CEnvelopeState

### DIFF
--- a/src/game/client/components/envelope_state.cpp
+++ b/src/game/client/components/envelope_state.cpp
@@ -35,38 +35,32 @@ void CEnvelopeState::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Resu
 	if(m_pEnvelopePoints->NumPoints() == 0)
 		return;
 
-	// online rendering
-	if(m_OnlineOnly)
-	{
-		// we are doing time integration for smoother animations
-		static nanoseconds s_OnlineTime{0};
-		static const nanoseconds s_NanosPerTick = nanoseconds(1s) / static_cast<int64_t>(Client()->GameTickSpeed());
+	nanoseconds Time;
 
+	// offline rendering (like menu background) relies on local time
+	if(!m_OnlineOnly)
+	{
+		Time = time_get_nanoseconds();
+	}
+	else
+	{
+		// online rendering
 		if(GameClient()->m_Snap.m_pGameInfoObj)
 		{
+			static const nanoseconds s_NanosPerTick = nanoseconds(1s) / static_cast<int64_t>(Client()->GameTickSpeed());
+
 			// get the lerp of the current tick and prev
 			const int MinTick = Client()->PrevGameTick(g_Config.m_ClDummy) - GameClient()->m_Snap.m_pGameInfoObj->m_RoundStartTick;
 			const int CurTick = Client()->GameTick(g_Config.m_ClDummy) - GameClient()->m_Snap.m_pGameInfoObj->m_RoundStartTick;
-			s_OnlineTime = std::chrono::nanoseconds((int64_t)(mix<double>(
-										  0,
-										  (CurTick - MinTick),
-										  (double)Client()->IntraGameTick(g_Config.m_ClDummy)) *
-									  s_NanosPerTick.count())) +
-				       MinTick * s_NanosPerTick;
+
+			double TickRatio = mix<double>(0, CurTick - MinTick, (double)Client()->IntraGameTick(g_Config.m_ClDummy));
+			Time = duration_cast<nanoseconds>(TickRatio * s_NanosPerTick) + MinTick * s_NanosPerTick;
 		}
-		CRenderMap::RenderEvalEnvelope(m_pEnvelopePoints.get(), s_OnlineTime + milliseconds(TimeOffsetMillis), Result, Channels);
+		else
+		{
+			Time = nanoseconds::zero();
+		}
 	}
-	else // offline rendering (like menu background) relies on local time
-	{
-		// integrate over time deltas for smoother animations
-		static auto s_LastLocalTime = time_get_nanoseconds();
-		nanoseconds CurTime = time_get_nanoseconds();
-		static nanoseconds s_Time{0};
-		s_Time += CurTime - s_LastLocalTime;
 
-		CRenderMap::RenderEvalEnvelope(m_pEnvelopePoints.get(), s_Time + milliseconds(TimeOffsetMillis), Result, Channels);
-
-		// update local timer
-		s_LastLocalTime = CurTime;
-	}
+	CRenderMap::RenderEvalEnvelope(m_pEnvelopePoints.get(), Time + milliseconds(TimeOffsetMillis), Result, Channels);
 }


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Remove (some) static variables from CEnvelopeState and use std::chrono more often.

followup of #11293

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

I used chatgpt in order to explain to me the concept of time-delta-integration in animation in order to find out, if we should keep them (which we should). No code was touched by AI.

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
