### PR TITLE
Fix scoreboard not opening while menu is active

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -37,9 +37,6 @@ void CScoreboard::ConKeyScoreboard(IConsole::IResult *pResult, void *pUserData)
 {
 	CScoreboard *pSelf = static_cast<CScoreboard *>(pUserData);
 
-	if(pSelf->GameClient()->m_Menus.IsActive())
-		return;
-
 	pSelf->GameClient()->m_Spectator.OnRelease();
 	pSelf->GameClient()->m_Emoticon.OnRelease();
 
@@ -58,7 +55,9 @@ void CScoreboard::ConToggleScoreboardCursor(IConsole::IResult *pResult, void *pU
 {
 	CScoreboard *pSelf = static_cast<CScoreboard *>(pUserData);
 
-	if(!pSelf->IsActive() || pSelf->Client()->State() == IClient::STATE_DEMOPLAYBACK)
+	if(!pSelf->IsActive() ||
+		pSelf->GameClient()->m_Menus.IsActive() ||
+		pSelf->Client()->State() == IClient::STATE_DEMOPLAYBACK)
 	{
 		return;
 	}


### PR DESCRIPTION
Regression from #11270. Usage of `toggle_scoreboard_cursor` should be prevented while the menu is open but not usage of `+scoreboard`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions