### PR TITLE
Feature: Extend player info and add and sort by milliseconds

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -266,6 +266,8 @@ Objects = [
 	NetObjectEx("DDNetPlayer", "player@netobj.ddnet.tw", [
 		NetIntAny("m_Flags"),
 		NetIntRange("m_AuthLevel", "AUTHED_NO", "AUTHED_ADMIN"),
+		NetIntRange("m_FinishTimeSeconds", 'FinishTime::UNSET', 'max_int', default='FinishTime::UNSET'),
+		NetIntRange("m_FinishTimeMillis", 0, 999, default=0),
 	]),
 
 	NetObjectEx("GameInfoEx", "gameinfo@netobj.ddnet.tw", [

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2358,8 +2358,8 @@ void CServer::CacheServerInfo(CCache *pCache, int Type, bool SendClients)
 			if(m_aClients[i].m_Score.has_value())
 			{
 				Score = m_aClients[i].m_Score.value();
-				if(Score == 9999)
-					Score = -10000;
+				if(Score == -FinishTime::NOT_FINISHED_TIMESCORE)
+					Score = FinishTime::NOT_FINISHED_TIMESCORE - 1;
 				else if(Score == 0) // 0 time isn't displayed otherwise.
 					Score = -1;
 				else
@@ -2367,7 +2367,7 @@ void CServer::CacheServerInfo(CCache *pCache, int Type, bool SendClients)
 			}
 			else
 			{
-				Score = -9999;
+				Score = FinishTime::NOT_FINISHED_TIMESCORE;
 			}
 
 			ADD_INT(q, Score); // client score
@@ -2701,7 +2701,7 @@ void CServer::UpdateRegisterServerInfo()
 			JsonWriter.WriteIntValue(m_aClients[i].m_Country); // ISO 3166-1 numeric
 
 			JsonWriter.WriteAttribute("score");
-			JsonWriter.WriteIntValue(m_aClients[i].m_Score.value_or(-9999));
+			JsonWriter.WriteIntValue(m_aClients[i].m_Score.value_or(FinishTime::NOT_FINISHED_TIMESCORE));
 
 			JsonWriter.WriteAttribute("is_player");
 			JsonWriter.WriteBoolValue(GameServer()->IsClientPlayer(i));

--- a/src/engine/shared/protocol.h
+++ b/src/engine/shared/protocol.h
@@ -158,6 +158,13 @@ namespace TuneZone
 	inline constexpr int NUM = 256;
 };
 
+namespace FinishTime
+{
+	inline constexpr int NOT_FINISHED_TIMESCORE = -9999;
+	inline constexpr int NOT_FINISHED_MILLIS = -1;
+	inline constexpr int UNSET = -2;
+}
+
 typedef std::bitset<MAX_CLIENTS> CClientMask;
 
 #endif

--- a/src/engine/shared/protocol7.h
+++ b/src/engine/shared/protocol7.h
@@ -73,6 +73,11 @@ namespace protocol7
 		MAX_SKIN_LENGTH = 24,
 		MAX_SKIN_ARRAY_SIZE = MAX_SKIN_LENGTH * UTF8_BYTE_LENGTH + 1,
 	};
+
+	namespace FinishTime
+	{
+		inline constexpr int NOT_FINISHED = -1;
+	}
 }
 
 #endif

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -346,7 +346,7 @@ void CHud::RenderScoreHud()
 						str_time((int64_t)absolute(apPlayerInfo[t]->m_Score) / 10, TIME_MINS_CENTISECS, aScore[t], sizeof(aScore[t]));
 					else if(GameClient()->m_GameInfo.m_TimeScore)
 					{
-						if(apPlayerInfo[t]->m_Score != -9999)
+						if(apPlayerInfo[t]->m_Score != FinishTime::NOT_FINISHED_TIMESCORE)
 							str_time((int64_t)absolute(apPlayerInfo[t]->m_Score) * 100, TIME_HOURS, aScore[t], sizeof(aScore[t]));
 						else
 							aScore[t][0] = 0;

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -551,7 +551,7 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 			// score
 			if(Race7)
 			{
-				if(pInfo->m_Score == -1)
+				if(pInfo->m_Score == protocol7::FinishTime::NOT_FINISHED)
 				{
 					aBuf[0] = '\0';
 				}
@@ -565,7 +565,7 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 			}
 			else if(TimeScore)
 			{
-				if(pInfo->m_Score == -9999)
+				if(pInfo->m_Score == FinishTime::NOT_FINISHED_TIMESCORE)
 				{
 					aBuf[0] = '\0';
 				}

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -676,6 +676,7 @@ void CGameClient::OnReset()
 	m_HammerInput = {};
 	m_DummyFire = 0;
 	m_ReceivedDDNetPlayer = false;
+	m_ReceivedDDNetPlayerFinishTimes = false;
 
 	m_Teams.Reset();
 	m_GameWorld.Clear();
@@ -1745,6 +1746,11 @@ void CGameClient::OnNewSnapshot()
 					m_aClients[Item.m_Id].m_Afk = pInfo->m_Flags & EXPLAYERFLAG_AFK;
 					m_aClients[Item.m_Id].m_Paused = pInfo->m_Flags & EXPLAYERFLAG_PAUSED;
 					m_aClients[Item.m_Id].m_Spec = pInfo->m_Flags & EXPLAYERFLAG_SPEC;
+					m_aClients[Item.m_Id].m_FinishTimeSeconds = pInfo->m_FinishTimeSeconds;
+					m_aClients[Item.m_Id].m_FinishTimeMillis = pInfo->m_FinishTimeMillis;
+
+					if(m_aClients[Item.m_Id].m_FinishTimeSeconds != FinishTime::UNSET)
+						m_ReceivedDDNetPlayerFinishTimes = true;
 
 					if(Item.m_Id == m_Snap.m_LocalClientId && (m_aClients[Item.m_Id].m_Paused || m_aClients[Item.m_Id].m_Spec))
 					{
@@ -2075,26 +2081,17 @@ void CGameClient::OnNewSnapshot()
 
 	// sort player infos by score
 	mem_copy(m_Snap.m_apInfoByScore, m_Snap.m_apInfoByName, sizeof(m_Snap.m_apInfoByScore));
-	if(Race7)
-		std::stable_sort(m_Snap.m_apInfoByScore, m_Snap.m_apInfoByScore + MAX_CLIENTS,
-			[](const CNetObj_PlayerInfo *pPlayer1, const CNetObj_PlayerInfo *pPlayer2) -> bool {
-				if(!pPlayer2)
-					return static_cast<bool>(pPlayer1);
-				if(!pPlayer1)
-					return false;
-				return (((pPlayer1->m_Score == -1) ? std::numeric_limits<int>::max() : pPlayer1->m_Score) <
-					((pPlayer2->m_Score == -1) ? std::numeric_limits<int>::max() : pPlayer2->m_Score));
-			});
-	else
-		std::stable_sort(m_Snap.m_apInfoByScore, m_Snap.m_apInfoByScore + MAX_CLIENTS,
-			[TimeScore](const CNetObj_PlayerInfo *pPlayer1, const CNetObj_PlayerInfo *pPlayer2) -> bool {
-				if(!pPlayer2)
-					return static_cast<bool>(pPlayer1);
-				if(!pPlayer1)
-					return false;
-				return (((TimeScore && pPlayer1->m_Score == -9999) ? std::numeric_limits<int>::min() : pPlayer1->m_Score) >
-					((TimeScore && pPlayer2->m_Score == -9999) ? std::numeric_limits<int>::min() : pPlayer2->m_Score));
-			});
+	auto TimeComparator = CGameClient::GetScoreComparator(TimeScore, m_ReceivedDDNetPlayerFinishTimes, Race7);
+	auto SortByTimeScore = [TimeComparator, this](const CNetObj_PlayerInfo *pPlayer1, const CNetObj_PlayerInfo *pPlayer2) -> bool {
+		if(!pPlayer2)
+			return static_cast<bool>(pPlayer1);
+		if(!pPlayer1)
+			return false;
+		if(m_ReceivedDDNetPlayerFinishTimes)
+			return TimeComparator(m_aClients[pPlayer1->m_ClientId].m_FinishTimeSeconds, m_aClients[pPlayer2->m_ClientId].m_FinishTimeSeconds, m_aClients[pPlayer1->m_ClientId].m_FinishTimeMillis, m_aClients[pPlayer2->m_ClientId].m_FinishTimeMillis);
+		return TimeComparator(pPlayer1->m_Score, pPlayer2->m_Score, 0, 0);
+	};
+	std::stable_sort(m_Snap.m_apInfoByScore, m_Snap.m_apInfoByScore + MAX_CLIENTS, SortByTimeScore);
 
 	// sort player infos by DDRace Team (and score between)
 	int Index = 0;
@@ -2357,6 +2354,50 @@ void CGameClient::OnNewSnapshot()
 	m_IsDummySwapping = 0;
 	if(Client()->State() != IClient::STATE_DEMOPLAYBACK)
 		UpdatePrediction();
+}
+
+std::function<bool(int, int, int, int)> CGameClient::GetScoreComparator(bool TimeScore, bool ReceivedMillisecondFinishTimes, bool Race7)
+{
+	// 0.7 race score
+	if(Race7)
+	{
+		auto CompareTimeMillis07 = [](int TimeMillis1, int TimeMillis2, int, int) {
+			TimeMillis1 = TimeMillis1 == protocol7::FinishTime::NOT_FINISHED ? std::numeric_limits<int>::max() : TimeMillis1;
+			TimeMillis2 = TimeMillis2 == protocol7::FinishTime::NOT_FINISHED ? std::numeric_limits<int>::max() : TimeMillis2;
+			return TimeMillis1 < TimeMillis2;
+		};
+		return CompareTimeMillis07;
+	}
+
+	// normal scores (like points), biggest score is highest in scoreboard
+	if(!TimeScore)
+	{
+		auto CompareScore = [](int Score1, int Score2, int, int) {
+			return Score1 > Score2;
+		};
+		return CompareScore;
+	}
+
+	// 'classical' times, times are send negative, so biggest value has shortest time
+	if(!ReceivedMillisecondFinishTimes)
+	{
+		auto CompareTimeScore = [](int TimeScore1, int TimeScore2, int, int) {
+			TimeScore1 = TimeScore1 == FinishTime::NOT_FINISHED_TIMESCORE ? std::numeric_limits<int>::min() : TimeScore1;
+			TimeScore2 = TimeScore2 == FinishTime::NOT_FINISHED_TIMESCORE ? std::numeric_limits<int>::min() : TimeScore2;
+			return TimeScore1 > TimeScore2;
+		};
+		return CompareTimeScore;
+	}
+
+	// long precise times, smallest value first, subsorting by milliseconds
+	auto CompareTimeMillis = [](int TimeSeconds1, int TimeSeconds2, int TimeMillis1, int TimeMillis2) {
+		TimeSeconds1 = TimeSeconds1 == FinishTime::NOT_FINISHED_MILLIS ? std::numeric_limits<int>::max() : TimeSeconds1;
+		TimeSeconds2 = TimeSeconds2 == FinishTime::NOT_FINISHED_MILLIS ? std::numeric_limits<int>::max() : TimeSeconds2;
+		if(TimeSeconds1 == TimeSeconds2)
+			return TimeMillis1 < TimeMillis2;
+		return TimeSeconds1 < TimeSeconds2;
+	};
+	return CompareTimeMillis;
 }
 
 void CGameClient::UpdateEditorIngameMoved()

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -254,6 +254,8 @@ private:
 
 	static void ConchainMenuMap(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
+	static std::function<bool(int, int, int, int)> GetScoreComparator(bool TimeScore, bool ReceivedMillisecondFinishTimes, bool Race7);
+
 	// only used in OnPredict
 	vec2 m_aLastPos[MAX_CLIENTS];
 	bool m_aLastActive[MAX_CLIENTS];
@@ -347,6 +349,7 @@ public:
 
 		const CNetObj_PlayerInfo *m_apPlayerInfos[MAX_CLIENTS];
 		const CNetObj_PlayerInfo *m_apPrevPlayerInfos[MAX_CLIENTS];
+
 		const CNetObj_PlayerInfo *m_apInfoByScore[MAX_CLIENTS];
 		const CNetObj_PlayerInfo *m_apInfoByName[MAX_CLIENTS];
 		const CNetObj_PlayerInfo *m_apInfoByDDTeamScore[MAX_CLIENTS];
@@ -484,6 +487,9 @@ public:
 		bool m_Afk;
 		bool m_Paused;
 		bool m_Spec;
+
+		int m_FinishTimeSeconds;
+		int m_FinishTimeMillis;
 
 		// Editor allows 256 switches for now.
 		bool m_aSwitchStates[256];
@@ -657,6 +663,7 @@ public:
 	CNetObj_PlayerInput m_HammerInput;
 	unsigned int m_DummyFire;
 	bool m_ReceivedDDNetPlayer;
+	bool m_ReceivedDDNetPlayerFinishTimes;
 
 	class CTeamsCore m_Teams;
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This PR extends the extended DDNetPlayer object and adds times as milliseconds. Currently the timescore is only shown as seconds and also contains a bug.

related #11137, #11363, #8223
needed for #11138

### Followup:

- integrate this into scoreboard

### Images:

No time below any time:
<img width="2560" height="1440" alt="screenshot_2025-12-01_19-42-44" src="https://github.com/user-attachments/assets/e65447b7-cc07-4e30-aa2c-2af7f43b3bd4" />

Slower time below faster time:
<img width="2560" height="1440" alt="screenshot_2025-12-01_19-50-51" src="https://github.com/user-attachments/assets/5edc02be-9333-498a-869a-212f4f657836" />

Slower time below faster time in Milliseconds:
<img width="2560" height="1440" alt="screenshot_2025-12-01_19-51-44" src="https://github.com/user-attachments/assets/901b3307-0682-4fb1-a734-9c43d5201dda" />

Overtaking:
<img width="2560" height="1440" alt="screenshot_2025-12-01_19-54-32" src="https://github.com/user-attachments/assets/4eef0b0e-ab49-4fa7-b070-de93d336dd4c" />

Old Servers are still working as expected:
<img width="2560" height="1440" alt="screenshot_2025-12-01_20-20-09" src="https://github.com/user-attachments/assets/d588bc04-a1e5-4f6f-b805-a9e963a730e3" />

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
