### PR TITLE
Elevate game and rendering threads priority

### DIFF
--- a/src/base/windows.cpp
+++ b/src/base/windows.cpp
@@ -466,4 +466,15 @@ void windows_shell_update()
 	SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
 }
 
+void windows_set_thread_priority(void *thread, int priority)
+{
+	if(thread == nullptr)
+		thread = GetCurrentThread();
+
+	if(!SetThreadPriority(thread, priority))
+	{
+		windows_print_error("set_thread_priority", "Failed to set thread priority", GetLastError());
+	}
+}
+
 #endif

--- a/src/base/windows.h
+++ b/src/base/windows.h
@@ -175,6 +175,18 @@ bool windows_shell_unregister_application(const char *executable, bool *updated)
  */
 void windows_shell_update();
 
+/**
+ * Tries to elevate the thread's priority.
+ *
+ * @ingroup Windows
+ *
+ * @param thread The handle of the thread to set the priority for. `nullptr` for the current thread.
+ * @param priority The priority level to set.
+ *
+ * @remark Elevating the thread priority increases the chance the CPU picks it first.
+ */
+void windows_set_thread_priority(void *thread, int priority);
+
 #endif
 
 #endif

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -3,6 +3,9 @@
 #include <base/log.h>
 #include <base/math.h>
 #include <base/system.h>
+#if defined(CONF_FAMILY_WINDOWS)
+#include <base/windows.h>
+#endif
 
 #include <engine/client/backend/backend_base.h>
 #include <engine/client/backend/vulkan/backend_vulkan.h>
@@ -7558,6 +7561,9 @@ public:
 				std::unique_lock<std::mutex> Lock(pRenderThread->m_Mutex);
 				m_vpRenderThreads.emplace_back(pRenderThread);
 				pRenderThread->m_Thread = std::thread([this, i]() { RunThread(i); });
+#if defined(CONF_FAMILY_WINDOWS)
+				windows_set_thread_priority(reinterpret_cast<void *>(pRenderThread->m_Thread.native_handle()), 1);
+#endif
 				// wait until thread started
 				pRenderThread->m_Cond.wait(Lock, [pRenderThread]() -> bool { return pRenderThread->m_Started; });
 			}

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1,4 +1,7 @@
 #include <base/detect.h>
+#if defined(CONF_FAMILY_WINDOWS)
+#include <base/windows.h>
+#endif
 
 #ifndef CONF_BACKEND_OPENGL_ES
 #include <GL/glew.h>
@@ -100,6 +103,9 @@ void CGraphicsBackend_Threaded::StartProcessor(ICommandProcessor *pProcessor)
 #if !defined(CONF_PLATFORM_EMSCRIPTEN)
 	std::unique_lock<std::mutex> Lock(m_BufferSwapMutex);
 	m_pThread = thread_init(ThreadFunc, this, "Graphics thread");
+#if defined(CONF_FAMILY_WINDOWS)
+	windows_set_thread_priority(m_pThread, 1);
+#endif
 	// wait for the thread to start
 	m_BufferSwapCond.wait(Lock, [this]() -> bool { return m_Started; });
 #endif

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4649,6 +4649,7 @@ int main(int argc, const char **argv)
 	gs_AndroidStarted = true;
 #elif defined(CONF_FAMILY_WINDOWS)
 	CWindowsComLifecycle WindowsComLifecycle(true);
+	windows_set_thread_priority(nullptr, 1);
 #endif
 	CCmdlineFix CmdlineFix(&argc, &argv);
 


### PR DESCRIPTION
Seems to be very common for games to up their thread's priority. See https://github.com/ddnet/ddnet/issues/11473


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
