### PR TITLE
Fix ogg and opus not detected as bundled during cmake configuration

### DIFF
--- a/cmake/FindOgg.cmake
+++ b/cmake/FindOgg.cmake
@@ -24,6 +24,7 @@ find_package_handle_standard_args(Ogg DEFAULT_MSG OGG_INCLUDEDIR)
 mark_as_advanced(OGG_INCLUDEDIR OGG_LIBRARY)
 
 if(OGG_FOUND)
+  is_bundled(OGG_BUNDLED "${OGG_LIBRARY}")
   set(OGG_INCLUDE_DIRS ${OGG_INCLUDEDIR})
   if(OGG_LIBRARY)
     set(OGG_LIBRARIES ${OGG_LIBRARY})

--- a/cmake/FindOpus.cmake
+++ b/cmake/FindOpus.cmake
@@ -24,6 +24,7 @@ find_package_handle_standard_args(Opus DEFAULT_MSG OPUS_INCLUDEDIR)
 mark_as_advanced(OPUS_INCLUDEDIR OPUS_LIBRARY)
 
 if(OPUS_FOUND)
+  is_bundled(OPUS_BUNDLED "${OPUS_LIBRARY}")
   set(OPUS_INCLUDE_DIRS ${OPUS_INCLUDEDIR})
   if(OPUS_LIBRARY)
     set(OPUS_LIBRARIES ${OPUS_LIBRARY})


### PR DESCRIPTION
Configuring the project logged `Ogg found`/`Opus found` when using the bundled version, but it should print `Ogg not found (using bundled version)`/`Opus not found (using bundled version)` like for other libraries.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions