### PR TITLE
Use `CEditorObject` interface getters instead of `Editor()`

### DIFF
--- a/src/game/editor/font_typer.cpp
+++ b/src/game/editor/font_typer.cpp
@@ -114,7 +114,7 @@ bool CFontTyper::OnInput(const IInput::CEvent &Event)
 	{
 		m_TextIndex.x--;
 		m_TextLineLen--;
-		if(Editor()->Input()->KeyIsPressed(KEY_LCTRL))
+		if(Input()->KeyIsPressed(KEY_LCTRL))
 		{
 			while(pLayer->GetTile(m_TextIndex.x, m_TextIndex.y).m_Index)
 			{
@@ -129,7 +129,7 @@ bool CFontTyper::OnInput(const IInput::CEvent &Event)
 	{
 		m_TextIndex.x++;
 		m_TextLineLen++;
-		if(Editor()->Input()->KeyIsPressed(KEY_LCTRL))
+		if(Input()->KeyIsPressed(KEY_LCTRL))
 		{
 			while(pLayer->GetTile(m_TextIndex.x, m_TextIndex.y).m_Index)
 			{
@@ -240,14 +240,14 @@ void CFontTyper::OnRender(CUIRect View)
 	{
 		std::shared_ptr<CLayerGroup> pGroup = Editor()->GetSelectedGroup();
 		pGroup->MapScreen();
-		Editor()->Graphics()->WrapClamp();
-		Editor()->Graphics()->TextureSet(m_CursorTextTexture);
-		Editor()->Graphics()->QuadsBegin();
-		Editor()->Graphics()->SetColor(1, 1, 1, 1);
+		Graphics()->WrapClamp();
+		Graphics()->TextureSet(m_CursorTextTexture);
+		Graphics()->QuadsBegin();
+		Graphics()->SetColor(1, 1, 1, 1);
 		IGraphics::CQuadItem QuadItem(m_TextIndex.x * 32, m_TextIndex.y * 32, 32.0f, 32.0f);
-		Editor()->Graphics()->QuadsDrawTL(&QuadItem, 1);
-		Editor()->Graphics()->QuadsEnd();
-		Editor()->Graphics()->WrapNormal();
-		Editor()->Ui()->MapScreen();
+		Graphics()->QuadsDrawTL(&QuadItem, 1);
+		Graphics()->QuadsEnd();
+		Graphics()->WrapNormal();
+		Ui()->MapScreen();
 	}
 }


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions