### PR TITLE
Add strict, unified error handling for all tiles layers to `IMap`

### DIFF
--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -130,6 +130,12 @@ public:
 	char *m_pDataStart;
 };
 
+class CDataProcessorWrapper
+{
+public:
+	FDataProcessor m_DataProcessor;
+};
+
 class CDatafile
 {
 public:
@@ -145,6 +151,8 @@ public:
 	CDatafileHeader m_Header;
 	int m_DataStartOffset;
 	void **m_ppDataPtrs;
+	CDataProcessorWrapper **m_ppDataProcessors;
+	CDatafileItem **m_ppOverriddenItems;
 	int *m_pDataSizes;
 	char *m_pData;
 
@@ -292,16 +300,45 @@ public:
 			}
 			m_pDataSizes[Index] = DataSize;
 		}
+
 		if(Swap)
 		{
 			SwapEndianInPlace(m_ppDataPtrs[Index], m_pDataSizes[Index]);
 		}
+
+		if(m_ppDataProcessors[Index] != nullptr)
+		{
+			const auto [pNewData, NewSize] = m_ppDataProcessors[Index]->m_DataProcessor(m_ppDataPtrs[Index], m_pDataSizes[Index]);
+			if(pNewData == nullptr)
+			{
+				m_ppDataPtrs[Index] = nullptr;
+				m_pDataSizes[Index] = -1;
+				return nullptr;
+			}
+			m_ppDataPtrs[Index] = pNewData;
+			m_pDataSizes[Index] = NewSize;
+		}
+
 		return m_ppDataPtrs[Index];
+	}
+
+	void AddDataProcessor(int Index, FDataProcessor DataProcessor) // NOLINT(readability-make-member-function-const)
+	{
+		dbg_assert(Index >= 0 && Index < m_Header.m_NumRawData, "Index invalid: %d", Index);
+		dbg_assert(m_ppDataProcessors[Index] == nullptr, "Data already intercepted: %d", Index);
+
+		m_ppDataProcessors[Index] = new CDataProcessorWrapper;
+		m_ppDataProcessors[Index]->m_DataProcessor = std::move(DataProcessor);
 	}
 
 	int GetFileItemSize(int Index) const
 	{
 		dbg_assert(Index >= 0 && Index < m_Header.m_NumItems, "Invalid Index: %d", Index);
+
+		if(m_ppOverriddenItems[Index] != nullptr)
+		{
+			return m_ppOverriddenItems[Index]->m_Size + sizeof(CDatafileItem);
+		}
 
 		if(Index == m_Header.m_NumItems - 1)
 		{
@@ -320,7 +357,33 @@ public:
 	{
 		dbg_assert(Index >= 0 && Index < m_Header.m_NumItems, "Invalid Index: %d", Index);
 
+		if(m_ppOverriddenItems[Index] != nullptr)
+		{
+			return m_ppOverriddenItems[Index];
+		}
 		return static_cast<CDatafileItem *>(static_cast<void *>(m_Info.m_pItemStart + m_Info.m_pItemOffsets[Index]));
+	}
+
+	bool OverrideItemData(int Index, const void *pData, size_t Size) // NOLINT(readability-make-member-function-const)
+	{
+		const CDatafileItem *pCurrentItem = GetItem(Index);
+		dbg_assert(m_ppOverriddenItems[Index] == nullptr, "Item already overridden: %d", Index);
+		dbg_assert(Size == 0 || pData != nullptr, "Data missing"); // Items without data are allowed
+		dbg_assert(Size <= (size_t)std::numeric_limits<int>::max(), "Data too large");
+		dbg_assert(Size % sizeof(int) == 0, "Invalid data boundary");
+		m_ppOverriddenItems[Index] = static_cast<CDatafileItem *>(malloc(sizeof(CDatafileItem) + Size));
+		if(m_ppOverriddenItems[Index] == nullptr)
+		{
+			log_error("datafile", "out of memory. could not allocate memory for overridden item data. index=%d size=%" PRIzu, Index, Size);
+			return false;
+		}
+		m_ppOverriddenItems[Index]->m_TypeAndId = pCurrentItem->m_TypeAndId;
+		m_ppOverriddenItems[Index]->m_Size = Size;
+		if(pData)
+		{
+			mem_copy(static_cast<void *>(m_ppOverriddenItems[Index] + 1), pData, Size);
+		}
+		return true;
 	}
 
 	bool Validate() const
@@ -595,6 +658,8 @@ bool CDataFileReader::Open(const char *pFullName, IStorage *pStorage, const char
 	int64_t AllocSize = Size;
 	AllocSize += sizeof(CDatafile); // add space for info structure
 	AllocSize += (int64_t)Header.m_NumRawData * sizeof(void *); // add space for data pointers
+	AllocSize += (int64_t)Header.m_NumRawData * sizeof(CDataProcessorWrapper *); // add space for data interceptors
+	AllocSize += (int64_t)Header.m_NumItems * sizeof(CDatafileItem *); // add space for item overrides
 	AllocSize += (int64_t)Header.m_NumRawData * sizeof(int); // add space for data sizes
 	if(AllocSize > MaxAllocSize)
 	{
@@ -613,7 +678,9 @@ bool CDataFileReader::Open(const char *pFullName, IStorage *pStorage, const char
 	pTmpDataFile->m_Header = Header;
 	pTmpDataFile->m_DataStartOffset = sizeof(CDatafileHeader) + Size;
 	pTmpDataFile->m_ppDataPtrs = (void **)(pTmpDataFile + 1);
-	pTmpDataFile->m_pDataSizes = (int *)(pTmpDataFile->m_ppDataPtrs + Header.m_NumRawData);
+	pTmpDataFile->m_ppDataProcessors = (CDataProcessorWrapper **)(pTmpDataFile->m_ppDataPtrs + Header.m_NumRawData);
+	pTmpDataFile->m_ppOverriddenItems = (CDatafileItem **)(pTmpDataFile->m_ppDataProcessors + Header.m_NumRawData);
+	pTmpDataFile->m_pDataSizes = (int *)(pTmpDataFile->m_ppOverriddenItems + Header.m_NumItems);
 	pTmpDataFile->m_pData = (char *)(pTmpDataFile->m_pDataSizes + Header.m_NumRawData);
 	pTmpDataFile->m_File = File;
 	str_copy(pTmpDataFile->m_aFullName, pFullName);
@@ -625,6 +692,8 @@ bool CDataFileReader::Open(const char *pFullName, IStorage *pStorage, const char
 
 	// clear the data pointers and sizes
 	mem_zero(pTmpDataFile->m_ppDataPtrs, Header.m_NumRawData * sizeof(void *));
+	mem_zero(pTmpDataFile->m_ppDataProcessors, Header.m_NumRawData * sizeof(CDataProcessorWrapper *));
+	mem_zero(pTmpDataFile->m_ppOverriddenItems, Header.m_NumItems * sizeof(CDatafileItem *));
 	mem_zero(pTmpDataFile->m_pDataSizes, Header.m_NumRawData * sizeof(int));
 
 	// read types, offsets, sizes and item data
@@ -687,6 +756,12 @@ void CDataFileReader::Close()
 	for(int i = 0; i < m_pDataFile->m_Header.m_NumRawData; i++)
 	{
 		free(m_pDataFile->m_ppDataPtrs[i]);
+		delete m_pDataFile->m_ppDataProcessors[i];
+	}
+
+	for(int i = 0; i < m_pDataFile->m_Header.m_NumItems; i++)
+	{
+		free(m_pDataFile->m_ppOverriddenItems[i]);
 	}
 
 	io_close(m_pDataFile->m_File);
@@ -750,14 +825,11 @@ const char *CDataFileReader::GetDataString(int Index)
 	return pData;
 }
 
-void CDataFileReader::ReplaceData(int Index, char *pData, size_t Size)
+void CDataFileReader::AddDataProcessor(int Index, FDataProcessor DataProcessor)
 {
 	dbg_assert(m_pDataFile != nullptr, "File not open");
-	dbg_assert(Index >= 0 && Index < m_pDataFile->m_Header.m_NumRawData, "Index invalid: %d", Index);
 
-	free(m_pDataFile->m_ppDataPtrs[Index]);
-	m_pDataFile->m_ppDataPtrs[Index] = pData;
-	m_pDataFile->m_pDataSizes[Index] = Size;
+	m_pDataFile->AddDataProcessor(Index, std::move(DataProcessor));
 }
 
 void CDataFileReader::UnloadData(int Index)
@@ -908,6 +980,13 @@ void *CDataFileReader::FindItem(int Type, int Id)
 		return nullptr;
 	}
 	return GetItem(Index);
+}
+
+bool CDataFileReader::OverrideItemData(int Index, const void *pData, size_t Size)
+{
+	dbg_assert(m_pDataFile != nullptr, "File not open");
+
+	return m_pDataFile->OverrideItemData(Index, pData, Size);
 }
 
 int CDataFileReader::NumItems() const

--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -11,6 +11,7 @@
 #include <engine/storage.h>
 
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <vector>
 
@@ -18,6 +19,15 @@ enum
 {
 	ITEMTYPE_EX = 0xFFFF,
 };
+
+/**
+ * The data processor function is called after a particular data item is first successfully uncompressed.
+ * The function can validate the data and return `std::make_pair(nullptr, 0)` on error or the original data
+ * on success. The function can also replace the data and return a new data pointer and size. The new data
+ * must be allocated with `malloc`. When returning different data or on errors, the original data must be
+ * freed by the function using `free`.
+ */
+typedef std::function<std::pair<void *, size_t>(void *pData, size_t Size)> FDataProcessor;
 
 // raw datafile access
 class CDataFileReader
@@ -41,7 +51,7 @@ public:
 	void *GetData(int Index);
 	void *GetDataSwapped(int Index); // makes sure that the data is 32bit LE ints when saved
 	const char *GetDataString(int Index);
-	void ReplaceData(int Index, char *pData, size_t Size); // memory for data must have been allocated with malloc
+	void AddDataProcessor(int Index, FDataProcessor DataProcessor);
 	void UnloadData(int Index);
 	int NumData() const;
 
@@ -50,6 +60,7 @@ public:
 	void GetType(int Type, int *pStart, int *pNum);
 	int FindItemIndex(int Type, int Id);
 	void *FindItem(int Type, int Id);
+	bool OverrideItemData(int Index, const void *pData, size_t Size);
 	int NumItems() const;
 
 	const char *FullName() const;

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -2,12 +2,15 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "map.h"
 
+#include <base/dbg.h>
 #include <base/fs.h>
 #include <base/log.h>
+#include <base/mem.h>
 #include <base/str.h>
 
 #include <engine/storage.h>
 
+#include <game/gamecore.h>
 #include <game/mapitems.h>
 
 CMap::CMap() = default;
@@ -77,6 +80,12 @@ int CMap::NumItems() const
 	return m_DataFile.NumItems();
 }
 
+static bool AtMostOneBitSet(int Flags)
+{
+	// https://graphics.stanford.edu/~seander/bithacks.html#DetermineIfPowerOf2
+	return (Flags & (Flags - 1)) == 0;
+}
+
 bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, int StorageType)
 {
 	// Ensure current datafile is not left in an inconsistent state if loading fails,
@@ -91,37 +100,76 @@ bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, in
 		return false;
 	}
 
-	// Replace compressed tile layers with uncompressed ones
 	int GroupsStart, GroupsNum, LayersStart, LayersNum;
 	NewDataFile.GetType(MAPITEMTYPE_GROUP, &GroupsStart, &GroupsNum);
 	NewDataFile.GetType(MAPITEMTYPE_LAYER, &LayersStart, &LayersNum);
-	for(int g = 0; g < GroupsNum; g++)
+
+	// Replace map items for old versions with items compatible with latest version to avoid version checks when using the map items.
+	for(int GroupIndex = 0; GroupIndex < GroupsNum; GroupIndex++)
 	{
-		const CMapItemGroup *pGroup = static_cast<CMapItemGroup *>(NewDataFile.GetItem(GroupsStart + g));
-		for(int l = 0; l < pGroup->m_NumLayers; l++)
+		const CMapItemGroup *pGroup = static_cast<CMapItemGroup *>(NewDataFile.GetItem(GroupsStart + GroupIndex));
+		for(int LayerIndex = 0; LayerIndex < pGroup->m_NumLayers; LayerIndex++)
 		{
-			CMapItemLayer *pLayer = static_cast<CMapItemLayer *>(NewDataFile.GetItem(LayersStart + pGroup->m_StartLayer + l));
+			const int LayerItemIndex = LayersStart + pGroup->m_StartLayer + LayerIndex;
+			CMapItemLayer *pLayer = static_cast<CMapItemLayer *>(NewDataFile.GetItem(LayerItemIndex));
+			const size_t LayerItemSize = NewDataFile.GetItemSize(LayerItemIndex);
+			if(LayerItemSize < sizeof(CMapItemLayer))
+			{
+				log_error("map/load", "Layer %d in group %d is truncated (size %" PRIzu ").", LayerIndex, GroupIndex, LayerItemSize);
+				return false;
+			}
+
+			if(pLayer->m_Version != 0)
+			{
+				log_debug("map/load", "Layer %d in group %d has unused version set to %d. Resetting to 0.", LayerIndex, GroupIndex, pLayer->m_Version);
+				pLayer->m_Version = 0;
+			}
+
 			if(pLayer->m_Type == LAYERTYPE_TILES)
 			{
-				CMapItemLayerTilemap *pTilemap = reinterpret_cast<CMapItemLayerTilemap *>(pLayer);
-				if(pTilemap->m_Version >= CMapItemLayerTilemap::VERSION_TEEWORLDS_TILESKIP)
+				if(!UpgradeAndValidateTilesLayerItem(NewDataFile, GroupIndex, LayerIndex, reinterpret_cast<CMapItemLayerTilemap *>(pLayer), LayerItemIndex, LayerItemSize))
 				{
-					const size_t TilemapCount = (size_t)pTilemap->m_Width * pTilemap->m_Height;
-					const size_t TilemapSize = TilemapCount * sizeof(CTile);
-
-					if(((int)TilemapCount / pTilemap->m_Width != pTilemap->m_Height) || (TilemapSize / sizeof(CTile) != TilemapCount))
-					{
-						log_error("map/load", "map layer too big (%d * %d * %d causes an integer overflow)", pTilemap->m_Width, pTilemap->m_Height, (int)sizeof(CTile));
-						return false;
-					}
-					CTile *pTiles = static_cast<CTile *>(malloc(TilemapSize));
-					if(!pTiles)
-						return false;
-					ExtractTiles(pTiles, (size_t)pTilemap->m_Width * pTilemap->m_Height, static_cast<CTile *>(NewDataFile.GetData(pTilemap->m_Data)), NewDataFile.GetDataSize(pTilemap->m_Data) / sizeof(CTile));
-					NewDataFile.ReplaceData(pTilemap->m_Data, reinterpret_cast<char *>(pTiles), TilemapSize);
+					return false;
 				}
 			}
 		}
+	}
+
+	// Lazily validate data and replace compressed tile layers with uncompressed ones.
+	// Ensure that we have a game layer and game group.
+	const CMapItemLayerTilemap *pGameLayer = nullptr;
+	std::set<int> UsedDataIndices;
+	for(int GroupIndex = 0; GroupIndex < GroupsNum; GroupIndex++)
+	{
+		const CMapItemGroup *pGroup = static_cast<CMapItemGroup *>(NewDataFile.GetItem(GroupsStart + GroupIndex));
+		for(int LayerIndex = 0; LayerIndex < pGroup->m_NumLayers; LayerIndex++)
+		{
+			CMapItemLayer *pLayer = static_cast<CMapItemLayer *>(NewDataFile.GetItem(LayersStart + pGroup->m_StartLayer + LayerIndex));
+			if(pLayer->m_Type == LAYERTYPE_TILES)
+			{
+				const CMapItemLayerTilemap *pLayerTilemap = reinterpret_cast<const CMapItemLayerTilemap *>(pLayer);
+				if(!ValidateAndUnpackTilesLayerData(NewDataFile, GroupIndex, LayerIndex, pLayerTilemap, UsedDataIndices))
+				{
+					return false;
+				}
+				if(pLayerTilemap->m_Flags & TILESLAYERFLAG_GAME)
+				{
+					pGameLayer = pLayerTilemap;
+				}
+			}
+		}
+	}
+	if(pGameLayer == nullptr)
+	{
+		log_error("map/load", "Game layer is missing.");
+		return false;
+	}
+	// Load and implicitly validate game layer tile data immediately because we need it.
+	// Do not preload other data to avoid excessive memory usage.
+	if(NewDataFile.GetData(pGameLayer->m_Data) == nullptr)
+	{
+		log_error("map/load", "Game layer data is invalid.");
+		return false;
 	}
 
 	// Replace existing datafile with new datafile
@@ -182,24 +230,6 @@ int CMap::Size() const
 	return m_DataFile.Size();
 }
 
-void CMap::ExtractTiles(CTile *pDest, size_t DestSize, const CTile *pSrc, size_t SrcSize)
-{
-	size_t DestIndex = 0;
-	size_t SrcIndex = 0;
-	while(DestIndex < DestSize && SrcIndex < SrcSize)
-	{
-		for(unsigned Counter = 0; Counter <= pSrc[SrcIndex].m_Skip && DestIndex < DestSize; Counter++)
-		{
-			pDest[DestIndex].m_Index = pSrc[SrcIndex].m_Index;
-			pDest[DestIndex].m_Flags = pSrc[SrcIndex].m_Flags;
-			pDest[DestIndex].m_Skip = 0;
-			pDest[DestIndex].m_MustBe0 = 0;
-			DestIndex++;
-		}
-		SrcIndex++;
-	}
-}
-
 bool CMap::ValidateMapVersion(CDataFileReader &NewDataFile)
 {
 	const int VersionItemIndex = NewDataFile.FindItemIndex(MAPITEMTYPE_VERSION, 0);
@@ -220,6 +250,441 @@ bool CMap::ValidateMapVersion(CDataFileReader &NewDataFile)
 		log_error("map/load", "Map version %d is not supported.", pVersionItem->m_Version);
 		return false;
 	}
+	return true;
+}
+
+bool CMap::ExtractTiles(CTile *pDest, size_t DestSize, const CTile *pSrc, size_t SrcSize)
+{
+	size_t DestIndex = 0;
+	size_t SrcIndex = 0;
+	while(DestIndex < DestSize && SrcIndex < SrcSize)
+	{
+		if(pSrc[SrcIndex].m_MustBe0 != 0)
+		{
+			log_error("map/load", "Tile layer data contains non-zero padding value %d at index %" PRIzu ".",
+				pSrc[SrcIndex].m_MustBe0, SrcIndex);
+			return false;
+		}
+		for(unsigned Counter = 0; Counter <= pSrc[SrcIndex].m_Skip && DestIndex < DestSize; Counter++)
+		{
+			pDest[DestIndex].m_Index = pSrc[SrcIndex].m_Index;
+			pDest[DestIndex].m_Flags = pSrc[SrcIndex].m_Flags;
+			pDest[DestIndex].m_Skip = 0;
+			pDest[DestIndex].m_MustBe0 = 0;
+			DestIndex++;
+		}
+		SrcIndex++;
+	}
+	if(DestIndex != DestSize)
+	{
+		log_error("map/load", "Tile layer data is truncated (got %" PRIzu ", wanted %" PRIzu ").",
+			DestIndex, DestSize);
+		return false;
+	}
+	if(SrcIndex != SrcSize)
+	{
+		log_error("map/load", "Too much tile layer data (read %" PRIzu ", total %" PRIzu ").",
+			SrcIndex, SrcSize);
+		return false;
+	}
+	return true;
+}
+
+static bool EnsureTileLayerProperties(int GroupIndex, int LayerIndex, CMapItemLayerTilemap &LayerTilemap)
+{
+	if(LayerTilemap.m_Width < 2)
+	{
+		log_error("map/load", "Tile layer %d in group %d has invalid width %d.",
+			LayerIndex, GroupIndex, LayerTilemap.m_Width);
+		return false;
+	}
+
+	if(LayerTilemap.m_Height < 2)
+	{
+		log_error("map/load", "Tile layer %d in group %d has invalid height %d.",
+			LayerIndex, GroupIndex, LayerTilemap.m_Height);
+		return false;
+	}
+
+	const auto &&EnsureValidName = [&](const char *pExpectedName) {
+		char aCurrentName[sizeof(LayerTilemap.m_aName)];
+		if(!IntsToStr(LayerTilemap.m_aName, std::size(LayerTilemap.m_aName), aCurrentName, std::size(aCurrentName)))
+		{
+			log_error("map/load", "Tile layer %d in group %d has invalid name.",
+				LayerIndex, GroupIndex);
+			return false;
+		}
+		else if(pExpectedName != nullptr && str_comp(aCurrentName, pExpectedName) != 0)
+		{
+			log_debug("map/load", "Physics tile layer %d in group %d has unexpected name '%s'. Resetting to '%s'.",
+				LayerIndex, GroupIndex, aCurrentName, pExpectedName);
+			StrToInts(LayerTilemap.m_aName, std::size(LayerTilemap.m_aName), pExpectedName);
+		}
+		return true;
+	};
+
+	const auto &&EnsureDefaultColor = [&]() {
+		const CColor DefaultColor = CColor{255, 255, 255, 255};
+		if(LayerTilemap.m_Color != DefaultColor)
+		{
+			log_debug("map/load", "Physics tile layer %d in group %d has unexpected color (%d, %d, %d, %d). Resetting to default.",
+				LayerIndex, GroupIndex, LayerTilemap.m_Color.r, LayerTilemap.m_Color.g, LayerTilemap.m_Color.b, LayerTilemap.m_Color.a);
+			LayerTilemap.m_Color = DefaultColor;
+		}
+	};
+
+	const auto &&EnsureNoDetailFlag = [&]() {
+		if(LayerTilemap.m_Layer.m_Flags & LAYERFLAG_DETAIL)
+		{
+			log_debug("map/load", "Physics tile layer %d in group %d has detail flag set. Resetting to non-detail.",
+				LayerIndex, GroupIndex);
+			LayerTilemap.m_Layer.m_Flags &= ~LAYERFLAG_DETAIL;
+		}
+	};
+
+	if(LayerTilemap.m_Flags & TILESLAYERFLAG_GAME)
+	{
+		if(!EnsureValidName("Game"))
+		{
+			return false;
+		}
+		EnsureDefaultColor();
+		EnsureNoDetailFlag();
+	}
+	else if(LayerTilemap.m_Flags & TILESLAYERFLAG_TELE)
+	{
+		if(!EnsureValidName("Tele"))
+		{
+			return false;
+		}
+		EnsureDefaultColor();
+		EnsureNoDetailFlag();
+	}
+	else if(LayerTilemap.m_Flags & TILESLAYERFLAG_SPEEDUP)
+	{
+		if(!EnsureValidName("Speedup"))
+		{
+			return false;
+		}
+		EnsureDefaultColor();
+		EnsureNoDetailFlag();
+	}
+	else if(LayerTilemap.m_Flags & TILESLAYERFLAG_FRONT)
+	{
+		if(!EnsureValidName("Front"))
+		{
+			return false;
+		}
+		EnsureDefaultColor();
+		EnsureNoDetailFlag();
+	}
+	else if(LayerTilemap.m_Flags & TILESLAYERFLAG_SWITCH)
+	{
+		if(!EnsureValidName("Switch"))
+		{
+			return false;
+		}
+		EnsureDefaultColor();
+		EnsureNoDetailFlag();
+	}
+	else if(LayerTilemap.m_Flags & TILESLAYERFLAG_TUNE)
+	{
+		if(!EnsureValidName("Tune"))
+		{
+			return false;
+		}
+		EnsureDefaultColor();
+		EnsureNoDetailFlag();
+	}
+	else
+	{
+		if(!EnsureValidName(nullptr))
+		{
+			return false;
+		}
+
+		if(!in_range(LayerTilemap.m_Color.r, 0, 255) ||
+			!in_range(LayerTilemap.m_Color.g, 0, 255) ||
+			!in_range(LayerTilemap.m_Color.b, 0, 255) ||
+			!in_range(LayerTilemap.m_Color.a, 0, 255))
+		{
+			log_error("map/load", "Tile layer %d in group %d has invalid color (%d, %d, %d, %d).",
+				LayerIndex, GroupIndex, LayerTilemap.m_Color.r, LayerTilemap.m_Color.g, LayerTilemap.m_Color.b, LayerTilemap.m_Color.a);
+			return false;
+		}
+	}
+
+	const auto &&EnsureUnsetPhysicsData = [&](int TilesLayerFlag, int *pDataIndex, const char *pName) {
+		if((LayerTilemap.m_Flags & TilesLayerFlag) == 0 && *pDataIndex != -1)
+		{
+			log_debug("map/load", "Tile layer %d in group %d has unused %s data index %d. Resetting to -1.",
+				LayerIndex, GroupIndex, pName, *pDataIndex);
+			*pDataIndex = -1;
+		}
+	};
+	EnsureUnsetPhysicsData(TILESLAYERFLAG_TELE, &LayerTilemap.m_Tele, "tele");
+	EnsureUnsetPhysicsData(TILESLAYERFLAG_SPEEDUP, &LayerTilemap.m_Speedup, "speedup");
+	EnsureUnsetPhysicsData(TILESLAYERFLAG_FRONT, &LayerTilemap.m_Front, "front");
+	EnsureUnsetPhysicsData(TILESLAYERFLAG_SWITCH, &LayerTilemap.m_Switch, "switch");
+	EnsureUnsetPhysicsData(TILESLAYERFLAG_TUNE, &LayerTilemap.m_Tune, "tune");
+
+	return true;
+}
+
+bool CMap::UpgradeAndValidateTilesLayerItem(
+	CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex,
+	CMapItemLayerTilemap_v2 *pLayerTilemapBase, int LayerItemIndex, size_t LayerItemSize)
+{
+	if(LayerItemSize < sizeof(CMapItemLayerTilemap_v2))
+	{
+		log_error("map/load", "Tile layer %d in group %d is truncated (size %" PRIzu ").",
+			LayerIndex, GroupIndex, LayerItemSize);
+		return false;
+	}
+
+	if(!in_range(pLayerTilemapBase->m_Version, 2, 4))
+	{
+		log_error("map/load", "Tile layer %d in group %d has unsupported version %d.",
+			LayerIndex, GroupIndex, pLayerTilemapBase->m_Version);
+		return false;
+	}
+
+	if(!AtMostOneBitSet(pLayerTilemapBase->m_Flags & (TILESLAYERFLAG_GAME | TILESLAYERFLAG_TELE | TILESLAYERFLAG_SPEEDUP | TILESLAYERFLAG_FRONT | TILESLAYERFLAG_SWITCH | TILESLAYERFLAG_TUNE)))
+	{
+		log_error("map/load", "Tile layer %d in group %d has invalid combination of flags %d. At most one physics tile layer flag can be set.",
+			LayerIndex, GroupIndex, pLayerTilemapBase->m_Flags);
+		return false;
+	}
+
+	const auto &&UnpackPhysicsLayerDataIndex = [&](int TilesLayerFlag, int *pTargetDataIndex, const int *pSourceDataIndex, const CMapItemLayerTilemap_v2 *pSourceTileLayer, const char *pName) {
+		// We have to check the size individually for each tile data index because old maps were created
+		// containing only some prefix of the physics tile data indices without incrementing the version.
+		if(LayerItemSize < reinterpret_cast<const uint8_t *>(pSourceDataIndex) - reinterpret_cast<const uint8_t *>(pSourceTileLayer) + sizeof(*pSourceDataIndex))
+		{
+			if(pSourceTileLayer->m_Flags & TilesLayerFlag)
+			{
+				log_error("map/load", "%s layer %d in group %d is truncated (version %d, size %" PRIzu ").",
+					pName, LayerIndex, GroupIndex, pSourceTileLayer->m_Version, LayerItemSize);
+				return false;
+			}
+			*pTargetDataIndex = -1;
+		}
+		else
+		{
+			*pTargetDataIndex = *pSourceDataIndex;
+		}
+		return true;
+	};
+
+	if(pLayerTilemapBase->m_Version == 2)
+	{
+		const CMapItemLayerTilemap_v2Legacy *pLayerTilemapLegacy = static_cast<const CMapItemLayerTilemap_v2Legacy *>(pLayerTilemapBase);
+		CMapItemLayerTilemap OverriddenLayerTilemap;
+		mem_copy(&OverriddenLayerTilemap, pLayerTilemapLegacy, sizeof(CMapItemLayerTilemap_v2));
+
+		// Version 2 items have no name. Default to empty string. We fix the name of physics layers later.
+		StrToInts(OverriddenLayerTilemap.m_aName, std::size(OverriddenLayerTilemap.m_aName), "");
+
+		if(!UnpackPhysicsLayerDataIndex(TILESLAYERFLAG_TELE, &OverriddenLayerTilemap.m_Tele, &pLayerTilemapLegacy->m_Tele, pLayerTilemapBase, "Tele") ||
+			!UnpackPhysicsLayerDataIndex(TILESLAYERFLAG_SPEEDUP, &OverriddenLayerTilemap.m_Speedup, &pLayerTilemapLegacy->m_Speedup, pLayerTilemapBase, "Speedup") ||
+			!UnpackPhysicsLayerDataIndex(TILESLAYERFLAG_FRONT, &OverriddenLayerTilemap.m_Front, &pLayerTilemapLegacy->m_Front, pLayerTilemapBase, "Front") ||
+			!UnpackPhysicsLayerDataIndex(TILESLAYERFLAG_SWITCH, &OverriddenLayerTilemap.m_Switch, &pLayerTilemapLegacy->m_Switch, pLayerTilemapBase, "Switch") ||
+			!UnpackPhysicsLayerDataIndex(TILESLAYERFLAG_TUNE, &OverriddenLayerTilemap.m_Tune, &pLayerTilemapLegacy->m_Tune, pLayerTilemapBase, "Tune"))
+		{
+			return false;
+		}
+		if(!EnsureTileLayerProperties(GroupIndex, LayerIndex, OverriddenLayerTilemap))
+		{
+			return false;
+		}
+		if(!NewDataFile.OverrideItemData(LayerItemIndex, &OverriddenLayerTilemap, sizeof(OverriddenLayerTilemap)))
+		{
+			return false;
+		}
+	}
+	else if(LayerItemSize < sizeof(CMapItemLayerTilemap))
+	{
+		const CMapItemLayerTilemap *pLayerTilemapLegacy = static_cast<const CMapItemLayerTilemap *>(pLayerTilemapBase);
+		CMapItemLayerTilemap OverriddenLayerTilemap;
+		mem_copy(&OverriddenLayerTilemap, pLayerTilemapLegacy, sizeof(CMapItemLayerTilemap_v3Teeworlds));
+
+		if(!UnpackPhysicsLayerDataIndex(TILESLAYERFLAG_TELE, &OverriddenLayerTilemap.m_Tele, &pLayerTilemapLegacy->m_Tele, pLayerTilemapBase, "Tele") ||
+			!UnpackPhysicsLayerDataIndex(TILESLAYERFLAG_SPEEDUP, &OverriddenLayerTilemap.m_Speedup, &pLayerTilemapLegacy->m_Speedup, pLayerTilemapBase, "Speedup") ||
+			!UnpackPhysicsLayerDataIndex(TILESLAYERFLAG_FRONT, &OverriddenLayerTilemap.m_Front, &pLayerTilemapLegacy->m_Front, pLayerTilemapBase, "Front") ||
+			!UnpackPhysicsLayerDataIndex(TILESLAYERFLAG_SWITCH, &OverriddenLayerTilemap.m_Switch, &pLayerTilemapLegacy->m_Switch, pLayerTilemapBase, "Switch") ||
+			!UnpackPhysicsLayerDataIndex(TILESLAYERFLAG_TUNE, &OverriddenLayerTilemap.m_Tune, &pLayerTilemapLegacy->m_Tune, pLayerTilemapBase, "Tune"))
+		{
+			return false;
+		}
+		if(!EnsureTileLayerProperties(GroupIndex, LayerIndex, OverriddenLayerTilemap))
+		{
+			return false;
+		}
+		if(!NewDataFile.OverrideItemData(LayerItemIndex, &OverriddenLayerTilemap, sizeof(OverriddenLayerTilemap)))
+		{
+			return false;
+		}
+	}
+	else // latest version, whole CMapItemLayerTilemap available
+	{
+		if(!EnsureTileLayerProperties(GroupIndex, LayerIndex, *static_cast<CMapItemLayerTilemap *>(pLayerTilemapBase)))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool CMap::ValidateAndUnpackTilesLayerData(CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex, const CMapItemLayerTilemap *pLayerTilemap, std::set<int> &UsedDataIndices)
+{
+	size_t TileSize;
+	int DataIndex;
+	int LayerType;
+	if(pLayerTilemap->m_Flags & TILESLAYERFLAG_GAME)
+	{
+		TileSize = sizeof(CTile);
+		DataIndex = pLayerTilemap->m_Data;
+		LayerType = LAYERTYPE_GAME;
+	}
+	else if(pLayerTilemap->m_Flags & TILESLAYERFLAG_TELE)
+	{
+		TileSize = sizeof(CTeleTile);
+		DataIndex = pLayerTilemap->m_Tele;
+		LayerType = LAYERTYPE_TELE;
+	}
+	else if(pLayerTilemap->m_Flags & TILESLAYERFLAG_SPEEDUP)
+	{
+		TileSize = sizeof(CSpeedupTile);
+		DataIndex = pLayerTilemap->m_Speedup;
+		LayerType = LAYERTYPE_SPEEDUP;
+	}
+	else if(pLayerTilemap->m_Flags & TILESLAYERFLAG_FRONT)
+	{
+		TileSize = sizeof(CTile);
+		DataIndex = pLayerTilemap->m_Front;
+		LayerType = LAYERTYPE_FRONT;
+	}
+	else if(pLayerTilemap->m_Flags & TILESLAYERFLAG_SWITCH)
+	{
+		TileSize = sizeof(CSwitchTile);
+		DataIndex = pLayerTilemap->m_Switch;
+		LayerType = LAYERTYPE_SWITCH;
+	}
+	else if(pLayerTilemap->m_Flags & TILESLAYERFLAG_TUNE)
+	{
+		TileSize = sizeof(CTuneTile);
+		DataIndex = pLayerTilemap->m_Tune;
+		LayerType = LAYERTYPE_TUNE;
+	}
+	else
+	{
+		TileSize = sizeof(CTile);
+		DataIndex = pLayerTilemap->m_Data;
+		LayerType = LAYERTYPE_TILES;
+	}
+
+	if(DataIndex < 0 || DataIndex >= NewDataFile.NumData())
+	{
+		log_error("map/load", "Tile data index %d of layer %d in group %d is invalid.", DataIndex, LayerIndex, GroupIndex);
+		return false;
+	}
+
+	const auto &[_, DataUnique] = UsedDataIndices.emplace(DataIndex);
+	if(!DataUnique)
+	{
+		log_error("map/load", "Tile data index %d of layer %d in group %d is not unique.", DataIndex, LayerIndex, GroupIndex);
+		return false;
+	}
+
+	const size_t TilemapCount = (size_t)pLayerTilemap->m_Width * pLayerTilemap->m_Height;
+	const size_t TilemapSize = TilemapCount * TileSize;
+
+	if(((int)TilemapCount / pLayerTilemap->m_Width != pLayerTilemap->m_Height) || (TilemapSize / TileSize != TilemapCount))
+	{
+		log_error("map/load", "Tile layer %d in group %d is too big (%d * %d * %" PRIzu " causes an integer overflow).",
+			LayerIndex, GroupIndex, pLayerTilemap->m_Width, pLayerTilemap->m_Height, TileSize);
+		return false;
+	}
+
+	NewDataFile.AddDataProcessor(DataIndex, [pLayerTilemap, TileSize, LayerType, GroupIndex, LayerIndex, TilemapCount, TilemapSize](void *pData, size_t Size) -> std::pair<void *, size_t> {
+		const size_t SavedTilesSize = Size / TileSize;
+		if(pLayerTilemap->m_Version >= 4)
+		{
+			// CMapItemLayerTilemap with this version are only written to maps in upstream Teeworlds.
+			// The tile data of tilemaps using this version must be unpacked by repeating tiles
+			// according to the CTile::m_Skip values of the packed tile data.
+			if(LayerType != LAYERTYPE_TILES && LayerType != LAYERTYPE_GAME)
+			{
+				log_error("map/load", "Layer %d in group %d uses tileskip but this is only supported for tiles and game layers.",
+					LayerIndex, GroupIndex);
+				free(pData);
+				return std::make_pair(nullptr, 0);
+			}
+			CTile *pTiles = static_cast<CTile *>(malloc(TilemapSize));
+			if(pTiles == nullptr)
+			{
+				log_error("map/load", "Failed to allocate memory for layer %d in group %d (size %d * %d).",
+					LayerIndex, GroupIndex, pLayerTilemap->m_Width, pLayerTilemap->m_Height);
+				free(pData);
+				return std::make_pair(nullptr, 0);
+			}
+			else if(!ExtractTiles(pTiles, (size_t)pLayerTilemap->m_Width * pLayerTilemap->m_Height, static_cast<const CTile *>(pData), SavedTilesSize))
+			{
+				log_error("map/load", "Failed to extract tiles of layer %d in group %d.",
+					LayerIndex, GroupIndex);
+				free(pTiles);
+				free(pData);
+				return std::make_pair(nullptr, 0);
+			}
+			free(pData);
+			return std::make_pair(pTiles, TilemapSize);
+		}
+		else if(SavedTilesSize < TilemapCount)
+		{
+			log_error("map/load", "Tile data of layer %d in group %d is truncated (got %" PRIzu ", wanted %" PRIzu ").",
+				LayerIndex, GroupIndex, SavedTilesSize, TilemapCount);
+			free(pData);
+			return std::make_pair(nullptr, 0);
+		}
+		else if(LayerType == LAYERTYPE_TILES || LayerType == LAYERTYPE_GAME || LayerType == LAYERTYPE_FRONT)
+		{
+			const CTile *pTileData = static_cast<const CTile *>(pData);
+			for(size_t TileIndex = 0; TileIndex < TilemapCount; ++TileIndex)
+			{
+				if(pTileData[TileIndex].m_Skip != 0)
+				{
+					log_error("map/load", "Tile data of layer %d in group %d contains non-zero skip value %d at index %" PRIzu " but version %d does not use tileskip.",
+						LayerIndex, GroupIndex, pTileData[TileIndex].m_Skip, TileIndex, pLayerTilemap->m_Version);
+					free(pData);
+					return std::make_pair(nullptr, 0);
+				}
+				if(pTileData[TileIndex].m_MustBe0 != 0)
+				{
+					log_error("map/load", "Tile data of layer %d in group %d contains non-zero padding value %d at index %" PRIzu ".",
+						LayerIndex, GroupIndex, pTileData[TileIndex].m_MustBe0, TileIndex);
+					free(pData);
+					return std::make_pair(nullptr, 0);
+				}
+			}
+		}
+		else if(LayerType == LAYERTYPE_SPEEDUP)
+		{
+			const CSpeedupTile *pSpeedupData = static_cast<const CSpeedupTile *>(pData);
+			for(size_t TileIndex = 0; TileIndex < TilemapCount; ++TileIndex)
+			{
+				if(pSpeedupData[TileIndex].m_MustBe0 != 0)
+				{
+					log_error("map/load", "Speedup tile data of layer %d in group %d contains non-zero padding value %d at index %" PRIzu ".",
+						LayerIndex, GroupIndex, pSpeedupData[TileIndex].m_MustBe0, TileIndex);
+					free(pData);
+					return std::make_pair(nullptr, 0);
+				}
+			}
+		}
+		return std::make_pair(pData, Size);
+	});
+
 	return true;
 }
 

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -105,12 +105,34 @@ bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, in
 	NewDataFile.GetType(MAPITEMTYPE_LAYER, &LayersStart, &LayersNum);
 
 	// Replace map items for old versions with items compatible with latest version to avoid version checks when using the map items.
+	// Ensure that we have a game layer and game group.
+	const CMapItemLayerTilemap *pGameLayer = nullptr;
+	std::set<int> UsedLayerItemIndices;
 	for(int GroupIndex = 0; GroupIndex < GroupsNum; GroupIndex++)
 	{
+		const size_t GroupItemSize = NewDataFile.GetItemSize(GroupsStart + GroupIndex);
+		if(GroupItemSize < sizeof(CMapItemGroup_v1))
+		{
+			log_error("map/load", "Group %d is truncated (size %" PRIzu ").", GroupIndex, GroupItemSize);
+			return false;
+		}
 		const CMapItemGroup *pGroup = static_cast<CMapItemGroup *>(NewDataFile.GetItem(GroupsStart + GroupIndex));
+		if(pGroup->m_StartLayer < 0 || pGroup->m_NumLayers < 0 ||
+			(int64_t)pGroup->m_StartLayer + pGroup->m_NumLayers > LayersNum)
+		{
+			log_error("map/load", "Group %d uses invalid layers %d to %d (the map contains %d layers).",
+				GroupIndex, pGroup->m_StartLayer, pGroup->m_StartLayer + pGroup->m_NumLayers - 1, LayersNum);
+			return false;
+		}
 		for(int LayerIndex = 0; LayerIndex < pGroup->m_NumLayers; LayerIndex++)
 		{
 			const int LayerItemIndex = LayersStart + pGroup->m_StartLayer + LayerIndex;
+			const auto &[_, LayerUnique] = UsedLayerItemIndices.emplace(LayerItemIndex);
+			if(!LayerUnique)
+			{
+				log_error("map/load", "Layer %d in group %d is also being used by another group.", LayerIndex, GroupIndex);
+				return false;
+			}
 			CMapItemLayer *pLayer = static_cast<CMapItemLayer *>(NewDataFile.GetItem(LayerItemIndex));
 			const size_t LayerItemSize = NewDataFile.GetItemSize(LayerItemIndex);
 			if(LayerItemSize < sizeof(CMapItemLayer))
@@ -131,27 +153,8 @@ bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, in
 				{
 					return false;
 				}
-			}
-		}
-	}
-
-	// Lazily validate data and replace compressed tile layers with uncompressed ones.
-	// Ensure that we have a game layer and game group.
-	const CMapItemLayerTilemap *pGameLayer = nullptr;
-	std::set<int> UsedDataIndices;
-	for(int GroupIndex = 0; GroupIndex < GroupsNum; GroupIndex++)
-	{
-		const CMapItemGroup *pGroup = static_cast<CMapItemGroup *>(NewDataFile.GetItem(GroupsStart + GroupIndex));
-		for(int LayerIndex = 0; LayerIndex < pGroup->m_NumLayers; LayerIndex++)
-		{
-			CMapItemLayer *pLayer = static_cast<CMapItemLayer *>(NewDataFile.GetItem(LayersStart + pGroup->m_StartLayer + LayerIndex));
-			if(pLayer->m_Type == LAYERTYPE_TILES)
-			{
-				const CMapItemLayerTilemap *pLayerTilemap = reinterpret_cast<const CMapItemLayerTilemap *>(pLayer);
-				if(!ValidateAndUnpackTilesLayerData(NewDataFile, GroupIndex, LayerIndex, pLayerTilemap, UsedDataIndices))
-				{
-					return false;
-				}
+				// The item may have been replaced, so the pointer must be determined again.
+				const CMapItemLayerTilemap *pLayerTilemap = static_cast<CMapItemLayerTilemap *>(NewDataFile.GetItem(LayerItemIndex));
 				if(pLayerTilemap->m_Flags & TILESLAYERFLAG_GAME)
 				{
 					pGameLayer = pLayerTilemap;
@@ -164,6 +167,25 @@ bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, in
 		log_error("map/load", "Game layer is missing.");
 		return false;
 	}
+
+	// Lazily validate data and replace compressed tile layers with uncompressed ones.
+	std::set<int> UsedDataIndices;
+	for(int GroupIndex = 0; GroupIndex < GroupsNum; GroupIndex++)
+	{
+		const CMapItemGroup *pGroup = static_cast<CMapItemGroup *>(NewDataFile.GetItem(GroupsStart + GroupIndex));
+		for(int LayerIndex = 0; LayerIndex < pGroup->m_NumLayers; LayerIndex++)
+		{
+			CMapItemLayer *pLayer = static_cast<CMapItemLayer *>(NewDataFile.GetItem(LayersStart + pGroup->m_StartLayer + LayerIndex));
+			if(pLayer->m_Type == LAYERTYPE_TILES)
+			{
+				if(!ValidateAndUnpackTilesLayerData(NewDataFile, GroupIndex, LayerIndex, reinterpret_cast<const CMapItemLayerTilemap *>(pLayer), *pGameLayer, UsedDataIndices))
+				{
+					return false;
+				}
+			}
+		}
+	}
+
 	// Load and implicitly validate game layer tile data immediately because we need it.
 	// Do not preload other data to avoid excessive memory usage.
 	if(NewDataFile.GetData(pGameLayer->m_Data) == nullptr)
@@ -502,6 +524,14 @@ bool CMap::UpgradeAndValidateTilesLayerItem(
 			return false;
 		}
 	}
+	else if(LayerItemSize < sizeof(CMapItemLayerTilemap_v3Teeworlds))
+	{
+		// Only the physics layer data indices added by DDRace may be truncated in
+		// version 3 and 4 items, the layer name must always be complete.
+		log_error("map/load", "Tile layer %d in group %d is truncated (version %d, size %" PRIzu ").",
+			LayerIndex, GroupIndex, pLayerTilemapBase->m_Version, LayerItemSize);
+		return false;
+	}
 	else if(LayerItemSize < sizeof(CMapItemLayerTilemap))
 	{
 		const CMapItemLayerTilemap *pLayerTilemapLegacy = static_cast<const CMapItemLayerTilemap *>(pLayerTilemapBase);
@@ -536,7 +566,7 @@ bool CMap::UpgradeAndValidateTilesLayerItem(
 	return true;
 }
 
-bool CMap::ValidateAndUnpackTilesLayerData(CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex, const CMapItemLayerTilemap *pLayerTilemap, std::set<int> &UsedDataIndices)
+bool CMap::ValidateAndUnpackTilesLayerData(CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex, const CMapItemLayerTilemap *pLayerTilemap, const CMapItemLayerTilemap &GameLayer, std::set<int> &UsedDataIndices)
 {
 	size_t TileSize;
 	int DataIndex;
@@ -604,6 +634,16 @@ bool CMap::ValidateAndUnpackTilesLayerData(CDataFileReader &NewDataFile, int Gro
 	{
 		log_error("map/load", "Tile layer %d in group %d is too big (%d * %d * %" PRIzu " causes an integer overflow).",
 			LayerIndex, GroupIndex, pLayerTilemap->m_Width, pLayerTilemap->m_Height, TileSize);
+		return false;
+	}
+
+	// The collision uses the size of the game layer for the data of all physics layers,
+	// so physics layers must contain at least as many tiles as the game layer.
+	if(LayerType != LAYERTYPE_TILES && LayerType != LAYERTYPE_GAME &&
+		TilemapCount < (size_t)GameLayer.m_Width * GameLayer.m_Height)
+	{
+		log_error("map/load", "Physics layer %d in group %d is smaller than the game layer (%d * %d < %d * %d).",
+			LayerIndex, GroupIndex, pLayerTilemap->m_Width, pLayerTilemap->m_Height, GameLayer.m_Width, GameLayer.m_Height);
 		return false;
 	}
 

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -9,6 +9,11 @@
 
 #include <engine/map.h>
 
+#include <set>
+
+class CMapItemLayerTilemap;
+class CMapItemLayerTilemap_v2;
+
 class CMap : public IMap
 {
 	CDataFileReader m_DataFile;
@@ -44,10 +49,12 @@ public:
 	unsigned Crc() const override;
 	int Size() const override;
 
-	static void ExtractTiles(class CTile *pDest, size_t DestSize, const class CTile *pSrc, size_t SrcSize);
-
 private:
 	static bool ValidateMapVersion(CDataFileReader &NewDataFile);
+	static bool ExtractTiles(class CTile *pDest, size_t DestSize, const class CTile *pSrc, size_t SrcSize);
+	bool UpgradeAndValidateTilesLayerItem(CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex,
+		CMapItemLayerTilemap_v2 *pLayerTilemapBase, int LayerItemIndex, size_t LayerItemSize);
+	bool ValidateAndUnpackTilesLayerData(CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex, const CMapItemLayerTilemap *pLayerTilemap, std::set<int> &UsedDataIndices);
 };
 
 #endif

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -54,7 +54,8 @@ private:
 	static bool ExtractTiles(class CTile *pDest, size_t DestSize, const class CTile *pSrc, size_t SrcSize);
 	bool UpgradeAndValidateTilesLayerItem(CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex,
 		CMapItemLayerTilemap_v2 *pLayerTilemapBase, int LayerItemIndex, size_t LayerItemSize);
-	bool ValidateAndUnpackTilesLayerData(CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex, const CMapItemLayerTilemap *pLayerTilemap, std::set<int> &UsedDataIndices);
+	bool ValidateAndUnpackTilesLayerData(CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex, const CMapItemLayerTilemap *pLayerTilemap,
+		const CMapItemLayerTilemap &GameLayer, std::set<int> &UsedDataIndices);
 };
 
 #endif

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -265,30 +265,20 @@ void CMenuBackground::LoadMenuBackground(bool HasDayHint, bool HasNightHint)
 			CMapLayers::OnMapLoad();
 
 			// look for custom positions
-			CMapItemLayerTilemap *pTLayer = m_pLayers->GameLayer();
-			if(pTLayer)
+			CMapItemLayerTilemap *pGameLayer = m_pLayers->GameLayer();
+			const CTile *pTiles = static_cast<const CTile *>(m_pLayers->Map()->GetData(pGameLayer->m_Data));
+			for(int y = 0; y < pGameLayer->m_Height; ++y)
 			{
-				int DataIndex = pTLayer->m_Data;
-				unsigned int Size = m_pLayers->Map()->GetDataSize(DataIndex);
-				void *pTiles = m_pLayers->Map()->GetData(DataIndex);
-				unsigned int TileSize = sizeof(CTile);
-
-				if(Size >= pTLayer->m_Width * pTLayer->m_Height * TileSize)
+				for(int x = 0; x < pGameLayer->m_Width; ++x)
 				{
-					for(int y = 0; y < pTLayer->m_Height; ++y)
+					unsigned char Index = pTiles[y * pGameLayer->m_Width + x].m_Index;
+					if(Index >= TILE_TIME_CHECKPOINT_FIRST && Index <= TILE_TIME_CHECKPOINT_LAST)
 					{
-						for(int x = 0; x < pTLayer->m_Width; ++x)
-						{
-							unsigned char Index = ((CTile *)pTiles)[y * pTLayer->m_Width + x].m_Index;
-							if(Index >= TILE_TIME_CHECKPOINT_FIRST && Index <= TILE_TIME_CHECKPOINT_LAST)
-							{
-								int ArrayIndex = std::clamp<int>((Index - TILE_TIME_CHECKPOINT_FIRST), 0, NUM_POS);
-								m_aPositions[ArrayIndex] = vec2(x * 32.0f + 16.0f, y * 32.0f + 16.0f);
-							}
-
-							x += ((CTile *)pTiles)[y * pTLayer->m_Width + x].m_Skip;
-						}
+						int ArrayIndex = std::clamp<int>((Index - TILE_TIME_CHECKPOINT_FIRST), 0, NUM_POS);
+						m_aPositions[ArrayIndex] = vec2(x * 32.0f + 16.0f, y * 32.0f + 16.0f);
 					}
+
+					x += pTiles[y * pGameLayer->m_Width + x].m_Skip;
 				}
 			}
 		}

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -60,40 +60,29 @@ void CCollision::Init(class CLayers *pLayers)
 
 	if(m_pLayers->TeleLayer())
 	{
-		unsigned int Size = m_pLayers->Map()->GetDataSize(m_pLayers->TeleLayer()->m_Tele);
-		if(Size >= (size_t)m_Width * m_Height * sizeof(CTeleTile))
-			m_pTele = static_cast<CTeleTile *>(m_pLayers->Map()->GetData(m_pLayers->TeleLayer()->m_Tele));
+		m_pTele = static_cast<CTeleTile *>(m_pLayers->Map()->GetData(m_pLayers->TeleLayer()->m_Tele));
 	}
 
 	if(m_pLayers->SpeedupLayer())
 	{
-		unsigned int Size = m_pLayers->Map()->GetDataSize(m_pLayers->SpeedupLayer()->m_Speedup);
-		if(Size >= (size_t)m_Width * m_Height * sizeof(CSpeedupTile))
-			m_pSpeedup = static_cast<CSpeedupTile *>(m_pLayers->Map()->GetData(m_pLayers->SpeedupLayer()->m_Speedup));
+		m_pSpeedup = static_cast<CSpeedupTile *>(m_pLayers->Map()->GetData(m_pLayers->SpeedupLayer()->m_Speedup));
 	}
 
 	if(m_pLayers->SwitchLayer())
 	{
-		unsigned int Size = m_pLayers->Map()->GetDataSize(m_pLayers->SwitchLayer()->m_Switch);
-		if(Size >= (size_t)m_Width * m_Height * sizeof(CSwitchTile))
-			m_pSwitch = static_cast<CSwitchTile *>(m_pLayers->Map()->GetData(m_pLayers->SwitchLayer()->m_Switch));
-
+		m_pSwitch = static_cast<CSwitchTile *>(m_pLayers->Map()->GetData(m_pLayers->SwitchLayer()->m_Switch));
 		m_pDoor = new CDoorTile[m_Width * m_Height];
 		mem_zero(m_pDoor, (size_t)m_Width * m_Height * sizeof(CDoorTile));
 	}
 
 	if(m_pLayers->TuneLayer())
 	{
-		unsigned int Size = m_pLayers->Map()->GetDataSize(m_pLayers->TuneLayer()->m_Tune);
-		if(Size >= (size_t)m_Width * m_Height * sizeof(CTuneTile))
-			m_pTune = static_cast<CTuneTile *>(m_pLayers->Map()->GetData(m_pLayers->TuneLayer()->m_Tune));
+		m_pTune = static_cast<CTuneTile *>(m_pLayers->Map()->GetData(m_pLayers->TuneLayer()->m_Tune));
 	}
 
 	if(m_pLayers->FrontLayer())
 	{
-		unsigned int Size = m_pLayers->Map()->GetDataSize(m_pLayers->FrontLayer()->m_Front);
-		if(Size >= (size_t)m_Width * m_Height * sizeof(CTile))
-			m_pFront = static_cast<CTile *>(m_pLayers->Map()->GetData(m_pLayers->FrontLayer()->m_Front));
+		m_pFront = static_cast<CTile *>(m_pLayers->Map()->GetData(m_pLayers->FrontLayer()->m_Front));
 	}
 
 	if(m_pSwitch)

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -7,7 +7,6 @@
 #include <engine/graphics.h>
 #include <engine/keys.h>
 #include <engine/shared/config.h>
-#include <engine/shared/map.h>
 
 #include <game/editor/editor.h>
 #include <game/editor/editor_actions.h>
@@ -135,20 +134,6 @@ void CLayerTiles::PrepareForSave()
 		for(int y = 0; y < m_Height; y++)
 			for(int x = 0; x < m_Width; x++)
 				m_pTiles[y * m_Width + x].m_Flags |= Map()->m_vpImages[m_Image]->m_aTileFlags[m_pTiles[y * m_Width + x].m_Index];
-	}
-}
-
-void CLayerTiles::ExtractTiles(const CTile *pSavedTiles, size_t SavedTilesSize) const
-{
-	const size_t DestSize = (size_t)m_Width * m_Height;
-	if(SavedTilesSize >= DestSize)
-	{
-		mem_copy(m_pTiles, pSavedTiles, DestSize * sizeof(CTile));
-		for(size_t TileIndex = 0; TileIndex < DestSize; ++TileIndex)
-		{
-			m_pTiles[TileIndex].m_Skip = 0;
-			m_pTiles[TileIndex].m_MustBe0 = 0;
-		}
 	}
 }
 
@@ -1008,40 +993,37 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 		FillGameTiles((EGameTileOp)Selected);
 	}
 
-	if(Map()->m_pGameLayer.get() != this)
+	if(m_Image >= 0 && (size_t)m_Image < Map()->m_vpImages.size() && Map()->m_vpImages[m_Image]->m_Automapper.IsLoaded() && m_AutomapperConfig != -1)
 	{
-		if(m_Image >= 0 && (size_t)m_Image < Map()->m_vpImages.size() && Map()->m_vpImages[m_Image]->m_Automapper.IsLoaded() && m_AutomapperConfig != -1)
+		pToolBox->HSplitBottom(2.0f, pToolBox, nullptr);
+		pToolBox->HSplitBottom(12.0f, pToolBox, &Button);
+		if(m_Seed != 0)
 		{
-			pToolBox->HSplitBottom(2.0f, pToolBox, nullptr);
-			pToolBox->HSplitBottom(12.0f, pToolBox, &Button);
-			if(m_Seed != 0)
+			CUIRect ButtonAuto;
+			Button.VSplitRight(16.0f, &Button, &ButtonAuto);
+			Button.VSplitRight(2.0f, &Button, nullptr);
+			static int s_AutomapperButtonAuto = 0;
+			if(Editor()->DoButton_Editor(&s_AutomapperButtonAuto, "A", m_AutoAutomapper, &ButtonAuto, BUTTONFLAG_LEFT, "Automatically run the automapper after modifications."))
 			{
-				CUIRect ButtonAuto;
-				Button.VSplitRight(16.0f, &Button, &ButtonAuto);
-				Button.VSplitRight(2.0f, &Button, nullptr);
-				static int s_AutomapperButtonAuto = 0;
-				if(Editor()->DoButton_Editor(&s_AutomapperButtonAuto, "A", m_AutoAutomapper, &ButtonAuto, BUTTONFLAG_LEFT, "Automatically run the automapper after modifications."))
+				m_AutoAutomapper = !m_AutoAutomapper;
+				FlagModified(0, 0, m_Width, m_Height);
+				if(!m_TilesHistory.empty()) // Sometimes pressing that button causes the automap to run so we should be able to undo that
 				{
-					m_AutoAutomapper = !m_AutoAutomapper;
-					FlagModified(0, 0, m_Width, m_Height);
-					if(!m_TilesHistory.empty()) // Sometimes pressing that button causes the automap to run so we should be able to undo that
-					{
-						// record undo
-						Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Map(), Map()->m_SelectedGroup, Map()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
-						ClearHistory();
-					}
+					// record undo
+					Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Map(), Map()->m_SelectedGroup, Map()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
+					ClearHistory();
 				}
 			}
+		}
 
-			static int s_AutomapperButton = 0;
-			if(Editor()->DoButton_Editor(&s_AutomapperButton, "Automap", 0, &Button, BUTTONFLAG_LEFT, "Run the automapper."))
-			{
-				Map()->m_vpImages[m_Image]->m_Automapper.Proceed(this, Map()->m_pGameLayer.get(), m_AutomapperReference, m_AutomapperConfig, m_Seed);
-				// record undo
-				Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Map(), Map()->m_SelectedGroup, Map()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
-				ClearHistory();
-				return CUi::POPUP_CLOSE_CURRENT;
-			}
+		static int s_AutomapperButton = 0;
+		if(Editor()->DoButton_Editor(&s_AutomapperButton, "Automap", 0, &Button, BUTTONFLAG_LEFT, "Run the automapper."))
+		{
+			Map()->m_vpImages[m_Image]->m_Automapper.Proceed(this, Map()->m_pGameLayer.get(), m_AutomapperReference, m_AutomapperConfig, m_Seed);
+			// record undo
+			Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Map(), Map()->m_SelectedGroup, Map()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
+			ClearHistory();
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 	}
 

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -993,37 +993,40 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 		FillGameTiles((EGameTileOp)Selected);
 	}
 
-	if(m_Image >= 0 && (size_t)m_Image < Map()->m_vpImages.size() && Map()->m_vpImages[m_Image]->m_Automapper.IsLoaded() && m_AutomapperConfig != -1)
+	if(Map()->m_pGameLayer.get() != this)
 	{
-		pToolBox->HSplitBottom(2.0f, pToolBox, nullptr);
-		pToolBox->HSplitBottom(12.0f, pToolBox, &Button);
-		if(m_Seed != 0)
+		if(m_Image >= 0 && (size_t)m_Image < Map()->m_vpImages.size() && Map()->m_vpImages[m_Image]->m_Automapper.IsLoaded() && m_AutomapperConfig != -1)
 		{
-			CUIRect ButtonAuto;
-			Button.VSplitRight(16.0f, &Button, &ButtonAuto);
-			Button.VSplitRight(2.0f, &Button, nullptr);
-			static int s_AutomapperButtonAuto = 0;
-			if(Editor()->DoButton_Editor(&s_AutomapperButtonAuto, "A", m_AutoAutomapper, &ButtonAuto, BUTTONFLAG_LEFT, "Automatically run the automapper after modifications."))
+			pToolBox->HSplitBottom(2.0f, pToolBox, nullptr);
+			pToolBox->HSplitBottom(12.0f, pToolBox, &Button);
+			if(m_Seed != 0)
 			{
-				m_AutoAutomapper = !m_AutoAutomapper;
-				FlagModified(0, 0, m_Width, m_Height);
-				if(!m_TilesHistory.empty()) // Sometimes pressing that button causes the automap to run so we should be able to undo that
+				CUIRect ButtonAuto;
+				Button.VSplitRight(16.0f, &Button, &ButtonAuto);
+				Button.VSplitRight(2.0f, &Button, nullptr);
+				static int s_AutomapperButtonAuto = 0;
+				if(Editor()->DoButton_Editor(&s_AutomapperButtonAuto, "A", m_AutoAutomapper, &ButtonAuto, BUTTONFLAG_LEFT, "Automatically run the automapper after modifications."))
 				{
-					// record undo
-					Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Map(), Map()->m_SelectedGroup, Map()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
-					ClearHistory();
+					m_AutoAutomapper = !m_AutoAutomapper;
+					FlagModified(0, 0, m_Width, m_Height);
+					if(!m_TilesHistory.empty()) // Sometimes pressing that button causes the automap to run so we should be able to undo that
+					{
+						// record undo
+						Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Map(), Map()->m_SelectedGroup, Map()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
+						ClearHistory();
+					}
 				}
 			}
-		}
 
-		static int s_AutomapperButton = 0;
-		if(Editor()->DoButton_Editor(&s_AutomapperButton, "Automap", 0, &Button, BUTTONFLAG_LEFT, "Run the automapper."))
-		{
-			Map()->m_vpImages[m_Image]->m_Automapper.Proceed(this, Map()->m_pGameLayer.get(), m_AutomapperReference, m_AutomapperConfig, m_Seed);
-			// record undo
-			Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Map(), Map()->m_SelectedGroup, Map()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
-			ClearHistory();
-			return CUi::POPUP_CLOSE_CURRENT;
+			static int s_AutomapperButton = 0;
+			if(Editor()->DoButton_Editor(&s_AutomapperButton, "Automap", 0, &Button, BUTTONFLAG_LEFT, "Run the automapper."))
+			{
+				Map()->m_vpImages[m_Image]->m_Automapper.Proceed(this, Map()->m_pGameLayer.get(), m_AutomapperReference, m_AutomapperConfig, m_Seed);
+				// record undo
+				Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(Map(), Map()->m_SelectedGroup, Map()->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
+				ClearHistory();
+				return CUi::POPUP_CLOSE_CURRENT;
+			}
 		}
 	}
 

--- a/src/game/editor/mapitems/layer_tiles.h
+++ b/src/game/editor/mapitems/layer_tiles.h
@@ -168,7 +168,6 @@ public:
 	void ModifyEnvelopeIndex(const FIndexModifyFunction &IndexModifyFunction) override;
 
 	void PrepareForSave();
-	void ExtractTiles(const CTile *pSavedTiles, size_t SavedTilesSize) const;
 
 	void GetSize(float *pWidth, float *pHeight) override
 	{

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -720,41 +720,26 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 					}
 					else if(pTilemapItem->m_Flags & TILESLAYERFLAG_TELE)
 					{
-						if(pTilemapItem->m_Version <= 2)
-							pTilemapItem->m_Tele = *((const int *)(pTilemapItem) + 15);
-
 						pTiles = std::make_shared<CLayerTele>(this, pTilemapItem->m_Width, pTilemapItem->m_Height);
 						MakeTeleLayer(pTiles);
 					}
 					else if(pTilemapItem->m_Flags & TILESLAYERFLAG_SPEEDUP)
 					{
-						if(pTilemapItem->m_Version <= 2)
-							pTilemapItem->m_Speedup = *((const int *)(pTilemapItem) + 16);
-
 						pTiles = std::make_shared<CLayerSpeedup>(this, pTilemapItem->m_Width, pTilemapItem->m_Height);
 						MakeSpeedupLayer(pTiles);
 					}
 					else if(pTilemapItem->m_Flags & TILESLAYERFLAG_FRONT)
 					{
-						if(pTilemapItem->m_Version <= 2)
-							pTilemapItem->m_Front = *((const int *)(pTilemapItem) + 17);
-
 						pTiles = std::make_shared<CLayerFront>(this, pTilemapItem->m_Width, pTilemapItem->m_Height);
 						MakeFrontLayer(pTiles);
 					}
 					else if(pTilemapItem->m_Flags & TILESLAYERFLAG_SWITCH)
 					{
-						if(pTilemapItem->m_Version <= 2)
-							pTilemapItem->m_Switch = *((const int *)(pTilemapItem) + 18);
-
 						pTiles = std::make_shared<CLayerSwitch>(this, pTilemapItem->m_Width, pTilemapItem->m_Height);
 						MakeSwitchLayer(pTiles);
 					}
 					else if(pTilemapItem->m_Flags & TILESLAYERFLAG_TUNE)
 					{
-						if(pTilemapItem->m_Version <= 2)
-							pTilemapItem->m_Tune = *((const int *)(pTilemapItem) + 19);
-
 						pTiles = std::make_shared<CLayerTune>(this, pTilemapItem->m_Width, pTilemapItem->m_Height);
 						MakeTuneLayer(pTiles);
 					}
@@ -778,18 +763,15 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 					}
 
 					// load layer name
-					if(pTilemapItem->m_Version >= 3)
-						IntsToStr(pTilemapItem->m_aName, std::size(pTilemapItem->m_aName), pTiles->m_aName, std::size(pTiles->m_aName));
+					IntsToStr(pTilemapItem->m_aName, std::size(pTilemapItem->m_aName), pTiles->m_aName, std::size(pTiles->m_aName));
 
 					if(pTiles->m_HasTele)
 					{
-						void *pTeleData = pMap->GetData(pTilemapItem->m_Tele);
-						unsigned int Size = pMap->GetDataSize(pTilemapItem->m_Tele);
-						if(Size >= (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTeleTile))
+						const void *pData = pMap->GetData(pTilemapItem->m_Tele);
+						if(pData != nullptr)
 						{
 							CTeleTile *pLayerTeleTiles = std::static_pointer_cast<CLayerTele>(pTiles)->m_pTeleTile;
-							mem_copy(pLayerTeleTiles, pTeleData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTeleTile));
-
+							mem_copy(pLayerTeleTiles, pData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTeleTile));
 							for(int i = 0; i < pTiles->m_Width * pTiles->m_Height; i++)
 							{
 								if(IsValidTeleTile(pLayerTeleTiles[i].m_Type))
@@ -802,14 +784,11 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 					}
 					else if(pTiles->m_HasSpeedup)
 					{
-						void *pSpeedupData = pMap->GetData(pTilemapItem->m_Speedup);
-						unsigned int Size = pMap->GetDataSize(pTilemapItem->m_Speedup);
-
-						if(Size >= (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CSpeedupTile))
+						const void *pData = pMap->GetData(pTilemapItem->m_Speedup);
+						if(pData != nullptr)
 						{
 							CSpeedupTile *pLayerSpeedupTiles = std::static_pointer_cast<CLayerSpeedup>(pTiles)->m_pSpeedupTile;
-							mem_copy(pLayerSpeedupTiles, pSpeedupData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CSpeedupTile));
-
+							mem_copy(pLayerSpeedupTiles, pData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CSpeedupTile));
 							for(int i = 0; i < pTiles->m_Width * pTiles->m_Height; i++)
 							{
 								if(IsValidSpeedupTile(pLayerSpeedupTiles[i].m_Type) && pLayerSpeedupTiles[i].m_Force > 0)
@@ -818,25 +797,24 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 									pTiles->m_pTiles[i].m_Index = 0;
 							}
 						}
-
 						pMap->UnloadData(pTilemapItem->m_Speedup);
 					}
 					else if(pTiles->m_HasFront)
 					{
-						void *pFrontData = pMap->GetData(pTilemapItem->m_Front);
-						unsigned int Size = pMap->GetDataSize(pTilemapItem->m_Front);
-						pTiles->ExtractTiles((CTile *)pFrontData, Size);
+						const void *pData = pMap->GetData(pTilemapItem->m_Front);
+						if(pData != nullptr)
+						{
+							mem_copy(pTiles->m_pTiles, pData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTile));
+						}
 						pMap->UnloadData(pTilemapItem->m_Front);
 					}
 					else if(pTiles->m_HasSwitch)
 					{
-						void *pSwitchData = pMap->GetData(pTilemapItem->m_Switch);
-						unsigned int Size = pMap->GetDataSize(pTilemapItem->m_Switch);
-						if(Size >= (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CSwitchTile))
+						const void *pData = pMap->GetData(pTilemapItem->m_Switch);
+						if(pData != nullptr)
 						{
 							CSwitchTile *pLayerSwitchTiles = std::static_pointer_cast<CLayerSwitch>(pTiles)->m_pSwitchTile;
-							mem_copy(pLayerSwitchTiles, pSwitchData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CSwitchTile));
-
+							mem_copy(pLayerSwitchTiles, pData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CSwitchTile));
 							for(int i = 0; i < pTiles->m_Width * pTiles->m_Height; i++)
 							{
 								if(((pLayerSwitchTiles[i].m_Type > (ENTITY_CRAZY_SHOTGUN + ENTITY_OFFSET) && pLayerSwitchTiles[i].m_Type < (ENTITY_DRAGGER_WEAK + ENTITY_OFFSET)) || pLayerSwitchTiles[i].m_Type == (ENTITY_LASER_O_FAST + 1 + ENTITY_OFFSET)))
@@ -854,18 +832,16 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 									pTiles->m_pTiles[i].m_Flags = pLayerSwitchTiles[i].m_Flags;
 								}
 							}
+							pMap->UnloadData(pTilemapItem->m_Switch);
 						}
-						pMap->UnloadData(pTilemapItem->m_Switch);
 					}
 					else if(pTiles->m_HasTune)
 					{
-						void *pTuneData = pMap->GetData(pTilemapItem->m_Tune);
-						unsigned int Size = pMap->GetDataSize(pTilemapItem->m_Tune);
-						if(Size >= (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTuneTile))
+						const void *pData = pMap->GetData(pTilemapItem->m_Tune);
+						if(pData != nullptr)
 						{
 							CTuneTile *pLayerTuneTiles = std::static_pointer_cast<CLayerTune>(pTiles)->m_pTuneTile;
-							mem_copy(pLayerTuneTiles, pTuneData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTuneTile));
-
+							mem_copy(pLayerTuneTiles, pData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTuneTile));
 							for(int i = 0; i < pTiles->m_Width * pTiles->m_Height; i++)
 							{
 								if(IsValidTuneTile(pLayerTuneTiles[i].m_Type))
@@ -873,14 +849,16 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 								else
 									pTiles->m_pTiles[i].m_Index = 0;
 							}
+							pMap->UnloadData(pTilemapItem->m_Tune);
 						}
-						pMap->UnloadData(pTilemapItem->m_Tune);
 					}
 					else // regular tile layer or game layer
 					{
-						void *pData = pMap->GetData(pTilemapItem->m_Data);
-						unsigned int Size = pMap->GetDataSize(pTilemapItem->m_Data);
-						pTiles->ExtractTiles((CTile *)pData, Size);
+						const void *pData = pMap->GetData(pTilemapItem->m_Data);
+						if(pData != nullptr)
+						{
+							mem_copy(pTiles->m_pTiles, pData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTile));
+						}
 						pMap->UnloadData(pTilemapItem->m_Data);
 					}
 				}

--- a/src/game/editor/proof_mode.cpp
+++ b/src/game/editor/proof_mode.cpp
@@ -62,21 +62,18 @@ void CProofMode::InitMenuBackgroundPositions()
 	std::array<vec2, CMenuBackground::NUM_POS> aBackgroundPositions = GenerateMenuBackgroundPositions();
 	State.m_vMenuBackgroundPositions.assign(aBackgroundPositions.begin(), aBackgroundPositions.end());
 
-	if(Map()->m_pGameLayer)
+	for(int y = 0; y < Map()->m_pGameLayer->m_Height; ++y)
 	{
-		for(int y = 0; y < Map()->m_pGameLayer->m_Height; ++y)
+		for(int x = 0; x < Map()->m_pGameLayer->m_Width; ++x)
 		{
-			for(int x = 0; x < Map()->m_pGameLayer->m_Width; ++x)
+			CTile Tile = Map()->m_pGameLayer->GetTile(x, y);
+			if(Tile.m_Index >= TILE_TIME_CHECKPOINT_FIRST && Tile.m_Index <= TILE_TIME_CHECKPOINT_LAST)
 			{
-				CTile Tile = Map()->m_pGameLayer->GetTile(x, y);
-				if(Tile.m_Index >= TILE_TIME_CHECKPOINT_FIRST && Tile.m_Index <= TILE_TIME_CHECKPOINT_LAST)
-				{
-					int ArrayIndex = std::clamp<int>((Tile.m_Index - TILE_TIME_CHECKPOINT_FIRST), 0, CMenuBackground::NUM_POS);
-					State.m_vMenuBackgroundPositions[ArrayIndex] = vec2(x * 32.0f + 16.0f, y * 32.0f + 16.0f);
-				}
-
-				x += Tile.m_Skip;
+				int ArrayIndex = std::clamp<int>((Tile.m_Index - TILE_TIME_CHECKPOINT_FIRST), 0, CMenuBackground::NUM_POS);
+				State.m_vMenuBackgroundPositions[ArrayIndex] = vec2(x * 32.0f + 16.0f, y * 32.0f + 16.0f);
 			}
+
+			x += Tile.m_Skip;
 		}
 	}
 

--- a/src/game/layers.cpp
+++ b/src/game/layers.cpp
@@ -29,7 +29,6 @@ void CLayers::Init(IMap *pMap, bool GameOnly, bool InitializeTilemapSkip)
 				continue;
 
 			CMapItemLayerTilemap *pTilemap = reinterpret_cast<CMapItemLayerTilemap *>(pLayer);
-			bool IsEntities = false;
 
 			if(pTilemap->m_Flags & TILESLAYERFLAG_GAME)
 			{
@@ -50,67 +49,29 @@ void CLayers::Init(IMap *pMap, bool GameOnly, bool InitializeTilemapSkip)
 					m_pGameGroup->m_ClipW = 0;
 					m_pGameGroup->m_ClipH = 0;
 				}
-
-				IsEntities = true;
 			}
-
-			if(!GameOnly)
+			else if(!GameOnly)
 			{
 				if(pTilemap->m_Flags & TILESLAYERFLAG_TELE)
 				{
-					if(pTilemap->m_Version <= 2)
-					{
-						pTilemap->m_Tele = *((int *)(pTilemap) + 15);
-					}
 					m_pTeleLayer = pTilemap;
-					IsEntities = true;
 				}
-
-				if(pTilemap->m_Flags & TILESLAYERFLAG_SPEEDUP)
+				else if(pTilemap->m_Flags & TILESLAYERFLAG_SPEEDUP)
 				{
-					if(pTilemap->m_Version <= 2)
-					{
-						pTilemap->m_Speedup = *((int *)(pTilemap) + 16);
-					}
 					m_pSpeedupLayer = pTilemap;
-					IsEntities = true;
 				}
-
-				if(pTilemap->m_Flags & TILESLAYERFLAG_FRONT)
+				else if(pTilemap->m_Flags & TILESLAYERFLAG_FRONT)
 				{
-					if(pTilemap->m_Version <= 2)
-					{
-						pTilemap->m_Front = *((int *)(pTilemap) + 17);
-					}
 					m_pFrontLayer = pTilemap;
-					IsEntities = true;
 				}
-
-				if(pTilemap->m_Flags & TILESLAYERFLAG_SWITCH)
+				else if(pTilemap->m_Flags & TILESLAYERFLAG_SWITCH)
 				{
-					if(pTilemap->m_Version <= 2)
-					{
-						pTilemap->m_Switch = *((int *)(pTilemap) + 18);
-					}
 					m_pSwitchLayer = pTilemap;
-					IsEntities = true;
 				}
-
-				if(pTilemap->m_Flags & TILESLAYERFLAG_TUNE)
+				else if(pTilemap->m_Flags & TILESLAYERFLAG_TUNE)
 				{
-					if(pTilemap->m_Version <= 2)
-					{
-						pTilemap->m_Tune = *((int *)(pTilemap) + 19);
-					}
 					m_pTuneLayer = pTilemap;
-					IsEntities = true;
 				}
-			}
-
-			if(IsEntities)
-			{
-				// Ensure default color for entities layers
-				pTilemap->m_Color = CColor(255, 255, 255, 255);
 			}
 		}
 	}
@@ -155,8 +116,7 @@ void CLayers::InitTilemapSkip(bool GameOnly)
 				continue;
 
 			CTile *pTiles = static_cast<CTile *>(m_pMap->GetData(pTilemap->m_Data));
-			if(pTiles == nullptr || pTilemap->m_Width < 0 || pTilemap->m_Height < 0 ||
-				(int64_t)pTilemap->m_Width * pTilemap->m_Height > m_pMap->GetDataSize(pTilemap->m_Data) / (int)sizeof(CTile))
+			if(pTiles == nullptr)
 			{
 				continue;
 			}

--- a/src/game/layers.cpp
+++ b/src/game/layers.cpp
@@ -78,7 +78,7 @@ void CLayers::Init(IMap *pMap, bool GameOnly, bool InitializeTilemapSkip)
 
 	if(InitializeTilemapSkip)
 	{
-		InitTilemapSkip(GameOnly);
+		InitTilemapSkip();
 	}
 }
 
@@ -100,7 +100,7 @@ void CLayers::Unload()
 	m_pTuneLayer = nullptr;
 }
 
-void CLayers::InitTilemapSkip(bool GameOnly)
+void CLayers::InitTilemapSkip()
 {
 	for(int GroupIndex = 0; GroupIndex < NumGroups(); GroupIndex++)
 	{
@@ -112,7 +112,9 @@ void CLayers::InitTilemapSkip(bool GameOnly)
 				continue;
 
 			const CMapItemLayerTilemap *pTilemap = reinterpret_cast<const CMapItemLayerTilemap *>(pLayer);
-			if(GameOnly && (pTilemap->m_Flags & (TILESLAYERFLAG_TELE | TILESLAYERFLAG_SPEEDUP | TILESLAYERFLAG_FRONT | TILESLAYERFLAG_SWITCH | TILESLAYERFLAG_TUNE)) != 0)
+			// Physics layers except the game layer store their tiles in their own data index,
+			// so their m_Data is neither used nor validated when the map is loaded.
+			if((pTilemap->m_Flags & (TILESLAYERFLAG_TELE | TILESLAYERFLAG_SPEEDUP | TILESLAYERFLAG_FRONT | TILESLAYERFLAG_SWITCH | TILESLAYERFLAG_TUNE)) != 0)
 				continue;
 
 			CTile *pTiles = static_cast<CTile *>(m_pMap->GetData(pTilemap->m_Data));

--- a/src/game/layers.h
+++ b/src/game/layers.h
@@ -48,7 +48,7 @@ private:
 	CMapItemLayerTilemap *m_pSwitchLayer;
 	CMapItemLayerTilemap *m_pTuneLayer;
 
-	void InitTilemapSkip(bool GameOnly);
+	void InitTilemapSkip();
 };
 
 #endif

--- a/src/game/map/map_renderer.cpp
+++ b/src/game/map/map_renderer.cpp
@@ -39,7 +39,7 @@ void CMapRenderer::Load(ERenderType Type, CLayers *pLayers, IMapImages *pMapImag
 		for(int LayerId = 0; LayerId < pGroup->m_NumLayers; LayerId++)
 		{
 			CMapItemLayer *pLayer = pLayers->GetLayer(pGroup->m_StartLayer + LayerId);
-			int LayerType = GetLayerType(pLayer, pLayers);
+			int LayerType = GetLayerType(pLayer);
 			PassedGameLayer |= LayerType == LAYER_GAME;
 
 			if(Type == ERenderType::RENDERTYPE_BACKGROUND_FORCE || Type == ERenderType::RENDERTYPE_BACKGROUND)
@@ -175,19 +175,26 @@ void CMapRenderer::Render(const CRenderLayerParams &Params)
 	}
 }
 
-int CMapRenderer::GetLayerType(const CMapItemLayer *pLayer, const CLayers *pLayers) const
+int CMapRenderer::GetLayerType(const CMapItemLayer *pLayer) const
 {
-	if(pLayer == (CMapItemLayer *)pLayers->GameLayer())
+	if(pLayer->m_Type != LAYERTYPE_TILES)
+		return LAYER_DEFAULT_TILESET;
+
+	// Physics layers must be determined by their flags instead of by comparing them with the
+	// layers of CLayers, which only knows the last physics layer of each type, as design tiles
+	// layers use the data index which is neither used nor validated for physics layers.
+	const int Flags = reinterpret_cast<const CMapItemLayerTilemap *>(pLayer)->m_Flags;
+	if(Flags & TILESLAYERFLAG_GAME)
 		return LAYER_GAME;
-	else if(pLayer == (CMapItemLayer *)pLayers->FrontLayer())
+	else if(Flags & TILESLAYERFLAG_FRONT)
 		return LAYER_FRONT;
-	else if(pLayer == (CMapItemLayer *)pLayers->SwitchLayer())
+	else if(Flags & TILESLAYERFLAG_SWITCH)
 		return LAYER_SWITCH;
-	else if(pLayer == (CMapItemLayer *)pLayers->TeleLayer())
+	else if(Flags & TILESLAYERFLAG_TELE)
 		return LAYER_TELE;
-	else if(pLayer == (CMapItemLayer *)pLayers->SpeedupLayer())
+	else if(Flags & TILESLAYERFLAG_SPEEDUP)
 		return LAYER_SPEEDUP;
-	else if(pLayer == (CMapItemLayer *)pLayers->TuneLayer())
+	else if(Flags & TILESLAYERFLAG_TUNE)
 		return LAYER_TUNE;
 	return LAYER_DEFAULT_TILESET;
 }

--- a/src/game/map/map_renderer.h
+++ b/src/game/map/map_renderer.h
@@ -17,7 +17,7 @@ public:
 	void Render(const CRenderLayerParams &Params);
 
 private:
-	int GetLayerType(const CMapItemLayer *pLayer, const CLayers *pLayers) const;
+	int GetLayerType(const CMapItemLayer *pLayer) const;
 
 	std::vector<std::unique_ptr<CRenderLayer>> m_vpRenderLayers;
 };

--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -898,23 +898,14 @@ void CRenderLayerTile::CTileLayerVisuals::Unload()
 	Graphics()->DeleteBufferContainer(m_BufferContainerIndex);
 }
 
-int CRenderLayerTile::GetDataIndex(unsigned int &TileSize) const
+int CRenderLayerTile::GetDataIndex() const
 {
-	TileSize = sizeof(CTile);
 	return m_pLayerTilemap->m_Data;
 }
 
 void *CRenderLayerTile::GetRawData() const
 {
-	unsigned int TileSize;
-	unsigned int DataIndex = GetDataIndex(TileSize);
-	void *pTiles = m_pMap->GetData(DataIndex);
-	int Size = m_pMap->GetDataSize(DataIndex);
-
-	if(!pTiles || Size < m_pLayerTilemap->m_Width * m_pLayerTilemap->m_Height * (int)TileSize)
-		return nullptr;
-
-	return pTiles;
+	return m_pMap->GetData(GetDataIndex());
 }
 
 void CRenderLayerTile::OnInit(IGraphics *pGraphics, ITextRender *pTextRender, CRenderMap *pRenderMap, std::shared_ptr<CEnvelopeManager> &pEnvelopeManager, IMap *pMap, IMapImages *pMapImages, std::optional<FRenderUploadCallback> &FRenderUploadCallbackOptional)
@@ -1531,9 +1522,8 @@ ColorRGBA CRenderLayerEntityGame::GetDeathBorderColor() const
 CRenderLayerEntityFront::CRenderLayerEntityFront(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap) :
 	CRenderLayerEntityBase(GroupId, LayerId, Flags, pLayerTilemap) {}
 
-int CRenderLayerEntityFront::GetDataIndex(unsigned int &TileSize) const
+int CRenderLayerEntityFront::GetDataIndex() const
 {
-	TileSize = sizeof(CTile);
 	return m_pLayerTilemap->m_Front;
 }
 
@@ -1541,9 +1531,8 @@ int CRenderLayerEntityFront::GetDataIndex(unsigned int &TileSize) const
 CRenderLayerEntityTele::CRenderLayerEntityTele(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap) :
 	CRenderLayerEntityBase(GroupId, LayerId, Flags, pLayerTilemap) {}
 
-int CRenderLayerEntityTele::GetDataIndex(unsigned int &TileSize) const
+int CRenderLayerEntityTele::GetDataIndex() const
 {
-	TileSize = sizeof(CTeleTile);
 	return m_pLayerTilemap->m_Tele;
 }
 
@@ -1610,9 +1599,8 @@ IGraphics::CTextureHandle CRenderLayerEntitySpeedup::GetTexture() const
 	return m_pMapImages->GetSpeedupArrow();
 }
 
-int CRenderLayerEntitySpeedup::GetDataIndex(unsigned int &TileSize) const
+int CRenderLayerEntitySpeedup::GetDataIndex() const
 {
-	TileSize = sizeof(CSpeedupTile);
 	return m_pLayerTilemap->m_Speedup;
 }
 
@@ -1690,9 +1678,8 @@ IGraphics::CTextureHandle CRenderLayerEntitySwitch::GetTexture() const
 	return m_pMapImages->GetEntities(MAP_IMAGE_ENTITY_LAYER_TYPE_SWITCH);
 }
 
-int CRenderLayerEntitySwitch::GetDataIndex(unsigned int &TileSize) const
+int CRenderLayerEntitySwitch::GetDataIndex() const
 {
-	TileSize = sizeof(CSwitchTile);
 	return m_pLayerTilemap->m_Switch;
 }
 
@@ -1791,9 +1778,8 @@ void CRenderLayerEntityTune::Init()
 	CRenderLayerTile::Init();
 }
 
-int CRenderLayerEntityTune::GetDataIndex(unsigned int &TileSize) const
+int CRenderLayerEntityTune::GetDataIndex() const
 {
-	TileSize = sizeof(CTuneTile);
 	return m_pLayerTilemap->m_Tune;
 }
 

--- a/src/game/map/render_layer.h
+++ b/src/game/map/render_layer.h
@@ -121,7 +121,7 @@ public:
 	void Init() override;
 	void OnInit(IGraphics *pGraphics, ITextRender *pTextRender, CRenderMap *pRenderMap, std::shared_ptr<CEnvelopeManager> &pEnvelopeManager, IMap *pMap, IMapImages *pMapImages, std::optional<FRenderUploadCallback> &FRenderUploadCallbackOptional) override;
 
-	virtual int GetDataIndex(unsigned int &TileSize) const;
+	virtual int GetDataIndex() const;
 	bool IsValid() const override { return GetRawData() != nullptr; }
 	void Unload() override;
 
@@ -309,14 +309,14 @@ class CRenderLayerEntityFront final : public CRenderLayerEntityBase
 {
 public:
 	CRenderLayerEntityFront(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
-	int GetDataIndex(unsigned int &TileSize) const override;
+	int GetDataIndex() const override;
 };
 
 class CRenderLayerEntityTele final : public CRenderLayerEntityBase
 {
 public:
 	CRenderLayerEntityTele(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
-	int GetDataIndex(unsigned int &TileSize) const override;
+	int GetDataIndex() const override;
 	void Init() override;
 	void InitTileData() override;
 	void Unload() override;
@@ -335,7 +335,7 @@ class CRenderLayerEntitySpeedup final : public CRenderLayerEntityBase
 {
 public:
 	CRenderLayerEntitySpeedup(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
-	int GetDataIndex(unsigned int &TileSize) const override;
+	int GetDataIndex() const override;
 	void Init() override;
 	void InitTileData() override;
 	void Unload() override;
@@ -356,7 +356,7 @@ class CRenderLayerEntitySwitch final : public CRenderLayerEntityBase
 {
 public:
 	CRenderLayerEntitySwitch(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
-	int GetDataIndex(unsigned int &TileSize) const override;
+	int GetDataIndex() const override;
 	void Init() override;
 	void InitTileData() override;
 	void Unload() override;
@@ -377,7 +377,7 @@ class CRenderLayerEntityTune final : public CRenderLayerEntityBase
 {
 public:
 	CRenderLayerEntityTune(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
-	int GetDataIndex(unsigned int &TileSize) const override;
+	int GetDataIndex() const override;
 	void Init() override;
 	void InitTileData() override;
 

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -474,6 +474,13 @@ public:
 	int m_Tune;
 };
 
+// The tiles layer items are cast from the raw map file data, so the base classes
+// must not add any padding to the derived classes.
+static_assert(sizeof(CMapItemLayerTilemap_v2) == 60);
+static_assert(sizeof(CMapItemLayerTilemap_v2Legacy) == 80);
+static_assert(sizeof(CMapItemLayerTilemap_v3Teeworlds) == 72);
+static_assert(sizeof(CMapItemLayerTilemap) == 92);
+
 class CMapItemLayerQuads
 {
 public:

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -424,18 +424,10 @@ public:
 	int m_Flags;
 };
 
-class CMapItemLayerTilemap
+// Teeworlds version 2 tiles layer items. Earliest supported version of tiles layers.
+class CMapItemLayerTilemap_v2
 {
 public:
-	/**
-	 * @link CMapItemLayerTilemap @endlink with this version are only written to maps in upstream Teeworlds.
-	 * The tile data of tilemaps using this version must be unpacked by repeating tiles according to the
-	 * @link CTile::m_Skip @endlink values of the packed tile data.
-	 *
-	 * @see CMap::ExtractTiles
-	 */
-	static constexpr int VERSION_TEEWORLDS_TILESKIP = 4;
-
 	CMapItemLayer m_Layer;
 	int m_Version;
 
@@ -449,11 +441,32 @@ public:
 
 	int m_Image;
 	int m_Data;
+};
 
+// DDRace added its own member variables to the existing Teeworlds version 2 tiles layer items.
+// Note that version 2 tiles layer items may also contain only a prefix of these member variables.
+class CMapItemLayerTilemap_v2Legacy : public CMapItemLayerTilemap_v2
+{
+public:
+	int m_Tele;
+	int m_Speedup;
+	int m_Front;
+	int m_Switch;
+	int m_Tune;
+};
+
+// Teeworlds added layer names to tiles layers in version 3 based on the original version 2 items.
+// Note that this map item is not compatible with the legacy version 2 map item added by DDRace.
+class CMapItemLayerTilemap_v3Teeworlds : public CMapItemLayerTilemap_v2
+{
+public:
 	int m_aName[3];
+};
 
-	// DDRace
-
+// DDRace added its own member variables to Teeworlds version 3 tiles layer items again.
+class CMapItemLayerTilemap : public CMapItemLayerTilemap_v3Teeworlds
+{
+public:
 	int m_Tele;
 	int m_Speedup;
 	int m_Front;
@@ -644,6 +657,7 @@ public:
 	unsigned char m_Force;
 	unsigned char m_MaxSpeed;
 	unsigned char m_Type;
+	unsigned char m_MustBe0;
 	short m_Angle;
 };
 

--- a/src/tools/dummy_map.cpp
+++ b/src/tools/dummy_map.cpp
@@ -38,7 +38,7 @@ static void CreateEmptyMap(IStorage *pStorage)
 	CTile aTiles[LayerWidth * LayerHeight];
 	std::fill(std::begin(aTiles), std::end(aTiles), CTile{.m_Index = TILE_SOLID, .m_Flags = 0, .m_Skip = 0, .m_MustBe0 = 0});
 
-	CMapItemLayerTilemap GameLayer;
+	CMapItemLayerTilemap_v2 GameLayer;
 	GameLayer.m_Layer.m_Version = 0; // Not set by the official client.
 	GameLayer.m_Layer.m_Type = LAYERTYPE_TILES;
 	GameLayer.m_Layer.m_Flags = 0;
@@ -54,9 +54,9 @@ static void CreateEmptyMap(IStorage *pStorage)
 	GameLayer.m_ColorEnvOffset = 0;
 	GameLayer.m_Image = -1;
 	GameLayer.m_Data = Writer.AddData(sizeof(aTiles), &aTiles);
-	Writer.AddItem(MAPITEMTYPE_LAYER, 0, sizeof(GameLayer) - sizeof(GameLayer.m_aName) - sizeof(GameLayer.m_Tele) - sizeof(GameLayer.m_Speedup) - sizeof(GameLayer.m_Front) - sizeof(GameLayer.m_Switch) - sizeof(GameLayer.m_Tune), &GameLayer);
+	Writer.AddItem(MAPITEMTYPE_LAYER, 0, sizeof(GameLayer), &GameLayer);
 
-	CMapItemLayerTilemap Layer;
+	CMapItemLayerTilemap_v2 Layer;
 	Layer.m_Layer.m_Version = 0;
 	Layer.m_Layer.m_Type = LAYERTYPE_TILES;
 	Layer.m_Layer.m_Flags = 0;
@@ -72,7 +72,7 @@ static void CreateEmptyMap(IStorage *pStorage)
 	Layer.m_ColorEnvOffset = 0;
 	Layer.m_Image = -1;
 	Layer.m_Data = Writer.AddData(sizeof(aTiles), &aTiles);
-	Writer.AddItem(MAPITEMTYPE_LAYER, 1, sizeof(Layer) - sizeof(Layer.m_aName) - sizeof(Layer.m_Tele) - sizeof(Layer.m_Speedup) - sizeof(Layer.m_Front) - sizeof(Layer.m_Switch) - sizeof(Layer.m_Tune), &Layer);
+	Writer.AddItem(MAPITEMTYPE_LAYER, 1, sizeof(Layer), &Layer);
 
 	Writer.Finish();
 

--- a/src/tools/map_diff.cpp
+++ b/src/tools/map_diff.cpp
@@ -4,53 +4,50 @@
 #include <base/os.h>
 #include <base/str.h>
 
-#include <engine/shared/datafile.h>
-#include <engine/shared/map.h>
+#include <engine/map.h>
 #include <engine/storage.h>
 
 #include <game/gamecore.h>
 #include <game/mapitems.h>
 
 #include <cstdlib>
+#include <memory>
 
 static int TileDataIndex(const CMapItemLayerTilemap *pTilemap, int PhysicsLayerFlags)
 {
-	const int *pPhysicsDataIndices = (const int *)pTilemap + (pTilemap->m_Version <= 2 ? 15 : 18);
 	if(PhysicsLayerFlags & TILESLAYERFLAG_TELE)
-		return pPhysicsDataIndices[0];
+		return pTilemap->m_Tele;
 	if(PhysicsLayerFlags & TILESLAYERFLAG_SPEEDUP)
-		return pPhysicsDataIndices[1];
+		return pTilemap->m_Speedup;
 	if(PhysicsLayerFlags & TILESLAYERFLAG_FRONT)
-		return pPhysicsDataIndices[2];
+		return pTilemap->m_Front;
 	if(PhysicsLayerFlags & TILESLAYERFLAG_SWITCH)
-		return pPhysicsDataIndices[3];
+		return pTilemap->m_Switch;
 	if(PhysicsLayerFlags & TILESLAYERFLAG_TUNE)
-		return pPhysicsDataIndices[4];
+		return pTilemap->m_Tune;
 	return pTilemap->m_Data;
 }
 
 template<typename T, typename FCompare>
-static bool DiffTileLayer(CDataFileReader aMaps[2], const char **pMapNames, const int aData[2], int Width, int Height, FCompare pfnCompare)
+static bool DiffTileLayer(std::shared_ptr<IMap> apMaps[2], const char *apMapNames[2], const int aData[2], int Width, int Height, FCompare pfnCompare)
 {
 	const T *apTile[2];
-	bool aValid[2];
 	for(int i = 0; i < 2; ++i)
 	{
-		apTile[i] = (const T *)aMaps[i].GetData(aData[i]);
-		aValid[i] = apTile[i] != nullptr && (size_t)aMaps[i].GetDataSize(aData[i]) >= (size_t)Width * Height * sizeof(T);
+		apTile[i] = (const T *)apMaps[i]->GetData(aData[i]);
 	}
 
-	if(!aValid[0] || !aValid[1])
+	if(apTile[0] == nullptr || apTile[1] == nullptr)
 	{
 		for(int i = 0; i < 2; ++i)
 		{
-			if(!aValid[i])
-				dbg_msg("map_diff", "invalid tile layer data in \"%s\"", pMapNames[i]);
+			if(apTile[i] == nullptr)
+				dbg_msg("map_diff", "invalid tile layer data in \"%s\"", apMapNames[i]);
 		}
 		for(int i = 0; i < 2; ++i)
-			aMaps[i].UnloadData(aData[i]);
+			apMaps[i]->UnloadData(aData[i]);
 		// Layers that are invalid in both maps are ignored
-		return aValid[0] == aValid[1];
+		return apTile[0] == apTile[1];
 	}
 
 	for(int y = 0; y < Height; y++)
@@ -63,69 +60,36 @@ static bool DiffTileLayer(CDataFileReader aMaps[2], const char **pMapNames, cons
 	}
 
 	for(int i = 0; i < 2; ++i)
-		aMaps[i].UnloadData(aData[i]);
+		apMaps[i]->UnloadData(aData[i]);
 	return true;
 }
 
-static bool Process(IStorage *pStorage, const char **pMapNames)
+static bool Process(IStorage *pStorage, const char *apMapNames[2])
 {
-	CDataFileReader aMaps[2];
+	std::shared_ptr<IMap> apMaps[2];
 
 	for(int i = 0; i < 2; ++i)
 	{
-		if(!aMaps[i].Open(pStorage, pMapNames[i], IStorage::TYPE_ABSOLUTE))
-		{
-			dbg_msg("map_diff", "error opening map '%s'", pMapNames[i]);
-			return false;
-		}
+		apMaps[i] = CreateMap();
 
-		const CMapItemVersion *pVersion = static_cast<CMapItemVersion *>(aMaps[i].FindItem(MAPITEMTYPE_VERSION, 0));
-		if(pVersion == nullptr || pVersion->m_Version != 1)
+		if(!apMaps[i]->Load(pStorage, apMapNames[i], IStorage::TYPE_ABSOLUTE))
 		{
-			dbg_msg("map_diff", "unsupported map version '%s'", pMapNames[i]);
+			dbg_msg("map_diff", "error opening map '%s'", apMapNames[i]);
 			return false;
 		}
 	}
 
 	int aStart[2], aLayersNum[2];
 	for(int i = 0; i < 2; ++i)
-		aMaps[i].GetType(MAPITEMTYPE_LAYER, &aStart[i], &aLayersNum[i]);
+		apMaps[i]->GetType(MAPITEMTYPE_LAYER, &aStart[i], &aLayersNum[i]);
 
 	// ensure basic layout
 	if(aLayersNum[0] != aLayersNum[1])
 	{
 		dbg_msg("map_diff", "different layer numbers:");
 		for(int i = 0; i < 2; ++i)
-			dbg_msg("map_diff", "  \"%s\": %d layers", pMapNames[i], aLayersNum[i]);
+			dbg_msg("map_diff", "  \"%s\": %d layers", apMapNames[i], aLayersNum[i]);
 		return false;
-	}
-
-	for(int j = 0; j < aLayersNum[0]; ++j)
-	{
-		for(int i = 0; i < 2; ++i)
-		{
-			CMapItemLayer *pItem = (CMapItemLayer *)aMaps[i].GetItem(aStart[i] + j);
-			if(pItem->m_Type != LAYERTYPE_TILES)
-				continue;
-			const CMapItemLayerTilemap *pTilemap = (CMapItemLayerTilemap *)pItem;
-			if(pTilemap->m_Version < CMapItemLayerTilemap::VERSION_TEEWORLDS_TILESKIP ||
-				pTilemap->m_Width <= 0 || pTilemap->m_Height <= 0)
-				continue;
-
-			const CTile *pPackedTiles = (const CTile *)aMaps[i].GetData(pTilemap->m_Data);
-			if(pPackedTiles == nullptr)
-				continue; // invalid data is reported when the layer is compared
-
-			const size_t TileCount = (size_t)pTilemap->m_Width * pTilemap->m_Height;
-			CTile *pTiles = (CTile *)calloc(TileCount, sizeof(CTile));
-			if(pTiles == nullptr)
-			{
-				dbg_msg("map_diff", "could not allocate tile layer of \"%s\" (%dx%d)", pMapNames[i], pTilemap->m_Width, pTilemap->m_Height);
-				return false;
-			}
-			CMap::ExtractTiles(pTiles, TileCount, pPackedTiles, aMaps[i].GetDataSize(pTilemap->m_Data) / sizeof(CTile));
-			aMaps[i].ReplaceData(pTilemap->m_Data, (char *)pTiles, TileCount * sizeof(CTile));
-		}
 	}
 
 	// compare
@@ -133,22 +97,18 @@ static bool Process(IStorage *pStorage, const char **pMapNames)
 	{
 		CMapItemLayer *apItem[2];
 		for(int i = 0; i < 2; ++i)
-			apItem[i] = (CMapItemLayer *)aMaps[i].GetItem(aStart[i] + j);
+			apItem[i] = (CMapItemLayer *)apMaps[i]->GetItem(aStart[i] + j);
 
 		if(apItem[0]->m_Type != LAYERTYPE_TILES || apItem[1]->m_Type != LAYERTYPE_TILES)
 			continue;
 
 		CMapItemLayerTilemap *apTilemap[2];
-		char aaName[2][12];
+		char aaName[2][sizeof(CMapItemLayerTilemap{}.m_aName)];
 
 		for(int i = 0; i < 2; ++i)
 		{
 			apTilemap[i] = (CMapItemLayerTilemap *)apItem[i];
-			// Tilemaps with version <= 2 do not have a name yet
-			if(apTilemap[i]->m_Version <= 2)
-				aaName[i][0] = '\0';
-			else
-				IntsToStr(apTilemap[i]->m_aName, std::size(apTilemap[i]->m_aName), aaName[i], std::size(aaName[i]));
+			IntsToStr(apTilemap[i]->m_aName, std::size(apTilemap[i]->m_aName), aaName[i], std::size(aaName[i]));
 		}
 
 		const int PhysicsLayerFlags = TILESLAYERFLAG_TELE | TILESLAYERFLAG_SPEEDUP | TILESLAYERFLAG_FRONT | TILESLAYERFLAG_SWITCH | TILESLAYERFLAG_TUNE;
@@ -159,7 +119,7 @@ static bool Process(IStorage *pStorage, const char **pMapNames)
 		{
 			dbg_msg("map_diff", "different tile layers:");
 			for(int i = 0; i < 2; ++i)
-				dbg_msg("map_diff", "  \"%s\" (%dx%d, flags: %d)", aaName[i], apTilemap[i]->m_Width, apTilemap[i]->m_Height, apTilemap[i]->m_Flags);
+				dbg_msg("map_diff", " [%d:%s] (%dx%d, flags: %d)", aLayersNum[i], aaName[i], apTilemap[i]->m_Width, apTilemap[i]->m_Height, apTilemap[i]->m_Flags);
 			return false;
 		}
 
@@ -170,7 +130,7 @@ static bool Process(IStorage *pStorage, const char **pMapNames)
 		bool Ok;
 		if(Flags & TILESLAYERFLAG_TELE)
 		{
-			Ok = DiffTileLayer<CTeleTile>(aMaps, pMapNames, aData, Width, Height, [&](const CTeleTile &Tile0, const CTeleTile &Tile1, int x, int y) {
+			Ok = DiffTileLayer<CTeleTile>(apMaps, apMapNames, aData, Width, Height, [&](const CTeleTile &Tile0, const CTeleTile &Tile1, int x, int y) {
 				if(Tile0.m_Number != Tile1.m_Number || Tile0.m_Type != Tile1.m_Type)
 				{
 					dbg_msg("map_diff", "[%d:%s] %dx%d: (number: %d, type: %d) != (number: %d, type: %d)",
@@ -180,7 +140,7 @@ static bool Process(IStorage *pStorage, const char **pMapNames)
 		}
 		else if(Flags & TILESLAYERFLAG_SPEEDUP)
 		{
-			Ok = DiffTileLayer<CSpeedupTile>(aMaps, pMapNames, aData, Width, Height, [&](const CSpeedupTile &Tile0, const CSpeedupTile &Tile1, int x, int y) {
+			Ok = DiffTileLayer<CSpeedupTile>(apMaps, apMapNames, aData, Width, Height, [&](const CSpeedupTile &Tile0, const CSpeedupTile &Tile1, int x, int y) {
 				if(Tile0.m_Force != Tile1.m_Force || Tile0.m_MaxSpeed != Tile1.m_MaxSpeed || Tile0.m_Type != Tile1.m_Type || Tile0.m_Angle != Tile1.m_Angle)
 				{
 					dbg_msg("map_diff", "[%d:%s] %dx%d: (force: %d, maxspeed: %d, angle: %d, type: %d) != (force: %d, maxspeed: %d, angle: %d, type: %d)",
@@ -190,7 +150,7 @@ static bool Process(IStorage *pStorage, const char **pMapNames)
 		}
 		else if(Flags & TILESLAYERFLAG_SWITCH)
 		{
-			Ok = DiffTileLayer<CSwitchTile>(aMaps, pMapNames, aData, Width, Height, [&](const CSwitchTile &Tile0, const CSwitchTile &Tile1, int x, int y) {
+			Ok = DiffTileLayer<CSwitchTile>(apMaps, apMapNames, aData, Width, Height, [&](const CSwitchTile &Tile0, const CSwitchTile &Tile1, int x, int y) {
 				if(Tile0.m_Number != Tile1.m_Number || Tile0.m_Type != Tile1.m_Type || Tile0.m_Flags != Tile1.m_Flags || Tile0.m_Delay != Tile1.m_Delay)
 				{
 					dbg_msg("map_diff", "[%d:%s] %dx%d: (number: %d, type: %d, flags: %d, delay: %d) != (number: %d, type: %d, flags: %d, delay: %d)",
@@ -200,7 +160,7 @@ static bool Process(IStorage *pStorage, const char **pMapNames)
 		}
 		else if(Flags & TILESLAYERFLAG_TUNE)
 		{
-			Ok = DiffTileLayer<CTuneTile>(aMaps, pMapNames, aData, Width, Height, [&](const CTuneTile &Tile0, const CTuneTile &Tile1, int x, int y) {
+			Ok = DiffTileLayer<CTuneTile>(apMaps, apMapNames, aData, Width, Height, [&](const CTuneTile &Tile0, const CTuneTile &Tile1, int x, int y) {
 				if(Tile0.m_Number != Tile1.m_Number || Tile0.m_Type != Tile1.m_Type)
 				{
 					dbg_msg("map_diff", "[%d:%s] %dx%d: (number: %d, type: %d) != (number: %d, type: %d)",
@@ -211,7 +171,7 @@ static bool Process(IStorage *pStorage, const char **pMapNames)
 		else
 		{
 			// Regular, game and front layers all store CTile
-			Ok = DiffTileLayer<CTile>(aMaps, pMapNames, aData, Width, Height, [&](const CTile &Tile0, const CTile &Tile1, int x, int y) {
+			Ok = DiffTileLayer<CTile>(apMaps, apMapNames, aData, Width, Height, [&](const CTile &Tile0, const CTile &Tile1, int x, int y) {
 				if(Tile0.m_Index != Tile1.m_Index || Tile0.m_Flags != Tile1.m_Flags)
 				{
 					dbg_msg("map_diff", "[%d:%s] %dx%d: (index: %d, flags: %d) != (index: %d, flags: %d)",
@@ -256,5 +216,6 @@ int main(int argc, const char *argv[])
 		return -1;
 	}
 
-	return Process(pStorage.get(), &argv[1]) ? 0 : 1;
+	const char *apMapNames[] = {argv[1], argv[2]};
+	return Process(pStorage.get(), apMapNames) ? 0 : 1;
 }

--- a/src/tools/map_diff.cpp
+++ b/src/tools/map_diff.cpp
@@ -119,7 +119,7 @@ static bool Process(IStorage *pStorage, const char *apMapNames[2])
 		{
 			dbg_msg("map_diff", "different tile layers:");
 			for(int i = 0; i < 2; ++i)
-				dbg_msg("map_diff", " [%d:%s] (%dx%d, flags: %d)", aLayersNum[i], aaName[i], apTilemap[i]->m_Width, apTilemap[i]->m_Height, apTilemap[i]->m_Flags);
+				dbg_msg("map_diff", " [%d:%s] (%dx%d, flags: %d)", j, aaName[i], apTilemap[i]->m_Width, apTilemap[i]->m_Height, apTilemap[i]->m_Flags);
 			return false;
 		}
 

--- a/src/tools/map_test.cpp
+++ b/src/tools/map_test.cpp
@@ -57,10 +57,11 @@ static int TestMap(const char *pMapPath, bool CalcHashes, IStorage *pStorage)
 	{
 		log_info(TOOL_NAME, "Data %d:", Index);
 
+		// The data must be loaded first, as the size is only final after the data has been processed.
+		const void *pData = pMap->GetData(Index);
 		const int Size = pMap->GetDataSize(Index);
 		log_info(TOOL_NAME, "  Size: %d bytes", Size);
 
-		const void *pData = pMap->GetData(Index);
 		if(pData == nullptr)
 		{
 			log_info(TOOL_NAME, "  Data erroneous");

--- a/src/tools/map_test.cpp
+++ b/src/tools/map_test.cpp
@@ -83,7 +83,9 @@ static int TestMap(const char *pMapPath, bool CalcHashes, IStorage *pStorage)
 int main(int argc, const char **argv)
 {
 	const CCmdlineFix CmdlineFix(&argc, &argv);
-	log_set_global_logger_default();
+	ILogger *pDefaultLogger = log_logger_default().release();
+	pDefaultLogger->SetFilter(CLogFilter{LEVEL_DEBUG});
+	log_set_global_logger(pDefaultLogger);
 
 	const char *pMapPath;
 	bool CalcHashes;


### PR DESCRIPTION
Follow-up to #11543. Instead of fixing maps with invalid tile data, fail to load maps entirely in the following cases:

- if any tiles layer item is truncated (while handling old maps gracefully, see details below),
- if any tiles layer width or height is less than 2,
- if any tiles layer size would cause an integer overflow, which was previously only checked for tiles layers that use tileskip,
- if any physics layer has an invalid combination of flags (i.e., multiple physics flags cannot be combined),
- if any design tiles layer RGBA color component is not between `0` and `255`,
- if any tiles layer name is not valid UTF-8,
- if the map does not contain a game layer, or
- if the game layer data is truncated or invalid.

These checks are now being performed once when the map is loaded, so they do not need to be performed separately when using the map items in menu background loading, layer initialization, collision initialization, editor map loading, and map rendering.

In order to reduce memory usage, the tile layer data is unpacked and validated lazily when the data is first requested with the `GetData` function. The `GetData` function will now return `nullptr` for tiles layer data in the following cases:

- if any design or physics tiles layer data is missing, corrupted or truncated (e.g., due to failed decompression),
- if any physics layer except the game layer uses the tileskip version, which should only be used for design and game tiles layers,
- if `CTile::m_Skip` is non-zero for a design, game or front tiles layer that does not use tileskip,
- if `CTile::m_MustBe0` is non-zero for the data of a design, game or front tiles layer,
- if `CSpeedupTile::m_MustBe0` (added to represent the speedup tile padding) is non-zero for the data of a speedup layer.

Furthermore, gracefully sanitize various tiles layer properties that are set incorrectly or left uninitialized in many official maps:

- ensure unused `CMapItemLayer::m_Version` is `0`,
- ensure physics layers have the default color (white) and name (e.g., `Game`),
- ensure physics layers do not have the detail-flag set, and
- ensure unused data indices of tiles layers are set to `-1` (e.g., `m_Tele` for a design or tune layer).

Log messages with debug level are printed when map properties being sanitized, as these changes can be verbose for many maps. Therefore, log messages with debug level by default in the `map_test` tool to also capture these messages.

The special handling for the struct layout change in tele, speedup, front, switch and tune layers of version 2 is also moved from `CLayers` and from editor map loading to the general map loading in `IMap`. This backwards compatiblity was previously broken in several ways. The read access to the legacy version 2 tile layer struct in lines like `pTilemap->m_Speedup = *((int *)(pTilemap) + 16);` could be out-of-bounds because the size of the item data was not checked. Furthermore, this was then unpacking the value based on the legacy struct layout (here: reading from `(int *)(pTilemap) + 16`) into the same underlying map layer item struct but with the version 3 layout (here: writing to `pTilemap->m_Speedup`). However, as the version 2 map layer items are smaller than version 3 map layer items, this write access was also out-of-bounds. This went undetected even though it was happening for existing maps (e.g., `Continuum`) because the write occurs to the metadata of the subsequent map item, which is apparently not used otherwise because we iterate over the range of map items of a particular type instead of checking the type, ID or size of individual map items. All subsequent read accesses to `pTilemap->m_Speedup` (e.g., during rendering) were also out-of-bounds, which mostly worked because it read back the intended value from the previous out-of-bounds write. This was found by using the `map_test` tool with the original backwards compatiblity, which revealed that the map item type and ID of adjacent map items were being corrupted.

## Checklist

- [X] Tested the change ingame, and with all official maps with the `map_test` tool
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions