### PR TITLE
Refactor ammo magic numbers, and predict ammo

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -206,8 +206,7 @@ Objects = [
 		NetIntRange("m_PlayerFlags", 0, 256),
 		NetIntRange("m_Health", 0, 10),
 		NetIntRange("m_Armor", 0, 10),
-		# -1 is infinite ammo
-		NetIntRange("m_AmmoCount", -1, 10),
+		NetIntRange("m_AmmoCount", 'Ammo::INFINITE', 'Ammo::MAX'),
 		NetIntRange("m_Weapon", -1, 'NUM_WEAPONS-1'),
 		NetIntRange("m_Emote", 0, len(Emotes)),
 		NetIntRange("m_AttackTick", 0, 'max_int'),

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -206,6 +206,7 @@ Objects = [
 		NetIntRange("m_PlayerFlags", 0, 256),
 		NetIntRange("m_Health", 0, 10),
 		NetIntRange("m_Armor", 0, 10),
+		# -1 is infinite ammo, 0 to 10 is normal ammo count
 		NetIntRange("m_AmmoCount", 'Ammo::INFINITE', 'Ammo::MAX'),
 		NetIntRange("m_Weapon", -1, 'NUM_WEAPONS-1'),
 		NetIntRange("m_Emote", 0, len(Emotes)),

--- a/src/engine/shared/protocol.h
+++ b/src/engine/shared/protocol.h
@@ -162,6 +162,13 @@ namespace FinishTime
 	inline constexpr int UNSET = -2;
 }
 
+namespace Ammo
+{
+	inline constexpr int INFINITE = -1;
+	// weapons can have more than 10 ammo, but the client receives max 10
+	inline constexpr int MAX = 10;
+}
+
 typedef std::bitset<MAX_CLIENTS> CClientMask;
 
 #endif

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -176,7 +176,7 @@ void CControls::OnMessage(int Msg, void *pRawMsg)
 		if(g_Config.m_ClAutoswitchWeapons)
 			m_aInputData[g_Config.m_ClDummy].m_WantedWeapon = pMsg->m_Weapon + 1;
 		// We don't really know ammo count, until we'll switch to that weapon, but any non-zero count will suffice here
-		m_aAmmoCount[maximum(0, pMsg->m_Weapon % NUM_WEAPONS)] = 10;
+		m_aAmmoCount[maximum(0, pMsg->m_Weapon % NUM_WEAPONS)] = Ammo::MAX;
 	}
 }
 

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -640,74 +640,76 @@ void CHud::RenderCursor()
 
 void CHud::PrepareAmmoHealthAndArmorQuads()
 {
-	float x = 5;
-	float y = 5;
-	IGraphics::CQuadItem Array[10];
+	const float QuadX = 5;
+	const float QuadY = 5;
+	IGraphics::CQuadItem aItems[10];
+	const int ItemsSize = static_cast<int>(std::size(aItems));
+	static_assert(ItemsSize == Ammo::MAX, "Max ammo doesn't match number of items that can be shown on the HUD");
 
 	// ammo of the different weapons
 	for(int i = 0; i < NUM_WEAPONS; ++i)
 	{
 		// 0.6
-		for(int n = 0; n < 10; n++)
-			Array[n] = IGraphics::CQuadItem(x + n * 12, y, 10, 10);
+		for(int n = 0; n < Ammo::MAX; n++)
+			aItems[n] = IGraphics::CQuadItem(QuadX + n * 12, QuadY, 10, 10);
 
-		m_aAmmoOffset[i] = Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, Array, 10);
+		m_aAmmoOffset[i] = Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, aItems, Ammo::MAX);
 
 		// 0.7
 		if(i == WEAPON_GRENADE)
 		{
 			// special case for 0.7 grenade
-			for(int n = 0; n < 10; n++)
-				Array[n] = IGraphics::CQuadItem(1 + x + n * 12, y, 10, 10);
+			for(int n = 0; n < Ammo::MAX; n++)
+				aItems[n] = IGraphics::CQuadItem(1 + QuadX + n * 12, QuadY, 10, 10);
 		}
 		else
 		{
-			for(int n = 0; n < 10; n++)
-				Array[n] = IGraphics::CQuadItem(x + n * 12, y, 12, 12);
+			for(int n = 0; n < Ammo::MAX; n++)
+				aItems[n] = IGraphics::CQuadItem(QuadX + n * 12, QuadY, 12, 12);
 		}
 
-		Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, Array, 10);
+		Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, aItems, Ammo::MAX);
 	}
 
 	// health
-	for(int i = 0; i < 10; ++i)
-		Array[i] = IGraphics::CQuadItem(x + i * 12, y, 10, 10);
-	m_HealthOffset = Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, Array, 10);
+	for(int i = 0; i < ItemsSize; ++i)
+		aItems[i] = IGraphics::CQuadItem(QuadX + i * 12, QuadY, 10, 10);
+	m_HealthOffset = Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, aItems, ItemsSize);
 
 	// 0.7
-	for(int i = 0; i < 10; ++i)
-		Array[i] = IGraphics::CQuadItem(x + i * 12, y, 12, 12);
-	Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, Array, 10);
+	for(int i = 0; i < ItemsSize; ++i)
+		aItems[i] = IGraphics::CQuadItem(QuadX + i * 12, QuadY, 12, 12);
+	Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, aItems, ItemsSize);
 
 	// empty health
-	for(int i = 0; i < 10; ++i)
-		Array[i] = IGraphics::CQuadItem(x + i * 12, y, 10, 10);
-	m_EmptyHealthOffset = Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, Array, 10);
+	for(int i = 0; i < ItemsSize; ++i)
+		aItems[i] = IGraphics::CQuadItem(QuadX + i * 12, QuadY, 10, 10);
+	m_EmptyHealthOffset = Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, aItems, ItemsSize);
 
 	// 0.7
-	for(int i = 0; i < 10; ++i)
-		Array[i] = IGraphics::CQuadItem(x + i * 12, y, 12, 12);
-	Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, Array, 10);
+	for(int i = 0; i < ItemsSize; ++i)
+		aItems[i] = IGraphics::CQuadItem(QuadX + i * 12, QuadY, 12, 12);
+	Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, aItems, ItemsSize);
 
 	// armor meter
-	for(int i = 0; i < 10; ++i)
-		Array[i] = IGraphics::CQuadItem(x + i * 12, y + 12, 10, 10);
-	m_ArmorOffset = Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, Array, 10);
+	for(int i = 0; i < ItemsSize; ++i)
+		aItems[i] = IGraphics::CQuadItem(QuadX + i * 12, QuadY + 12, 10, 10);
+	m_ArmorOffset = Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, aItems, ItemsSize);
 
 	// 0.7
-	for(int i = 0; i < 10; ++i)
-		Array[i] = IGraphics::CQuadItem(x + i * 12, y + 12, 12, 12);
-	Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, Array, 10);
+	for(int i = 0; i < ItemsSize; ++i)
+		aItems[i] = IGraphics::CQuadItem(QuadX + i * 12, QuadY + 12, 12, 12);
+	Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, aItems, ItemsSize);
 
 	// empty armor meter
-	for(int i = 0; i < 10; ++i)
-		Array[i] = IGraphics::CQuadItem(x + i * 12, y + 12, 10, 10);
-	m_EmptyArmorOffset = Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, Array, 10);
+	for(int i = 0; i < ItemsSize; ++i)
+		aItems[i] = IGraphics::CQuadItem(QuadX + i * 12, QuadY + 12, 10, 10);
+	m_EmptyArmorOffset = Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, aItems, ItemsSize);
 
 	// 0.7
-	for(int i = 0; i < 10; ++i)
-		Array[i] = IGraphics::CQuadItem(x + i * 12, y + 12, 12, 12);
-	Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, Array, 10);
+	for(int i = 0; i < ItemsSize; ++i)
+		aItems[i] = IGraphics::CQuadItem(QuadX + i * 12, QuadY + 12, 12, 12);
+	Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, aItems, ItemsSize);
 }
 
 void CHud::RenderAmmoHealthAndArmor(const CNetObj_Character *pCharacter)
@@ -738,11 +740,11 @@ void CHud::RenderAmmoHealthAndArmor(const CNetObj_Character *pCharacter)
 			Graphics()->TextureSet(GameClient()->m_GameSkin.m_aSpriteWeaponProjectiles[CurWeapon]);
 			if(AmmoOffsetY > 0)
 			{
-				Graphics()->RenderQuadContainerEx(m_HudQuadContainerIndex, m_aAmmoOffset[CurWeapon] + QuadOffsetSixup, std::clamp(pCharacter->m_AmmoCount, 0, 10), 0, AmmoOffsetY);
+				Graphics()->RenderQuadContainerEx(m_HudQuadContainerIndex, m_aAmmoOffset[CurWeapon] + QuadOffsetSixup, std::clamp(pCharacter->m_AmmoCount, 0, Ammo::MAX), 0, AmmoOffsetY);
 			}
 			else
 			{
-				Graphics()->RenderQuadContainer(m_HudQuadContainerIndex, m_aAmmoOffset[CurWeapon] + QuadOffsetSixup, std::clamp(pCharacter->m_AmmoCount, 0, 10));
+				Graphics()->RenderQuadContainer(m_HudQuadContainerIndex, m_aAmmoOffset[CurWeapon] + QuadOffsetSixup, std::clamp(pCharacter->m_AmmoCount, 0, Ammo::MAX));
 			}
 		}
 	}
@@ -767,16 +769,17 @@ void CHud::PreparePlayerStateQuads()
 {
 	float x = 5;
 	float y = 5 + 24;
-	IGraphics::CQuadItem Array[10];
+	IGraphics::CQuadItem aItems[10];
+	const int ItemsSize = static_cast<int>(std::size(aItems));
 
 	// Quads for displaying the available and used jumps
-	for(int i = 0; i < 10; ++i)
-		Array[i] = IGraphics::CQuadItem(x + i * 12, y, 12, 12);
-	m_AirjumpOffset = Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, Array, 10);
+	for(int i = 0; i < ItemsSize; ++i)
+		aItems[i] = IGraphics::CQuadItem(x + i * 12, y, 12, 12);
+	m_AirjumpOffset = Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, aItems, ItemsSize);
 
-	for(int i = 0; i < 10; ++i)
-		Array[i] = IGraphics::CQuadItem(x + i * 12, y, 12, 12);
-	m_AirjumpEmptyOffset = Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, Array, 10);
+	for(int i = 0; i < ItemsSize; ++i)
+		aItems[i] = IGraphics::CQuadItem(x + i * 12, y, 12, 12);
+	m_AirjumpEmptyOffset = Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, aItems, ItemsSize);
 
 	// Quads for displaying weapons
 	for(int Weapon = 0; Weapon < NUM_WEAPONS; ++Weapon)

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -72,7 +72,7 @@ class CHud : public CComponent
 	void RenderTeambalanceWarning();
 
 	void PrepareAmmoHealthAndArmorQuads();
-	void RenderAmmoHealthAndArmor(const CNetObj_Character *pCharacter);
+	void RenderAmmoHealthAndArmor(int ClientId);
 
 	void PreparePlayerStateQuads();
 	void RenderPlayerState(int ClientId);

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -456,6 +456,11 @@ void CCharacter::FireWeapon()
 
 	m_AttackTick = GameWorld()->GameTick(); // NOLINT(clang-analyzer-unix.Malloc)
 
