### PR TITLE
Actually queue resend in `CServer::ExpireServerInfoAndQueueResend`

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2583,7 +2583,7 @@ void CServer::ExpireServerInfo()
 void CServer::ExpireServerInfoAndQueueResend()
 {
 	m_ServerInfoNeedsUpdate = true;
-	m_ServerInfoNeedsResend = false;
+	m_ServerInfoNeedsResend = true;
 }
 
 void CServer::UpdateRegisterServerInfo()


### PR DESCRIPTION
Follow-up fix for #11649. Found while reading the diff.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions