### PR TITLE
Assert that we never use negative values for ddrace teams

### DIFF
--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -1,6 +1,8 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 #include "gamecontext.h"
 
+#include <base/log.h>
+
 #include <engine/antibot.h>
 #include <engine/shared/config.h>
 
@@ -9,6 +11,7 @@
 #include <game/server/player.h>
 #include <game/server/save.h>
 #include <game/server/teams.h>
+#include <game/teamscore.h>
 
 void CGameContext::ConGoLeft(IConsole::IResult *pResult, void *pUserData)
 {
@@ -523,8 +526,11 @@ void CGameContext::ConSetDDRTeam(IConsole::IResult *pResult, void *pUserData)
 	int Target = pResult->GetVictim();
 	int Team = pResult->GetInteger(1);
 
-	if(!pController->Teams().IsValidTeamNumber(Team))
+	if(Team < 0 || !pController->Teams().IsValidTeamNumber(Team))
+	{
+		log_error("server", "Invalid DDRace Team: %d", Team);
 		return;
+	}
 
 	CCharacter *pChr = pSelf->GetPlayerChar(Target);
 

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -13,6 +13,7 @@
 #include <game/mapitems.h>
 #include <game/server/entities/character.h>
 #include <game/team_state.h>
+#include <game/teamscore.h>
 
 CGameTeams::CGameTeams(CGameContext *pGameContext) :
 	m_pGameContext(pGameContext)
@@ -1438,5 +1439,6 @@ bool CGameTeams::IsPractice(int Team)
 
 bool CGameTeams::IsValidTeamNumber(int Team) const
 {
+	dbg_assert(Team >= TEAM_FLOCK, "Invalid Team: %d", Team);
 	return Team >= TEAM_FLOCK && Team < NUM_DDRACE_TEAMS - 1; // no TEAM_SUPER
 }


### PR DESCRIPTION
CC #11357

I see two places where `Team` is set by user input.
That is the chat command **/team** and the rcon command `set_team_ddr`.
Invalid user input should be dropped in the command.
And at any later point in time it should die with an assert because
the value should not be passed around when invalid.

Before this commit the rcon command `set_team_ddr` would silently fail
when the team is out of bounds.
This commit now shows a helpful error message to the rcon user instead.

Before this commit both the /join and /team command would try to search
for a free team when out of bounds. For the /join command that made
little sense and it also should have never happend.
So this out of bounds logic is now explicitly only moved to the /team
command.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
