### PR TITLE
Add `c` parameter for colors commands, cleanup argument parsing

### DIFF
--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -149,7 +149,7 @@ void SColorConfigVariable::CommandCallback(IConsole::IResult *pResult, void *pUs
 
 void SColorConfigVariable::Register()
 {
-	m_pConsole->Register(m_pScriptName, "?i", m_Flags, CommandCallback, this, m_pHelp);
+	m_pConsole->Register(m_pScriptName, "?c", m_Flags, CommandCallback, this, m_pHelp);
 }
 
 bool SColorConfigVariable::IsDefault() const

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -141,7 +141,7 @@ class CConsole : public IConsole
 		PARSEARGS_INVALID_FLOAT,
 	};
 
-	int ParseArgs(CResult *pResult, const char *pFormat, bool IsColor = false);
+	int ParseArgs(CResult *pResult, const char *pFormat);
 
 	/*
 	this function will set pFormat to the next parameter (i,s,r,v,?) it contains and


### PR DESCRIPTION
Cleanup console color argument handling by adding `c` parameter for commands with color arguments, instead of weirdly checking if the command callback belongs to a color config variable and then separately passing this to the `CConsole::ParseArgs` function with a `bool IsColor` argument.

Various refactoring of the `CConsole::ParseArgs` function:

- Return result directly instead of setting `Error` result variable.
- Reduce indentation by using `continue`.
- Use `for`- instead of `while`-loop.
- Use `bool` instead of `int`.
- Use `'\0'` instead of `0`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
