### PR TITLE
Do not ignore errors in macOS CI setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,8 +102,8 @@ jobs:
     - name: Prepare macOS
       if: contains(matrix.os, 'macOS')
       run: |
-        brew update || true
-        brew install pkg-config sdl2 ffmpeg ninja molten-vk rust || true
+        brew update
+        brew install ffmpeg molten-vk ninja pkg-config rust sdl2
         brew upgrade freetype
         pip3 install --break-system-packages dmgbuild
         echo /Library/Frameworks/Python.framework/Versions/3.12/bin >> $GITHUB_PATH


### PR DESCRIPTION
Do not ignore errors when installing macOS dependencies, as this would cause less obvious failures later on. Closes #10923.

Retried 10 times over several days and has not failed so far.

## Checklist

- [X] Tested the change
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions