### PR TITLE
Fix: Round milliseconds similar to str_time_float

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3131,7 +3131,7 @@ int str_time(int64_t centisecs, int format, char *buffer, int buffer_size)
 
 int str_time_float(float secs, int format, char *buffer, int buffer_size)
 {
-	return str_time(llroundf(secs * 1000) / 10, format, buffer, buffer_size);
+	return str_time(static_cast<int64_t>(roundf(secs * 1000) / 10), format, buffer, buffer_size);
 }
 
 void net_stats(NETSTATS *stats_inout)

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -484,12 +484,13 @@ void CPlayer::Snap(int SnappingClient)
 	// set precise finish time instead of timescore
 	if(m_Score.has_value() && (!g_Config.m_SvHideScore || SnappingClient == m_ClientId))
 	{
-		float Seconds, Millis;
-		Millis = std::modf(GameServer()->Score()->PlayerData(m_ClientId)->m_BestTime, &Seconds);
-		Millis = std::floor(Millis * 1000.0f);
+		// same as in str_time_float
+		int64_t TimeMilliseconds = static_cast<int64_t>(std::roundf(GameServer()->Score()->PlayerData(m_ClientId)->m_BestTime * 1000.0f));
+		int Seconds = static_cast<int>(TimeMilliseconds / 1000);
+		int Millis = static_cast<int>(TimeMilliseconds % 1000);
 
-		pDDNetPlayer->m_FinishTimeSeconds = static_cast<int>(Seconds);
-		pDDNetPlayer->m_FinishTimeMillis = static_cast<int>(Millis);
+		pDDNetPlayer->m_FinishTimeSeconds = Seconds;
+		pDDNetPlayer->m_FinishTimeMillis = Millis;
 	}
 	else
 	{


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Currently the milliseconds of the new finish time netmessage are floored. It looks like ConRank ( `/rank` ) rounds the value to the nearest millisecond and then converts it into hundredths, which can lead to a different time between the netmessage and the command.

This PR uses the same rounding method as [`str_time_float`](https://github.com/ddnet/ddnet/blob/878d8bc415f33a29845335111843b9e73a68a7e0/src/base/system.cpp#L3134)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
