### PR TITLE
Show team colors in serverbrowser player list

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -722,6 +722,11 @@ void CServerBrowser::SetInfo(CServerEntry *pEntry, const CServerInfo &Info) cons
 		}
 	}
 
+	if(pEntry->m_Info.m_ClientTeamKind == CServerInfo::CLIENT_TEAM_KIND_UNSPECIFIED)
+	{
+		pEntry->m_Info.m_ClientTeamKind = CServerInfo::CLIENT_TEAM_KIND_NONE;
+	}
+
 	class CPlayerScoreNameLess
 	{
 		const int m_ScoreKind;
@@ -766,6 +771,23 @@ void CServerBrowser::SetInfo(CServerEntry *pEntry, const CServerInfo &Info) cons
 	};
 
 	std::sort(pEntry->m_Info.m_aClients, pEntry->m_Info.m_aClients + Info.m_NumReceivedClients, CPlayerScoreNameLess(pEntry->m_Info.m_ClientScoreKind));
+
+	for(int ReceivedClientId = 0; ReceivedClientId < pEntry->m_Info.m_NumReceivedClients; ReceivedClientId++)
+		pEntry->m_Info.m_aSortedClientsByTeam[ReceivedClientId] = ReceivedClientId;
+
+	if(pEntry->m_Info.m_ClientTeamKind != CServerInfo::CLIENT_TEAM_KIND_NONE)
+	{
+		std::stable_sort(pEntry->m_Info.m_aSortedClientsByTeam, pEntry->m_Info.m_aSortedClientsByTeam + pEntry->m_Info.m_NumReceivedClients, [&](int Index1, int Index2) {
+			const int Team1 = pEntry->m_Info.m_aClients[Index1].m_Team;
+			const int Team2 = pEntry->m_Info.m_aClients[Index2].m_Team;
+			// spectators are last
+			if(Team1 == -1)
+				return false;
+			if(Team2 == -1)
+				return true;
+			return Team1 < Team2;
+		});
+	}
 
 	pEntry->m_GotInfo = 1;
 }

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -364,6 +364,7 @@ public:
 	virtual const char *GameType() const = 0;
 	virtual const char *Version() const = 0;
 	virtual const char *NetVersion() const = 0;
+	virtual const char *TeamKind() const = 0;
 
 	virtual CNetObjHandler *GetNetObjHandler() = 0;
 	virtual protocol7::CNetObjHandler *GetNetObjHandler7() = 0;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2655,6 +2655,9 @@ void CServer::UpdateRegisterServerInfo()
 	JsonWriter.WriteAttribute("client_score_kind");
 	JsonWriter.WriteStrValue("time"); // "points" or "time"
 
+	JsonWriter.WriteAttribute("client_team_kind");
+	JsonWriter.WriteStrValue(GameServer()->TeamKind()); // "vanilla" or "ddrace" or "none"
+
 	JsonWriter.WriteAttribute("requires_login");
 	JsonWriter.WriteBoolValue(false);
 

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -50,6 +50,14 @@ public:
 		CLIENT_SCORE_KIND_TIME_BACKCOMPAT,
 	};
 
+	enum EClientTeamKind
+	{
+		CLIENT_TEAM_KIND_UNSPECIFIED,
+		CLIENT_TEAM_KIND_NONE,
+		CLIENT_TEAM_KIND_VANILLA,
+		CLIENT_TEAM_KIND_DDRACE,
+	};
+
 	enum ERankState
 	{
 		RANK_UNAVAILABLE,
@@ -73,6 +81,7 @@ public:
 		int m_Score;
 		bool m_Player;
 		bool m_Afk;
+		int m_Team;
 		int m_FriendState;
 		// skin info 0.6
 		char m_aSkin[MAX_SKIN_LENGTH];
@@ -104,6 +113,7 @@ public:
 	int m_NumPlayers;
 	int m_Flags;
 	EClientScoreKind m_ClientScoreKind;
+	EClientTeamKind m_ClientTeamKind;
 	TRISTATE m_Favorite;
 	TRISTATE m_FavoriteAllowPing;
 	char m_aCommunityId[MAX_COMMUNITY_ID_LENGTH];
@@ -121,6 +131,7 @@ public:
 	char m_aVersion[32];
 	char m_aAddress[MAX_SERVER_ADDRESSES * NETADDR_MAXSTRSIZE];
 	CClient m_aClients[SERVERINFO_MAX_CLIENTS];
+	int m_aSortedClientsByTeam[SERVERINFO_MAX_CLIENTS];
 	int m_NumFilteredPlayers;
 	bool m_RequiresLogin;
 

--- a/src/engine/shared/serverinfo.h
+++ b/src/engine/shared/serverinfo.h
@@ -21,6 +21,7 @@ public:
 		int m_Score;
 		bool m_IsPlayer;
 		bool m_IsAfk;
+		int m_Team;
 		// skin info 0.6
 		char m_aSkin[MAX_SKIN_LENGTH];
 		bool m_CustomSkinColors;
@@ -38,6 +39,7 @@ public:
 	int m_MaxPlayers;
 	int m_NumPlayers; // Not serialized.
 	CServerInfo::EClientScoreKind m_ClientScoreKind;
+	CServerInfo::EClientTeamKind m_ClientTeamKind;
 	bool m_Passworded;
 	char m_aGameType[16];
 	char m_aName[64];

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -72,6 +72,7 @@ namespace FontIcons
 	[[maybe_unused]] static const char *FONT_ICON_MAGNIFYING_GLASS = "\xEF\x80\x82";
 	[[maybe_unused]] static const char *FONT_ICON_HEART = "\xEF\x80\x84";
 	[[maybe_unused]] static const char *FONT_ICON_HEART_CRACK = "\xEF\x9E\xA9";
+	[[maybe_unused]] static const char *FONT_ICON_SHIELD_HEART = "\xEE\x95\xB4";
 	[[maybe_unused]] static const char *FONT_ICON_STAR = "\xEF\x80\x85";
 	[[maybe_unused]] static const char *FONT_ICON_XMARK = "\xEF\x80\x8D";
 	[[maybe_unused]] static const char *FONT_ICON_CIRCLE = "\xEF\x84\x91";

--- a/src/game/client/animstate.cpp
+++ b/src/game/client/animstate.cpp
@@ -94,3 +94,18 @@ const CAnimState *CAnimState::GetIdle()
 
 	return &s_State;
 }
+
+const CAnimState *CAnimState::GetSitting()
+{
+	static CAnimState s_State;
+	static bool s_Init = true;
+
+	if(s_Init)
+	{
+		s_State.Set(&g_pData->m_aAnimations[ANIM_BASE], 0.0f);
+		s_State.Add(&g_pData->m_aAnimations[ANIM_SIT_RIGHT], 0.0f, 1.0f);
+		s_Init = false;
+	}
+
+	return &s_State;
+}

--- a/src/game/client/animstate.h
+++ b/src/game/client/animstate.h
@@ -23,6 +23,7 @@ public:
 	void Add(CAnimation *pAnim, float Time, float Amount);
 
 	const static CAnimState *GetIdle();
+	const static CAnimState *GetSitting();
 };
 
 #endif

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -23,21 +23,7 @@
 
 using namespace FontIcons;
 
-static constexpr ColorRGBA gs_HighlightedTextColor = ColorRGBA(0.4f, 0.4f, 1.0f, 1.0f);
-
-static ColorRGBA PlayerBackgroundColor(bool Friend, bool Clan, bool Afk, bool InSelectedServer, bool Inside)
-{
-	static const ColorRGBA COLORS[] = {ColorRGBA(0.5f, 1.0f, 0.5f), ColorRGBA(0.4f, 0.4f, 1.0f), ColorRGBA(0.75f, 0.75f, 0.75f)};
-	static const ColorRGBA COLORS_AFK[] = {ColorRGBA(1.0f, 1.0f, 0.5f), ColorRGBA(0.4f, 0.75f, 1.0f), ColorRGBA(0.6f, 0.6f, 0.6f)};
-	int i;
-	if(Friend)
-		i = 0;
-	else if(Clan)
-		i = 1;
-	else
-		i = 2;
-	return (Afk ? COLORS_AFK[i] : COLORS[i]).WithAlpha(0.3f + (Inside ? 0.15f : 0.0f) + (InSelectedServer ? 0.12f : 0.0f));
-}
+static constexpr ColorRGBA HIGHLIGHTED_TEXT_COLOR = ColorRGBA(0.4f, 0.4f, 1.0f, 1.0f);
 
 template<size_t N>
 static void FormatServerbrowserPing(char (&aBuffer)[N], const CServerInfo *pInfo)
@@ -395,7 +381,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 				if(g_Config.m_BrFilterString[0] && (pItem->m_QuickSearchHit & IServerBrowser::QUICK_SERVERNAME))
 					Printed = PrintHighlighted(pItem->m_aName, [&](const char *pFilteredStr, const int FilterLen) {
 						Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_NAME_1), &Button, pItem->m_aName, FontSize, TEXTALIGN_ML, Props, (int)(pFilteredStr - pItem->m_aName));
-						TextRender()->TextColor(gs_HighlightedTextColor);
+						TextRender()->TextColor(HIGHLIGHTED_TEXT_COLOR);
 						Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_NAME_2), &Button, pFilteredStr, FontSize, TEXTALIGN_ML, Props, FilterLen, &pUiElement->Rect(UI_ELEM_NAME_1)->m_Cursor);
 						TextRender()->TextColor(TextRender()->DefaultTextColor());
 						Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_NAME_3), &Button, pFilteredStr + FilterLen, FontSize, TEXTALIGN_ML, Props, -1, &pUiElement->Rect(UI_ELEM_NAME_2)->m_Cursor);
@@ -437,7 +423,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 				if(g_Config.m_BrFilterString[0] && (pItem->m_QuickSearchHit & IServerBrowser::QUICK_MAPNAME))
 					Printed = PrintHighlighted(pItem->m_aMap, [&](const char *pFilteredStr, const int FilterLen) {
 						Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_MAP_1), &Button, pItem->m_aMap, FontSize, TEXTALIGN_ML, Props, (int)(pFilteredStr - pItem->m_aMap));
-						TextRender()->TextColor(gs_HighlightedTextColor);
+						TextRender()->TextColor(HIGHLIGHTED_TEXT_COLOR);
 						Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_MAP_2), &Button, pFilteredStr, FontSize, TEXTALIGN_ML, Props, FilterLen, &pUiElement->Rect(UI_ELEM_MAP_1)->m_Cursor);
 						TextRender()->TextColor(TextRender()->DefaultTextColor());
 						Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_MAP_3), &Button, pFilteredStr + FilterLen, FontSize, TEXTALIGN_ML, Props, -1, &pUiElement->Rect(UI_ELEM_MAP_2)->m_Cursor);
@@ -465,7 +451,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 				str_format(aTemp, sizeof(aTemp), "%i/%i", pItem->m_NumFilteredPlayers, ServerBrowser()->Max(*pItem));
 				if(g_Config.m_BrFilterString[0] && (pItem->m_QuickSearchHit & IServerBrowser::QUICK_PLAYER))
 				{
-					TextRender()->TextColor(gs_HighlightedTextColor);
+					TextRender()->TextColor(HIGHLIGHTED_TEXT_COLOR);
 				}
 				Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_PLAYERS), &Button, aTemp, FontSize, TEXTALIGN_MR);
 				TextRender()->TextColor(TextRender()->DefaultTextColor());
@@ -1279,22 +1265,45 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 
 	for(int i = 0; i < pSelectedServer->m_NumReceivedClients; i++)
 	{
-		const CServerInfo::CClient &CurrentClient = pSelectedServer->m_aClients[i];
+		const CServerInfo::CClient &CurrentClient = pSelectedServer->m_aClients[pSelectedServer->m_aSortedClientsByTeam[i]];
 		const CListboxItem Item = s_ListBox.DoNextItem(&CurrentClient);
 		if(!Item.m_Visible)
 			continue;
 
-		CUIRect Skin, Name, Clan, Score, Flag;
+		CUIRect Skin, Name, Clan, Score, Flag, FriendIcon;
 		Name = Item.m_Rect;
 
-		const ColorRGBA Color = PlayerBackgroundColor(CurrentClient.m_FriendState == IFriends::FRIEND_PLAYER, CurrentClient.m_FriendState == IFriends::FRIEND_CLAN, CurrentClient.m_Afk, false, false);
-		Name.Draw(Color, IGraphics::CORNER_ALL, 4.0f);
+		ColorRGBA BackgroundColor = ColorRGBA(0.75f, 0.75f, 0.75f, 0.3f);
+		if(pSelectedServer->m_ClientTeamKind != CServerInfo::CLIENT_TEAM_KIND_NONE)
+		{
+			if(pSelectedServer->m_ClientTeamKind == CServerInfo::CLIENT_TEAM_KIND_VANILLA)
+			{
+				if(CurrentClient.m_Player)
+				{
+					if(CurrentClient.m_Team == TEAM_RED)
+						BackgroundColor = ColorRGBA(0.975f, 0.17f, 0.17f, 0.5f);
+					else if(CurrentClient.m_Team == TEAM_BLUE)
+						BackgroundColor = ColorRGBA(0.17f, 0.46f, 0.975f, 0.5f);
+				}
+			}
+			else if(CurrentClient.m_Team != TEAM_FLOCK && CurrentClient.m_Team != TEAM_SPECTATORS)
+				BackgroundColor = GameClient()->GetDDTeamColor(CurrentClient.m_Team).WithAlpha(0.5f);
+		}
+
+		Name.Draw(BackgroundColor, IGraphics::CORNER_ALL, 4.0f);
+
 		Name.VSplitLeft(1.0f, nullptr, &Name);
 		Name.VSplitLeft(34.0f, &Score, &Name);
 		Name.VSplitLeft(18.0f, &Skin, &Name);
+		const bool IsFriend = CurrentClient.m_FriendState == IFriends::FRIEND_PLAYER;
+		const bool IsClan = CurrentClient.m_FriendState == IFriends::FRIEND_CLAN;
+		if(IsFriend)
+			Name.VSplitLeft(10.0f, &FriendIcon, &Name);
 		Name.VSplitRight(26.0f, &Name, &Flag);
 		Flag.HMargin(6.0f, &Flag);
 		Name.HSplitTop(12.0f, &Name, &Clan);
+		if(IsFriend)
+			FriendIcon.HSplitTop(12.0f, &FriendIcon, nullptr);
 
 		// score
 		char aTemp[16];
@@ -1336,14 +1345,15 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 		Ui()->DoLabel(&Score, aTemp, FontSize, TEXTALIGN_ML);
 
 		// render tee if available
+		const CAnimState *pAnimState = CurrentClient.m_Afk ? CAnimState::GetSitting() : CAnimState::GetIdle();
+
 		if(CurrentClient.m_aSkin[0] != '\0')
 		{
 			const CTeeRenderInfo TeeInfo = GetTeeRenderInfo(vec2(Skin.w, Skin.h), CurrentClient.m_aSkin, CurrentClient.m_CustomSkinColors, CurrentClient.m_CustomSkinColorBody, CurrentClient.m_CustomSkinColorFeet);
-			const CAnimState *pIdleState = CAnimState::GetIdle();
 			vec2 OffsetToMid;
-			CRenderTools::GetRenderTeeOffsetToRenderedTee(pIdleState, &TeeInfo, OffsetToMid);
+			CRenderTools::GetRenderTeeOffsetToRenderedTee(pAnimState, &TeeInfo, OffsetToMid);
 			const vec2 TeeRenderPos = vec2(Skin.x + TeeInfo.m_Size / 2.0f, Skin.y + Skin.h / 2.0f + OffsetToMid.y);
-			RenderTools()->RenderTee(pIdleState, &TeeInfo, CurrentClient.m_Afk ? EMOTE_BLINK : EMOTE_NORMAL, vec2(1.0f, 0.0f), TeeRenderPos);
+			RenderTools()->RenderTee(pAnimState, &TeeInfo, CurrentClient.m_Afk ? EMOTE_BLINK : EMOTE_NORMAL, vec2(1.0f, 0.0f), TeeRenderPos);
 			Ui()->DoButtonLogic(&CurrentClient.m_aSkin, 0, &Skin, BUTTONFLAG_NONE);
 			GameClient()->m_Tooltips.DoToolTip(&CurrentClient.m_aSkin, &Skin, CurrentClient.m_aSkin);
 		}
@@ -1356,11 +1366,20 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 				GameClient()->m_Skins7.FindSkinPart(Part, CurrentClient.m_aaSkin7[Part], true)->ApplyTo(TeeInfo.m_aSixup[g_Config.m_ClDummy]);
 				GameClient()->m_Skins7.ApplyColorTo(TeeInfo.m_aSixup[g_Config.m_ClDummy], CurrentClient.m_aUseCustomSkinColor7[Part], CurrentClient.m_aCustomSkinColor7[Part], Part);
 			}
-			const CAnimState *pIdleState = CAnimState::GetIdle();
 			vec2 OffsetToMid;
-			CRenderTools::GetRenderTeeOffsetToRenderedTee(pIdleState, &TeeInfo, OffsetToMid);
+			CRenderTools::GetRenderTeeOffsetToRenderedTee(pAnimState, &TeeInfo, OffsetToMid);
 			const vec2 TeeRenderPos = vec2(Skin.x + TeeInfo.m_Size / 2.0f, Skin.y + Skin.h / 2.0f + OffsetToMid.y);
-			RenderTools()->RenderTee(pIdleState, &TeeInfo, CurrentClient.m_Afk ? EMOTE_BLINK : EMOTE_NORMAL, vec2(1.0f, 0.0f), TeeRenderPos);
+			RenderTools()->RenderTee(pAnimState, &TeeInfo, CurrentClient.m_Afk ? EMOTE_BLINK : EMOTE_NORMAL, vec2(1.0f, 0.0f), TeeRenderPos);
+		}
+
+		// friend icon
+		if(IsFriend)
+		{
+			TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
+			TextRender()->TextColor(ColorRGBA(0.94f, 0.4f, 0.4f, 1.0f));
+			Ui()->DoLabel(&FriendIcon, FONT_ICON_HEART, 8.0f, TEXTALIGN_MC);
+			TextRender()->TextColor(TextRender()->DefaultTextColor());
+			TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 		}
 
 		// name
@@ -1374,7 +1393,7 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 		if(g_Config.m_BrFilterString[0])
 			Printed = PrintHighlighted(pName, [&](const char *pFilteredStr, const int FilterLen) {
 				TextRender()->TextEx(&NameCursor, pName, (int)(pFilteredStr - pName));
-				TextRender()->TextColor(gs_HighlightedTextColor);
+				TextRender()->TextColor(HIGHLIGHTED_TEXT_COLOR);
 				TextRender()->TextEx(&NameCursor, pFilteredStr, FilterLen);
 				TextRender()->TextColor(TextRender()->DefaultTextColor());
 				TextRender()->TextEx(&NameCursor, pFilteredStr + FilterLen, -1);
@@ -1383,6 +1402,17 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 			TextRender()->TextEx(&NameCursor, pName, -1);
 
 		// clan
+		if(IsClan)
+		{
+			CUIRect ClanIcon;
+			Clan.VSplitLeft(8.0f, &ClanIcon, &Clan);
+			TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
+			TextRender()->TextColor(ColorRGBA(0.94f, 0.4f, 0.4f, 1.0f));
+			Ui()->DoLabel(&ClanIcon, FONT_ICON_SHIELD_HEART, 7.0f, TEXTALIGN_ML);
+			TextRender()->TextColor(TextRender()->DefaultTextColor());
+			TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
+		}
+
 		CTextCursor ClanCursor;
 		ClanCursor.SetPosition(vec2(Clan.x, Clan.y + (Clan.h - (FontSize - 2.0f)) / 2.0f));
 		ClanCursor.m_FontSize = FontSize - 2.0f;
@@ -1393,13 +1423,15 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 		if(g_Config.m_BrFilterString[0])
 			Printed = PrintHighlighted(pClan, [&](const char *pFilteredStr, const int FilterLen) {
 				TextRender()->TextEx(&ClanCursor, pClan, (int)(pFilteredStr - pClan));
-				TextRender()->TextColor(0.4f, 0.4f, 1.0f, 1.0f);
+				TextRender()->TextColor(HIGHLIGHTED_TEXT_COLOR);
 				TextRender()->TextEx(&ClanCursor, pFilteredStr, FilterLen);
 				TextRender()->TextColor(TextRender()->DefaultTextColor());
 				TextRender()->TextEx(&ClanCursor, pFilteredStr + FilterLen, -1);
 			});
 		if(!Printed)
+		{
 			TextRender()->TextEx(&ClanCursor, pClan, -1);
+		}
 
 		// flag
 		GameClient()->m_CountryFlags.Render(CurrentClient.m_Country, ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f), Flag.x, Flag.y, Flag.w, Flag.h);
@@ -1408,7 +1440,7 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 	const int NewSelected = s_ListBox.DoEnd();
 	if(s_ListBox.WasItemSelected())
 	{
-		const CServerInfo::CClient &SelectedClient = pSelectedServer->m_aClients[NewSelected];
+		const CServerInfo::CClient &SelectedClient = pSelectedServer->m_aClients[pSelectedServer->m_aSortedClientsByTeam[NewSelected]];
 		if(SelectedClient.m_FriendState == IFriends::FRIEND_PLAYER)
 			GameClient()->Friends()->RemoveFriend(SelectedClient.m_aName, SelectedClient.m_aClan);
 		else
@@ -1544,9 +1576,9 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 
 				// Compare unsorted server id of the friend with the unsorted id of the currently selected server
 				bool InSelectedServer = m_SelectedIndex >= 0 && Friend.ServerInfo() && Friend.ServerInfo()->m_ServerIndex == ServerBrowser()->SortedGet(m_SelectedIndex)->m_ServerIndex;
+				const ColorRGBA BackgroundColor = ColorRGBA(0.75f, 0.75f, 0.75f, 0.3f + (Inside ? 0.15f : 0.0f) + (InSelectedServer ? 0.12f : 0.0f));
 
-				const ColorRGBA Color = PlayerBackgroundColor(FriendType == FRIEND_PLAYER_ON, FriendType == FRIEND_CLAN_ON, FriendType == FRIEND_OFF ? true : Friend.IsAfk(), InSelectedServer, Inside);
-				Rect.Draw(Color, IGraphics::CORNER_ALL, 5.0f);
+				Rect.Draw(BackgroundColor, IGraphics::CORNER_ALL, 5.0f);
 				Rect.Margin(2.0f, &Rect);
 
 				CUIRect RemoveButton, NameLabel, ClanLabel, InfoLabel;
@@ -1563,14 +1595,14 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 				CUIRect Skin;
 				Rect.VSplitLeft(Rect.h, &Skin, &Rect);
 				Rect.VSplitLeft(2.0f, nullptr, &Rect);
+				const CAnimState *pAnimState = Friend.IsAfk() ? CAnimState::GetSitting() : CAnimState::GetIdle();
 				if(Friend.Skin()[0] != '\0')
 				{
 					const CTeeRenderInfo TeeInfo = GetTeeRenderInfo(vec2(Skin.w, Skin.h), Friend.Skin(), Friend.CustomSkinColors(), Friend.CustomSkinColorBody(), Friend.CustomSkinColorFeet());
-					const CAnimState *pIdleState = CAnimState::GetIdle();
 					vec2 OffsetToMid;
-					CRenderTools::GetRenderTeeOffsetToRenderedTee(pIdleState, &TeeInfo, OffsetToMid);
+					CRenderTools::GetRenderTeeOffsetToRenderedTee(pAnimState, &TeeInfo, OffsetToMid);
 					const vec2 TeeRenderPos = vec2(Skin.x + Skin.w / 2.0f, Skin.y + Skin.h * 0.55f + OffsetToMid.y);
-					RenderTools()->RenderTee(pIdleState, &TeeInfo, Friend.IsAfk() ? EMOTE_BLINK : EMOTE_NORMAL, vec2(1.0f, 0.0f), TeeRenderPos);
+					RenderTools()->RenderTee(pAnimState, &TeeInfo, Friend.IsAfk() ? EMOTE_BLINK : EMOTE_NORMAL, vec2(1.0f, 0.0f), TeeRenderPos);
 					Ui()->DoButtonLogic(Friend.SkinTooltipId(), 0, &Skin, BUTTONFLAG_NONE);
 					GameClient()->m_Tooltips.DoToolTip(Friend.SkinTooltipId(), &Skin, Friend.Skin());
 				}
@@ -1583,18 +1615,39 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 						GameClient()->m_Skins7.FindSkinPart(Part, Friend.Skin7(Part), true)->ApplyTo(TeeInfo.m_aSixup[g_Config.m_ClDummy]);
 						GameClient()->m_Skins7.ApplyColorTo(TeeInfo.m_aSixup[g_Config.m_ClDummy], Friend.UseCustomSkinColor7(Part), Friend.CustomSkinColor7(Part), Part);
 					}
-					const CAnimState *pIdleState = CAnimState::GetIdle();
 					vec2 OffsetToMid;
-					CRenderTools::GetRenderTeeOffsetToRenderedTee(pIdleState, &TeeInfo, OffsetToMid);
+					CRenderTools::GetRenderTeeOffsetToRenderedTee(pAnimState, &TeeInfo, OffsetToMid);
 					const vec2 TeeRenderPos = vec2(Skin.x + Skin.w / 2.0f, Skin.y + Skin.h * 0.55f + OffsetToMid.y);
-					RenderTools()->RenderTee(pIdleState, &TeeInfo, Friend.IsAfk() ? EMOTE_BLINK : EMOTE_NORMAL, vec2(1.0f, 0.0f), TeeRenderPos);
+					RenderTools()->RenderTee(pAnimState, &TeeInfo, Friend.IsAfk() ? EMOTE_BLINK : EMOTE_NORMAL, vec2(1.0f, 0.0f), TeeRenderPos);
 				}
 				Rect.HSplitTop(11.0f, &NameLabel, &ClanLabel);
+
+				// friend icon
+				if(FriendType == FRIEND_PLAYER_ON)
+				{
+					CUIRect Icon;
+					NameLabel.VSplitLeft(10.0f, &Icon, &NameLabel);
+					TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
+					TextRender()->TextColor(ColorRGBA(0.94f, 0.4f, 0.4f, 1.0f));
+					Ui()->DoLabel(&Icon, FONT_ICON_HEART, 8.0f, TEXTALIGN_ML);
+					TextRender()->TextColor(TextRender()->DefaultTextColor());
+					TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
+				}
 
 				// name
 				Ui()->DoLabel(&NameLabel, Friend.Name(), FontSize - 1.0f, TEXTALIGN_ML);
 
 				// clan
+				if(FriendType == FRIEND_CLAN_ON)
+				{
+					CUIRect Icon;
+					ClanLabel.VSplitLeft(8.0f, &Icon, &ClanLabel);
+					TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
+					TextRender()->TextColor(ColorRGBA(0.94f, 0.4f, 0.4f, 1.0f));
+					Ui()->DoLabel(&Icon, FONT_ICON_SHIELD_HEART, 7.0f, TEXTALIGN_ML);
+					TextRender()->TextColor(TextRender()->DefaultTextColor());
+					TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
+				}
 				Ui()->DoLabel(&ClanLabel, Friend.Clan(), FontSize - 2.0f, TEXTALIGN_ML);
 
 				// server info

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4720,6 +4720,12 @@ const char *CGameContext::GameType() const
 }
 const char *CGameContext::Version() const { return GAME_VERSION; }
 const char *CGameContext::NetVersion() const { return GAME_NETVERSION; }
+const char *CGameContext::TeamKind() const
+{
+	if(g_Config.m_SvSoloServer)
+		return "none";
+	return m_pController->IsTeamPlay() ? "vanilla" : "ddrace";
+}
 
 IGameServer *CreateGameServer() { return new CGameContext; }
 
@@ -5403,7 +5409,19 @@ void CGameContext::OnUpdatePlayerServerInfo(CJsonWriter *pJsonWriter, int Client
 	pJsonWriter->WriteAttribute("afk");
 	pJsonWriter->WriteBoolValue(m_apPlayers[ClientId]->IsAfk());
 
-	const int Team = m_pController->IsTeamPlay() ? m_apPlayers[ClientId]->GetTeam() : (m_apPlayers[ClientId]->GetTeam() == TEAM_SPECTATORS ? -1 : GetDDRaceTeam(ClientId));
+	int Team;
+	if(m_pController->IsTeamPlay())
+	{
+		Team = m_apPlayers[ClientId]->GetTeam();
+	}
+	else if(m_apPlayers[ClientId]->GetTeam() == TEAM_SPECTATORS)
+	{
+		Team = -1;
+	}
+	else
+	{
+		Team = GetDDRaceTeam(ClientId);
+	}
 
 	pJsonWriter->WriteAttribute("team");
 	pJsonWriter->WriteIntValue(Team);

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -382,6 +382,7 @@ public:
 	const char *GameType() const override;
 	const char *Version() const override;
 	const char *NetVersion() const override;
+	const char *TeamKind() const override;
 
 	// DDRace
 	void OnPreTickTeehistorian() override;


### PR DESCRIPTION
Fixes #10382

Colors player's background based on their ddrace team and orders them by team+time, same as in-game scoreboard 
Clan color uses `cl_same_clan_color`, and friends have a heart icon. Sitting tee to indicate afk

<img width="377" height="816" alt="image" src="https://github.com/user-attachments/assets/b635a504-fca2-42c0-8f21-6f21d6adb1f7" />



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
