### PR TITLE
Track all selected items separately for each editor map

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -166,9 +166,6 @@ public:
 	const CMapView *MapView() const { return &m_MapView; }
 	CLayerSelector *LayerSelector() { return &m_LayerSelector; }
 
-	void SelectNextLayer();
-	void SelectPreviousLayer();
-
 	void FillGameTiles(EGameTileOp FillTile) const;
 	bool CanFillGameTiles() const;
 	void AddQuadOrSound();
@@ -236,14 +233,6 @@ public:
 		m_AnimateTime = 0;
 		m_AnimateSpeed = 1;
 		m_AnimateUpdatePopup = false;
-
-		m_SelectedQuadEnvelope = -1;
-
-		m_vSelectedEnvelopePoints = {};
-		m_UpdateEnvPointInfo = false;
-		m_SelectedTangentInPoint = std::pair(-1, -1);
-		m_SelectedTangentOutPoint = std::pair(-1, -1);
-		m_CurrentQuadIndex = -1;
 
 		for(size_t i = 0; i < std::size(m_aSavedColors); ++i)
 		{
@@ -356,41 +345,6 @@ public:
 	void RenderMousePointer();
 	void RenderGameEntities(const std::shared_ptr<CLayerTiles> &pTiles);
 	void RenderSwitchEntities(const std::shared_ptr<CLayerTiles> &pTiles);
-
-	std::vector<CQuad *> GetSelectedQuads();
-	std::shared_ptr<CLayer> GetSelectedLayerType(int Index, int Type) const;
-	std::shared_ptr<CLayer> GetSelectedLayer(int Index) const;
-	std::shared_ptr<CLayerGroup> GetSelectedGroup() const;
-	CSoundSource *GetSelectedSource() const;
-	void SelectLayer(int LayerIndex, int GroupIndex = -1);
-	void AddSelectedLayer(int LayerIndex);
-	void SelectQuad(int Index);
-	void ToggleSelectQuad(int Index);
-	void DeselectQuads();
-	void DeselectQuadPoints();
-	void SelectQuadPoint(int QuadIndex, int Index);
-	void ToggleSelectQuadPoint(int QuadIndex, int Index);
-	void DeleteSelectedQuads();
-	bool IsQuadSelected(int Index) const;
-	bool IsQuadCornerSelected(int Index) const;
-	bool IsQuadPointSelected(int QuadIndex, int Index) const;
-	int FindSelectedQuadIndex(int Index) const;
-
-	int FindEnvPointIndex(int Index, int Channel) const;
-	void SelectEnvPoint(int Index);
-	void SelectEnvPoint(int Index, int Channel);
-	void ToggleEnvPoint(int Index, int Channel);
-	bool IsEnvPointSelected(int Index, int Channel) const;
-	bool IsEnvPointSelected(int Index) const;
-	void DeselectEnvPoints();
-	void SelectTangentOutPoint(int Index, int Channel);
-	bool IsTangentOutPointSelected(int Index, int Channel) const;
-	void SelectTangentInPoint(int Index, int Channel);
-	bool IsTangentInPointSelected(int Index, int Channel) const;
-	bool IsTangentInSelected() const;
-	bool IsTangentOutSelected() const;
-	bool IsTangentSelected() const;
-	std::pair<CFixedTime, int> EnvGetSelectedTimeAndValue() const;
 
 	template<typename E>
 	SEditResult<E> DoPropertiesWithState(CUIRect *pToolbox, CProperty *pProps, int *pIds, int *pNewVal, const std::vector<ColorRGBA> &vColors = {});
@@ -524,19 +478,6 @@ public:
 	EQuadEnvelopePointOperation m_QuadEnvelopePointOperation = EQuadEnvelopePointOperation::NONE;
 
 	bool m_ShowPicker;
-
-	std::vector<int> m_vSelectedLayers;
-	std::vector<int> m_vSelectedQuads;
-	int m_SelectedGroup;
-	int m_SelectedQuadPoints;
-	int m_SelectedEnvelope;
-	std::vector<std::pair<int, int>> m_vSelectedEnvelopePoints;
-	int m_SelectedQuadEnvelope;
-	int m_CurrentQuadIndex;
-	int m_SelectedSource;
-	std::pair<int, int> m_SelectedTangentInPoint;
-	std::pair<int, int> m_SelectedTangentOutPoint;
-	bool m_UpdateEnvPointInfo;
 
 	// Color palette and pipette
 	ColorRGBA m_aSavedColors[8];
@@ -793,8 +734,6 @@ public:
 	void UpdateHotEnvelopePoint(const CUIRect &View, const CEnvelope *pEnvelope, int ActiveChannels);
 
 	void RenderMenubar(CUIRect Menubar);
-
-	void SelectGameLayer();
 
 	void DoAudioPreview(CUIRect View, const void *pPlayPauseButtonId, const void *pStopButtonId, const void *pSeekBarId, int SampleId);
 

--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -595,7 +595,7 @@ void CEditorActionAddLayer::Undo()
 
 	Map()->m_vpGroups[m_GroupIndex]->m_Collapse = false;
 	if(m_LayerIndex >= (int)vLayers.size())
-		Editor()->SelectLayer(vLayers.size() - 1, m_GroupIndex);
+		Map()->SelectLayer(vLayers.size() - 1, m_GroupIndex);
 
 	Map()->OnModify();
 }
@@ -623,7 +623,7 @@ void CEditorActionAddLayer::Redo()
 	vLayers.insert(vLayers.begin() + m_LayerIndex, m_pLayer);
 
 	Map()->m_vpGroups[m_GroupIndex]->m_Collapse = false;
-	Editor()->SelectLayer(m_LayerIndex, m_GroupIndex);
+	Map()->SelectLayer(m_LayerIndex, m_GroupIndex);
 	Map()->OnModify();
 }
 
@@ -657,7 +657,7 @@ void CEditorActionDeleteLayer::Redo()
 
 	Map()->m_vpGroups[m_GroupIndex]->m_Collapse = false;
 	if(m_LayerIndex >= (int)vLayers.size())
-		Editor()->SelectLayer(vLayers.size() - 1, m_GroupIndex);
+		Map()->SelectLayer(vLayers.size() - 1, m_GroupIndex);
 
 	Map()->OnModify();
 }
@@ -685,7 +685,7 @@ void CEditorActionDeleteLayer::Undo()
 	vLayers.insert(vLayers.begin() + m_LayerIndex, m_pLayer);
 
 	Map()->m_vpGroups[m_GroupIndex]->m_Collapse = false;
-	Editor()->SelectLayer(m_LayerIndex, m_GroupIndex);
+	Map()->SelectLayer(m_LayerIndex, m_GroupIndex);
 	Map()->OnModify();
 }
 
@@ -705,14 +705,14 @@ void CEditorActionGroup::Undo()
 	{
 		// Undo: add back the group
 		Map()->m_vpGroups.insert(Map()->m_vpGroups.begin() + m_GroupIndex, m_pGroup);
-		Editor()->m_SelectedGroup = m_GroupIndex;
+		Map()->m_SelectedGroup = m_GroupIndex;
 		Map()->OnModify();
 	}
 	else
 	{
 		// Undo: delete the group
 		Map()->DeleteGroup(m_GroupIndex);
-		Editor()->m_SelectedGroup = maximum(0, m_GroupIndex - 1);
+		Map()->m_SelectedGroup = maximum(0, m_GroupIndex - 1);
 	}
 
 	Map()->OnModify();
@@ -724,13 +724,13 @@ void CEditorActionGroup::Redo()
 	{
 		// Redo: add back the group
 		Map()->m_vpGroups.insert(Map()->m_vpGroups.begin() + m_GroupIndex, m_pGroup);
-		Editor()->m_SelectedGroup = m_GroupIndex;
+		Map()->m_SelectedGroup = m_GroupIndex;
 	}
 	else
 	{
 		// Redo: delete the group
 		Map()->DeleteGroup(m_GroupIndex);
-		Editor()->m_SelectedGroup = maximum(0, m_GroupIndex - 1);
+		Map()->m_SelectedGroup = maximum(0, m_GroupIndex - 1);
 	}
 
 	Map()->OnModify();
@@ -761,7 +761,7 @@ void CEditorActionEditGroupProp::Undo()
 
 	if(m_Prop == EGroupProp::PROP_ORDER)
 	{
-		Editor()->m_SelectedGroup = Map()->MoveGroup(m_Current, m_Previous);
+		Map()->m_SelectedGroup = Map()->MoveGroup(m_Current, m_Previous);
 	}
 	else
 		Apply(m_Previous);
@@ -773,7 +773,7 @@ void CEditorActionEditGroupProp::Redo()
 
 	if(m_Prop == EGroupProp::PROP_ORDER)
 	{
-		Editor()->m_SelectedGroup = Map()->MoveGroup(m_Previous, m_Current);
+		Map()->m_SelectedGroup = Map()->MoveGroup(m_Previous, m_Current);
 	}
 	else
 		Apply(m_Current);
@@ -829,7 +829,7 @@ void CEditorActionEditLayerProp::Undo()
 
 	if(m_Prop == ELayerProp::PROP_ORDER)
 	{
-		Editor()->SelectLayer(pCurrentGroup->MoveLayer(m_Current, m_Previous));
+		Map()->SelectLayer(pCurrentGroup->MoveLayer(m_Current, m_Previous));
 	}
 	else
 		Apply(m_Previous);
@@ -841,7 +841,7 @@ void CEditorActionEditLayerProp::Redo()
 
 	if(m_Prop == ELayerProp::PROP_ORDER)
 	{
-		Editor()->SelectLayer(pCurrentGroup->MoveLayer(m_Previous, m_Current));
+		Map()->SelectLayer(pCurrentGroup->MoveLayer(m_Previous, m_Current));
 	}
 	else
 		Apply(m_Current);
@@ -858,8 +858,8 @@ void CEditorActionEditLayerProp::Apply(int Value)
 			pPreviousGroup->m_vpLayers.insert(pPreviousGroup->m_vpLayers.begin() + m_LayerIndex, m_pLayer);
 		else
 			pPreviousGroup->m_vpLayers.push_back(m_pLayer);
-		Editor()->m_SelectedGroup = Value;
-		Editor()->SelectLayer(m_LayerIndex);
+		Map()->m_SelectedGroup = Value;
+		Map()->SelectLayer(m_LayerIndex);
 	}
 	else if(m_Prop == ELayerProp::PROP_HQ)
 	{
@@ -1160,8 +1160,8 @@ void CEditorActionEditLayersGroupAndOrder::Undo()
 		pPreviousGroup->m_vpLayers.insert(pPreviousGroup->m_vpLayers.begin() + m_LayerIndices[k++], pLayer);
 	}
 
-	Editor()->m_vSelectedLayers = m_LayerIndices;
-	Editor()->m_SelectedGroup = m_GroupIndex;
+	Map()->m_vSelectedLayers = m_LayerIndices;
+	Map()->m_SelectedGroup = m_GroupIndex;
 }
 
 void CEditorActionEditLayersGroupAndOrder::Redo()
@@ -1181,8 +1181,8 @@ void CEditorActionEditLayersGroupAndOrder::Redo()
 		pPreviousGroup->m_vpLayers.insert(pPreviousGroup->m_vpLayers.begin() + m_NewLayerIndices[k++], pLayer);
 	}
 
-	Editor()->m_vSelectedLayers = m_NewLayerIndices;
-	Editor()->m_SelectedGroup = m_NewGroupIndex;
+	Map()->m_vSelectedLayers = m_NewLayerIndices;
+	Map()->m_SelectedGroup = m_NewGroupIndex;
 }
 
 // -----------------------------------
@@ -1459,7 +1459,7 @@ CEditorActionEnvelopeAdd::CEditorActionEnvelopeAdd(CEditorMap *pMap, CEnvelope::
 	m_EnvelopeType(EnvelopeType)
 {
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Add new %s envelope", EnvelopeType == CEnvelope::EType::COLOR ? "color" : (EnvelopeType == CEnvelope::EType::POSITION ? "position" : "sound"));
-	m_PreviousSelectedEnvelope = Editor()->m_SelectedEnvelope;
+	m_PreviousSelectedEnvelope = Map()->m_SelectedEnvelope;
 }
 
 void CEditorActionEnvelopeAdd::Undo()
@@ -1467,14 +1467,14 @@ void CEditorActionEnvelopeAdd::Undo()
 	// Undo is removing the envelope, which was added at the back of the list
 	Map()->m_vpEnvelopes.pop_back();
 	Map()->OnModify();
-	Editor()->m_SelectedEnvelope = m_PreviousSelectedEnvelope;
+	Map()->m_SelectedEnvelope = m_PreviousSelectedEnvelope;
 }
 
 void CEditorActionEnvelopeAdd::Redo()
 {
 	// Redo is adding a new envelope at the back of the list
 	Map()->NewEnvelope(m_EnvelopeType);
-	Editor()->m_SelectedEnvelope = Map()->m_vpEnvelopes.size() - 1;
+	Map()->m_SelectedEnvelope = Map()->m_vpEnvelopes.size() - 1;
 }
 
 CEditorActionEnvelopeDelete::CEditorActionEnvelopeDelete(CEditorMap *pMap, int EnvelopeIndex, std::vector<std::shared_ptr<IEditorEnvelopeReference>> &vpObjectReferences, std::shared_ptr<CEnvelope> &pEnvelope) :
@@ -1521,7 +1521,7 @@ void CEditorActionEnvelopeEdit::Undo()
 	}
 	}
 	Map()->OnModify();
-	Editor()->m_SelectedEnvelope = m_EnvelopeIndex;
+	Map()->m_SelectedEnvelope = m_EnvelopeIndex;
 }
 
 void CEditorActionEnvelopeEdit::Redo()
@@ -1540,7 +1540,7 @@ void CEditorActionEnvelopeEdit::Redo()
 	}
 	}
 	Map()->OnModify();
-	Editor()->m_SelectedEnvelope = m_EnvelopeIndex;
+	Map()->m_SelectedEnvelope = m_EnvelopeIndex;
 }
 
 CEditorActionEnvelopeEditPointTime::CEditorActionEnvelopeEditPointTime(CEditorMap *pMap, int EnvelopeIndex, int PointIndex, CFixedTime Previous, CFixedTime Current) :
@@ -1661,7 +1661,7 @@ void CEditorActionEditEnvelopePointValue::Apply(bool Undo)
 	}
 
 	Map()->OnModify();
-	Editor()->m_UpdateEnvPointInfo = true;
+	Map()->m_UpdateEnvPointInfo = true;
 }
 
 // ---------------------
@@ -1722,12 +1722,12 @@ void CEditorActionDeleteEnvelopePoint::Redo()
 	std::shared_ptr<CEnvelope> pEnvelope = Map()->m_vpEnvelopes[m_EnvelopeIndex];
 	pEnvelope->m_vPoints.erase(pEnvelope->m_vPoints.begin() + m_PointIndex);
 
-	auto pSelectedPointIt = std::find_if(Editor()->m_vSelectedEnvelopePoints.begin(), Editor()->m_vSelectedEnvelopePoints.end(), [this](const std::pair<int, int> Pair) {
+	auto pSelectedPointIt = std::find_if(Map()->m_vSelectedEnvelopePoints.begin(), Map()->m_vSelectedEnvelopePoints.end(), [this](const std::pair<int, int> Pair) {
 		return Pair.first == m_PointIndex;
 	});
 
-	if(pSelectedPointIt != Editor()->m_vSelectedEnvelopePoints.end())
-		Editor()->m_vSelectedEnvelopePoints.erase(pSelectedPointIt);
+	if(pSelectedPointIt != Map()->m_vSelectedEnvelopePoints.end())
+		Map()->m_vSelectedEnvelopePoints.erase(pSelectedPointIt);
 
 	Map()->OnModify();
 }
@@ -1782,7 +1782,7 @@ void CEditorActionDeleteSoundSource::Undo()
 {
 	std::shared_ptr<CLayerSounds> pLayerSounds = std::static_pointer_cast<CLayerSounds>(m_pLayer);
 	pLayerSounds->m_vSources.insert(pLayerSounds->m_vSources.begin() + m_SourceIndex, m_Source);
-	Editor()->m_SelectedSource = m_SourceIndex;
+	Map()->m_SelectedSoundSource = m_SourceIndex;
 	Map()->OnModify();
 }
 
@@ -1790,7 +1790,7 @@ void CEditorActionDeleteSoundSource::Redo()
 {
 	std::shared_ptr<CLayerSounds> pLayerSounds = std::static_pointer_cast<CLayerSounds>(m_pLayer);
 	pLayerSounds->m_vSources.erase(pLayerSounds->m_vSources.begin() + m_SourceIndex);
-	Editor()->m_SelectedSource--;
+	Map()->m_SelectedSoundSource--;
 	Map()->OnModify();
 }
 

--- a/src/game/editor/editor_trackers.cpp
+++ b/src/game/editor/editor_trackers.cpp
@@ -37,8 +37,8 @@ void CQuadEditTracker::BeginQuadTrack(const std::shared_ptr<CLayerQuads> &pLayer
 	m_Tracking = true;
 	m_vSelectedQuads.clear();
 	m_pLayer = pLayer;
-	m_GroupIndex = GroupIndex < 0 ? Editor()->m_SelectedGroup : GroupIndex;
-	m_LayerIndex = LayerIndex < 0 ? Editor()->m_vSelectedLayers[0] : LayerIndex;
+	m_GroupIndex = GroupIndex < 0 ? Map()->m_SelectedGroup : GroupIndex;
+	m_LayerIndex = LayerIndex < 0 ? Map()->m_vSelectedLayers[0] : LayerIndex;
 	// Init all points
 	for(auto QuadIndex : vSelectedQuads)
 	{
@@ -74,8 +74,8 @@ void CQuadEditTracker::BeginQuadPropTrack(const std::shared_ptr<CLayerQuads> &pL
 		return;
 	m_TrackedProp = Prop;
 	m_pLayer = pLayer;
-	m_GroupIndex = GroupIndex < 0 ? Editor()->m_SelectedGroup : GroupIndex;
-	m_LayerIndex = LayerIndex < 0 ? Editor()->m_vSelectedLayers[0] : LayerIndex;
+	m_GroupIndex = GroupIndex < 0 ? Map()->m_SelectedGroup : GroupIndex;
+	m_LayerIndex = LayerIndex < 0 ? Map()->m_vSelectedLayers[0] : LayerIndex;
 	m_vSelectedQuads = vSelectedQuads;
 	m_PreviousValues.clear();
 
@@ -146,8 +146,8 @@ void CQuadEditTracker::BeginQuadPointPropTrack(const std::shared_ptr<CLayerQuads
 		return;
 
 	m_pLayer = pLayer;
-	m_GroupIndex = GroupIndex < 0 ? Editor()->m_SelectedGroup : GroupIndex;
-	m_LayerIndex = LayerIndex < 0 ? Editor()->m_vSelectedLayers[0] : LayerIndex;
+	m_GroupIndex = GroupIndex < 0 ? Map()->m_SelectedGroup : GroupIndex;
+	m_LayerIndex = LayerIndex < 0 ? Map()->m_vSelectedLayers[0] : LayerIndex;
 	m_SelectedQuadPoints = SelectedQuadPoints;
 	m_vSelectedQuads = vSelectedQuads;
 	m_PreviousValuesPoint.clear();
@@ -338,9 +338,9 @@ void CEnvelopeEditorOperationTracker::HandlePointDragStart()
 {
 	// Figure out which points are selected and which channels
 	// Save their X and Y position (time and value)
-	auto pEnvelope = Map()->m_vpEnvelopes[Editor()->m_SelectedEnvelope];
+	auto pEnvelope = Map()->m_vpEnvelopes[Map()->m_SelectedEnvelope];
 
-	for(auto [PointIndex, Channel] : Editor()->m_vSelectedEnvelopePoints)
+	for(auto [PointIndex, Channel] : Map()->m_vSelectedEnvelopePoints)
 	{
 		auto &Point = pEnvelope->m_vPoints[PointIndex];
 		auto &Data = m_SavedValues[PointIndex];
@@ -357,7 +357,7 @@ void CEnvelopeEditorOperationTracker::HandlePointDragEnd(bool Switch)
 	if(Switch && m_TrackedOp != EEnvelopeEditorOp::OP_SCALE)
 		return;
 
-	int EnvelopeIndex = Editor()->m_SelectedEnvelope;
+	int EnvelopeIndex = Map()->m_SelectedEnvelope;
 	auto pEnvelope = Map()->m_vpEnvelopes[EnvelopeIndex];
 	std::vector<std::shared_ptr<IEditorAction>> vpActions;
 
@@ -425,7 +425,7 @@ void CSoundSourceOperationTracker::End()
 		if(m_Data.m_OriginalPoint != m_pSource->m_Position)
 		{
 			Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionMoveSoundSource>(
-				Map(), Editor()->m_SelectedGroup, m_LayerIndex, Editor()->m_SelectedSource, m_Data.m_OriginalPoint, m_pSource->m_Position));
+				Map(), Map()->m_SelectedGroup, m_LayerIndex, Map()->m_SelectedSoundSource, m_Data.m_OriginalPoint, m_pSource->m_Position));
 		}
 	}
 
@@ -436,12 +436,12 @@ void CSoundSourceOperationTracker::End()
 
 int SPropTrackerHelper::GetDefaultGroupIndex(CEditorMap *pMap)
 {
-	return pMap->Editor()->m_SelectedGroup;
+	return pMap->m_SelectedGroup;
 }
 
 int SPropTrackerHelper::GetDefaultLayerIndex(CEditorMap *pMap)
 {
-	return pMap->Editor()->m_vSelectedLayers[0];
+	return pMap->m_vSelectedLayers[0];
 }
 
 // -----------------------------------------------------------------------
@@ -591,14 +591,14 @@ int CLayerTilesCommonPropTracker::PropToValue(ETilesCommonProp Prop)
 
 void CLayerGroupPropTracker::OnEnd(EGroupProp Prop, int Value)
 {
-	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionEditGroupProp>(Map(), Editor()->m_SelectedGroup, Prop, m_OriginalValue, Value));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionEditGroupProp>(Map(), Map()->m_SelectedGroup, Prop, m_OriginalValue, Value));
 }
 
 int CLayerGroupPropTracker::PropToValue(EGroupProp Prop)
 {
 	switch(Prop)
 	{
-	case EGroupProp::PROP_ORDER: return Editor()->m_SelectedGroup;
+	case EGroupProp::PROP_ORDER: return Map()->m_SelectedGroup;
 	case EGroupProp::PROP_POS_X: return m_pObject->m_OffsetX;
 	case EGroupProp::PROP_POS_Y: return m_pObject->m_OffsetY;
 	case EGroupProp::PROP_PARA_X: return m_pObject->m_ParallaxX;
@@ -646,7 +646,7 @@ int CLayerSoundsPropTracker::PropToValue(ELayerSoundsProp Prop)
 
 void CSoundSourcePropTracker::OnEnd(ESoundProp Prop, int Value)
 {
-	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionEditSoundSourceProp>(Map(), m_OriginalGroupIndex, m_OriginalLayerIndex, Editor()->m_SelectedSource, Prop, m_OriginalValue, Value));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionEditSoundSourceProp>(Map(), m_OriginalGroupIndex, m_OriginalLayerIndex, Map()->m_SelectedSoundSource, Prop, m_OriginalValue, Value));
 }
 
 int CSoundSourcePropTracker::PropToValue(ESoundProp Prop)
@@ -671,7 +671,7 @@ int CSoundSourcePropTracker::PropToValue(ESoundProp Prop)
 
 void CSoundSourceRectShapePropTracker::OnEnd(ERectangleShapeProp Prop, int Value)
 {
-	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionEditRectSoundSourceShapeProp>(Map(), m_OriginalGroupIndex, m_OriginalLayerIndex, Editor()->m_SelectedSource, Prop, m_OriginalValue, Value));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionEditRectSoundSourceShapeProp>(Map(), m_OriginalGroupIndex, m_OriginalLayerIndex, Map()->m_SelectedSoundSource, Prop, m_OriginalValue, Value));
 }
 
 int CSoundSourceRectShapePropTracker::PropToValue(ERectangleShapeProp Prop)
@@ -686,7 +686,7 @@ int CSoundSourceRectShapePropTracker::PropToValue(ERectangleShapeProp Prop)
 
 void CSoundSourceCircleShapePropTracker::OnEnd(ECircleShapeProp Prop, int Value)
 {
-	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionEditCircleSoundSourceShapeProp>(Map(), m_OriginalGroupIndex, m_OriginalLayerIndex, Editor()->m_SelectedSource, Prop, m_OriginalValue, Value));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionEditCircleSoundSourceShapeProp>(Map(), m_OriginalGroupIndex, m_OriginalLayerIndex, Map()->m_SelectedSoundSource, Prop, m_OriginalValue, Value));
 }
 
 int CSoundSourceCircleShapePropTracker::PropToValue(ECircleShapeProp Prop)

--- a/src/game/editor/font_typer.cpp
+++ b/src/game/editor/font_typer.cpp
@@ -34,7 +34,7 @@ void CFontTyper::SetTile(ivec2 Pos, unsigned char Index, const std::shared_ptr<C
 
 bool CFontTyper::OnInput(const IInput::CEvent &Event)
 {
-	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Editor()->GetSelectedLayerType(0, LAYERTYPE_TILES));
+	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Editor()->Map()->SelectedLayerType(0, LAYERTYPE_TILES));
 	if(!pLayer)
 	{
 		if(IsActive())
@@ -161,7 +161,7 @@ bool CFontTyper::OnInput(const IInput::CEvent &Event)
 
 void CFontTyper::TextModeOn()
 {
-	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Editor()->GetSelectedLayerType(0, LAYERTYPE_TILES));
+	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Editor()->Map()->SelectedLayerType(0, LAYERTYPE_TILES));
 	if(!pLayer)
 		return;
 	if(pLayer->m_Image == -1)
@@ -181,7 +181,7 @@ void CFontTyper::TextModeOff()
 	if(Editor()->m_Dialog == DIALOG_PSEUDO_FONT_TYPER)
 		Editor()->m_Dialog = DIALOG_NONE;
 	if(m_TilesPlacedSinceActivate)
-		Editor()->Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorBrushDrawAction>(Editor()->Map(), Editor()->m_SelectedGroup), "Font typer");
+		Editor()->Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorBrushDrawAction>(Editor()->Map(), Editor()->Map()->m_SelectedGroup), "Font typer");
 	m_TilesPlacedSinceActivate = 0;
 	m_Active = false;
 	m_pLastLayer = nullptr;
@@ -212,7 +212,7 @@ void CFontTyper::OnRender(CUIRect View)
 		TextModeOff();
 	str_copy(Editor()->m_aTooltip, "Type on your keyboard to insert letters and numbers. Press Escape to end text mode.");
 
-	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Editor()->GetSelectedLayerType(0, LAYERTYPE_TILES));
+	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Editor()->Map()->SelectedLayerType(0, LAYERTYPE_TILES));
 	if(!pLayer)
 		return;
 
@@ -238,7 +238,7 @@ void CFontTyper::OnRender(CUIRect View)
 		m_CursorRenderTime = time_get_nanoseconds();
 	if((CurTime - m_CursorRenderTime) > 500ms)
 	{
-		std::shared_ptr<CLayerGroup> pGroup = Editor()->GetSelectedGroup();
+		std::shared_ptr<CLayerGroup> pGroup = Editor()->Map()->SelectedGroup();
 		pGroup->MapScreen();
 		Graphics()->WrapClamp();
 		Graphics()->TextureSet(m_CursorTextTexture);

--- a/src/game/editor/layer_selector.cpp
+++ b/src/game/editor/layer_selector.cpp
@@ -49,7 +49,7 @@ bool CLayerSelector::SelectByTile()
 	{
 		if(!IsFound)
 			m_SelectionOffset = 1;
-		Editor()->SelectLayer(MatchedLayer, MatchedGroup);
+		Editor()->Map()->SelectLayer(MatchedLayer, MatchedGroup);
 		return true;
 	}
 	return false;

--- a/src/game/editor/map_grid.cpp
+++ b/src/game/editor/map_grid.cpp
@@ -20,7 +20,7 @@ void CMapGrid::OnRender(CUIRect View)
 		return;
 	}
 
-	std::shared_ptr<CLayerGroup> pGroup = Editor()->GetSelectedGroup();
+	std::shared_ptr<CLayerGroup> pGroup = Editor()->Map()->SelectedGroup();
 	if(!pGroup)
 	{
 		return;

--- a/src/game/editor/map_view.cpp
+++ b/src/game/editor/map_view.cpp
@@ -51,14 +51,14 @@ void CMapView::Focus()
 
 void CMapView::RenderGroupBorder()
 {
-	std::shared_ptr<CLayerGroup> pGroup = Editor()->GetSelectedGroup();
+	std::shared_ptr<CLayerGroup> pGroup = Editor()->Map()->SelectedGroup();
 	if(pGroup)
 	{
 		pGroup->MapScreen();
 
-		for(size_t i = 0; i < Editor()->m_vSelectedLayers.size(); i++)
+		for(size_t i = 0; i < Editor()->Map()->m_vSelectedLayers.size(); i++)
 		{
-			std::shared_ptr<CLayer> pLayer = Editor()->GetSelectedLayerType(i, LAYERTYPE_TILES);
+			std::shared_ptr<CLayer> pLayer = Editor()->Map()->SelectedLayerType(i, LAYERTYPE_TILES);
 			if(pLayer)
 			{
 				CUIRect BorderRect;
@@ -112,10 +112,10 @@ void CMapView::RenderEditorMap()
 		}
 	}
 
-	std::shared_ptr<CLayerTiles> pSelectedTilesLayer = std::static_pointer_cast<CLayerTiles>(Editor()->GetSelectedLayerType(0, LAYERTYPE_TILES));
+	std::shared_ptr<CLayerTiles> pSelectedTilesLayer = std::static_pointer_cast<CLayerTiles>(Editor()->Map()->SelectedLayerType(0, LAYERTYPE_TILES));
 	if(Editor()->m_ShowTileInfo != CEditor::SHOW_TILE_OFF && pSelectedTilesLayer && pSelectedTilesLayer->m_Visible && m_Zoom.GetValue() <= 300.0f)
 	{
-		Editor()->GetSelectedGroup()->MapScreen();
+		Editor()->Map()->SelectedGroup()->MapScreen();
 		pSelectedTilesLayer->ShowInfo();
 	}
 }

--- a/src/game/editor/mapitems/layer_quads.cpp
+++ b/src/game/editor/mapitems/layer_quads.cpp
@@ -130,7 +130,7 @@ void CLayerQuads::BrushPlace(CLayer *pBrush, vec2 WorldPos)
 		m_vQuads.push_back(NewQuad);
 		vAddedQuads.push_back(NewQuad);
 	}
-	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionQuadPlace>(Map(), Editor()->m_SelectedGroup, Editor()->m_vSelectedLayers[0], vAddedQuads));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionQuadPlace>(Map(), Map()->m_SelectedGroup, Map()->m_vSelectedLayers[0], vAddedQuads));
 	Map()->OnModify();
 }
 

--- a/src/game/editor/mapitems/layer_sounds.cpp
+++ b/src/game/editor/mapitems/layer_sounds.cpp
@@ -153,7 +153,7 @@ void CLayerSounds::BrushPlace(CLayer *pBrush, vec2 WorldPos)
 		m_vSources.push_back(NewSource);
 		vAddedSources.push_back(NewSource);
 	}
-	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionSoundPlace>(Map(), Editor()->m_SelectedGroup, Editor()->m_vSelectedLayers[0], vAddedSources));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionSoundPlace>(Map(), Map()->m_SelectedGroup, Map()->m_vSelectedLayers[0], vAddedSources));
 	Map()->OnModify();
 }
 

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -792,7 +792,7 @@ void CLayerTiles::FillGameTiles(EGameTileOp Fill)
 	int Result = GameTileOpToIndex(Fill);
 	if(Result > -1)
 	{
-		std::shared_ptr<CLayerGroup> pGroup = Map()->m_vpGroups[Editor()->m_SelectedGroup];
+		std::shared_ptr<CLayerGroup> pGroup = Map()->m_vpGroups[Map()->m_SelectedGroup];
 		m_FillGameTile = Result;
 		const int OffsetX = -pGroup->m_OffsetX / 32;
 		const int OffsetY = -pGroup->m_OffsetY / 32;
@@ -947,7 +947,7 @@ bool CLayerTiles::CanFillGameTiles() const
 	if(EntitiesLayer)
 		return false;
 
-	std::shared_ptr<CLayerGroup> pGroup = Map()->m_vpGroups[Editor()->m_SelectedGroup];
+	std::shared_ptr<CLayerGroup> pGroup = Map()->m_vpGroups[Map()->m_SelectedGroup];
 
 	// Game tiles can only be constructed if the layer is relative to the game layer
 	return !(pGroup->m_OffsetX % 32) && !(pGroup->m_OffsetY % 32) && pGroup->m_ParallaxX == 100 && pGroup->m_ParallaxY == 100;
@@ -1016,7 +1016,7 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 					if(!m_TilesHistory.empty()) // Sometimes pressing that button causes the automap to run so we should be able to undo that
 					{
 						// record undo
-						Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Map(), Editor()->m_SelectedGroup, Editor()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
+						Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Map(), Map()->m_SelectedGroup, Map()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
 						ClearHistory();
 					}
 				}
@@ -1027,7 +1027,7 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 			{
 				Map()->m_vpImages[m_Image]->m_AutoMapper.Proceed(this, Map()->m_pGameLayer.get(), m_AutoMapperReference, m_AutoMapperConfig, m_Seed);
 				// record undo
-				Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Map(), Editor()->m_SelectedGroup, Editor()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
+				Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Map(), Map()->m_SelectedGroup, Map()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
 				ClearHistory();
 				return CUi::POPUP_CLOSE_CURRENT;
 			}
@@ -1173,7 +1173,7 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 		// Record undo if automapper was ran
 		if(m_AutoAutoMap && !m_TilesHistory.empty())
 		{
-			Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Map(), Editor()->m_SelectedGroup, Editor()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
+			Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Map(), Map()->m_SelectedGroup, Map()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
 			ClearHistory();
 		}
 	}
@@ -1201,7 +1201,7 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropSta
 
 			std::vector<std::shared_ptr<IEditorAction>> vpActions;
 			int j = 0;
-			int GroupIndex = pEditor->m_SelectedGroup;
+			int GroupIndex = pEditorMap->m_SelectedGroup;
 			for(auto &pLayer : vpLayers)
 			{
 				int LayerIndex = vLayerIndices[j++];

--- a/src/game/editor/mapitems/map.cpp
+++ b/src/game/editor/mapitems/map.cpp
@@ -3,6 +3,7 @@
 #include <base/system.h>
 
 #include <game/editor/editor.h>
+#include <game/editor/editor_actions.h>
 #include <game/editor/mapitems/image.h>
 #include <game/editor/mapitems/layer_front.h>
 #include <game/editor/mapitems/layer_game.h>
@@ -44,6 +45,508 @@ void CEditorMap::ResetModifiedState()
 	m_LastSaveTime = Editor()->Client()->GlobalTime();
 }
 
+void CEditorMap::Clean()
+{
+	m_aFilename[0] = '\0';
+	m_ValidSaveFilename = false;
+	ResetModifiedState();
+
+	m_vpGroups.clear();
+	m_vpEnvelopes.clear();
+	m_vpImages.clear();
+	m_vpSounds.clear();
+	m_vSettings.clear();
+
+	m_pGameGroup = nullptr;
+	m_pGameLayer = nullptr;
+	m_pTeleLayer = nullptr;
+	m_pSpeedupLayer = nullptr;
+	m_pFrontLayer = nullptr;
+	m_pSwitchLayer = nullptr;
+	m_pTuneLayer = nullptr;
+
+	m_MapInfo.Reset();
+	m_MapInfoTmp.Reset();
+
+	m_EditorHistory.Clear();
+	m_EnvelopeEditorHistory.Clear();
+	m_ServerSettingsHistory.Clear();
+	m_EnvOpTracker.Reset();
+
+	m_SelectedGroup = 0;
+	m_vSelectedLayers.clear();
+	DeselectQuads();
+	DeselectQuadPoints();
+	m_SelectedQuadEnvelope = -1;
+	m_CurrentQuadIndex = -1;
+	m_SelectedEnvelope = 0;
+	m_UpdateEnvPointInfo = false;
+	m_vSelectedEnvelopePoints.clear();
+	m_SelectedTangentInPoint = std::pair(-1, -1);
+	m_SelectedTangentOutPoint = std::pair(-1, -1);
+	m_SelectedImage = 0;
+	m_SelectedSound = 0;
+	m_SelectedSoundSource = -1;
+
+	m_ShiftBy = 1;
+
+	m_QuadKnife.m_Active = false;
+	m_QuadKnife.m_Count = 0;
+	m_QuadKnife.m_SelectedQuadIndex = -1;
+	std::fill(std::begin(m_QuadKnife.m_aPoints), std::end(m_QuadKnife.m_aPoints), vec2(0.0f, 0.0f));
+}
+
+void CEditorMap::CreateDefault()
+{
+	// Add default background group, quad layer and quad
+	std::shared_ptr<CLayerGroup> pGroup = NewGroup();
+	pGroup->m_ParallaxX = 0;
+	pGroup->m_ParallaxY = 0;
+	std::shared_ptr<CLayerQuads> pLayer = std::make_shared<CLayerQuads>(this);
+	CQuad *pQuad = pLayer->NewQuad(0, 0, 1600, 1200);
+	pQuad->m_aColors[0].r = pQuad->m_aColors[1].r = 94;
+	pQuad->m_aColors[0].g = pQuad->m_aColors[1].g = 132;
+	pQuad->m_aColors[0].b = pQuad->m_aColors[1].b = 174;
+	pQuad->m_aColors[2].r = pQuad->m_aColors[3].r = 204;
+	pQuad->m_aColors[2].g = pQuad->m_aColors[3].g = 232;
+	pQuad->m_aColors[2].b = pQuad->m_aColors[3].b = 255;
+	pGroup->AddLayer(pLayer);
+
+	// Add game group and layer
+	MakeGameGroup(NewGroup());
+	MakeGameLayer(std::make_shared<CLayerGame>(this, 50, 50));
+	m_pGameGroup->AddLayer(m_pGameLayer);
+
+	ResetModifiedState();
+	CheckIntegrity();
+	SelectGameLayer();
+}
+
+void CEditorMap::CheckIntegrity()
+{
+	const auto &&CheckObjectInMap = [&](const CMapObject *pMapObject, const char *pName) {
+		dbg_assert(pMapObject != nullptr, "%s missing in map", pName);
+		dbg_assert(pMapObject->Map() == this, "%s does not belong to map (object_map=%p, this_map=%p)", pName, pMapObject->Map(), this);
+	};
+	bool GameGroupMissing = true;
+	CheckObjectInMap(m_pGameGroup.get(), "Game group");
+	dbg_assert(m_pGameGroup->m_GameGroup, "Game group not marked as such");
+	bool GameLayerMissing = true;
+	CheckObjectInMap(m_pGameLayer.get(), "Game layer");
+	dbg_assert(m_pGameLayer->m_HasGame, "Game layer not marked as such");
+	bool FrontLayerMissing = false;
+	if(m_pFrontLayer != nullptr)
+	{
+		FrontLayerMissing = true;
+		CheckObjectInMap(m_pFrontLayer.get(), "Front layer");
+		dbg_assert(m_pFrontLayer->m_HasFront, "Front layer not marked as such");
+	}
+	bool TeleLayerMissing = false;
+	if(m_pTeleLayer != nullptr)
+	{
+		TeleLayerMissing = true;
+		CheckObjectInMap(m_pTeleLayer.get(), "Tele layer");
+		dbg_assert(m_pTeleLayer->m_HasTele, "Tele layer not marked as such");
+	}
+	bool SpeedupLayerMissing = false;
+	if(m_pSpeedupLayer != nullptr)
+	{
+		SpeedupLayerMissing = true;
+		CheckObjectInMap(m_pSpeedupLayer.get(), "Speedup layer");
+		dbg_assert(m_pSpeedupLayer->m_HasSpeedup, "Speedup layer not marked as such");
+	}
+	bool SwitchLayerMissing = false;
+	if(m_pSwitchLayer != nullptr)
+	{
+		SwitchLayerMissing = true;
+		CheckObjectInMap(m_pSwitchLayer.get(), "Switch layer");
+		dbg_assert(m_pSwitchLayer->m_HasSwitch, "Switch layer not marked as such");
+	}
+	bool TuneLayerMissing = false;
+	if(m_pTuneLayer != nullptr)
+	{
+		TuneLayerMissing = true;
+		CheckObjectInMap(m_pTuneLayer.get(), "Tune layer");
+		dbg_assert(m_pTuneLayer->m_HasTune, "Tune layer not marked as such");
+	}
+	for(const auto &pGroup : m_vpGroups)
+	{
+		CheckObjectInMap(pGroup.get(), "Group");
+		for(const auto &pLayer : pGroup->m_vpLayers)
+		{
+			CheckObjectInMap(pLayer.get(), "Layer");
+		}
+		if(pGroup == m_pGameGroup)
+		{
+			GameGroupMissing = false;
+			for(const auto &pLayer : pGroup->m_vpLayers)
+			{
+				if(pLayer == m_pGameLayer)
+				{
+					GameLayerMissing = false;
+				}
+				if(pLayer == m_pFrontLayer)
+				{
+					FrontLayerMissing = false;
+				}
+				if(pLayer == m_pTeleLayer)
+				{
+					TeleLayerMissing = false;
+				}
+				if(pLayer == m_pSpeedupLayer)
+				{
+					SpeedupLayerMissing = false;
+				}
+				if(pLayer == m_pSwitchLayer)
+				{
+					SwitchLayerMissing = false;
+				}
+				if(pLayer == m_pTuneLayer)
+				{
+					TuneLayerMissing = false;
+				}
+			}
+			dbg_assert(!GameLayerMissing, "Game layer missing in game group");
+			dbg_assert(!FrontLayerMissing, "Front layer missing in game group");
+			dbg_assert(!TeleLayerMissing, "Tele layer missing in game group");
+			dbg_assert(!SpeedupLayerMissing, "Speedup layer missing in game group");
+			dbg_assert(!SwitchLayerMissing, "Switch layer missing in game group");
+			dbg_assert(!TuneLayerMissing, "Tune layer missing in game group");
+		}
+	}
+	dbg_assert(!GameGroupMissing, "Game group missing in list of groups");
+	for(const auto &pImage : m_vpImages)
+	{
+		CheckObjectInMap(pImage.get(), "Image");
+	}
+	for(const auto &pSound : m_vpSounds)
+	{
+		CheckObjectInMap(pSound.get(), "Sound");
+	}
+}
+
+void CEditorMap::ModifyImageIndex(const FIndexModifyFunction &IndexModifyFunction)
+{
+	OnModify();
+	for(auto &pGroup : m_vpGroups)
+	{
+		pGroup->ModifyImageIndex(IndexModifyFunction);
+	}
+}
+
+void CEditorMap::ModifyEnvelopeIndex(const FIndexModifyFunction &IndexModifyFunction)
+{
+	OnModify();
+	for(auto &pGroup : m_vpGroups)
+	{
+		pGroup->ModifyEnvelopeIndex(IndexModifyFunction);
+	}
+}
+
+void CEditorMap::ModifySoundIndex(const FIndexModifyFunction &IndexModifyFunction)
+{
+	OnModify();
+	for(auto &pGroup : m_vpGroups)
+	{
+		pGroup->ModifySoundIndex(IndexModifyFunction);
+	}
+}
+
+std::shared_ptr<CLayerGroup> CEditorMap::SelectedGroup() const
+{
+	if(m_SelectedGroup >= 0 && m_SelectedGroup < (int)m_vpGroups.size())
+		return m_vpGroups[m_SelectedGroup];
+	return nullptr;
+}
+
+std::shared_ptr<CLayerGroup> CEditorMap::NewGroup()
+{
+	OnModify();
+	std::shared_ptr<CLayerGroup> pGroup = std::make_shared<CLayerGroup>(this);
+	m_vpGroups.push_back(pGroup);
+	return pGroup;
+}
+
+int CEditorMap::MoveGroup(int IndexFrom, int IndexTo)
+{
+	if(IndexFrom < 0 || IndexFrom >= (int)m_vpGroups.size())
+		return IndexFrom;
+	if(IndexTo < 0 || IndexTo >= (int)m_vpGroups.size())
+		return IndexFrom;
+	if(IndexFrom == IndexTo)
+		return IndexFrom;
+	OnModify();
+	auto pMovedGroup = m_vpGroups[IndexFrom];
+	m_vpGroups.erase(m_vpGroups.begin() + IndexFrom);
+	m_vpGroups.insert(m_vpGroups.begin() + IndexTo, pMovedGroup);
+	return IndexTo;
+}
+
+void CEditorMap::DeleteGroup(int Index)
+{
+	if(Index < 0 || Index >= (int)m_vpGroups.size())
+		return;
+	OnModify();
+	m_vpGroups.erase(m_vpGroups.begin() + Index);
+}
+
+void CEditorMap::MakeGameGroup(std::shared_ptr<CLayerGroup> pGroup)
+{
+	m_pGameGroup = std::move(pGroup);
+	m_pGameGroup->m_GameGroup = true;
+	str_copy(m_pGameGroup->m_aName, "Game");
+}
+
+std::shared_ptr<CLayer> CEditorMap::SelectedLayer(int Index) const
+{
+	std::shared_ptr<CLayerGroup> pGroup = SelectedGroup();
+	if(!pGroup)
+		return nullptr;
+
+	if(Index < 0 || Index >= (int)m_vSelectedLayers.size())
+		return nullptr;
+
+	int LayerIndex = m_vSelectedLayers[Index];
+
+	if(LayerIndex >= 0 && LayerIndex < (int)m_vpGroups[m_SelectedGroup]->m_vpLayers.size())
+		return pGroup->m_vpLayers[LayerIndex];
+	return nullptr;
+}
+
+std::shared_ptr<CLayer> CEditorMap::SelectedLayerType(int Index, int Type) const
+{
+	std::shared_ptr<CLayer> pLayer = SelectedLayer(Index);
+	if(pLayer && pLayer->m_Type == Type)
+		return pLayer;
+	return nullptr;
+}
+
+void CEditorMap::SelectLayer(int LayerIndex, int GroupIndex)
+{
+	if(GroupIndex != -1)
+		m_SelectedGroup = GroupIndex;
+
+	m_vSelectedLayers.clear();
+	DeselectQuads();
+	DeselectQuadPoints();
+	AddSelectedLayer(LayerIndex);
+}
+
+void CEditorMap::AddSelectedLayer(int LayerIndex)
+{
+	m_vSelectedLayers.push_back(LayerIndex);
+	m_QuadKnife.m_Active = false;
+}
+
+void CEditorMap::SelectNextLayer()
+{
+	int CurrentLayer = 0;
+	for(const auto &Selected : m_vSelectedLayers)
+		CurrentLayer = maximum(Selected, CurrentLayer);
+	SelectLayer(CurrentLayer);
+
+	if(m_vSelectedLayers[0] < (int)m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1)
+	{
+		SelectLayer(m_vSelectedLayers[0] + 1);
+	}
+	else
+	{
+		for(size_t Group = m_SelectedGroup + 1; Group < m_vpGroups.size(); Group++)
+		{
+			if(!m_vpGroups[Group]->m_vpLayers.empty())
+			{
+				SelectLayer(0, Group);
+				break;
+			}
+		}
+	}
+}
+
+void CEditorMap::SelectPreviousLayer()
+{
+	int CurrentLayer = std::numeric_limits<int>::max();
+	for(const auto &Selected : m_vSelectedLayers)
+		CurrentLayer = minimum(Selected, CurrentLayer);
+	SelectLayer(CurrentLayer);
+
+	if(m_vSelectedLayers[0] > 0)
+	{
+		SelectLayer(m_vSelectedLayers[0] - 1);
+	}
+	else
+	{
+		for(int Group = m_SelectedGroup - 1; Group >= 0; Group--)
+		{
+			if(!m_vpGroups[Group]->m_vpLayers.empty())
+			{
+				SelectLayer(m_vpGroups[Group]->m_vpLayers.size() - 1, Group);
+				break;
+			}
+		}
+	}
+}
+
+void CEditorMap::SelectGameLayer()
+{
+	for(size_t g = 0; g < m_vpGroups.size(); g++)
+	{
+		for(size_t i = 0; i < m_vpGroups[g]->m_vpLayers.size(); i++)
+		{
+			if(m_vpGroups[g]->m_vpLayers[i] == m_pGameLayer)
+			{
+				SelectLayer(i, g);
+				return;
+			}
+		}
+	}
+}
+
+void CEditorMap::MakeGameLayer(const std::shared_ptr<CLayer> &pLayer)
+{
+	m_pGameLayer = std::static_pointer_cast<CLayerGame>(pLayer);
+}
+
+void CEditorMap::MakeTeleLayer(const std::shared_ptr<CLayer> &pLayer)
+{
+	m_pTeleLayer = std::static_pointer_cast<CLayerTele>(pLayer);
+}
+
+void CEditorMap::MakeSpeedupLayer(const std::shared_ptr<CLayer> &pLayer)
+{
+	m_pSpeedupLayer = std::static_pointer_cast<CLayerSpeedup>(pLayer);
+}
+
+void CEditorMap::MakeFrontLayer(const std::shared_ptr<CLayer> &pLayer)
+{
+	m_pFrontLayer = std::static_pointer_cast<CLayerFront>(pLayer);
+}
+
+void CEditorMap::MakeSwitchLayer(const std::shared_ptr<CLayer> &pLayer)
+{
+	m_pSwitchLayer = std::static_pointer_cast<CLayerSwitch>(pLayer);
+}
+
+void CEditorMap::MakeTuneLayer(const std::shared_ptr<CLayer> &pLayer)
+{
+	m_pTuneLayer = std::static_pointer_cast<CLayerTune>(pLayer);
+}
+
+std::vector<CQuad *> CEditorMap::SelectedQuads()
+{
+	std::shared_ptr<CLayerQuads> pQuadLayer = std::static_pointer_cast<CLayerQuads>(SelectedLayerType(0, LAYERTYPE_QUADS));
+	std::vector<CQuad *> vpQuads;
+	if(!pQuadLayer)
+		return vpQuads;
+	vpQuads.reserve(m_vSelectedQuads.size());
+	for(const auto &SelectedQuad : m_vSelectedQuads)
+	{
+		if(SelectedQuad >= (int)pQuadLayer->m_vQuads.size())
+			continue;
+		vpQuads.push_back(&pQuadLayer->m_vQuads[SelectedQuad]);
+	}
+	return vpQuads;
+}
+
+bool CEditorMap::IsQuadSelected(int Index) const
+{
+	return FindSelectedQuadIndex(Index) >= 0;
+}
+
+int CEditorMap::FindSelectedQuadIndex(int Index) const
+{
+	for(size_t i = 0; i < m_vSelectedQuads.size(); ++i)
+		if(m_vSelectedQuads[i] == Index)
+			return i;
+	return -1;
+}
+
+void CEditorMap::SelectQuad(int Index)
+{
+	m_vSelectedQuads.clear();
+	m_vSelectedQuads.push_back(Index);
+}
+
+void CEditorMap::ToggleSelectQuad(int Index)
+{
+	int ListIndex = FindSelectedQuadIndex(Index);
+	if(ListIndex < 0)
+		m_vSelectedQuads.push_back(Index);
+	else
+		m_vSelectedQuads.erase(m_vSelectedQuads.begin() + ListIndex);
+}
+
+void CEditorMap::DeselectQuads()
+{
+	m_vSelectedQuads.clear();
+}
+
+bool CEditorMap::IsQuadCornerSelected(int Index) const
+{
+	return m_SelectedQuadPoints & (1 << Index);
+}
+
+bool CEditorMap::IsQuadPointSelected(int QuadIndex, int Index) const
+{
+	return IsQuadSelected(QuadIndex) && IsQuadCornerSelected(Index);
+}
+
+void CEditorMap::SelectQuadPoint(int QuadIndex, int Index)
+{
+	SelectQuad(QuadIndex);
+	m_SelectedQuadPoints = 1 << Index;
+}
+
+void CEditorMap::ToggleSelectQuadPoint(int QuadIndex, int Index)
+{
+	if(IsQuadPointSelected(QuadIndex, Index))
+	{
+		m_SelectedQuadPoints ^= 1 << Index;
+	}
+	else
+	{
+		if(!IsQuadSelected(QuadIndex))
+		{
+			ToggleSelectQuad(QuadIndex);
+		}
+
+		if(!(m_SelectedQuadPoints & 1 << Index))
+		{
+			m_SelectedQuadPoints ^= 1 << Index;
+		}
+	}
+}
+
+void CEditorMap::DeselectQuadPoints()
+{
+	m_SelectedQuadPoints = 0;
+}
+
+void CEditorMap::DeleteSelectedQuads()
+{
+	std::shared_ptr<CLayerQuads> pLayer = std::static_pointer_cast<CLayerQuads>(SelectedLayerType(0, LAYERTYPE_QUADS));
+	if(!pLayer)
+		return;
+
+	std::vector<int> vSelectedQuads(m_vSelectedQuads);
+	std::vector<CQuad> vDeletedQuads;
+	vDeletedQuads.reserve(m_vSelectedQuads.size());
+	for(int i = 0; i < (int)m_vSelectedQuads.size(); ++i)
+	{
+		auto const &Quad = pLayer->m_vQuads[m_vSelectedQuads[i]];
+		vDeletedQuads.push_back(Quad);
+
+		pLayer->m_vQuads.erase(pLayer->m_vQuads.begin() + m_vSelectedQuads[i]);
+		for(int j = i + 1; j < (int)m_vSelectedQuads.size(); ++j)
+			if(m_vSelectedQuads[j] > m_vSelectedQuads[i])
+				m_vSelectedQuads[j]--;
+
+		m_vSelectedQuads.erase(m_vSelectedQuads.begin() + i);
+		i--;
+	}
+
+	m_EditorHistory.RecordAction(std::make_shared<CEditorActionDeleteQuad>(this, m_SelectedGroup, m_vSelectedLayers[0], vSelectedQuads, vDeletedQuads));
+}
+
 std::shared_ptr<CEnvelope> CEditorMap::NewEnvelope(CEnvelope::EType Type)
 {
 	OnModify();
@@ -67,7 +570,7 @@ void CEditorMap::InsertEnvelope(int Index, std::shared_ptr<CEnvelope> &pEnvelope
 	if(Index < 0 || Index >= (int)m_vpEnvelopes.size() + 1)
 		return;
 	m_vpEnvelopes.push_back(pEnvelope);
-	m_pEditor->m_SelectedEnvelope = MoveEnvelope((int)m_vpEnvelopes.size() - 1, Index);
+	m_SelectedEnvelope = MoveEnvelope((int)m_vpEnvelopes.size() - 1, Index);
 }
 
 void CEditorMap::UpdateEnvelopeReferences(int Index, std::shared_ptr<CEnvelope> &pEnvelope, std::vector<std::shared_ptr<IEditorEnvelopeReference>> &vpEditorObjectReferences)
@@ -178,266 +681,137 @@ std::vector<std::shared_ptr<IEditorEnvelopeReference>> CEditorMap::VisitEnvelope
 	return vpUpdatedReferences;
 }
 
-std::shared_ptr<CLayerGroup> CEditorMap::NewGroup()
+int CEditorMap::FindEnvPointIndex(int Index, int Channel) const
 {
-	OnModify();
-	std::shared_ptr<CLayerGroup> pGroup = std::make_shared<CLayerGroup>(this);
-	m_vpGroups.push_back(pGroup);
-	return pGroup;
+	auto Iter = std::find(
+		m_vSelectedEnvelopePoints.begin(),
+		m_vSelectedEnvelopePoints.end(),
+		std::pair(Index, Channel));
+
+	if(Iter != m_vSelectedEnvelopePoints.end())
+		return Iter - m_vSelectedEnvelopePoints.begin();
+	else
+		return -1;
 }
 
-int CEditorMap::MoveGroup(int IndexFrom, int IndexTo)
+void CEditorMap::SelectEnvPoint(int Index)
 {
-	if(IndexFrom < 0 || IndexFrom >= (int)m_vpGroups.size())
-		return IndexFrom;
-	if(IndexTo < 0 || IndexTo >= (int)m_vpGroups.size())
-		return IndexFrom;
-	if(IndexFrom == IndexTo)
-		return IndexFrom;
-	OnModify();
-	auto pMovedGroup = m_vpGroups[IndexFrom];
-	m_vpGroups.erase(m_vpGroups.begin() + IndexFrom);
-	m_vpGroups.insert(m_vpGroups.begin() + IndexTo, pMovedGroup);
-	return IndexTo;
+	m_vSelectedEnvelopePoints.clear();
+
+	for(int c = 0; c < CEnvPoint::MAX_CHANNELS; c++)
+		m_vSelectedEnvelopePoints.emplace_back(Index, c);
 }
 
-void CEditorMap::DeleteGroup(int Index)
+void CEditorMap::SelectEnvPoint(int Index, int Channel)
 {
-	if(Index < 0 || Index >= (int)m_vpGroups.size())
-		return;
-	OnModify();
-	m_vpGroups.erase(m_vpGroups.begin() + Index);
+	DeselectEnvPoints();
+	m_vSelectedEnvelopePoints.emplace_back(Index, Channel);
 }
 
-void CEditorMap::ModifyImageIndex(const FIndexModifyFunction &IndexModifyFunction)
+void CEditorMap::ToggleEnvPoint(int Index, int Channel)
 {
-	OnModify();
-	for(auto &pGroup : m_vpGroups)
+	if(IsTangentSelected())
+		DeselectEnvPoints();
+
+	int ListIndex = FindEnvPointIndex(Index, Channel);
+
+	if(ListIndex >= 0)
 	{
-		pGroup->ModifyImageIndex(IndexModifyFunction);
+		m_vSelectedEnvelopePoints.erase(m_vSelectedEnvelopePoints.begin() + ListIndex);
 	}
+	else
+		m_vSelectedEnvelopePoints.emplace_back(Index, Channel);
 }
 
-void CEditorMap::ModifyEnvelopeIndex(const FIndexModifyFunction &IndexModifyFunction)
+bool CEditorMap::IsEnvPointSelected(int Index, int Channel) const
 {
-	OnModify();
-	for(auto &pGroup : m_vpGroups)
+	int ListIndex = FindEnvPointIndex(Index, Channel);
+
+	return ListIndex >= 0;
+}
+
+bool CEditorMap::IsEnvPointSelected(int Index) const
+{
+	auto Iter = std::find_if(
+		m_vSelectedEnvelopePoints.begin(),
+		m_vSelectedEnvelopePoints.end(),
+		[&](const auto &Pair) { return Pair.first == Index; });
+
+	return Iter != m_vSelectedEnvelopePoints.end();
+}
+
+void CEditorMap::DeselectEnvPoints()
+{
+	m_vSelectedEnvelopePoints.clear();
+	m_SelectedTangentInPoint = std::pair(-1, -1);
+	m_SelectedTangentOutPoint = std::pair(-1, -1);
+}
+
+bool CEditorMap::IsTangentSelected() const
+{
+	return IsTangentInSelected() || IsTangentOutSelected();
+}
+
+bool CEditorMap::IsTangentOutPointSelected(int Index, int Channel) const
+{
+	return m_SelectedTangentOutPoint == std::pair(Index, Channel);
+}
+
+bool CEditorMap::IsTangentOutSelected() const
+{
+	return m_SelectedTangentOutPoint != std::pair(-1, -1);
+}
+
+void CEditorMap::SelectTangentOutPoint(int Index, int Channel)
+{
+	DeselectEnvPoints();
+	m_SelectedTangentOutPoint = std::pair(Index, Channel);
+}
+
+bool CEditorMap::IsTangentInPointSelected(int Index, int Channel) const
+{
+	return m_SelectedTangentInPoint == std::pair(Index, Channel);
+}
+
+bool CEditorMap::IsTangentInSelected() const
+{
+	return m_SelectedTangentInPoint != std::pair(-1, -1);
+}
+
+void CEditorMap::SelectTangentInPoint(int Index, int Channel)
+{
+	DeselectEnvPoints();
+	m_SelectedTangentInPoint = std::pair(Index, Channel);
+}
+
+std::pair<CFixedTime, int> CEditorMap::SelectedEnvelopeTimeAndValue() const
+{
+	if(m_SelectedEnvelope < 0 || m_SelectedEnvelope >= (int)m_vpEnvelopes.size())
+		return {};
+
+	std::shared_ptr<CEnvelope> pEnvelope = m_vpEnvelopes[m_SelectedEnvelope];
+	CFixedTime CurrentTime;
+	int CurrentValue;
+	if(IsTangentInSelected())
 	{
-		pGroup->ModifyEnvelopeIndex(IndexModifyFunction);
+		auto [SelectedIndex, SelectedChannel] = m_SelectedTangentInPoint;
+		CurrentTime = pEnvelope->m_vPoints[SelectedIndex].m_Time + pEnvelope->m_vPoints[SelectedIndex].m_Bezier.m_aInTangentDeltaX[SelectedChannel];
+		CurrentValue = pEnvelope->m_vPoints[SelectedIndex].m_aValues[SelectedChannel] + pEnvelope->m_vPoints[SelectedIndex].m_Bezier.m_aInTangentDeltaY[SelectedChannel];
 	}
-}
-
-void CEditorMap::ModifySoundIndex(const FIndexModifyFunction &IndexModifyFunction)
-{
-	OnModify();
-	for(auto &pGroup : m_vpGroups)
+	else if(IsTangentOutSelected())
 	{
-		pGroup->ModifySoundIndex(IndexModifyFunction);
+		auto [SelectedIndex, SelectedChannel] = m_SelectedTangentOutPoint;
+		CurrentTime = pEnvelope->m_vPoints[SelectedIndex].m_Time + pEnvelope->m_vPoints[SelectedIndex].m_Bezier.m_aOutTangentDeltaX[SelectedChannel];
+		CurrentValue = pEnvelope->m_vPoints[SelectedIndex].m_aValues[SelectedChannel] + pEnvelope->m_vPoints[SelectedIndex].m_Bezier.m_aOutTangentDeltaY[SelectedChannel];
 	}
-}
-
-void CEditorMap::Clean()
-{
-	m_aFilename[0] = '\0';
-	m_ValidSaveFilename = false;
-	ResetModifiedState();
-
-	m_vpGroups.clear();
-	m_vpEnvelopes.clear();
-	m_vpImages.clear();
-	m_vpSounds.clear();
-	m_vSettings.clear();
-
-	m_pGameGroup = nullptr;
-	m_pGameLayer = nullptr;
-	m_pTeleLayer = nullptr;
-	m_pSpeedupLayer = nullptr;
-	m_pFrontLayer = nullptr;
-	m_pSwitchLayer = nullptr;
-	m_pTuneLayer = nullptr;
-
-	m_MapInfo.Reset();
-	m_MapInfoTmp.Reset();
-
-	m_EditorHistory.Clear();
-	m_EnvelopeEditorHistory.Clear();
-	m_ServerSettingsHistory.Clear();
-	m_EnvOpTracker.Reset();
-
-	m_SelectedImage = 0;
-	m_SelectedSound = 0;
-
-	m_ShiftBy = 1;
-
-	m_QuadKnife.m_Active = false;
-	m_QuadKnife.m_Count = 0;
-	m_QuadKnife.m_SelectedQuadIndex = -1;
-	std::fill(std::begin(m_QuadKnife.m_aPoints), std::end(m_QuadKnife.m_aPoints), vec2(0.0f, 0.0f));
-}
-
-void CEditorMap::CreateDefault()
-{
-	// Add default background group, quad layer and quad
-	std::shared_ptr<CLayerGroup> pGroup = NewGroup();
-	pGroup->m_ParallaxX = 0;
-	pGroup->m_ParallaxY = 0;
-	std::shared_ptr<CLayerQuads> pLayer = std::make_shared<CLayerQuads>(this);
-	CQuad *pQuad = pLayer->NewQuad(0, 0, 1600, 1200);
-	pQuad->m_aColors[0].r = pQuad->m_aColors[1].r = 94;
-	pQuad->m_aColors[0].g = pQuad->m_aColors[1].g = 132;
-	pQuad->m_aColors[0].b = pQuad->m_aColors[1].b = 174;
-	pQuad->m_aColors[2].r = pQuad->m_aColors[3].r = 204;
-	pQuad->m_aColors[2].g = pQuad->m_aColors[3].g = 232;
-	pQuad->m_aColors[2].b = pQuad->m_aColors[3].b = 255;
-	pGroup->AddLayer(pLayer);
-
-	// Add game group and layer
-	MakeGameGroup(NewGroup());
-	MakeGameLayer(std::make_shared<CLayerGame>(this, 50, 50));
-	m_pGameGroup->AddLayer(m_pGameLayer);
-
-	ResetModifiedState();
-	CheckIntegrity();
-}
-
-void CEditorMap::CheckIntegrity()
-{
-	const auto &&CheckObjectInMap = [&](const CMapObject *pMapObject, const char *pName) {
-		dbg_assert(pMapObject != nullptr, "%s missing in map", pName);
-		dbg_assert(pMapObject->Map() == this, "%s does not belong to map (object_map=%p, this_map=%p)", pName, pMapObject->Map(), this);
-	};
-	bool GameGroupMissing = true;
-	CheckObjectInMap(m_pGameGroup.get(), "Game group");
-	dbg_assert(m_pGameGroup->m_GameGroup, "Game group not marked as such");
-	bool GameLayerMissing = true;
-	CheckObjectInMap(m_pGameLayer.get(), "Game layer");
-	dbg_assert(m_pGameLayer->m_HasGame, "Game layer not marked as such");
-	bool FrontLayerMissing = false;
-	if(m_pFrontLayer != nullptr)
+	else
 	{
-		FrontLayerMissing = true;
-		CheckObjectInMap(m_pFrontLayer.get(), "Front layer");
-		dbg_assert(m_pFrontLayer->m_HasFront, "Front layer not marked as such");
+		auto [SelectedIndex, SelectedChannel] = m_vSelectedEnvelopePoints.front();
+		CurrentTime = pEnvelope->m_vPoints[SelectedIndex].m_Time;
+		CurrentValue = pEnvelope->m_vPoints[SelectedIndex].m_aValues[SelectedChannel];
 	}
-	bool TeleLayerMissing = false;
-	if(m_pTeleLayer != nullptr)
-	{
-		TeleLayerMissing = true;
-		CheckObjectInMap(m_pTeleLayer.get(), "Tele layer");
-		dbg_assert(m_pTeleLayer->m_HasTele, "Tele layer not marked as such");
-	}
-	bool SpeedupLayerMissing = false;
-	if(m_pSpeedupLayer != nullptr)
-	{
-		SpeedupLayerMissing = true;
-		CheckObjectInMap(m_pSpeedupLayer.get(), "Speedup layer");
-		dbg_assert(m_pSpeedupLayer->m_HasSpeedup, "Speedup layer not marked as such");
-	}
-	bool SwitchLayerMissing = false;
-	if(m_pSwitchLayer != nullptr)
-	{
-		SwitchLayerMissing = true;
-		CheckObjectInMap(m_pSwitchLayer.get(), "Switch layer");
-		dbg_assert(m_pSwitchLayer->m_HasSwitch, "Switch layer not marked as such");
-	}
-	bool TuneLayerMissing = false;
-	if(m_pTuneLayer != nullptr)
-	{
-		TuneLayerMissing = true;
-		CheckObjectInMap(m_pTuneLayer.get(), "Tune layer");
-		dbg_assert(m_pTuneLayer->m_HasTune, "Tune layer not marked as such");
-	}
-	for(const auto &pGroup : m_vpGroups)
-	{
-		CheckObjectInMap(pGroup.get(), "Group");
-		for(const auto &pLayer : pGroup->m_vpLayers)
-		{
-			CheckObjectInMap(pLayer.get(), "Layer");
-		}
-		if(pGroup == m_pGameGroup)
-		{
-			GameGroupMissing = false;
-			for(const auto &pLayer : pGroup->m_vpLayers)
-			{
-				if(pLayer == m_pGameLayer)
-				{
-					GameLayerMissing = false;
-				}
-				if(pLayer == m_pFrontLayer)
-				{
-					FrontLayerMissing = false;
-				}
-				if(pLayer == m_pTeleLayer)
-				{
-					TeleLayerMissing = false;
-				}
-				if(pLayer == m_pSpeedupLayer)
-				{
-					SpeedupLayerMissing = false;
-				}
-				if(pLayer == m_pSwitchLayer)
-				{
-					SwitchLayerMissing = false;
-				}
-				if(pLayer == m_pTuneLayer)
-				{
-					TuneLayerMissing = false;
-				}
-			}
-			dbg_assert(!GameLayerMissing, "Game layer missing in game group");
-			dbg_assert(!FrontLayerMissing, "Front layer missing in game group");
-			dbg_assert(!TeleLayerMissing, "Tele layer missing in game group");
-			dbg_assert(!SpeedupLayerMissing, "Speedup layer missing in game group");
-			dbg_assert(!SwitchLayerMissing, "Switch layer missing in game group");
-			dbg_assert(!TuneLayerMissing, "Tune layer missing in game group");
-		}
-	}
-	dbg_assert(!GameGroupMissing, "Game group missing in list of groups");
-	for(const auto &pImage : m_vpImages)
-	{
-		CheckObjectInMap(pImage.get(), "Image");
-	}
-	for(const auto &pSound : m_vpSounds)
-	{
-		CheckObjectInMap(pSound.get(), "Sound");
-	}
-}
 
-void CEditorMap::MakeGameLayer(const std::shared_ptr<CLayer> &pLayer)
-{
-	m_pGameLayer = std::static_pointer_cast<CLayerGame>(pLayer);
-}
-
-void CEditorMap::MakeGameGroup(std::shared_ptr<CLayerGroup> pGroup)
-{
-	m_pGameGroup = std::move(pGroup);
-	m_pGameGroup->m_GameGroup = true;
-	str_copy(m_pGameGroup->m_aName, "Game");
-}
-
-void CEditorMap::MakeTeleLayer(const std::shared_ptr<CLayer> &pLayer)
-{
-	m_pTeleLayer = std::static_pointer_cast<CLayerTele>(pLayer);
-}
-
-void CEditorMap::MakeSpeedupLayer(const std::shared_ptr<CLayer> &pLayer)
-{
-	m_pSpeedupLayer = std::static_pointer_cast<CLayerSpeedup>(pLayer);
-}
-
-void CEditorMap::MakeFrontLayer(const std::shared_ptr<CLayer> &pLayer)
-{
-	m_pFrontLayer = std::static_pointer_cast<CLayerFront>(pLayer);
-}
-
-void CEditorMap::MakeSwitchLayer(const std::shared_ptr<CLayer> &pLayer)
-{
-	m_pSwitchLayer = std::static_pointer_cast<CLayerSwitch>(pLayer);
-}
-
-void CEditorMap::MakeTuneLayer(const std::shared_ptr<CLayer> &pLayer)
-{
-	m_pTuneLayer = std::static_pointer_cast<CLayerTune>(pLayer);
+	return std::pair<CFixedTime, int>{CurrentTime, CurrentValue};
 }
 
 std::shared_ptr<CEditorImage> CEditorMap::SelectedImage() const
@@ -622,4 +996,14 @@ bool CEditorMap::IsSoundUsed(int SoundIndex) const
 		}
 	}
 	return false;
+}
+
+CSoundSource *CEditorMap::SelectedSoundSource() const
+{
+	std::shared_ptr<CLayerSounds> pSounds = std::static_pointer_cast<CLayerSounds>(SelectedLayerType(0, LAYERTYPE_SOUNDS));
+	if(!pSounds)
+		return nullptr;
+	if(m_SelectedSoundSource >= 0 && m_SelectedSoundSource < (int)pSounds->m_vSources.size())
+		return &pSounds->m_vSources[m_SelectedSoundSource];
+	return nullptr;
 }

--- a/src/game/editor/mapitems/map.h
+++ b/src/game/editor/mapitems/map.h
@@ -135,8 +135,21 @@ public:
 	CSoundSourceRectShapePropTracker m_SoundSourceRectShapePropTracker;
 	CSoundSourceCircleShapePropTracker m_SoundSourceCircleShapePropTracker;
 
+	// Selections
+	int m_SelectedGroup;
+	std::vector<int> m_vSelectedLayers;
+	std::vector<int> m_vSelectedQuads;
+	int m_SelectedQuadPoints;
+	int m_SelectedQuadEnvelope;
+	int m_CurrentQuadIndex;
+	int m_SelectedEnvelope;
+	bool m_UpdateEnvPointInfo;
+	std::vector<std::pair<int, int>> m_vSelectedEnvelopePoints;
+	std::pair<int, int> m_SelectedTangentInPoint;
+	std::pair<int, int> m_SelectedTangentOutPoint;
 	int m_SelectedImage;
 	int m_SelectedSound;
+	int m_SelectedSoundSource;
 
 	int m_ShiftBy;
 
@@ -151,6 +164,60 @@ public:
 	};
 	CQuadKnife m_QuadKnife;
 
+	// Housekeeping
+	void Clean();
+	void CreateDefault();
+	void CheckIntegrity();
+
+	// Indices
+	void ModifyImageIndex(const FIndexModifyFunction &IndexModifyFunction);
+	void ModifyEnvelopeIndex(const FIndexModifyFunction &IndexModifyFunction);
+	void ModifySoundIndex(const FIndexModifyFunction &IndexModifyFunction);
+
+	// I/O
+	bool Save(const char *pFilename, const FErrorHandler &ErrorHandler);
+	bool PerformPreSaveSanityChecks(const FErrorHandler &ErrorHandler);
+	bool Load(const char *pFilename, int StorageType, const FErrorHandler &ErrorHandler);
+	void PerformSanityChecks(const FErrorHandler &ErrorHandler);
+	bool PerformAutosave(const FErrorHandler &ErrorHandler);
+
+	// Groups
+	std::shared_ptr<CLayerGroup> SelectedGroup() const;
+	std::shared_ptr<CLayerGroup> NewGroup();
+	int MoveGroup(int IndexFrom, int IndexTo);
+	void DeleteGroup(int Index);
+	void MakeGameGroup(std::shared_ptr<CLayerGroup> pGroup);
+
+	// Layers
+	std::shared_ptr<CLayer> SelectedLayer(int Index) const;
+	std::shared_ptr<CLayer> SelectedLayerType(int Index, int Type) const;
+	void SelectLayer(int LayerIndex, int GroupIndex = -1);
+	void AddSelectedLayer(int LayerIndex);
+	void SelectNextLayer();
+	void SelectPreviousLayer();
+	void SelectGameLayer();
+	void MakeGameLayer(const std::shared_ptr<CLayer> &pLayer);
+	void MakeTeleLayer(const std::shared_ptr<CLayer> &pLayer);
+	void MakeSpeedupLayer(const std::shared_ptr<CLayer> &pLayer);
+	void MakeFrontLayer(const std::shared_ptr<CLayer> &pLayer);
+	void MakeSwitchLayer(const std::shared_ptr<CLayer> &pLayer);
+	void MakeTuneLayer(const std::shared_ptr<CLayer> &pLayer);
+
+	// Quads
+	std::vector<CQuad *> SelectedQuads();
+	bool IsQuadSelected(int Index) const;
+	int FindSelectedQuadIndex(int Index) const;
+	void SelectQuad(int Index);
+	void ToggleSelectQuad(int Index);
+	void DeselectQuads();
+	bool IsQuadCornerSelected(int Index) const;
+	bool IsQuadPointSelected(int QuadIndex, int Index) const;
+	void SelectQuadPoint(int QuadIndex, int Index);
+	void ToggleSelectQuadPoint(int QuadIndex, int Index);
+	void DeselectQuadPoints();
+	void DeleteSelectedQuads();
+
+	// Envelopes
 	std::shared_ptr<CEnvelope> NewEnvelope(CEnvelope::EType Type);
 	void InsertEnvelope(int Index, std::shared_ptr<CEnvelope> &pEnvelope);
 	void UpdateEnvelopeReferences(int Index, std::shared_ptr<CEnvelope> &pEnvelope, std::vector<std::shared_ptr<IEditorEnvelopeReference>> &vpEditorObjectReferences);
@@ -159,33 +226,24 @@ public:
 	template<typename F>
 	std::vector<std::shared_ptr<IEditorEnvelopeReference>> VisitEnvelopeReferences(F &&Visitor);
 
-	std::shared_ptr<CLayerGroup> NewGroup();
-	int MoveGroup(int IndexFrom, int IndexTo);
-	void DeleteGroup(int Index);
-	void ModifyImageIndex(const FIndexModifyFunction &IndexModifyFunction);
-	void ModifyEnvelopeIndex(const FIndexModifyFunction &IndexModifyFunction);
-	void ModifySoundIndex(const FIndexModifyFunction &IndexModifyFunction);
+	// Envelope points
+	int FindEnvPointIndex(int Index, int Channel) const;
+	void SelectEnvPoint(int Index);
+	void SelectEnvPoint(int Index, int Channel);
+	void ToggleEnvPoint(int Index, int Channel);
+	bool IsEnvPointSelected(int Index, int Channel) const;
+	bool IsEnvPointSelected(int Index) const;
+	void DeselectEnvPoints();
+	bool IsTangentSelected() const;
+	bool IsTangentOutPointSelected(int Index, int Channel) const;
+	bool IsTangentOutSelected() const;
+	void SelectTangentOutPoint(int Index, int Channel);
+	bool IsTangentInPointSelected(int Index, int Channel) const;
+	bool IsTangentInSelected() const;
+	void SelectTangentInPoint(int Index, int Channel);
+	std::pair<CFixedTime, int> SelectedEnvelopeTimeAndValue() const;
 
-	// Housekeeping
-	void Clean();
-	void CreateDefault();
-	void CheckIntegrity();
-
-	// io
-	bool Save(const char *pFilename, const FErrorHandler &ErrorHandler);
-	bool PerformPreSaveSanityChecks(const FErrorHandler &ErrorHandler);
-	bool Load(const char *pFilename, int StorageType, const FErrorHandler &ErrorHandler);
-	void PerformSanityChecks(const FErrorHandler &ErrorHandler);
-	bool PerformAutosave(const FErrorHandler &ErrorHandler);
-
-	void MakeGameGroup(std::shared_ptr<CLayerGroup> pGroup);
-	void MakeGameLayer(const std::shared_ptr<CLayer> &pLayer);
-	void MakeTeleLayer(const std::shared_ptr<CLayer> &pLayer);
-	void MakeSpeedupLayer(const std::shared_ptr<CLayer> &pLayer);
-	void MakeFrontLayer(const std::shared_ptr<CLayer> &pLayer);
-	void MakeSwitchLayer(const std::shared_ptr<CLayer> &pLayer);
-	void MakeTuneLayer(const std::shared_ptr<CLayer> &pLayer);
-
+	// Images
 	std::shared_ptr<CEditorImage> SelectedImage() const;
 	void SelectImage(const std::shared_ptr<CEditorImage> &pImage);
 	void SelectNextImage();
@@ -193,11 +251,13 @@ public:
 	bool IsImageUsed(int ImageIndex) const;
 	std::vector<int> SortImages();
 
+	// Sounds
 	std::shared_ptr<CEditorSound> SelectedSound() const;
 	void SelectSound(const std::shared_ptr<CEditorSound> &pSound);
 	void SelectNextSound();
 	void SelectPreviousSound();
 	bool IsSoundUsed(int SoundIndex) const;
+	CSoundSource *SelectedSoundSource() const;
 
 private:
 	CEditor *m_pEditor;

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -1056,6 +1056,9 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 	CheckIntegrity();
 	PerformSanityChecks(ErrorHandler);
 
+	SortImages();
+	SelectGameLayer();
+
 	ResetModifiedState();
 	return true;
 }

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -179,7 +179,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupMenuTools(void *pContext, CUIRect Vi
 	View.HSplitTop(12.0f, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_BorderButton, "Place border", 0, &Slot, BUTTONFLAG_LEFT, "Place tiles in a 2-tile wide border at the edges of the selected tile layer."))
 	{
-		std::shared_ptr<CLayerTiles> pT = std::static_pointer_cast<CLayerTiles>(pEditor->GetSelectedLayerType(0, LAYERTYPE_TILES));
+		std::shared_ptr<CLayerTiles> pT = std::static_pointer_cast<CLayerTiles>(pEditor->Map()->SelectedLayerType(0, LAYERTYPE_TILES));
 		if(pT && !pT->m_HasTele && !pT->m_HasSpeedup && !pT->m_HasSwitch && !pT->m_HasFront && !pT->m_HasTune)
 		{
 			pEditor->m_PopupEventType = POPEVENT_PLACE_BORDER_TILES;
@@ -493,13 +493,13 @@ CUi::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 	static int s_DeleteButton = 0;
 
 	// don't allow deletion of game group
-	if(pEditor->Map()->m_pGameGroup != pEditor->GetSelectedGroup())
+	if(pEditor->Map()->m_pGameGroup != pEditor->Map()->SelectedGroup())
 	{
 		if(pEditor->DoButton_Editor(&s_DeleteButton, "Delete group", 0, &Button, BUTTONFLAG_LEFT, "Delete the group."))
 		{
-			pEditor->Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionGroup>(pEditor->Map(), pEditor->m_SelectedGroup, true));
-			pEditor->Map()->DeleteGroup(pEditor->m_SelectedGroup);
-			pEditor->m_SelectedGroup = maximum(0, pEditor->m_SelectedGroup - 1);
+			pEditor->Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionGroup>(pEditor->Map(), pEditor->Map()->m_SelectedGroup, true));
+			pEditor->Map()->DeleteGroup(pEditor->Map()->m_SelectedGroup);
+			pEditor->Map()->m_SelectedGroup = maximum(0, pEditor->Map()->m_SelectedGroup - 1);
 			return CUi::POPUP_CLOSE_CURRENT;
 		}
 	}
@@ -557,7 +557,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 				else
 				{
 					// record undo
-					pEditor->Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(pEditor->Map(), pEditor->m_SelectedGroup, GameLayerIndex, "Clean up game tiles", pGameLayer->m_TilesHistory));
+					pEditor->Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(pEditor->Map(), pEditor->Map()->m_SelectedGroup, GameLayerIndex, "Clean up game tiles", pGameLayer->m_TilesHistory));
 				}
 				pGameLayer->ClearHistory();
 			}
@@ -566,7 +566,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 		}
 	}
 
-	if(pEditor->GetSelectedGroup()->m_GameGroup && !pEditor->Map()->m_pTeleLayer)
+	if(pEditor->Map()->SelectedGroup()->m_GameGroup && !pEditor->Map()->m_pTeleLayer)
 	{
 		// new tele layer
 		View.HSplitBottom(5.0f, &View, nullptr);
@@ -578,7 +578,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 		}
 	}
 
-	if(pEditor->GetSelectedGroup()->m_GameGroup && !pEditor->Map()->m_pSpeedupLayer)
+	if(pEditor->Map()->SelectedGroup()->m_GameGroup && !pEditor->Map()->m_pSpeedupLayer)
 	{
 		// new speedup layer
 		View.HSplitBottom(5.0f, &View, nullptr);
@@ -590,7 +590,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 		}
 	}
 
-	if(pEditor->GetSelectedGroup()->m_GameGroup && !pEditor->Map()->m_pTuneLayer)
+	if(pEditor->Map()->SelectedGroup()->m_GameGroup && !pEditor->Map()->m_pTuneLayer)
 	{
 		// new tune layer
 		View.HSplitBottom(5.0f, &View, nullptr);
@@ -602,7 +602,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 		}
 	}
 
-	if(pEditor->GetSelectedGroup()->m_GameGroup && !pEditor->Map()->m_pFrontLayer)
+	if(pEditor->Map()->SelectedGroup()->m_GameGroup && !pEditor->Map()->m_pFrontLayer)
 	{
 		// new front layer
 		View.HSplitBottom(5.0f, &View, nullptr);
@@ -614,7 +614,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 		}
 	}
 
-	if(pEditor->GetSelectedGroup()->m_GameGroup && !pEditor->Map()->m_pSwitchLayer)
+	if(pEditor->Map()->SelectedGroup()->m_GameGroup && !pEditor->Map()->m_pSwitchLayer)
 	{
 		// new Switch layer
 		View.HSplitBottom(5.0f, &View, nullptr);
@@ -654,34 +654,34 @@ CUi::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 	}
 
 	// group name
-	if(!pEditor->GetSelectedGroup()->m_GameGroup)
+	if(!pEditor->Map()->SelectedGroup()->m_GameGroup)
 	{
 		View.HSplitBottom(5.0f, &View, nullptr);
 		View.HSplitBottom(12.0f, &View, &Button);
 		pEditor->Ui()->DoLabel(&Button, "Name:", 10.0f, TEXTALIGN_ML);
 		Button.VSplitLeft(40.0f, nullptr, &Button);
 		static CLineInput s_NameInput;
-		s_NameInput.SetBuffer(pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_aName, sizeof(pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_aName));
+		s_NameInput.SetBuffer(pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_aName, sizeof(pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_aName));
 		if(pEditor->DoEditBox(&s_NameInput, &Button, 10.0f))
 			pEditor->Map()->OnModify();
 	}
 
 	CProperty aProps[] = {
-		{"Order", pEditor->m_SelectedGroup, PROPTYPE_INT, 0, (int)pEditor->Map()->m_vpGroups.size() - 1},
-		{"Pos X", -pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_OffsetX, PROPTYPE_INT, -1000000, 1000000},
-		{"Pos Y", -pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_OffsetY, PROPTYPE_INT, -1000000, 1000000},
-		{"Para X", pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_ParallaxX, PROPTYPE_INT, -1000000, 1000000},
-		{"Para Y", pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_ParallaxY, PROPTYPE_INT, -1000000, 1000000},
-		{"Use Clipping", pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_UseClipping, PROPTYPE_BOOL, 0, 1},
-		{"Clip X", pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_ClipX, PROPTYPE_INT, -1000000, 1000000},
-		{"Clip Y", pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_ClipY, PROPTYPE_INT, -1000000, 1000000},
-		{"Clip W", pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_ClipW, PROPTYPE_INT, 0, 1000000},
-		{"Clip H", pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_ClipH, PROPTYPE_INT, 0, 1000000},
+		{"Order", pEditor->Map()->m_SelectedGroup, PROPTYPE_INT, 0, (int)pEditor->Map()->m_vpGroups.size() - 1},
+		{"Pos X", -pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_OffsetX, PROPTYPE_INT, -1000000, 1000000},
+		{"Pos Y", -pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_OffsetY, PROPTYPE_INT, -1000000, 1000000},
+		{"Para X", pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_ParallaxX, PROPTYPE_INT, -1000000, 1000000},
+		{"Para Y", pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_ParallaxY, PROPTYPE_INT, -1000000, 1000000},
+		{"Use Clipping", pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_UseClipping, PROPTYPE_BOOL, 0, 1},
+		{"Clip X", pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_ClipX, PROPTYPE_INT, -1000000, 1000000},
+		{"Clip Y", pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_ClipY, PROPTYPE_INT, -1000000, 1000000},
+		{"Clip W", pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_ClipW, PROPTYPE_INT, 0, 1000000},
+		{"Clip H", pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_ClipH, PROPTYPE_INT, 0, 1000000},
 		{nullptr},
 	};
 
 	// cut the properties that aren't needed
-	if(pEditor->GetSelectedGroup()->m_GameGroup)
+	if(pEditor->Map()->SelectedGroup()->m_GameGroup)
 		aProps[(int)EGroupProp::PROP_POS_X].m_pName = nullptr;
 
 	static int s_aIds[(int)EGroupProp::NUM_PROPS] = {0};
@@ -692,51 +692,51 @@ CUi::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 		pEditor->Map()->OnModify();
 	}
 
-	pEditor->Map()->m_LayerGroupPropTracker.Begin(pEditor->GetSelectedGroup().get(), Prop, State);
+	pEditor->Map()->m_LayerGroupPropTracker.Begin(pEditor->Map()->SelectedGroup().get(), Prop, State);
 
 	if(Prop == EGroupProp::PROP_ORDER)
 	{
-		pEditor->m_SelectedGroup = pEditor->Map()->MoveGroup(pEditor->m_SelectedGroup, NewVal);
+		pEditor->Map()->m_SelectedGroup = pEditor->Map()->MoveGroup(pEditor->Map()->m_SelectedGroup, NewVal);
 	}
 
 	// these can not be changed on the game group
-	if(!pEditor->GetSelectedGroup()->m_GameGroup)
+	if(!pEditor->Map()->SelectedGroup()->m_GameGroup)
 	{
 		if(Prop == EGroupProp::PROP_PARA_X)
 		{
-			pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_ParallaxX = NewVal;
+			pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_ParallaxX = NewVal;
 		}
 		else if(Prop == EGroupProp::PROP_PARA_Y)
 		{
-			pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_ParallaxY = NewVal;
+			pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_ParallaxY = NewVal;
 		}
 		else if(Prop == EGroupProp::PROP_POS_X)
 		{
-			pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_OffsetX = -NewVal;
+			pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_OffsetX = -NewVal;
 		}
 		else if(Prop == EGroupProp::PROP_POS_Y)
 		{
-			pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_OffsetY = -NewVal;
+			pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_OffsetY = -NewVal;
 		}
 		else if(Prop == EGroupProp::PROP_USE_CLIPPING)
 		{
-			pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_UseClipping = NewVal;
+			pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_UseClipping = NewVal;
 		}
 		else if(Prop == EGroupProp::PROP_CLIP_X)
 		{
-			pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_ClipX = NewVal;
+			pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_ClipX = NewVal;
 		}
 		else if(Prop == EGroupProp::PROP_CLIP_Y)
 		{
-			pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_ClipY = NewVal;
+			pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_ClipY = NewVal;
 		}
 		else if(Prop == EGroupProp::PROP_CLIP_W)
 		{
-			pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_ClipW = NewVal;
+			pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_ClipW = NewVal;
 		}
 		else if(Prop == EGroupProp::PROP_CLIP_H)
 		{
-			pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->m_ClipH = NewVal;
+			pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->m_ClipH = NewVal;
 		}
 	}
 
@@ -750,8 +750,8 @@ CUi::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 	SLayerPopupContext *pPopup = (SLayerPopupContext *)pContext;
 	CEditor *pEditor = pPopup->m_pEditor;
 
-	std::shared_ptr<CLayerGroup> pCurrentGroup = pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup];
-	std::shared_ptr<CLayer> pCurrentLayer = pEditor->GetSelectedLayer(0);
+	std::shared_ptr<CLayerGroup> pCurrentGroup = pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup];
+	std::shared_ptr<CLayer> pCurrentLayer = pEditor->Map()->SelectedLayer(0);
 
 	if(!pCurrentLayer || !pCurrentGroup)
 		return CUi::POPUP_CLOSE_CURRENT;
@@ -784,8 +784,8 @@ CUi::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 		static int s_DuplicationButton = 0;
 		if(pEditor->DoButton_Editor(&s_DuplicationButton, "Duplicate layer", 0, &DuplicateButton, BUTTONFLAG_LEFT, "Create an identical copy of the selected layer."))
 		{
-			pEditor->Map()->m_vpGroups[pEditor->m_SelectedGroup]->DuplicateLayer(pEditor->m_vSelectedLayers[0]);
-			pEditor->Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(pEditor->Map(), pEditor->m_SelectedGroup, pEditor->m_vSelectedLayers[0] + 1, true));
+			pEditor->Map()->m_vpGroups[pEditor->Map()->m_SelectedGroup]->DuplicateLayer(pEditor->Map()->m_vSelectedLayers[0]);
+			pEditor->Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(pEditor->Map(), pEditor->Map()->m_SelectedGroup, pEditor->Map()->m_vSelectedLayers[0] + 1, true));
 			return CUi::POPUP_CLOSE_CURRENT;
 		}
 	}
@@ -809,8 +809,8 @@ CUi::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 		View.HSplitBottom(10.0f, &View, nullptr);
 
 	CProperty aProps[] = {
-		{"Group", pEditor->m_SelectedGroup, PROPTYPE_INT, 0, (int)pEditor->Map()->m_vpGroups.size() - 1},
-		{"Order", pEditor->m_vSelectedLayers[0], PROPTYPE_INT, 0, (int)pCurrentGroup->m_vpLayers.size() - 1},
+		{"Group", pEditor->Map()->m_SelectedGroup, PROPTYPE_INT, 0, (int)pEditor->Map()->m_vpGroups.size() - 1},
+		{"Order", pEditor->Map()->m_vSelectedLayers[0], PROPTYPE_INT, 0, (int)pCurrentGroup->m_vpLayers.size() - 1},
 		{"Detail", pCurrentLayer->m_Flags & LAYERFLAG_DETAIL, PROPTYPE_BOOL, 0, 1},
 		{nullptr},
 	};
@@ -834,18 +834,18 @@ CUi::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 
 	if(Prop == ELayerProp::PROP_ORDER)
 	{
-		pEditor->SelectLayer(pCurrentGroup->MoveLayer(pEditor->m_vSelectedLayers[0], NewVal));
+		pEditor->Map()->SelectLayer(pCurrentGroup->MoveLayer(pEditor->Map()->m_vSelectedLayers[0], NewVal));
 	}
 	else if(Prop == ELayerProp::PROP_GROUP)
 	{
-		if(NewVal >= 0 && (size_t)NewVal < pEditor->Map()->m_vpGroups.size() && NewVal != pEditor->m_SelectedGroup)
+		if(NewVal >= 0 && (size_t)NewVal < pEditor->Map()->m_vpGroups.size() && NewVal != pEditor->Map()->m_SelectedGroup)
 		{
 			auto Position = std::find(pCurrentGroup->m_vpLayers.begin(), pCurrentGroup->m_vpLayers.end(), pCurrentLayer);
 			if(Position != pCurrentGroup->m_vpLayers.end())
 				pCurrentGroup->m_vpLayers.erase(Position);
 			pEditor->Map()->m_vpGroups[NewVal]->m_vpLayers.push_back(pCurrentLayer);
-			pEditor->m_SelectedGroup = NewVal;
-			pEditor->SelectLayer(pEditor->Map()->m_vpGroups[NewVal]->m_vpLayers.size() - 1);
+			pEditor->Map()->m_SelectedGroup = NewVal;
+			pEditor->Map()->SelectLayer(pEditor->Map()->m_vpGroups[NewVal]->m_vpLayers.size() - 1);
 		}
 	}
 	else if(Prop == ELayerProp::PROP_HQ)
@@ -864,13 +864,13 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 {
 	CQuadPopupContext *pQuadPopupContext = static_cast<CQuadPopupContext *>(pContext);
 	CEditor *pEditor = pQuadPopupContext->m_pEditor;
-	std::vector<CQuad *> vpQuads = pEditor->GetSelectedQuads();
+	std::vector<CQuad *> vpQuads = pEditor->Map()->SelectedQuads();
 	if(!in_range<int>(pQuadPopupContext->m_SelectedQuadIndex, 0, vpQuads.size() - 1))
 	{
 		return CUi::POPUP_CLOSE_CURRENT;
 	}
 	CQuad *pCurrentQuad = vpQuads[pQuadPopupContext->m_SelectedQuadIndex];
-	std::shared_ptr<CLayerQuads> pLayer = std::static_pointer_cast<CLayerQuads>(pEditor->GetSelectedLayerType(0, LAYERTYPE_QUADS));
+	std::shared_ptr<CLayerQuads> pLayer = std::static_pointer_cast<CLayerQuads>(pEditor->Map()->SelectedLayerType(0, LAYERTYPE_QUADS));
 
 	CUIRect Button;
 
@@ -882,7 +882,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 		if(pLayer)
 		{
 			pEditor->Map()->OnModify();
-			pEditor->DeleteSelectedQuads();
+			pEditor->Map()->DeleteSelectedQuads();
 		}
 		return CUi::POPUP_CLOSE_CURRENT;
 	}
@@ -895,7 +895,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 		static int s_AspectRatioButton = 0;
 		if(pEditor->DoButton_Editor(&s_AspectRatioButton, "Aspect ratio", 0, &Button, BUTTONFLAG_LEFT, "Resize the current quad based on the aspect ratio of its image."))
 		{
-			pEditor->Map()->m_QuadTracker.BeginQuadTrack(pLayer, pEditor->m_vSelectedQuads);
+			pEditor->Map()->m_QuadTracker.BeginQuadTrack(pLayer, pEditor->Map()->m_vSelectedQuads);
 			for(auto &pQuad : vpQuads)
 			{
 				int Top = pQuad->m_aPoints[0].y;
@@ -936,7 +936,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 	static int s_CenterButton = 0;
 	if(pEditor->DoButton_Editor(&s_CenterButton, "Center pivot", 0, &Button, BUTTONFLAG_LEFT, "Center the pivot of the current quad."))
 	{
-		pEditor->Map()->m_QuadTracker.BeginQuadTrack(pLayer, pEditor->m_vSelectedQuads);
+		pEditor->Map()->m_QuadTracker.BeginQuadTrack(pLayer, pEditor->Map()->m_vSelectedQuads);
 		int Top = pCurrentQuad->m_aPoints[0].y;
 		int Left = pCurrentQuad->m_aPoints[0].x;
 		int Bottom = pCurrentQuad->m_aPoints[0].y;
@@ -967,7 +967,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 	static int s_AlignButton = 0;
 	if(pEditor->DoButton_Editor(&s_AlignButton, "Align", 0, &Button, BUTTONFLAG_LEFT, "Align coordinates of the quad points."))
 	{
-		pEditor->Map()->m_QuadTracker.BeginQuadTrack(pLayer, pEditor->m_vSelectedQuads);
+		pEditor->Map()->m_QuadTracker.BeginQuadTrack(pLayer, pEditor->Map()->m_vSelectedQuads);
 		for(auto &pQuad : vpQuads)
 		{
 			for(int k = 1; k < 4; k++)
@@ -987,7 +987,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 	static int s_Button = 0;
 	if(pEditor->DoButton_Editor(&s_Button, "Square", 0, &Button, BUTTONFLAG_LEFT, "Square the current quad."))
 	{
-		pEditor->Map()->m_QuadTracker.BeginQuadTrack(pLayer, pEditor->m_vSelectedQuads);
+		pEditor->Map()->m_QuadTracker.BeginQuadTrack(pLayer, pEditor->Map()->m_vSelectedQuads);
 		for(auto &pQuad : vpQuads)
 		{
 			int Top = pQuad->m_aPoints[0].y;
@@ -1035,7 +1035,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 
 	const int NumQuads = pLayer ? (int)pLayer->m_vQuads.size() : 0;
 	CProperty aProps[] = {
-		{"Order", pEditor->m_vSelectedQuads[pQuadPopupContext->m_SelectedQuadIndex], PROPTYPE_INT, 0, NumQuads},
+		{"Order", pEditor->Map()->m_vSelectedQuads[pQuadPopupContext->m_SelectedQuadIndex], PROPTYPE_INT, 0, NumQuads},
 		{"Pos X", fx2i(pCurrentQuad->m_aPoints[4].x), PROPTYPE_INT, -1000000, 1000000},
 		{"Pos Y", fx2i(pCurrentQuad->m_aPoints[4].y), PROPTYPE_INT, -1000000, 1000000},
 		{"Pos. Env", pCurrentQuad->m_PosEnv + 1, PROPTYPE_ENVELOPE, 0, 0},
@@ -1051,7 +1051,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 	auto [State, Prop] = pEditor->DoPropertiesWithState<EQuadProp>(&View, aProps, s_aIds, &NewVal);
 	if(Prop != EQuadProp::PROP_NONE && (State == EEditState::START || State == EEditState::ONE_GO))
 	{
-		pEditor->Map()->m_QuadTracker.BeginQuadPropTrack(pLayer, pEditor->m_vSelectedQuads, Prop);
+		pEditor->Map()->m_QuadTracker.BeginQuadPropTrack(pLayer, pEditor->Map()->m_vSelectedQuads, Prop);
 	}
 
 	const float OffsetX = i2fx(NewVal) - pCurrentQuad->m_aPoints[4].x;
@@ -1059,8 +1059,8 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 
 	if(Prop == EQuadProp::PROP_ORDER && pLayer)
 	{
-		const int QuadIndex = pLayer->SwapQuads(pEditor->m_vSelectedQuads[pQuadPopupContext->m_SelectedQuadIndex], NewVal);
-		pEditor->m_vSelectedQuads[pQuadPopupContext->m_SelectedQuadIndex] = QuadIndex;
+		const int QuadIndex = pLayer->SwapQuads(pEditor->Map()->m_vSelectedQuads[pQuadPopupContext->m_SelectedQuadIndex], NewVal);
+		pEditor->Map()->m_vSelectedQuads[pQuadPopupContext->m_SelectedQuadIndex] = QuadIndex;
 	}
 
 	for(auto &pQuad : vpQuads)
@@ -1134,7 +1134,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 CUi::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
-	CSoundSource *pSource = pEditor->GetSelectedSource();
+	CSoundSource *pSource = pEditor->Map()->SelectedSoundSource();
 	if(!pSource)
 		return CUi::POPUP_CLOSE_CURRENT;
 
@@ -1145,10 +1145,10 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 	static int s_DeleteButton = 0;
 	if(pEditor->DoButton_Editor(&s_DeleteButton, "Delete", 0, &Button, BUTTONFLAG_LEFT, "Delete the current sound source."))
 	{
-		std::shared_ptr<CLayerSounds> pLayer = std::static_pointer_cast<CLayerSounds>(pEditor->GetSelectedLayerType(0, LAYERTYPE_SOUNDS));
+		std::shared_ptr<CLayerSounds> pLayer = std::static_pointer_cast<CLayerSounds>(pEditor->Map()->SelectedLayerType(0, LAYERTYPE_SOUNDS));
 		if(pLayer)
 		{
-			pEditor->Map()->m_EditorHistory.Execute(std::make_shared<CEditorActionDeleteSoundSource>(pEditor->Map(), pEditor->m_SelectedGroup, pEditor->m_vSelectedLayers[0], pEditor->m_SelectedSource));
+			pEditor->Map()->m_EditorHistory.Execute(std::make_shared<CEditorActionDeleteSoundSource>(pEditor->Map(), pEditor->Map()->m_SelectedGroup, pEditor->Map()->m_vSelectedLayers[0], pEditor->Map()->m_SelectedSoundSource));
 		}
 		return CUi::POPUP_CLOSE_CURRENT;
 	}
@@ -1167,7 +1167,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 	static int s_ShapeTypeButton = 0;
 	if(pEditor->DoButton_Editor(&s_ShapeTypeButton, s_apShapeNames[pSource->m_Shape.m_Type], 0, &ShapeButton, BUTTONFLAG_LEFT, "Change sound source shape."))
 	{
-		pEditor->Map()->m_EditorHistory.Execute(std::make_shared<CEditorActionEditSoundSourceShape>(pEditor->Map(), pEditor->m_SelectedGroup, pEditor->m_vSelectedLayers[0], pEditor->m_SelectedSource, (pSource->m_Shape.m_Type + 1) % CSoundShape::NUM_SHAPES));
+		pEditor->Map()->m_EditorHistory.Execute(std::make_shared<CEditorActionEditSoundSourceShape>(pEditor->Map(), pEditor->Map()->m_SelectedGroup, pEditor->Map()->m_vSelectedLayers[0], pEditor->Map()->m_SelectedSoundSource, (pSource->m_Shape.m_Type + 1) % CSoundShape::NUM_SHAPES));
 	}
 
 	CProperty aProps[] = {
@@ -1323,13 +1323,13 @@ CUi::EPopupMenuFunctionResult CEditor::PopupPoint(void *pContext, CUIRect View, 
 {
 	CPointPopupContext *pPointPopupContext = static_cast<CPointPopupContext *>(pContext);
 	CEditor *pEditor = pPointPopupContext->m_pEditor;
-	std::vector<CQuad *> vpQuads = pEditor->GetSelectedQuads();
+	std::vector<CQuad *> vpQuads = pEditor->Map()->SelectedQuads();
 	if(!in_range<int>(pPointPopupContext->m_SelectedQuadIndex, 0, vpQuads.size() - 1))
 	{
 		return CUi::POPUP_CLOSE_CURRENT;
 	}
 	CQuad *pCurrentQuad = vpQuads[pPointPopupContext->m_SelectedQuadIndex];
-	std::shared_ptr<CLayerQuads> pLayer = std::static_pointer_cast<CLayerQuads>(pEditor->GetSelectedLayerType(0, LAYERTYPE_QUADS));
+	std::shared_ptr<CLayerQuads> pLayer = std::static_pointer_cast<CLayerQuads>(pEditor->Map()->SelectedLayerType(0, LAYERTYPE_QUADS));
 
 	const int X = fx2i(pCurrentQuad->m_aPoints[pPointPopupContext->m_SelectedQuadPoint].x);
 	const int Y = fx2i(pCurrentQuad->m_aPoints[pPointPopupContext->m_SelectedQuadPoint].y);
@@ -1350,7 +1350,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupPoint(void *pContext, CUIRect View, 
 	auto [State, Prop] = pEditor->DoPropertiesWithState<EQuadPointProp>(&View, aProps, s_aIds, &NewVal);
 	if(Prop != EQuadPointProp::PROP_NONE && (State == EEditState::START || State == EEditState::ONE_GO))
 	{
-		pEditor->Map()->m_QuadTracker.BeginQuadPointPropTrack(pLayer, pEditor->m_vSelectedQuads, pEditor->m_SelectedQuadPoints);
+		pEditor->Map()->m_QuadTracker.BeginQuadPointPropTrack(pLayer, pEditor->Map()->m_vSelectedQuads, pEditor->Map()->m_SelectedQuadPoints);
 		pEditor->Map()->m_QuadTracker.AddQuadPointPropTrack(Prop);
 	}
 
@@ -1359,20 +1359,20 @@ CUi::EPopupMenuFunctionResult CEditor::PopupPoint(void *pContext, CUIRect View, 
 		if(Prop == EQuadPointProp::PROP_POS_X)
 		{
 			for(int v = 0; v < 4; v++)
-				if(pEditor->IsQuadCornerSelected(v))
+				if(pEditor->Map()->IsQuadCornerSelected(v))
 					pQuad->m_aPoints[v].x = i2fx(fx2i(pQuad->m_aPoints[v].x) + NewVal - X);
 		}
 		else if(Prop == EQuadPointProp::PROP_POS_Y)
 		{
 			for(int v = 0; v < 4; v++)
-				if(pEditor->IsQuadCornerSelected(v))
+				if(pEditor->Map()->IsQuadCornerSelected(v))
 					pQuad->m_aPoints[v].y = i2fx(fx2i(pQuad->m_aPoints[v].y) + NewVal - Y);
 		}
 		else if(Prop == EQuadPointProp::PROP_COLOR)
 		{
 			for(int v = 0; v < 4; v++)
 			{
-				if(pEditor->IsQuadCornerSelected(v))
+				if(pEditor->Map()->IsQuadCornerSelected(v))
 				{
 					pQuad->m_aColors[v] = UnpackColor(NewVal);
 				}
@@ -1381,13 +1381,13 @@ CUi::EPopupMenuFunctionResult CEditor::PopupPoint(void *pContext, CUIRect View, 
 		else if(Prop == EQuadPointProp::PROP_TEX_U)
 		{
 			for(int v = 0; v < 4; v++)
-				if(pEditor->IsQuadCornerSelected(v))
+				if(pEditor->Map()->IsQuadCornerSelected(v))
 					pQuad->m_aTexcoords[v].x = f2fx(fx2f(pQuad->m_aTexcoords[v].x) + (NewVal - TextureU) / 1024.0f);
 		}
 		else if(Prop == EQuadPointProp::PROP_TEX_V)
 		{
 			for(int v = 0; v < 4; v++)
-				if(pEditor->IsQuadCornerSelected(v))
+				if(pEditor->Map()->IsQuadCornerSelected(v))
 					pQuad->m_aTexcoords[v].y = f2fx(fx2f(pQuad->m_aTexcoords[v].y) + (NewVal - TextureV) / 1024.0f);
 		}
 	}
@@ -1404,7 +1404,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupPoint(void *pContext, CUIRect View, 
 CUi::EPopupMenuFunctionResult CEditor::PopupEnvPoint(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
-	if(pEditor->m_SelectedEnvelope < 0 || pEditor->m_SelectedEnvelope >= (int)pEditor->Map()->m_vpEnvelopes.size())
+	if(pEditor->Map()->m_SelectedEnvelope < 0 || pEditor->Map()->m_SelectedEnvelope >= (int)pEditor->Map()->m_vpEnvelopes.size())
 		return CUi::POPUP_CLOSE_CURRENT;
 
 	const float RowHeight = 12.0f;
@@ -1412,9 +1412,9 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEnvPoint(void *pContext, CUIRect Vie
 
 	pEditor->m_ActiveEnvelopePreview = EEnvelopePreview::SELECTED;
 
-	std::shared_ptr<CEnvelope> pEnvelope = pEditor->Map()->m_vpEnvelopes[pEditor->m_SelectedEnvelope];
+	std::shared_ptr<CEnvelope> pEnvelope = pEditor->Map()->m_vpEnvelopes[pEditor->Map()->m_SelectedEnvelope];
 
-	if(pEnvelope->GetChannels() == 4 && !pEditor->IsTangentSelected())
+	if(pEnvelope->GetChannels() == 4 && !pEditor->Map()->IsTangentSelected())
 	{
 		View.HSplitTop(RowHeight, &Row, &View);
 		View.HSplitTop(4.0f, nullptr, &View);
@@ -1422,7 +1422,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEnvPoint(void *pContext, CUIRect Vie
 		Row.VSplitLeft(10.0f, nullptr, &EditBox);
 		pEditor->Ui()->DoLabel(&Label, "Color:", RowHeight - 2.0f, TEXTALIGN_ML);
 
-		const auto SelectedPoint = pEditor->m_vSelectedEnvelopePoints.front();
+		const auto SelectedPoint = pEditor->Map()->m_vSelectedEnvelopePoints.front();
 		const int SelectedIndex = SelectedPoint.first;
 		auto *pValues = pEnvelope->m_vPoints[SelectedIndex].m_aValues;
 		const ColorRGBA Color = pEnvelope->m_vPoints[SelectedIndex].ColorValue();
@@ -1446,15 +1446,15 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEnvPoint(void *pContext, CUIRect Vie
 
 				for(int Channel = 0; Channel < 4; ++Channel)
 				{
-					vpActions[Channel] = std::make_shared<CEditorActionEnvelopeEditPoint>(pEditor->Map(), pEditor->m_SelectedEnvelope, SelectedIndex, Channel, CEditorActionEnvelopeEditPoint::EEditType::VALUE, s_Values[Channel], f2fx(NewColor[Channel]));
+					vpActions[Channel] = std::make_shared<CEditorActionEnvelopeEditPoint>(pEditor->Map(), pEditor->Map()->m_SelectedEnvelope, SelectedIndex, Channel, CEditorActionEnvelopeEditPoint::EEditType::VALUE, s_Values[Channel], f2fx(NewColor[Channel]));
 				}
 
 				char aDisplay[256];
-				str_format(aDisplay, sizeof(aDisplay), "Edit color of point %d of envelope %d", SelectedIndex, pEditor->m_SelectedEnvelope);
+				str_format(aDisplay, sizeof(aDisplay), "Edit color of point %d of envelope %d", SelectedIndex, pEditor->Map()->m_SelectedEnvelope);
 				pEditor->Map()->m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionBulk>(pEditor->Map(), vpActions, aDisplay));
 			}
 
-			pEditor->m_UpdateEnvPointInfo = true;
+			pEditor->Map()->m_UpdateEnvPointInfo = true;
 			pEditor->Map()->OnModify();
 		};
 		static char s_ColorPickerButton;
@@ -1467,11 +1467,11 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEnvPoint(void *pContext, CUIRect Vie
 	static float s_CurrentTime = 0;
 	static float s_CurrentValue = 0;
 
-	if(pEditor->m_UpdateEnvPointInfo)
+	if(pEditor->Map()->m_UpdateEnvPointInfo)
 	{
-		pEditor->m_UpdateEnvPointInfo = false;
+		pEditor->Map()->m_UpdateEnvPointInfo = false;
 
-		const auto &[CurrentTime, CurrentValue] = pEditor->EnvGetSelectedTimeAndValue();
+		const auto &[CurrentTime, CurrentValue] = pEditor->Map()->SelectedEnvelopeTimeAndValue();
 
 		// update displayed text
 		s_CurValueInput.SetFloat(fx2f(CurrentValue));
@@ -1500,26 +1500,26 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEnvPoint(void *pContext, CUIRect Vie
 		float CurrentValue = s_CurValueInput.GetFloat();
 		if(!(absolute(CurrentTime - s_CurrentTime) < 0.0001f && absolute(CurrentValue - s_CurrentValue) < 0.0001f))
 		{
-			const auto &[OldTime, OldValue] = pEditor->EnvGetSelectedTimeAndValue();
+			const auto &[OldTime, OldValue] = pEditor->Map()->SelectedEnvelopeTimeAndValue();
 
-			if(pEditor->IsTangentInSelected())
+			if(pEditor->Map()->IsTangentInSelected())
 			{
-				auto [SelectedIndex, SelectedChannel] = pEditor->m_SelectedTangentInPoint;
+				auto [SelectedIndex, SelectedChannel] = pEditor->Map()->m_SelectedTangentInPoint;
 
-				pEditor->Map()->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionEditEnvelopePointValue>(pEditor->Map(), pEditor->m_SelectedEnvelope, SelectedIndex, SelectedChannel, CEditorActionEditEnvelopePointValue::EType::TANGENT_IN, OldTime, OldValue, CFixedTime::FromSeconds(CurrentTime), f2fx(CurrentValue)));
+				pEditor->Map()->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionEditEnvelopePointValue>(pEditor->Map(), pEditor->Map()->m_SelectedEnvelope, SelectedIndex, SelectedChannel, CEditorActionEditEnvelopePointValue::EType::TANGENT_IN, OldTime, OldValue, CFixedTime::FromSeconds(CurrentTime), f2fx(CurrentValue)));
 				CurrentTime = (pEnvelope->m_vPoints[SelectedIndex].m_Time + pEnvelope->m_vPoints[SelectedIndex].m_Bezier.m_aInTangentDeltaX[SelectedChannel]).AsSeconds();
 			}
-			else if(pEditor->IsTangentOutSelected())
+			else if(pEditor->Map()->IsTangentOutSelected())
 			{
-				auto [SelectedIndex, SelectedChannel] = pEditor->m_SelectedTangentOutPoint;
+				auto [SelectedIndex, SelectedChannel] = pEditor->Map()->m_SelectedTangentOutPoint;
 
-				pEditor->Map()->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionEditEnvelopePointValue>(pEditor->Map(), pEditor->m_SelectedEnvelope, SelectedIndex, SelectedChannel, CEditorActionEditEnvelopePointValue::EType::TANGENT_OUT, OldTime, OldValue, CFixedTime::FromSeconds(CurrentTime), f2fx(CurrentValue)));
+				pEditor->Map()->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionEditEnvelopePointValue>(pEditor->Map(), pEditor->Map()->m_SelectedEnvelope, SelectedIndex, SelectedChannel, CEditorActionEditEnvelopePointValue::EType::TANGENT_OUT, OldTime, OldValue, CFixedTime::FromSeconds(CurrentTime), f2fx(CurrentValue)));
 				CurrentTime = (pEnvelope->m_vPoints[SelectedIndex].m_Time + pEnvelope->m_vPoints[SelectedIndex].m_Bezier.m_aOutTangentDeltaX[SelectedChannel]).AsSeconds();
 			}
 			else
 			{
-				auto [SelectedIndex, SelectedChannel] = pEditor->m_vSelectedEnvelopePoints.front();
-				pEditor->Map()->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionEditEnvelopePointValue>(pEditor->Map(), pEditor->m_SelectedEnvelope, SelectedIndex, SelectedChannel, CEditorActionEditEnvelopePointValue::EType::POINT, OldTime, OldValue, CFixedTime::FromSeconds(CurrentTime), f2fx(CurrentValue)));
+				auto [SelectedIndex, SelectedChannel] = pEditor->Map()->m_vSelectedEnvelopePoints.front();
+				pEditor->Map()->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionEditEnvelopePointValue>(pEditor->Map(), pEditor->Map()->m_SelectedEnvelope, SelectedIndex, SelectedChannel, CEditorActionEditEnvelopePointValue::EType::POINT, OldTime, OldValue, CFixedTime::FromSeconds(CurrentTime), f2fx(CurrentValue)));
 
 				if(SelectedIndex != 0)
 				{
@@ -1543,26 +1543,26 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEnvPoint(void *pContext, CUIRect Vie
 	View.HSplitTop(6.0f, nullptr, &View);
 	View.HSplitTop(RowHeight, &Row, &View);
 	static int s_DeleteButtonId = 0;
-	const char *pButtonText = pEditor->IsTangentSelected() ? "Reset" : "Delete";
-	const char *pTooltip = pEditor->IsTangentSelected() ? "Reset tangent point to default value." : "Delete current envelope point in all channels.";
+	const char *pButtonText = pEditor->Map()->IsTangentSelected() ? "Reset" : "Delete";
+	const char *pTooltip = pEditor->Map()->IsTangentSelected() ? "Reset tangent point to default value." : "Delete current envelope point in all channels.";
 	if(pEditor->DoButton_Editor(&s_DeleteButtonId, pButtonText, 0, &Row, BUTTONFLAG_LEFT, pTooltip))
 	{
-		if(pEditor->IsTangentInSelected())
+		if(pEditor->Map()->IsTangentInSelected())
 		{
-			auto [SelectedIndex, SelectedChannel] = pEditor->m_SelectedTangentInPoint;
-			const auto &[OldTime, OldValue] = pEditor->EnvGetSelectedTimeAndValue();
-			pEditor->Map()->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionResetEnvelopePointTangent>(pEditor->Map(), pEditor->m_SelectedEnvelope, SelectedIndex, SelectedChannel, true, OldTime, OldValue));
+			auto [SelectedIndex, SelectedChannel] = pEditor->Map()->m_SelectedTangentInPoint;
+			const auto &[OldTime, OldValue] = pEditor->Map()->SelectedEnvelopeTimeAndValue();
+			pEditor->Map()->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionResetEnvelopePointTangent>(pEditor->Map(), pEditor->Map()->m_SelectedEnvelope, SelectedIndex, SelectedChannel, true, OldTime, OldValue));
 		}
-		else if(pEditor->IsTangentOutSelected())
+		else if(pEditor->Map()->IsTangentOutSelected())
 		{
-			auto [SelectedIndex, SelectedChannel] = pEditor->m_SelectedTangentOutPoint;
-			const auto &[OldTime, OldValue] = pEditor->EnvGetSelectedTimeAndValue();
-			pEditor->Map()->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionResetEnvelopePointTangent>(pEditor->Map(), pEditor->m_SelectedEnvelope, SelectedIndex, SelectedChannel, false, OldTime, OldValue));
+			auto [SelectedIndex, SelectedChannel] = pEditor->Map()->m_SelectedTangentOutPoint;
+			const auto &[OldTime, OldValue] = pEditor->Map()->SelectedEnvelopeTimeAndValue();
+			pEditor->Map()->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionResetEnvelopePointTangent>(pEditor->Map(), pEditor->Map()->m_SelectedEnvelope, SelectedIndex, SelectedChannel, false, OldTime, OldValue));
 		}
 		else
 		{
-			auto [SelectedIndex, SelectedChannel] = pEditor->m_vSelectedEnvelopePoints.front();
-			pEditor->Map()->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionDeleteEnvelopePoint>(pEditor->Map(), pEditor->m_SelectedEnvelope, SelectedIndex));
+			auto [SelectedIndex, SelectedChannel] = pEditor->Map()->m_vSelectedEnvelopePoints.front();
+			pEditor->Map()->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionDeleteEnvelopePoint>(pEditor->Map(), pEditor->Map()->m_SelectedEnvelope, SelectedIndex));
 		}
 
 		return CUi::POPUP_CLOSE_CURRENT;
@@ -1629,13 +1629,13 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEnvPointCurveType(void *pContext, CU
 
 	if(CurveType >= 0)
 	{
-		std::shared_ptr<CEnvelope> pEnvelope = pEditor->Map()->m_vpEnvelopes.at(pEditor->m_SelectedEnvelope);
+		std::shared_ptr<CEnvelope> pEnvelope = pEditor->Map()->m_vpEnvelopes.at(pEditor->Map()->m_SelectedEnvelope);
 
 		for(int c = 0; c < pEnvelope->GetChannels(); c++)
 		{
 			int FirstSelectedIndex = pEnvelope->m_vPoints.size();
 			int LastSelectedIndex = -1;
-			for(auto [SelectedIndex, SelectedChannel] : pEditor->m_vSelectedEnvelopePoints)
+			for(auto [SelectedIndex, SelectedChannel] : pEditor->Map()->m_vSelectedEnvelopePoints)
 			{
 				if(SelectedChannel == c)
 				{
@@ -1654,7 +1654,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEnvPointCurveType(void *pContext, CU
 				HelperEnvelope.AddPoint(LastPoint.m_Time, {LastPoint.m_aValues[c], 0, 0, 0});
 				HelperEnvelope.m_vPoints[0].m_Curvetype = CurveType;
 
-				for(auto [SelectedIndex, SelectedChannel] : pEditor->m_vSelectedEnvelopePoints)
+				for(auto [SelectedIndex, SelectedChannel] : pEditor->Map()->m_vSelectedEnvelopePoints)
 				{
 					if(SelectedChannel == c)
 					{
@@ -1665,7 +1665,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEnvPointCurveType(void *pContext, CU
 							HelperEnvelope.Eval(CurrentPoint.m_Time.AsSeconds(), Channels, 1);
 							int PrevValue = CurrentPoint.m_aValues[c];
 							CurrentPoint.m_aValues[c] = f2fx(Channels.r);
-							vpActions.push_back(std::make_shared<CEditorActionEnvelopeEditPoint>(pEditor->Map(), pEditor->m_SelectedEnvelope, SelectedIndex, SelectedChannel, CEditorActionEnvelopeEditPoint::EEditType::VALUE, PrevValue, CurrentPoint.m_aValues[c]));
+							vpActions.push_back(std::make_shared<CEditorActionEnvelopeEditPoint>(pEditor->Map(), pEditor->Map()->m_SelectedEnvelope, SelectedIndex, SelectedChannel, CEditorActionEnvelopeEditPoint::EEditType::VALUE, PrevValue, CurrentPoint.m_aValues[c]));
 						}
 					}
 				}
@@ -2430,7 +2430,7 @@ static int s_AutoMapConfigCurrent = -100;
 CUi::EPopupMenuFunctionResult CEditor::PopupSelectConfigAutoMap(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
-	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(pEditor->GetSelectedLayer(0));
+	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(pEditor->Map()->SelectedLayer(0));
 	CAutoMapper *pAutoMapper = &pEditor->Map()->m_vpImages[pLayer->m_Image]->m_AutoMapper;
 
 	const float ButtonHeight = 12.0f;
@@ -2469,7 +2469,7 @@ void CEditor::PopupSelectConfigAutoMapInvoke(int Current, float x, float y)
 	static SPopupMenuId s_PopupSelectConfigAutoMapId;
 	s_AutoMapConfigSelected = -100;
 	s_AutoMapConfigCurrent = Current;
-	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(GetSelectedLayer(0));
+	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Map()->SelectedLayer(0));
 	const int ItemCount = minimum(Map()->m_vpImages[pLayer->m_Image]->m_AutoMapper.ConfigNamesNum() + 1, 10); // +1 for None-entry
 	// Width for buttons is 120, 15 is the scrollbar width, 2 is the margin between both.
 	Ui()->DoPopupMenu(&s_PopupSelectConfigAutoMapId, x, y, 120.0f + 15.0f + 2.0f, 10.0f + 12.0f * ItemCount + 2.0f * (ItemCount - 1) + CScrollRegion::HEIGHT_MAGIC_FIX, this, PopupSelectConfigAutoMap);
@@ -2491,7 +2491,7 @@ static int s_AutoMapReferenceCurrent = -100;
 CUi::EPopupMenuFunctionResult CEditor::PopupSelectAutoMapReference(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
-	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(pEditor->GetSelectedLayer(0));
+	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(pEditor->Map()->SelectedLayer(0));
 
 	const float ButtonHeight = 12.0f;
 	const float ButtonMargin = 2.0f;
@@ -2528,7 +2528,7 @@ void CEditor::PopupSelectAutoMapReferenceInvoke(int Current, float x, float y)
 	static SPopupMenuId s_PopupSelectAutoMapReferenceId;
 	s_AutoMapReferenceSelected = -100;
 	s_AutoMapReferenceCurrent = Current;
-	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(GetSelectedLayer(0));
+	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Map()->SelectedLayer(0));
 	// Width for buttons is 120, 15 is the scrollbar width, 2 is the margin between both.
 	Ui()->DoPopupMenu(&s_PopupSelectAutoMapReferenceId, x, y, 120.0f + 15.0f + 2.0f, 26.0f + 14.0f * std::size(AUTOMAP_REFERENCE_NAMES) + 1, this, PopupSelectAutoMapReference);
 }
@@ -3082,11 +3082,11 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEnvelopeCurvetype(void *pContext, CU
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
-	if(pEditor->m_SelectedEnvelope < 0 || pEditor->m_SelectedEnvelope >= (int)pEditor->Map()->m_vpEnvelopes.size())
+	if(pEditor->Map()->m_SelectedEnvelope < 0 || pEditor->Map()->m_SelectedEnvelope >= (int)pEditor->Map()->m_vpEnvelopes.size())
 	{
 		return CUi::POPUP_CLOSE_CURRENT;
 	}
-	std::shared_ptr<CEnvelope> pEnvelope = pEditor->Map()->m_vpEnvelopes[pEditor->m_SelectedEnvelope];
+	std::shared_ptr<CEnvelope> pEnvelope = pEditor->Map()->m_vpEnvelopes[pEditor->Map()->m_SelectedEnvelope];
 
 	if(pEditor->m_PopupEnvelopeSelectedPoint < 0 || pEditor->m_PopupEnvelopeSelectedPoint >= (int)pEnvelope->m_vPoints.size())
 	{
@@ -3109,7 +3109,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEnvelopeCurvetype(void *pContext, CU
 			{
 				SelectedPoint.m_Curvetype = Type;
 				pEditor->Map()->m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeEditPoint>(pEditor->Map(),
-					pEditor->m_SelectedEnvelope, pEditor->m_PopupEnvelopeSelectedPoint, 0, CEditorActionEnvelopeEditPoint::EEditType::CURVE_TYPE, PrevCurve, SelectedPoint.m_Curvetype));
+					pEditor->Map()->m_SelectedEnvelope, pEditor->m_PopupEnvelopeSelectedPoint, 0, CEditorActionEnvelopeEditPoint::EEditType::CURVE_TYPE, PrevCurve, SelectedPoint.m_Curvetype));
 				pEditor->Map()->OnModify();
 				return CUi::POPUP_CLOSE_CURRENT;
 			}

--- a/src/game/editor/quick_actions.cpp
+++ b/src/game/editor/quick_actions.cpp
@@ -8,14 +8,14 @@
 
 void CEditor::FillGameTiles(EGameTileOp FillTile) const
 {
-	std::shared_ptr<CLayerTiles> pTileLayer = std::static_pointer_cast<CLayerTiles>(GetSelectedLayerType(0, LAYERTYPE_TILES));
+	std::shared_ptr<CLayerTiles> pTileLayer = std::static_pointer_cast<CLayerTiles>(Map()->SelectedLayerType(0, LAYERTYPE_TILES));
 	if(pTileLayer)
 		pTileLayer->FillGameTiles(FillTile);
 }
 
 bool CEditor::CanFillGameTiles() const
 {
-	std::shared_ptr<CLayerTiles> pTileLayer = std::static_pointer_cast<CLayerTiles>(GetSelectedLayerType(0, LAYERTYPE_TILES));
+	std::shared_ptr<CLayerTiles> pTileLayer = std::static_pointer_cast<CLayerTiles>(Map()->SelectedLayerType(0, LAYERTYPE_TILES));
 	if(pTileLayer)
 		return pTileLayer->CanFillGameTiles();
 	return false;
@@ -23,13 +23,13 @@ bool CEditor::CanFillGameTiles() const
 
 void CEditor::AddQuadOrSound()
 {
-	std::shared_ptr<CLayer> pLayer = GetSelectedLayer(0);
+	std::shared_ptr<CLayer> pLayer = Map()->SelectedLayer(0);
 	if(!pLayer)
 		return;
 	if(pLayer->m_Type != LAYERTYPE_QUADS && pLayer->m_Type != LAYERTYPE_SOUNDS)
 		return;
 
-	std::shared_ptr<CLayerGroup> pGroup = GetSelectedGroup();
+	std::shared_ptr<CLayerGroup> pGroup = Map()->SelectedGroup();
 
 	float aMapping[4];
 	pGroup->Mapping(aMapping);
@@ -42,106 +42,106 @@ void CEditor::AddQuadOrSound()
 	}
 
 	if(pLayer->m_Type == LAYERTYPE_QUADS)
-		Map()->m_EditorHistory.Execute(std::make_shared<CEditorActionNewEmptyQuad>(Map(), m_SelectedGroup, m_vSelectedLayers[0], x, y));
+		Map()->m_EditorHistory.Execute(std::make_shared<CEditorActionNewEmptyQuad>(Map(), Map()->m_SelectedGroup, Map()->m_vSelectedLayers[0], x, y));
 	else if(pLayer->m_Type == LAYERTYPE_SOUNDS)
-		Map()->m_EditorHistory.Execute(std::make_shared<CEditorActionNewEmptySound>(Map(), m_SelectedGroup, m_vSelectedLayers[0], x, y));
+		Map()->m_EditorHistory.Execute(std::make_shared<CEditorActionNewEmptySound>(Map(), Map()->m_SelectedGroup, Map()->m_vSelectedLayers[0], x, y));
 }
 
 void CEditor::AddGroup()
 {
 	Map()->NewGroup();
-	m_SelectedGroup = Map()->m_vpGroups.size() - 1;
-	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionGroup>(Map(), m_SelectedGroup, false));
+	Map()->m_SelectedGroup = Map()->m_vpGroups.size() - 1;
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionGroup>(Map(), Map()->m_SelectedGroup, false));
 }
 
 void CEditor::AddSoundLayer()
 {
 	std::shared_ptr<CLayer> pSoundLayer = std::make_shared<CLayerSounds>(Map());
-	Map()->m_vpGroups[m_SelectedGroup]->AddLayer(pSoundLayer);
-	int LayerIndex = Map()->m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
-	SelectLayer(LayerIndex);
-	Map()->m_vpGroups[m_SelectedGroup]->m_Collapse = false;
-	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), m_SelectedGroup, LayerIndex));
+	Map()->m_vpGroups[Map()->m_SelectedGroup]->AddLayer(pSoundLayer);
+	int LayerIndex = Map()->m_vpGroups[Map()->m_SelectedGroup]->m_vpLayers.size() - 1;
+	Map()->SelectLayer(LayerIndex);
+	Map()->m_vpGroups[Map()->m_SelectedGroup]->m_Collapse = false;
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), Map()->m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddTileLayer()
 {
 	std::shared_ptr<CLayer> pTileLayer = std::make_shared<CLayerTiles>(Map(), Map()->m_pGameLayer->m_Width, Map()->m_pGameLayer->m_Height);
-	Map()->m_vpGroups[m_SelectedGroup]->AddLayer(pTileLayer);
-	int LayerIndex = Map()->m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
-	SelectLayer(LayerIndex);
-	Map()->m_vpGroups[m_SelectedGroup]->m_Collapse = false;
-	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), m_SelectedGroup, LayerIndex));
+	Map()->m_vpGroups[Map()->m_SelectedGroup]->AddLayer(pTileLayer);
+	int LayerIndex = Map()->m_vpGroups[Map()->m_SelectedGroup]->m_vpLayers.size() - 1;
+	Map()->SelectLayer(LayerIndex);
+	Map()->m_vpGroups[Map()->m_SelectedGroup]->m_Collapse = false;
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), Map()->m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddQuadsLayer()
 {
 	std::shared_ptr<CLayer> pQuadLayer = std::make_shared<CLayerQuads>(Map());
-	Map()->m_vpGroups[m_SelectedGroup]->AddLayer(pQuadLayer);
-	int LayerIndex = Map()->m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
-	SelectLayer(LayerIndex);
-	Map()->m_vpGroups[m_SelectedGroup]->m_Collapse = false;
-	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), m_SelectedGroup, LayerIndex));
+	Map()->m_vpGroups[Map()->m_SelectedGroup]->AddLayer(pQuadLayer);
+	int LayerIndex = Map()->m_vpGroups[Map()->m_SelectedGroup]->m_vpLayers.size() - 1;
+	Map()->SelectLayer(LayerIndex);
+	Map()->m_vpGroups[Map()->m_SelectedGroup]->m_Collapse = false;
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), Map()->m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddSwitchLayer()
 {
 	std::shared_ptr<CLayer> pSwitchLayer = std::make_shared<CLayerSwitch>(Map(), Map()->m_pGameLayer->m_Width, Map()->m_pGameLayer->m_Height);
 	Map()->MakeSwitchLayer(pSwitchLayer);
-	Map()->m_vpGroups[m_SelectedGroup]->AddLayer(pSwitchLayer);
-	int LayerIndex = Map()->m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
-	SelectLayer(LayerIndex);
+	Map()->m_vpGroups[Map()->m_SelectedGroup]->AddLayer(pSwitchLayer);
+	int LayerIndex = Map()->m_vpGroups[Map()->m_SelectedGroup]->m_vpLayers.size() - 1;
+	Map()->SelectLayer(LayerIndex);
 	m_pBrush->Clear();
-	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), m_SelectedGroup, LayerIndex));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), Map()->m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddFrontLayer()
 {
 	std::shared_ptr<CLayer> pFrontLayer = std::make_shared<CLayerFront>(Map(), Map()->m_pGameLayer->m_Width, Map()->m_pGameLayer->m_Height);
 	Map()->MakeFrontLayer(pFrontLayer);
-	Map()->m_vpGroups[m_SelectedGroup]->AddLayer(pFrontLayer);
-	int LayerIndex = Map()->m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
-	SelectLayer(LayerIndex);
+	Map()->m_vpGroups[Map()->m_SelectedGroup]->AddLayer(pFrontLayer);
+	int LayerIndex = Map()->m_vpGroups[Map()->m_SelectedGroup]->m_vpLayers.size() - 1;
+	Map()->SelectLayer(LayerIndex);
 	m_pBrush->Clear();
-	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), m_SelectedGroup, LayerIndex));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), Map()->m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddTuneLayer()
 {
 	std::shared_ptr<CLayer> pTuneLayer = std::make_shared<CLayerTune>(Map(), Map()->m_pGameLayer->m_Width, Map()->m_pGameLayer->m_Height);
 	Map()->MakeTuneLayer(pTuneLayer);
-	Map()->m_vpGroups[m_SelectedGroup]->AddLayer(pTuneLayer);
-	int LayerIndex = Map()->m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
-	SelectLayer(LayerIndex);
+	Map()->m_vpGroups[Map()->m_SelectedGroup]->AddLayer(pTuneLayer);
+	int LayerIndex = Map()->m_vpGroups[Map()->m_SelectedGroup]->m_vpLayers.size() - 1;
+	Map()->SelectLayer(LayerIndex);
 	m_pBrush->Clear();
-	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), m_SelectedGroup, LayerIndex));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), Map()->m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddSpeedupLayer()
 {
 	std::shared_ptr<CLayer> pSpeedupLayer = std::make_shared<CLayerSpeedup>(Map(), Map()->m_pGameLayer->m_Width, Map()->m_pGameLayer->m_Height);
 	Map()->MakeSpeedupLayer(pSpeedupLayer);
-	Map()->m_vpGroups[m_SelectedGroup]->AddLayer(pSpeedupLayer);
-	int LayerIndex = Map()->m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
-	SelectLayer(LayerIndex);
+	Map()->m_vpGroups[Map()->m_SelectedGroup]->AddLayer(pSpeedupLayer);
+	int LayerIndex = Map()->m_vpGroups[Map()->m_SelectedGroup]->m_vpLayers.size() - 1;
+	Map()->SelectLayer(LayerIndex);
 	m_pBrush->Clear();
-	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), m_SelectedGroup, LayerIndex));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), Map()->m_SelectedGroup, LayerIndex));
 }
 
 void CEditor::AddTeleLayer()
 {
 	std::shared_ptr<CLayer> pTeleLayer = std::make_shared<CLayerTele>(Map(), Map()->m_pGameLayer->m_Width, Map()->m_pGameLayer->m_Height);
 	Map()->MakeTeleLayer(pTeleLayer);
-	Map()->m_vpGroups[m_SelectedGroup]->AddLayer(pTeleLayer);
-	int LayerIndex = Map()->m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1;
-	SelectLayer(LayerIndex);
+	Map()->m_vpGroups[Map()->m_SelectedGroup]->AddLayer(pTeleLayer);
+	int LayerIndex = Map()->m_vpGroups[Map()->m_SelectedGroup]->m_vpLayers.size() - 1;
+	Map()->SelectLayer(LayerIndex);
 	m_pBrush->Clear();
-	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), m_SelectedGroup, LayerIndex));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(Map(), Map()->m_SelectedGroup, LayerIndex));
 }
 
 bool CEditor::IsNonGameTileLayerSelected() const
 {
-	std::shared_ptr<CLayer> pLayer = GetSelectedLayer(0);
+	std::shared_ptr<CLayer> pLayer = Map()->SelectedLayer(0);
 	if(!pLayer)
 		return false;
 	if(pLayer->m_Type != LAYERTYPE_TILES)
@@ -163,7 +163,7 @@ void CEditor::LayerSelectImage()
 	if(!IsNonGameTileLayerSelected())
 		return;
 
-	std::shared_ptr<CLayer> pLayer = GetSelectedLayer(0);
+	std::shared_ptr<CLayer> pLayer = Map()->SelectedLayer(0);
 	std::shared_ptr<CLayerTiles> pTiles = std::static_pointer_cast<CLayerTiles>(pLayer);
 
 	static SLayerPopupContext s_LayerPopupContext = {};
@@ -192,13 +192,13 @@ void CEditor::MapDetails()
 
 void CEditor::DeleteSelectedLayer()
 {
-	std::shared_ptr<CLayer> pCurrentLayer = GetSelectedLayer(0);
+	std::shared_ptr<CLayer> pCurrentLayer = Map()->SelectedLayer(0);
 	if(!pCurrentLayer)
 		return;
 	if(Map()->m_pGameLayer == pCurrentLayer)
 		return;
 
-	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionDeleteLayer>(Map(), m_SelectedGroup, m_vSelectedLayers[0]));
+	Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionDeleteLayer>(Map(), Map()->m_SelectedGroup, Map()->m_vSelectedLayers[0]));
 
 	if(pCurrentLayer == Map()->m_pFrontLayer)
 		Map()->m_pFrontLayer = nullptr;
@@ -210,9 +210,9 @@ void CEditor::DeleteSelectedLayer()
 		Map()->m_pSwitchLayer = nullptr;
 	if(pCurrentLayer == Map()->m_pTuneLayer)
 		Map()->m_pTuneLayer = nullptr;
-	Map()->m_vpGroups[m_SelectedGroup]->DeleteLayer(m_vSelectedLayers[0]);
+	Map()->m_vpGroups[Map()->m_SelectedGroup]->DeleteLayer(Map()->m_vSelectedLayers[0]);
 
-	SelectPreviousLayer();
+	Map()->SelectPreviousLayer();
 }
 
 void CEditor::TestMapLocally()

--- a/src/game/editor/quick_actions.h
+++ b/src/game/editor/quick_actions.h
@@ -174,7 +174,7 @@ REGISTER_QUICK_ACTION(
 	AddSwitchLayer,
 	"Add switch layer",
 	[&]() { AddSwitchLayer(); },
-	[&]() -> bool { return !GetSelectedGroup()->m_GameGroup || Map()->m_pSwitchLayer; },
+	[&]() -> bool { return !Map()->SelectedGroup()->m_GameGroup || Map()->m_pSwitchLayer; },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
 	"Create a new switch layer.")
@@ -182,7 +182,7 @@ REGISTER_QUICK_ACTION(
 	AddTuneLayer,
 	"Add tune layer",
 	[&]() { AddTuneLayer(); },
-	[&]() -> bool { return !GetSelectedGroup()->m_GameGroup || Map()->m_pTuneLayer; },
+	[&]() -> bool { return !Map()->SelectedGroup()->m_GameGroup || Map()->m_pTuneLayer; },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
 	"Create a new tuning layer.")
@@ -190,7 +190,7 @@ REGISTER_QUICK_ACTION(
 	AddSpeedupLayer,
 	"Add speedup layer",
 	[&]() { AddSpeedupLayer(); },
-	[&]() -> bool { return !GetSelectedGroup()->m_GameGroup || Map()->m_pSpeedupLayer; },
+	[&]() -> bool { return !Map()->SelectedGroup()->m_GameGroup || Map()->m_pSpeedupLayer; },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
 	"Create a new speedup layer.")
@@ -198,7 +198,7 @@ REGISTER_QUICK_ACTION(
 	AddTeleLayer,
 	"Add tele layer",
 	[&]() { AddTeleLayer(); },
-	[&]() -> bool { return !GetSelectedGroup()->m_GameGroup || Map()->m_pTeleLayer; },
+	[&]() -> bool { return !Map()->SelectedGroup()->m_GameGroup || Map()->m_pTeleLayer; },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
 	"Create a new tele layer.")
@@ -206,7 +206,7 @@ REGISTER_QUICK_ACTION(
 	AddFrontLayer,
 	"Add front layer",
 	[&]() { AddFrontLayer(); },
-	[&]() -> bool { return !GetSelectedGroup()->m_GameGroup || Map()->m_pFrontLayer; },
+	[&]() -> bool { return !Map()->SelectedGroup()->m_GameGroup || Map()->m_pFrontLayer; },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
 	"Create a new item layer.")
@@ -333,7 +333,7 @@ REGISTER_QUICK_ACTION(
 	"Delete layer",
 	[&]() { DeleteSelectedLayer(); },
 	[&]() -> bool {
-		std::shared_ptr<CLayer> pCurrentLayer = GetSelectedLayer(0);
+		std::shared_ptr<CLayer> pCurrentLayer = Map()->SelectedLayer(0);
 		if(!pCurrentLayer)
 			return true;
 		return Map()->m_pGameLayer == pCurrentLayer;
@@ -362,7 +362,7 @@ REGISTER_QUICK_ACTION(
 	"Add quad",
 	[&]() { AddQuadOrSound(); },
 	[&]() -> bool {
-		std::shared_ptr<CLayer> pLayer = GetSelectedLayer(0);
+		std::shared_ptr<CLayer> pLayer = Map()->SelectedLayer(0);
 		if(!pLayer)
 			return false;
 		return pLayer->m_Type != LAYERTYPE_QUADS;
@@ -375,7 +375,7 @@ REGISTER_QUICK_ACTION(
 	"Add sound source",
 	[&]() { AddQuadOrSound(); },
 	[&]() -> bool {
-		std::shared_ptr<CLayer> pLayer = GetSelectedLayer(0);
+		std::shared_ptr<CLayer> pLayer = Map()->SelectedLayer(0);
 		if(!pLayer)
 			return false;
 		return pLayer->m_Type != LAYERTYPE_SOUNDS;


### PR DESCRIPTION
All selected items in the editor (e.g. selected group, layers, envelope points etc.) should be tracked separately for each editor map to support using multiple maps at the same time.

Move all relevant variables and functions to `CEditorMap`. Group and reorder the functions.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions