### PR TITLE
Move editor quad knife state to `CEditorMap`

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -243,11 +243,6 @@ public:
 		m_SelectedTangentOutPoint = std::pair(-1, -1);
 		m_CurrentQuadIndex = -1;
 
-		m_QuadKnifeActive = false;
-		m_QuadKnifeCount = 0;
-		m_QuadKnifeSelectedQuadIndex = -1;
-		std::fill(std::begin(m_aQuadKnifePoints), std::end(m_aQuadKnifePoints), vec2(0.0f, 0.0f));
-
 		for(size_t i = 0; i < std::size(m_aSavedColors); ++i)
 		{
 			m_aSavedColors[i] = color_cast<ColorRGBA>(ColorHSLA(i / (float)std::size(m_aSavedColors), 1.0f, 0.5f));
@@ -540,11 +535,6 @@ public:
 	std::pair<int, int> m_SelectedTangentInPoint;
 	std::pair<int, int> m_SelectedTangentOutPoint;
 	bool m_UpdateEnvPointInfo;
-
-	bool m_QuadKnifeActive;
-	int m_QuadKnifeCount;
-	int m_QuadKnifeSelectedQuadIndex;
-	vec2 m_aQuadKnifePoints[4];
 
 	// Color palette and pipette
 	ColorRGBA m_aSavedColors[8];

--- a/src/game/editor/mapitems/map.cpp
+++ b/src/game/editor/mapitems/map.cpp
@@ -268,6 +268,11 @@ void CEditorMap::Clean()
 	m_SelectedSound = 0;
 
 	m_ShiftBy = 1;
+
+	m_QuadKnife.m_Active = false;
+	m_QuadKnife.m_Count = 0;
+	m_QuadKnife.m_SelectedQuadIndex = -1;
+	std::fill(std::begin(m_QuadKnife.m_aPoints), std::end(m_QuadKnife.m_aPoints), vec2(0.0f, 0.0f));
 }
 
 void CEditorMap::CreateDefault()

--- a/src/game/editor/mapitems/map.h
+++ b/src/game/editor/mapitems/map.h
@@ -140,6 +140,17 @@ public:
 
 	int m_ShiftBy;
 
+	// Quad knife
+	class CQuadKnife
+	{
+	public:
+		bool m_Active;
+		int m_SelectedQuadIndex;
+		int m_Count;
+		vec2 m_aPoints[4];
+	};
+	CQuadKnife m_QuadKnife;
+
 	std::shared_ptr<CEnvelope> NewEnvelope(CEnvelope::EType Type);
 	void InsertEnvelope(int Index, std::shared_ptr<CEnvelope> &pEnvelope);
 	void UpdateEnvelopeReferences(int Index, std::shared_ptr<CEnvelope> &pEnvelope, std::vector<std::shared_ptr<IEditorEnvelopeReference>> &vpEditorObjectReferences);

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1027,9 +1027,9 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 	static int s_SliceButton = 0;
 	if(pEditor->DoButton_Editor(&s_SliceButton, "Slice", 0, &Button, BUTTONFLAG_LEFT, "Enable quad knife mode."))
 	{
-		pEditor->m_QuadKnifeActive = true;
-		pEditor->m_QuadKnifeCount = 0;
-		pEditor->m_QuadKnifeSelectedQuadIndex = pQuadPopupContext->m_SelectedQuadIndex;
+		pEditor->m_Map.m_QuadKnife.m_Active = true;
+		pEditor->m_Map.m_QuadKnife.m_Count = 0;
+		pEditor->m_Map.m_QuadKnife.m_SelectedQuadIndex = pQuadPopupContext->m_SelectedQuadIndex;
 		return CUi::POPUP_CLOSE_CURRENT;
 	}
 


### PR DESCRIPTION
Track quad knife state separately for each editor map so the tool can be used independently for each map when there are multiple.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
