### PR TITLE
Feature: Add option to select your favorite team color

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -99,6 +99,8 @@ MACRO_CONFIG_INT(ClSpecAutoSync, cl_spec_auto_sync, 0, 0, 1, CFGFLAG_CLIENT | CF
 MACRO_CONFIG_INT(ClAirjumpindicator, cl_airjumpindicator, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show the air jump indicator")
 MACRO_CONFIG_INT(ClThreadsoundloading, cl_threadsoundloading, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Load sound files threaded")
 
+MACRO_CONFIG_INT(ClFavoriteTeam, cl_favorite_team, 1, 0, 64, CFGFLAG_CLIENT | CFGFLAG_SAVE, "The favorite team (0 = disable)");
+
 MACRO_CONFIG_INT(ClWarningTeambalance, cl_warning_teambalance, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Warn about team balance")
 
 MACRO_CONFIG_INT(ClMouseDeadzone, cl_mouse_deadzone, 0, 0, 3000, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Deadzone for the camera to follow the cursor")

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1032,9 +1032,18 @@ bool CGameClient::PredictDummy() const
 
 ColorRGBA CGameClient::GetDDTeamColor(int DDTeam, float Lightness) const
 {
+	int ColorTeam = DDTeam;
+	// offset colors to your favorite
+	int LocalTeam = m_Teams.Team(m_aLocalIds[g_Config.m_ClDummy]);
+	if(LocalTeam != TEAM_FLOCK && g_Config.m_ClFavoriteTeam != 0)
+	{
+		ColorTeam = DDTeam + (g_Config.m_ClFavoriteTeam - LocalTeam) + TEAM_SUPER;
+		ColorTeam = ((ColorTeam - 1) % TEAM_SUPER) + 1;
+	}
+
 	// Use golden angle to generate unique colors with distinct adjacent colors.
 	// The first DDTeam (team 1) gets angle 0°, i.e. red hue.
-	const float Hue = std::fmod((DDTeam - 1) * (137.50776f / 360.0f), 1.0f);
+	const float Hue = std::fmod((ColorTeam - 1) * (137.50776f / 360.0f), 1.0f);
 	return color_cast<ColorRGBA>(ColorHSLA(Hue, 1.0f, Lightness));
 }
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This PR adds an option, that your team color always matches your favorite team.

This would solve #10646 without bringing back the old team colors and is a **preparation** for the **removal** of user facing team ids. There is no need for team ids to face the user, if we add a join/invite button in the scoreboard. But if we give a player a random team, he can't select the color anymore.

### Followups:
- Scoreboard join/invite button
- UI for selecting your favorite team
- Removal of team ids from the scoreboard

### Screenshots:

<img width="2560" height="1440" alt="screenshot_2025-11-29_13-35-25" src="https://github.com/user-attachments/assets/9d01b653-a786-4ae9-8213-68a0ba65573a" />
<img width="2560" height="1440" alt="screenshot_2025-11-29_13-35-34" src="https://github.com/user-attachments/assets/a3efa8ef-da60-47f2-a7a0-a70145740734" />
<img width="2560" height="1440" alt="screenshot_2025-11-29_13-35-40" src="https://github.com/user-attachments/assets/e6cfbbc1-ee29-4e88-a8df-916164e4ca5c" />


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
