### PR TITLE
Make cmdlist list only commands without practice flag

### DIFF
--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -73,6 +73,7 @@ class CConsole : public IConsole
 	static void Con_Exec(IResult *pResult, void *pUserData);
 	static void ConCommandAccess(IResult *pResult, void *pUser);
 	static void ConCommandStatus(IConsole::IResult *pResult, void *pUser);
+	void PrintCommandList(EAccessLevel MinAccessLevel, int ExcludeFlagMask);
 
 	void ExecuteLineStroked(int Stroke, const char *pStr, int ClientId = IConsole::CLIENT_ID_UNSPECIFIED, bool InterpretSemicolons = true) override;
 


### PR DESCRIPTION
With more and more practice commands getting added, `cmdlist` became basically unreadable with how many commands there is.
Since `practicecmdlist` exists, I don't think `cmdlist` needs to list literally everything

Before:

<img width="755" height="449" alt="image" src="https://github.com/user-attachments/assets/a452a5f9-b582-4b86-abb6-e8541fc34f39" />


After:
<img width="747" height="307" alt="image" src="https://github.com/user-attachments/assets/0fbf679a-8a3e-43d1-9a12-8344b1898607" />


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
