### PR TITLE
Superswap

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -912,12 +912,6 @@ void CGameContext::ConCancelSwap(IConsole::IResult *pResult, void *pUserData)
 
 	int Team = Teams.m_Core.Team(pResult->m_ClientId);
 
-	if(!pSelf->m_pController->Teams().IsValidTeamNumber(Team))
-	{
-		log_info("chatresp", "You aren't in a valid team.");
-		return;
-	}
-
 	bool SwapPending = pPlayer->m_SwapTargetsClientId != -1 && !pSelf->Server()->ClientSlotEmpty(pPlayer->m_SwapTargetsClientId);
 
 	if(!SwapPending)

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -796,9 +796,11 @@ void CGameContext::ConSwap(IConsole::IResult *pResult, void *pUserData)
 
 	int Team = Teams.m_Core.Team(pResult->m_ClientId);
 
-	if(!Teams.IsValidTeamNumber(Team))
+	if(Team == TEAM_SUPER)
 	{
-		log_info("chatresp", "You aren't in a valid team.");
+		log_info(
+			"chatresp",
+			"Turn off super to use swap feature, which means you can swap positions with each other.");
 		return;
 	}
 


### PR DESCRIPTION
Discovered by @KebsCS in https://github.com/ddnet/ddnet/pull/11232

I feel like both checks were changed in a rush or copy pasted resulting in not the most optimal code.

Back in the days there was no swapping in team 0 (TEAM_FLOCK). So this if statement was protecting that case. Then 4 years ago we got swapping in team 0 with https://github.com/ddnet/ddnet/pull/4475.
So this if statement is now only used for super but the error message still talks about teams not about super.

When cancelswap was introduced I assume the check was just copy pasted. But I do not see why super players should not be allowed to cancel their swap.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
