### PR TITLE
Refactor ddrace team validation

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -648,7 +648,7 @@ void CGameContext::ConPractice(IConsole::IResult *pResult, void *pUserData)
 
 	int Team = Teams.m_Core.Team(pResult->m_ClientId);
 
-	if(!Teams.IsValidTeamNumber(Team) || (Team == TEAM_FLOCK && g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO))
+	if(Team == TEAM_FLOCK && g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO)
 	{
 		pSelf->Console()->Print(
 			IConsole::OUTPUT_LEVEL_STANDARD,
@@ -838,18 +838,7 @@ void CGameContext::ConSwap(IConsole::IResult *pResult, void *pUserData)
 	}
 
 	CGameTeams &Teams = pSelf->m_pController->Teams();
-
 	int Team = Teams.m_Core.Team(pResult->m_ClientId);
-
-	if(!Teams.IsValidTeamNumber(Team))
-	{
-		pSelf->Console()->Print(
-			IConsole::OUTPUT_LEVEL_STANDARD,
-			"chatresp",
-			"You aren't in a valid team.");
-		return;
-	}
-
 	int TargetClientId = -1;
 	if(pResult->NumArguments() == 1)
 	{
@@ -963,16 +952,6 @@ void CGameContext::ConCancelSwap(IConsole::IResult *pResult, void *pUserData)
 	CGameTeams &Teams = pSelf->m_pController->Teams();
 
 	int Team = Teams.m_Core.Team(pResult->m_ClientId);
-
-	if(!pSelf->m_pController->Teams().IsValidTeamNumber(Team))
-	{
-		pSelf->Console()->Print(
-			IConsole::OUTPUT_LEVEL_STANDARD,
-			"chatresp",
-			"You aren't in a valid team.");
-		return;
-	}
-
 	bool SwapPending = pPlayer->m_SwapTargetsClientId != -1 && !pSelf->Server()->ClientSlotEmpty(pPlayer->m_SwapTargetsClientId);
 
 	if(!SwapPending)
@@ -1086,7 +1065,7 @@ void CGameContext::ConLock(IConsole::IResult *pResult, void *pUserData)
 	if(pResult->NumArguments() > 0)
 		Lock = !pResult->GetInteger(0);
 
-	if(Team == TEAM_FLOCK || !pSelf->m_pController->Teams().IsValidTeamNumber(Team))
+	if(Team == TEAM_FLOCK)
 	{
 		pSelf->Console()->Print(
 			IConsole::OUTPUT_LEVEL_STANDARD,
@@ -1130,7 +1109,8 @@ void CGameContext::ConUnlock(IConsole::IResult *pResult, void *pUserData)
 
 	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientId);
 
-	if(Team == TEAM_FLOCK || !pSelf->m_pController->Teams().IsValidTeamNumber(Team))
+	// TODO: should this print an error?
+	if(Team == TEAM_FLOCK)
 		return;
 
 	if(pSelf->ProcessSpamProtection(pResult->m_ClientId, false))
@@ -1256,7 +1236,7 @@ void CGameContext::ConInvite(IConsole::IResult *pResult, void *pUserData)
 	}
 
 	int Team = pController->Teams().m_Core.Team(pResult->m_ClientId);
-	if(Team != TEAM_FLOCK && pController->Teams().IsValidTeamNumber(Team))
+	if(Team != TEAM_FLOCK)
 	{
 		int Target = -1;
 		for(int i = 0; i < MAX_CLIENTS; i++)
@@ -1327,7 +1307,7 @@ void CGameContext::ConTeam0Mode(IConsole::IResult *pResult, void *pUserData)
 	int Team = pController->Teams().m_Core.Team(pResult->m_ClientId);
 	bool Mode = pController->Teams().TeamFlock(Team);
 
-	if(Team == TEAM_FLOCK || !pController->Teams().IsValidTeamNumber(Team))
+	if(Team == TEAM_FLOCK)
 	{
 		pSelf->Console()->Print(
 			IConsole::OUTPUT_LEVEL_STANDARD,

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2148,7 +2148,7 @@ void CCharacter::SetTeams(CGameTeams *pTeams)
 bool CCharacter::TrySetRescue(int RescueMode)
 {
 	bool Set = false;
-	if(g_Config.m_SvRescue || ((g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || Team() > TEAM_FLOCK) && Teams()->IsValidTeamNumber(Team())))
+	if(g_Config.m_SvRescue || ((g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || Team() > TEAM_FLOCK)))
 	{
 		// check for nearby health pickups (also freeze)
 		bool InHealthPickup = false;

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -69,7 +69,7 @@ void CGameControllerDDRace::HandleCharacterTiles(CCharacter *pChr, int MapIndex)
 			pChr->Die(ClientId, WEAPON_WORLD);
 			return;
 		}
-		if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && Team != TEAM_FLOCK && Teams().IsValidTeamNumber(Team) && Teams().Count(Team) < g_Config.m_SvMinTeamSize && !Teams().TeamFlock(Team))
+		if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && Team != TEAM_FLOCK && Teams().Count(Team) < g_Config.m_SvMinTeamSize && !Teams().TeamFlock(Team))
 		{
 			char aBuf[128];
 			str_format(aBuf, sizeof(aBuf), "Your team has fewer than %d players, so your team rank won't count", g_Config.m_SvMinTeamSize);

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -520,8 +520,9 @@ ESaveResult CSaveTeam::Save(CGameContext *pGameServer, int Team, bool Dry, bool 
 {
 	IGameController *pController = pGameServer->m_pController;
 	CGameTeams *pTeams = &pController->Teams();
+	pTeams->AssertValidTeamNumber(Team);
 
-	if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && (Team == TEAM_FLOCK || !pTeams->IsValidTeamNumber(Team)) && !Force)
+	if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && (Team == TEAM_FLOCK) && !Force)
 		return ESaveResult::TEAM_FLOCK;
 
 	if(pTeams->TeamFlock(Team) && !Force)

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -348,7 +348,7 @@ void CScore::LoadTeam(const char *pCode, int ClientId)
 		GameServer()->SendChatTarget(ClientId, "Team load already in progress");
 		return;
 	}
-	if(!pController->Teams().IsValidTeamNumber(Team) || (g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && Team == TEAM_FLOCK))
+	if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && Team == TEAM_FLOCK)
 	{
 		GameServer()->SendChatTarget(ClientId, "You have to be in a team (from 1-63)");
 		return;

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -727,7 +727,7 @@ void CGameTeams::OnTeamFinish(int Team, CPlayer **Players, unsigned int Size, in
 	{
 		aPlayerCids[i] = Players[i]->GetCid();
 
-		if(g_Config.m_SvRejoinTeam0 && g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && (!IsValidTeamNumber(m_Core.Team(Players[i]->GetCid())) || !m_aTeamLocked[m_Core.Team(Players[i]->GetCid())]))
+		if(g_Config.m_SvRejoinTeam0 && g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && !m_aTeamLocked[m_Core.Team(Players[i]->GetCid())])
 		{
 			SetForceCharacterTeam(Players[i]->GetCid(), TEAM_FLOCK);
 			char aBuf[512];
@@ -1185,7 +1185,7 @@ void CGameTeams::OnCharacterSpawn(int ClientId)
 	if(GetSaving(Team))
 		return;
 
-	if(!IsValidTeamNumber(Team) || !m_aTeamLocked[Team])
+	if(!m_aTeamLocked[Team])
 	{
 		if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO)
 			SetForceCharacterTeam(ClientId, TEAM_FLOCK);
@@ -1275,13 +1275,15 @@ void CGameTeams::OnCharacterDeath(int ClientId, int Weapon)
 
 void CGameTeams::SetTeamLock(int Team, bool Lock)
 {
-	if(Team != TEAM_FLOCK && IsValidTeamNumber(Team))
+	AssertValidTeamNumber(Team);
+	if(Team != TEAM_FLOCK)
 		m_aTeamLocked[Team] = Lock;
 }
 
 void CGameTeams::SetTeamFlock(int Team, bool Mode)
 {
-	if(Team != TEAM_FLOCK && IsValidTeamNumber(Team))
+	AssertValidTeamNumber(Team);
+	if(Team != TEAM_FLOCK)
 		m_aTeamFlock[Team] = Mode;
 }
 
@@ -1292,7 +1294,8 @@ void CGameTeams::ResetInvited(int Team)
 
 void CGameTeams::SetClientInvited(int Team, int ClientId, bool Invited)
 {
-	if(Team != TEAM_FLOCK && IsValidTeamNumber(Team))
+	AssertValidTeamNumber(Team);
+	if(Team != TEAM_FLOCK)
 	{
 		if(Invited)
 			m_aInvited[Team].set(ClientId);
@@ -1357,7 +1360,8 @@ ETeamState CGameTeams::GetTeamState(int Team) const
 
 bool CGameTeams::TeamLocked(int Team) const
 {
-	if(Team == TEAM_FLOCK || !IsValidTeamNumber(Team))
+	AssertValidTeamNumber(Team);
+	if(Team == TEAM_FLOCK)
 		return false;
 
 	return m_aTeamLocked[Team];
@@ -1365,8 +1369,9 @@ bool CGameTeams::TeamLocked(int Team) const
 
 bool CGameTeams::TeamFlock(int Team) const
 {
+	AssertValidTeamNumber(Team);
 	// this is for team0mode, TEAM_FLOCK is handled differently
-	if(Team == TEAM_FLOCK || !IsValidTeamNumber(Team))
+	if(Team == TEAM_FLOCK)
 		return false;
 
 	return m_aTeamFlock[Team];
@@ -1399,8 +1404,7 @@ void CGameTeams::SetSaving(int TeamId, std::shared_ptr<CScoreSaveResult> &SaveRe
 
 bool CGameTeams::GetSaving(int TeamId) const
 {
-	if(!IsValidTeamNumber(TeamId))
-		return false;
+	AssertValidTeamNumber(TeamId);
 	if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && TeamId == TEAM_FLOCK)
 		return false;
 
@@ -1409,8 +1413,7 @@ bool CGameTeams::GetSaving(int TeamId) const
 
 void CGameTeams::SetPractice(int Team, bool Enabled)
 {
-	if(!IsValidTeamNumber(Team))
-		return;
+	AssertValidTeamNumber(Team);
 	if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && Team == TEAM_FLOCK)
 	{
 		// allow to enable practice in team 0, for practice by default
@@ -1423,8 +1426,7 @@ void CGameTeams::SetPractice(int Team, bool Enabled)
 
 bool CGameTeams::IsPractice(int Team)
 {
-	if(!IsValidTeamNumber(Team))
-		return false;
+	AssertValidTeamNumber(Team);
 	if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && Team == TEAM_FLOCK)
 	{
 		if(GameServer()->PracticeByDefault())
@@ -1438,5 +1440,10 @@ bool CGameTeams::IsPractice(int Team)
 
 bool CGameTeams::IsValidTeamNumber(int Team) const
 {
-	return Team >= TEAM_FLOCK && Team < NUM_DDRACE_TEAMS - 1; // no TEAM_SUPER
+	return m_Core.IsValidTeam(Team);
+}
+
+void CGameTeams::AssertValidTeamNumber(int Team) const
+{
+	m_Core.AssertValidTeam(Team);
 }

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -126,6 +126,7 @@ public:
 	void SetPractice(int Team, bool Enabled);
 	bool IsPractice(int Team);
 	bool IsValidTeamNumber(int Team) const;
+	void AssertValidTeamNumber(int Team) const;
 };
 
 #endif

--- a/src/game/teamscore.cpp
+++ b/src/game/teamscore.cpp
@@ -10,6 +10,17 @@ CTeamsCore::CTeamsCore()
 	Reset();
 }
 
+bool CTeamsCore::IsValidTeam(int Team) const
+{
+	// TODO: @KebsCS remove TEAM_SUPER here
+	return Team >= TEAM_FLOCK && Team < NUM_DDRACE_TEAMS;
+}
+
+void CTeamsCore::AssertValidTeam(int Team) const
+{
+	dbg_assert(IsValidTeam(Team), "Invalid Team: %d", Team);
+}
+
 bool CTeamsCore::SameTeam(int ClientId1, int ClientId2) const
 {
 	return m_aTeam[ClientId1] == TEAM_SUPER || m_aTeam[ClientId2] == TEAM_SUPER || m_aTeam[ClientId1] == m_aTeam[ClientId2];
@@ -22,7 +33,7 @@ int CTeamsCore::Team(int ClientId) const
 
 void CTeamsCore::Team(int ClientId, int Team)
 {
-	dbg_assert(Team >= TEAM_FLOCK && Team < NUM_DDRACE_TEAMS, "Invalid Team: %d", Team);
+	AssertValidTeam(Team);
 	m_aTeam[ClientId] = Team;
 }
 

--- a/src/game/teamscore.h
+++ b/src/game/teamscore.h
@@ -31,6 +31,9 @@ public:
 
 	CTeamsCore();
 
+	bool IsValidTeam(int Team) const;
+	void AssertValidTeam(int Team) const;
+
 	bool SameTeam(int ClientId1, int ClientId2) const;
 
 	bool CanKeepHook(int ClientId1, int ClientId2) const;


### PR DESCRIPTION
There were two conditions that determine what a valid ddrace team number is. They are now merged and there is only one source of truth.

The main responsible variable for storing team ids is

`int CTeamsCore::m_aTeam[MAX_CLIENTS];`

It is a private variable. And it is only set in one place. Its setter. That setter has an assert to only store valid team values. But still all over the code base every call to the getter would duplicate the same check
making the entire code more complicated to read.

We can and we should trust this value. It is correct at all times.

Furthermore I only call IsValidTeamNumber in 3ish places for user input. To drop invalid values with an error message as soon as possible.

Any other internal code switched from `IsValidTeamNumber` to `AssertValidTeam`. This will avoid future logic bugs like passing `TEAM_SPECTATOR` to a ddrace team method.

CC #11357
CC #11358

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
