### PR TITLE
Feature: Add real HSL values to the Hsla scrollbars

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1734,8 +1734,8 @@ bool CMenus::RenderHslaScrollbars(CUIRect *pRect, unsigned int *pColor, bool Alp
 		CUIRect Button, Label;
 		pRect->HSplitTop(SizePerEntry, &Button, pRect);
 		pRect->HSplitTop(MarginPerEntry, nullptr, pRect);
-		Button.VSplitLeft(10.0f, nullptr, &Button);
-		Button.VSplitLeft(100.0f, &Label, &Button);
+		Button.VSplitLeft(140.0f, &Label, &Button);
+		Label.VMargin(10.0f, &Label);
 
 		Button.Draw(ColorRGBA(0.15f, 0.15f, 0.15f, 1.0f), IGraphics::CORNER_ALL, 1.0f);
 
@@ -1743,8 +1743,21 @@ bool CMenus::RenderHslaScrollbars(CUIRect *pRect, unsigned int *pColor, bool Alp
 		Button.Margin(2.0f, &Rail);
 
 		char aBuf[32];
-		str_format(aBuf, sizeof(aBuf), "%s: %03d", apLabels[i], round_to_int(Color[i] * 255.0f));
-		Ui()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_ML);
+
+		// Hue
+		if(i == 0)
+			str_format(aBuf, sizeof(aBuf), "%s: %.1f° (%03d)", apLabels[i], Color[i] * 360.0f, round_to_int(Color[i] * 255.0f));
+		// Lht
+		else if(i == 2)
+		{
+			// handle internal light clamping, see `UnclampLighting`
+			float Lht = DarkestLight + Color[i] * (1.0f - DarkestLight);
+			str_format(aBuf, sizeof(aBuf), "%s: %.1f%% (%03d)", apLabels[i], Lht * 100.0f, round_to_int(Color[i] * 255.0f));
+		}
+		// Sat and Alpha
+		else
+			str_format(aBuf, sizeof(aBuf), "%s: %.1f%% (%03d)", apLabels[i], Color[i] * 100.0f, round_to_int(Color[i] * 255.0f));
+		Ui()->DoLabel(&Label, aBuf, 12.0f, TEXTALIGN_ML);
 
 		ColorRGBA HandleColor;
 		Graphics()->TextureClear();


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Currently the HSL(A) scrollbars show values between 0 and 255, which is not nice and doesn't follow the usual HSL color values. This PR adds the normal representation to the scrollbars, i.e. 0 to 360° (degree) to the Hue value, and 0% - 100% to all other values. The old values are still shown. This is an actual issue, we had players on discord complaining, that the Hue is broken in ddnet.

This is also more in line with the `debug_color_body` command, which **returns values in this format**

Tested ingame:

<img width="2560" height="1440" alt="screenshot_2026-01-23_15-03-29" src="https://github.com/user-attachments/assets/92346cc7-d140-4caf-b862-ac440fbfa7d5" />
<img width="2560" height="1440" alt="screenshot_2026-01-23_15-07-58" src="https://github.com/user-attachments/assets/e8097747-a302-43d5-962d-d33611186b0e" />


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
