### PR TITLE
Use `class`es instead of `struct`s for editor trackers

### DIFF
--- a/src/game/editor/editor_trackers.cpp
+++ b/src/game/editor/editor_trackers.cpp
@@ -434,12 +434,12 @@ void CSoundSourceOperationTracker::End()
 
 // -----------------------------------------------------------------------
 
-int SPropTrackerHelper::GetDefaultGroupIndex(CEditorMap *pMap)
+int CPropTrackerHelper::GetDefaultGroupIndex(CEditorMap *pMap)
 {
 	return pMap->m_SelectedGroup;
 }
 
-int SPropTrackerHelper::GetDefaultLayerIndex(CEditorMap *pMap)
+int CPropTrackerHelper::GetDefaultLayerIndex(CEditorMap *pMap)
 {
 	return pMap->m_vSelectedLayers[0];
 }

--- a/src/game/editor/editor_trackers.h
+++ b/src/game/editor/editor_trackers.h
@@ -85,14 +85,15 @@ public:
 private:
 	EEnvelopeEditorOp m_TrackedOp = EEnvelopeEditorOp::OP_NONE;
 
-	struct SPointData
+	class CPointData
 	{
+	public:
 		bool m_Used;
 		CFixedTime m_Time;
 		std::map<int, int> m_Values;
 	};
 
-	std::map<int, SPointData> m_SavedValues;
+	std::map<int, CPointData> m_SavedValues;
 
 	void HandlePointDragStart();
 	void HandlePointDragEnd(bool Switch);
@@ -111,15 +112,17 @@ private:
 	ESoundSourceOp m_TrackedOp;
 	int m_LayerIndex;
 
-	struct SData
+	class CData
 	{
+	public:
 		CPoint m_OriginalPoint;
 	};
-	SData m_Data;
+	CData m_Data;
 };
 
-struct SPropTrackerHelper
+class CPropTrackerHelper
 {
+public:
 	static int GetDefaultGroupIndex(CEditorMap *pMap);
 	static int GetDefaultLayerIndex(CEditorMap *pMap);
 };
@@ -144,8 +147,8 @@ public:
 			return;
 		m_pObject = pObject;
 
-		m_OriginalGroupIndex = GroupIndex < 0 ? SPropTrackerHelper::GetDefaultGroupIndex(Map()) : GroupIndex;
-		m_OriginalLayerIndex = LayerIndex < 0 ? SPropTrackerHelper::GetDefaultLayerIndex(Map()) : LayerIndex;
+		m_OriginalGroupIndex = GroupIndex < 0 ? CPropTrackerHelper::GetDefaultGroupIndex(Map()) : GroupIndex;
+		m_OriginalLayerIndex = LayerIndex < 0 ? CPropTrackerHelper::GetDefaultLayerIndex(Map()) : LayerIndex;
 		m_CurrentGroupIndex = m_OriginalGroupIndex;
 		m_CurrentLayerIndex = m_OriginalLayerIndex;
 
@@ -163,8 +166,8 @@ public:
 		if(!m_Tracking || Prop == static_cast<E>(-1))
 			return;
 
-		m_CurrentGroupIndex = GroupIndex < 0 ? SPropTrackerHelper::GetDefaultGroupIndex(Map()) : GroupIndex;
-		m_CurrentLayerIndex = LayerIndex < 0 ? SPropTrackerHelper::GetDefaultLayerIndex(Map()) : LayerIndex;
+		m_CurrentGroupIndex = GroupIndex < 0 ? CPropTrackerHelper::GetDefaultGroupIndex(Map()) : GroupIndex;
+		m_CurrentLayerIndex = LayerIndex < 0 ? CPropTrackerHelper::GetDefaultLayerIndex(Map()) : LayerIndex;
 
 		if(State == EEditState::END || State == EEditState::ONE_GO)
 		{


### PR DESCRIPTION

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions