### PR TITLE
Replace `secure_rand` with `secure_random_fill`/`secure_rand_below`

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2542,7 +2542,8 @@ int fs_remove(const char *filename)
 	}
 	const std::wstring wide_filename = windows_utf8_to_wide(filename);
 
-	unsigned random_num = secure_rand();
+	unsigned random_num;
+	secure_random_fill(&random_num, sizeof(random_num));
 	std::wstring wide_filename_temp;
 	do
 	{
@@ -3156,13 +3157,6 @@ void secure_random_fill(void *bytes, unsigned length)
 #else
 	dbg_assert(length == io_read(secure_random_data.urandom, bytes, length), "io_read returned with a short read");
 #endif
-}
-
-int secure_rand()
-{
-	unsigned int i;
-	secure_random_fill(&i, sizeof(i));
-	return (int)(i % RAND_MAX);
 }
 
 // From https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2.

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1546,17 +1546,6 @@ void secure_random_password(char *buffer, unsigned length, unsigned pw_length);
 void secure_random_fill(void *bytes, unsigned length);
 
 /**
- * Returns random `int`.
- *
- * @ingroup Secure-Random
- *
- * @return Random int.
- *
- * @remark Can be used as a replacement for the `rand` function.
- */
-int secure_rand();
-
-/**
  * Returns a random nonnegative integer below the given number,
  * with a uniform distribution.
  *

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2997,7 +2997,7 @@ void CServer::UpdateDebugDummies(bool ForceDisconnect)
 			Client.m_DebugDummyAddr.ip[11] = 0x00;
 			uint_to_bytes_be(&Client.m_DebugDummyAddr.ip[12], ClientId);
 			// Port: random like normal clients
-			Client.m_DebugDummyAddr.port = (secure_rand() % (65535 - 1024)) + 1024;
+			Client.m_DebugDummyAddr.port = secure_rand_below(65535 - 1024) + 1024;
 			net_addr_str(&Client.m_DebugDummyAddr, Client.m_aDebugDummyAddrString.data(), Client.m_aDebugDummyAddrString.size(), true);
 			net_addr_str(&Client.m_DebugDummyAddr, Client.m_aDebugDummyAddrStringNoPort.data(), Client.m_aDebugDummyAddrStringNoPort.size(), false);
 

--- a/src/test/net_test.cpp
+++ b/src/test/net_test.cpp
@@ -16,7 +16,7 @@ TEST(Net, Ipv4AndIpv6Work)
 	Socket2 = net_udp_create(Bindaddr);
 	do
 	{
-		Bindaddr.port = secure_rand() % 64511 + 1024;
+		Bindaddr.port = secure_rand_below(65535 - 1024) + 1024;
 	} while(!(Socket1 = net_udp_create(Bindaddr)));
 
 	NETADDR LocalhostV4;


### PR DESCRIPTION
The `secure_rand` function returned an integer below `RAND_MAX` (which can be as low as `0x7FFF`) to be compatible with `rand()`, but it was expected to produce larger values for random filenames and ports.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions