### PR TITLE
Fix: Map best time beeing assumed not finished instead of unset

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1224,8 +1224,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 		}
 		else if(m_MapBestTimeSeconds == FinishTime::UNSET)
 		{
-			m_MapBestTimeSeconds = FinishTime::NOT_FINISHED_MILLIS;
-			m_MapBestTimeMillis = 0;
+			// some PvP mods based on DDNet accidentally send a best time of 0, despite having no finished races
 		}
 	}
 }


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Regression from #11503 , legacy record messages cause the client to believe, that the server sends map-best-times (unfinished), when it doesn't. This comes from older server code:

`MsgLegacy.m_PlayerTimeBest = Msg.m_PlayerTimeBest = round_to_int(Score()->PlayerData(ClientId)->m_BestTime.value_or(0.0f) * 100.0f);`

If no best time is there, which is the usual case in pvp mods, the server sends 0.0f as best time.

Either we convince all modders and mods not to send this message (impossible) or we fix the client behavior on the legacy messages here.

Gladly on a race-server this doesn't make much of a change, because UNSET and NOT_FINISHED just skip the rendering of any value.

Thank you @ChillerDragon for the report!

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change (see other PR, chillerdragon comment)
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
