### PR TITLE
Add button to start and connect to local server when LAN tab empty

### DIFF
--- a/src/game/client/components/local_server.cpp
+++ b/src/game/client/components/local_server.cpp
@@ -7,7 +7,7 @@
 #include <android/android_main.h>
 #endif
 
-void CLocalServer::RunServer(const std::vector<const char *> &vpArguments)
+bool CLocalServer::RunServer(const std::vector<const char *> &vpArguments)
 {
 	secure_random_password(m_aRconPassword, sizeof(m_aRconPassword), 16);
 	char aAuthCommand[64 + sizeof(m_aRconPassword)];
@@ -20,11 +20,13 @@ void CLocalServer::RunServer(const std::vector<const char *> &vpArguments)
 	if(StartAndroidServer(vpArgumentsWithAuth.data(), vpArgumentsWithAuth.size()))
 	{
 		GameClient()->m_Menus.ForceRefreshLanPage();
+		return true;
 	}
 	else
 	{
 		Client()->AddWarning(SWarning(Localize("Server could not be started. Make sure to grant the notification permission in the app settings so the server can run in the background.")));
 		mem_zero(m_aRconPassword, sizeof(m_aRconPassword));
+		return false;
 	}
 #else
 	char aBuf[IO_MAX_PATH_LENGTH];
@@ -36,17 +38,20 @@ void CLocalServer::RunServer(const std::vector<const char *> &vpArguments)
 		if(m_Process != INVALID_PROCESS)
 		{
 			GameClient()->m_Menus.ForceRefreshLanPage();
+			return true;
 		}
 		else
 		{
 			Client()->AddWarning(SWarning(Localize("Server could not be started")));
 			mem_zero(m_aRconPassword, sizeof(m_aRconPassword));
+			return false;
 		}
 	}
 	else
 	{
 		Client()->AddWarning(SWarning(Localize("Server executable not found, can't run server")));
 		mem_zero(m_aRconPassword, sizeof(m_aRconPassword));
+		return false;
 	}
 #endif
 }

--- a/src/game/client/components/local_server.h
+++ b/src/game/client/components/local_server.h
@@ -10,7 +10,7 @@
 class CLocalServer : public CComponentInterfaces
 {
 public:
-	void RunServer(const std::vector<const char *> &vpArguments);
+	bool RunServer(const std::vector<const char *> &vpArguments);
 	void KillServer();
 	bool IsServerRunning();
 	void RconAuthIfPossible();

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2487,9 +2487,9 @@ void CMenus::SetMenuPage(int NewPage)
 	{
 		g_Config.m_UiPage = NewPage;
 		bool ForceRefresh = false;
-		if(m_ForceRefreshLanPage)
+		if(m_ForceRefreshLanPage && NewPage == PAGE_LAN)
 		{
-			ForceRefresh = NewPage == PAGE_LAN;
+			ForceRefresh = true;
 			m_ForceRefreshLanPage = false;
 		}
 		if(OldPage != NewPage || ForceRefresh)


### PR DESCRIPTION
When no LAN servers are running, show a button to start and connect to the local server in the middle of the empty LAN server list.

Refresh the LAN tab after connecting to the server.

Do not try to connect to the server if it failed to be started.

Show confirmation popup when this would disconnect from a server and `cl_confirm_disconnect_time` is set.

Closes #10718. Supersedes #10731.

<img src="https://github.com/user-attachments/assets/f03cafd9-5856-4175-ba89-3914b5a96193" />

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
