### PR TITLE
Lint: Add additional ruff checks

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -16,6 +16,12 @@ indent-style = "tab"
 preview = true # allow complex single line arguments to start on the same line, like `fn({`
 
 [lint]
+extend-select = [
+    "A", # detect shadowed builtins
+    "B006", # mutable default arguments
+    "BLE", # disallow catch-all exceptions
+]
+
 ignore = [
     "E741", # ambiguous-variable-name: prohibits `l` as variable name
 ]

--- a/scripts/extract_identifiers.py
+++ b/scripts/extract_identifiers.py
@@ -55,7 +55,7 @@ def get_complex_type(typ):
 		return get_complex_type(typ.get_pointee())
 	if typ.kind == TypeKind.POINTER:
 		return "p" + get_complex_type(typ.get_pointee())
-	if is_array_type(type):
+	if is_array_type(typ):
 		return "a" + get_complex_type(typ.element_type)
 	if typ.kind == TypeKind.FUNCTIONPROTO:
 		return "fn"
@@ -89,7 +89,7 @@ def is_static_member_definition_hack(node):
 def is_const(typ):
 	if typ.is_const_qualified():
 		return True
-	if is_array_type(type):
+	if is_array_type(typ):
 		return is_const(typ.element_type)
 	return False
 

--- a/scripts/generate_community_token.py
+++ b/scripts/generate_community_token.py
@@ -5,16 +5,16 @@ import binascii
 import secrets
 
 
-def _crc32(bytes):
-	return binascii.crc32(bytes).to_bytes(4, "big")
+def _crc32(bytes_):
+	return binascii.crc32(bytes_).to_bytes(4, "big")
 
 
 def _add_crc32(s):
 	return s + _urlsafe_encode(_crc32(s.encode("ascii")))
 
 
-def _urlsafe_encode(bytes):
-	return base64.urlsafe_b64encode(bytes).decode("ascii").rstrip("=")
+def _urlsafe_encode(bytes_):
+	return base64.urlsafe_b64encode(bytes_).decode("ascii").rstrip("=")
 
 
 def _generate_token_impl():

--- a/scripts/import_file_score.py
+++ b/scripts/import_file_score.py
@@ -73,7 +73,8 @@ def main():
 			");"
 		)
 		c.executemany(
-			"INSERT INTO record_race (Map, Name, Time, Server, " + "".join(f"cp{i + 1}, " for i in range(25)) + "GameId, DDNet7) " + f"VALUES ({','.join('?' * 31)})", [(map, r.name, float(r.time), "TEXT", *[float(c) for c in r.checkpoints], None, False) for map, record in records.items() for r in record]
+			"INSERT INTO record_race (Map, Name, Time, Server, " + "".join(f"cp{i + 1}, " for i in range(25)) + "GameId, DDNet7) " + f"VALUES ({','.join('?' * 31)})",
+			[(ddnet_map, r.name, float(r.time), "TEXT", *[float(c) for c in r.checkpoints], None, False) for ddnet_map, record in records.items() for r in record]
 		)
 		conn.commit()
 		conn.close()

--- a/scripts/languages/twlang.py
+++ b/scripts/languages/twlang.py
@@ -91,5 +91,5 @@ def translations(filename):
 
 
 def localizes():
-	englishlist = list(check_folder("src"))
-	return englishlist
+	english_list = list(check_folder("src"))
+	return english_list

--- a/scripts/unicode.py
+++ b/scripts/unicode.py
@@ -4,8 +4,8 @@ import csv
 def confusables():
 	with open("confusables.txt", encoding="utf-8-sig") as f:
 		# Filter comments
-		f = map(lambda line: line.split("#")[0], f)
-		return list(csv.DictReader(f, fieldnames=["Value", "Target", "Category"], delimiter=";"))
+		lines = (line.split("#")[0] for line in f)
+		return list(csv.DictReader(lines, fieldnames=["Value", "Target", "Category"], delimiter=";"))
 
 
 UNICODEDATA_FIELDS = (


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

| ruff rule | explanation |
| --- | --- |
| "A", # detect shadowed builtins | we should really not name variables like buildins, this is bad practice and can lead to very |
| "B006", # mutable default argument | python is really weird and this can only cause error prone code if you don't pay attention
 |   "BLE", # disallow catch-all exceptions | broad exceptions are bad in general, we enforced this in pylint already|

`f = (lambda line: line.split("#")[0], f)` doesn't make sense this way, applying it to f, which was previously a file. I find this line very bad and rewrote it.

## Checklist

- [ ] Tested the change ingame (Doesn't apply)
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->

I asked AI for the `f = (lambda line: line.split("#")[0], f)`, because I found it so obscure. The new version is much better readable
