### PR TITLE
Add scoreboard popup with map info

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -659,4 +659,8 @@ Messages = [
 	NetMessageEx("Cl_EnableSpectatorCount", "enable-spectator-count@netmsg.ddnet.org", [
 		NetBool("m_Enable"),
 	]),
+	
+	NetMessageEx("Sv_MapInfo", "map-info@netmsg.ddnet.org", [
+		NetString("m_pDescription"),
+	]),
 ]

--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -58,9 +58,20 @@ class CScoreboard : public CComponent
 		int m_ClientId;
 		bool m_IsLocal;
 		bool m_IsSpectating;
+
+		static CUi::EPopupMenuFunctionResult Render(void *pContext, CUIRect View, bool Active);
 	} m_ScoreboardPopupContext;
 
-	static CUi::EPopupMenuFunctionResult PopupScoreboard(void *pContext, CUIRect View, bool Active);
+	class CMapTitlePopupContext : public SPopupMenuId
+	{
+	public:
+		CScoreboard *m_pScoreboard = nullptr;
+
+		float m_FontSize;
+
+		static CUi::EPopupMenuFunctionResult Render(void *pContext, CUIRect View, bool Active);
+	} m_MapTitlePopupContext;
+	char m_MapTitleButtonId;
 
 	class CPlayerElement
 	{

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -696,6 +696,7 @@ void CGameClient::OnReset()
 
 	m_MapBestTimeSeconds = FinishTime::UNSET;
 	m_MapBestTimeMillis = 0;
+	m_aMapDescription[0] = '\0';
 
 	// m_MapBugs and m_aTuningList are reset in LoadMapSettings
 
@@ -1228,6 +1229,11 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 		{
 			// some PvP mods based on DDNet accidentally send a best time of 0, despite having no finished races
 		}
+	}
+	else if(MsgId == NETMSGTYPE_SV_MAPINFO)
+	{
+		CNetMsg_Sv_MapInfo *pMsg = static_cast<CNetMsg_Sv_MapInfo *>(pRawMsg);
+		str_copy(m_aMapDescription, pMsg->m_pDescription);
 	}
 }
 

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -887,6 +887,7 @@ public:
 	void CleanMultiViewId(int ClientId);
 	int m_MapBestTimeSeconds;
 	int m_MapBestTimeMillis;
+	char m_aMapDescription[512];
 
 private:
 	std::vector<CSnapEntities> m_vSnapEntities;

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -576,6 +576,14 @@ void CGameContext::ConMapInfo(IConsole::IResult *pResult, void *pUserData)
 	if(!pPlayer)
 		return;
 
+	// use cached map info for current map
+	const bool IsCurrentMap = pResult->NumArguments() == 0 || str_comp_nocase(pResult->GetString(0), pSelf->Server()->GetMapName()) == 0;
+	if(IsCurrentMap && pSelf->m_aMapInfoMessage[0] != '\0')
+	{
+		pSelf->SendChatTarget(pResult->m_ClientId, pSelf->m_aMapInfoMessage);
+		return;
+	}
+
 	if(pResult->NumArguments() > 0)
 		pSelf->Score()->MapInfo(pResult->m_ClientId, pResult->GetString(0));
 	else

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -56,6 +56,7 @@ class IEngine;
 class IStorage;
 struct CAntibotRoundData;
 struct CScoreRandomMapResult;
+struct CScorePlayerResult;
 
 struct CSnapContext
 {
@@ -409,6 +410,10 @@ public:
 	bool PracticeByDefault() const;
 
 	std::shared_ptr<CScoreRandomMapResult> m_SqlRandomMapResult;
+
+	// cached map info from database
+	std::shared_ptr<CScorePlayerResult> m_pLoadMapInfoResult;
+	char m_aMapInfoMessage[512];
 
 private:
 	// starting 1 to make 0 the special value "no client id"

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -124,6 +124,20 @@ void CScore::LoadBestTime()
 	m_pPool->Execute(CScoreWorker::LoadBestTime, std::move(Tmp), "load best time");
 }
 
+void CScore::LoadMapInfo()
+{
+	if(m_pGameServer->m_pLoadMapInfoResult)
+		return; // already in progress
+
+	auto pResult = std::make_shared<CScorePlayerResult>();
+	m_pGameServer->m_pLoadMapInfoResult = pResult;
+
+	auto Tmp = std::make_unique<CSqlPlayerRequest>(pResult);
+	str_copy(Tmp->m_aName, Server()->GetMapName(), sizeof(Tmp->m_aName));
+	Tmp->m_aRequestingPlayer[0] = '\0'; // no player, so no "your time" in result
+	m_pPool->Execute(CScoreWorker::MapInfo, std::move(Tmp), "load map info");
+}
+
 void CScore::LoadPlayerData(int ClientId, const char *pName)
 {
 	ExecPlayerThread(CScoreWorker::LoadPlayerData, "load player data", ClientId, pName, 0);

--- a/src/game/server/score.h
+++ b/src/game/server/score.h
@@ -44,6 +44,7 @@ public:
 	CPlayerData *PlayerData(int Id) { return &m_aPlayerData[Id]; }
 
 	void LoadBestTime();
+	void LoadMapInfo();
 	void MapInfo(int ClientId, const char *pMapName);
 	void MapVote(int ClientId, const char *pMapName);
 	void LoadPlayerData(int ClientId, const char *pName = "");


### PR DESCRIPTION
https://github.com/ddnet/ddnet/issues/11499

<img width="294" height="137" alt="image" src="https://github.com/user-attachments/assets/1f5c480c-bd75-4180-8a6d-bcacbaabf8bb" />


<img width="739" height="204" alt="image" src="https://github.com/user-attachments/assets/13b08acd-e71c-4ab1-964e-aa9ac8644a7a" />


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
