### PR TITLE
Add `FErrorHandler` type alias for editor map IO

### DIFF
--- a/src/game/editor/mapitems/map.h
+++ b/src/game/editor/mapitems/map.h
@@ -47,6 +47,8 @@ public:
 	const char *GetTempFilename() const { return m_aTempFilename; }
 };
 
+using FErrorHandler = std::function<void(const char *pErrorMessage)>;
+
 class CEditorMap
 {
 public:
@@ -155,10 +157,10 @@ public:
 	void CheckIntegrity();
 
 	// io
-	bool Save(const char *pFilename, const std::function<void(const char *pErrorMessage)> &ErrorHandler);
-	bool PerformPreSaveSanityChecks(const std::function<void(const char *pErrorMessage)> &ErrorHandler);
-	bool Load(const char *pFilename, int StorageType, const std::function<void(const char *pErrorMessage)> &ErrorHandler);
-	void PerformSanityChecks(const std::function<void(const char *pErrorMessage)> &ErrorHandler);
+	bool Save(const char *pFilename, const FErrorHandler &ErrorHandler);
+	bool PerformPreSaveSanityChecks(const FErrorHandler &ErrorHandler);
+	bool Load(const char *pFilename, int StorageType, const FErrorHandler &ErrorHandler);
+	void PerformSanityChecks(const FErrorHandler &ErrorHandler);
 
 	void MakeGameGroup(std::shared_ptr<CLayerGroup> pGroup);
 	void MakeGameLayer(const std::shared_ptr<CLayer> &pLayer);

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -40,7 +40,7 @@ CDataFileWriterFinishJob::CDataFileWriterFinishJob(const char *pRealFilename, co
 	str_copy(m_aTempFilename, pTempFilename);
 }
 
-bool CEditorMap::Save(const char *pFilename, const std::function<void(const char *pErrorMessage)> &ErrorHandler)
+bool CEditorMap::Save(const char *pFilename, const FErrorHandler &ErrorHandler)
 {
 	char aFilenameTmp[IO_MAX_PATH_LENGTH];
 	IStorage::FormatTmpPath(aFilenameTmp, sizeof(aFilenameTmp), pFilename);
@@ -414,7 +414,7 @@ bool CEditorMap::Save(const char *pFilename, const std::function<void(const char
 	return true;
 }
 
-bool CEditorMap::PerformPreSaveSanityChecks(const std::function<void(const char *pErrorMessage)> &ErrorHandler)
+bool CEditorMap::PerformPreSaveSanityChecks(const FErrorHandler &ErrorHandler)
 {
 	bool Success = true;
 	char aErrorMessage[256];
@@ -442,7 +442,7 @@ bool CEditorMap::PerformPreSaveSanityChecks(const std::function<void(const char 
 	return Success;
 }
 
-bool CEditorMap::Load(const char *pFilename, int StorageType, const std::function<void(const char *pErrorMessage)> &ErrorHandler)
+bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandler &ErrorHandler)
 {
 	CDataFileReader DataFile;
 	if(!DataFile.Open(m_pEditor->Storage(), pFilename, StorageType))
@@ -1054,7 +1054,7 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const std::functio
 	return true;
 }
 
-void CEditorMap::PerformSanityChecks(const std::function<void(const char *pErrorMessage)> &ErrorHandler)
+void CEditorMap::PerformSanityChecks(const FErrorHandler &ErrorHandler)
 {
 	// Check if there are any images with a width or height that is not divisible by 16 which are
 	// used in tile layers. Reset the image for these layers, to prevent crashes with some drivers.


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions

