### PR TITLE
Allow creating teeinfo from read only data

### DIFF
--- a/src/game/server/teeinfo.cpp
+++ b/src/game/server/teeinfo.cpp
@@ -33,7 +33,7 @@ static constexpr CStandardSkin STANDARD_SKINS[] = {
 	{"greensward", {"greensward", "duodonny", "", "standard", "standard", "standard"}, {true, true, false, false, false, false}, {5635840, -11141356, 65408, 65408, 65408, 65408}},
 };
 
-CTeeInfo::CTeeInfo(const char *pSkinName, int UseCustomColor, int ColorBody, int ColorFeet)
+CTeeInfo::CTeeInfo(const char *const pSkinName, int UseCustomColor, int ColorBody, int ColorFeet)
 {
 	str_copy(m_aSkinName, pSkinName);
 	m_UseCustomColor = UseCustomColor;
@@ -41,7 +41,7 @@ CTeeInfo::CTeeInfo(const char *pSkinName, int UseCustomColor, int ColorBody, int
 	m_ColorFeet = ColorFeet;
 }
 
-CTeeInfo::CTeeInfo(const char *apSkinPartNames[protocol7::NUM_SKINPARTS], int aUseCustomColors[protocol7::NUM_SKINPARTS], int aSkinPartColors[protocol7::NUM_SKINPARTS])
+CTeeInfo::CTeeInfo(const char *const apSkinPartNames[protocol7::NUM_SKINPARTS], const int aUseCustomColors[protocol7::NUM_SKINPARTS], const int aSkinPartColors[protocol7::NUM_SKINPARTS])
 {
 	for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
 	{

--- a/src/game/server/teeinfo.h
+++ b/src/game/server/teeinfo.h
@@ -20,7 +20,7 @@ public:
 
 	CTeeInfo() = default;
 	CTeeInfo(const char *pSkinName, int UseCustomColor, int ColorBody, int ColorFeet);
-	CTeeInfo(const char *apSkinPartNames[protocol7::NUM_SKINPARTS], int aUseCustomColors[protocol7::NUM_SKINPARTS], int aSkinPartColors[protocol7::NUM_SKINPARTS]);
+	CTeeInfo(const char *const apSkinPartNames[protocol7::NUM_SKINPARTS], const int aUseCustomColors[protocol7::NUM_SKINPARTS], const int aSkinPartColors[protocol7::NUM_SKINPARTS]);
 
 	void FromSixup();
 	void ToSixup();


### PR DESCRIPTION
ddnet does not need it right now because it holds
the incoming network traffic in a mutable buffer.

But this change allows the constructor to be called in more restrictive scenarios.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions