### PR TITLE
Add missing `#include <cstddef>` for `size_t` in `android_main.h`

### DIFF
--- a/src/android/android_main.h
+++ b/src/android/android_main.h
@@ -6,6 +6,8 @@
 #error "This header should only be included when compiling for Android"
 #endif
 
+#include <cstddef>
+
 /**
  * @defgroup Android Android
  *


### PR DESCRIPTION


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions