### PR TITLE
Mark `logfile` read only on the server side

### DIFF
--- a/src/engine/server/main.cpp
+++ b/src/engine/server/main.cpp
@@ -172,6 +172,7 @@ int main(int argc, const char **argv)
 	pConfigManager->SetReadOnly("sv_rescue", true);
 	pConfigManager->SetReadOnly("sv_port", true);
 	pConfigManager->SetReadOnly("bindaddr", true);
+	pConfigManager->SetReadOnly("logfile", true);
 
 	if(g_Config.m_Logfile[0])
 	{


### PR DESCRIPTION
The command has no effect when set from rcon anways. Not even using `reload` helps to actually get it to log.

So being able to set it was misleading.

And we also probably do not want it to take effect when being set from rcon. Because of security concerns (see #11376).

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions