### PR TITLE
Feature: Lock scoreboards if you fetch the mouse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2424,6 +2424,8 @@ if(CLIENT)
     components/race_demo.h
     components/scoreboard.cpp
     components/scoreboard.h
+    components/scoreboard_lock.cpp
+    components/scoreboard_lock.h
     components/skins.cpp
     components/skins.h
     components/skins7.cpp

--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -10,6 +10,8 @@
 #include <game/client/ui.h>
 #include <game/client/ui_rect.h>
 
+class CScoreboardLock;
+
 class CScoreboard : public CComponent
 {
 	struct CScoreboardRenderState
@@ -44,6 +46,8 @@ class CScoreboard : public CComponent
 	void SetUiMousePos(vec2 Pos);
 	void LockMouse();
 
+	CScoreboardLock *m_pScoreboardLock;
+
 	class CScoreboardPopupContext : public SPopupMenuId
 	{
 	public:
@@ -71,6 +75,7 @@ class CScoreboard : public CComponent
 
 public:
 	CScoreboard();
+	~CScoreboard() override;
 	int Sizeof() const override { return sizeof(*this); }
 	void OnConsoleInit() override;
 	void OnInit() override;

--- a/src/game/client/components/scoreboard_lock.cpp
+++ b/src/game/client/components/scoreboard_lock.cpp
@@ -1,0 +1,108 @@
+#include "scoreboard_lock.h"
+
+CScoreboardLock::CScoreboardLock()
+{
+	m_IsSet = false;
+
+	ResetLocks();
+
+	// these will be overwritten on demand
+	m_DisconnectedPlayerInfo.m_ClientId = -1;
+	m_DisconnectedPlayerInfo.m_Team = -2;
+	m_DisconnectedClientData.m_aClan[0] = '\0';
+	m_DisconnectedClientData.m_aName[0] = '\0';
+	m_DisconnectedClientData.m_Country = 0;
+
+	// these are fixed
+	m_DisconnectedPlayerInfo.m_Latency = 999; // bad ping
+	m_DisconnectedPlayerInfo.m_Local = 0;
+	m_DisconnectedPlayerInfo.m_Score = -9999; // show no time
+
+	m_DisconnectedClientData.m_Active = true; // we want the disconnected player to show up
+	m_DisconnectedClientData.m_aSkinName[0] = '\0';
+	m_DisconnectedClientData.m_Team = 0; // might be wrong in teammodes :(
+	m_DisconnectedClientData.m_Afk = false;
+	m_DisconnectedClientData.m_AuthLevel = 0; // not authed
+}
+
+void CScoreboardLock::Reset()
+{
+	if(m_IsSet)
+	{
+		m_IsSet = false;
+		ResetLocks();
+	}
+}
+
+void CScoreboardLock::Set(const CNetObj_PlayerInfo *const *ppPlayerInfoSorted, const CGameClient::CClientData *pClientData, int Team)
+{
+	for(int ArrayId = 0; ArrayId < MAX_CLIENTS; ArrayId++)
+	{
+		const CNetObj_PlayerInfo *pInfo = ppPlayerInfoSorted[ArrayId];
+		if(pInfo && pInfo->m_Team == Team)
+		{
+			m_aLockedPlayers[ArrayId].m_Team = pInfo->m_Team;
+			m_aLockedPlayers[ArrayId].m_ClientId = pInfo->m_ClientId;
+			m_aLockedPlayers[ArrayId].m_Lock = EPlayerLockState::CONNECTED;
+
+			m_aLockedPlayers[ArrayId].m_Country = pClientData[pInfo->m_ClientId].m_Country;
+			str_copy(m_aLockedPlayers[ArrayId].m_aName, pClientData[pInfo->m_ClientId].m_aName);
+			str_copy(m_aLockedPlayers[ArrayId].m_aClan, pClientData[pInfo->m_ClientId].m_aClan);
+		}
+	}
+}
+
+void CScoreboardLock::Update(const CNetObj_PlayerInfo *const *ppPlayerInfoById)
+{
+	for(auto &PlayerData : m_aLockedPlayers)
+	{
+		if(PlayerData.m_Lock == EPlayerLockState::CONNECTED && !ppPlayerInfoById[PlayerData.m_ClientId])
+		{
+			PlayerData.m_Lock = EPlayerLockState::DISCONNECTED;
+		}
+		// TODO handle team switches?
+	}
+}
+
+bool CScoreboardLock::IsDisconnected(int ArrayId) const
+{
+	if(!m_IsSet)
+		return false;
+	return m_aLockedPlayers[ArrayId].m_Lock == EPlayerLockState::DISCONNECTED;
+}
+
+bool CScoreboardLock::IsInactive(int ArrayId) const
+{
+	if(!m_IsSet)
+		return false;
+	return m_aLockedPlayers[ArrayId].m_Lock == EPlayerLockState::SLOT_EMPTY;
+}
+
+void CScoreboardLock::ResetLocks()
+{
+	for(auto &LockedPlayer : m_aLockedPlayers)
+	{
+		LockedPlayer.m_aName[0] = '\0';
+		LockedPlayer.m_aClan[0] = '\0';
+		LockedPlayer.m_ClientId = -1;
+		LockedPlayer.m_Lock = EPlayerLockState::SLOT_EMPTY;
+		LockedPlayer.m_Country = 0;
+		LockedPlayer.m_Team = -2;
+	}
+}
+
+const CNetObj_PlayerInfo *CScoreboardLock::DisconnectedPlayerInfo(int ArrayId)
+{
+	m_DisconnectedPlayerInfo.m_ClientId = m_aLockedPlayers[ArrayId].m_ClientId;
+	m_DisconnectedPlayerInfo.m_Team = m_aLockedPlayers[ArrayId].m_Team;
+	return &m_DisconnectedPlayerInfo;
+}
+
+const CGameClient::CClientData *CScoreboardLock::DisconnectedClientData(int ArrayId)
+{
+	// this is not neat, instead we could make a getter for the name and clan
+	str_copy(m_DisconnectedClientData.m_aName, m_aLockedPlayers[ArrayId].m_aName);
+	str_copy(m_DisconnectedClientData.m_aClan, m_aLockedPlayers[ArrayId].m_aClan);
+	m_DisconnectedClientData.m_Country = m_aLockedPlayers[ArrayId].m_Country;
+	return &m_DisconnectedClientData;
+}

--- a/src/game/client/components/scoreboard_lock.h
+++ b/src/game/client/components/scoreboard_lock.h
@@ -1,0 +1,53 @@
+#ifndef GAME_CLIENT_COMPONENTS_SCOREBOARD_LOCK_H
+#define GAME_CLIENT_COMPONENTS_SCOREBOARD_LOCK_H
+
+#include <game/client/gameclient.h>
+
+#include <optional>
+
+class CScoreboardLock
+{
+public:
+	CScoreboardLock();
+
+	void Reset();
+	void Lock() { m_IsSet = true; }
+	bool IsSet() const { return m_IsSet; }
+	void Set(const CNetObj_PlayerInfo *const *ppPlayerInfoSorted, const CGameClient::CClientData *pClientData, int Team);
+	void Update(const CNetObj_PlayerInfo *const *pPlayerInfoById);
+
+	const CNetObj_PlayerInfo *DisconnectedPlayerInfo(int ArrayId);
+	const CGameClient::CClientData *DisconnectedClientData(int ArrayId);
+	bool IsDisconnected(int ArrayId) const;
+	bool IsInactive(int ArrayId) const;
+	int ClientId(int ArrayId) const { return m_aLockedPlayers[ArrayId].m_ClientId; }
+
+private:
+	void ResetLocks();
+
+	enum class EPlayerLockState
+	{
+		CONNECTED,
+		DISCONNECTED,
+		SLOT_EMPTY,
+	};
+
+	class CPlayerLockData
+	{
+	public:
+		int m_ClientId;
+		int m_Team;
+		int m_Country;
+		EPlayerLockState m_Lock;
+		char m_aName[16];
+		char m_aClan[12];
+	};
+
+	CPlayerLockData m_aLockedPlayers[MAX_CLIENTS];
+	bool m_IsSet;
+
+	CNetObj_PlayerInfo m_DisconnectedPlayerInfo;
+	CGameClient::CClientData m_DisconnectedClientData;
+};
+
+#endif


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

As promised to @heinrich5991 and as a followup of #11270 I implemented scoreboard locking. In order to lock the scoreboard, you need to collect the data somewhere if you fetch the mouse. I created an own class for it, as it made it much easier for importing classes (like CGameClient::CClientData) and handling data copies. This is not at all trivial, as you need to copy data from multiple sources.

- The popup still closes, if the ClientId you opened the popup from drops
- Dropped clients are now highlighted dark and you can't click them
- Highlighting is moved to the end in order to highlight **over everything**

Known issues: I don't know how to copy the CNetObject_GameData object. It looks like copying this is disabled. This can cause flags to be displayed wrong potentially.

<img width="2560" height="1440" alt="screenshot_2025-11-27_19-31-29" src="https://github.com/user-attachments/assets/62facd3f-b78d-429e-8bc2-277a6605f623" />

I don't know if some copies might be to shallow, this PR needs extensive testing.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

I wish AI would have been able to help me here at all.

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
