### PR TITLE
Improve client input validation on server-side

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1070,9 +1070,19 @@ void CServer::DoSnapshot()
 			int DeltaTick = -1;
 			const CSnapshot *pDeltashot = CSnapshot::EmptySnapshot();
 			{
-				int DeltashotSize = m_aClients[i].m_Snapshots.Get(m_aClients[i].m_LastAckedSnapshot, nullptr, &pDeltashot, nullptr);
+				int DeltashotSize;
+				if(m_aClients[i].m_LastAckedSnapshot >= MIN_TICK)
+				{
+					DeltashotSize = m_aClients[i].m_Snapshots.Get(m_aClients[i].m_LastAckedSnapshot, nullptr, &pDeltashot, nullptr);
+				}
+				else
+				{
+					DeltashotSize = -1;
+				}
 				if(DeltashotSize >= 0)
+				{
 					DeltaTick = m_aClients[i].m_LastAckedSnapshot;
+				}
 				else
 				{
 					// no acked package found, force client to recover rate
@@ -1845,21 +1855,51 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 		}
 		else if(Msg == NETMSG_INPUT)
 		{
+			if((pPacket->m_Flags & NET_CHUNKFLAG_VITAL) != 0)
+			{
+				return;
+			}
+			if(m_aClients[ClientId].m_State != CClient::STATE_INGAME)
+			{
+				return;
+			}
+
 			const int LastAckedSnapshot = Unpacker.GetInt();
+			if(Unpacker.Error() ||
+				LastAckedSnapshot < -1 ||
+				LastAckedSnapshot > Tick())
+			{
+				return;
+			}
+
 			int IntendedTick = Unpacker.GetInt();
-			int Size = Unpacker.GetInt();
-			if(Unpacker.Error() || Size / 4 > MAX_INPUT_SIZE || IntendedTick < MIN_TICK || IntendedTick >= MAX_TICK)
+			if(Unpacker.Error() ||
+				IntendedTick < MIN_TICK ||
+				IntendedTick > MAX_TICK)
+			{
+				return;
+			}
+
+			const int Size = Unpacker.GetInt();
+			if(Unpacker.Error() ||
+				Size % (int)sizeof(int32_t) != 0 ||
+				Size / (int)sizeof(int32_t) < MIN_INPUT_SIZE ||
+				Size / (int)sizeof(int32_t) > MAX_INPUT_SIZE)
 			{
 				return;
 			}
 
 			m_aClients[ClientId].m_LastAckedSnapshot = LastAckedSnapshot;
-			if(m_aClients[ClientId].m_LastAckedSnapshot > 0)
+			if(m_aClients[ClientId].m_LastAckedSnapshot >= MIN_TICK)
+			{
 				m_aClients[ClientId].m_SnapRate = CClient::SNAPRATE_FULL;
 
-			int64_t TagTime;
-			if(m_aClients[ClientId].m_Snapshots.Get(m_aClients[ClientId].m_LastAckedSnapshot, &TagTime, nullptr, nullptr) >= 0)
-				m_aClients[ClientId].m_Latency = (int)(((time_get() - TagTime) * 1000) / time_freq());
+				int64_t TagTime;
+				if(m_aClients[ClientId].m_Snapshots.Get(m_aClients[ClientId].m_LastAckedSnapshot, &TagTime, nullptr, nullptr) >= 0)
+				{
+					m_aClients[ClientId].m_Latency = (int)(((time_get() - TagTime) * 1000) / time_freq());
+				}
+			}
 
 			// add message to report the input timing
 			// skip packets that are old
@@ -1872,17 +1912,13 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 				Msgp.AddInt(TimeLeft);
 				SendMsg(&Msgp, 0, ClientId);
 			}
-
 			m_aClients[ClientId].m_LastInputTick = IntendedTick;
 
+			IntendedTick = std::max(IntendedTick, Tick() + 1);
+
 			CClient::CInput *pInput = &m_aClients[ClientId].m_aInputs[m_aClients[ClientId].m_CurrentInput];
-
-			if(IntendedTick <= Tick())
-				IntendedTick = Tick() + 1;
-
 			pInput->m_GameTick = IntendedTick;
-
-			for(int i = 0; i < Size / 4; i++)
+			for(int i = 0; i < Size / (int)sizeof(int32_t); i++)
 			{
 				pInput->m_aData[i] = Unpacker.GetInt();
 			}
@@ -1891,7 +1927,8 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 				return;
 			}
 
-			if(g_Config.m_SvPreInput)
+			if(g_Config.m_SvPreInput &&
+				IntendedTick <= Tick() + 4 * TickSpeed() + 1)
 			{
 				// send preinputs of ClientId to valid clients
 				bool aPreInputClients[MAX_CLIENTS] = {};
@@ -1924,6 +1961,8 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 					{
 						if(!aPreInputClients[Id])
 							continue;
+						if(m_aClients[Id].m_SnapRate != CClient::SNAPRATE_FULL)
+							continue;
 
 						SendPackMsg(&PreInput, MSGFLAG_FLUSH | MSGFLAG_NORECORD, Id);
 					}
@@ -1931,14 +1970,13 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 			}
 
 			GameServer()->OnClientPrepareInput(ClientId, pInput->m_aData);
-			mem_copy(m_aClients[ClientId].m_LatestInput.m_aData, pInput->m_aData, MAX_INPUT_SIZE * sizeof(int));
+			mem_copy(m_aClients[ClientId].m_LatestInput.m_aData, pInput->m_aData, sizeof(m_aClients[ClientId].m_LatestInput.m_aData));
 
 			m_aClients[ClientId].m_CurrentInput++;
 			m_aClients[ClientId].m_CurrentInput %= 200;
 
 			// call the mod with the fresh input data
-			if(m_aClients[ClientId].m_State == CClient::STATE_INGAME)
-				GameServer()->OnClientDirectInput(ClientId, m_aClients[ClientId].m_LatestInput.m_aData);
+			GameServer()->OnClientDirectInput(ClientId, m_aClients[ClientId].m_LatestInput.m_aData);
 		}
 		else if(Msg == NETMSG_RCON_CMD)
 		{

--- a/src/engine/shared/protocol.h
+++ b/src/engine/shared/protocol.h
@@ -93,6 +93,15 @@ enum
 	MIN_TICK = 0,
 	MAX_TICK = 0x6FFFFFFF,
 
+	/**
+	 * The minimum size of inputs (in `int32_t`s) accepted by the server.
+	 *
+	 * Currently `10` because this has always been the minimum size of CNetObj_PlayerInput in all supported protocols.
+	 */
+	MIN_INPUT_SIZE = 10,
+	/**
+	 * The maximum size of inputs (in `int32_t`s) accepted by the server.
+	 */
 	MAX_INPUT_SIZE = 128,
 	MAX_SNAPSHOT_PACKSIZE = 900,
 


### PR DESCRIPTION
Reject inputs if the vital-flag is set. Inputs are always non-vital.

Reject inputs for clients that are not ingame. Previously, the direct input was not passed to the game server for clients that are not ingame, but there is no need to handle the input at all, as clients are not expected to send any input until they are ingame.

Reject inputs if the size is not aligned with `int32_t`s as expected, or if the size is smaller than `CNetObj_PlayerInput` has been for the last 15 years.

Reject inputs if the last acked snapshot is out of range. The value `-1` is used when the client first connects and no snapshot has been acked. Other negative values are not expected. Values above the current tick are also not expected, as the client cannot acknowledged a snapshot from a future tick.

Avoid sending preinputs for inputs whose intended tick is more than 4 seconds into the future.

Avoid sending preinputs to clients that are not in full snapshot mode, to allow them to recover and reduce the amount of optional messages sent to them.

Avoid trying to retrieve a snapshot with negative tick from the snapshot storage when the last acked snapshot is still unset, as the snapshot storage is either empty (with regular clients) or this causes an unnecessary linear search for an entry that the snapshot storage cannot contain (with modified clients).

Use `sizeof(int32_t)` instead of `4`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions