### PR TITLE
Include some headers directly that were transitive

### DIFF
--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -3,10 +3,13 @@
 #ifndef GAME_SERVER_GAMECONTROLLER_H
 #define GAME_SERVER_GAMECONTROLLER_H
 
+#include <base/dbg.h>
 #include <base/vmath.h>
 
 #include <engine/map.h>
 #include <engine/shared/protocol.h>
+
+#include <generated/protocol.h>
 
 #include <game/server/teams.h>
 

--- a/src/game/server/gamemodes/DDRace.h
+++ b/src/game/server/gamemodes/DDRace.h
@@ -4,6 +4,8 @@
 
 #include <game/server/gamecontroller.h>
 
+class CScore;
+
 class CGameControllerDDRace : public IGameController
 {
 public:

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -3,10 +3,12 @@
 #include "player.h"
 #include "teams.h"
 
+#include <engine/server.h>
 #include <engine/shared/config.h>
 #include <engine/shared/protocol.h>
 
 #include <game/server/entities/character.h>
+#include <game/server/gamecontext.h>
 #include <game/server/gamemodes/DDRace.h>
 #include <game/team_state.h>
 

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -6,6 +6,7 @@
 
 #include <base/system.h>
 
+#include <engine/server.h>
 #include <engine/server/databases/connection_pool.h>
 #include <engine/shared/config.h>
 #include <engine/shared/console.h>
@@ -14,6 +15,7 @@
 
 #include <generated/wordlist.h>
 
+#include <game/server/gamecontext.h>
 #include <game/server/gamemodes/DDRace.h>
 #include <game/team_state.h>
 

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -12,6 +12,7 @@
 
 #include <game/mapitems.h>
 #include <game/server/entities/character.h>
+#include <game/server/gamecontext.h>
 #include <game/team_state.h>
 
 CGameTeams::CGameTeams(CGameContext *pGameContext) :

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -9,6 +9,9 @@
 #include <game/team_state.h>
 #include <game/teamscore.h>
 
+#include <memory>
+#include <optional>
+
 class CCharacter;
 class CPlayer;
 struct CScoreSaveResult;


### PR DESCRIPTION
The file teams.h includes gamecontext.h which brings a bunch of indirect includes to a few files. Which is bad style.

This is the less controsversial part of #11583