### PR TITLE
Fix: Map best time being shown as score, if we detect times

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -146,9 +146,12 @@ void CScoreboard::RenderTitle(CUIRect TitleBar, int Team, const char *pTitle)
 	dbg_assert(Team == TEAM_RED || Team == TEAM_BLUE, "Team invalid");
 
 	char aScore[128] = "";
-	if(GameClient()->m_MapBestTimeSeconds != FinishTime::UNSET)
+	const CNetObj_GameInfo *pGameInfoObj = GameClient()->m_Snap.m_pGameInfoObj;
+	const bool TimeScore = GameClient()->m_GameInfo.m_TimeScore;
+	const bool Race7 = Client()->IsSixup() && pGameInfoObj && pGameInfoObj->m_GameFlags & protocol7::GAMEFLAG_RACE;
+	if(GameClient()->m_ReceivedDDNetPlayerFinishTimes || TimeScore || Race7)
 	{
-		if(GameClient()->m_MapBestTimeSeconds != FinishTime::NOT_FINISHED_MILLIS)
+		if(GameClient()->m_MapBestTimeSeconds != FinishTime::NOT_FINISHED_MILLIS && GameClient()->m_MapBestTimeSeconds != FinishTime::UNSET)
 		{
 			int64_t TimeCentiseconds = static_cast<int64_t>(GameClient()->m_MapBestTimeSeconds) * 100 + static_cast<int64_t>(GameClient()->m_MapBestTimeMillis) / 10;
 			str_time(TimeCentiseconds, TIME_HOURS, aScore, sizeof(aScore));


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

~~Make the client ignore send best times, if they are from non-time-based mods. This supersedes #11622.~~
A send time of 0 can have two meanings, i.e. UNSET and NOT_FINISHED. Depending on the mod this needs to be handled differently.

Before: 

<img width="2560" height="1440" alt="screenshot_2026-01-15_10-09-13" src="https://github.com/user-attachments/assets/75a23718-f944-4e65-9f61-1a2983f7d127" />

After:
<img width="2560" height="1440" alt="screenshot_2026-01-15_10-32-52" src="https://github.com/user-attachments/assets/730f55d6-b0fd-4446-928d-ece62cd3f510" />

I also tested this on noby's fng server

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
