### PR TITLE
Fix overlapping sequence bit packing of 0.6 network chunk header, add more tests for chunk header packing/unpacking

### DIFF
--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -403,12 +403,12 @@ unsigned char *CNetChunkHeader::Pack(unsigned char *pData, int Split) const
 {
 	dbg_assert(m_Size >= 0 && m_Size < 1 << (Split + 6), "Invalid network chunk size: %d", m_Size);
 
-	pData[0] = ((m_Flags & 3) << 6) | ((m_Size >> Split) & 0x3f);
+	pData[0] = ((m_Flags & 0b00000011) << 6) | ((m_Size >> Split) & 0b00111111);
 	pData[1] = (m_Size & ((1 << Split) - 1));
 	if(m_Flags & NET_CHUNKFLAG_VITAL)
 	{
-		pData[1] |= (m_Sequence >> 2) & (~((1 << Split) - 1));
-		pData[2] = m_Sequence & 0xff;
+		pData[1] |= (m_Sequence >> 2) & 0b11000000;
+		pData[2] = m_Sequence & 0b11111111;
 		return pData + 3;
 	}
 	return pData + 2;
@@ -416,14 +416,14 @@ unsigned char *CNetChunkHeader::Pack(unsigned char *pData, int Split) const
 
 unsigned char *CNetChunkHeader::Unpack(unsigned char *pData, int Split)
 {
-	m_Flags = (pData[0] >> 6) & 3;
-	m_Size = ((pData[0] & 0x3f) << Split) | (pData[1] & ((1 << Split) - 1));
-	m_Sequence = -1;
+	m_Flags = (pData[0] >> 6) & 0b00000011;
+	m_Size = ((pData[0] & 0b00111111) << Split) | (pData[1] & ((1 << Split) - 1));
 	if(m_Flags & NET_CHUNKFLAG_VITAL)
 	{
-		m_Sequence = ((pData[1] & (~((1 << Split) - 1))) << 2) | pData[2];
+		m_Sequence = ((pData[1] & 0b11000000) << 2) | pData[2];
 		return pData + 3;
 	}
+	m_Sequence = -1;
 	return pData + 2;
 }
 

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -41,11 +41,6 @@ CURRENT:
 		(unsigned char padding[3])	// 24 bit extra in case it's a connection less packet
 									// this is to make sure that it's compatible with the
 									// old protocol
-
-	chunk header: 2-3 bytes
-		unsigned char flags_size; // 2bit flags, 6 bit size
-		unsigned char size_seq; // 4bit size, 4bit seq
-		(unsigned char seq;) // 8bit seq, if vital flag is set
 */
 
 enum
@@ -148,6 +143,33 @@ struct CNetChunk
 	unsigned char m_aExtraData[NET_CONNLESS_EXTRA_SIZE];
 };
 
+/**
+ * Network chunk header.
+ *
+ * Packed into 2-3 bytes as follows:
+ *
+ * ```
+ * // 2 bit flags, 6 bit size
+ * // FFZZZZZZ
+ * unsigned char flags_size;
+ *
+ * // 4 or 6 bit size, 2 bit sequence (if vital flag is set)
+ * // QQ00zzzz (0.6 protocol, with Split=4)
+ * // QQzzzzzz (0.7 protocol, with Split=6)
+ * unsigned char size_seq;
+ *
+ * // 8 bit sequence (if vital flag is set)
+ * // qqqqqqqq
+ * unsigned char seq;
+ *
+ * F = flags (NET_CHUNKFLAG_VITAL and NET_CHUNKFLAG_RESEND)
+ * Z = size (upper bits)
+ * z = size (lower bits)
+ * Q = sequence (upper bits)
+ * q = sequence (lower bits)
+ * 0 = should be zero otherwise it messes up the sequence for old 0.6 servers/clients
+ * ```
+ */
 class CNetChunkHeader
 {
 public:

--- a/src/test/chunk_header_test.cpp
+++ b/src/test/chunk_header_test.cpp
@@ -6,75 +6,212 @@
 
 #include <gtest/gtest.h>
 
-template<size_t PackedSize>
-static void AssertHeader(const CNetChunkHeader &Header, unsigned char aPacked[PackedSize])
+static void TestPackUnpack(
+	const CNetChunkHeader &Header,
+	int Split,
+	std::initializer_list<unsigned char> ExpectedPacked)
 {
-	unsigned char aData[8];
+	unsigned char aData[3];
+	ASSERT_LE(ExpectedPacked.size(), std::size(aData));
 	unsigned char *pData = &aData[0];
-	const int BytesWritten = Header.Pack(pData) - pData;
-	EXPECT_EQ(BytesWritten, PackedSize);
-	EXPECT_EQ(pData[0], aPacked[0]);
-	EXPECT_EQ(pData[1], aPacked[1]);
-	if(PackedSize > 2)
+	const int BytesPacked = Header.Pack(pData, Split) - pData;
+	ASSERT_EQ(BytesPacked, ExpectedPacked.size());
+
+	// Unpack function expects non-const pointer but does not modify it
+	unsigned char *pPacked = const_cast<unsigned char *>(std::data(ExpectedPacked));
+	for(size_t i = 0; i < ExpectedPacked.size(); ++i)
 	{
-		EXPECT_EQ(pData[2], aPacked[2]);
+		EXPECT_EQ(pData[i], pPacked[i]);
+	}
+
+	CNetChunkHeader UnpackedHeader{};
+	const int BytesUnpacked = UnpackedHeader.Unpack(pPacked, Split) - pPacked;
+	ASSERT_EQ(BytesUnpacked, ExpectedPacked.size());
+	EXPECT_EQ(Header.m_Flags, UnpackedHeader.m_Flags);
+	EXPECT_EQ(Header.m_Size, UnpackedHeader.m_Size);
+	if(BytesUnpacked == 3)
+	{
+		EXPECT_EQ(UnpackedHeader.m_Sequence, Header.m_Sequence);
+	}
+	else
+	{
+		EXPECT_EQ(UnpackedHeader.m_Sequence, -1);
 	}
 }
 
-TEST(ChunkHeader, Seq255)
+TEST(ChunkHeader, PackZeroed)
+{
+	CNetChunkHeader Header;
+	Header.m_Flags = 0;
+	Header.m_Size = 0;
+	Header.m_Sequence = 0;
+	TestPackUnpack(Header, 4, {0x00, 0x00});
+	TestPackUnpack(Header, 6, {0x00, 0x00});
+}
+
+TEST(ChunkHeader, PackFlagVital)
 {
 	CNetChunkHeader Header;
 	Header.m_Flags = NET_CHUNKFLAG_VITAL;
 	Header.m_Size = 0;
-	Header.m_Sequence = 255;
-
-	unsigned char aExpected[3] = {
-		0x40,
-		0x30, // this is weird
-		0xff};
-	AssertHeader<3>(Header, aExpected);
+	Header.m_Sequence = 0;
+	TestPackUnpack(Header, 4, {0x40, 0x00, 0x00});
+	TestPackUnpack(Header, 6, {0x40, 0x00, 0x00});
 }
 
-TEST(ChunkHeader, Seq126)
+TEST(ChunkHeader, PackFlagResend)
 {
 	CNetChunkHeader Header;
-	Header.m_Flags = NET_CHUNKFLAG_VITAL;
+	Header.m_Flags = NET_CHUNKFLAG_RESEND;
 	Header.m_Size = 0;
-	Header.m_Sequence = 126;
-
-	unsigned char aExpected[3] = {0x40, 0x10, 0x7e};
-	AssertHeader<3>(Header, aExpected);
+	Header.m_Sequence = 0;
+	TestPackUnpack(Header, 4, {0x80, 0x00});
+	TestPackUnpack(Header, 6, {0x80, 0x00});
 }
 
-TEST(ChunkHeader, Seq63)
+TEST(ChunkHeader, PackFlagVitalResend)
 {
 	CNetChunkHeader Header;
-	Header.m_Flags = NET_CHUNKFLAG_VITAL;
+	Header.m_Flags = NET_CHUNKFLAG_VITAL | NET_CHUNKFLAG_RESEND;
 	Header.m_Size = 0;
-	Header.m_Sequence = 63;
-
-	unsigned char aExpected[3] = {0x40, 0x00, 0x3f};
-	AssertHeader<3>(Header, aExpected);
+	Header.m_Sequence = 0;
+	TestPackUnpack(Header, 4, {0xC0, 0x00, 0x00});
+	TestPackUnpack(Header, 6, {0xC0, 0x00, 0x00});
 }
 
-TEST(ChunkHeader, Seq64)
+TEST(ChunkHeader, PackSize15)
 {
 	CNetChunkHeader Header;
-	Header.m_Flags = NET_CHUNKFLAG_VITAL;
-	Header.m_Size = 0;
-	Header.m_Sequence = 64;
-
-	unsigned char aExpected[3] = {0x40, 0x10, 0x40};
-	AssertHeader<3>(Header, aExpected);
+	Header.m_Flags = 0;
+	Header.m_Size = 15;
+	Header.m_Sequence = 0;
+	TestPackUnpack(Header, 4, {0x00, 0x0F});
+	TestPackUnpack(Header, 6, {0x00, 0x0F});
 }
 
-TEST(ChunkHeader, Seq5)
+TEST(ChunkHeader, PackSize255)
+{
+	CNetChunkHeader Header;
+	Header.m_Flags = 0;
+	Header.m_Size = 255;
+	Header.m_Sequence = 0;
+	TestPackUnpack(Header, 4, {0x0F, 0x0F});
+	TestPackUnpack(Header, 6, {0x03, 0x3F});
+}
+
+TEST(ChunkHeader, PackSize511)
+{
+	CNetChunkHeader Header;
+	Header.m_Flags = 0;
+	Header.m_Size = 511;
+	Header.m_Sequence = 0;
+	TestPackUnpack(Header, 4, {0x1F, 0x0F});
+	TestPackUnpack(Header, 6, {0x07, 0x3F});
+}
+
+TEST(ChunkHeader, PackSize1023)
+{
+	CNetChunkHeader Header;
+	Header.m_Flags = 0;
+	Header.m_Size = 1023;
+	Header.m_Sequence = 0;
+	TestPackUnpack(Header, 4, {0x3F, 0x0F});
+	TestPackUnpack(Header, 6, {0x0F, 0x3F});
+}
+
+TEST(ChunkHeader, PackSize4095)
+{
+	CNetChunkHeader Header;
+	Header.m_Flags = 0;
+	Header.m_Size = 4095;
+	Header.m_Sequence = 0;
+	// The maximum size with Split=6 is 4095, whereas with Split=4 it is 1023
+	TestPackUnpack(Header, 6, {0x3F, 0x3F});
+}
+
+TEST(ChunkHeader, PackSeq5)
 {
 	CNetChunkHeader Header;
 	Header.m_Flags = NET_CHUNKFLAG_VITAL;
 	Header.m_Size = 0;
 	Header.m_Sequence = 5;
+	TestPackUnpack(Header, 4, {0x40, 0x00, 0x05});
+	TestPackUnpack(Header, 6, {0x40, 0x00, 0x05});
+}
 
-	unsigned char aExpected[3] = {0x40, 0x00, 0x05};
-	AssertHeader<3>(Header, aExpected);
+TEST(ChunkHeader, PackSeq63)
+{
+	CNetChunkHeader Header;
+	Header.m_Flags = NET_CHUNKFLAG_VITAL;
+	Header.m_Size = 0;
+	Header.m_Sequence = 63;
+	TestPackUnpack(Header, 4, {0x40, 0x00, 0x3F});
+	TestPackUnpack(Header, 6, {0x40, 0x00, 0x3F});
+}
+
+TEST(ChunkHeader, PackSeq64)
+{
+	CNetChunkHeader Header;
+	Header.m_Flags = NET_CHUNKFLAG_VITAL;
+	Header.m_Size = 0;
+	Header.m_Sequence = 64;
+	TestPackUnpack(Header, 4, {0x40, 0x10, 0x40});
+	TestPackUnpack(Header, 6, {0x40, 0x00, 0x40});
+}
+
+TEST(ChunkHeader, PackSeq126)
+{
+	CNetChunkHeader Header;
+	Header.m_Flags = NET_CHUNKFLAG_VITAL;
+	Header.m_Size = 0;
+	Header.m_Sequence = 126;
+	TestPackUnpack(Header, 4, {0x40, 0x10, 0x7E});
+	TestPackUnpack(Header, 6, {0x40, 0x00, 0x7E});
+}
+
+TEST(ChunkHeader, PackSeq255)
+{
+	CNetChunkHeader Header;
+	Header.m_Flags = NET_CHUNKFLAG_VITAL;
+	Header.m_Size = 0;
+	Header.m_Sequence = 255;
+	TestPackUnpack(Header, 4, {0x40, 0x30, 0xFF});
+	TestPackUnpack(Header, 6, {0x40, 0x00, 0xFF});
+}
+
+TEST(ChunkHeader, PackSeqMax)
+{
+	CNetChunkHeader Header;
+	Header.m_Flags = NET_CHUNKFLAG_VITAL;
+	Header.m_Size = 0;
+	Header.m_Sequence = NET_MAX_SEQUENCE - 1;
+	TestPackUnpack(Header, 4, {0x40, 0xF0, 0xFF});
+	TestPackUnpack(Header, 6, {0x40, 0xC0, 0xFF});
+}
+
+TEST(ChunkHeader, PackSize255Seq511)
+{
+	CNetChunkHeader Header;
+	Header.m_Flags = NET_CHUNKFLAG_VITAL;
+	Header.m_Size = 255;
+	Header.m_Sequence = 511;
+	TestPackUnpack(Header, 4, {0x4F, 0x7F, 0xFF});
+	TestPackUnpack(Header, 6, {0x43, 0x7F, 0xFF});
+}
+
+TEST(ChunkHeader, PackAllBits)
+{
+	CNetChunkHeader HeaderSplit4;
+	HeaderSplit4.m_Flags = NET_CHUNKFLAG_VITAL | NET_CHUNKFLAG_RESEND;
+	HeaderSplit4.m_Size = 1023;
+	HeaderSplit4.m_Sequence = NET_MAX_SEQUENCE - 1;
+
+	CNetChunkHeader HeaderSplit6;
+	HeaderSplit6.m_Flags = NET_CHUNKFLAG_VITAL | NET_CHUNKFLAG_RESEND;
+	HeaderSplit6.m_Size = 4095;
+	HeaderSplit6.m_Sequence = NET_MAX_SEQUENCE - 1;
+
+	// Packing with Split=4 leaves 2 bits unused
+	TestPackUnpack(HeaderSplit4, 4, {0xFF, 0xFF, 0xFF});
+	TestPackUnpack(HeaderSplit6, 6, {0xFF, 0xFF, 0xFF});
 }

--- a/src/test/chunk_header_test.cpp
+++ b/src/test/chunk_header_test.cpp
@@ -155,7 +155,7 @@ TEST(ChunkHeader, PackSeq64)
 	Header.m_Flags = NET_CHUNKFLAG_VITAL;
 	Header.m_Size = 0;
 	Header.m_Sequence = 64;
-	TestPackUnpack(Header, 4, {0x40, 0x10, 0x40});
+	TestPackUnpack(Header, 4, {0x40, 0x00, 0x40});
 	TestPackUnpack(Header, 6, {0x40, 0x00, 0x40});
 }
 
@@ -165,7 +165,7 @@ TEST(ChunkHeader, PackSeq126)
 	Header.m_Flags = NET_CHUNKFLAG_VITAL;
 	Header.m_Size = 0;
 	Header.m_Sequence = 126;
-	TestPackUnpack(Header, 4, {0x40, 0x10, 0x7E});
+	TestPackUnpack(Header, 4, {0x40, 0x00, 0x7E});
 	TestPackUnpack(Header, 6, {0x40, 0x00, 0x7E});
 }
 
@@ -175,7 +175,7 @@ TEST(ChunkHeader, PackSeq255)
 	Header.m_Flags = NET_CHUNKFLAG_VITAL;
 	Header.m_Size = 0;
 	Header.m_Sequence = 255;
-	TestPackUnpack(Header, 4, {0x40, 0x30, 0xFF});
+	TestPackUnpack(Header, 4, {0x40, 0x00, 0xFF});
 	TestPackUnpack(Header, 6, {0x40, 0x00, 0xFF});
 }
 
@@ -185,7 +185,7 @@ TEST(ChunkHeader, PackSeqMax)
 	Header.m_Flags = NET_CHUNKFLAG_VITAL;
 	Header.m_Size = 0;
 	Header.m_Sequence = NET_MAX_SEQUENCE - 1;
-	TestPackUnpack(Header, 4, {0x40, 0xF0, 0xFF});
+	TestPackUnpack(Header, 4, {0x40, 0xC0, 0xFF});
 	TestPackUnpack(Header, 6, {0x40, 0xC0, 0xFF});
 }
 
@@ -195,7 +195,7 @@ TEST(ChunkHeader, PackSize255Seq511)
 	Header.m_Flags = NET_CHUNKFLAG_VITAL;
 	Header.m_Size = 255;
 	Header.m_Sequence = 511;
-	TestPackUnpack(Header, 4, {0x4F, 0x7F, 0xFF});
+	TestPackUnpack(Header, 4, {0x4F, 0x4F, 0xFF});
 	TestPackUnpack(Header, 6, {0x43, 0x7F, 0xFF});
 }
 
@@ -212,6 +212,6 @@ TEST(ChunkHeader, PackAllBits)
 	HeaderSplit6.m_Sequence = NET_MAX_SEQUENCE - 1;
 
 	// Packing with Split=4 leaves 2 bits unused
-	TestPackUnpack(HeaderSplit4, 4, {0xFF, 0xFF, 0xFF});
+	TestPackUnpack(HeaderSplit4, 4, {0xFF, 0xCF, 0xFF});
 	TestPackUnpack(HeaderSplit6, 6, {0xFF, 0xFF, 0xFF});
 }


### PR DESCRIPTION
Previously, the upper two bits of the lower byte of the network chunk sequence were packed into the 0.6 chunk header twice. With `Split` being `4` for 0.6 chunks, the second byte in the chunk header was split between 4 bits of the sequence and 4 bits of the size, but the lower 2 of those sequence bits were the same as the upper 2 bits that are packed into the third chunk header byte. This worked because the same bits are combined with logic-or when unpacking, so it has no effect overall.

For 0.7 chunks with `Split` being `6`, this was changed to pack 2 bits of the sequence and 6 bits of the size, allowing chunks to theoretically be 4x as large (although the maximum packet size would only allow a much smaller increase).

For 0.6 chunks, this is now changed such that only 2 bits of sequence are packed into the second chunk header byte regardless of the `Split` value. The unused bits are now set to `0`, which is compatible with the old approach because it does not change the result of the logic-or when the chunk header is unpacked.

CC #9417.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options: old client+new server, new client+old server, 0.7 client, 
- [X] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions