### PR TITLE
Revert "Separate infjump and invincible"

### DIFF
--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1104,9 +1104,9 @@ void CCharacter::DDRacePostCoreTick()
 		m_Core.m_Jumped = 1;
 	}
 
-	if((m_Core.m_Super || m_Core.m_EndlessJump) && m_Core.m_Jumped > 1)
+	if((m_Core.m_Super || m_Core.m_Invincible || m_Core.m_EndlessJump) && m_Core.m_Jumped > 1)
 	{
-		// Super players and players with infinite jumps always have light feet
+		// Super players, invincible players and players with infinite jumps always have light feet
 		m_Core.m_Jumped = 1;
 	}
 

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -207,8 +207,6 @@ void CCharacter::SetInvincible(bool Invincible)
 	m_Core.m_Invincible = Invincible;
 	if(Invincible)
 		UnFreeze();
-
-	SetEndlessJump(Invincible);
 }
 
 void CCharacter::SetCollisionDisabled(bool CollisionDisabled)
@@ -2281,9 +2279,9 @@ void CCharacter::DDRacePostCoreTick()
 		m_Core.m_Jumped = 1;
 	}
 
-	if((m_Core.m_Super || m_Core.m_EndlessJump) && m_Core.m_Jumped > 1)
+	if((m_Core.m_Super || m_Core.m_Invincible || m_Core.m_EndlessJump) && m_Core.m_Jumped > 1)
 	{
-		// Super players and players with infinite jumps always have light feet
+		// Super players, invincible players and players with infinite jumps always have light feet
 		m_Core.m_Jumped = 1;
 	}
 

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -498,7 +498,7 @@ bool CSaveHotReloadTee::Load(CCharacter *pChr, int Team)
 {
 	bool Result = m_SaveTee.Load(pChr, Team);
 	pChr->SetSuper(m_Super);
-	pChr->m_Core.m_Invincible = m_Invincible;
+	pChr->SetInvincible(m_Invincible);
 	pChr->GetPlayer()->m_LastTeleTee = m_SavedTeleTee;
 	pChr->GetPlayer()->m_LastDeath = m_LastDeath;
 


### PR DESCRIPTION
This reverts commit 148f4d0ceab47ca17fdf36807992c976dcbf5269.

@KebsCS I think this commit added in another bug -- if a player picks up infinite jump before they enter /invincible and then leaves /invincible, they suddenly lose the original infinite jump powerup. I think this is bad because entering and leaving /invincible should keep the player's prior state to the best possible accuracy.

I don't understand what the original PR fixed, so if this revert also brings back old bugs, I can fix them as well

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
