### PR TITLE
Fix: Hookline showing player hook on quantum misses

### DIFF
--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -270,9 +270,21 @@ void CPlayers::RenderHookCollLine(
 			if(!HookEnteredTelehook)
 			{
 				vec2 RetractingHookEndPos = BasePos + normalize(SegmentEndPos - BasePos) * HookLength;
-				if(GameClient()->IntersectCharacter(SegmentStartPos, RetractingHookEndPos, HitPos, ClientId, &IntersectedPlayerPosition) != -1)
+
+				// you can't hook a player, if the hook is behind solids, however you miss the solids as well
+				int Hit = Collision()->IntersectLineTeleHook(SegmentStartPos, RetractingHookEndPos, &HitPos, nullptr, &Tele);
+
+				if(GameClient()->IntersectCharacter(SegmentStartPos, HitPos, RetractingHookEndPos, ClientId, &IntersectedPlayerPosition) != -1)
 				{
-					AddHookPlayerSegment(LineStartPos, SegmentEndPos, IntersectedPlayerPosition, HitPos);
+					AddHookPlayerSegment(LineStartPos, SegmentEndPos, IntersectedPlayerPosition, RetractingHookEndPos);
+					break;
+				}
+
+				// Retracting hooks don't go through hook teleporters
+				if(Hit && Hit != TILE_TELEINHOOK)
+				{
+					// The hook misses the player, but also misses the solid
+					vLineSegments.emplace_back(LineStartPos, SegmentStartPos);
 					break;
 				}
 			}


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

The hookline shows a player hook, when the retracting hook would hook a player, if it's not obfuscated by a tile.

**The hook can miss a player, by beeing obfuscated, by a solid tile, that it misses**.

related to #11268

Before:

As reported by @dropalways 
<img width="2560" height="1440" alt="screenshot_2026-01-09_00-04-04" src="https://github.com/user-attachments/assets/193fa16f-cce8-4862-a870-37c0b999e4fd" />

This hook misses both the player and the block. This is not hitbox bleeding.

I also tested this behavior on telehooks, but a retracting hook seems to miss telehooks (as it also misses solids), but also seems to obfuscate the player, so the player hook misses.

I don't know how to explain this issue properly, this sounds crazy, because these physics sound like quantum physics. You only hook a player if no solid is observed, even if you miss all solids.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
