### PR TITLE
Replace `SHA256_ZEROED` uses with `std::optional<SHA256_DIGEST>`s

### DIFF
--- a/src/base/hash.cpp
+++ b/src/base/hash.cpp
@@ -3,8 +3,6 @@
 #include "hash_ctxt.h"
 #include "system.h"
 
-const SHA256_DIGEST SHA256_ZEROED = {{0}};
-
 static void digest_str(const unsigned char *digest, size_t digest_len, char *str, size_t max_len)
 {
 	if(max_len > digest_len * 2 + 1)

--- a/src/base/hash.h
+++ b/src/base/hash.h
@@ -31,8 +31,6 @@ void md5_str(MD5_DIGEST digest, char *str, size_t max_len);
 int md5_from_str(MD5_DIGEST *out, const char *str);
 int md5_comp(MD5_DIGEST digest1, MD5_DIGEST digest2);
 
-extern const SHA256_DIGEST SHA256_ZEROED;
-
 inline bool operator==(const SHA256_DIGEST &that, const SHA256_DIGEST &other)
 {
 	return sha256_comp(that, other) == 0;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -154,13 +154,12 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	int m_MapdownloadCrc = 0;
 	int m_MapdownloadAmount = -1;
 	int m_MapdownloadTotalsize = -1;
-	bool m_MapdownloadSha256Present = false;
-	SHA256_DIGEST m_MapdownloadSha256 = SHA256_ZEROED;
+	std::optional<SHA256_DIGEST> m_MapdownloadSha256;
 
 	bool m_MapDetailsPresent = false;
 	char m_aMapDetailsName[256] = "";
 	int m_MapDetailsCrc = 0;
-	SHA256_DIGEST m_MapDetailsSha256 = SHA256_ZEROED;
+	SHA256_DIGEST m_MapDetailsSha256;
 	char m_aMapDetailsUrl[256] = "";
 
 	EInfoState m_InfoState = EInfoState::ERROR;
@@ -370,8 +369,8 @@ public:
 	const char *DummyName() override;
 	const char *ErrorString() const override;
 
-	const char *LoadMap(const char *pName, const char *pFilename, SHA256_DIGEST *pWantedSha256, unsigned WantedCrc);
-	const char *LoadMapSearch(const char *pMapName, SHA256_DIGEST *pWantedSha256, int WantedCrc);
+	const char *LoadMap(const char *pName, const char *pFilename, const std::optional<SHA256_DIGEST> &WantedSha256, unsigned WantedCrc);
+	const char *LoadMapSearch(const char *pMapName, const std::optional<SHA256_DIGEST> &WantedSha256, int WantedCrc);
 
 	int TranslateSysMsg(int *pMsgId, bool System, CUnpacker *pUnpacker, CPacker *pPacker, CNetChunk *pPacket, bool *pIsExMsg);
 

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -1358,7 +1358,7 @@ void CServerBrowser::LoadDDNetInfoJson()
 	unsigned Length;
 	if(!m_pStorage->ReadFile(DDNET_INFO_FILE, IStorage::TYPE_SAVE, &pBuf, &Length))
 	{
-		m_DDNetInfoSha256 = SHA256_ZEROED;
+		// Keep old info if available
 		return;
 	}
 
@@ -1592,7 +1592,7 @@ void CServerBrowser::LoadDDNetServers()
 
 	// Add default none community
 	{
-		CCommunity NoneCommunity(COMMUNITY_NONE, "None", SHA256_ZEROED, "");
+		CCommunity NoneCommunity(COMMUNITY_NONE, "None", std::nullopt, "");
 		NoneCommunity.m_vCountries.emplace_back(COMMUNITY_COUNTRY_NONE, -1);
 		NoneCommunity.m_vTypes.emplace_back(COMMUNITY_TYPE_NONE);
 		m_vCommunities.push_back(std::move(NoneCommunity));

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -12,6 +12,7 @@
 
 #include <functional>
 #include <map>
+#include <optional>
 #include <set>
 
 typedef struct _json_value json_value;
@@ -221,7 +222,7 @@ private:
 class CCommunityCache : public ICommunityCache
 {
 	IServerBrowser *m_pServerBrowser;
-	SHA256_DIGEST m_InfoSha256 = SHA256_ZEROED;
+	std::optional<SHA256_DIGEST> m_InfoSha256;
 	int m_LastType = IServerBrowser::NUM_TYPES; // initial value does not appear normally, marking uninitialized cache
 	unsigned m_SelectedCommunitiesHash = 0;
 	std::vector<const CCommunity *> m_vpSelectedCommunities;
@@ -286,7 +287,7 @@ public:
 	unsigned CurrentCommunitiesHash() const override;
 
 	bool DDNetInfoAvailable() const override { return m_pDDNetInfo != nullptr; }
-	SHA256_DIGEST DDNetInfoSha256() const override { return m_DDNetInfoSha256; }
+	std::optional<SHA256_DIGEST> DDNetInfoSha256() const override { return m_DDNetInfoSha256; }
 
 	ICommunityCache &CommunityCache() override { return m_CommunityCache; }
 	const ICommunityCache &CommunityCache() const override { return m_CommunityCache; }
@@ -349,7 +350,7 @@ private:
 	CExcludedCommunityTypeFilterList m_TypesFilter;
 
 	json_value *m_pDDNetInfo = nullptr;
-	SHA256_DIGEST m_DDNetInfoSha256 = SHA256_ZEROED;
+	std::optional<SHA256_DIGEST> m_DDNetInfoSha256;
 
 	CServerEntry *m_pFirstReqServer; // request list
 	CServerEntry *m_pLastReqServer;

--- a/src/engine/demo.h
+++ b/src/engine/demo.h
@@ -11,6 +11,7 @@
 #include <engine/shared/uuid_manager.h>
 
 #include <cstdint>
+#include <optional>
 
 enum
 {
@@ -54,7 +55,7 @@ struct CTimelineMarkers
 struct CMapInfo
 {
 	char m_aName[MAX_MAP_LENGTH];
-	SHA256_DIGEST m_Sha256;
+	std::optional<SHA256_DIGEST> m_Sha256;
 	unsigned m_Crc;
 	unsigned m_Size;
 };

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -13,6 +13,7 @@
 
 #include <generated/protocol7.h>
 
+#include <optional>
 #include <unordered_set>
 #include <vector>
 
@@ -213,7 +214,7 @@ class CCommunity
 
 	char m_aId[CServerInfo::MAX_COMMUNITY_ID_LENGTH];
 	char m_aName[64];
-	SHA256_DIGEST m_IconSha256;
+	std::optional<SHA256_DIGEST> m_IconSha256;
 	char m_aIconUrl[128];
 	std::vector<CCommunityCountry> m_vCountries;
 	std::vector<CCommunityType> m_vTypes;
@@ -221,7 +222,7 @@ class CCommunity
 	std::unordered_set<CCommunityMap, CCommunityMap::SHash> m_FinishedMaps;
 
 public:
-	CCommunity(const char *pId, const char *pName, SHA256_DIGEST IconSha256, const char *pIconUrl) :
+	CCommunity(const char *pId, const char *pName, std::optional<SHA256_DIGEST> IconSha256, const char *pIconUrl) :
 		m_IconSha256(IconSha256)
 	{
 		str_copy(m_aId, pId);
@@ -232,7 +233,7 @@ public:
 	const char *Id() const { return m_aId; }
 	const char *Name() const { return m_aName; }
 	const char *IconUrl() const { return m_aIconUrl; }
-	const SHA256_DIGEST &IconSha256() const { return m_IconSha256; }
+	const std::optional<SHA256_DIGEST> &IconSha256() const { return m_IconSha256; }
 	const std::vector<CCommunityCountry> &Countries() const { return m_vCountries; }
 	const std::vector<CCommunityType> &Types() const { return m_vTypes; }
 	bool HasCountry(const char *pCountryName) const;
@@ -361,7 +362,7 @@ public:
 	virtual unsigned CurrentCommunitiesHash() const = 0;
 
 	virtual bool DDNetInfoAvailable() const = 0;
-	virtual SHA256_DIGEST DDNetInfoSha256() const = 0;
+	virtual std::optional<SHA256_DIGEST> DDNetInfoSha256() const = 0;
 
 	virtual ICommunityCache &CommunityCache() = 0;
 	virtual const ICommunityCache &CommunityCache() const = 0;

--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -92,9 +92,9 @@ class CHttpRequest : public IHttpRequest
 	int64_t m_IfModifiedSince = -1;
 	REQUEST m_Type = REQUEST::GET;
 
-	SHA256_DIGEST m_ActualSha256 = SHA256_ZEROED;
+	std::optional<SHA256_DIGEST> m_ActualSha256;
 	SHA256_CTX m_ActualSha256Ctx;
-	SHA256_DIGEST m_ExpectedSha256 = SHA256_ZEROED;
+	std::optional<SHA256_DIGEST> m_ExpectedSha256;
 
 	bool m_WriteToMemory = true;
 	bool m_WriteToFile = false;

--- a/src/game/client/components/community_icons.h
+++ b/src/game/client/components/community_icons.h
@@ -11,6 +11,8 @@
 #include <game/client/component.h>
 #include <game/client/ui_rect.h>
 
+#include <optional>
+
 class CCommunityIcon
 {
 	friend class CCommunityIcons;
@@ -76,7 +78,7 @@ private:
 	std::vector<CCommunityIcon> m_vCommunityIcons;
 	std::deque<std::shared_ptr<CCommunityIconLoadJob>> m_CommunityIconLoadJobs;
 	std::deque<std::shared_ptr<CCommunityIconDownloadJob>> m_CommunityIconDownloadJobs;
-	SHA256_DIGEST m_CommunityIconsInfoSha256 = SHA256_ZEROED;
+	std::optional<SHA256_DIGEST> m_CommunityIconsInfoSha256;
 	static int FileScan(const char *pName, int IsDir, int DirType, void *pUser);
 	bool LoadFile(const char *pPath, int DirType, CImageInfo &Info, CImageInfo &InfoGrayscale, SHA256_DIGEST &Sha256);
 	void LoadFinish(const char *pCommunityId, CImageInfo &Info, CImageInfo &InfoGrayscale, const SHA256_DIGEST &Sha256);

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -1422,12 +1422,12 @@ void CMenus::RenderDemoBrowserDetails(CUIRect DetailsView)
 	Contents.HSplitTop(4.0f, nullptr, &Contents);
 
 	Contents.HSplitTop(18.0f, &Left, &Contents);
-	if(pItem->m_MapInfo.m_Sha256 != SHA256_ZEROED)
+	if(pItem->m_MapInfo.m_Sha256.has_value())
 	{
 		Ui()->DoLabel(&Left, "SHA256", FontSize, TEXTALIGN_ML);
 		Contents.HSplitTop(18.0f, &Left, &Contents);
 		char aSha[SHA256_MAXSTRSIZE];
-		sha256_str(pItem->m_MapInfo.m_Sha256, aSha, sizeof(aSha));
+		sha256_str(pItem->m_MapInfo.m_Sha256.value(), aSha, sizeof(aSha));
 		SLabelProperties Props;
 		Props.m_MaxWidth = Left.w;
 		Props.m_EllipsisAtEnd = true;


### PR DESCRIPTION
Using `SHA256_ZEROED` to denote an unset SHA256 value is an anti-pattern.

Clean up interfaces by using `std::optional`s instead of nullable pointers.

Remove `SHA256_ZEROED` constant entirely because it should not be used.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions