### PR TITLE
Add tooltip to HSLA scrollbar

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1772,6 +1772,7 @@ bool CMenus::RenderHslaScrollbars(CUIRect *pRect, unsigned int *pColor, bool Alp
 		Graphics()->TrianglesEnd();
 
 		Color[i] = Ui()->DoScrollbarH(&((char *)pColor)[i], &Button, Color[i], &HandleColor);
+		GameClient()->m_Tooltips.DoToolTip(&((char *)pColor)[i], &Button, Localize("Use left mouse button to drag and change the value. Hold shift to be more precise."));
 	}
 
 	if(OriginalColor != Color)


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Add a tooltip to the HSLA scrollbars and describe, that you can change the values in small increments by holding shift.

<img width="2560" height="1440" alt="screenshot_2026-01-29_14-49-55" src="https://github.com/user-attachments/assets/c9b10a43-c382-44e6-b9af-38bf1d1128f1" />

closes #11700 

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
