### PR TITLE
Move team join delay check to `CanJoinTeam`

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1190,12 +1190,7 @@ void CGameContext::AttemptJoinTeam(int ClientId, int Team)
 	}
 
 	char aError[512];
-	if(pPlayer->m_LastDDRaceTeamChange + (int64_t)Server()->TickSpeed() * g_Config.m_SvTeamChangeDelay > Server()->Tick())
-	{
-		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp",
-			"You can't change teams that fast!");
-	}
-	else if(Team != TEAM_FLOCK && m_pController->Teams().TeamLocked(Team) && !m_pController->Teams().IsInvited(Team, ClientId))
+	if(Team != TEAM_FLOCK && m_pController->Teams().TeamLocked(Team) && !m_pController->Teams().IsInvited(Team, ClientId))
 	{
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp",
 			g_Config.m_SvInvite ?

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -389,6 +389,17 @@ bool CGameTeams::CanJoinTeam(int ClientId, int Team, char *pError, int ErrorSize
 		str_format(pError, ErrorSize, "Invalid client ID: %d", ClientId);
 		return false;
 	}
+	const CPlayer *pPlayer = GetPlayer(ClientId);
+	if(!pPlayer)
+	{
+		str_format(pError, ErrorSize, "There is no player with ClientId %d", ClientId);
+		return false;
+	}
+	if(pPlayer->m_LastDDRaceTeamChange + (int64_t)Server()->TickSpeed() * g_Config.m_SvTeamChangeDelay > Server()->Tick())
+	{
+		str_copy(pError, "You can't change teams that fast!", ErrorSize);
+		return false;
+	}
 	if(Team < 0 || Team > NUM_DDRACE_TEAMS)
 	{
 		str_format(pError, ErrorSize, "Invalid team number: %d", Team);
@@ -884,6 +895,11 @@ CPlayer *CGameTeams::GetPlayer(int ClientId)
 	return GameServer()->m_apPlayers[ClientId];
 }
 
+const CPlayer *CGameTeams::GetPlayer(int ClientId) const
+{
+	return GameServer()->m_apPlayers[ClientId];
+}
+
 CGameContext *CGameTeams::GameServer()
 {
 	return m_pGameContext;
@@ -894,7 +910,12 @@ const CGameContext *CGameTeams::GameServer() const
 	return m_pGameContext;
 }
 
-class IServer *CGameTeams::Server()
+IServer *CGameTeams::Server()
+{
+	return m_pGameContext->Server();
+}
+
+const IServer *CGameTeams::Server() const
 {
 	return m_pGameContext->Server();
 }

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -62,9 +62,11 @@ public:
 	CCharacter *Character(int ClientId);
 	const CCharacter *Character(int ClientId) const;
 	CPlayer *GetPlayer(int ClientId);
+	const CPlayer *GetPlayer(int ClientId) const;
 	CGameContext *GameServer();
 	const CGameContext *GameServer() const;
-	class IServer *Server();
+	IServer *Server();
+	const IServer *Server() const;
 
 	void OnCharacterStart(int ClientId);
 	void OnCharacterFinish(int ClientId);


### PR DESCRIPTION
## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions
