### PR TITLE
Improve server logging of auth key usage

### DIFF
--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -581,7 +581,7 @@ def smoke_test(test_env):
 	server.wait_for_log_exact("chat: 0:-2:client1: hello world")
 
 	client1.command(f"rcon_auth {server.rcon_password}")
-	server.wait_for_log_exact("server: ClientId=0 authed with key=default_admin (admin)")
+	server.wait_for_log_exact("server: ClientId=0 authed with key='default_admin' (admin)")
 
 	client1.command("say \"/mc; {}\"".format("; ".join(l.strip() for l in """
 		top5

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1618,12 +1618,9 @@ static inline int MsgFromSixup(int Msg, bool System)
 
 bool CServer::CheckReservedSlotAuth(int ClientId, const char *pPassword)
 {
-	char aBuf[256];
-
 	if(Config()->m_SvReservedSlotsPass[0] && !str_comp(Config()->m_SvReservedSlotsPass, pPassword))
 	{
-		str_format(aBuf, sizeof(aBuf), "cid=%d joining reserved slot with reserved pass", ClientId);
-		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
+		log_info("server", "ClientId=%d joining reserved slot with reserved slots password", ClientId);
 		return true;
 	}
 
@@ -1639,8 +1636,7 @@ bool CServer::CheckReservedSlotAuth(int ClientId, const char *pPassword)
 		int Slot = m_AuthManager.FindKey(aName);
 		if(m_AuthManager.CheckKey(Slot, pInnerPassword + 1) && m_AuthManager.KeyLevel(Slot) >= Config()->m_SvReservedSlotsAuthLevel)
 		{
-			str_format(aBuf, sizeof(aBuf), "cid=%d joining reserved slot with key=%s", ClientId, m_AuthManager.KeyIdent(Slot));
-			Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
+			log_info("server", "ClientId=%d joining reserved slot with key='%s'", ClientId, m_AuthManager.KeyIdent(Slot));
 			return true;
 		}
 	}
@@ -1961,9 +1957,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 			{
 				if(GameServer()->PlayerExists(ClientId))
 				{
-					char aBuf[256];
-					str_format(aBuf, sizeof(aBuf), "ClientId=%d rcon='%s'", ClientId, pCmd);
-					Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
+					log_info("server", "ClientId=%d key='%s' rcon='%s'", ClientId, GetAuthName(ClientId), pCmd);
 					m_RconClientId = ClientId;
 					m_RconAuthLevel = GetAuthedState(ClientId);
 					{
@@ -2041,30 +2035,28 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 						}
 					}
 
-					char aBuf[256];
 					const char *pIdent = m_AuthManager.KeyIdent(KeySlot);
 					switch(AuthLevel)
 					{
 					case AUTHED_ADMIN:
 					{
 						SendRconLine(ClientId, "Admin authentication successful. Full remote console access granted.");
-						str_format(aBuf, sizeof(aBuf), "ClientId=%d authed with key=%s (admin)", ClientId, pIdent);
+						log_info("server", "ClientId=%d authed with key='%s' (admin)", ClientId, pIdent);
 						break;
 					}
 					case AUTHED_MOD:
 					{
 						SendRconLine(ClientId, "Moderator authentication successful. Limited remote console access granted.");
-						str_format(aBuf, sizeof(aBuf), "ClientId=%d authed with key=%s (moderator)", ClientId, pIdent);
+						log_info("server", "ClientId=%d authed with key='%s' (moderator)", ClientId, pIdent);
 						break;
 					}
 					case AUTHED_HELPER:
 					{
 						SendRconLine(ClientId, "Helper authentication successful. Limited remote console access granted.");
-						str_format(aBuf, sizeof(aBuf), "ClientId=%d authed with key=%s (helper)", ClientId, pIdent);
+						log_info("server", "ClientId=%d authed with key='%s' (helper)", ClientId, pIdent);
 						break;
 					}
 					}
-					Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
 
 					// DDRace
 					GameServer()->OnSetAuthed(ClientId, AuthLevel);
@@ -3528,7 +3520,7 @@ void CServer::ConStatus(IConsole::IResult *pResult, void *pUser)
 					pAuthStr = "(Helper)";
 				}
 
-				str_format(aAuthStr, sizeof(aAuthStr), " key=%s %s", pThis->m_AuthManager.KeyIdent(pThis->m_aClients[i].m_AuthKey), pAuthStr);
+				str_format(aAuthStr, sizeof(aAuthStr), " key='%s' %s", pThis->m_AuthManager.KeyIdent(pThis->m_aClients[i].m_AuthKey), pAuthStr);
 			}
 
 			const char *pClientPrefix = "";
@@ -4173,24 +4165,22 @@ void CServer::LogoutClient(int ClientId, const char *pReason)
 	m_aClients[ClientId].m_pRconCmdToSend = nullptr;
 	m_aClients[ClientId].m_MaplistEntryToSend = CClient::MAPLIST_UNINITIALIZED;
 
-	char aBuf[64];
 	if(*pReason)
 	{
+		char aBuf[64];
 		str_format(aBuf, sizeof(aBuf), "Logged out by %s.", pReason);
 		SendRconLine(ClientId, aBuf);
-		str_format(aBuf, sizeof(aBuf), "ClientId=%d with key=%s logged out by %s", ClientId, m_AuthManager.KeyIdent(m_aClients[ClientId].m_AuthKey), pReason);
+		log_info("server", "ClientId=%d with key='%s' logged out by %s", ClientId, m_AuthManager.KeyIdent(m_aClients[ClientId].m_AuthKey), pReason);
 	}
 	else
 	{
 		SendRconLine(ClientId, "Logout successful.");
-		str_format(aBuf, sizeof(aBuf), "ClientId=%d with key=%s logged out", ClientId, m_AuthManager.KeyIdent(m_aClients[ClientId].m_AuthKey));
+		log_info("server", "ClientId=%d with key='%s' logged out", ClientId, m_AuthManager.KeyIdent(m_aClients[ClientId].m_AuthKey));
 	}
 
 	m_aClients[ClientId].m_AuthKey = -1;
 
 	GameServer()->OnSetAuthed(ClientId, AUTHED_NO);
-
-	Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
 }
 
 void CServer::LogoutKey(int Key, const char *pReason)


### PR DESCRIPTION
When executing rcon commands, also log the auth key name instead of only the client ID that executes the command. Addresses part of #11317.

Slightly improve other log messages regarding authentication events. Replace `cid` with `ClientId`. Enclose auth key in apostrophes as it can contain spaces. Use `log_info` instead of `IConsole::Print`.

Using `log_info` also fixes that rcon command log lines could be truncated when executing very long commands.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
