### PR TITLE
Fix unset map name being passed to demo recorder functions

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -178,7 +178,7 @@ public:
 #if defined(CONF_VIDEORECORDER)
 	virtual const char *DemoPlayer_Render(const char *pFilename, int StorageType, const char *pVideoName, int SpeedIndex, bool StartPaused = false) = 0;
 #endif
-	virtual void DemoRecorder_Start(const char *pFilename, bool WithTimestamp, int Recorder, bool Verbose = false) = 0;
+	virtual void DemoRecorder_Start(const char *pFilename, bool WithTimestamp, int Recorder) = 0;
 	virtual void DemoRecorder_HandleAutoStart() = 0;
 	virtual void DemoRecorder_UpdateReplayRecorder() = 0;
 	virtual class IDemoRecorder *DemoRecorder(int Recorder) = 0;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -471,7 +471,7 @@ public:
 	void RegisterCommands();
 
 	const char *DemoPlayer_Play(const char *pFilename, int StorageType) override;
-	void DemoRecorder_Start(const char *pFilename, bool WithTimestamp, int Recorder, bool Verbose = false) override;
+	void DemoRecorder_Start(const char *pFilename, bool WithTimestamp, int Recorder) override;
 	void DemoRecorder_HandleAutoStart() override;
 	void DemoRecorder_UpdateReplayRecorder() override;
 	void DemoRecorder_AddDemoMarker(int Recorder);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2684,7 +2684,10 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	if(DoButton_CheckBox(&g_Config.m_ClReplays, Localize("Enable replays"), g_Config.m_ClReplays, &Button))
 	{
 		g_Config.m_ClReplays ^= 1;
-		Client()->DemoRecorder_UpdateReplayRecorder();
+		if(Client()->State() == IClient::STATE_ONLINE)
+		{
+			Client()->DemoRecorder_UpdateReplayRecorder();
+		}
 	}
 
 	Left.HSplitTop(20.0f, &Button, &Left);


### PR DESCRIPTION
When starting the client, the conchain for `cl_replays` calls the `DemoRecorder_UpdateReplayRecorder` function which tries to start the demo recorder with the current map name. Similarly, launching the client with `record` will attempt to start the demo recorder with the current map name. However, the current map name is unset (empty string) on client launch and recording is not started because the client is not online.

This is not really an issue right now, but it will be problematic when the current map name is not stored in the engine client anymore but within the engine `CMap` class itself. Then, accessing the name of the map while it is not open will fail with an assertion like all other `CMap` functions. Therefore, do not handle `cl_replays` conchain while the client is not online, and move the check for the online state when using the `record` command into the `Con_Record` callback.

Also slightly improve the error messages.

The `RaceRecord_Start` function is not called when the client is not online, so it should assert instead of logging an error message.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions