### PR TITLE
Add `CEditor::Map` getter, make `CEditor::m_Map` private

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -160,6 +160,8 @@ public:
 	CUi *Ui() { return &m_UI; }
 	CRenderMap *RenderMap() { return &m_RenderMap; }
 
+	CEditorMap *Map() { return &m_Map; }
+	const CEditorMap *Map() const { return &m_Map; }
 	CMapView *MapView() { return &m_MapView; }
 	const CMapView *MapView() const { return &m_MapView; }
 	CLayerSelector *LayerSelector() { return &m_LayerSelector; }
@@ -194,8 +196,8 @@ public:
 #undef REGISTER_QUICK_ACTION
 		m_ZoomEnvelopeX(1.0f, 0.1f, 600.0f),
 		m_ZoomEnvelopeY(640.0f, 0.1f, 32000.0f),
-		m_Map(this),
-		m_MapSettingsCommandContext(m_MapSettingsBackend.NewContext(&m_SettingsCommandInput))
+		m_MapSettingsCommandContext(m_MapSettingsBackend.NewContext(&m_SettingsCommandInput)),
+		m_Map(this)
 	{
 		m_EntitiesTexture.Invalidate();
 		m_FrontTexture.Invalidate();
@@ -302,7 +304,7 @@ public:
 	void OnWindowResize() override;
 	void OnClose() override;
 	void OnDialogClose();
-	bool HasUnsavedData() const override { return m_Map.m_Modified; }
+	bool HasUnsavedData() const override { return Map()->m_Modified; }
 	void UpdateMentions() override { m_Mentions++; }
 	void ResetMentions() override { m_Mentions = 0; }
 	void OnIngameMoved() override { m_IngameMoved = true; }
@@ -561,7 +563,6 @@ public:
 
 	const void *m_pUiGotContext = nullptr;
 
-	CEditorMap m_Map;
 	std::deque<std::shared_ptr<CDataFileWriterFinishJob>> m_WriterFinishJobs;
 
 	void EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels) override;
@@ -839,6 +840,8 @@ public:
 	void AdjustBrushSpecialTiles(bool UseNextFree, int Adjust = 0);
 
 private:
+	CEditorMap m_Map;
+
 	CEditorHistory &ActiveHistory();
 
 	std::map<int, CPoint[5]> m_QuadDragOriginalPoints;

--- a/src/game/editor/editor_props.cpp
+++ b/src/game/editor/editor_props.cpp
@@ -136,7 +136,7 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 			if(pProps[i].m_Value < 0)
 				pName = "None";
 			else
-				pName = m_Map.m_vpImages[pProps[i].m_Value]->m_aName;
+				pName = Map()->m_vpImages[pProps[i].m_Value]->m_aName;
 
 			if(DoButton_Ex(&pIds[i], pName, 0, &Shifter, BUTTONFLAG_LEFT, nullptr, IGraphics::CORNER_ALL))
 				PopupSelectImageInvoke(pProps[i].m_Value, Ui()->MouseX(), Ui()->MouseY());
@@ -192,7 +192,7 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 			if(pProps[i].m_Value < 0)
 				pName = "None";
 			else
-				pName = m_Map.m_vpSounds[pProps[i].m_Value]->m_aName;
+				pName = Map()->m_vpSounds[pProps[i].m_Value]->m_aName;
 
 			if(DoButton_Ex(&pIds[i], pName, 0, &Shifter, BUTTONFLAG_LEFT, nullptr, IGraphics::CORNER_ALL))
 				PopupSelectSoundInvoke(pProps[i].m_Value, Ui()->MouseX(), Ui()->MouseY());
@@ -208,10 +208,10 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 		else if(pProps[i].m_Type == PROPTYPE_AUTOMAPPER)
 		{
 			const char *pName;
-			if(pProps[i].m_Value < 0 || pProps[i].m_Min < 0 || pProps[i].m_Min >= (int)m_Map.m_vpImages.size())
+			if(pProps[i].m_Value < 0 || pProps[i].m_Min < 0 || pProps[i].m_Min >= (int)Map()->m_vpImages.size())
 				pName = "None";
 			else
-				pName = m_Map.m_vpImages[pProps[i].m_Min]->m_AutoMapper.GetConfigName(pProps[i].m_Value);
+				pName = Map()->m_vpImages[pProps[i].m_Min]->m_AutoMapper.GetConfigName(pProps[i].m_Value);
 
 			if(DoButton_Ex(&pIds[i], pName, 0, &Shifter, BUTTONFLAG_LEFT, nullptr, IGraphics::CORNER_ALL))
 				PopupSelectConfigAutoMapInvoke(pProps[i].m_Value, Ui()->MouseX(), Ui()->MouseY());
@@ -252,13 +252,13 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 			Shifter.VSplitRight(10.0f, &Shifter, &Inc);
 			Shifter.VSplitLeft(10.0f, &Dec, &Shifter);
 
-			if(CurValue <= 0 || CurValue > (int)m_Map.m_vpEnvelopes.size())
+			if(CurValue <= 0 || CurValue > (int)Map()->m_vpEnvelopes.size())
 			{
 				str_copy(aBuf, "None:");
 			}
-			else if(m_Map.m_vpEnvelopes[CurValue - 1]->m_aName[0])
+			else if(Map()->m_vpEnvelopes[CurValue - 1]->m_aName[0])
 			{
-				str_format(aBuf, sizeof(aBuf), "%s:", m_Map.m_vpEnvelopes[CurValue - 1]->m_aName);
+				str_format(aBuf, sizeof(aBuf), "%s:", Map()->m_vpEnvelopes[CurValue - 1]->m_aName);
 				if(!str_endswith(aBuf, ":"))
 				{
 					aBuf[sizeof(aBuf) - 2] = ':';
@@ -270,7 +270,7 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 				aBuf[0] = '\0';
 			}
 
-			auto NewValueRes = UiDoValueSelector((char *)&pIds[i], &Shifter, aBuf, CurValue, 0, m_Map.m_vpEnvelopes.size(), 1, 1.0f, "Select envelope.", false, false, IGraphics::CORNER_NONE);
+			auto NewValueRes = UiDoValueSelector((char *)&pIds[i], &Shifter, aBuf, CurValue, 0, Map()->m_vpEnvelopes.size(), 1, 1.0f, "Select envelope.", false, false, IGraphics::CORNER_NONE);
 			int NewVal = NewValueRes.m_Value;
 			if(NewVal != CurValue || (NewValueRes.m_State != EEditState::NONE && NewValueRes.m_State != EEditState::EDITING))
 			{

--- a/src/game/editor/editor_server_settings.cpp
+++ b/src/game/editor/editor_server_settings.cpp
@@ -59,7 +59,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 	static CListBox s_ListBox;
 	s_ListBox.SetActive(!m_MapSettingsCommandContext.m_DropdownContext.m_ListBox.Active() && m_Dialog == DIALOG_NONE && !Ui()->IsPopupOpen());
 
-	bool GotSelection = s_ListBox.Active() && s_CommandSelectedIndex >= 0 && (size_t)s_CommandSelectedIndex < m_Map.m_vSettings.size();
+	bool GotSelection = s_ListBox.Active() && s_CommandSelectedIndex >= 0 && (size_t)s_CommandSelectedIndex < Map()->m_vSettings.size();
 	const bool CurrentInputValid = m_MapSettingsCommandContext.Valid(); // Use the context to validate the input
 
 	CUIRect ToolBar, Button, Label, List, DragBar;
@@ -78,31 +78,31 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 	static int s_DeleteButton = 0;
 	if(DoButton_FontIcon(&s_DeleteButton, FONT_ICON_TRASH, GotSelection ? 0 : -1, &Button, BUTTONFLAG_LEFT, "[Delete] Delete the selected command from the command list.", IGraphics::CORNER_ALL, 9.0f) || (GotSelection && CLineInput::GetActiveInput() == nullptr && m_Dialog == DIALOG_NONE && Ui()->ConsumeHotkey(CUi::HOTKEY_DELETE)))
 	{
-		m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::DELETE, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand));
+		Map()->m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(Map(), CEditorCommandAction::EType::DELETE, &s_CommandSelectedIndex, s_CommandSelectedIndex, Map()->m_vSettings[s_CommandSelectedIndex].m_aCommand));
 
-		m_Map.m_vSettings.erase(m_Map.m_vSettings.begin() + s_CommandSelectedIndex);
-		if(s_CommandSelectedIndex >= (int)m_Map.m_vSettings.size())
-			s_CommandSelectedIndex = m_Map.m_vSettings.size() - 1;
+		Map()->m_vSettings.erase(Map()->m_vSettings.begin() + s_CommandSelectedIndex);
+		if(s_CommandSelectedIndex >= (int)Map()->m_vSettings.size())
+			s_CommandSelectedIndex = Map()->m_vSettings.size() - 1;
 		if(s_CommandSelectedIndex >= 0)
-			m_SettingsCommandInput.Set(m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand);
+			m_SettingsCommandInput.Set(Map()->m_vSettings[s_CommandSelectedIndex].m_aCommand);
 		else
 			m_SettingsCommandInput.Clear();
-		m_Map.OnModify();
+		Map()->OnModify();
 		m_MapSettingsCommandContext.Update();
 		s_ListBox.ScrollToSelected();
 	}
 
 	// move down button
 	ToolBar.VSplitRight(25.0f, &ToolBar, &Button);
-	const bool CanMoveDown = GotSelection && s_CommandSelectedIndex < (int)m_Map.m_vSettings.size() - 1;
+	const bool CanMoveDown = GotSelection && s_CommandSelectedIndex < (int)Map()->m_vSettings.size() - 1;
 	static int s_DownButton = 0;
 	if(DoButton_FontIcon(&s_DownButton, FONT_ICON_SORT_DOWN, CanMoveDown ? 0 : -1, &Button, BUTTONFLAG_LEFT, "[Alt+Down] Move the selected command down.", IGraphics::CORNER_R, 11.0f) || (CanMoveDown && Input()->AltIsPressed() && Ui()->ConsumeHotkey(CUi::HOTKEY_DOWN)))
 	{
-		m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::MOVE_DOWN, &s_CommandSelectedIndex, s_CommandSelectedIndex));
+		Map()->m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(Map(), CEditorCommandAction::EType::MOVE_DOWN, &s_CommandSelectedIndex, s_CommandSelectedIndex));
 
-		std::swap(m_Map.m_vSettings[s_CommandSelectedIndex], m_Map.m_vSettings[s_CommandSelectedIndex + 1]);
+		std::swap(Map()->m_vSettings[s_CommandSelectedIndex], Map()->m_vSettings[s_CommandSelectedIndex + 1]);
 		s_CommandSelectedIndex++;
-		m_Map.OnModify();
+		Map()->OnModify();
 		s_ListBox.ScrollToSelected();
 	}
 
@@ -113,32 +113,32 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 	static int s_UpButton = 0;
 	if(DoButton_FontIcon(&s_UpButton, FONT_ICON_SORT_UP, CanMoveUp ? 0 : -1, &Button, BUTTONFLAG_LEFT, "[Alt+Up] Move the selected command up.", IGraphics::CORNER_L, 11.0f) || (CanMoveUp && Input()->AltIsPressed() && Ui()->ConsumeHotkey(CUi::HOTKEY_UP)))
 	{
-		m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::MOVE_UP, &s_CommandSelectedIndex, s_CommandSelectedIndex));
+		Map()->m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(Map(), CEditorCommandAction::EType::MOVE_UP, &s_CommandSelectedIndex, s_CommandSelectedIndex));
 
-		std::swap(m_Map.m_vSettings[s_CommandSelectedIndex], m_Map.m_vSettings[s_CommandSelectedIndex - 1]);
+		std::swap(Map()->m_vSettings[s_CommandSelectedIndex], Map()->m_vSettings[s_CommandSelectedIndex - 1]);
 		s_CommandSelectedIndex--;
-		m_Map.OnModify();
+		Map()->OnModify();
 		s_ListBox.ScrollToSelected();
 	}
 
 	// redo button
 	ToolBar.VSplitRight(25.0f, &ToolBar, &Button);
 	static int s_RedoButton = 0;
-	if(DoButton_FontIcon(&s_RedoButton, FONT_ICON_REDO, m_Map.m_ServerSettingsHistory.CanRedo() ? 0 : -1, &Button, BUTTONFLAG_LEFT, "[Ctrl+Y] Redo the last command edit.", IGraphics::CORNER_R, 11.0f))
+	if(DoButton_FontIcon(&s_RedoButton, FONT_ICON_REDO, Map()->m_ServerSettingsHistory.CanRedo() ? 0 : -1, &Button, BUTTONFLAG_LEFT, "[Ctrl+Y] Redo the last command edit.", IGraphics::CORNER_R, 11.0f))
 	{
-		m_Map.m_ServerSettingsHistory.Redo();
+		Map()->m_ServerSettingsHistory.Redo();
 	}
 
 	// undo button
 	ToolBar.VSplitRight(25.0f, &ToolBar, &Button);
 	ToolBar.VSplitRight(5.0f, &ToolBar, nullptr);
 	static int s_UndoButton = 0;
-	if(DoButton_FontIcon(&s_UndoButton, FONT_ICON_UNDO, m_Map.m_ServerSettingsHistory.CanUndo() ? 0 : -1, &Button, BUTTONFLAG_LEFT, "[Ctrl+Z] Undo the last command edit.", IGraphics::CORNER_L, 11.0f))
+	if(DoButton_FontIcon(&s_UndoButton, FONT_ICON_UNDO, Map()->m_ServerSettingsHistory.CanUndo() ? 0 : -1, &Button, BUTTONFLAG_LEFT, "[Ctrl+Z] Undo the last command edit.", IGraphics::CORNER_L, 11.0f))
 	{
-		m_Map.m_ServerSettingsHistory.Undo();
+		Map()->m_ServerSettingsHistory.Undo();
 	}
 
-	GotSelection = s_ListBox.Active() && s_CommandSelectedIndex >= 0 && (size_t)s_CommandSelectedIndex < m_Map.m_vSettings.size();
+	GotSelection = s_ListBox.Active() && s_CommandSelectedIndex >= 0 && (size_t)s_CommandSelectedIndex < Map()->m_vSettings.size();
 
 	int CollidingCommandIndex = -1;
 	ECollisionCheckResult CheckResult = ECollisionCheckResult::ERROR;
@@ -150,7 +150,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 	const bool CanAdd = CheckResult == ECollisionCheckResult::ADD;
 	const bool CanReplace = CheckResult == ECollisionCheckResult::REPLACE;
 
-	const bool CanUpdate = GotSelection && CurrentInputValid && str_comp(m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, m_SettingsCommandInput.GetString()) != 0;
+	const bool CanUpdate = GotSelection && CurrentInputValid && str_comp(Map()->m_vSettings[s_CommandSelectedIndex].m_aCommand, m_SettingsCommandInput.GetString()) != 0;
 
 	static int s_UpdateButton = 0;
 	if(DoButton_FontIcon(&s_UpdateButton, FONT_ICON_PENCIL, CanUpdate ? 0 : -1, &Button, BUTTONFLAG_LEFT, "[Alt+Enter] Update the selected command based on the entered value.", IGraphics::CORNER_R, 9.0f) || (CanUpdate && Input()->AltIsPressed() && m_Dialog == DIALOG_NONE && m_SettingsCommandInput.IsActive() && Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
@@ -159,9 +159,9 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 		{
 			bool Found = false;
 			int i;
-			for(i = 0; i < (int)m_Map.m_vSettings.size(); ++i)
+			for(i = 0; i < (int)Map()->m_vSettings.size(); ++i)
 			{
-				if(i != s_CommandSelectedIndex && !str_comp(m_Map.m_vSettings[i].m_aCommand, m_SettingsCommandInput.GetString()))
+				if(i != s_CommandSelectedIndex && !str_comp(Map()->m_vSettings[i].m_aCommand, m_SettingsCommandInput.GetString()))
 				{
 					Found = true;
 					break;
@@ -169,15 +169,15 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 			}
 			if(Found)
 			{
-				m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::DELETE, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand));
-				m_Map.m_vSettings.erase(m_Map.m_vSettings.begin() + s_CommandSelectedIndex);
+				Map()->m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(Map(), CEditorCommandAction::EType::DELETE, &s_CommandSelectedIndex, s_CommandSelectedIndex, Map()->m_vSettings[s_CommandSelectedIndex].m_aCommand));
+				Map()->m_vSettings.erase(Map()->m_vSettings.begin() + s_CommandSelectedIndex);
 				s_CommandSelectedIndex = i > s_CommandSelectedIndex ? i - 1 : i;
 			}
 			else
 			{
 				const char *pStr = m_SettingsCommandInput.GetString();
-				m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::EDIT, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr));
-				str_copy(m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr);
+				Map()->m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(Map(), CEditorCommandAction::EType::EDIT, &s_CommandSelectedIndex, s_CommandSelectedIndex, Map()->m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr));
+				str_copy(Map()->m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr);
 			}
 		}
 		else
@@ -185,8 +185,8 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 			if(s_CommandSelectedIndex == CollidingCommandIndex)
 			{ // If we are editing the currently collinding line, then we can just call EDIT on it
 				const char *pStr = m_SettingsCommandInput.GetString();
-				m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::EDIT, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr));
-				str_copy(m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr);
+				Map()->m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(Map(), CEditorCommandAction::EType::EDIT, &s_CommandSelectedIndex, s_CommandSelectedIndex, Map()->m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr));
+				str_copy(Map()->m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr);
 			}
 			else
 			{ // If not, then editing the current selected line will result in the deletion of the colliding line, and the editing of the selected line
@@ -195,20 +195,20 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 				char aBuf[256];
 				str_format(aBuf, sizeof(aBuf), "Delete command %d; Edit command %d", CollidingCommandIndex, s_CommandSelectedIndex);
 
-				m_Map.m_ServerSettingsHistory.BeginBulk();
+				Map()->m_ServerSettingsHistory.BeginBulk();
 				// Delete the colliding command
-				m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::DELETE, &s_CommandSelectedIndex, CollidingCommandIndex, m_Map.m_vSettings[CollidingCommandIndex].m_aCommand));
-				m_Map.m_vSettings.erase(m_Map.m_vSettings.begin() + CollidingCommandIndex);
+				Map()->m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(Map(), CEditorCommandAction::EType::DELETE, &s_CommandSelectedIndex, CollidingCommandIndex, Map()->m_vSettings[CollidingCommandIndex].m_aCommand));
+				Map()->m_vSettings.erase(Map()->m_vSettings.begin() + CollidingCommandIndex);
 				// Edit the selected command
 				s_CommandSelectedIndex = s_CommandSelectedIndex > CollidingCommandIndex ? s_CommandSelectedIndex - 1 : s_CommandSelectedIndex;
-				m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::EDIT, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr));
-				str_copy(m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr);
+				Map()->m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(Map(), CEditorCommandAction::EType::EDIT, &s_CommandSelectedIndex, s_CommandSelectedIndex, Map()->m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr));
+				str_copy(Map()->m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr);
 
-				m_Map.m_ServerSettingsHistory.EndBulk(aBuf);
+				Map()->m_ServerSettingsHistory.EndBulk(aBuf);
 			}
 		}
 
-		m_Map.OnModify();
+		Map()->OnModify();
 		s_ListBox.ScrollToSelected();
 		m_SettingsCommandInput.Clear();
 		m_MapSettingsCommandContext.Reset(); // Reset context
@@ -228,17 +228,17 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 			s_CommandSelectedIndex = CollidingCommandIndex;
 
 			const char *pStr = m_SettingsCommandInput.GetString();
-			m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::EDIT, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr));
-			str_copy(m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr);
+			Map()->m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(Map(), CEditorCommandAction::EType::EDIT, &s_CommandSelectedIndex, s_CommandSelectedIndex, Map()->m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr));
+			str_copy(Map()->m_vSettings[s_CommandSelectedIndex].m_aCommand, pStr);
 		}
 		else if(CanAdd)
 		{
-			m_Map.m_vSettings.emplace_back(m_SettingsCommandInput.GetString());
-			s_CommandSelectedIndex = m_Map.m_vSettings.size() - 1;
-			m_Map.m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(&m_Map, CEditorCommandAction::EType::ADD, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand));
+			Map()->m_vSettings.emplace_back(m_SettingsCommandInput.GetString());
+			s_CommandSelectedIndex = Map()->m_vSettings.size() - 1;
+			Map()->m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(Map(), CEditorCommandAction::EType::ADD, &s_CommandSelectedIndex, s_CommandSelectedIndex, Map()->m_vSettings[s_CommandSelectedIndex].m_aCommand));
 		}
 
-		m_Map.OnModify();
+		Map()->OnModify();
 		s_ListBox.ScrollToSelected();
 		m_SettingsCommandInput.Clear();
 		m_MapSettingsCommandContext.Reset(); // Reset context
@@ -253,11 +253,11 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 	TextRender()->TextColor(TextRender()->DefaultTextColor());
 
 	// command list
-	s_ListBox.DoStart(15.0f, m_Map.m_vSettings.size(), 1, 3, s_CommandSelectedIndex, &List);
+	s_ListBox.DoStart(15.0f, Map()->m_vSettings.size(), 1, 3, s_CommandSelectedIndex, &List);
 
-	for(size_t i = 0; i < m_Map.m_vSettings.size(); i++)
+	for(size_t i = 0; i < Map()->m_vSettings.size(); i++)
 	{
-		const CListboxItem Item = s_ListBox.DoNextItem(&m_Map.m_vSettings[i], s_CommandSelectedIndex >= 0 && (size_t)s_CommandSelectedIndex == i);
+		const CListboxItem Item = s_ListBox.DoNextItem(&Map()->m_vSettings[i], s_CommandSelectedIndex >= 0 && (size_t)s_CommandSelectedIndex == i);
 		if(!Item.m_Visible)
 			continue;
 
@@ -266,7 +266,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 		SLabelProperties Props;
 		Props.m_MaxWidth = Label.w;
 		Props.m_EllipsisAtEnd = true;
-		Ui()->DoLabel(&Label, m_Map.m_vSettings[i].m_aCommand, 10.0f, TEXTALIGN_ML, Props);
+		Ui()->DoLabel(&Label, Map()->m_vSettings[i].m_aCommand, 10.0f, TEXTALIGN_ML, Props);
 	}
 
 	const int NewSelected = s_ListBox.DoEnd();
@@ -275,7 +275,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 		s_CommandSelectedIndex = NewSelected;
 		if(m_SettingsCommandInput.IsEmpty() || !Input()->ModifierIsPressed()) // Allow ctrl+click to only change selection
 		{
-			m_SettingsCommandInput.Set(m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand);
+			m_SettingsCommandInput.Set(Map()->m_vSettings[s_CommandSelectedIndex].m_aCommand);
 			m_MapSettingsCommandContext.Update();
 			m_MapSettingsCommandContext.UpdateCursor(true);
 		}
@@ -614,7 +614,7 @@ void CEditor::RenderMapSettingsErrorDialog()
 		bool DisplayFixInput = false;
 		float DropdownHeight = 110.0f;
 
-		for(int i = 0; i < (int)m_Map.m_vSettings.size(); i++)
+		for(int i = 0; i < (int)Map()->m_vSettings.size(); i++)
 		{
 			CUIRect Slot;
 
@@ -778,7 +778,7 @@ void CEditor::RenderMapSettingsErrorDialog()
 
 				// Draw the label
 				Props.m_MaxWidth = Label.w;
-				Ui()->DoLabel(&Label, m_Map.m_vSettings[i].m_aCommand, 10.0f, TEXTALIGN_ML, Props);
+				Ui()->DoLabel(&Label, Map()->m_vSettings[i].m_aCommand, 10.0f, TEXTALIGN_ML, Props);
 
 				// Draw the list of duplicates, with a "Choose" button for each duplicate
 				// In case a duplicate is also invalid, then we draw a "Fix" button which behaves like the fix button above
@@ -859,7 +859,7 @@ void CEditor::RenderMapSettingsErrorDialog()
 						//                       If we write any other setting, like "sv_hit 1", it won't work as it does not match "sv_deepfly".
 						// To do that, we use the context and we check for collision with the current map setting
 						ECollisionCheckResult Res = ECollisionCheckResult::ERROR;
-						s_Context.CheckCollision({m_Map.m_vSettings[i]}, Res);
+						s_Context.CheckCollision({Map()->m_vSettings[i]}, Res);
 						bool Valid = s_Context.Valid() && Res == ECollisionCheckResult::REPLACE;
 
 						if(DoButton_Editor(&s_Ok, "Done", Valid ? 0 : -1, &OkBtn, BUTTONFLAG_LEFT, "Confirm editing of this command.") || (s_Input.IsActive() && Valid && Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
@@ -943,7 +943,7 @@ void CEditor::RenderMapSettingsErrorDialog()
 		{
 			if(FixedSetting.m_Context.m_Fixed)
 			{
-				str_copy(m_Map.m_vSettings[FixedSetting.m_Index].m_aCommand, FixedSetting.m_aSetting);
+				str_copy(Map()->m_vSettings[FixedSetting.m_Index].m_aCommand, FixedSetting.m_aSetting);
 			}
 		}
 
@@ -958,7 +958,7 @@ void CEditor::RenderMapSettingsErrorDialog()
 				if(!Setting.m_Context.m_Chosen)
 					vSettingsToErase.emplace_back(Setting.m_aSetting);
 				else
-					vSettingsToErase.emplace_back(m_Map.m_vSettings[Setting.m_CollidingIndex].m_aCommand);
+					vSettingsToErase.emplace_back(Map()->m_vSettings[Setting.m_CollidingIndex].m_aCommand);
 			}
 		}
 
@@ -967,25 +967,25 @@ void CEditor::RenderMapSettingsErrorDialog()
 		{
 			if(DeletedSetting.m_Context.m_Deleted)
 			{
-				m_Map.m_vSettings.erase(
-					std::remove_if(m_Map.m_vSettings.begin(), m_Map.m_vSettings.end(), [&](const CEditorMapSetting &MapSetting) {
+				Map()->m_vSettings.erase(
+					std::remove_if(Map()->m_vSettings.begin(), Map()->m_vSettings.end(), [&](const CEditorMapSetting &MapSetting) {
 						return str_comp_nocase(MapSetting.m_aCommand, DeletedSetting.m_aSetting) == 0;
 					}),
-					m_Map.m_vSettings.end());
+					Map()->m_vSettings.end());
 			}
 		}
 
 		// Erase settings to erase
 		for(auto &Setting : vSettingsToErase)
 		{
-			m_Map.m_vSettings.erase(
-				std::remove_if(m_Map.m_vSettings.begin(), m_Map.m_vSettings.end(), [&](const CEditorMapSetting &MapSetting) {
+			Map()->m_vSettings.erase(
+				std::remove_if(Map()->m_vSettings.begin(), Map()->m_vSettings.end(), [&](const CEditorMapSetting &MapSetting) {
 					return str_comp_nocase(MapSetting.m_aCommand, Setting.m_aCommand) == 0;
 				}),
-				m_Map.m_vSettings.end());
+				Map()->m_vSettings.end());
 		}
 
-		m_Map.OnModify();
+		Map()->OnModify();
 	};
 
 	auto &&FixAllUnknown = [&] {
@@ -1839,7 +1839,7 @@ void CMapSettingsBackend::CContext::ColorArguments(std::vector<STextColorSplit> 
 
 int CMapSettingsBackend::CContext::CheckCollision(ECollisionCheckResult &Result) const
 {
-	return CheckCollision(m_pBackend->Editor()->m_Map.m_vSettings, Result);
+	return CheckCollision(m_pBackend->Editor()->Map()->m_vSettings, Result);
 }
 
 int CMapSettingsBackend::CContext::CheckCollision(const std::vector<CEditorMapSetting> &vSettings, ECollisionCheckResult &Result) const
@@ -2089,7 +2089,7 @@ void CMapSettingsBackend::OnMapLoad()
 	// Load & validate all map settings
 	m_LoadedMapSettings.Reset();
 
-	auto &vLoadedMapSettings = Editor()->m_Map.m_vSettings;
+	auto &vLoadedMapSettings = Editor()->Map()->m_vSettings;
 
 	// Keep a vector of valid map settings, to check collision against: m_vValidLoadedMapSettings
 

--- a/src/game/editor/font_typer.cpp
+++ b/src/game/editor/font_typer.cpp
@@ -181,7 +181,7 @@ void CFontTyper::TextModeOff()
 	if(Editor()->m_Dialog == DIALOG_PSEUDO_FONT_TYPER)
 		Editor()->m_Dialog = DIALOG_NONE;
 	if(m_TilesPlacedSinceActivate)
-		Editor()->m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorBrushDrawAction>(&Editor()->m_Map, Editor()->m_SelectedGroup), "Font typer");
+		Editor()->Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorBrushDrawAction>(Editor()->Map(), Editor()->m_SelectedGroup), "Font typer");
 	m_TilesPlacedSinceActivate = 0;
 	m_Active = false;
 	m_pLastLayer = nullptr;

--- a/src/game/editor/layer_selector.cpp
+++ b/src/game/editor/layer_selector.cpp
@@ -27,8 +27,8 @@ bool CLayerSelector::SelectByTile()
 	bool IsFound = false;
 	for(const auto &HoverTile : Editor()->HoverTiles())
 	{
-		if(!Editor()->m_Map.m_vpGroups[HoverTile.m_Group]->m_Visible ||
-			!Editor()->m_Map.m_vpGroups[HoverTile.m_Group]->m_vpLayers[HoverTile.m_Layer]->m_Visible)
+		if(!Editor()->Map()->m_vpGroups[HoverTile.m_Group]->m_Visible ||
+			!Editor()->Map()->m_vpGroups[HoverTile.m_Group]->m_vpLayers[HoverTile.m_Layer]->m_Visible)
 			continue;
 
 		if(MatchedGroup == -1)

--- a/src/game/editor/map_view.cpp
+++ b/src/game/editor/map_view.cpp
@@ -76,36 +76,36 @@ void CMapView::RenderEditorMap()
 	if(Editor()->m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && Input()->ShiftIsPressed() && !Input()->ModifierIsPressed() && Input()->KeyPress(KEY_G))
 	{
 		const bool AnyHidden =
-			!Editor()->m_Map.m_pGameLayer->m_Visible ||
-			(Editor()->m_Map.m_pFrontLayer && !Editor()->m_Map.m_pFrontLayer->m_Visible) ||
-			(Editor()->m_Map.m_pTeleLayer && !Editor()->m_Map.m_pTeleLayer->m_Visible) ||
-			(Editor()->m_Map.m_pSpeedupLayer && !Editor()->m_Map.m_pSpeedupLayer->m_Visible) ||
-			(Editor()->m_Map.m_pTuneLayer && !Editor()->m_Map.m_pTuneLayer->m_Visible) ||
-			(Editor()->m_Map.m_pSwitchLayer && !Editor()->m_Map.m_pSwitchLayer->m_Visible);
-		Editor()->m_Map.m_pGameLayer->m_Visible = AnyHidden;
-		if(Editor()->m_Map.m_pFrontLayer)
-			Editor()->m_Map.m_pFrontLayer->m_Visible = AnyHidden;
-		if(Editor()->m_Map.m_pTeleLayer)
-			Editor()->m_Map.m_pTeleLayer->m_Visible = AnyHidden;
-		if(Editor()->m_Map.m_pSpeedupLayer)
-			Editor()->m_Map.m_pSpeedupLayer->m_Visible = AnyHidden;
-		if(Editor()->m_Map.m_pTuneLayer)
-			Editor()->m_Map.m_pTuneLayer->m_Visible = AnyHidden;
-		if(Editor()->m_Map.m_pSwitchLayer)
-			Editor()->m_Map.m_pSwitchLayer->m_Visible = AnyHidden;
+			!Editor()->Map()->m_pGameLayer->m_Visible ||
+			(Editor()->Map()->m_pFrontLayer && !Editor()->Map()->m_pFrontLayer->m_Visible) ||
+			(Editor()->Map()->m_pTeleLayer && !Editor()->Map()->m_pTeleLayer->m_Visible) ||
+			(Editor()->Map()->m_pSpeedupLayer && !Editor()->Map()->m_pSpeedupLayer->m_Visible) ||
+			(Editor()->Map()->m_pTuneLayer && !Editor()->Map()->m_pTuneLayer->m_Visible) ||
+			(Editor()->Map()->m_pSwitchLayer && !Editor()->Map()->m_pSwitchLayer->m_Visible);
+		Editor()->Map()->m_pGameLayer->m_Visible = AnyHidden;
+		if(Editor()->Map()->m_pFrontLayer)
+			Editor()->Map()->m_pFrontLayer->m_Visible = AnyHidden;
+		if(Editor()->Map()->m_pTeleLayer)
+			Editor()->Map()->m_pTeleLayer->m_Visible = AnyHidden;
+		if(Editor()->Map()->m_pSpeedupLayer)
+			Editor()->Map()->m_pSpeedupLayer->m_Visible = AnyHidden;
+		if(Editor()->Map()->m_pTuneLayer)
+			Editor()->Map()->m_pTuneLayer->m_Visible = AnyHidden;
+		if(Editor()->Map()->m_pSwitchLayer)
+			Editor()->Map()->m_pSwitchLayer->m_Visible = AnyHidden;
 	}
 
-	for(auto &pGroup : Editor()->m_Map.m_vpGroups)
+	for(auto &pGroup : Editor()->Map()->m_vpGroups)
 	{
 		if(pGroup->m_Visible)
 			pGroup->Render();
 	}
 
 	// render the game, tele, speedup, front, tune and switch above everything else
-	if(Editor()->m_Map.m_pGameGroup->m_Visible)
+	if(Editor()->Map()->m_pGameGroup->m_Visible)
 	{
-		Editor()->m_Map.m_pGameGroup->MapScreen();
-		for(auto &pLayer : Editor()->m_Map.m_pGameGroup->m_vpLayers)
+		Editor()->Map()->m_pGameGroup->MapScreen();
+		for(auto &pLayer : Editor()->Map()->m_pGameGroup->m_vpLayers)
 		{
 			if(pLayer->m_Visible && pLayer->IsEntitiesLayer())
 				pLayer->Render();

--- a/src/game/editor/proof_mode.cpp
+++ b/src/game/editor/proof_mode.cpp
@@ -60,13 +60,13 @@ void CProofMode::ResetMenuBackgroundPositions()
 	std::array<vec2, CMenuBackground::NUM_POS> aBackgroundPositions = GenerateMenuBackgroundPositions();
 	m_vMenuBackgroundPositions.assign(aBackgroundPositions.begin(), aBackgroundPositions.end());
 
-	if(Editor()->m_Map.m_pGameLayer)
+	if(Editor()->Map()->m_pGameLayer)
 	{
-		for(int y = 0; y < Editor()->m_Map.m_pGameLayer->m_Height; ++y)
+		for(int y = 0; y < Editor()->Map()->m_pGameLayer->m_Height; ++y)
 		{
-			for(int x = 0; x < Editor()->m_Map.m_pGameLayer->m_Width; ++x)
+			for(int x = 0; x < Editor()->Map()->m_pGameLayer->m_Width; ++x)
 			{
-				CTile Tile = Editor()->m_Map.m_pGameLayer->GetTile(x, y);
+				CTile Tile = Editor()->Map()->m_pGameLayer->GetTile(x, y);
 				if(Tile.m_Index >= TILE_TIME_CHECKPOINT_FIRST && Tile.m_Index <= TILE_TIME_CHECKPOINT_LAST)
 				{
 					int ArrayIndex = std::clamp<int>((Tile.m_Index - TILE_TIME_CHECKPOINT_FIRST), 0, CMenuBackground::NUM_POS);
@@ -97,7 +97,7 @@ void CProofMode::RenderScreenSizes()
 	// render screen sizes
 	if(m_ProofBorders != PROOF_BORDER_OFF)
 	{
-		std::shared_ptr<CLayerGroup> pGameGroup = Editor()->m_Map.m_pGameGroup;
+		std::shared_ptr<CLayerGroup> pGameGroup = Editor()->Map()->m_pGameGroup;
 		pGameGroup->MapScreen();
 
 		Graphics()->TextureClear();

--- a/src/game/editor/quadart.cpp
+++ b/src/game/editor/quadart.cpp
@@ -173,7 +173,7 @@ void CEditor::AddQuadArt(bool IgnoreHistory)
 	char aQuadArtName[IO_MAX_PATH_LENGTH];
 	IStorage::StripPathAndExtension(m_QuadArtParameters.m_aFilename, aQuadArtName, sizeof(aQuadArtName));
 
-	std::shared_ptr<CLayerGroup> pGroup = m_Map.NewGroup();
+	std::shared_ptr<CLayerGroup> pGroup = Map()->NewGroup();
 	str_copy(pGroup->m_aName, aQuadArtName);
 	pGroup->m_UseClipping = true;
 	pGroup->m_ClipX = -1;
@@ -181,7 +181,7 @@ void CEditor::AddQuadArt(bool IgnoreHistory)
 	pGroup->m_ClipH = std::ceil(m_QuadArtImageInfo.m_Height * 1.f * m_QuadArtParameters.m_QuadPixelSize / m_QuadArtParameters.m_ImagePixelSize) + 2;
 	pGroup->m_ClipW = std::ceil(m_QuadArtImageInfo.m_Width * 1.f * m_QuadArtParameters.m_QuadPixelSize / m_QuadArtParameters.m_ImagePixelSize) + 2;
 
-	std::shared_ptr<CLayerQuads> pLayer = std::make_shared<CLayerQuads>(&m_Map);
+	std::shared_ptr<CLayerQuads> pLayer = std::make_shared<CLayerQuads>(Map());
 	str_copy(pLayer->m_aName, aQuadArtName);
 	pGroup->AddLayer(pLayer);
 	pLayer->m_Flags |= LAYERFLAG_DETAIL;
@@ -190,9 +190,9 @@ void CEditor::AddQuadArt(bool IgnoreHistory)
 	QuadArt.Create(pLayer);
 
 	if(!IgnoreHistory)
-		m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionQuadArt>(&m_Map, m_QuadArtParameters));
+		Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionQuadArt>(Map(), m_QuadArtParameters));
 
-	m_Map.OnModify();
+	Map()->OnModify();
 	OnDialogClose();
 }
 

--- a/src/game/editor/quick_actions.cpp
+++ b/src/game/editor/quick_actions.cpp
@@ -42,101 +42,101 @@ void CEditor::AddQuadOrSound()
 	}
 
 	if(pLayer->m_Type == LAYERTYPE_QUADS)
-		m_Map.m_EditorHistory.Execute(std::make_shared<CEditorActionNewEmptyQuad>(&m_Map, m_SelectedGroup, m_vSelectedLayers[0], x, y));
+		Map()->m_EditorHistory.Execute(std::make_shared<CEditorActionNewEmptyQuad>(Map(), m_SelectedGroup, m_vSelectedLayers[0], x, y));
 	else if(pLayer->m_Type == LAYERTYPE_SOUNDS)
-		m_Map.m_EditorHistory.Execute(std::make_shared<CEditorActionNewEmptySound>(&m_Map, m_SelectedGroup, m_vSelectedLayers[0], x, y));
+		Map()->m_EditorHistory.Execute(std::make_shared<CEditorActionNewEmptySound>(Map(), m_SelectedGroup, m_vSelectedLayers[0], x, y));
 }
 
 void CEditor::AddGroup()
 {
-	m_Map.NewGroup();
-	m_SelectedGroup = m_Map.m_vpGroups.size() - 1;
-	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionGroup>(&m_Map, m_SelectedGroup, false));
+	Map()->NewGroup();
+	m_SelectedGroup = Map()->m_vpGroups.size() - 1;
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionGroup>(Map(), m_SelectedGroup, false));
 }
 
 void CEditor::AddSoundLayer()
 {
-	std::shared_ptr<CLayer> pSoundLayer = std::make_shared<CLayerSounds>(&m_Map);
-	m_Map.m_vpGroups[m_SelectedGroup]->AddLayer(pSoundLayer);
-	int LayerIndex = m_Map.m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
+	std::shared_ptr<CLayer> pSoundLayer = std::make_shared<CLayerSounds>(Map());
+	Map()->m_vpGroups[m_SelectedGroup]->AddLayer(pSoundLayer);
+	int LayerIndex = Map()->m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
 	SelectLayer(LayerIndex);
-	m_Map.m_vpGroups[m_SelectedGroup]->m_Collapse = false;
-	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(&m_Map, m_SelectedGroup, LayerIndex));
+	Map()->m_vpGroups[m_SelectedGroup]->m_Collapse = false;
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddTileLayer()
 {
-	std::shared_ptr<CLayer> pTileLayer = std::make_shared<CLayerTiles>(&m_Map, m_Map.m_pGameLayer->m_Width, m_Map.m_pGameLayer->m_Height);
-	m_Map.m_vpGroups[m_SelectedGroup]->AddLayer(pTileLayer);
-	int LayerIndex = m_Map.m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
+	std::shared_ptr<CLayer> pTileLayer = std::make_shared<CLayerTiles>(Map(), Map()->m_pGameLayer->m_Width, Map()->m_pGameLayer->m_Height);
+	Map()->m_vpGroups[m_SelectedGroup]->AddLayer(pTileLayer);
+	int LayerIndex = Map()->m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
 	SelectLayer(LayerIndex);
-	m_Map.m_vpGroups[m_SelectedGroup]->m_Collapse = false;
-	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(&m_Map, m_SelectedGroup, LayerIndex));
+	Map()->m_vpGroups[m_SelectedGroup]->m_Collapse = false;
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddQuadsLayer()
 {
-	std::shared_ptr<CLayer> pQuadLayer = std::make_shared<CLayerQuads>(&m_Map);
-	m_Map.m_vpGroups[m_SelectedGroup]->AddLayer(pQuadLayer);
-	int LayerIndex = m_Map.m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
+	std::shared_ptr<CLayer> pQuadLayer = std::make_shared<CLayerQuads>(Map());
+	Map()->m_vpGroups[m_SelectedGroup]->AddLayer(pQuadLayer);
+	int LayerIndex = Map()->m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
 	SelectLayer(LayerIndex);
-	m_Map.m_vpGroups[m_SelectedGroup]->m_Collapse = false;
-	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(&m_Map, m_SelectedGroup, LayerIndex));
+	Map()->m_vpGroups[m_SelectedGroup]->m_Collapse = false;
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddSwitchLayer()
 {
-	std::shared_ptr<CLayer> pSwitchLayer = std::make_shared<CLayerSwitch>(&m_Map, m_Map.m_pGameLayer->m_Width, m_Map.m_pGameLayer->m_Height);
-	m_Map.MakeSwitchLayer(pSwitchLayer);
-	m_Map.m_vpGroups[m_SelectedGroup]->AddLayer(pSwitchLayer);
-	int LayerIndex = m_Map.m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
+	std::shared_ptr<CLayer> pSwitchLayer = std::make_shared<CLayerSwitch>(Map(), Map()->m_pGameLayer->m_Width, Map()->m_pGameLayer->m_Height);
+	Map()->MakeSwitchLayer(pSwitchLayer);
+	Map()->m_vpGroups[m_SelectedGroup]->AddLayer(pSwitchLayer);
+	int LayerIndex = Map()->m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
 	SelectLayer(LayerIndex);
 	m_pBrush->Clear();
-	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(&m_Map, m_SelectedGroup, LayerIndex));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddFrontLayer()
 {
-	std::shared_ptr<CLayer> pFrontLayer = std::make_shared<CLayerFront>(&m_Map, m_Map.m_pGameLayer->m_Width, m_Map.m_pGameLayer->m_Height);
-	m_Map.MakeFrontLayer(pFrontLayer);
-	m_Map.m_vpGroups[m_SelectedGroup]->AddLayer(pFrontLayer);
-	int LayerIndex = m_Map.m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
+	std::shared_ptr<CLayer> pFrontLayer = std::make_shared<CLayerFront>(Map(), Map()->m_pGameLayer->m_Width, Map()->m_pGameLayer->m_Height);
+	Map()->MakeFrontLayer(pFrontLayer);
+	Map()->m_vpGroups[m_SelectedGroup]->AddLayer(pFrontLayer);
+	int LayerIndex = Map()->m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
 	SelectLayer(LayerIndex);
 	m_pBrush->Clear();
-	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(&m_Map, m_SelectedGroup, LayerIndex));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddTuneLayer()
 {
-	std::shared_ptr<CLayer> pTuneLayer = std::make_shared<CLayerTune>(&m_Map, m_Map.m_pGameLayer->m_Width, m_Map.m_pGameLayer->m_Height);
-	m_Map.MakeTuneLayer(pTuneLayer);
-	m_Map.m_vpGroups[m_SelectedGroup]->AddLayer(pTuneLayer);
-	int LayerIndex = m_Map.m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
+	std::shared_ptr<CLayer> pTuneLayer = std::make_shared<CLayerTune>(Map(), Map()->m_pGameLayer->m_Width, Map()->m_pGameLayer->m_Height);
+	Map()->MakeTuneLayer(pTuneLayer);
+	Map()->m_vpGroups[m_SelectedGroup]->AddLayer(pTuneLayer);
+	int LayerIndex = Map()->m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
 	SelectLayer(LayerIndex);
 	m_pBrush->Clear();
-	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(&m_Map, m_SelectedGroup, LayerIndex));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddSpeedupLayer()
 {
-	std::shared_ptr<CLayer> pSpeedupLayer = std::make_shared<CLayerSpeedup>(&m_Map, m_Map.m_pGameLayer->m_Width, m_Map.m_pGameLayer->m_Height);
-	m_Map.MakeSpeedupLayer(pSpeedupLayer);
-	m_Map.m_vpGroups[m_SelectedGroup]->AddLayer(pSpeedupLayer);
-	int LayerIndex = m_Map.m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
+	std::shared_ptr<CLayer> pSpeedupLayer = std::make_shared<CLayerSpeedup>(Map(), Map()->m_pGameLayer->m_Width, Map()->m_pGameLayer->m_Height);
+	Map()->MakeSpeedupLayer(pSpeedupLayer);
+	Map()->m_vpGroups[m_SelectedGroup]->AddLayer(pSpeedupLayer);
+	int LayerIndex = Map()->m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
 	SelectLayer(LayerIndex);
 	m_pBrush->Clear();
-	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(&m_Map, m_SelectedGroup, LayerIndex));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddTeleLayer()
 {
-	std::shared_ptr<CLayer> pTeleLayer = std::make_shared<CLayerTele>(&m_Map, m_Map.m_pGameLayer->m_Width, m_Map.m_pGameLayer->m_Height);
-	m_Map.MakeTeleLayer(pTeleLayer);
-	m_Map.m_vpGroups[m_SelectedGroup]->AddLayer(pTeleLayer);
-	int LayerIndex = m_Map.m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
+	std::shared_ptr<CLayer> pTeleLayer = std::make_shared<CLayerTele>(Map(), Map()->m_pGameLayer->m_Width, Map()->m_pGameLayer->m_Height);
+	Map()->MakeTeleLayer(pTeleLayer);
+	Map()->m_vpGroups[m_SelectedGroup]->AddLayer(pTeleLayer);
+	int LayerIndex = Map()->m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
 	SelectLayer(LayerIndex);
 	m_pBrush->Clear();
-	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(&m_Map, m_SelectedGroup, LayerIndex));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), m_SelectedGroup, LayerIndex));
 }
 
 bool CEditor::IsNonGameTileLayerSelected() const
@@ -147,12 +147,12 @@ bool CEditor::IsNonGameTileLayerSelected() const
 	if(pLayer->m_Type != LAYERTYPE_TILES)
 		return false;
 	if(
-		pLayer == m_Map.m_pGameLayer ||
-		pLayer == m_Map.m_pFrontLayer ||
-		pLayer == m_Map.m_pSwitchLayer ||
-		pLayer == m_Map.m_pTeleLayer ||
-		pLayer == m_Map.m_pSpeedupLayer ||
-		pLayer == m_Map.m_pTuneLayer)
+		pLayer == Map()->m_pGameLayer ||
+		pLayer == Map()->m_pFrontLayer ||
+		pLayer == Map()->m_pSwitchLayer ||
+		pLayer == Map()->m_pTeleLayer ||
+		pLayer == Map()->m_pSpeedupLayer ||
+		pLayer == Map()->m_pTuneLayer)
 		return false;
 
 	return true;
@@ -175,7 +175,7 @@ void CEditor::LayerSelectImage()
 void CEditor::MapDetails()
 {
 	const CUIRect *pScreen = Ui()->Screen();
-	m_Map.m_MapInfoTmp.Copy(m_Map.m_MapInfo);
+	Map()->m_MapInfoTmp.Copy(Map()->m_MapInfo);
 	static SPopupMenuId s_PopupMapInfoId;
 	constexpr float PopupWidth = 400.0f;
 	constexpr float PopupHeight = 170.0f;
@@ -195,29 +195,29 @@ void CEditor::DeleteSelectedLayer()
 	std::shared_ptr<CLayer> pCurrentLayer = GetSelectedLayer(0);
 	if(!pCurrentLayer)
 		return;
-	if(m_Map.m_pGameLayer == pCurrentLayer)
+	if(Map()->m_pGameLayer == pCurrentLayer)
 		return;
 
-	m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionDeleteLayer>(&m_Map, m_SelectedGroup, m_vSelectedLayers[0]));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionDeleteLayer>(Map(), m_SelectedGroup, m_vSelectedLayers[0]));
 
-	if(pCurrentLayer == m_Map.m_pFrontLayer)
-		m_Map.m_pFrontLayer = nullptr;
-	if(pCurrentLayer == m_Map.m_pTeleLayer)
-		m_Map.m_pTeleLayer = nullptr;
-	if(pCurrentLayer == m_Map.m_pSpeedupLayer)
-		m_Map.m_pSpeedupLayer = nullptr;
-	if(pCurrentLayer == m_Map.m_pSwitchLayer)
-		m_Map.m_pSwitchLayer = nullptr;
-	if(pCurrentLayer == m_Map.m_pTuneLayer)
-		m_Map.m_pTuneLayer = nullptr;
-	m_Map.m_vpGroups[m_SelectedGroup]->DeleteLayer(m_vSelectedLayers[0]);
+	if(pCurrentLayer == Map()->m_pFrontLayer)
+		Map()->m_pFrontLayer = nullptr;
+	if(pCurrentLayer == Map()->m_pTeleLayer)
+		Map()->m_pTeleLayer = nullptr;
+	if(pCurrentLayer == Map()->m_pSpeedupLayer)
+		Map()->m_pSpeedupLayer = nullptr;
+	if(pCurrentLayer == Map()->m_pSwitchLayer)
+		Map()->m_pSwitchLayer = nullptr;
+	if(pCurrentLayer == Map()->m_pTuneLayer)
+		Map()->m_pTuneLayer = nullptr;
+	Map()->m_vpGroups[m_SelectedGroup]->DeleteLayer(m_vSelectedLayers[0]);
 
 	SelectPreviousLayer();
 }
 
 void CEditor::TestMapLocally()
 {
-	const char *pFilenameNoMaps = str_startswith(m_Map.m_aFilename, "maps/");
+	const char *pFilenameNoMaps = str_startswith(Map()->m_aFilename, "maps/");
 	if(!pFilenameNoMaps)
 	{
 		ShowFileDialogError("The map isn't saved in the maps/ folder. It must be saved there to load on the server.");

--- a/src/game/editor/quick_actions.h
+++ b/src/game/editor/quick_actions.h
@@ -174,7 +174,7 @@ REGISTER_QUICK_ACTION(
 	AddSwitchLayer,
 	"Add switch layer",
 	[&]() { AddSwitchLayer(); },
-	[&]() -> bool { return !GetSelectedGroup()->m_GameGroup || m_Map.m_pSwitchLayer; },
+	[&]() -> bool { return !GetSelectedGroup()->m_GameGroup || Map()->m_pSwitchLayer; },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
 	"Create a new switch layer.")
@@ -182,7 +182,7 @@ REGISTER_QUICK_ACTION(
 	AddTuneLayer,
 	"Add tune layer",
 	[&]() { AddTuneLayer(); },
-	[&]() -> bool { return !GetSelectedGroup()->m_GameGroup || m_Map.m_pTuneLayer; },
+	[&]() -> bool { return !GetSelectedGroup()->m_GameGroup || Map()->m_pTuneLayer; },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
 	"Create a new tuning layer.")
@@ -190,7 +190,7 @@ REGISTER_QUICK_ACTION(
 	AddSpeedupLayer,
 	"Add speedup layer",
 	[&]() { AddSpeedupLayer(); },
-	[&]() -> bool { return !GetSelectedGroup()->m_GameGroup || m_Map.m_pSpeedupLayer; },
+	[&]() -> bool { return !GetSelectedGroup()->m_GameGroup || Map()->m_pSpeedupLayer; },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
 	"Create a new speedup layer.")
@@ -198,7 +198,7 @@ REGISTER_QUICK_ACTION(
 	AddTeleLayer,
 	"Add tele layer",
 	[&]() { AddTeleLayer(); },
-	[&]() -> bool { return !GetSelectedGroup()->m_GameGroup || m_Map.m_pTeleLayer; },
+	[&]() -> bool { return !GetSelectedGroup()->m_GameGroup || Map()->m_pTeleLayer; },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
 	"Create a new tele layer.")
@@ -206,7 +206,7 @@ REGISTER_QUICK_ACTION(
 	AddFrontLayer,
 	"Add front layer",
 	[&]() { AddFrontLayer(); },
-	[&]() -> bool { return !GetSelectedGroup()->m_GameGroup || m_Map.m_pFrontLayer; },
+	[&]() -> bool { return !GetSelectedGroup()->m_GameGroup || Map()->m_pFrontLayer; },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
 	"Create a new item layer.")
@@ -219,7 +219,7 @@ REGISTER_QUICK_ACTION(
 	"Save as",
 	[&]() {
 		char aDefaultName[IO_MAX_PATH_LENGTH];
-		fs_split_file_extension(fs_filename(m_Map.m_aFilename), aDefaultName, sizeof(aDefaultName));
+		fs_split_file_extension(fs_filename(Map()->m_aFilename), aDefaultName, sizeof(aDefaultName));
 		m_FileBrowser.ShowFileDialog(IStorage::TYPE_SAVE, CFileBrowser::EFileType::MAP, "Save map", "Save as", "maps", aDefaultName, CallbackSaveMap, this);
 	},
 	ALWAYS_FALSE,
@@ -336,7 +336,7 @@ REGISTER_QUICK_ACTION(
 		std::shared_ptr<CLayer> pCurrentLayer = GetSelectedLayer(0);
 		if(!pCurrentLayer)
 			return true;
-		return m_Map.m_pGameLayer == pCurrentLayer;
+		return Map()->m_pGameLayer == pCurrentLayer;
 	},
 	ALWAYS_FALSE,
 	DEFAULT_BTN,

--- a/src/game/editor/tileart.cpp
+++ b/src/game/editor/tileart.cpp
@@ -143,10 +143,10 @@ void CEditor::AddTileart(bool IgnoreHistory)
 	char aTileArtFilename[IO_MAX_PATH_LENGTH];
 	IStorage::StripPathAndExtension(m_aTileartFilename, aTileArtFilename, sizeof(aTileArtFilename));
 
-	std::shared_ptr<CLayerGroup> pGroup = m_Map.NewGroup();
+	std::shared_ptr<CLayerGroup> pGroup = Map()->NewGroup();
 	str_copy(pGroup->m_aName, aTileArtFilename);
 
-	int ImageCount = m_Map.m_vpImages.size();
+	int ImageCount = Map()->m_vpImages.size();
 
 	auto vUniqueColors = GetUniqueColors(m_TileartImageInfo);
 	auto vaColorGroups = GroupColors(vUniqueColors);
@@ -155,18 +155,18 @@ void CEditor::AddTileart(bool IgnoreHistory)
 	for(size_t i = 0; i < vColorImages.size(); i++)
 	{
 		str_format(aImageName, sizeof(aImageName), "%s %" PRIzu, aTileArtFilename, i + 1);
-		std::shared_ptr<CLayerTiles> pLayer = AddLayerWithImage(&m_Map, pGroup, m_TileartImageInfo.m_Width, m_TileartImageInfo.m_Height, vColorImages[i], aImageName);
+		std::shared_ptr<CLayerTiles> pLayer = AddLayerWithImage(Map(), pGroup, m_TileartImageInfo.m_Width, m_TileartImageInfo.m_Height, vColorImages[i], aImageName);
 		SetTilelayerIndices(pLayer, vaColorGroups[i], m_TileartImageInfo);
 	}
-	auto IndexMap = m_Map.SortImages();
+	auto IndexMap = Map()->SortImages();
 
 	if(!IgnoreHistory)
 	{
-		m_Map.m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileArt>(&m_Map, ImageCount, m_aTileartFilename, IndexMap));
+		Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileArt>(Map(), ImageCount, m_aTileartFilename, IndexMap));
 	}
 
 	m_TileartImageInfo.Free();
-	m_Map.OnModify();
+	Map()->OnModify();
 	OnDialogClose();
 }
 
@@ -174,7 +174,7 @@ void CEditor::TileartCheckColors()
 {
 	auto vUniqueColors = GetUniqueColors(m_TileartImageInfo);
 	int NumColorGroups = std::ceil(vUniqueColors.size() / 255.0f);
-	if(m_Map.m_vpImages.size() + NumColorGroups >= 64)
+	if(Map()->m_vpImages.size() + NumColorGroups >= 64)
 	{
 		m_PopupEventType = CEditor::POPEVENT_TILEART_TOO_MANY_COLORS;
 		m_PopupEventActivated = true;


### PR DESCRIPTION
To support opening multiple maps at the same time in the future. The `Map()` getter will eventually return a pointer to the currently selected map instead of a pointer to the singleton map.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions