### PR TITLE
Fix changing spectator in demo player when paused

### DIFF
--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -1010,7 +1010,7 @@ bool CDemoPlayer::SeekTick(ETickOffset TickOffset)
 	switch(TickOffset)
 	{
 	case TICK_CURRENT:
-		// TODO: WantedTick == m_Info.m_NextTick is used to update spectator info when paused so seeking must be done
+		// TODO: https://github.com/ddnet/ddnet/issues/11681
 		WantedTick = m_Info.m_Info.m_CurrentTick;
 		break;
 	case TICK_PREVIOUS:
@@ -1033,7 +1033,7 @@ bool CDemoPlayer::SetPos(int WantedTick)
 	if(!m_File)
 		return false;
 
-	// TODO: WantedTick == m_Info.m_NextTick is used to update spectator info when paused so seeking must be done
+	// TODO: Early exit when WantedTick > m_Info.m_Info.m_CurrentTick && WantedTick <= m_Info.m_NextTick with https://github.com/ddnet/ddnet/issues/11681
 
 	int LastSeekableTick = m_Info.m_Info.m_LastTick;
 	if(m_Info.m_Info.m_LiveDemo)
@@ -1053,7 +1053,6 @@ bool CDemoPlayer::SetPos(int WantedTick)
 	// Just the next tick
 	if(WantedTick == m_Info.m_NextTick + 1)
 	{
-		// This does handle looping correctly
 		DoTick();
 		Play();
 		return true;
@@ -1069,7 +1068,9 @@ bool CDemoPlayer::SetPos(int WantedTick)
 	while(KeyFrame > 0 && m_vKeyFrames[KeyFrame].m_Tick > KeyFrameWantedTick)
 		KeyFrame--;
 
+	// TODO Remove `WantedTick <= m_Info.m_NextTick` with https://github.com/ddnet/ddnet/issues/11681
 	if(WantedTick <= m_Info.m_Info.m_CurrentTick || // if we are seeking backwards (must be <= for high bandwidth demos) OR
+		WantedTick <= m_Info.m_NextTick || // if seeking to current tick OR
 		m_Info.m_Info.m_CurrentTick < m_vKeyFrames[KeyFrame].m_Tick || // we are before the wanted KeyFrame OR
 		(KeyFrame != m_vKeyFrames.size() - 1 && m_Info.m_Info.m_CurrentTick >= m_vKeyFrames[KeyFrame + 1].m_Tick)) // we are after the wanted KeyFrame
 	{

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -601,7 +601,7 @@ void CSpectator::Spectate(int SpectatorId)
 	{
 		GameClient()->m_DemoSpecId = std::clamp(SpectatorId, (int)SPEC_FOLLOW, MAX_CLIENTS - 1);
 		// The tick must be rendered for the spectator mode to be updated, so we do it manually when demo playback is paused
-		// TODO: Update spectator info some other way
+		// TODO: https://github.com/ddnet/ddnet/issues/11681
 		if(DemoPlayer()->BaseInfo()->m_Paused)
 			GameClient()->m_Menus.DemoSeekTick(IDemoPlayer::TICK_CURRENT);
 		return;


### PR DESCRIPTION
Caused by #10613 (sorry!)

Before #10613 when spec was changed it would resim from the latest keyframe
After the intention (but not what happened) was to keep supporting TICK_CURRENT and (imo incorrectly) still resim from the latest keyframe.
Instead of using TICK_CURRENT this removes it and when spectator changes during demo paused goes 1 tick backward and forward

Also removed comment `// This does handle looping correctly` which is true, but it is the same behaviour as using arrow keys to seek


Before (excuse my TClient):
![before](https://github.com/user-attachments/assets/60a70701-9671-4a26-b32b-e57f9b69e030)
* Multiview works
* Changing spectator doesn't work when paused and leads to weird behaviour when moving mouse

After (why doesn't it embed?!):
![after](https://github.com/user-attachments/assets/e42399e1-9eb7-4a53-a46b-4004a7e13150)


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
