### PR TITLE
Fix reset.cfg contents not being sent to the client

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4467,10 +4467,32 @@ bool CGameContext::OnMapChange(char *pNewMapName, int MapNameSize)
 	char aConfig[IO_MAX_PATH_LENGTH];
 	str_format(aConfig, sizeof(aConfig), "maps/%s.cfg", g_Config.m_SvMap);
 
-	CLineReader LineReader;
-	if(!LineReader.OpenFile(Storage()->OpenFile(aConfig, IOFLAG_READ, IStorage::TYPE_ALL)))
+	std::vector<const char *> vpLines;
+	int TotalLength = 0;
+
+	CLineReader ResetFileLineReader;
+	if(ResetFileLineReader.OpenFile(Storage()->OpenFile(g_Config.m_SvResetFile, IOFLAG_READ, IStorage::TYPE_ALL)))
 	{
-		// No map-specific config, just return.
+		while(const char *pLine = ResetFileLineReader.Get())
+		{
+			vpLines.push_back(pLine);
+			TotalLength += str_length(pLine) + 1;
+		}
+	}
+
+	CLineReader LineReader;
+	if(LineReader.OpenFile(Storage()->OpenFile(aConfig, IOFLAG_READ, IStorage::TYPE_ALL)))
+	{
+		while(const char *pLine = LineReader.Get())
+		{
+			vpLines.push_back(pLine);
+			TotalLength += str_length(pLine) + 1;
+		}
+	}
+
+	if(vpLines.empty())
+	{
+		// No map-specific config or reset.cfg, just return.
 		return true;
 	}
 
@@ -4479,14 +4501,6 @@ bool CGameContext::OnMapChange(char *pNewMapName, int MapNameSize)
 	{
 		log_error("mapchange", "Failed to import settings from '%s': failed to open map '%s' for reading", aConfig, pNewMapName);
 		return false;
-	}
-
-	std::vector<const char *> vpLines;
-	int TotalLength = 0;
-	while(const char *pLine = LineReader.Get())
-	{
-		vpLines.push_back(pLine);
-		TotalLength += str_length(pLine) + 1;
 	}
 
 	char *pSettings = (char *)malloc(std::max(1, TotalLength));


### PR DESCRIPTION
Previously the reset file would be loaded by the server but the client was not informed about its contents this caused the client to use wrong predictions when antiping is on.

Closed #10916

I verified that the order is the same as it is when loading it server side. If both the mapname.cfg and the reset.cfg set the same config the mapname.cfg is stronger.

Heinrich would like to remove the reset file see #8392 but I very much need it! If we remove it or not this fixes a bug.

CC https://github.com/ddnet-insta/ddnet-insta/issues/509, #7589

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
