### PR TITLE
Move editor shift-by property to map

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -7438,7 +7438,6 @@ void CEditor::Reset(bool CreateDefault)
 
 	m_ActiveEnvelopePreview = EEnvelopePreview::NONE;
 	m_QuadEnvelopePointOperation = EQuadEnvelopePointOperation::NONE;
-	m_ShiftBy = 1;
 
 	m_ResetZoomEnvelope = true;
 	m_SettingsCommandInput.Clear();

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -574,8 +574,6 @@ public:
 	CEditorMap m_Map;
 	std::deque<std::shared_ptr<CDataFileWriterFinishJob>> m_WriterFinishJobs;
 
-	int m_ShiftBy;
-
 	void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels) override;
 
 	CLineInputBuffered<256> m_SettingsCommandInput;

--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -930,7 +930,7 @@ void CEditorActionEditLayerTilesProp::Undo()
 	}
 	else if(m_Prop == ETilesProp::PROP_SHIFT_BY)
 	{
-		Editor()->m_ShiftBy = m_Previous;
+		Map()->m_ShiftBy = m_Previous;
 	}
 	else if(m_Prop == ETilesProp::PROP_IMAGE)
 	{
@@ -1014,7 +1014,7 @@ void CEditorActionEditLayerTilesProp::Redo()
 	}
 	else if(m_Prop == ETilesProp::PROP_SHIFT_BY)
 	{
-		Editor()->m_ShiftBy = m_Current;
+		Map()->m_ShiftBy = m_Current;
 	}
 	else if(m_Prop == ETilesProp::PROP_IMAGE)
 	{

--- a/src/game/editor/editor_trackers.cpp
+++ b/src/game/editor/editor_trackers.cpp
@@ -526,7 +526,7 @@ int CLayerTilesPropTracker::PropToValue(ETilesProp Prop)
 	case ETilesProp::PROP_WIDTH: return m_pObject->m_Width;
 	case ETilesProp::PROP_IMAGE: return m_pObject->m_Image;
 	case ETilesProp::PROP_SEED: return m_pObject->m_Seed;
-	case ETilesProp::PROP_SHIFT_BY: return Editor()->m_ShiftBy;
+	case ETilesProp::PROP_SHIFT_BY: return Map()->m_ShiftBy;
 	default: return 0;
 	}
 }
@@ -583,7 +583,7 @@ bool CLayerTilesCommonPropTracker::EndChecker(ETilesCommonProp Prop, int Value)
 int CLayerTilesCommonPropTracker::PropToValue(ETilesCommonProp Prop)
 {
 	if(Prop == ETilesCommonProp::PROP_SHIFT_BY)
-		return Editor()->m_ShiftBy;
+		return Map()->m_ShiftBy;
 	return 0;
 }
 

--- a/src/game/editor/mapitems/layer_speedup.cpp
+++ b/src/game/editor/mapitems/layer_speedup.cpp
@@ -52,7 +52,7 @@ void CLayerSpeedup::Resize(int NewW, int NewH)
 void CLayerSpeedup::Shift(EShiftDirection Direction)
 {
 	CLayerTiles::Shift(Direction);
-	ShiftImpl(m_pSpeedupTile, Direction, Editor()->m_ShiftBy);
+	ShiftImpl(m_pSpeedupTile, Direction, Map()->m_ShiftBy);
 }
 
 bool CLayerSpeedup::IsEmpty() const

--- a/src/game/editor/mapitems/layer_switch.cpp
+++ b/src/game/editor/mapitems/layer_switch.cpp
@@ -54,7 +54,7 @@ void CLayerSwitch::Resize(int NewW, int NewH)
 void CLayerSwitch::Shift(EShiftDirection Direction)
 {
 	CLayerTiles::Shift(Direction);
-	ShiftImpl(m_pSwitchTile, Direction, Editor()->m_ShiftBy);
+	ShiftImpl(m_pSwitchTile, Direction, Map()->m_ShiftBy);
 }
 
 bool CLayerSwitch::IsEmpty() const

--- a/src/game/editor/mapitems/layer_tele.cpp
+++ b/src/game/editor/mapitems/layer_tele.cpp
@@ -55,7 +55,7 @@ void CLayerTele::Resize(int NewW, int NewH)
 void CLayerTele::Shift(EShiftDirection Direction)
 {
 	CLayerTiles::Shift(Direction);
-	ShiftImpl(m_pTeleTile, Direction, Editor()->m_ShiftBy);
+	ShiftImpl(m_pTeleTile, Direction, Map()->m_ShiftBy);
 }
 
 bool CLayerTele::IsEmpty() const

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -709,7 +709,7 @@ void CLayerTiles::Resize(int NewW, int NewH)
 
 void CLayerTiles::Shift(EShiftDirection Direction)
 {
-	ShiftImpl(m_pTiles, Direction, Editor()->m_ShiftBy);
+	ShiftImpl(m_pTiles, Direction, Map()->m_ShiftBy);
 }
 
 void CLayerTiles::ShowInfo()
@@ -1029,7 +1029,7 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 		{"Width", m_Width, PROPTYPE_INT, 1, 100000},
 		{"Height", m_Height, PROPTYPE_INT, 1, 100000},
 		{"Shift", 0, PROPTYPE_SHIFT, 0, 0},
-		{"Shift by", Editor()->m_ShiftBy, PROPTYPE_INT, 1, 100000},
+		{"Shift by", Map()->m_ShiftBy, PROPTYPE_INT, 1, 100000},
 		{"Image", m_Image, PROPTYPE_IMAGE, 0, 0},
 		{"Color", PackColor(m_Color), PROPTYPE_COLOR, 0, 0},
 		{"Color Env", m_ColorEnv + 1, PROPTYPE_ENVELOPE, 0, 0},
@@ -1088,7 +1088,7 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 	}
 	else if(Prop == ETilesProp::PROP_SHIFT_BY)
 	{
-		Editor()->m_ShiftBy = NewVal;
+		Map()->m_ShiftBy = NewVal;
 	}
 	else if(Prop == ETilesProp::PROP_IMAGE)
 	{
@@ -1281,7 +1281,7 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropSta
 		{"Width", State.m_Width, PROPTYPE_INT, 1, 100000},
 		{"Height", State.m_Height, PROPTYPE_INT, 1, 100000},
 		{"Shift", 0, PROPTYPE_SHIFT, 0, 0},
-		{"Shift by", pEditor->m_ShiftBy, PROPTYPE_INT, 1, 100000},
+		{"Shift by", pEditorMap->m_ShiftBy, PROPTYPE_INT, 1, 100000},
 		{"Color", State.m_Color, PROPTYPE_COLOR, 0, 0},
 		{nullptr},
 	};
@@ -1322,7 +1322,7 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropSta
 	}
 	else if(Prop == ETilesCommonProp::PROP_SHIFT_BY)
 	{
-		pEditor->m_ShiftBy = NewVal;
+		pEditorMap->m_ShiftBy = NewVal;
 	}
 	else if(Prop == ETilesCommonProp::PROP_COLOR)
 	{

--- a/src/game/editor/mapitems/layer_tune.cpp
+++ b/src/game/editor/mapitems/layer_tune.cpp
@@ -55,7 +55,7 @@ void CLayerTune::Resize(int NewW, int NewH)
 void CLayerTune::Shift(EShiftDirection Direction)
 {
 	CLayerTiles::Shift(Direction);
-	ShiftImpl(m_pTuneTile, Direction, Editor()->m_ShiftBy);
+	ShiftImpl(m_pTuneTile, Direction, Map()->m_ShiftBy);
 }
 
 bool CLayerTune::IsEmpty() const

--- a/src/game/editor/mapitems/map.cpp
+++ b/src/game/editor/mapitems/map.cpp
@@ -266,6 +266,8 @@ void CEditorMap::Clean()
 
 	m_SelectedImage = 0;
 	m_SelectedSound = 0;
+
+	m_ShiftBy = 1;
 }
 
 void CEditorMap::CreateDefault()

--- a/src/game/editor/mapitems/map.h
+++ b/src/game/editor/mapitems/map.h
@@ -138,6 +138,8 @@ public:
 	int m_SelectedImage;
 	int m_SelectedSound;
 
+	int m_ShiftBy;
+
 	std::shared_ptr<CEnvelope> NewEnvelope(CEnvelope::EType Type);
 	void InsertEnvelope(int Index, std::shared_ptr<CEnvelope> &pEnvelope);
 	void UpdateEnvelopeReferences(int Index, std::shared_ptr<CEnvelope> &pEnvelope, std::vector<std::shared_ptr<IEditorEnvelopeReference>> &vpEditorObjectReferences);


### PR DESCRIPTION
The shift-by value should be set separately for each map when there are multiple.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions