### PR TITLE
Fix stuck emote wheel when dead and scoreboard lock during game pause

### DIFF
--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -96,7 +96,7 @@ void CEmoticon::OnRender()
 		return;
 	}
 
-	if(GameClient()->m_Snap.m_SpecInfo.m_Active)
+	if(GameClient()->m_Snap.m_SpecInfo.m_Active || !GameClient()->m_Snap.m_pLocalCharacter)
 	{
 		m_Active = false;
 		m_WasActive = false;

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -817,7 +817,14 @@ void CScoreboard::OnRender()
 		return;
 
 	if(!IsActive())
+	{
+		// lock mouse if scoreboard was opened by being dead or game pause
+		if(m_MouseUnlocked)
+		{
+			LockMouse();
+		}
 		return;
+	}
 
 	if(!GameClient()->m_Menus.IsActive() && !GameClient()->m_Chat.IsActive())
 	{


### PR DESCRIPTION
Fixes #11521

Closes emote wheel when character is dead (you can't emote when dead anyway)



And game pause or dead screen [opened scoreboard](https://github.com/ddnet/ddnet/blob/7424b78053111ee2aef1ec1081dc61d9e41e12eb/src/game/client/components/scoreboard.cpp#L999), but didn't call `OnRelease` when being closed. So now make sure to always lock the mouse if scoreboard is closed 


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
