### PR TITLE
Keep integration test temporary directories on Valgrind errors

### DIFF
--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -133,6 +133,7 @@ class TestRunner:
 					error = env.format_valgrind_memcheck_errors()
 					if error:
 						error = error + env.format_stdout_stderr()
+						tmp_dir_cleanup = False
 					else:
 						error = None
 		finally:


### PR DESCRIPTION
Temporary directories of integration tests should be kept for tests that are failing due to Valgrind errors.

## Checklist

- [X] Tested the change
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
