### PR TITLE
Persist temporarily invalid country filters

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -2114,19 +2114,8 @@ void CExcludedCommunityCountryFilterList::Clean(const std::vector<CCommunity> &v
 		if(CommunityEntry != m_Entries.end())
 		{
 			auto &CountryEntries = CommunityEntry->second;
-			for(auto It = CountryEntries.begin(); It != CountryEntries.end();)
-			{
-				if(AllowedCommunity.HasCountry(It->Name()))
-				{
-					++It;
-				}
-				else
-				{
-					It = CountryEntries.erase(It);
-				}
-			}
 			// Prevent filter that would exclude all allowed countries
-			if(CountryEntries.size() == AllowedCommunity.Countries().size())
+			if(std::ranges::all_of(AllowedCommunity.Countries(), [&](const CCommunityCountry &Country) { return CountryEntries.contains(Country.Name()); }))
 			{
 				CountryEntries.clear();
 			}
@@ -2137,17 +2126,6 @@ void CExcludedCommunityCountryFilterList::Clean(const std::vector<CCommunity> &v
 	if(AllCommunityEntry != m_Entries.end())
 	{
 		auto &CountryEntries = AllCommunityEntry->second;
-		for(auto It = CountryEntries.begin(); It != CountryEntries.end();)
-		{
-			if(std::any_of(vAllowedCommunities.begin(), vAllowedCommunities.end(), [&](const auto &Community) { return Community.HasCountry(It->Name()); }))
-			{
-				++It;
-			}
-			else
-			{
-				It = CountryEntries.erase(It);
-			}
-		}
 		// Prevent filter that would exclude all allowed countries
 		std::set<CCommunityCountryName> UniqueCountries;
 		for(const CCommunity &AllowedCommunity : vAllowedCommunities)
@@ -2157,7 +2135,7 @@ void CExcludedCommunityCountryFilterList::Clean(const std::vector<CCommunity> &v
 				UniqueCountries.emplace(Country.Name());
 			}
 		}
-		if(CountryEntries.size() == UniqueCountries.size())
+		if(std::ranges::all_of(UniqueCountries, [&](const CCommunityCountryName &Name) { return CountryEntries.contains(Name); }))
 		{
 			CountryEntries.clear();
 		}

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -21,6 +21,8 @@
 #include <game/client/ui_listbox.h>
 #include <game/localization.h>
 
+#include <ranges>
+
 using namespace FontIcons;
 
 static constexpr ColorRGBA gs_HighlightedTextColor = ColorRGBA(0.4f, 0.4f, 1.0f, 1.0f);
@@ -905,8 +907,9 @@ void CMenus::RenderServerbrowserDDNetFilter(CUIRect View,
 		const int Click = Ui()->DoButtonLogic(pItemId, 0, &Item, BUTTONFLAG_ALL);
 		if(Click == 1 || Click == 2)
 		{
-			// left/right click to toggle filter
-			if(Filter.Empty())
+			// left/right click to toggle filter when none is active
+			// don't use Empty() to prevent interference from unselectable items
+			if(std::ranges::none_of(std::views::iota(0, MaxItems), [&](int j) { return Filter.Filtered(GetItemName(j)); }))
 			{
 				if(Click == 1)
 				{


### PR DESCRIPTION
Excluded community country reappear automatically when servers from certain country are shut down and then come back later, which is annoying.


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
