### PR TITLE
Revert "add check for empty strings in text-width"

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -1440,9 +1440,6 @@ public:
 
 	void TextEx(CTextCursor *pCursor, const char *pText, int Length = -1) override
 	{
-		if(pText[0] == '\0')
-			return;
-
 		const unsigned OldRenderFlags = m_RenderFlags;
 		m_RenderFlags |= TEXT_RENDER_FLAG_ONE_TIME_USE;
 		STextContainerIndex TextCont;


### PR DESCRIPTION
This reverts commit d55dd342263f5b40040d5710e85c7908fb2a03b4.

Closes #11555. Reverts #11539.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
