### PR TITLE
Mostly fix flaky integration tests

### DIFF
--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -111,7 +111,7 @@ class TestRunner:
 		self.timeout_multiplier = timeout_multiplier
 		self.valgrind_memcheck = valgrind_memcheck
 		if self.valgrind_memcheck:
-			self.timeout_multiplier *= 10
+			self.timeout_multiplier *= 20
 
 	def run_test(self, test):
 		tmp_dir = tempfile.mkdtemp(prefix=f"integration_{test.name}_", dir=self.test_dir)
@@ -678,7 +678,7 @@ def smoke_test(test_env):
 	client1.command("stdout_output_level 2; loglevel 2")
 	client1.command(f"connect localhost:{server.port}")
 	server.wait_for_log_prefix("server: player has entered the game", timeout=10)
-	client1.wait_for_log_exact("client: state change. last=2 current=3", timeout=10)
+	client1.wait_for_log_exact("client: state change. last=2 current=3", timeout=15)
 	client1.command("stdout_output_level 0; loglevel 0")
 	client1.command("debug 0")
 	client1.command("record client1")


### PR DESCRIPTION
First tested by repeating the integration tests with Valgrind around 50 times, of which 4 individual tests failed. Notably, the smoke test failed because the recorded demos are orders of magnitude longer than the expected 20 seconds when the are recorded with Valgrind. In other failed tests, the timeout was exceeded waiting for different individual messages like rcon authentication and server shutdown, which should be delivered immediately.

Therefore, increasing the Valgrind timeout multiplier seems like the correct solution, as the slowdown introduced by Valgrind is simply too large. The change was tested by repeating the integration tests with Valgrind another 50 times, of which 1 individual test still failed. For that, the specific timeout waiting for for log line `client: state change. last=2 current=3` was also increased. Repeating the integration tests with Valgrind another 50 times succeeded without failed tests.

## Checklist

- [X] Tested the change (in workflow runners)
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions