### PR TITLE
Only show kick/spec votes to players on same team

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1072,6 +1072,11 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 				m_Chat.OnMessage(MsgId, pRawMsg);
 			}
 		}
+		// handle vote messages when dummy is on a different team
+		if(MsgId == NETMSGTYPE_SV_VOTESET || MsgId == NETMSGTYPE_SV_VOTESTATUS)
+		{
+			m_Voting.OnMessage(MsgId, pRawMsg);
+		}
 		return; // no need of all that stuff for the dummy
 	}
 

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -235,6 +235,7 @@ public:
 	void SendVoteSet(int ClientId);
 	void SendVoteStatus(int ClientId, int Total, int Yes, int No);
 	void AbortVoteKickOnDisconnect(int ClientId);
+	bool CanParticipateInVote(int ClientId);
 
 	int m_VoteCreator;
 	int m_VoteType;


### PR DESCRIPTION
https://github.com/ddnet/ddnet/issues/2727

Still not allowed to call another vote, while a team vote is running. This would require a massive rework to allow each team have its own vote

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
