### PR TITLE
Fix active quad envelope point changed when moving over other point

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3289,7 +3289,7 @@ void CEditor::UpdateHotQuadPoint(const CLayerQuads *pLayer)
 			for(const auto &EnvPoint : m_Map.m_vpEnvelopes[Quad.m_PosEnv]->m_vPoints)
 			{
 				const vec2 Position = vec2(fx2f(Quad.m_aPoints[4].x) + fx2f(EnvPoint.m_aValues[0]), fx2f(Quad.m_aPoints[4].y) + fx2f(EnvPoint.m_aValues[1]));
-				if(UpdateMinimum(Position, &EnvPoint))
+				if(UpdateMinimum(Position, &EnvPoint) && Ui()->ActiveItem() == nullptr)
 				{
 					m_CurrentQuadIndex = &Quad - pLayer->m_vQuads.data();
 				}


### PR DESCRIPTION
When dragging the active quad envelope point over another quad envelope point that uses a different position envelope, the active item was incorrectly unset or changed to the other point.

Before:

https://github.com/user-attachments/assets/c1a1961a-8e01-4508-9740-5a587af361b0

After:

https://github.com/user-attachments/assets/6e1e50f3-d0bf-4f22-93a1-4bf0791bd268

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions