### PR TITLE
Refactor: Rewrite `FindPointIndex` of IEnvelopePointAccess

### DIFF
--- a/src/game/map/render_map.h
+++ b/src/game/map/render_map.h
@@ -26,7 +26,7 @@ public:
 	virtual int NumPoints() const = 0;
 	virtual const CEnvPoint *GetPoint(int Index) const = 0;
 	virtual const CEnvPointBezier *GetBezier(int Index) const = 0;
-	int FindPointIndex(CFixedTime Time) const;
+	int FindPointIndex(const CFixedTime &Time) const;
 };
 
 class CMapBasedEnvelopePointAccess : public IEnvelopePointAccess


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

The current implementation of `FindPointIndex` is not really performant. This PR doesn't really change that, since this would require a bigger overhaul.

The new implementation has 2 core ideas:
- Move the boundary checks into an early exit
- Use the implementation of std::upper_bound and hopefully reduce the number of `GetPoint` calls

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
