### PR TITLE
Improve integration smoke test output on unexpected ranks

### DIFF
--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -766,7 +766,9 @@ def smoke_test(test_env):
 	if not ranks:
 		raise AssertionError("no ranks found")
 	if ranks != expected_ranks:
-		raise AssertionError(f"unexpected ranks:\n{ranks}\n\n{expected_ranks}")
+		ranks_string = "\n".join([str(rank) for rank in ranks])
+		expected_ranks_string = "\n".join([str(rank) for rank in expected_ranks])
+		raise AssertionError(f"unexpected ranks.\n\nactual:\n{ranks_string}\n\nexpected:\n{expected_ranks_string}")
 
 
 @test(requires_mastersrv=True)


### PR DESCRIPTION
Split actual and expected ranks over multiple lines.

Label which values are actual and which are expected.

## Checklist

- [X] Tested the change
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions