### PR TITLE
Fix debug assertion crash of headless client

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1123,6 +1123,11 @@ int CGraphicsBackend_SDL_GL::Init(const char *pName, int *pScreen, int *pWidth, 
 	int GlewMajor = 0;
 	int GlewMinor = 0;
 	int GlewPatch = 0;
+	*pScreen = 0;
+	*pWidth = *pDesktopWidth = *pCurrentWidth = 800;
+	*pHeight = *pDesktopHeight = *pCurrentHeight = 600;
+	*pRefreshRate = 60;
+	*pFsaaSamples = 0;
 	log_info("gfx", "Created headless context");
 #else
 	// print sdl version


### PR DESCRIPTION
Initialize graphics screen width and height to plausible default values, otherwise the `CUi::UpdateClipping` function will call `CGraphics_Threaded::ClipEnable` with an invalid clipping region size, which causes an assertion crash when passed to `std::clamp`.

https://github.com/ddnet/ddnet/blob/4b5b0c575c1a08ed42e957da461af6333d6c8836/src/game/client/ui.cpp#L496-L509

https://github.com/ddnet/ddnet/blob/4b5b0c575c1a08ed42e957da461af6333d6c8836/src/engine/client/graphics_threaded.cpp#L137-L154

https://gcc.gnu.org/onlinedocs/libstdc++/latest-doxygen/a00428_source.html#l03622

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
