### PR TITLE
Ensure tile skip and padding are zeroed for editor tile layers

### DIFF
--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -168,8 +168,10 @@ void CMap::ExtractTiles(CTile *pDest, size_t DestSize, const CTile *pSrc, size_t
 	{
 		for(unsigned Counter = 0; Counter <= pSrc[SrcIndex].m_Skip && DestIndex < DestSize; Counter++)
 		{
-			pDest[DestIndex] = pSrc[SrcIndex];
+			pDest[DestIndex].m_Index = pSrc[SrcIndex].m_Index;
+			pDest[DestIndex].m_Flags = pSrc[SrcIndex].m_Flags;
 			pDest[DestIndex].m_Skip = 0;
+			pDest[DestIndex].m_Reserved = 0;
 			DestIndex++;
 		}
 		SrcIndex++;

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -141,9 +141,18 @@ void CLayerTiles::ExtractTiles(int TilemapItemVersion, const CTile *pSavedTiles,
 {
 	const size_t DestSize = (size_t)m_Width * m_Height;
 	if(TilemapItemVersion >= CMapItemLayerTilemap::VERSION_TEEWORLDS_TILESKIP)
+	{
 		CMap::ExtractTiles(m_pTiles, DestSize, pSavedTiles, SavedTilesSize);
+	}
 	else if(SavedTilesSize >= DestSize)
+	{
 		mem_copy(m_pTiles, pSavedTiles, DestSize * sizeof(CTile));
+		for(size_t TileIndex = 0; TileIndex < DestSize; ++TileIndex)
+		{
+			m_pTiles[TileIndex].m_Skip = 0;
+			m_pTiles[TileIndex].m_Reserved = 0;
+		}
+	}
 }
 
 void CLayerTiles::MakePalette() const


### PR DESCRIPTION
Always set `CTile::m_Skip` to zero when loading tile layer data in editor. The skip value is unused for tilemap item versions lower than `CMapItemLayerTilemap::VERSION_TEEWORLDS_TILESKIP` (`4`) but maps could contain non-zero values which would cause bugs in tile layer rendering.

Always set `CTile::m_Reserved` to zero to avoid propagating garbage values in this unused padding byte.

Example broken map provided by louis: [Afterimage.zip](https://github.com/user-attachments/files/24400767/Afterimage.zip)
- Before: <img src="https://github.com/user-attachments/assets/f0cf70c3-4104-441f-9526-3434045f6aec" />
- After: <img src="https://github.com/user-attachments/assets/b6fa7b6c-256d-443e-823c-e636669ffcc3" />

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions