### PR TITLE
Feature: Add option to click on spectators

### DIFF
--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -56,9 +56,18 @@ class CScoreboard : public CComponent
 
 		int m_ClientId;
 		bool m_IsLocal;
+		bool m_IsSpectating;
 	} m_ScoreboardPopupContext;
 
 	static CUi::EPopupMenuFunctionResult PopupScoreboard(void *pContext, CUIRect View, bool Active);
+
+	class CPlayerElement
+	{
+	public:
+		char m_PlayerButtonId;
+		char m_SpectatorSecondLineButtonId;
+	};
+	CPlayerElement m_aPlayers[MAX_CLIENTS];
 
 public:
 	CScoreboard();


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

With #11270 in place, we also need an option to click on spectators. This PR implements this by simply making the name clickable. It also handles the line breaks properly. You can not spectate a spectator, so the spectate button is disabled if you click on a spectator.

How does it work? I am detecting the cursor position before and after adding the spectator texts and calculate an UIRect from it. If the cursor Y position mismatches, we have a line break and I need to calculate two UIRects from it

closes #11366

### Screenshots:

Hovering:
<img width="2560" height="1440" alt="screenshot_2025-12-03_13-08-22" src="https://github.com/user-attachments/assets/80e8fdf1-8ad9-4533-adf9-7b929416b7e0" />
<img width="2560" height="1440" alt="screenshot_2025-12-03_13-08-40" src="https://github.com/user-attachments/assets/cb168a47-a2e8-4641-b1f3-08c00e338399" />


Popup:
<img width="2560" height="1440" alt="screenshot_2025-12-03_13-00-15" src="https://github.com/user-attachments/assets/f3af8bf9-73d4-4c5d-aaa1-af1fa9d454f0" />
<img width="2560" height="1440" alt="screenshot_2025-12-03_13-00-18" src="https://github.com/user-attachments/assets/0b92ab22-b580-40e9-8966-dc628f601732" />
<img width="2560" height="1440" alt="screenshot_2025-12-03_13-00-22" src="https://github.com/user-attachments/assets/af46c864-cc1e-4870-b453-a8611a7e0075" />
<img width="2560" height="1440" alt="screenshot_2025-12-03_13-00-26" src="https://github.com/user-attachments/assets/e07350dd-7e23-46f8-856c-f9863ebe0ce3" />


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
