### PR TITLE
Fix headless Emscripten client not yielding control to browser

### DIFF
--- a/src/engine/client/backend/null/backend_null.cpp
+++ b/src/engine/client/backend/null/backend_null.cpp
@@ -2,6 +2,10 @@
 
 #include <engine/client/backend_sdl.h>
 
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+#include <emscripten/emscripten.h>
+#endif
+
 ERunCommandReturnTypes CCommandProcessorFragment_Null::RunCommand(const CCommandBuffer::SCommand *pBaseCommand)
 {
 	switch(pBaseCommand->m_Cmd)
@@ -17,6 +21,9 @@ ERunCommandReturnTypes CCommandProcessorFragment_Null::RunCommand(const CCommand
 		break;
 	case CCommandBuffer::CMD_TEXT_TEXTURE_UPDATE:
 		Cmd_TextTexture_Update(static_cast<const CCommandBuffer::SCommand_TextTexture_Update *>(pBaseCommand));
+		break;
+	case CCommandBuffer::CMD_SWAP:
+		Cmd_Swap(static_cast<const CCommandBuffer::SCommand_Swap *>(pBaseCommand));
 		break;
 	}
 	return ERunCommandReturnTypes::RUN_COMMAND_COMMAND_HANDLED;
@@ -58,4 +65,13 @@ void CCommandProcessorFragment_Null::Cmd_TextTextures_Create(const CCommandBuffe
 void CCommandProcessorFragment_Null::Cmd_TextTexture_Update(const CCommandBuffer::SCommand_TextTexture_Update *pCommand)
 {
 	free(pCommand->m_pData);
+}
+
+void CCommandProcessorFragment_Null::Cmd_Swap(const CCommandBuffer::SCommand_Swap *pCommand)
+{
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+	// Return control to the browser's main thread. This is normally done in SDL_GL_SwapWindow,
+	// but with headless graphics we do not have a GL context to call this function.
+	emscripten_sleep(0);
+#endif
 }

--- a/src/engine/client/backend/null/backend_null.h
+++ b/src/engine/client/backend/null/backend_null.h
@@ -8,9 +8,10 @@ class CCommandProcessorFragment_Null : public CCommandProcessorFragment_GLBase
 	bool GetPresentedImageData(uint32_t &Width, uint32_t &Height, CImageInfo::EImageFormat &Format, std::vector<uint8_t> &vDstData) override { return false; }
 	ERunCommandReturnTypes RunCommand(const CCommandBuffer::SCommand *pBaseCommand) override;
 	bool Cmd_Init(const SCommand_Init *pCommand);
-	virtual void Cmd_Texture_Create(const CCommandBuffer::SCommand_Texture_Create *pCommand);
-	virtual void Cmd_TextTextures_Create(const CCommandBuffer::SCommand_TextTextures_Create *pCommand);
-	virtual void Cmd_TextTexture_Update(const CCommandBuffer::SCommand_TextTexture_Update *pCommand);
+	void Cmd_Texture_Create(const CCommandBuffer::SCommand_Texture_Create *pCommand);
+	void Cmd_TextTextures_Create(const CCommandBuffer::SCommand_TextTextures_Create *pCommand);
+	void Cmd_TextTexture_Update(const CCommandBuffer::SCommand_TextTexture_Update *pCommand);
+	void Cmd_Swap(const CCommandBuffer::SCommand_Swap *pCommand);
 };
 
 #endif


### PR DESCRIPTION
This is normally handled by SDL, but in the headless Emscripten client we need to call `emscripten_sleep` manually on graphics swap-commands to return control to the browser's main thread periodically.

## Checklist

- [X] Tested the change
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
