### PR TITLE
Fix esc when scoreboard is open

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -33,6 +33,14 @@ void CScoreboard::SetUiMousePos(vec2 Pos)
 	Ui()->OnCursorMove(Pos.x - UpdatedMousePos.x, Pos.y - UpdatedMousePos.y);
 }
 
+void CScoreboard::LockMouse()
+{
+	Ui()->ClosePopupMenus();
+	m_MouseUnlocked = false;
+	SetUiMousePos(m_LastMousePos.value());
+	m_LastMousePos = Ui()->MousePos();
+}
+
 void CScoreboard::ConKeyScoreboard(IConsole::IResult *pResult, void *pUserData)
 {
 	CScoreboard *pSelf = static_cast<CScoreboard *>(pUserData);
@@ -44,10 +52,7 @@ void CScoreboard::ConKeyScoreboard(IConsole::IResult *pResult, void *pUserData)
 
 	if(!pSelf->IsActive() && pSelf->m_MouseUnlocked)
 	{
-		pSelf->Ui()->ClosePopupMenus();
-		pSelf->m_MouseUnlocked = false;
-		pSelf->SetUiMousePos(pSelf->m_LastMousePos.value());
-		pSelf->m_LastMousePos = pSelf->Ui()->MousePos();
+		pSelf->LockMouse();
 	}
 }
 
@@ -110,10 +115,7 @@ void CScoreboard::OnRelease()
 
 	if(m_MouseUnlocked)
 	{
-		Ui()->ClosePopupMenus();
-		m_MouseUnlocked = false;
-		SetUiMousePos(m_LastMousePos.value());
-		m_LastMousePos = Ui()->MousePos();
+		LockMouse();
 	}
 }
 
@@ -144,6 +146,12 @@ bool CScoreboard::OnCursorMove(float x, float y, IInput::ECursorType CursorType)
 
 bool CScoreboard::OnInput(const IInput::CEvent &Event)
 {
+	if(m_MouseUnlocked && Event.m_Key == KEY_ESCAPE && (Event.m_Flags & IInput::FLAG_PRESS))
+	{
+		LockMouse();
+		return true;
+	}
+
 	return IsActive() && m_MouseUnlocked;
 }
 
@@ -908,7 +916,6 @@ void CScoreboard::OnRender()
 			RenderTools()->RenderCursor(Ui()->MousePos(), 24.0f);
 
 		Ui()->FinishCheck();
-		Ui()->ClearHotkeys();
 	}
 }
 

--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -42,6 +42,7 @@ class CScoreboard : public CComponent
 	bool m_MouseUnlocked = false;
 
 	void SetUiMousePos(vec2 Pos);
+	void LockMouse();
 
 	class CScoreboardPopupContext : public SPopupMenuId
 	{


### PR DESCRIPTION
Fixes https://github.com/ddnet/ddnet/issues/11332
Scoreboard doesn't call any `Ui()->ConsumeHotkey` so `ClearHotkeys` was redundant here and broke ESC menu key

Also allow locking mouse with Esc key

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
