### PR TITLE
Ensure strict-weak ordering for CMapNameItem::CompareFilenameAscending

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3670,10 +3670,10 @@ struct CMapNameItem
 
 	static bool CompareFilenameAscending(const CMapNameItem Lhs, const CMapNameItem Rhs)
 	{
-		if(str_comp(Lhs.m_aName, "..") == 0)
-			return true;
 		if(str_comp(Rhs.m_aName, "..") == 0)
 			return false;
+		if(str_comp(Lhs.m_aName, "..") == 0)
+			return true;
 		if(Lhs.m_IsDirectory != Rhs.m_IsDirectory)
 			return Lhs.m_IsDirectory;
 		return str_comp_filenames(Lhs.m_aName, Rhs.m_aName) < 0;


### PR DESCRIPTION
Fixes server crash on MacOS.
<details><summary>Details</summary>
<p>

💣 Program crashed: Aborted at 0x0000000181c5e5b0

Platform: arm64 macOS 26.0.1 (25A362)

Thread 0 crashed:

  0 0x0000000181c5e5b0 __pthread_kill + 8 in libsystem_kernel.dylib
  1 0x0000000181b9e808 abort + 124 in libsystem_c.dylib
  2 void std::__1::__check_strict_weak_ordering_sorted[abi:dn200100]<CMapNameItem*, bool (*)(CMapNameItem, CMapNameItem)>(CMapNameItem*, CMapNameItem*, bool (*&)(CMapNameItem, CMapNameItem)) + 620 in DDNet-Server at /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.0.sdk/usr/include/c++/v1/__debug_utils/strict_weak_ordering_check.h:49:11

    47│       for (__diff_t __b = __p; __b < __q; ++__b) {
    48│         for (__diff_t __a = __p; __a <= __b; ++__a) {
    49│           _LIBCPP_ASSERT_SEMANTIC_REQUIREMENT(
      │           ▲
    50│               !__comp(*(__first + __a), *(__first + __b)), "Your comparator is not a valid strict-weak ordering");
    51│           _LIBCPP_ASSERT_SEMANTIC_REQUIREMENT(

  3 void std::__1::__sort_impl[abi:dn200100]<std::__1::_ClassicAlgPolicy, std::__1::__wrap_iter<CMapNameItem*>, bool (*)(CMapNameItem, CMapNameItem)>(std::__1::__wrap_iter<CMapNameItem*>, std::__1::__wrap_iter<CMapNameItem*>, bool (*&)(CMapNameItem, CMapNameItem)) + 172 in DDNet-Server at /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.0.sdk/usr/include/c++/v1/__algorithm/sort.h:955:3

   953│     std::__sort_dispatch<_AlgPolicy>(std::__unwrap_iter(__first), std::__unwrap_iter(__last), __comp);
   954│   }
   955│   std::__check_strict_weak_ordering_sorted(std::__unwrap_iter(__first), std::__unwrap_iter(__last), __comp);
      │   ▲
   956│ }
   957│

  4 void std::__1::sort[abi:dn200100]<std::__1::__wrap_iter<CMapNameItem*>, bool (*)(CMapNameItem, CMapNameItem)>(std::__1::__wrap_iter<CMapNameItem*>, std::__1::__wrap_iter<CMapNameItem*>, bool (*)(CMapNameItem, CMapNameItem)) + 76 in DDNet-Server at /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.0.sdk/usr/include/c++/v1/__algorithm/sort.h:961:3

   959│ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void
   960│ sort(_RandomAccessIterator __first, _RandomAccessIterator __last, _Comp __comp) {
   961│   std::__sort_impl<_ClassicAlgPolicy>(std::move(__first), std::move(__last), __comp);
      │   ▲
   962│ }
   963│

  5 CGameContext::ConAddMapVotes(IConsole::IResult*, void*) + 280 in DDNet-Server at /DDNet/src/game/server/gamecontext.cpp:3697:2
  6 CConsole::ExecuteLineStroked(int, char const*, int, bool) + 2144 in DDNet-Server at /DDNet/src/engine/shared/console.cpp:623:8
  7 CConsole::ExecuteLine(char const*, int, bool) + 60 in DDNet-Server at /DDNet/src/engine/shared/console.cpp:698:12
  8 CConsole::ExecuteFile(char const*, int, bool, int) + 488 in DDNet-Server at /DDNet/src/engine/shared/console.cpp:742:4
  9 main + 1532 in DDNet-Server at /DDNet/src/engine/server/main.cpp:160:13

</p>
</details> 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
