### PR TITLE
Rename ddrace controller to ddnet controller

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2814,8 +2814,8 @@ if(SERVER)
     gamecontext.h
     gamecontroller.cpp
     gamecontroller.h
-    gamemodes/DDRace.cpp
-    gamemodes/DDRace.h
+    gamemodes/ddnet.cpp
+    gamemodes/ddnet.h
     gamemodes/mod.cpp
     gamemodes/mod.h
     gameworld.cpp

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -10,7 +10,7 @@
 
 #include <game/mapitems.h>
 #include <game/server/entities/character.h>
-#include <game/server/gamemodes/DDRace.h>
+#include <game/server/gamemodes/ddnet.h>
 #include <game/server/teams.h>
 #include <game/team_state.h>
 #include <game/teamscore.h>

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -5,7 +5,7 @@
 #include <engine/shared/config.h>
 
 #include <game/server/entities/character.h>
-#include <game/server/gamemodes/DDRace.h>
+#include <game/server/gamemodes/ddnet.h>
 #include <game/server/player.h>
 #include <game/server/save.h>
 #include <game/server/teams.h>

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -10,7 +10,7 @@
 
 #include <game/mapitems.h>
 #include <game/server/gamecontext.h>
-#include <game/server/gamemodes/DDRace.h>
+#include <game/server/gamemodes/ddnet.h>
 
 CLaser::CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEnergy, int Owner, int Type) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_LASER)

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -10,7 +10,7 @@
 
 #include <game/mapitems.h>
 #include <game/server/gamecontext.h>
-#include <game/server/gamemodes/DDRace.h>
+#include <game/server/gamemodes/ddnet.h>
 
 CProjectile::CProjectile(
 	CGameWorld *pGameWorld,

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3,7 +3,7 @@
 #include "gamecontext.h"
 
 #include "entities/character.h"
-#include "gamemodes/DDRace.h"
+#include "gamemodes/ddnet.h"
 #include "gamemodes/mod.h"
 #include "player.h"
 #include "score.h"
@@ -4193,7 +4193,7 @@ void CGameContext::OnInit(const void *pPersistentData)
 	if(!str_comp(Config()->m_SvGametype, "mod"))
 		m_pController = new CGameControllerMod(this);
 	else
-		m_pController = new CGameControllerDDRace(this);
+		m_pController = new CGameControllerDDNet(this);
 
 	ReadCensorList();
 

--- a/src/game/server/gamemodes/ddnet.cpp
+++ b/src/game/server/gamemodes/ddnet.cpp
@@ -1,6 +1,6 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 /* Based on Race mod stuff and tweaked by GreYFoX@GTi and others to fit our DDRace needs. */
-#include "DDRace.h"
+#include "ddnet.h"
 
 #include <engine/server.h>
 #include <engine/shared/config.h>
@@ -17,21 +17,21 @@
 #define GAME_TYPE_NAME "DDraceNetwork"
 #define TEST_TYPE_NAME "TestDDraceNetwork"
 
-CGameControllerDDRace::CGameControllerDDRace(class CGameContext *pGameServer) :
+CGameControllerDDNet::CGameControllerDDNet(class CGameContext *pGameServer) :
 	IGameController(pGameServer)
 {
 	m_pGameType = g_Config.m_SvTestingCommands ? TEST_TYPE_NAME : GAME_TYPE_NAME;
 	m_GameFlags = protocol7::GAMEFLAG_RACE;
 }
 
-CGameControllerDDRace::~CGameControllerDDRace() = default;
+CGameControllerDDNet::~CGameControllerDDNet() = default;
 
-CScore *CGameControllerDDRace::Score()
+CScore *CGameControllerDDNet::Score()
 {
 	return GameServer()->Score();
 }
 
-void CGameControllerDDRace::HandleCharacterTiles(CCharacter *pChr, int MapIndex)
+void CGameControllerDDNet::HandleCharacterTiles(CCharacter *pChr, int MapIndex)
 {
 	CPlayer *pPlayer = pChr->GetPlayer();
 	const int ClientId = pPlayer->GetCid();
@@ -115,12 +115,12 @@ void CGameControllerDDRace::HandleCharacterTiles(CCharacter *pChr, int MapIndex)
 	}
 }
 
-void CGameControllerDDRace::SetArmorProgress(CCharacter *pCharacter, int Progress)
+void CGameControllerDDNet::SetArmorProgress(CCharacter *pCharacter, int Progress)
 {
 	pCharacter->SetArmor(std::clamp(10 - (Progress / 15), 0, 10));
 }
 
-int CGameControllerDDRace::SnapPlayerScore(int SnappingClient, CPlayer *pPlayer)
+int CGameControllerDDNet::SnapPlayerScore(int SnappingClient, CPlayer *pPlayer)
 {
 	bool HideScore = g_Config.m_SvHideScore && SnappingClient != pPlayer->GetCid();
 	std::optional<float> Score = GameServer()->Score()->PlayerData(pPlayer->GetCid())->m_BestTime;
@@ -151,7 +151,7 @@ int CGameControllerDDRace::SnapPlayerScore(int SnappingClient, CPlayer *pPlayer)
 	return -ScoreSeconds;
 }
 
-IGameController::CFinishTime CGameControllerDDRace::SnapPlayerTime(int SnappingClient, CPlayer *pPlayer)
+IGameController::CFinishTime CGameControllerDDNet::SnapPlayerTime(int SnappingClient, CPlayer *pPlayer)
 {
 	std::optional<float> BestTime = GameServer()->Score()->PlayerData(pPlayer->GetCid())->m_BestTime;
 	if(BestTime.has_value() && (!g_Config.m_SvHideScore || SnappingClient == pPlayer->GetCid()))
@@ -165,7 +165,7 @@ IGameController::CFinishTime CGameControllerDDRace::SnapPlayerTime(int SnappingC
 	return CFinishTime::NotFinished();
 }
 
-IGameController::CFinishTime CGameControllerDDRace::SnapMapBestTime(int SnappingClient)
+IGameController::CFinishTime CGameControllerDDNet::SnapMapBestTime(int SnappingClient)
 {
 	if(m_CurrentRecord.has_value() && !g_Config.m_SvHideScore)
 	{
@@ -178,7 +178,7 @@ IGameController::CFinishTime CGameControllerDDRace::SnapMapBestTime(int Snapping
 	return CFinishTime::NotFinished();
 }
 
-void CGameControllerDDRace::OnPlayerConnect(CPlayer *pPlayer)
+void CGameControllerDDNet::OnPlayerConnect(CPlayer *pPlayer)
 {
 	IGameController::OnPlayerConnect(pPlayer);
 	int ClientId = pPlayer->GetCid();
@@ -201,7 +201,7 @@ void CGameControllerDDRace::OnPlayerConnect(CPlayer *pPlayer)
 	}
 }
 
-void CGameControllerDDRace::OnPlayerDisconnect(CPlayer *pPlayer, const char *pReason)
+void CGameControllerDDNet::OnPlayerDisconnect(CPlayer *pPlayer, const char *pReason)
 {
 	int ClientId = pPlayer->GetCid();
 	bool WasModerator = pPlayer->m_Moderating && Server()->ClientIngame(ClientId);
@@ -219,20 +219,20 @@ void CGameControllerDDRace::OnPlayerDisconnect(CPlayer *pPlayer, const char *pRe
 			Teams().SetClientInvited(Team, ClientId, false);
 }
 
-void CGameControllerDDRace::OnReset()
+void CGameControllerDDNet::OnReset()
 {
 	IGameController::OnReset();
 	Teams().Reset();
 }
 
-void CGameControllerDDRace::Tick()
+void CGameControllerDDNet::Tick()
 {
 	IGameController::Tick();
 	Teams().ProcessSaveTeam();
 	Teams().Tick();
 }
 
-void CGameControllerDDRace::DoTeamChange(class CPlayer *pPlayer, int Team, bool DoChatMsg)
+void CGameControllerDDNet::DoTeamChange(class CPlayer *pPlayer, int Team, bool DoChatMsg)
 {
 	if(!IsValidTeam(Team))
 		return;

--- a/src/game/server/gamemodes/ddnet.h
+++ b/src/game/server/gamemodes/ddnet.h
@@ -1,16 +1,16 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
-#ifndef GAME_SERVER_GAMEMODES_DDRACE_H
-#define GAME_SERVER_GAMEMODES_DDRACE_H
+#ifndef GAME_SERVER_GAMEMODES_DDNET_H
+#define GAME_SERVER_GAMEMODES_DDNET_H
 
 #include <game/server/gamecontroller.h>
 
 class CScore;
 
-class CGameControllerDDRace : public IGameController
+class CGameControllerDDNet : public IGameController
 {
 public:
-	CGameControllerDDRace(class CGameContext *pGameServer);
-	~CGameControllerDDRace() override;
+	CGameControllerDDNet(class CGameContext *pGameServer);
+	~CGameControllerDDNet() override;
 
 	CScore *Score();
 
@@ -29,4 +29,4 @@ public:
 
 	void DoTeamChange(class CPlayer *pPlayer, int Team, bool DoChatMsg = true) override;
 };
-#endif // GAME_SERVER_GAMEMODES_DDRACE_H
+#endif // GAME_SERVER_GAMEMODES_DDNET_H

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -9,7 +9,7 @@
 
 #include <game/server/entities/character.h>
 #include <game/server/gamecontext.h>
-#include <game/server/gamemodes/DDRace.h>
+#include <game/server/gamemodes/ddnet.h>
 #include <game/team_state.h>
 
 #include <cstdio> // sscanf

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -16,7 +16,7 @@
 #include <generated/wordlist.h>
 
 #include <game/server/gamecontext.h>
-#include <game/server/gamemodes/DDRace.h>
+#include <game/server/gamemodes/ddnet.h>
 #include <game/team_state.h>
 
 #include <memory>


### PR DESCRIPTION
Fixes the filename convention violation
https://github.com/ddnet/ddnet/blob/3f2e9acd9879bc7cfa0c8972b4145c061e97e2bf/CONTRIBUTING.md#filenames

And also uses the proper project name instead of the legacy name.

Apparently ddnet is quite protective of its "ddnet" brand see https://github.com/MilkeeyCat/ddnet_protocol/issues/147

I would then like to free the "ddrace" name again if ddnet does not use it.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions