### PR TITLE
Wait sequentially for clients in smoke test to quit

### DIFF
--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -735,11 +735,12 @@ def smoke_test(test_env):
 	client1.wait_for_log_prefix("chat/server: *** client1 finished in:", timeout=20)
 	client2.wait_for_log_prefix("chat/server: *** client1 finished in:", timeout=20)
 
+	# Wait for first client to quit before quitting second client, to avoid saving config to the same file at the same time.
 	client1.exit()
-	client2.exit()
-	server.exit()
 	client1.wait_for_exit()
+	client2.exit()
 	client2.wait_for_exit()
+	server.exit()
 	server.wait_for_exit()
 
 	if not all(any(word in line for line in client1.full_stdout) for word in "cmdlist pause rank points".split()):


### PR DESCRIPTION
Quitting both clients at the same time can cause them to rename the temporary config file to the real filename at same time on Windows, which will fail for one client. Failing to save the config shows a popup error message, that prevents the client from quitting and causes the smoke test to fail waiting for the client to exit.

See https://github.com/Robyt3/ddnet/actions/runs/20537983687/job/58998668418

```
TimeoutError: timeout waiting for exit
--- client0 ---
2025-12-27 11:04:27 I config: saved to settings_ddnet.cfg
--- client1 ---
2025-12-27 11:04:27 E filesystem: Failed to rename file './settings_ddnet.cfg.5816.tmp' to './settings_ddnet.cfg' (5 'Access is denied. ')
2025-12-27 11:04:27 E config: ERROR: renaming settings_ddnet.cfg.5816.tmp to settings_ddnet.cfg failed
```

## Checklist

- [X] Tested the change
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions