### PR TITLE
Move editor map filename to `CEditorMap`

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -211,9 +211,7 @@ public:
 
 		m_BrushColorEnabled = true;
 
-		m_aFilename[0] = '\0';
-		m_aFilenamePending[0] = '\0';
-		m_ValidSaveFilename = false;
+		m_aFilenamePendingLoad[0] = '\0';
 
 		m_PopupEventActivated = false;
 		m_PopupEventWasActivated = false;
@@ -336,7 +334,6 @@ public:
 	 */
 	float m_LastAutosaveUpdateTime = -1.0f;
 	void HandleAutosave();
-	bool PerformAutosave();
 	void HandleWriterFinishJobs();
 
 	// TODO: The name of the ShowFileDialogError function is not accurate anymore, this is used for generic error messages.
@@ -414,9 +411,10 @@ public:
 
 	bool m_BrushColorEnabled;
 
-	char m_aFilename[IO_MAX_PATH_LENGTH];
-	char m_aFilenamePending[IO_MAX_PATH_LENGTH];
-	bool m_ValidSaveFilename;
+	/**
+	 * File which is pending to be loaded by @link POPEVENT_LOADDROP @endlink.
+	 */
+	char m_aFilenamePendingLoad[IO_MAX_PATH_LENGTH] = "";
 
 	enum
 	{

--- a/src/game/editor/editor_server_settings.cpp
+++ b/src/game/editor/editor_server_settings.cpp
@@ -1012,7 +1012,6 @@ void CEditor::RenderMapSettingsErrorDialog()
 	if(DoButton_Editor(&s_CancelButton, "Cancel", 0, &CancelButton, BUTTONFLAG_LEFT, nullptr) || (Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE)))
 	{
 		Reset();
-		m_aFilename[0] = 0;
 		OnDialogClose();
 	}
 }

--- a/src/game/editor/mapitems/layer_speedup.cpp
+++ b/src/game/editor/mapitems/layer_speedup.cpp
@@ -83,7 +83,7 @@ void CLayerSpeedup::BrushDraw(CLayer *pBrush, vec2 WorldPos)
 	CLayerSpeedup *pSpeedupLayer = static_cast<CLayerSpeedup *>(pBrush);
 	int sx = ConvertX(WorldPos.x);
 	int sy = ConvertY(WorldPos.y);
-	if(str_comp(pSpeedupLayer->m_aFilename, Editor()->m_aFilename))
+	if(str_comp(pSpeedupLayer->m_aFilename, pSpeedupLayer->Map()->m_aFilename))
 	{
 		Editor()->m_SpeedupAngle = pSpeedupLayer->m_SpeedupAngle;
 		Editor()->m_SpeedupForce = pSpeedupLayer->m_SpeedupForce;

--- a/src/game/editor/mapitems/layer_switch.cpp
+++ b/src/game/editor/mapitems/layer_switch.cpp
@@ -85,7 +85,7 @@ void CLayerSwitch::BrushDraw(CLayer *pBrush, vec2 WorldPos)
 	CLayerSwitch *pSwitchLayer = static_cast<CLayerSwitch *>(pBrush);
 	int sx = ConvertX(WorldPos.x);
 	int sy = ConvertY(WorldPos.y);
-	if(str_comp(pSwitchLayer->m_aFilename, Editor()->m_aFilename))
+	if(str_comp(pSwitchLayer->m_aFilename, pSwitchLayer->Map()->m_aFilename))
 	{
 		Editor()->m_SwitchNumber = pSwitchLayer->m_SwitchNumber;
 		Editor()->m_SwitchDelay = pSwitchLayer->m_SwitchDelay;

--- a/src/game/editor/mapitems/layer_tele.cpp
+++ b/src/game/editor/mapitems/layer_tele.cpp
@@ -86,7 +86,7 @@ void CLayerTele::BrushDraw(CLayer *pBrush, vec2 WorldPos)
 	CLayerTele *pTeleLayer = static_cast<CLayerTele *>(pBrush);
 	int sx = ConvertX(WorldPos.x);
 	int sy = ConvertY(WorldPos.y);
-	if(str_comp(pTeleLayer->m_aFilename, Editor()->m_aFilename))
+	if(str_comp(pTeleLayer->m_aFilename, pTeleLayer->Map()->m_aFilename))
 		Editor()->m_TeleNumber = pTeleLayer->m_TeleNumber;
 
 	bool Destructive = Editor()->m_BrushDrawDestructive || pTeleLayer->IsEmpty();

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -346,7 +346,7 @@ int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 		pGrabbed->m_TeleNumber = Editor()->m_TeleNumber;
 		pGrabbed->m_TeleCheckpointNumber = Editor()->m_TeleCheckpointNumber;
 
-		str_copy(pGrabbed->m_aFilename, Editor()->m_aFilename);
+		str_copy(pGrabbed->m_aFilename, pGrabbed->Map()->m_aFilename);
 	}
 	else if(m_HasSpeedup)
 	{
@@ -390,7 +390,7 @@ int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 		pGrabbed->m_SpeedupForce = Editor()->m_SpeedupForce;
 		pGrabbed->m_SpeedupMaxSpeed = Editor()->m_SpeedupMaxSpeed;
 		pGrabbed->m_SpeedupAngle = Editor()->m_SpeedupAngle;
-		str_copy(pGrabbed->m_aFilename, Editor()->m_aFilename);
+		str_copy(pGrabbed->m_aFilename, pGrabbed->Map()->m_aFilename);
 	}
 	else if(m_HasSwitch)
 	{
@@ -432,7 +432,7 @@ int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 
 		pGrabbed->m_SwitchNumber = Editor()->m_SwitchNumber;
 		pGrabbed->m_SwitchDelay = Editor()->m_SwitchDelay;
-		str_copy(pGrabbed->m_aFilename, Editor()->m_aFilename);
+		str_copy(pGrabbed->m_aFilename, pGrabbed->Map()->m_aFilename);
 	}
 
 	else if(m_HasTune)
@@ -470,7 +470,7 @@ int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 		}
 
 		pGrabbed->m_TuningNumber = Editor()->m_TuningNumber;
-		str_copy(pGrabbed->m_aFilename, Editor()->m_aFilename);
+		str_copy(pGrabbed->m_aFilename, pGrabbed->Map()->m_aFilename);
 	}
 	else // game, front and tiles layers
 	{
@@ -495,7 +495,7 @@ int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 		for(int y = 0; y < r.h; y++)
 			for(int x = 0; x < r.w; x++)
 				pGrabbed->m_pTiles[y * pGrabbed->m_Width + x] = GetTile(r.x + x, r.y + y);
-		str_copy(pGrabbed->m_aFilename, Editor()->m_aFilename);
+		str_copy(pGrabbed->m_aFilename, pGrabbed->Map()->m_aFilename);
 	}
 
 	return 1;

--- a/src/game/editor/mapitems/layer_tune.cpp
+++ b/src/game/editor/mapitems/layer_tune.cpp
@@ -86,7 +86,7 @@ void CLayerTune::BrushDraw(CLayer *pBrush, vec2 WorldPos)
 	CLayerTune *pTuneLayer = static_cast<CLayerTune *>(pBrush);
 	int sx = ConvertX(WorldPos.x);
 	int sy = ConvertY(WorldPos.y);
-	if(str_comp(pTuneLayer->m_aFilename, Editor()->m_aFilename))
+	if(str_comp(pTuneLayer->m_aFilename, pTuneLayer->Map()->m_aFilename))
 	{
 		Editor()->m_TuningNumber = pTuneLayer->m_TuningNumber;
 	}

--- a/src/game/editor/mapitems/map.cpp
+++ b/src/game/editor/mapitems/map.cpp
@@ -238,6 +238,8 @@ void CEditorMap::ModifySoundIndex(const FIndexModifyFunction &IndexModifyFunctio
 
 void CEditorMap::Clean()
 {
+	m_aFilename[0] = '\0';
+	m_ValidSaveFilename = false;
 	ResetModifiedState();
 
 	m_vpGroups.clear();

--- a/src/game/editor/mapitems/map.h
+++ b/src/game/editor/mapitems/map.h
@@ -75,6 +75,8 @@ public:
 	const CEditor *Editor() const { return m_pEditor; }
 	CEditor *Editor() { return m_pEditor; }
 
+	char m_aFilename[IO_MAX_PATH_LENGTH];
+	bool m_ValidSaveFilename;
 	/**
 	 * Map has unsaved changes for manual save.
 	 */
@@ -161,6 +163,7 @@ public:
 	bool PerformPreSaveSanityChecks(const FErrorHandler &ErrorHandler);
 	bool Load(const char *pFilename, int StorageType, const FErrorHandler &ErrorHandler);
 	void PerformSanityChecks(const FErrorHandler &ErrorHandler);
+	bool PerformAutosave(const FErrorHandler &ErrorHandler);
 
 	void MakeGameGroup(std::shared_ptr<CLayerGroup> pGroup);
 	void MakeGameLayer(const std::shared_ptr<CLayer> &pLayer);

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -49,7 +49,6 @@ CUi::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 		else
 		{
 			pEditor->Reset();
-			pEditor->m_aFilename[0] = 0;
 		}
 		return CUi::POPUP_CLOSE_CURRENT;
 	}
@@ -88,9 +87,9 @@ CUi::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 	View.HSplitTop(12.0f, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_SaveButton, "Save", 0, &Slot, BUTTONFLAG_LEFT, "[Ctrl+S] Save the current map."))
 	{
-		if(pEditor->m_aFilename[0] != '\0' && pEditor->m_ValidSaveFilename)
+		if(pEditor->m_Map.m_aFilename[0] != '\0' && pEditor->m_Map.m_ValidSaveFilename)
 		{
-			CallbackSaveMap(pEditor->m_aFilename, IStorage::TYPE_SAVE, pEditor);
+			CallbackSaveMap(pEditor->m_Map.m_aFilename, IStorage::TYPE_SAVE, pEditor);
 		}
 		else
 		{
@@ -112,7 +111,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 	if(pEditor->DoButton_MenuItem(&s_SaveCopyButton, "Save copy", 0, &Slot, BUTTONFLAG_LEFT, "[Ctrl+Shift+Alt+S] Save a copy of the current map under a new name."))
 	{
 		char aDefaultName[IO_MAX_PATH_LENGTH];
-		fs_split_file_extension(fs_filename(pEditor->m_aFilename), aDefaultName, sizeof(aDefaultName));
+		fs_split_file_extension(fs_filename(pEditor->m_Map.m_aFilename), aDefaultName, sizeof(aDefaultName));
 		pEditor->m_FileBrowser.ShowFileDialog(IStorage::TYPE_SAVE, CFileBrowser::EFileType::MAP, "Save map", "Save copy", "maps", aDefaultName, CallbackSaveCopyMap, pEditor);
 		return CUi::POPUP_CLOSE_CURRENT;
 	}
@@ -2148,7 +2147,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEvent(void *pContext, CUIRect View, 
 		if(pEditor->DoButton_Editor(&s_CancelButton, "Cancel", 0, &Button, BUTTONFLAG_LEFT, nullptr))
 		{
 			if(pEditor->m_PopupEventType == POPEVENT_LOADDROP)
-				pEditor->m_aFilenamePending[0] = 0;
+				pEditor->m_aFilenamePendingLoad[0] = 0;
 
 			else if(pEditor->m_PopupEventType == POPEVENT_TILEART_BIG_IMAGE || pEditor->m_PopupEventType == POPEVENT_TILEART_MANY_COLORS)
 				pEditor->m_TileartImageInfo.Free();
@@ -2183,15 +2182,14 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEvent(void *pContext, CUIRect View, 
 		}
 		else if(pEditor->m_PopupEventType == POPEVENT_LOADDROP)
 		{
-			int Result = pEditor->Load(pEditor->m_aFilenamePending, IStorage::TYPE_ALL_OR_ABSOLUTE);
+			int Result = pEditor->Load(pEditor->m_aFilenamePendingLoad, IStorage::TYPE_ALL_OR_ABSOLUTE);
 			if(!Result)
-				dbg_msg("editor", "editing passed map file '%s' failed", pEditor->m_aFilenamePending);
-			pEditor->m_aFilenamePending[0] = 0;
+				dbg_msg("editor", "editing passed map file '%s' failed", pEditor->m_aFilenamePendingLoad);
+			pEditor->m_aFilenamePendingLoad[0] = 0;
 		}
 		else if(pEditor->m_PopupEventType == POPEVENT_NEW)
 		{
 			pEditor->Reset();
-			pEditor->m_aFilename[0] = 0;
 		}
 		else if(pEditor->m_PopupEventType == POPEVENT_PLACE_BORDER_TILES)
 		{

--- a/src/game/editor/quick_actions.cpp
+++ b/src/game/editor/quick_actions.cpp
@@ -217,7 +217,7 @@ void CEditor::DeleteSelectedLayer()
 
 void CEditor::TestMapLocally()
 {
-	const char *pFilenameNoMaps = str_startswith(m_aFilename, "maps/");
+	const char *pFilenameNoMaps = str_startswith(m_Map.m_aFilename, "maps/");
 	if(!pFilenameNoMaps)
 	{
 		ShowFileDialogError("The map isn't saved in the maps/ folder. It must be saved there to load on the server.");

--- a/src/game/editor/quick_actions.h
+++ b/src/game/editor/quick_actions.h
@@ -219,7 +219,7 @@ REGISTER_QUICK_ACTION(
 	"Save as",
 	[&]() {
 		char aDefaultName[IO_MAX_PATH_LENGTH];
-		fs_split_file_extension(fs_filename(m_aFilename), aDefaultName, sizeof(aDefaultName));
+		fs_split_file_extension(fs_filename(m_Map.m_aFilename), aDefaultName, sizeof(aDefaultName));
 		m_FileBrowser.ShowFileDialog(IStorage::TYPE_SAVE, CFileBrowser::EFileType::MAP, "Save map", "Save as", "maps", aDefaultName, CallbackSaveMap, this);
 	},
 	ALWAYS_FALSE,


### PR DESCRIPTION
Each editor map should have its own filename instead of one filename being used globally in the editor.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions