### PR TITLE
Refactor: Abstract SendPlayerTime into gamemodes

### DIFF
--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -151,6 +151,40 @@ public:
 	 */
 	virtual int SnapPlayerScore(int SnappingClient, CPlayer *pPlayer) { return 0; }
 
+	class CFinishTime
+	{
+	public:
+		CFinishTime(int Seconds, int Milliseconds) :
+			m_Seconds(Seconds), m_Milliseconds(Milliseconds)
+		{
+			dbg_assert(Seconds >= 0, "Invalid Seconds: %d", Seconds);
+			dbg_assert(Milliseconds >= 0 && Milliseconds < 1000, "Invalid Milliseconds: %d", Milliseconds);
+		}
+
+		int m_Seconds;
+		int m_Milliseconds;
+
+		static CFinishTime Unset() { return CFinishTime(FinishTime::UNSET); }
+		static CFinishTime NotFinished() { return CFinishTime(FinishTime::NOT_FINISHED_MILLIS); }
+
+	private:
+		CFinishTime(int Type)
+		{
+			m_Seconds = Type;
+			m_Milliseconds = 0;
+		}
+	};
+
+	/**
+	 * Returns the finish time value that will be shown in the scoreboard.
+	 *
+	 * @param SnappingClient Client ID of the player that will receive the snapshot.
+	 * @param pPlayer Player that is being snapped.
+	 *
+	 * @return The time split into seconds and the milliseconds remainder, use CFinishTime::Unset if you want the server to prefer scores.
+	 */
+	virtual CFinishTime SnapPlayerTime(int SnappingClient, CPlayer *pPlayer) { return CFinishTime::Unset(); }
+
 	// spawn
 	virtual bool CanSpawn(int Team, vec2 *pOutPos, int ClientId);
 

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -151,6 +151,20 @@ int CGameControllerDDRace::SnapPlayerScore(int SnappingClient, CPlayer *pPlayer)
 	return -ScoreSeconds;
 }
 
+IGameController::CFinishTime CGameControllerDDRace::SnapPlayerTime(int SnappingClient, CPlayer *pPlayer)
+{
+	std::optional<float> BestTime = GameServer()->Score()->PlayerData(pPlayer->GetCid())->m_BestTime;
+	if(BestTime.has_value() && (!g_Config.m_SvHideScore || SnappingClient == pPlayer->GetCid()))
+	{
+		// same as in str_time_float
+		int64_t TimeMilliseconds = static_cast<int64_t>(std::roundf(BestTime.value() * 1000.0f));
+		int Seconds = static_cast<int>(TimeMilliseconds / 1000);
+		int Millis = static_cast<int>(TimeMilliseconds % 1000);
+		return CFinishTime(Seconds, Millis);
+	}
+	return CFinishTime::NotFinished();
+}
+
 void CGameControllerDDRace::OnPlayerConnect(CPlayer *pPlayer)
 {
 	IGameController::OnPlayerConnect(pPlayer);

--- a/src/game/server/gamemodes/DDRace.h
+++ b/src/game/server/gamemodes/DDRace.h
@@ -15,6 +15,7 @@ public:
 	void HandleCharacterTiles(class CCharacter *pChr, int MapIndex) override;
 	void SetArmorProgress(CCharacter *pCharacter, int Progress) override;
 	int SnapPlayerScore(int SnappingClient, CPlayer *pPlayer) override;
+	CFinishTime SnapPlayerTime(int SnappingClient, CPlayer *pPlayer) override;
 
 	void OnPlayerConnect(class CPlayer *pPlayer) override;
 	void OnPlayerDisconnect(class CPlayer *pPlayer, const char *pReason) override;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -458,24 +458,9 @@ void CPlayer::Snap(int SnappingClient)
 	if(m_Paused == PAUSE_PAUSED)
 		pDDNetPlayer->m_Flags |= EXPLAYERFLAG_PAUSED;
 
-	std::optional<float> BestTime = GameServer()->Score()->PlayerData(m_ClientId)->m_BestTime;
-
-	// set precise finish time instead of timescore
-	if(BestTime.has_value() && (!g_Config.m_SvHideScore || SnappingClient == m_ClientId))
-	{
-		// same as in str_time_float
-		int64_t TimeMilliseconds = static_cast<int64_t>(std::roundf(BestTime.value() * 1000.0f));
-		int Seconds = static_cast<int>(TimeMilliseconds / 1000);
-		int Millis = static_cast<int>(TimeMilliseconds % 1000);
-
-		pDDNetPlayer->m_FinishTimeSeconds = Seconds;
-		pDDNetPlayer->m_FinishTimeMillis = Millis;
-	}
-	else
-	{
-		pDDNetPlayer->m_FinishTimeSeconds = FinishTime::NOT_FINISHED_MILLIS;
-		pDDNetPlayer->m_FinishTimeMillis = 0;
-	}
+	IGameController::CFinishTime PlayerTime = GameServer()->m_pController->SnapPlayerTime(SnappingClient, this);
+	pDDNetPlayer->m_FinishTimeSeconds = PlayerTime.m_Seconds;
+	pDDNetPlayer->m_FinishTimeMillis = PlayerTime.m_Milliseconds;
 
 	if(Server()->IsSixup(SnappingClient) && m_pCharacter && m_pCharacter->m_DDRaceState == ERaceState::STARTED &&
 		GameServer()->m_apPlayers[SnappingClient]->m_TimerType == TIMERTYPE_SIXUP)


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Part of #11467 : I believe the new netmessage is written in a way, that it causes confusion among modders, because it introduces FinishTime::UNSET and FinishTime::NOT_FINISHED which are not the same. This doesn't close the issue, but is spiritual followup of #11437

Technically this also changes behavior of the `mod`-Mod.

Also part of #7777

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
