### PR TITLE
Use consistent names for envelope index/start/num variables

### DIFF
--- a/src/game/client/components/envelope_state.cpp
+++ b/src/game/client/components/envelope_state.cpp
@@ -14,19 +14,19 @@ CEnvelopeState::CEnvelopeState(IMap *pMap, bool OnlineOnly) :
 	m_OnlineOnly = OnlineOnly;
 }
 
-void CEnvelopeState::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels)
+void CEnvelopeState::EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels)
 {
 	using namespace std::chrono;
 
 	if(!m_pMap)
 		return;
 
-	int EnvStart, EnvNum;
-	m_pMap->GetType(MAPITEMTYPE_ENVELOPE, &EnvStart, &EnvNum);
-	if(Env < 0 || Env >= EnvNum)
+	int EnvelopeStart, EnvelopeNum;
+	m_pMap->GetType(MAPITEMTYPE_ENVELOPE, &EnvelopeStart, &EnvelopeNum);
+	if(EnvelopeIndex < 0 || EnvelopeIndex >= EnvelopeNum)
 		return;
 
-	const CMapItemEnvelope *pItem = (CMapItemEnvelope *)m_pMap->GetItem(EnvStart + Env);
+	const CMapItemEnvelope *pItem = (CMapItemEnvelope *)m_pMap->GetItem(EnvelopeStart + EnvelopeIndex);
 	if(pItem->m_Channels <= 0)
 		return;
 	Channels = minimum<size_t>(Channels, pItem->m_Channels, CEnvPoint::MAX_CHANNELS);

--- a/src/game/client/components/envelope_state.h
+++ b/src/game/client/components/envelope_state.h
@@ -13,7 +13,7 @@ public:
 	CEnvelopeState() :
 		m_pEnvelopePoints(nullptr), m_pMap(nullptr) {}
 	CEnvelopeState(IMap *pMap, bool OnlineOnly);
-	void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels) override;
+	void EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels) override;
 
 	int Sizeof() const override { return sizeof(*this); }
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -78,16 +78,16 @@ bool CEditor::IsVanillaImage(const char *pImage)
 	return std::any_of(std::begin(VANILLA_IMAGES), std::end(VANILLA_IMAGES), [pImage](const char *pVanillaImage) { return str_comp(pImage, pVanillaImage) == 0; });
 }
 
-void CEditor::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels)
+void CEditor::EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels)
 {
-	if(Env < 0 || Env >= (int)m_Map.m_vpEnvelopes.size())
+	if(EnvelopeIndex < 0 || EnvelopeIndex >= (int)m_Map.m_vpEnvelopes.size())
 		return;
 
-	std::shared_ptr<CEnvelope> pEnv = m_Map.m_vpEnvelopes[Env];
+	std::shared_ptr<CEnvelope> pEnvelope = m_Map.m_vpEnvelopes[EnvelopeIndex];
 	float Time = m_AnimateTime;
 	Time *= m_AnimateSpeed;
 	Time += (TimeOffsetMillis / 1000.0f);
-	pEnv->Eval(Time, Result, Channels);
+	pEnvelope->Eval(Time, Result, Channels);
 }
 
 std::shared_ptr<CLayerGroup> CEditor::GetSelectedGroup() const

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -574,7 +574,7 @@ public:
 	CEditorMap m_Map;
 	std::deque<std::shared_ptr<CDataFileWriterFinishJob>> m_WriterFinishJobs;
 
-	void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels) override;
+	void EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels) override;
 
 	CLineInputBuffered<256> m_SettingsCommandInput;
 	CMapSettingsBackend m_MapSettingsBackend;

--- a/src/game/editor/editor_trackers.cpp
+++ b/src/game/editor/editor_trackers.cpp
@@ -338,11 +338,11 @@ void CEnvelopeEditorOperationTracker::HandlePointDragStart()
 {
 	// Figure out which points are selected and which channels
 	// Save their X and Y position (time and value)
-	auto pEnv = Map()->m_vpEnvelopes[Editor()->m_SelectedEnvelope];
+	auto pEnvelope = Map()->m_vpEnvelopes[Editor()->m_SelectedEnvelope];
 
 	for(auto [PointIndex, Channel] : Editor()->m_vSelectedEnvelopePoints)
 	{
-		auto &Point = pEnv->m_vPoints[PointIndex];
+		auto &Point = pEnvelope->m_vPoints[PointIndex];
 		auto &Data = m_SavedValues[PointIndex];
 		Data.m_Values[Channel] = Point.m_aValues[Channel];
 		if(Data.m_Used)
@@ -357,19 +357,19 @@ void CEnvelopeEditorOperationTracker::HandlePointDragEnd(bool Switch)
 	if(Switch && m_TrackedOp != EEnvelopeEditorOp::OP_SCALE)
 		return;
 
-	int EnvIndex = Editor()->m_SelectedEnvelope;
-	auto pEnv = Map()->m_vpEnvelopes[EnvIndex];
+	int EnvelopeIndex = Editor()->m_SelectedEnvelope;
+	auto pEnvelope = Map()->m_vpEnvelopes[EnvelopeIndex];
 	std::vector<std::shared_ptr<IEditorAction>> vpActions;
 
 	for(auto const &Entry : m_SavedValues)
 	{
 		int PointIndex = Entry.first;
-		auto &Point = pEnv->m_vPoints[PointIndex];
+		auto &Point = pEnvelope->m_vPoints[PointIndex];
 		const auto &Data = Entry.second;
 
 		if(Data.m_Time != Point.m_Time)
 		{ // Save time
-			vpActions.push_back(std::make_shared<CEditorActionEnvelopeEditPointTime>(Map(), EnvIndex, PointIndex, Data.m_Time, Point.m_Time));
+			vpActions.push_back(std::make_shared<CEditorActionEnvelopeEditPointTime>(Map(), EnvelopeIndex, PointIndex, Data.m_Time, Point.m_Time));
 		}
 
 		for(auto Value : Data.m_Values)
@@ -378,7 +378,7 @@ void CEnvelopeEditorOperationTracker::HandlePointDragEnd(bool Switch)
 			int Channel = Value.first;
 			if(Value.second != Point.m_aValues[Channel])
 			{ // Save value
-				vpActions.push_back(std::make_shared<CEditorActionEnvelopeEditPoint>(Map(), EnvIndex, PointIndex, Channel, CEditorActionEnvelopeEditPoint::EEditType::VALUE, Value.second, Point.m_aValues[Channel]));
+				vpActions.push_back(std::make_shared<CEditorActionEnvelopeEditPoint>(Map(), EnvelopeIndex, PointIndex, Channel, CEditorActionEnvelopeEditPoint::EEditType::VALUE, Value.second, Point.m_aValues[Channel]));
 			}
 		}
 	}

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -984,11 +984,11 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 	{
 		const CMapBasedEnvelopePointAccess EnvelopePoints(&DataFile);
 
-		int EnvStart, EnvNum;
-		DataFile.GetType(MAPITEMTYPE_ENVELOPE, &EnvStart, &EnvNum);
-		for(int e = 0; e < EnvNum; e++)
+		int EnvelopeStart, EnvelopeNum;
+		DataFile.GetType(MAPITEMTYPE_ENVELOPE, &EnvelopeStart, &EnvelopeNum);
+		for(int EnvelopeIndex = 0; EnvelopeIndex < EnvelopeNum; EnvelopeIndex++)
 		{
-			CMapItemEnvelope *pItem = (CMapItemEnvelope *)DataFile.GetItem(EnvStart + e);
+			CMapItemEnvelope *pItem = (CMapItemEnvelope *)DataFile.GetItem(EnvelopeStart + EnvelopeIndex);
 			int Channels = pItem->m_Channels;
 			if(Channels <= 0 || Channels == 2 || Channels > CEnvPoint::MAX_CHANNELS)
 			{
@@ -998,26 +998,26 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 			if(Channels != pItem->m_Channels)
 			{
 				char aBuf[128];
-				str_format(aBuf, sizeof(aBuf), "Error: Envelope %d had an invalid number of channels, %d, which was changed to %d.", e, pItem->m_Channels, Channels);
+				str_format(aBuf, sizeof(aBuf), "Error: Envelope %d had an invalid number of channels, %d, which was changed to %d.", EnvelopeIndex, pItem->m_Channels, Channels);
 				ErrorHandler(aBuf);
 			}
 
-			std::shared_ptr<CEnvelope> pEnv = std::make_shared<CEnvelope>(Channels);
-			pEnv->m_vPoints.resize(pItem->m_NumPoints);
-			for(int p = 0; p < pItem->m_NumPoints; p++)
+			std::shared_ptr<CEnvelope> pEnvelope = std::make_shared<CEnvelope>(Channels);
+			pEnvelope->m_vPoints.resize(pItem->m_NumPoints);
+			for(int PointIndex = 0; PointIndex < pItem->m_NumPoints; PointIndex++)
 			{
-				const CEnvPoint *pPoint = EnvelopePoints.GetPoint(pItem->m_StartPoint + p);
+				const CEnvPoint *pPoint = EnvelopePoints.GetPoint(pItem->m_StartPoint + PointIndex);
 				if(pPoint != nullptr)
-					mem_copy(&pEnv->m_vPoints[p], pPoint, sizeof(CEnvPoint));
-				const CEnvPointBezier *pPointBezier = EnvelopePoints.GetBezier(pItem->m_StartPoint + p);
+					mem_copy(&pEnvelope->m_vPoints[PointIndex], pPoint, sizeof(CEnvPoint));
+				const CEnvPointBezier *pPointBezier = EnvelopePoints.GetBezier(pItem->m_StartPoint + PointIndex);
 				if(pPointBezier != nullptr)
-					mem_copy(&pEnv->m_vPoints[p].m_Bezier, pPointBezier, sizeof(CEnvPointBezier));
+					mem_copy(&pEnvelope->m_vPoints[PointIndex].m_Bezier, pPointBezier, sizeof(CEnvPointBezier));
 			}
 			if(pItem->m_aName[0] != -1) // compatibility with old maps
-				IntsToStr(pItem->m_aName, std::size(pItem->m_aName), pEnv->m_aName, std::size(pEnv->m_aName));
-			m_vpEnvelopes.push_back(pEnv);
+				IntsToStr(pItem->m_aName, std::size(pItem->m_aName), pEnvelope->m_aName, std::size(pEnvelope->m_aName));
+			m_vpEnvelopes.push_back(pEnvelope);
 			if(pItem->m_Version >= 2)
-				pEnv->m_Synchronized = pItem->m_Synchronized;
+				pEnvelope->m_Synchronized = pItem->m_Synchronized;
 		}
 	}
 

--- a/src/game/editor/references.cpp
+++ b/src/game/editor/references.cpp
@@ -5,38 +5,38 @@
 #include <game/editor/mapitems/layer_sounds.h>
 #include <game/editor/mapitems/layer_tiles.h>
 
-void CLayerTilesEnvelopeReference::SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvIndex)
+void CLayerTilesEnvelopeReference::SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvelopeIndex)
 {
 	if(pEnvelope->Type() == CEnvelope::EType::COLOR)
 	{
-		m_pLayerTiles->m_ColorEnv = EnvIndex;
+		m_pLayerTiles->m_ColorEnv = EnvelopeIndex;
 	}
 }
 
-void CLayerQuadsEnvelopeReference::SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvIndex)
+void CLayerQuadsEnvelopeReference::SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvelopeIndex)
 {
 	for(auto &QuadIndex : m_vQuadIndices)
 	{
 		if(QuadIndex >= 0 && QuadIndex < (int)m_pLayerQuads->m_vQuads.size())
 		{
 			if(pEnvelope->Type() == CEnvelope::EType::COLOR)
-				m_pLayerQuads->m_vQuads[QuadIndex].m_ColorEnv = EnvIndex;
+				m_pLayerQuads->m_vQuads[QuadIndex].m_ColorEnv = EnvelopeIndex;
 			else if(pEnvelope->Type() == CEnvelope::EType::POSITION)
-				m_pLayerQuads->m_vQuads[QuadIndex].m_PosEnv = EnvIndex;
+				m_pLayerQuads->m_vQuads[QuadIndex].m_PosEnv = EnvelopeIndex;
 		}
 	}
 }
 
-void CLayerSoundEnvelopeReference::SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvIndex)
+void CLayerSoundEnvelopeReference::SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvelopeIndex)
 {
 	for(auto &SoundSourceIndex : m_vSoundSourceIndices)
 	{
 		if(SoundSourceIndex >= 0 && SoundSourceIndex <= (int)m_pLayerSounds->m_vSources.size())
 		{
 			if(pEnvelope->Type() == CEnvelope::EType::SOUND)
-				m_pLayerSounds->m_vSources[SoundSourceIndex].m_SoundEnv = EnvIndex;
+				m_pLayerSounds->m_vSources[SoundSourceIndex].m_SoundEnv = EnvelopeIndex;
 			else if(pEnvelope->Type() == CEnvelope::EType::POSITION)
-				m_pLayerSounds->m_vSources[SoundSourceIndex].m_PosEnv = EnvIndex;
+				m_pLayerSounds->m_vSources[SoundSourceIndex].m_PosEnv = EnvelopeIndex;
 		}
 	}
 }

--- a/src/game/editor/references.h
+++ b/src/game/editor/references.h
@@ -12,7 +12,7 @@ class CLayerTiles;
 class IEditorEnvelopeReference
 {
 public:
-	virtual void SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvIndex) = 0;
+	virtual void SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvelopeIndex) = 0;
 	virtual ~IEditorEnvelopeReference() = default;
 };
 
@@ -21,7 +21,7 @@ class CLayerTilesEnvelopeReference : public IEditorEnvelopeReference
 public:
 	CLayerTilesEnvelopeReference(std::shared_ptr<CLayerTiles> pLayerTiles) :
 		m_pLayerTiles(std::move(pLayerTiles)) {}
-	void SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvIndex) override;
+	void SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvelopeIndex) override;
 
 private:
 	std::shared_ptr<CLayerTiles> m_pLayerTiles;
@@ -32,7 +32,7 @@ class CLayerQuadsEnvelopeReference : public IEditorEnvelopeReference
 public:
 	CLayerQuadsEnvelopeReference(std::shared_ptr<CLayerQuads> pLayerQuads) :
 		m_pLayerQuads(std::move(pLayerQuads)) {}
-	void SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvIndex) override;
+	void SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvelopeIndex) override;
 	void AddQuadIndex(int QuadIndex) { m_vQuadIndices.push_back(QuadIndex); }
 	bool Empty() const { return m_vQuadIndices.empty(); }
 
@@ -46,7 +46,7 @@ class CLayerSoundEnvelopeReference : public IEditorEnvelopeReference
 public:
 	CLayerSoundEnvelopeReference(std::shared_ptr<CLayerSounds> pLayerSounds) :
 		m_pLayerSounds(std::move(pLayerSounds)) {}
-	void SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvIndex) override;
+	void SetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope, int EnvelopeIndex) override;
 	void AddSoundSourceIndex(int SoundSourceIndex) { m_vSoundSourceIndices.push_back(SoundSourceIndex); }
 	bool Empty() const { return m_vSoundSourceIndices.empty(); }
 

--- a/src/game/map/envelope_extrema.cpp
+++ b/src/game/map/envelope_extrema.cpp
@@ -18,9 +18,9 @@ CEnvelopeExtrema::CEnvelopeExtrema(IMap *pMap) :
 	CalculateExtrema();
 }
 
-void CEnvelopeExtrema::CalculateEnvelope(const CMapItemEnvelope *pEnvelopeItem, int EnvId)
+void CEnvelopeExtrema::CalculateEnvelope(const CMapItemEnvelope *pEnvelopeItem, int EnvelopeIndex)
 {
-	CEnvelopeExtremaItem &EnvExt = m_vEnvelopeExtrema[EnvId];
+	CEnvelopeExtremaItem &EnvExt = m_vEnvelopeExtrema[EnvelopeIndex];
 
 	// setup default values
 	for(int Channel = 0; Channel < 2; ++Channel)
@@ -81,21 +81,21 @@ void CEnvelopeExtrema::CalculateEnvelope(const CMapItemEnvelope *pEnvelopeItem, 
 
 void CEnvelopeExtrema::CalculateExtrema()
 {
-	int EnvStart, EnvNum;
-	m_pMap->GetType(MAPITEMTYPE_ENVELOPE, &EnvStart, &EnvNum);
-	m_vEnvelopeExtrema.resize(EnvNum);
-	for(int EnvId = 0; EnvId < EnvNum; ++EnvId)
+	int EnvelopeStart, EnvelopeNum;
+	m_pMap->GetType(MAPITEMTYPE_ENVELOPE, &EnvelopeStart, &EnvelopeNum);
+	m_vEnvelopeExtrema.resize(EnvelopeNum);
+	for(int EnvelopeIndex = 0; EnvelopeIndex < EnvelopeNum; ++EnvelopeIndex)
 	{
-		const CMapItemEnvelope *pItem = static_cast<const CMapItemEnvelope *>(m_pMap->GetItem(EnvStart + EnvId));
-		CalculateEnvelope(pItem, EnvId);
+		const CMapItemEnvelope *pItem = static_cast<const CMapItemEnvelope *>(m_pMap->GetItem(EnvelopeStart + EnvelopeIndex));
+		CalculateEnvelope(pItem, EnvelopeIndex);
 	}
 }
 
-const CEnvelopeExtrema::CEnvelopeExtremaItem &CEnvelopeExtrema::GetExtrema(int Env) const
+const CEnvelopeExtrema::CEnvelopeExtremaItem &CEnvelopeExtrema::GetExtrema(int EnvelopeIndex) const
 {
-	if(Env == -1)
+	if(EnvelopeIndex == -1)
 		return m_EnvelopeExtremaItemNone; // No envelope just means no movement
-	else if(Env < -1 || Env >= (int)m_vEnvelopeExtrema.size())
+	else if(EnvelopeIndex < -1 || EnvelopeIndex >= (int)m_vEnvelopeExtrema.size())
 		return m_EnvelopeExtremaItemInvalid;
-	return m_vEnvelopeExtrema[Env];
+	return m_vEnvelopeExtrema[EnvelopeIndex];
 }

--- a/src/game/map/envelope_extrema.h
+++ b/src/game/map/envelope_extrema.h
@@ -21,10 +21,10 @@ public:
 		ivec2 m_Maxima;
 	};
 
-	const CEnvelopeExtremaItem &GetExtrema(int Env) const;
+	const CEnvelopeExtremaItem &GetExtrema(int EnvelopeIndex) const;
 
 private:
-	void CalculateEnvelope(const CMapItemEnvelope *pEnvelopeItem, int EnvId);
+	void CalculateEnvelope(const CMapItemEnvelope *pEnvelopeItem, int EnvelopeIndex);
 	void CalculateExtrema();
 
 	CEnvelopeExtremaItem m_EnvelopeExtremaItemNone;

--- a/src/game/map/render_interfaces.h
+++ b/src/game/map/render_interfaces.h
@@ -23,7 +23,7 @@ class IEnvelopeEval
 {
 public:
 	virtual ~IEnvelopeEval() = default;
-	virtual void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels) = 0;
+	virtual void EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels) = 0;
 };
 
 class IMapImages

--- a/src/game/map/render_map.cpp
+++ b/src/game/map/render_map.cpp
@@ -53,11 +53,11 @@ int IEnvelopePointAccess::FindPointIndex(CFixedTime Time) const
 CMapBasedEnvelopePointAccess::CMapBasedEnvelopePointAccess(CDataFileReader *pReader)
 {
 	bool FoundBezierEnvelope = false;
-	int EnvStart, EnvNum;
-	pReader->GetType(MAPITEMTYPE_ENVELOPE, &EnvStart, &EnvNum);
-	for(int EnvIndex = 0; EnvIndex < EnvNum; EnvIndex++)
+	int EnvelopeStart, EnvelopeNum;
+	pReader->GetType(MAPITEMTYPE_ENVELOPE, &EnvelopeStart, &EnvelopeNum);
+	for(int EnvelopeIndex = 0; EnvelopeIndex < EnvelopeNum; EnvelopeIndex++)
 	{
-		CMapItemEnvelope *pEnvelope = static_cast<CMapItemEnvelope *>(pReader->GetItem(EnvStart + EnvIndex));
+		CMapItemEnvelope *pEnvelope = static_cast<CMapItemEnvelope *>(pReader->GetItem(EnvelopeStart + EnvelopeIndex));
 		if(pEnvelope->m_Version >= CMapItemEnvelope::VERSION_TEEWORLDS_BEZIER)
 		{
 			FoundBezierEnvelope = true;


### PR DESCRIPTION
- `e`, `Env`, `EnvId`, `EnvIndex` --> `EnvelopeIndex`
- `EnvStart` --> `EnvelopeStart`
- `EnvNum` --> `EnvelopeNum`
- `pEnv` --> `pEnvelope`
- `p` --> `PointIndex`

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
