### PR TITLE
Fix LAN server info handled as pong when not online

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1461,7 +1461,9 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 		//
 		// SERVERINFO_EXTENDED_MORE doesn't carry any server
 		// information, so just skip it.
-		if(net_addr_comp(&ServerAddress(), pFrom) == 0 && RawType != SERVERINFO_EXTENDED_MORE)
+		if(m_aNetClient[CONN_MAIN].State() == NETSTATE_ONLINE &&
+			ServerAddress() == *pFrom &&
+			RawType != SERVERINFO_EXTENDED_MORE)
 		{
 			// Only accept server info that has a type that is
 			// newer or equal to something the server already sent


### PR DESCRIPTION
When disconnecting from a local server, the client immediately requests the server info from LAN servers. This server info is incorrectly considered to be the server info pong, which is only expected to be received when connecting to a server, because `ServerAddress()` still contains the value of the last server that the client connected to.

The pong was considered invalid, so it did not enter the `ValidPong` branch below, but it caused `Discord()->UpdateServerInfo` to be called while not online with the previous map name. This will be an issue when the current map name is stored inside the map class and not separately in the client, at which point accessing the map name will crash with an assertion when the map is unloaded.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions