### PR TITLE
Only save settings for first client in smoke test

### DIFF
--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -442,6 +442,7 @@ class Client(Runnable):
 				test_env.ddnet,
 				f"cl_input_fifo {self.fifo_name}",
 				"gfx_fullscreen 0",
+				"cl_save_settings 0",
 			]
 			+ extra_args,
 		)
@@ -643,7 +644,7 @@ def open_editor(test_env):
 
 @test
 def smoke_test(test_env):
-	client1 = test_env.client(["logfile client1.log", "player_name client1"])
+	client1 = test_env.client(["logfile client1.log", "player_name client1", "cl_save_settings 1"])
 	server = test_env.server(["logfile server.log", "sv_demo_chat 1", "sv_map coverage", "sv_tee_historian 1"])
 	wait_for_startup([client1, server])
 	# Start client2 after client1 to avoid fetching resources twice.


### PR DESCRIPTION
Quitting both clients at the same time can cause them to rename the temporary config file to the real filename at same time on Windows, which will fail for one client. Failing to save the config shows a popup error message, that prevents the client from quitting and causes the smoke test to fail waiting for the client to exit.

Alternative to #11506.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions