### PR TITLE
Support dropping demos/maps and `ddnet` URLs into Emscripten client

### DIFF
--- a/cmake/toolchains/Emscripten.toolchain
+++ b/cmake/toolchains/Emscripten.toolchain
@@ -25,6 +25,8 @@ set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s FULL_ES3=1")
 
 # Make sure C callback functions are available to JS.
 set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=[\\$autoResumeAudioContext,\\$dynCall]")
+set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s EXPORTED_FUNCTIONS=_main,_EmscriptenCallbackDropFile")
+set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s EXPORTED_RUNTIME_METHODS=ccall")
 
 # Very important: use same stack size that other platforms have, as the default of 64 KiB that Emscripten uses is too small for our code and causes stack overflows.
 set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s STACK_SIZE=1MB")

--- a/other/emscripten/minimal.html
+++ b/other/emscripten/minimal.html
@@ -66,6 +66,78 @@
 				output.scrollTop = output.scrollHeight;
 				Module['canvas'].style.display = "none";
 			};
+			Module['canvas'].addEventListener('dragover', e => {
+				e.preventDefault();
+				e.dataTransfer.dropEffect = "none";
+				if (!e.dataTransfer.items) {
+					return;
+				}
+				for (const item of e.dataTransfer.items) {
+					if (item.kind == 'file' || item.kind == 'string') {
+						e.dataTransfer.dropEffect = "copy";
+						return;
+					}
+				}
+			});
+			Module['canvas'].addEventListener('drop', async e => {
+				e.preventDefault();
+				if (!e.dataTransfer.items) {
+					return;
+				}
+				var dropFile = null;
+				var dropPath = null;
+				var dropLink = null;
+				for (const item of e.dataTransfer.items) {
+					if (item.kind == 'file') {
+						const file = item.getAsFile();
+						const isDemo = file.name.endsWith(".demo");
+						const isMap = file.name.endsWith(".map");
+						const homePath = "/home/web_user/.local/share/ddnet"
+						var path;
+						if (isDemo) {
+							path = `${homePath}/demos`
+						} else if (isMap) {
+							path = `${homePath}/maps`
+						} else {
+							continue;
+						}
+						if (dropLink != null) {
+							alert("You cannot drop files and links at the same time.");
+							break;
+						}
+						if (dropFile != null) {
+							alert("You cannot open multiple files at the same time. Only the first file will be opened.");
+							break;
+						}
+						dropFile = file;
+						dropPath = path;
+					} else if (item.kind == 'string') {
+						const string = e.dataTransfer.getData(item.type);
+						if (string.startsWith('ddnet://')) {
+							if (dropFile != null) {
+								alert("You cannot drop files and links at the same time.");
+								break;
+							}
+							if (dropLink != null && dropLink != string) {
+								alert("You cannot connect to multiple URLs at the same time. You will be connected to the first URL.");
+								break;
+							}
+							dropLink = string;
+						}
+					}
+				}
+				if (dropFile != null) {
+					const buffer = await dropFile.arrayBuffer();
+					const data = new Uint8Array(buffer);
+					FS.createPath(dropPath, "upload", true, true);
+					FS.writeFile(`${dropPath}/upload/${dropFile.name}`, data);
+					Module.ccall('EmscriptenCallbackDropFile', null, ['string'], [`${dropPath}/upload/${dropFile.name}`]);
+				} else if (dropLink != null) {
+					Module.ccall('EmscriptenCallbackDropFile', null, ['string'], [dropLink]);
+				} else {
+					alert("The items you dropped are not supported. You can drop .demo and .map files, as well as ddnet:// links.");
+				}
+			});
 		</script>
 		<script src="DDNet.js"></script>
 	</body>

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -909,8 +909,28 @@ void CInput::ProcessSystemMessage(SDL_SysWMmsg *pMsg)
 #endif
 }
 
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+extern "C" {
+
+// This will be called from Emscripten JS code
+char aEmscriptenDropFile[IO_MAX_PATH_LENGTH] = "";
+void EmscriptenCallbackDropFile(const char *pFile)
+{
+	str_copy(aEmscriptenDropFile, pFile);
+}
+}
+#endif
+
 bool CInput::GetDropFile(char *aBuf, int Len)
 {
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+	if(aEmscriptenDropFile[0] != '\0')
+	{
+		str_copy(aBuf, aEmscriptenDropFile, Len);
+		aEmscriptenDropFile[0] = '\0';
+		return true;
+	}
+#endif
 	if(m_aDropFile[0] != '\0')
 	{
 		str_copy(aBuf, m_aDropFile, Len);


### PR DESCRIPTION
Add drop-handler to the canvas of the Emscripten wrapper that accepts `.demo` and `.map` files being dropped, writes them into the `demos/upload` and `maps/upload` folders within the internal storage of the Emscripten client, then calls the client's drop handler to open the file. Also support dropping `ddnet://` URLs as strings into the canvas.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
