### PR TITLE
Use reliable APIs to retrieve executable path

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -426,39 +426,12 @@ IOHANDLE io_stderr()
 
 IOHANDLE io_current_exe()
 {
-	// From https://stackoverflow.com/a/1024937.
-#if defined(CONF_FAMILY_WINDOWS)
-	wchar_t wide_path[IO_MAX_PATH_LENGTH];
-	if(GetModuleFileNameW(nullptr, wide_path, std::size(wide_path)) == 0 || GetLastError() != ERROR_SUCCESS)
+	char path[IO_MAX_PATH_LENGTH];
+	if(fs_executable_path(path, sizeof(path)) != 0)
 	{
 		return nullptr;
 	}
-	const std::optional<std::string> path = windows_wide_to_utf8(wide_path);
-	return path.has_value() ? io_open(path.value().c_str(), IOFLAG_READ) : nullptr;
-#elif defined(CONF_PLATFORM_MACOS)
-	char path[IO_MAX_PATH_LENGTH];
-	uint32_t path_size = sizeof(path);
-	if(_NSGetExecutablePath(path, &path_size))
-	{
-		return 0;
-	}
 	return io_open(path, IOFLAG_READ);
-#else
-	static const char *NAMES[] = {
-		"/proc/self/exe", // Linux, Android
-		"/proc/curproc/exe", // NetBSD
-		"/proc/curproc/file", // DragonFly
-	};
-	for(auto &name : NAMES)
-	{
-		IOHANDLE result = io_open(name, IOFLAG_READ);
-		if(result)
-		{
-			return result;
-		}
-	}
-	return 0;
-#endif
 }
 
 #define ASYNC_BUFSIZE (8 * 1024)
@@ -2453,6 +2426,65 @@ int fs_storage_path(const char *appname, char *path, int max)
 #endif
 
 	return 0;
+#endif
+}
+
+int fs_executable_path(char *buffer, int buffer_size)
+{
+	// https://stackoverflow.com/a/1024937
+#if defined(CONF_FAMILY_WINDOWS)
+	wchar_t wide_path[IO_MAX_PATH_LENGTH];
+	if(GetModuleFileNameW(nullptr, wide_path, std::size(wide_path)) == 0 || GetLastError() != ERROR_SUCCESS)
+	{
+		buffer[0] = '\0';
+		return -1;
+	}
+	const std::optional<std::string> path = windows_wide_to_utf8(wide_path);
+	if(!path.has_value())
+	{
+		buffer[0] = '\0';
+		return -1;
+	}
+	str_copy(buffer, path.value().c_str(), buffer_size);
+	return 0;
+#elif defined(CONF_PLATFORM_MACOS)
+	// Get the size
+	uint32_t path_size = 0;
+	_NSGetExecutablePath(nullptr, &path_size);
+
+	char *path = (char *)malloc(path_size);
+	if(_NSGetExecutablePath(path, &path_size) != 0)
+	{
+		free(path);
+		buffer[0] = '\0';
+		return -1;
+	}
+	str_copy(buffer, path, buffer_size);
+	free(path);
+	return 0;
+#else
+	char path[IO_MAX_PATH_LENGTH];
+	static const char *NAMES[] = {
+		"/proc/self/exe", // Linux, Android
+		"/proc/curproc/exe", // NetBSD
+		"/proc/curproc/file", // DragonFly
+	};
+	for(auto &name : NAMES)
+	{
+		if(ssize_t bytes_written = readlink(name, path, sizeof(path) - 1); bytes_written != -1)
+		{
+			path[bytes_written] = '\0'; // readlink does NOT null-terminate
+			// if the file gets deleted or replaced (not renamed) linux appends (deleted) to the symlink (see https://man7.org/linux/man-pages/man5/proc_pid_exe.5.html)
+			if(const char *deleted = str_endswith(path, " (deleted)"); deleted != nullptr)
+			{
+				path[deleted - path] = '\0';
+			}
+			str_copy(buffer, path, buffer_size);
+			return 0;
+		}
+	}
+	buffer[0] = '\0';
+	return -1;
 #endif
 }
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1395,6 +1395,22 @@ int fs_makedir_rec_for(const char *path);
 int fs_storage_path(const char *appname, char *path, int max);
 
 /**
+ * Gets the absolute path to the executable.
+ *
+ * @ingroup Filesystem
+ *
+ * @param buffer Buffer that will receive the path of the executable.
+ * @param buffer_size Size of the buffer.
+ *
+ * @return `0` on success. Negative value on failure.
+ *
+ * @remark The executable name is included in the result.
+ *
+ * @remark The strings are treated as null-terminated strings.
+ */
+int fs_executable_path(char *buffer, int buffer_size);
+
+/**
  * Checks if a file exists.
  *
  * @ingroup Filesystem

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -362,6 +362,12 @@ public:
 		return;
 #endif
 
+		if(fs_executable_path(m_aBinarydir, sizeof(m_aBinarydir)) == 0)
+		{
+			fs_parent_dir(m_aBinarydir);
+			return;
+		}
+
 		// check for usable path in argv[0]
 		{
 			unsigned int Pos = ~0U;
@@ -378,14 +384,12 @@ public:
 				{
 					return;
 				}
-#if defined(CONF_PLATFORM_MACOS)
-				str_append(m_aBinarydir, "/../../../DDNet-Server.app/Contents/MacOS");
-				str_format(aBuf, sizeof(aBuf), "%s/" PLAT_SERVER_EXEC, m_aBinarydir);
+				// Also look for client binary. (see https://github.com/ddnet/ddnet/issues/11418)
+				str_format(aBuf, sizeof(aBuf), "%s/" PLAT_CLIENT_EXEC, m_aBinarydir);
 				if(fs_is_file(aBuf))
 				{
 					return;
 				}
-#endif
 			}
 		}
 

--- a/src/game/client/components/local_server.cpp
+++ b/src/game/client/components/local_server.cpp
@@ -29,6 +29,14 @@ void CLocalServer::RunServer(const std::vector<const char *> &vpArguments)
 #else
 	char aBuf[IO_MAX_PATH_LENGTH];
 	Storage()->GetBinaryPath(PLAT_SERVER_EXEC, aBuf, sizeof(aBuf));
+#if defined(CONF_PLATFORM_MACOS)
+	if(!fs_is_file(aBuf))
+	{
+		fs_parent_dir(aBuf);
+		str_append(aBuf, "/../../../DDNet-Server.app/Contents/MacOS/");
+		str_append(aBuf, PLAT_SERVER_EXEC);
+	}
+#endif
 	// No / in binary path means to search in $PATH, so it is expected that the file can't be opened. Just try executing anyway.
 	if(str_find(aBuf, "/") == nullptr || fs_is_file(aBuf))
 	{

--- a/src/test/fs_test.cpp
+++ b/src/test/fs_test.cpp
@@ -91,6 +91,15 @@ TEST(Filesystem, StoragePath)
 	EXPECT_TRUE(str_endswith_nocase(aStoragePath, "/TestAppName"));
 }
 
+TEST(Filesystem, ExecutablePath)
+{
+	char aExecutablePath[IO_MAX_PATH_LENGTH];
+	ASSERT_FALSE(fs_executable_path(aExecutablePath, sizeof(aExecutablePath)));
+	EXPECT_TRUE(fs_is_file(aExecutablePath));
+	fs_parent_dir(aExecutablePath);
+	EXPECT_FALSE(fs_is_relative_path(aExecutablePath));
+}
+
 TEST(Filesystem, CreateCloseDelete)
 {
 	CTestInfo Info;


### PR DESCRIPTION
Adds OS api calls to reliably get executable path. (and use argv[0] as backup)
The MacOS/Linux code needs more testing though, especially with the updater.
Also fixes #11418 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

