### PR TITLE
Allow building Android without a git repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ target
 
 /build*
 /integration_test/*
+/source_date_epoch
 
 # IDE project files
 .cache

--- a/scripts/android/cmake_android.sh
+++ b/scripts/android/cmake_android.sh
@@ -119,7 +119,16 @@ function build_for_type() {
 		build_extra_cflags="${build_extra_cflags} ${ANDROID_EXTRA_RELEASE_CFLAGS}"
 	fi
 
-	SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
+	if [[ -n ${SOURCE_DATE_EPOCH:-} ]]; then
+		: # Prefer the explicitly passed date
+	elif [[ -f source_date_epoch ]]; then
+		SOURCE_DATE_EPOCH=$(cat source_date_epoch)
+	elif git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+		SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
+	else
+		log_error "For reproducibility build inside a git repository, or provide either a SOURCE_DATE_EPOCH env. variable or source_date_epoch file, containing the seconds since Jan 1, 1970, 00:00:00 UTC"
+		exit 1
+	fi
 	export SOURCE_DATE_EPOCH
 	cmake \
 		-H. \


### PR DESCRIPTION
Follow-up to https://github.com/ddnet/ddnet/pull/11497

Noticed during the nightly builds:
```
+build_android:12> BUILD_FLAGS=-j1 scripts/android/cmake_android.sh all DDNet-19.7-20251231 org.ddnet.client Release build-android
Android build type: all
Game name: DDNet-19.7-20251231
Package name: org.ddnet.client
Build type: Release
Build folder: build-android
Did not pass a version code, using default: 19070
Building cmake (arm)...
fatal: not a git repository (or any of the parent directories): .git
```
## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