+	if(m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo > 0)
+	{
+		m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo--;
+	}
+
 	if(!m_ReloadTimer)
 	{
 		float FireDelay;
@@ -1179,7 +1184,14 @@ void CCharacter::GiveWeapon(int Weapon, bool Remove)
 	}
 	else
 	{
-		m_Core.m_aWeapons[Weapon].m_Ammo = Ammo::INFINITE;
+		if(GameWorld()->m_WorldConfig.m_IsVanilla)
+		{
+			m_Core.m_aWeapons[Weapon].m_Ammo = g_pData->m_Weapons.m_aId[Weapon].m_Maxammo;
+		}
+		else
+		{
+			m_Core.m_aWeapons[Weapon].m_Ammo = Ammo::INFINITE;
+		}
 	}
 
 	m_Core.m_aWeapons[Weapon].m_Got = !Remove;

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -487,7 +487,7 @@ void CCharacter::GiveNinja()
 	m_Core.m_Ninja.m_ActivationTick = GameWorld()->GameTick();
 	m_Core.m_aWeapons[WEAPON_NINJA].m_Got = true;
 	if(m_FreezeTime == 0)
-		m_Core.m_aWeapons[WEAPON_NINJA].m_Ammo = -1;
+		m_Core.m_aWeapons[WEAPON_NINJA].m_Ammo = Ammo::INFINITE;
 	if(m_Core.m_ActiveWeapon != WEAPON_NINJA)
 		m_LastWeapon = m_Core.m_ActiveWeapon;
 	SetActiveWeapon(WEAPON_NINJA);
@@ -1179,7 +1179,7 @@ void CCharacter::GiveWeapon(int Weapon, bool Remove)
 	}
 	else
 	{
-		m_Core.m_aWeapons[Weapon].m_Ammo = -1;
+		m_Core.m_aWeapons[Weapon].m_Ammo = Ammo::INFINITE;
 	}
 
 	m_Core.m_aWeapons[Weapon].m_Got = !Remove;
@@ -1283,7 +1283,7 @@ void CCharacter::ResetPrediction()
 	for(int w = 0; w < NUM_WEAPONS; w++)
 	{
 		SetWeaponGot(w, false);
-		SetWeaponAmmo(w, -1);
+		SetWeaponAmmo(w, Ammo::INFINITE);
 	}
 	if(m_Core.HookedPlayer() >= 0)
 	{
@@ -1367,7 +1367,7 @@ void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtende
 		{
 			m_Core.m_Jetpack = true;
 			m_Core.m_aWeapons[WEAPON_GUN].m_Got = true;
-			m_Core.m_aWeapons[WEAPON_GUN].m_Ammo = -1;
+			m_Core.m_aWeapons[WEAPON_GUN].m_Ammo = Ammo::INFINITE;
 			m_NinjaJetpack = pChar->m_Weapon == WEAPON_NINJA;
 		}
 		else if(pChar->m_Weapon != WEAPON_NINJA)
@@ -1432,7 +1432,7 @@ void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtende
 	// set the current weapon
 	if(pChar->m_Weapon >= 0 && pChar->m_Weapon != WEAPON_NINJA)
 	{
-		m_Core.m_aWeapons[pChar->m_Weapon].m_Ammo = (GameWorld()->m_WorldConfig.m_InfiniteAmmo || pChar->m_Weapon == WEAPON_HAMMER) ? -1 : pChar->m_AmmoCount;
+		m_Core.m_aWeapons[pChar->m_Weapon].m_Ammo = (GameWorld()->m_WorldConfig.m_InfiniteAmmo || pChar->m_Weapon == WEAPON_HAMMER) ? Ammo::INFINITE : pChar->m_AmmoCount;
 		if(pChar->m_Weapon != m_Core.m_ActiveWeapon)
 			SetActiveWeapon(pChar->m_Weapon);
 	}

--- a/src/game/client/prediction/entities/pickup.cpp
+++ b/src/game/client/prediction/entities/pickup.cpp
@@ -116,7 +116,7 @@ void CPickup::Tick()
 				break;
 
 			case POWERUP_WEAPON:
-				if(m_Subtype >= 0 && m_Subtype < NUM_WEAPONS && (!pChr->GetWeaponGot(m_Subtype) || pChr->GetWeaponAmmo(m_Subtype) != -1))
+				if(m_Subtype >= 0 && m_Subtype < NUM_WEAPONS && (!pChr->GetWeaponGot(m_Subtype) || pChr->GetWeaponAmmo(m_Subtype) != Ammo::INFINITE))
 					pChr->GiveWeapon(m_Subtype);
 				break;
 

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -666,7 +666,7 @@ void CCharacter::GiveNinja()
 {
 	m_Core.m_Ninja.m_ActivationTick = Server()->Tick();
 	m_Core.m_aWeapons[WEAPON_NINJA].m_Got = true;
-	m_Core.m_aWeapons[WEAPON_NINJA].m_Ammo = -1;
+	m_Core.m_aWeapons[WEAPON_NINJA].m_Ammo = Ammo::INFINITE;
 	if(m_Core.m_ActiveWeapon != WEAPON_NINJA)
 		m_LastWeapon = m_Core.m_ActiveWeapon;
 	m_Core.m_ActiveWeapon = WEAPON_NINJA;
@@ -1122,7 +1122,7 @@ void CCharacter::SnapCharacter(int SnappingClient, int Id)
 	if(m_pPlayer->m_NinjaJetpack && m_Core.m_Jetpack && m_Core.m_ActiveWeapon == WEAPON_GUN && !m_Core.m_DeepFrozen && m_FreezeTime == 0 && !m_Core.m_HasTelegunGun)
 	{
 		Weapon = WEAPON_NINJA;
-		AmmoCount = 10;
+		AmmoCount = Ammo::MAX;
 	}
 
 	if(m_pPlayer->GetCid() == SnappingClient || SnappingClient == SERVER_DEMO_CLIENT ||
@@ -2383,7 +2383,7 @@ void CCharacter::GiveWeapon(int Weapon, bool Remove)
 	}
 	else
 	{
-		m_Core.m_aWeapons[Weapon].m_Ammo = -1;
+		m_Core.m_aWeapons[Weapon].m_Ammo = Ammo::INFINITE;
 	}
 
 	m_Core.m_aWeapons[Weapon].m_Got = !Remove;

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -132,7 +132,7 @@ void CPickup::Tick()
 
 			case POWERUP_WEAPON:
 
-				if(m_Subtype >= 0 && m_Subtype < NUM_WEAPONS && (!pChr->GetWeaponGot(m_Subtype) || pChr->GetWeaponAmmo(m_Subtype) != -1))
+				if(m_Subtype >= 0 && m_Subtype < NUM_WEAPONS && (!pChr->GetWeaponGot(m_Subtype) || pChr->GetWeaponAmmo(m_Subtype) != Ammo::INFINITE))
 				{
 					pChr->GiveWeapon(m_Subtype);
 

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -154,7 +154,7 @@ bool CSaveTee::Load(CCharacter *pChr, std::optional<int> Team)
 	{
 		pChr->m_Core.m_aWeapons[i].m_AmmoRegenStart = m_aWeapons[i].m_AmmoRegenStart;
 		// m_Ammo not used anymore for tracking freeze following https://github.com/ddnet/ddnet/pull/2086
-		pChr->m_Core.m_aWeapons[i].m_Ammo = -1;
+		pChr->m_Core.m_aWeapons[i].m_Ammo = Ammo::INFINITE;
 		pChr->m_Core.m_aWeapons[i].m_Ammocost = m_aWeapons[i].m_Ammocost;
 		pChr->m_Core.m_aWeapons[i].m_Got = m_aWeapons[i].m_Got;
 	}


### PR DESCRIPTION
`-1` -> `Ammo::INFINITE`
`10` -> `Ammo::MAX`

Predict ammo on servers that use ammo. DDnet currently uses infinite ammo everywhere so this has no effect on ddnet servers. Hud prediction only for local player, other players on vanilla seem to not have CharacterCore

Taken from teeworlds https://github.com/teeworlds/teeworlds/blob/5d682733e482950f686663c129adc4b751c8d790/src/game/server/entities/character.cpp#L402
And `GiveWeapon` max from https://github.com/teeworlds/teeworlds/blob/5d682733e482950f686663c129adc4b751c8d790/src/game/server/entities/pickup.cpp#L69

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
