### PR TITLE
Fix double sound prediction in rare cases with hook attach

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2620,8 +2620,6 @@ void CGameClient::OnPredict()
 
 		m_PredictedWorld.Tick();
 
-		HandlePredictedEvents(Tick);
-
 		// fetch the current characters
 		if(Tick == PredictionTick)
 		{
@@ -2683,6 +2681,8 @@ void CGameClient::OnPredict()
 				if(Events & COREEVENT_AIR_JUMP)
 					m_Effects.AirJump(Pos, 1.0f, 1.0f);
 		}
+
+		HandlePredictedEvents(Tick);
 	}
 
 	// detect mispredictions of other players and make corrections smoother when possible


### PR DESCRIPTION
The issue was that `HandlePredictedEvents(Tick)` was being called before the code that creates predicted sounds for triggered events, so the event was created with `m_Handled = false`, but `HandlePredictedEvents` had already run for that tick.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
