### PR TITLE
Fix: Envelope animation beeing off by 2 ticks

### DIFF
--- a/src/game/client/components/envelope_state.cpp
+++ b/src/game/client/components/envelope_state.cpp
@@ -49,12 +49,12 @@ void CEnvelopeState::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Resu
 		{
 			static const nanoseconds s_NanosPerTick = nanoseconds(1s) / static_cast<int64_t>(Client()->GameTickSpeed());
 
-			// get the lerp of the current tick and prev
+			// get the lerp of the current tick and the next tick
 			const int MinTick = Client()->PrevGameTick(g_Config.m_ClDummy) - GameClient()->m_Snap.m_pGameInfoObj->m_RoundStartTick;
 			const int CurTick = Client()->GameTick(g_Config.m_ClDummy) - GameClient()->m_Snap.m_pGameInfoObj->m_RoundStartTick;
 
 			double TickRatio = mix<double>(0, CurTick - MinTick, (double)Client()->IntraGameTick(g_Config.m_ClDummy));
-			Time = duration_cast<nanoseconds>(TickRatio * s_NanosPerTick) + MinTick * s_NanosPerTick;
+			Time = duration_cast<nanoseconds>(TickRatio * s_NanosPerTick) + CurTick * s_NanosPerTick;
 		}
 		else
 		{


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

The current animation is off by one tick. You can notice this by doing a slowmo of a rotating envelope in a demo.

### Before:

The map timer already jumps to 30 before the envelope hits the start line

<img width="2560" height="1440" alt="screenshot_2025-12-04_00-10-19" src="https://github.com/user-attachments/assets/52543ba0-831d-49ae-b9b6-38ff75a03212" />

### After:

The map timer jumps to 30 exactly with the envelope hitting the start line

<img width="2560" height="1440" alt="screenshot_2025-12-04_00-09-44" src="https://github.com/user-attachments/assets/c2eddbba-f040-4131-a8cf-47cfc845c273" />

### Testmap + demo:

[envelope-rotation-test_2025-12-03_23-44-13.zip](https://github.com/user-attachments/files/23918321/envelope-rotation-test_2025-12-03_23-44-13.zip)

### Extra

- No, I did not introduce this bug, it's already here for a very long time
- Needed for #11299

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
- [x] This bug made me sad

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
