### PR TITLE
Cleanup editor includes

### DIFF
--- a/src/game/editor/auto_map.cpp
+++ b/src/game/editor/auto_map.cpp
@@ -7,6 +7,7 @@
 
 #include <game/editor/editor_actions.h>
 #include <game/editor/mapitems/layer_tiles.h>
+#include <game/editor/mapitems/map.h>
 #include <game/mapitems.h>
 
 #include <cinttypes>

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -12,6 +12,7 @@
 
 #include <engine/client.h>
 #include <engine/console.h>
+#include <engine/engine.h>
 #include <engine/gfx/image_loader.h>
 #include <engine/gfx/image_manipulation.h>
 #include <engine/graphics.h>
@@ -4530,6 +4531,11 @@ void CEditor::RenderSounds(CUIRect ToolBox)
 			m_FileBrowser.ShowFileDialog(IStorage::TYPE_ALL, CFileBrowser::EFileType::SOUND, "Add sound", "Add", "mapres", "", AddSound, this);
 	}
 	s_ScrollRegion.End();
+}
+
+bool CEditor::CStringKeyComparator::operator()(const char *pLhs, const char *pRhs) const
+{
+	return str_comp(pLhs, pRhs) < 0;
 }
 
 void CEditor::ShowFileDialogError(const char *pFormat, ...)

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -14,14 +14,9 @@
 #include "smooth_value.h"
 
 #include <base/bezier.h>
-#include <base/system.h>
 
-#include <engine/console.h>
 #include <engine/editor.h>
-#include <engine/engine.h>
 #include <engine/graphics.h>
-#include <engine/shared/datafile.h>
-#include <engine/shared/jobs.h>
 
 #include <game/client/ui.h>
 #include <game/client/ui_listbox.h>
@@ -345,14 +340,12 @@ public:
 
 	// TODO: The name of the ShowFileDialogError function is not accurate anymore, this is used for generic error messages.
 	//       Popups in UI should be shared_ptrs to make this even more generic.
-	struct SStringKeyComparator
+	class CStringKeyComparator
 	{
-		bool operator()(const char *pLhs, const char *pRhs) const
-		{
-			return str_comp(pLhs, pRhs) < 0;
-		}
+	public:
+		bool operator()(const char *pLhs, const char *pRhs) const;
 	};
-	std::map<const char *, CUi::SMessagePopupContext *, SStringKeyComparator> m_PopupMessageContexts;
+	std::map<const char *, CUi::SMessagePopupContext *, CStringKeyComparator> m_PopupMessageContexts;
 	[[gnu::format(printf, 2, 3)]] void ShowFileDialogError(const char *pFormat, ...);
 
 	void Reset(bool CreateDefault = true);

--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -1,6 +1,14 @@
 #include "editor_actions.h"
 
+#include <game/editor/editor.h>
+#include <game/editor/mapitems.h>
 #include <game/editor/mapitems/image.h>
+#include <game/editor/mapitems/layer.h>
+#include <game/editor/mapitems/layer_front.h>
+#include <game/editor/mapitems/layer_group.h>
+#include <game/editor/mapitems/layer_quads.h>
+#include <game/editor/mapitems/layer_sounds.h>
+#include <game/editor/mapitems/map.h>
 
 CEditorBrushDrawAction::CEditorBrushDrawAction(CEditorMap *pMap, int Group) :
 	IEditorAction(pMap), m_Group(Group)

--- a/src/game/editor/editor_actions.h
+++ b/src/game/editor/editor_actions.h
@@ -1,10 +1,23 @@
 #ifndef GAME_EDITOR_EDITOR_ACTIONS_H
 #define GAME_EDITOR_EDITOR_ACTIONS_H
 
-#include "editor.h"
 #include "editor_action.h"
 
-#include <game/editor/references.h>
+#include <game/editor/mapitems/envelope.h>
+#include <game/editor/mapitems/layer_speedup.h>
+#include <game/editor/mapitems/layer_switch.h>
+#include <game/editor/mapitems/layer_tele.h>
+#include <game/editor/mapitems/layer_tiles.h>
+#include <game/editor/mapitems/layer_tune.h>
+#include <game/editor/quadart.h>
+#include <game/mapitems.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+class CEditorMap;
+class IEditorEnvelopeReference;
 
 class CEditorActionLayerBase : public IEditorAction
 {

--- a/src/game/editor/editor_trackers.h
+++ b/src/game/editor/editor_trackers.h
@@ -1,18 +1,20 @@
 #ifndef GAME_EDITOR_EDITOR_TRACKERS_H
 #define GAME_EDITOR_EDITOR_TRACKERS_H
 
+#include <game/client/ui.h>
 #include <game/editor/map_object.h>
 #include <game/editor/mapitems.h>
-#include <game/editor/mapitems/layer_quads.h>
 #include <game/mapitems.h>
 
 #include <map>
 #include <memory>
 #include <vector>
 
-class CLayerTiles;
+class CLayer;
 class CLayerGroup;
+class CLayerQuads;
 class CLayerSounds;
+class CLayerTiles;
 class CSoundSource;
 
 class CQuadEditTracker : public CMapObject

--- a/src/game/editor/font_typer.cpp
+++ b/src/game/editor/font_typer.cpp
@@ -3,7 +3,7 @@
 #include "editor.h"
 
 #include <base/log.h>
-#include <base/system.h>
+#include <base/str.h>
 
 #include <engine/keys.h>
 

--- a/src/game/editor/font_typer.h
+++ b/src/game/editor/font_typer.h
@@ -7,10 +7,13 @@
 
 #include <engine/graphics.h>
 
-#include <game/editor/mapitems/layer_tiles.h>
+#include <game/client/ui.h>
 
 #include <chrono>
 #include <memory>
+
+class CLayer;
+class CLayerTiles;
 
 class CFontTyper : public CEditorComponent
 {
@@ -24,7 +27,7 @@ class CFontTyper : public CEditorComponent
 	bool m_Active = false;
 	std::chrono::nanoseconds m_CursorRenderTime;
 	IGraphics::CTextureHandle m_CursorTextTexture;
-	std::shared_ptr<class CLayer> m_pLastLayer;
+	std::shared_ptr<CLayer> m_pLastLayer;
 	CUi::SConfirmPopupContext m_ConfirmActivatePopupContext;
 	int m_TilesPlacedSinceActivate = 0;
 

--- a/src/game/editor/mapitems/layer.cpp
+++ b/src/game/editor/mapitems/layer.cpp
@@ -1,6 +1,6 @@
 #include "layer.h"
 
-#include <base/system.h>
+#include <base/str.h>
 
 #include <game/mapitems.h>
 

--- a/src/game/editor/mapitems/layer.h
+++ b/src/game/editor/mapitems/layer.h
@@ -1,8 +1,6 @@
 #ifndef GAME_EDITOR_MAPITEMS_LAYER_H
 #define GAME_EDITOR_MAPITEMS_LAYER_H
 
-#include <base/system.h>
-
 #include <game/client/ui.h>
 #include <game/client/ui_rect.h>
 #include <game/editor/map_object.h>

--- a/src/game/editor/mapitems/map.cpp
+++ b/src/game/editor/mapitems/map.cpp
@@ -11,6 +11,7 @@
 #include <game/editor/mapitems/layer_sounds.h>
 #include <game/editor/mapitems/layer_tiles.h>
 #include <game/editor/mapitems/sound.h>
+#include <game/editor/references.h>
 
 void CEditorMap::CMapInfo::Reset()
 {

--- a/src/game/editor/mapitems/map.h
+++ b/src/game/editor/mapitems/map.h
@@ -13,7 +13,6 @@
 #include <game/editor/editor_trackers.h>
 #include <game/editor/mapitems/envelope.h>
 #include <game/editor/mapitems/layer.h>
-#include <game/editor/references.h>
 
 #include <functional>
 #include <memory>
@@ -32,6 +31,7 @@ class CLayerSwitch;
 class CLayerTele;
 class CLayerTune;
 class CQuad;
+class IEditorEnvelopeReference;
 
 class CDataFileWriterFinishJob : public IJob
 {

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -3,9 +3,9 @@
 
 #include <engine/client.h>
 #include <engine/console.h>
+#include <engine/engine.h>
 #include <engine/gfx/image_manipulation.h>
 #include <engine/graphics.h>
-#include <engine/serverbrowser.h>
 #include <engine/shared/datafile.h>
 #include <engine/sound.h>
 #include <engine/storage.h>

--- a/src/game/editor/prompt.h
+++ b/src/game/editor/prompt.h
@@ -5,7 +5,8 @@
 
 #include <game/client/lineinput.h>
 #include <game/client/ui_rect.h>
-#include <game/editor/quick_action.h>
+
+class CQuickAction;
 
 class CPrompt : public CEditorComponent
 {

--- a/src/game/editor/references.cpp
+++ b/src/game/editor/references.cpp
@@ -1,5 +1,10 @@
 #include "references.h"
 
+#include <game/editor/mapitems/envelope.h>
+#include <game/editor/mapitems/layer_quads.h>
+#include <game/editor/mapitems/layer_sounds.h>
+#include <game/editor/mapitems/layer_tiles.h>
+
 void CLayerTilesEnvelopeReference::SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvIndex)
 {
 	if(pEnvelope->Type() == CEnvelope::EType::COLOR)

--- a/src/game/editor/references.h
+++ b/src/game/editor/references.h
@@ -1,10 +1,13 @@
 #ifndef GAME_EDITOR_REFERENCES_H
 #define GAME_EDITOR_REFERENCES_H
 
-#include <game/editor/mapitems/envelope.h>
-#include <game/editor/mapitems/layer_quads.h>
-#include <game/editor/mapitems/layer_sounds.h>
-#include <game/editor/mapitems/layer_tiles.h>
+#include <memory>
+#include <vector>
+
+class CEnvelope;
+class CLayerQuads;
+class CLayerSounds;
+class CLayerTiles;
 
 class IEditorEnvelopeReference
 {


### PR DESCRIPTION
- Use forward declarations to avoid includes in header files when possible.
- Avoid including large `base/system.h` and `game/editor/editor.h` in header files.
- Include `str.h` instead of `system.h` when possible.
- Remove unused includes.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
