### PR TITLE
Close editor dialogs when opening dropped map file

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -7924,6 +7924,7 @@ bool CEditor::Save(const char *pFilename)
 
 bool CEditor::HandleMapDrop(const char *pFilename, int StorageType)
 {
+	OnDialogClose();
 	if(HasUnsavedData())
 	{
 		str_copy(m_aFilenamePendingLoad, pFilename);


### PR DESCRIPTION
Previously, dialogs like the map settings error dialog where kept open when loading a dropped map file, causing an empty list of incorrect map settings to be shown.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
