### PR TITLE
Cleanup: Server browser list memory management

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -80,7 +80,6 @@ CServerBrowser::CServerBrowser() :
 
 CServerBrowser::~CServerBrowser()
 {
-	free(m_ppServerlist);
 	free(m_pSortedServerlist);
 	json_value_free(m_pDDNetInfo);
 
@@ -847,13 +846,15 @@ CServerBrowser::CServerEntry *CServerBrowser::Add(const NETADDR *pAddrs, int Num
 
 	if(m_NumServers == m_NumServerCapacity)
 	{
-		CServerEntry **ppNewlist;
 		m_NumServerCapacity += 100;
-		ppNewlist = (CServerEntry **)calloc(m_NumServerCapacity, sizeof(CServerEntry *)); // NOLINT(bugprone-sizeof-expression)
+		std::unique_ptr<CServerEntry *[]> ppNewList = std::make_unique<CServerEntry *[]>(m_NumServerCapacity);
+
 		if(m_NumServers > 0)
-			mem_copy(ppNewlist, m_ppServerlist, m_NumServers * sizeof(CServerEntry *)); // NOLINT(bugprone-sizeof-expression)
-		free(m_ppServerlist);
-		m_ppServerlist = ppNewlist;
+		{
+			std::memcpy(ppNewList.get(), m_ppServerlist.get(), m_NumServers * sizeof(CServerEntry *)); // NOLINT(bugprone-bitwise-pointer-cast)
+		}
+
+		m_ppServerlist = std::move(ppNewList);
 	}
 
 	// add to list

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -12,6 +12,7 @@
 
 #include <functional>
 #include <map>
+#include <memory>
 #include <set>
 
 typedef struct _json_value json_value;
@@ -333,7 +334,7 @@ private:
 	const char *m_pHttpPrevBestUrl = nullptr;
 
 	CHeap m_ServerlistHeap;
-	CServerEntry **m_ppServerlist;
+	std::unique_ptr<CServerEntry *[]> m_ppServerlist;
 	int *m_pSortedServerlist;
 	std::unordered_map<NETADDR, int> m_ByAddr;
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Github Security and my IDE complains about use after free, which **is a false positive**. But I find the memory management for the server browser list a bit poorly. This PR just introduces a unique pointer for safer memory management.

I don't understand why we are not just using a vector here, but I guess it's fine.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
