### PR TITLE
Fix `deprecated-enum-float-conversion` warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,7 +343,6 @@ if(NOT MSVC AND NOT HAIKU)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wsuggest-override)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wdynamic-class-memaccess) # clang
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wclass-memaccess) # gcc
-  add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wno-deprecated-enum-float-conversion) # c++20 arithmetic between floating-point type and enumeration type
   add_linker_flag_if_supported(OUR_FLAGS_LINK -Wno-alloc-size-larger-than) # save.cpp with LTO
   # add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wdouble-promotion) # Many occurrences
   # add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wnull-dereference) # Many occurrences

--- a/scripts/export_settings_commands_table.py
+++ b/scripts/export_settings_commands_table.py
@@ -80,8 +80,8 @@ def parse_tunings(lines):
 	def parse_value(value):
 		value = value.strip()
 		try:
-			if value.endswith("f / SERVER_TICK_SPEED"):
-				return float(value.rstrip("f / SERVER_TICK_SPEED")) / 50.0
+			if value.endswith("f / (float)SERVER_TICK_SPEED"):
+				return float(value.rstrip("f / (float)SERVER_TICK_SPEED")) / 50.0
 			return float(value.strip("f"))
 		except Exception as e:
 			raise RuntimeError("Failed to parse tuning value: {value}") from e

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -1199,7 +1199,7 @@ void CDemoPlayer::Update(bool RealTime)
 	{
 		if(m_Info.m_Info.m_LiveDemo &&
 			m_Info.m_Info.m_Speed > 1.0f &&
-			m_Info.m_Info.m_LastTick - m_Info.m_Info.m_CurrentTick <= (DeltaTime * (double)m_Info.m_Info.m_Speed / Freq + 2) * SERVER_TICK_SPEED)
+			m_Info.m_Info.m_LastTick - m_Info.m_Info.m_CurrentTick <= (DeltaTime * (double)m_Info.m_Info.m_Speed / Freq + 2) * (float)SERVER_TICK_SPEED)
 		{
 			// Reset to default speed if we are fast-forwarding to the end of a live demo,
 			// to prevent playback error due to final demo chunk data still being written.

--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -138,9 +138,9 @@ void CEmoticon::OnRender()
 	m_SelectedEmote = -1;
 	m_SelectedEyeEmote = -1;
 	if(length(m_SelectorMouse) > 110.0f)
-		m_SelectedEmote = (int)(SelectedAngle / (2 * pi) * NUM_EMOTICONS);
+		m_SelectedEmote = (int)(SelectedAngle / (2 * pi) * (float)NUM_EMOTICONS);
 	else if(length(m_SelectorMouse) > 40.0f)
-		m_SelectedEyeEmote = (int)(SelectedAngle / (2 * pi) * NUM_EMOTES);
+		m_SelectedEyeEmote = (int)(SelectedAngle / (2 * pi) * (float)NUM_EMOTES);
 
 	const vec2 ScreenCenter = Screen.Center();
 
@@ -157,7 +157,7 @@ void CEmoticon::OnRender()
 	Graphics()->WrapClamp();
 	for(int Emote = 0; Emote < NUM_EMOTICONS; Emote++)
 	{
-		float Angle = 2 * pi * Emote / NUM_EMOTICONS;
+		float Angle = 2 * pi * Emote / (float)NUM_EMOTICONS;
 		if(Angle > pi)
 			Angle -= 2 * pi;
 
@@ -184,7 +184,7 @@ void CEmoticon::OnRender()
 
 		for(int Emote = 0; Emote < NUM_EMOTES; Emote++)
 		{
-			float Angle = 2 * pi * Emote / NUM_EMOTES;
+			float Angle = 2 * pi * Emote / (float)NUM_EMOTES;
 			if(Angle > pi)
 				Angle -= 2 * pi;
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -437,7 +437,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 		Checkboxes.VSplitLeft(MainView.w * 0.35f, &Checkboxes, &SkinPrefix);
 		MainView.HSplitTop(5.0f, nullptr, &MainView);
 		MainView.HSplitTop(EyeButtonSize, &Eyes, &MainView);
-		Eyes.VSplitRight(EyeButtonSize * NUM_EMOTES + 5.0f * (NUM_EMOTES - 1), nullptr, &Eyes);
+		Eyes.VSplitRight(EyeButtonSize * (float)NUM_EMOTES + 5.0f * (float)(NUM_EMOTES - 1), nullptr, &Eyes);
 	}
 	else
 	{
@@ -1800,7 +1800,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 	CUIRect TabBar, LeftView, RightView, Button;
 
 	MainView.HSplitTop(20.0f, &TabBar, &MainView);
-	const float TabWidth = TabBar.w / NUMBER_OF_APPEARANCE_TABS;
+	const float TabWidth = TabBar.w / (float)NUMBER_OF_APPEARANCE_TABS;
 	static CButtonContainer s_aPageTabs[NUMBER_OF_APPEARANCE_TABS] = {};
 	const char *apTabNames[NUMBER_OF_APPEARANCE_TABS] = {
 		Localize("HUD"),

--- a/src/game/client/components/menus_settings7.cpp
+++ b/src/game/client/components/menus_settings7.cpp
@@ -252,7 +252,7 @@ void CMenus::RenderSettingsTeeCustom7(CUIRect MainView)
 	CustomColorsButton.VSplitRight(30.0f, &CustomColorsButton, &RandomSkinButton);
 	CustomColorsButton.VSplitRight(20.0f, &CustomColorsButton, nullptr);
 
-	const float ButtonWidth = ButtonBar.w / protocol7::NUM_SKINPARTS;
+	const float ButtonWidth = ButtonBar.w / (float)protocol7::NUM_SKINPARTS;
 
 	static CButtonContainer s_aSkinPartButtons[protocol7::NUM_SKINPARTS];
 	for(int i = 0; i < protocol7::NUM_SKINPARTS; i++)

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -351,7 +351,7 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 	CUIRect TabBar, CustomList, QuickSearch, DirectoryButton, ReloadButton;
 
 	MainView.HSplitTop(20.0f, &TabBar, &MainView);
-	const float TabWidth = TabBar.w / NUMBER_OF_ASSETS_TABS;
+	const float TabWidth = TabBar.w / (float)NUMBER_OF_ASSETS_TABS;
 	static CButtonContainer s_aPageTabs[NUMBER_OF_ASSETS_TABS] = {};
 	const char *apTabNames[NUMBER_OF_ASSETS_TABS] = {
 		Localize("Entities"),

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5618,7 +5618,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 					{
 						m_PopupEnvelopeSelectedPoint = i;
 						static SPopupMenuId s_PopupCurvetypeId;
-						Ui()->DoPopupMenu(&s_PopupCurvetypeId, Ui()->MouseX(), Ui()->MouseY(), 80, NUM_CURVETYPES * 14.0f + 10.0f, this, PopupEnvelopeCurvetype);
+						Ui()->DoPopupMenu(&s_PopupCurvetypeId, Ui()->MouseX(), Ui()->MouseY(), 80, (float)NUM_CURVETYPES * 14.0f + 10.0f, this, PopupEnvelopeCurvetype);
 					}
 				}
 			}

--- a/src/game/tuning.h
+++ b/src/game/tuning.h
@@ -10,11 +10,11 @@
 
 // physics tuning
 MACRO_TUNING_PARAM(GroundControlSpeed, ground_control_speed, 10.0f, "Max speed the tee can get on ground")
-MACRO_TUNING_PARAM(GroundControlAccel, ground_control_accel, 100.0f / SERVER_TICK_SPEED, "Acceleration speed on the ground")
+MACRO_TUNING_PARAM(GroundControlAccel, ground_control_accel, 100.0f / (float)SERVER_TICK_SPEED, "Acceleration speed on the ground")
 MACRO_TUNING_PARAM(GroundFriction, ground_friction, 0.5f, "Friction on the ground")
 MACRO_TUNING_PARAM(GroundJumpImpulse, ground_jump_impulse, 13.2f, "Impulse when jumping on ground")
 MACRO_TUNING_PARAM(AirJumpImpulse, air_jump_impulse, 12.0f, "Impulse when jumping in air")
-MACRO_TUNING_PARAM(AirControlSpeed, air_control_speed, 250.0f / SERVER_TICK_SPEED, "Max speed the tee can get in the air")
+MACRO_TUNING_PARAM(AirControlSpeed, air_control_speed, 250.0f / (float)SERVER_TICK_SPEED, "Max speed the tee can get in the air")
 MACRO_TUNING_PARAM(AirControlAccel, air_control_accel, 1.5f, "Acceleration speed in air")
 MACRO_TUNING_PARAM(AirFriction, air_friction, 0.95f, "Friction in the air")
 MACRO_TUNING_PARAM(HookLength, hook_length, 380.0f, "Length of the hook")


### PR DESCRIPTION
Seen in the Emscripten CI (#11547) which does not seem to suppress the warning.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions