### PR TITLE
Fix 1 tick slower auto fire when paused

### DIFF
--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -70,6 +70,7 @@ public:
 
 	void OnPredictedInput(const CNetObj_PlayerInput *pNewInput);
 	void OnDirectInput(const CNetObj_PlayerInput *pNewInput);
+	const CNetObj_PlayerInput &LatestInput() const { return m_LatestInput; }
 	void ReleaseHook();
 	void ResetHook();
 	void ResetInput();

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -590,12 +590,15 @@ void CPlayer::OnPredictedEarlyInput(const CNetObj_PlayerInput *pNewInput)
 	if(!m_pCharacter && m_Team != TEAM_SPECTATORS && (pNewInput->m_Fire & 1))
 		m_Spawning = true;
 
-	// skip the input if chat is active
-	if(m_PlayerFlags & PLAYERFLAG_CHATTING)
-		return;
-
-	if(m_pCharacter && !m_Paused && !(m_PlayerFlags & PLAYERFLAG_SPEC_CAM))
-		m_pCharacter->OnDirectInput(pNewInput);
+	if(m_pCharacter)
+	{
+		// Use last input to prevent new actions, but still call OnDirectInput
+		// so weapon handling (e.g. reload timer) stays consistent
+		if((m_PlayerFlags & PLAYERFLAG_CHATTING) || m_Paused || (m_PlayerFlags & PLAYERFLAG_SPEC_CAM))
+			m_pCharacter->OnDirectInput(&m_pCharacter->LatestInput());
+		else
+			m_pCharacter->OnDirectInput(pNewInput);
+	}
 }
 
 int CPlayer::GetClientVersion() const


### PR DESCRIPTION
`OnDirectInput` calls `FireWeapon` before `HandleWeapons` decrements the reload timer in the same tick. When `OnDirectInput` was skipped (due to pause or chat), weapons only fired through `HandleWeapons`, making auto fire 1 tick slower (e.g. laser every 26 ticks instead of 25).

Instead of skipping `OnDirectInput` entirely, call it with the last known input so weapon handling stays consistent without accepting new input from the client

Video of the bug:

https://github.com/user-attachments/assets/e9a5a299-8e6b-41c6-9478-a3c3a9053fff



## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
