### PR TITLE
Refresh skins when changing `events` setting

### DIFF
--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -494,15 +494,7 @@ void CSkins::OnConsoleInit()
 
 void CSkins::OnInit()
 {
-	m_aEventSkinPrefix[0] = '\0';
-
-	if(g_Config.m_Events)
-	{
-		if(time_season() == SEASON_XMAS)
-		{
-			str_copy(m_aEventSkinPrefix, "santa");
-		}
-	}
+	RefreshEventSkins();
 
 	// load skins
 	Refresh([this]() {
@@ -668,6 +660,19 @@ void CSkins::UpdateFinishLoading(CSkinLoadingStats &Stats, std::chrono::nanoseco
 				Stats.m_NumError++;
 			}
 			pSkinContainer->m_pLoadJob = nullptr;
+		}
+	}
+}
+
+void CSkins::RefreshEventSkins()
+{
+	m_aEventSkinPrefix[0] = '\0';
+
+	if(g_Config.m_Events)
+	{
+		if(time_season() == SEASON_XMAS)
+		{
+			str_copy(m_aEventSkinPrefix, "santa");
 		}
 	}
 }

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -234,6 +234,7 @@ public:
 	void OnShutdown() override;
 	void OnUpdate() override;
 
+	void RefreshEventSkins();
 	void Refresh(TSkinLoadedCallback &&SkinLoadedCallback);
 	CSkinLoadingStats LoadingStats() const;
 	CSkinList &SkinList();

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -267,6 +267,7 @@ void CGameClient::OnConsoleInit()
 	Console()->Chain("cl_download_skins", ConchainRefreshSkins, this);
 	Console()->Chain("cl_download_community_skins", ConchainRefreshSkins, this);
 	Console()->Chain("cl_vanilla_skins_only", ConchainRefreshSkins, this);
+	Console()->Chain("events", ConchainRefreshEventSkins, this);
 
 	Console()->Chain("cl_dummy", ConchainSpecialDummy, this);
 
@@ -4531,6 +4532,17 @@ void CGameClient::ConchainRefreshSkins(IConsole::IResult *pResult, void *pUserDa
 	pfnCallback(pResult, pCallbackUserData);
 	if(pResult->NumArguments() && pThis->m_Menus.IsInit())
 	{
+		pThis->RefreshSkins(CSkinDescriptor::FLAG_SIX);
+	}
+}
+
+void CGameClient::ConchainRefreshEventSkins(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
+{
+	CGameClient *pThis = static_cast<CGameClient *>(pUserData);
+	pfnCallback(pResult, pCallbackUserData);
+	if(pResult->NumArguments() && pThis->m_Menus.IsInit())
+	{
+		pThis->m_Skins.RefreshEventSkins();
 		pThis->RefreshSkins(CSkinDescriptor::FLAG_SIX);
 	}
 }

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -246,6 +246,7 @@ private:
 	static void ConchainSpecialInfoupdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainSpecialDummyInfoupdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainRefreshSkins(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+	static void ConchainRefreshEventSkins(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainSpecialDummy(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
 	static void ConTuneParam(IConsole::IResult *pResult, void *pUserData);


### PR DESCRIPTION
Previously, the santa skin prefix was only updated when restarting the client after changing the `events` setting.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions