### PR TITLE
Add weapon ammo with switch tiles

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -318,6 +318,7 @@ Objects = [
 		NetIntRange("m_Subtype", 0, 'max_int'),
 		NetIntAny("m_SwitchNumber"),
 		NetIntAny("m_Flags", default=0),
+		NetIntAny("m_SwitchDelay", default=0),
 	]),
 
 	NetObjectEx("DDNetSpectatorInfo", "spectator-info@netobj.ddnet.org", [

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -729,7 +729,7 @@ void CHud::RenderAmmoHealthAndArmor(const CNetObj_Character *pCharacter)
 	bool IsSixupGameSkin = GameClient()->m_GameSkin.IsSixup();
 	int QuadOffsetSixup = (IsSixupGameSkin ? 10 : 0);
 
-	if(GameClient()->m_GameInfo.m_HudAmmo)
+	if(GameClient()->m_GameInfo.m_HudAmmo && !GameClient()->m_GameInfo.m_HudDDRace)
 	{
 		// ammo display
 		float AmmoOffsetY = GameClient()->m_GameInfo.m_HudHealthArmor ? 24 : 0;
@@ -883,8 +883,7 @@ void CHud::RenderPlayerState(const int ClientId)
 		}
 
 		// render available and used jumps
-		int JumpsOffsetY = ((GameClient()->m_GameInfo.m_HudHealthArmor && g_Config.m_ClShowhudHealthAmmo ? 24 : 0) +
-				    (GameClient()->m_GameInfo.m_HudAmmo && g_Config.m_ClShowhudHealthAmmo ? 12 : 0));
+		int JumpsOffsetY = GameClient()->m_GameInfo.m_HudHealthArmor && g_Config.m_ClShowhudHealthAmmo ? 24 : 0;
 		if(JumpsOffsetY > 0)
 		{
 			Graphics()->TextureSet(GameClient()->m_HudSkin.m_SpriteHudAirjump);
@@ -902,8 +901,7 @@ void CHud::RenderPlayerState(const int ClientId)
 	}
 
 	float x = 5 + 12;
-	float y = (5 + 12 + (GameClient()->m_GameInfo.m_HudHealthArmor && g_Config.m_ClShowhudHealthAmmo ? 24 : 0) +
-		   (GameClient()->m_GameInfo.m_HudAmmo && g_Config.m_ClShowhudHealthAmmo ? 12 : 0));
+	float y = 5 + 12 + (GameClient()->m_GameInfo.m_HudHealthArmor && g_Config.m_ClShowhudHealthAmmo ? 24 : 0);
 
 	// render weapons
 	{
@@ -939,13 +937,49 @@ void CHud::RenderPlayerState(const int ClientId)
 		}
 	}
 
-	// render capabilities
-	x = 5;
 	y += 12;
 	if(TotalJumpsToDisplay > 0)
 	{
 		y += 12;
 	}
+
+	if(GameClient()->m_GameInfo.m_HudAmmo)
+	{
+		x = 0;
+
+		int ActiveWeapon;
+		int Ammo;
+		// pCharacter is predicted but doesn't work in demo playback
+		if(Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		{
+			ActiveWeapon = pCharacter->m_ActiveWeapon;
+			Ammo = pCharacter->m_aWeapons[ActiveWeapon].m_Ammo;
+		}
+		else
+		{
+			ActiveWeapon = pPlayer->m_Weapon;
+			Ammo = pPlayer->m_AmmoCount;
+		}
+
+		if(ActiveWeapon != -1)
+		{
+			const bool IsSixupGameSkin = GameClient()->m_GameSkin.IsSixup();
+			const int QuadOffsetSixup = (IsSixupGameSkin ? 10 : 0);
+			if(GameClient()->m_GameSkin.m_aSpriteWeaponProjectiles[ActiveWeapon].IsValid() &&
+				(ActiveWeapon == WEAPON_SHOTGUN || ActiveWeapon == WEAPON_GRENADE || ActiveWeapon == WEAPON_LASER) &&
+				Ammo != -1)
+			{
+				Graphics()->TextureSet(GameClient()->m_GameSkin.m_aSpriteWeaponProjectiles[ActiveWeapon]);
+				Graphics()->RenderQuadContainerEx(m_HudQuadContainerIndex, m_aAmmoOffset[ActiveWeapon] + QuadOffsetSixup,
+					std::clamp(Ammo, 0, 10), x, y);
+
+				y += 20;
+			}
+		}
+	}
+
+	// render capabilities
+	x = 5;
 	bool HasCapabilities = false;
 	if(pCharacter->m_EndlessJump)
 	{

--- a/src/game/client/components/items.h
+++ b/src/game/client/components/items.h
@@ -15,7 +15,7 @@ class CLaserData;
 class CItems : public CComponent
 {
 	void RenderProjectile(const CProjectileData *pCurrent, int ItemId);
-	void RenderPickup(const CNetObj_Pickup *pPrev, const CNetObj_Pickup *pCurrent, bool IsPredicted, int Flags);
+	void RenderPickup(const CNetObj_Pickup *pPrev, const CNetObj_Pickup *pCurrent, bool IsPredicted, int Flags, int Delay);
 	void RenderFlags();
 	void RenderFlag(const CNetObj_Flag *pPrev, const CNetObj_Flag *pCurrent, const CNetObj_GameData *pPrevGameData, const CNetObj_GameData *pCurGameData);
 	void RenderLaser(const CLaserData *pCurrent, bool IsPredicted = false);

--- a/src/game/client/pickup_data.cpp
+++ b/src/game/client/pickup_data.cpp
@@ -39,6 +39,7 @@ CPickupData ExtractPickupInfoDDNet(const CNetObj_DDNetPickup *pPickup)
 	Result.m_Subtype = pPickup->m_Subtype;
 	Result.m_SwitchNumber = pPickup->m_SwitchNumber;
 	Result.m_Flags = pPickup->m_Flags;
+	Result.m_SwitchDelay = pPickup->m_SwitchDelay;
 
 	return Result;
 }

--- a/src/game/client/pickup_data.h
+++ b/src/game/client/pickup_data.h
@@ -17,6 +17,7 @@ public:
 	int m_Subtype;
 	int m_SwitchNumber;
 	int m_Flags;
+	int m_SwitchDelay;
 };
 
 CPickupData ExtractPickupInfo(int NetObjType, const void *pData, const CNetObj_EntityEx *pEntEx);

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -485,10 +485,23 @@ void CCharacter::FireWeapon()
 
 	m_AttackTick = GameWorld()->GameTick(); // NOLINT(clang-analyzer-unix.Malloc)
 
+	if(m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo > 0)
+	{
+		m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo--;
+	}
+
 	// -1 is no weapon, handled here so pain sound still plays when firing in freeze
 	if(!m_ReloadTimer && m_Core.m_ActiveWeapon != -1)
 	{
 		m_ReloadTimer = GetTuning(GetOverriddenTuneZone())->GetWeaponFireDelay(m_Core.m_ActiveWeapon) * GameWorld()->GameTickSpeed();
+	}
+
+	if(GameWorld()->m_WorldConfig.m_IsDDRace && m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo == 0)
+	{
+		SetWeaponGot(m_Core.m_ActiveWeapon, false);
+		SetLastWeapon(WEAPON_GUN);
+		GameWorld()->CreatePredictedSound(m_Pos, SOUND_WEAPON_NOAMMO, GetCid());
+		SetActiveWeapon(WEAPON_HAMMER);
 	}
 }
 

--- a/src/game/client/prediction/entities/pickup.cpp
+++ b/src/game/client/prediction/entities/pickup.cpp
@@ -123,20 +123,36 @@ void CPickup::Tick()
 				break;
 
 			case POWERUP_WEAPON:
-				if(m_Subtype >= 0 && m_Subtype < NUM_WEAPONS && (!pChr->GetWeaponGot(m_Subtype) || pChr->GetWeaponAmmo(m_Subtype) != -1))
+				if(GameWorld()->m_WorldConfig.m_IsDDRace && GameWorld()->m_WorldConfig.m_PredictDDRace)
 				{
-					pChr->GiveWeapon(m_Subtype);
-
-					if(GameWorld()->m_WorldConfig.m_IsDDRace && GameWorld()->m_WorldConfig.m_PredictDDRace)
+					const int Ammo = m_Delay == 0 ? -1 : m_Delay;
+					if(m_Subtype >= 0 && m_Subtype < NUM_WEAPONS &&
+						(!pChr->GetWeaponGot(m_Subtype) || (pChr->GetWeaponAmmo(m_Subtype) != -1 && (Ammo == -1 || pChr->GetWeaponAmmo(m_Subtype) < Ammo))))
 					{
-						if(m_Subtype == WEAPON_GRENADE)
-							GameWorld()->CreatePredictedSound(m_Pos, SOUND_PICKUP_GRENADE, pChr->GetCid());
-						else if(m_Subtype == WEAPON_SHOTGUN)
-							GameWorld()->CreatePredictedSound(m_Pos, SOUND_PICKUP_SHOTGUN, pChr->GetCid());
-						else if(m_Subtype == WEAPON_LASER)
-							GameWorld()->CreatePredictedSound(m_Pos, SOUND_PICKUP_SHOTGUN, pChr->GetCid());
+						pChr->GiveWeapon(m_Subtype);
+						pChr->SetWeaponAmmo(m_Subtype, Ammo);
+						CreateSound = true;
 					}
 				}
+				else
+				{
+					if(m_Subtype >= 0 && m_Subtype < NUM_WEAPONS && (!pChr->GetWeaponGot(m_Subtype) || pChr->GetWeaponAmmo(m_Subtype) != -1))
+					{
+						pChr->GiveWeapon(m_Subtype);
+						CreateSound = true;
+					}
+				}
+
+				if(CreateSound && GameWorld()->m_WorldConfig.m_IsDDRace && GameWorld()->m_WorldConfig.m_PredictDDRace)
+				{
+					if(m_Subtype == WEAPON_GRENADE)
+						GameWorld()->CreatePredictedSound(m_Pos, SOUND_PICKUP_GRENADE, pChr->GetCid());
+					else if(m_Subtype == WEAPON_SHOTGUN)
+						GameWorld()->CreatePredictedSound(m_Pos, SOUND_PICKUP_SHOTGUN, pChr->GetCid());
+					else if(m_Subtype == WEAPON_LASER)
+						GameWorld()->CreatePredictedSound(m_Pos, SOUND_PICKUP_SHOTGUN, pChr->GetCid());
+				}
+
 				break;
 
 			case POWERUP_NINJA:
@@ -177,6 +193,7 @@ CPickup::CPickup(CGameWorld *pGameWorld, int Id, const CPickupData *pPickup) :
 	m_Number = pPickup->m_SwitchNumber;
 	m_Layer = m_Number > 0 ? LAYER_SWITCH : LAYER_GAME;
 	m_Flags = pPickup->m_Flags;
+	m_Delay = pPickup->m_SwitchDelay;
 }
 
 void CPickup::FillInfo(CNetObj_Pickup *pPickup)

--- a/src/game/client/prediction/entities/pickup.h
+++ b/src/game/client/prediction/entities/pickup.h
@@ -22,11 +22,13 @@ public:
 	int Type() const { return m_Type; }
 	int Subtype() const { return m_Subtype; }
 	int Flags() const { return m_Flags; }
+	int Delay() const { return m_Delay; }
 
 private:
 	int m_Type;
 	int m_Subtype;
 	int m_Flags;
+	int m_Delay;
 
 	// DDRace
 

--- a/src/game/editor/explanations.cpp
+++ b/src/game/editor/explanations.cpp
@@ -371,11 +371,11 @@ const char *CExplanations::ExplainDDNet(int Tile, int Layer)
 		break;
 	case ENTITY_OFFSET + ENTITY_WEAPON_SHOTGUN:
 		if(Layer == LAYER_GAME || Layer == LAYER_FRONT || Layer == LAYER_SWITCH)
-			return "SHOTGUN: Drags the tees towards it. Bounces off the walls.";
+			return "SHOTGUN: Drags the tees towards it. Bounces off the walls. Use a switch layer delay to set a limited number of ammo.";
 		break;
 	case ENTITY_OFFSET + ENTITY_WEAPON_GRENADE:
 		if(Layer == LAYER_GAME || Layer == LAYER_FRONT || Layer == LAYER_SWITCH)
-			return "GRENADE LAUNCHER: Throws exploding bullets. Also known as rocket.";
+			return "GRENADE LAUNCHER: Throws exploding bullets. Also known as rocket. Use a switch layer delay to set a limited number of ammo.";
 		break;
 	case ENTITY_OFFSET + ENTITY_POWERUP_NINJA:
 		if(Layer == LAYER_GAME || Layer == LAYER_FRONT || Layer == LAYER_SWITCH)
@@ -383,7 +383,7 @@ const char *CExplanations::ExplainDDNet(int Tile, int Layer)
 		break;
 	case ENTITY_OFFSET + ENTITY_WEAPON_LASER:
 		if(Layer == LAYER_GAME || Layer == LAYER_FRONT || Layer == LAYER_SWITCH)
-			return "LASER: Unfreezes hit tee. Bounces off the walls. Also known as laser.";
+			return "LASER: Unfreezes hit tee. Bounces off the walls. Also known as laser. Use a switch layer delay to set a limited number of ammo.";
 		break;
 	case ENTITY_OFFSET + ENTITY_LASER_FAST_CCW:
 		if(Layer == LAYER_GAME || Layer == LAYER_FRONT || Layer == LAYER_SWITCH)

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -635,10 +635,23 @@ void CCharacter::FireWeapon()
 
 	m_AttackTick = Server()->Tick();
 
+	if(m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo > 0)
+	{
+		m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo--;
+	}
+
 	// -1 is no weapon, handled here so pain sound still plays when firing in freeze
 	if(!m_ReloadTimer && m_Core.m_ActiveWeapon != -1)
 	{
 		m_ReloadTimer = GetTuning(m_TuneZone)->GetWeaponFireDelay(m_Core.m_ActiveWeapon) * Server()->TickSpeed();
+	}
+
+	if(m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo == 0)
+	{
+		SetWeaponGot(m_Core.m_ActiveWeapon, false);
+		SetLastWeapon(WEAPON_GUN);
+		GameServer()->CreateSound(m_Pos, SOUND_WEAPON_NOAMMO, TeamMask());
+		SetActiveWeapon(WEAPON_HAMMER);
 	}
 }
 
@@ -1130,7 +1143,7 @@ void CCharacter::SnapCharacter(int SnappingClient, int Id)
 	{
 		Health = m_Health;
 		Armor = m_Armor;
-		AmmoCount = (m_FreezeTime == 0) ? m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo : 0;
+		AmmoCount = m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo;
 	}
 
 	if(!Server()->IsSixup(SnappingClient))

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -13,12 +13,13 @@
 
 static constexpr int PICKUP_PHYSICS_RADIUS = 14;
 
-CPickup::CPickup(CGameWorld *pGameWorld, int Type, int SubType, int Layer, int Number, int Flags) :
+CPickup::CPickup(CGameWorld *pGameWorld, int Type, int SubType, int Layer, int Number, int Flags, int Delay) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_PICKUP, vec2(0, 0), PICKUP_PHYSICS_RADIUS)
 {
 	m_Core = vec2(0.0f, 0.0f);
 	m_Type = Type;
 	m_Subtype = SubType;
+	m_Delay = Delay;
 
 	m_Layer = Layer;
 	m_Number = Number;
@@ -131,10 +132,13 @@ void CPickup::Tick()
 				break;
 
 			case POWERUP_WEAPON:
-
-				if(m_Subtype >= 0 && m_Subtype < NUM_WEAPONS && (!pChr->GetWeaponGot(m_Subtype) || pChr->GetWeaponAmmo(m_Subtype) != -1))
+			{
+				const int Ammo = m_Delay == 0 ? -1 : m_Delay;
+				if(m_Subtype >= 0 && m_Subtype < NUM_WEAPONS &&
+					(!pChr->GetWeaponGot(m_Subtype) || (pChr->GetWeaponAmmo(m_Subtype) != -1 && (Ammo == -1 || pChr->GetWeaponAmmo(m_Subtype) < Ammo))))
 				{
 					pChr->GiveWeapon(m_Subtype);
+					pChr->SetWeaponAmmo(m_Subtype, Ammo);
 
 					if(m_Subtype == WEAPON_GRENADE)
 						GameServer()->CreateSound(m_Pos, SOUND_PICKUP_GRENADE, pChr->TeamMask());
@@ -147,7 +151,7 @@ void CPickup::Tick()
 						GameServer()->SendWeaponPickup(pChr->GetPlayer()->GetCid(), m_Subtype);
 				}
 				break;
-
+			}
 			case POWERUP_NINJA:
 			{
 				// activate ninja on target player
@@ -185,7 +189,7 @@ void CPickup::Snap(int SnappingClient)
 			return;
 	}
 
-	GameServer()->SnapPickup(CSnapContext(SnappingClientVersion, Sixup, SnappingClient), GetId(), m_Pos, m_Type, m_Subtype, m_Number, m_Flags);
+	GameServer()->SnapPickup(CSnapContext(SnappingClientVersion, Sixup, SnappingClient), GetId(), m_Pos, m_Type, m_Subtype, m_Number, m_Flags, m_Delay);
 }
 
 void CPickup::Move()

--- a/src/game/server/entities/pickup.h
+++ b/src/game/server/entities/pickup.h
@@ -10,7 +10,7 @@ class CPickup : public CEntity
 public:
 	static const int ms_CollisionExtraSize = 6;
 
-	CPickup(CGameWorld *pGameWorld, int Type, int SubType, int Layer, int Number, int Flags);
+	CPickup(CGameWorld *pGameWorld, int Type, int SubType, int Layer, int Number, int Flags, int Delay);
 
 	void Reset() override;
 	void Tick() override;
@@ -24,6 +24,7 @@ private:
 	int m_Type;
 	int m_Subtype;
 	int m_Flags;
+	int m_Delay;
 
 	// DDRace
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -556,7 +556,7 @@ bool CGameContext::SnapLaserObject(const CSnapContext &Context, int SnapId, cons
 	return true;
 }
 
-bool CGameContext::SnapPickup(const CSnapContext &Context, int SnapId, const vec2 &Pos, int Type, int SubType, int SwitchNumber, int Flags) const
+bool CGameContext::SnapPickup(const CSnapContext &Context, int SnapId, const vec2 &Pos, int Type, int SubType, int SwitchNumber, int Flags, int SwitchDelay) const
 {
 	if(Context.IsSixup())
 	{
@@ -580,6 +580,7 @@ bool CGameContext::SnapPickup(const CSnapContext &Context, int SnapId, const vec
 		pPickup->m_Subtype = SubType;
 		pPickup->m_SwitchNumber = SwitchNumber;
 		pPickup->m_Flags = Flags;
+		pPickup->m_SwitchDelay = SwitchDelay;
 	}
 	else
 	{
@@ -4442,7 +4443,7 @@ void CGameContext::CreateAllEntities(bool Initial)
 				// if(SwitchType == TILE_DOOR_OFF)
 				if(SwitchType >= ENTITY_OFFSET)
 				{
-					m_pController->OnEntity(SwitchType - ENTITY_OFFSET, x, y, LAYER_SWITCH, pSwitch[Index].m_Flags, Initial, pSwitch[Index].m_Number);
+					m_pController->OnEntity(SwitchType - ENTITY_OFFSET, x, y, LAYER_SWITCH, pSwitch[Index].m_Flags, Initial, pSwitch[Index].m_Number, pSwitch[Index].m_Delay);
 				}
 			}
 		}

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -295,7 +295,7 @@ public:
 
 	void SnapSwitchers(int SnappingClient);
 	bool SnapLaserObject(const CSnapContext &Context, int SnapId, const vec2 &To, const vec2 &From, int StartTick, int Owner = -1, int LaserType = -1, int Subtype = -1, int SwitchNumber = -1) const;
-	bool SnapPickup(const CSnapContext &Context, int SnapId, const vec2 &Pos, int Type, int SubType, int SwitchNumber, int Flags) const;
+	bool SnapPickup(const CSnapContext &Context, int SnapId, const vec2 &Pos, int Type, int SubType, int SwitchNumber, int Flags, int SwitchDelay) const;
 
 	enum
 	{

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -180,7 +180,7 @@ bool IGameController::CanSpawn(int Team, vec2 *pOutPos, int ClientId)
 	return Eval.m_Got;
 }
 
-bool IGameController::OnEntity(int Index, int x, int y, int Layer, int Flags, bool Initial, int Number)
+bool IGameController::OnEntity(int Index, int x, int y, int Layer, int Flags, bool Initial, int Number, int Delay)
 {
 	dbg_assert(Index >= 0, "Invalid entity index");
 
@@ -391,7 +391,7 @@ bool IGameController::OnEntity(int Index, int x, int y, int Layer, int Flags, bo
 	if(Type != -1) // NOLINT(clang-analyzer-unix.Malloc)
 	{
 		int PickupFlags = TileFlagsToPickupFlags(Flags);
-		CPickup *pPickup = new CPickup(&GameServer()->m_World, Type, SubType, Layer, Number, PickupFlags);
+		CPickup *pPickup = new CPickup(&GameServer()->m_World, Type, SubType, Layer, Number, PickupFlags, Delay);
 		pPickup->m_Pos = Pos;
 		return true; // NOLINT(clang-analyzer-unix.Malloc)
 	}
@@ -658,7 +658,11 @@ void IGameController::Snap(int SnappingClient)
 		GAMEINFOFLAG_ENTITIES_DDRACE |
 		GAMEINFOFLAG_ENTITIES_RACE |
 		GAMEINFOFLAG_RACE;
-	pGameInfoEx->m_Flags2 = GAMEINFOFLAG2_HUD_DDRACE | GAMEINFOFLAG2_DDRACE_TEAM | GAMEINFOFLAG2_PREDICT_EVENTS;
+	pGameInfoEx->m_Flags2 =
+		GAMEINFOFLAG2_HUD_DDRACE |
+		GAMEINFOFLAG2_DDRACE_TEAM |
+		GAMEINFOFLAG2_PREDICT_EVENTS |
+		GAMEINFOFLAG2_HUD_AMMO;
 	if(g_Config.m_SvNoWeakHook)
 		pGameInfoEx->m_Flags2 |= GAMEINFOFLAG2_NO_WEAK_HOOK;
 	pGameInfoEx->m_Version = GAMEINFO_CURVERSION;

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -123,7 +123,7 @@ public:
 		Returns:
 			bool?
 	*/
-	virtual bool OnEntity(int Index, int x, int y, int Layer, int Flags, bool Initial, int Number = 0);
+	virtual bool OnEntity(int Index, int x, int y, int Layer, int Flags, bool Initial, int Number = 0, int Delay = 0);
 
 	virtual void OnPlayerConnect(class CPlayer *pPlayer);
 	virtual void OnPlayerDisconnect(class CPlayer *pPlayer, const char *pReason);

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -156,7 +156,7 @@ bool CSaveTee::Load(CCharacter *pChr, std::optional<int> Team)
 	{
 		pChr->m_Core.m_aWeapons[i].m_AmmoRegenStart = m_aWeapons[i].m_AmmoRegenStart;
 		// m_Ammo not used anymore for tracking freeze following https://github.com/ddnet/ddnet/pull/2086
-		pChr->m_Core.m_aWeapons[i].m_Ammo = -1;
+		pChr->m_Core.m_aWeapons[i].m_Ammo = m_aWeapons[i].m_Ammo;
 		pChr->m_Core.m_aWeapons[i].m_Ammocost = m_aWeapons[i].m_Ammocost;
 		pChr->m_Core.m_aWeapons[i].m_Got = m_aWeapons[i].m_Got;
 	}


### PR DESCRIPTION
Closes #11540

Allows to set ammo for a weapon using a switch tile delay. Picking up the weapon will refill your ammo up to that number, but only if you have less than the specified amount. For example, if a grenade has a delay of 5, picking it up will set your grenade ammo to 5, but only if your current ammo is below 5.

Old clients also have HUD ammo display. I just made it nicer in this PR



https://github.com/user-attachments/assets/3a12bbbb-324b-4b6d-955b-89a43a89d0cb



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
