### PR TITLE
Revert "add AI disclaimer"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,3 @@
 - [ ] Considered possible null pointers and out of bounds array indexing
 - [ ] Changed no physics that affect existing maps
 - [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
-- [ ] I didn't use generative AI to generate more than single-line completions
-
-<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->


### PR DESCRIPTION
What's the point of this checkbox if maintainers are going to waste both the contributor's and their own time by nitpicking that the box isn't checked, instead of actually reviewing the code https://github.com/ddnet/ddnet/pull/11360#issuecomment-3607303152

If the point of the checkbox was to avoid AI-generated, low quality code (https://github.com/ddnet/ddnet/pull/11275#discussion_r2539885849), but I'm still being nitpicked about it after having sumbitted 160+ PRs to this repo, then it is just a pointless formality that doesn't bring in any value

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)