### PR TITLE
Use `const` pointers in editor trackers

### DIFF
--- a/src/game/editor/editor_trackers.cpp
+++ b/src/game/editor/editor_trackers.cpp
@@ -400,7 +400,7 @@ CSoundSourceOperationTracker::CSoundSourceOperationTracker(CEditorMap *pMap) :
 {
 }
 
-void CSoundSourceOperationTracker::Begin(CSoundSource *pSource, ESoundSourceOp Operation, int LayerIndex)
+void CSoundSourceOperationTracker::Begin(const CSoundSource *pSource, ESoundSourceOp Operation, int LayerIndex)
 {
 	if(m_TrackedOp == Operation || m_TrackedOp != ESoundSourceOp::OP_NONE)
 		return;

--- a/src/game/editor/editor_trackers.h
+++ b/src/game/editor/editor_trackers.h
@@ -103,11 +103,11 @@ class CSoundSourceOperationTracker : public CMapObject
 public:
 	explicit CSoundSourceOperationTracker(CEditorMap *pMap);
 
-	void Begin(CSoundSource *pSource, ESoundSourceOp Operation, int LayerIndex);
+	void Begin(const CSoundSource *pSource, ESoundSourceOp Operation, int LayerIndex);
 	void End();
 
 private:
-	CSoundSource *m_pSource;
+	const CSoundSource *m_pSource;
 	ESoundSourceOp m_TrackedOp;
 	int m_LayerIndex;
 
@@ -138,7 +138,7 @@ public:
 		m_CurrentGroupIndex(-1),
 		m_Tracking(false) {}
 
-	void Begin(T *pObject, E Prop, EEditState State, int GroupIndex = -1, int LayerIndex = -1)
+	void Begin(const T *pObject, E Prop, EEditState State, int GroupIndex = -1, int LayerIndex = -1)
 	{
 		if(m_Tracking || Prop == static_cast<E>(-1))
 			return;
@@ -185,7 +185,7 @@ protected:
 	}
 
 	int m_OriginalValue;
-	T *m_pObject;
+	const T *m_pObject;
 	int m_OriginalLayerIndex;
 	int m_OriginalGroupIndex;
 	int m_CurrentLayerIndex;


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
