### PR TITLE
Move the "No login required" checkbox to a more noticeable spot

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -515,7 +515,10 @@ void CMenus::RenderServerbrowserStatusBox(CUIRect StatusBox, bool WasListboxItem
 	TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 
 	CUIRect SearchInfoAndAddr, ServersAndConnect, ServersPlayersOnline, SearchAndInfo, ServerAddr, ConnectButtons;
-	StatusBox.VSplitRight(135.0f, &SearchInfoAndAddr, &ServersAndConnect);
+	const char *pNoLoginRequiredText = Localize("No login required");
+	const float NoLoginRequiredTextWidth = TextRender()->TextWidth(14.0f, pNoLoginRequiredText);
+	const float NoLoginRequiredCheckBoxWidth = 18.0f + NoLoginRequiredTextWidth + 5.0f;  // checkbox margin + text + right margin
+	StatusBox.VSplitRight(135.0f + NoLoginRequiredCheckBoxWidth, &SearchInfoAndAddr, &ServersAndConnect);
 	if(SearchInfoAndAddr.w > 350.0f)
 		SearchInfoAndAddr.VSplitLeft(350.0f, &SearchInfoAndAddr, nullptr);
 	SearchInfoAndAddr.HSplitTop(40.0f, &SearchAndInfo, &ServerAddr);
@@ -618,8 +621,16 @@ void CMenus::RenderServerbrowserStatusBox(CUIRect StatusBox, bool WasListboxItem
 
 	// buttons
 	{
-		CUIRect ButtonRefresh, ButtonConnect;
+		CUIRect CheckBoxNoLoginRequired, ButtonRefresh, ButtonConnect;
+
+		ConnectButtons.VSplitLeft(NoLoginRequiredCheckBoxWidth, &CheckBoxNoLoginRequired, &ConnectButtons);
 		ConnectButtons.VSplitMid(&ButtonRefresh, &ButtonConnect, 5.0f);
+
+		// no login required checkbox
+		{
+			if(DoButton_CheckBox(&g_Config.m_BrFilterLogin, pNoLoginRequiredText, g_Config.m_BrFilterLogin, &CheckBoxNoLoginRequired))
+				g_Config.m_BrFilterLogin ^= 1;
+		}
 
 		// refresh button
 		{
@@ -706,10 +717,6 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 	View.HSplitTop(RowHeight, &Button, &View);
 	if(DoButton_CheckBox(&g_Config.m_BrFilterPw, Localize("No password"), g_Config.m_BrFilterPw, &Button))
 		g_Config.m_BrFilterPw ^= 1;
-
-	View.HSplitTop(RowHeight, &Button, &View);
-	if(DoButton_CheckBox(&g_Config.m_BrFilterLogin, Localize("No login required"), g_Config.m_BrFilterLogin, &Button))
-		g_Config.m_BrFilterLogin ^= 1;
 
 	View.HSplitTop(RowHeight, &Button, &View);
 	if(DoButton_CheckBox(&g_Config.m_BrFilterGametypeStrict, Localize("Strict gametype filter"), g_Config.m_BrFilterGametypeStrict, &Button))


### PR DESCRIPTION
A lot of players on messaging apps have been asking why they can’t find servers that require login. I often end up walking new players through how to turn off the “no login required” filter manually.
Moving this checkbox to a more noticeable spot could help reduce this kind of confusion and make more players aware of the option, since many of them don’t really check the server filter.

Maybe this needs some discussion

Before:
<img width="662" height="804" alt="图片" src="https://github.com/user-attachments/assets/6e69ec24-4f15-4a33-b0e3-c1500c595e04" />

After:
<img width="936" height="804" alt="图片" src="https://github.com/user-attachments/assets/b06541d6-536d-4f14-a068-a5679a429b0d" />

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
