### PR TITLE
Close scoreboard popups when locking mouse

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -64,6 +64,11 @@ void CScoreboard::ConToggleScoreboardCursor(IConsole::IResult *pResult, void *pU
 
 	pSelf->m_MouseUnlocked = !pSelf->m_MouseUnlocked;
 
+	if(!pSelf->m_MouseUnlocked)
+	{
+		pSelf->Ui()->ClosePopupMenus();
+	}
+
 	vec2 OldMousePos = pSelf->Ui()->MousePos();
 
 	if(pSelf->m_LastMousePos == std::nullopt)


### PR DESCRIPTION
Locking the scoreboard mouse should also close popup menus, as they are not usable without.

Due to the order in which inputs are processed, locking the mouse while the scoreboard is open is only possible when binding `toggle_scoreboard_cursor` to a function key.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions