### PR TITLE
mastersrv: Actually disallow port 0

### DIFF
--- a/src/mastersrv/src/addr.rs
+++ b/src/mastersrv/src/addr.rs
@@ -206,6 +206,7 @@ pub enum ParseRegisterAddrError {
     Protocol(UnknownProtocol),
     HostNotConnectingAddressInvalid,
     PortNotPresent,
+    Port0,
 }
 
 impl fmt::Display for ParseRegisterAddrError {
@@ -219,6 +220,7 @@ impl fmt::Display for ParseRegisterAddrError {
                 "register address must have domain connecting-address.invalid"
             ),
             PortNotPresent => write!(f, "register address must specify port"),
+            Port0 => write!(f, "register port can't be 0"),
         }
     }
 }
@@ -233,6 +235,9 @@ impl FromStr for RegisterAddr {
             return Err(Error::HostNotConnectingAddressInvalid);
         }
         let port = url.port().ok_or(Error::PortNotPresent)?;
+        if port == 0 {
+            return Err(Error::Port0);
+        }
         Ok(RegisterAddr { port, protocol })
     }
 }


### PR DESCRIPTION
PR #11016 disallowed port 0 in the wrong place, this now actually catches port 0 early in the registration process.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions