### PR TITLE
Fix 4:3 aspect ratio support on Wayland

### DIFF
--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -4055,12 +4055,19 @@ public:
 
 		VkExtent2D AutoViewportExtent = RetSize;
 		bool UsesForcedViewport = false;
-		// keep this in sync with graphics_threaded AdjustViewport's check
+#ifdef CONF_FAMILY_WINDOWS
 		if(AutoViewportExtent.height > 4 * AutoViewportExtent.width / 5)
 		{
 			AutoViewportExtent.height = 4 * AutoViewportExtent.width / 5;
 			UsesForcedViewport = true;
 		}
+#else
+		if(AutoViewportExtent.height > 3 * AutoViewportExtent.width / 4)
+		{
+			AutoViewportExtent.height = 3 * AutoViewportExtent.width / 4;
+			UsesForcedViewport = true;
+		}
+#endif
 
 		SSwapImgViewportExtent Ext;
 		Ext.m_SwapImageViewport = RetSize;

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1142,10 +1142,7 @@ int CGraphicsBackend_SDL_GL::Init(const char *pName, int *pScreen, int *pWidth, 
 			Compiled.major, Compiled.minor, Compiled.patch);
 
 #if CONF_PLATFORM_LINUX && SDL_VERSION_ATLEAST(2, 0, 22)
-		// needed to workaround SDL from forcing exclusively X11 if linking against the GLX flavour of GLEW instead of the EGL one
-		// w/o this on Wayland systems (no XWayland support) SDL's Video subsystem will fail to load (starting from SDL2.30+)
-		if(Linked.major == 2 && Linked.minor >= 30)
-			SDL_SetHint(SDL_HINT_VIDEODRIVER, "x11,wayland");
+		SDL_SetHintWithPriority(SDL_HINT_VIDEODRIVER, "wayland,x11", SDL_HINT_OVERRIDE);
 #endif
 	}
 

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -2242,8 +2242,7 @@ int CGraphics_Threaded::IssueInit()
 
 void CGraphics_Threaded::AdjustViewport(bool SendViewportChangeToBackend)
 {
-	// adjust the viewport to only allow certain aspect ratios
-	// keep this in sync with backend_vulkan GetSwapImageSize's check
+#ifdef CONF_FAMILY_WINDOWS
 	if(m_ScreenHeight > 4 * m_ScreenWidth / 5)
 	{
 		m_IsForcedViewport = true;
@@ -2258,6 +2257,22 @@ void CGraphics_Threaded::AdjustViewport(bool SendViewportChangeToBackend)
 	{
 		m_IsForcedViewport = false;
 	}
+#else
+	if(m_ScreenHeight > 3 * m_ScreenWidth / 4)
+	{
+		m_IsForcedViewport = true;
+		m_ScreenHeight = 3 * m_ScreenWidth / 4;
+
+		if(SendViewportChangeToBackend)
+		{
+			UpdateViewport(0, 0, m_ScreenWidth, m_ScreenHeight, true);
+		}
+	}
+	else
+	{
+		m_IsForcedViewport = false;
+	}
+#endif
 }
 
 void CGraphics_Threaded::UpdateViewport(int X, int Y, int W, int H, bool ByResize)


### PR DESCRIPTION
I noticed that the game doesn't start or scale correctly when using a 4:3 aspect ratio on Wayland environments. This PR updates the scaling logic in both SDL and Vulkan backends and fixes the aspect ratio calculations in graphics_threaded.cpp to handle this properly.

Tested on:
- OS: Arch Linux
- DE: KDE Plasma 6.5.4
- GPU: RTX 3080 (Nvidia)