### PR TITLE
 Set server info map based on loaded map, use for Discord activity

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -429,10 +429,7 @@ void CClient::SetState(EClientState State)
 	if(State == IClient::STATE_ONLINE)
 	{
 		const bool Registered = m_ServerBrowser.IsRegistered(ServerAddress());
-		CServerInfo CurrentServerInfo;
-		GetServerInfo(&CurrentServerInfo);
-
-		Discord()->SetGameInfo(CurrentServerInfo, GameClient()->Map()->BaseName(), Registered);
+		Discord()->SetGameInfo(m_CurrentServerInfo, Registered);
 		Steam()->SetGameInfo(ServerAddress(), GameClient()->Map()->BaseName(), Registered);
 	}
 	else if(OldState == IClient::STATE_ONLINE)
@@ -858,13 +855,22 @@ bool CClient::DummyAllowed() const
 
 void CClient::GetServerInfo(CServerInfo *pServerInfo) const
 {
-	mem_copy(pServerInfo, &m_CurrentServerInfo, sizeof(m_CurrentServerInfo));
+	*pServerInfo = m_CurrentServerInfo;
 }
 
 void CClient::ServerInfoRequest()
 {
 	mem_zero(&m_CurrentServerInfo, sizeof(m_CurrentServerInfo));
 	m_CurrentServerInfoRequestTime = 0;
+}
+
+void CClient::SetCurrentServerInfo(const CServerInfo &ServerInfo)
+{
+	m_CurrentServerInfo = ServerInfo;
+	m_CurrentServerInfoRequestTime = -1;
+	str_copy(m_CurrentServerInfo.m_aMap, GameClient()->Map()->BaseName());
+	m_CurrentServerInfo.m_MapCrc = GameClient()->Map()->Crc();
+	m_CurrentServerInfo.m_MapSize = GameClient()->Map()->Size();
 }
 
 void CClient::LoadDebugFont()
@@ -1468,9 +1474,8 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 			// us.
 			if(SavedType >= m_CurrentServerInfo.m_Type)
 			{
-				m_CurrentServerInfo = Info;
-				m_CurrentServerInfoRequestTime = -1;
-				Discord()->UpdateServerInfo(Info, GameClient()->Map()->BaseName());
+				SetCurrentServerInfo(Info);
+				Discord()->UpdateServerInfo(m_CurrentServerInfo);
 			}
 
 			bool ValidPong = false;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -345,6 +345,7 @@ public:
 
 	void GetServerInfo(CServerInfo *pServerInfo) const override;
 	void ServerInfoRequest();
+	void SetCurrentServerInfo(const CServerInfo &ServerInfo);
 
 	void LoadDebugFont();
 

--- a/src/engine/client/discord.cpp
+++ b/src/engine/client/discord.cpp
@@ -99,7 +99,7 @@ public:
 		m_UpdateActivity = true;
 	}
 
-	void SetGameInfo(const CServerInfo &ServerInfo, const char *pMapName, bool Registered) override
+	void SetGameInfo(const CServerInfo &ServerInfo, bool Registered) override
 	{
 		mem_zero(&m_Activity, sizeof(DiscordActivity));
 
@@ -110,7 +110,7 @@ public:
 		m_Activity.instance = true;
 
 		str_copy(m_Activity.details, ServerInfo.m_aName, sizeof(m_Activity.details));
-		str_copy(m_Activity.state, pMapName, sizeof(m_Activity.state));
+		str_copy(m_Activity.state, ServerInfo.m_aMap, sizeof(m_Activity.state));
 		m_Activity.party.size.current_size = ServerInfo.m_NumClients;
 		m_Activity.party.size.max_size = ServerInfo.m_MaxClients;
 		// private makes it so the game isn't public to join, but there's 'Ask to Join' button instead
@@ -128,7 +128,7 @@ public:
 		m_UpdateActivity = true;
 	}
 
-	void UpdateServerInfo(const CServerInfo &ServerInfo, const char *pMapName) override
+	void UpdateServerInfo(const CServerInfo &ServerInfo) override
 	{
 		if(!m_Activity.instance)
 			return;
@@ -136,7 +136,7 @@ public:
 		UpdateServerIp(ServerInfo);
 
 		str_copy(m_Activity.details, ServerInfo.m_aName, sizeof(m_Activity.details));
-		str_copy(m_Activity.state, pMapName, sizeof(m_Activity.state));
+		str_copy(m_Activity.state, ServerInfo.m_aMap, sizeof(m_Activity.state));
 		m_Activity.party.size.max_size = ServerInfo.m_MaxClients;
 		m_UpdateActivity = true;
 	}
@@ -214,8 +214,8 @@ class CDiscordStub : public IDiscord
 {
 	void Update() override {}
 	void ClearGameInfo() override {}
-	void SetGameInfo(const CServerInfo &ServerInfo, const char *pMapName, bool Registered) override {}
-	void UpdateServerInfo(const CServerInfo &ServerInfo, const char *pMapName) override {}
+	void SetGameInfo(const CServerInfo &ServerInfo, bool Registered) override {}
+	void UpdateServerInfo(const CServerInfo &ServerInfo) override {}
 	void UpdatePlayerCount(int Count) override {}
 };
 

--- a/src/engine/client/sixup_translate_system.cpp
+++ b/src/engine/client/sixup_translate_system.cpp
@@ -41,7 +41,7 @@ int CClient::TranslateSysMsg(int *pMsgId, bool System, CUnpacker *pUnpacker, CPa
 		str_copy(m_CurrentServerInfo.m_aName, pUnpacker->GetString(CUnpacker::SANITIZE_CC | CUnpacker::SKIP_START_WHITESPACES));
 		str_clean_whitespaces(m_CurrentServerInfo.m_aName);
 		pUnpacker->GetString(CUnpacker::SANITIZE_CC | CUnpacker::SKIP_START_WHITESPACES); // Hostname
-		str_copy(m_CurrentServerInfo.m_aMap, pUnpacker->GetString(CUnpacker::SANITIZE_CC | CUnpacker::SKIP_START_WHITESPACES));
+		pUnpacker->GetString(CUnpacker::SANITIZE_CC | CUnpacker::SKIP_START_WHITESPACES); // Map, determined based on filename
 		str_copy(m_CurrentServerInfo.m_aGameType, pUnpacker->GetString(CUnpacker::SANITIZE_CC | CUnpacker::SKIP_START_WHITESPACES));
 		int Flags = pUnpacker->GetInt();
 		if(Flags & SERVER_FLAG_PASSWORD)

--- a/src/engine/discord.h
+++ b/src/engine/discord.h
@@ -14,8 +14,8 @@ public:
 	virtual void Update() = 0;
 
 	virtual void ClearGameInfo() = 0;
-	virtual void SetGameInfo(const CServerInfo &ServerInfo, const char *pMapName, bool Registered) = 0;
-	virtual void UpdateServerInfo(const CServerInfo &ServerInfo, const char *pMapName) = 0;
+	virtual void SetGameInfo(const CServerInfo &ServerInfo, bool Registered) = 0;
+	virtual void UpdateServerInfo(const CServerInfo &ServerInfo) = 0;
 	virtual void UpdatePlayerCount(int Count) = 0;
 };
 


### PR DESCRIPTION
Set the map name, size and CRC of the current server's server info based on the currently loaded map to ensure that it matches the actual map.

Use the map name of the server info for the Discord activity, instead of passing it separately.

Do not unpack the map name from 0.7 server info because it is already determined based on the loaded map.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions