### PR TITLE
Mitigate bad input device debounce in activities like deepfly

### DIFF
--- a/scripts/export_settings_commands_table.py
+++ b/scripts/export_settings_commands_table.py
@@ -90,6 +90,10 @@ def parse_settings(lines):
 			parsed = parse_arguments(args[2], num=7, name="int setting")
 			flags = parse_flags(parsed[5], f"int setting '{parsed[1]}'")
 			setting = {"type": "int", "flags": flags, "name": parsed[1], "description": parsed[6], "default": parse_value(parsed[2]), "min": parse_value(parsed[3]), "max": parse_value(parsed[4])}
+		elif args[1] == "INP":
+			parsed = parse_arguments(args[2], num=4, name="int setting")
+			flags = parse_flags(parsed[2], f"int setting '{parsed[1]}'")
+			setting = {"type": "int", "flags": flags, "name": parsed[1], "description": parsed[3], "default": 0, "min": 0, "max": 1}
 		elif args[1] == "COL":
 			parsed = parse_arguments(args[2], num=5, name="color setting")
 			flags = parse_flags(parsed[3], f"color setting '{parsed[1]}'")

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4356,11 +4356,8 @@ int CClient::HandleChecksum(int Conn, CUuid Uuid, CUnpacker *pUnpacker)
 	{ \
 		m_Checksum.m_Data.m_Config.m_##Name = g_Config.m_##Name; \
 	}
-#define MACRO_CONFIG_COL(Name, ScriptName, Def, Flags, Desc) \
-	if(CHECKSUM_RECORD(Flags)) \
-	{ \
-		m_Checksum.m_Data.m_Config.m_##Name = g_Config.m_##Name; \
-	}
+#define MACRO_CONFIG_INP(Name, ScriptName, Flags, Desc) MACRO_CONFIG_INT(Name, ScriptName, 0, 0, 1, Flags, Desc)
+#define MACRO_CONFIG_COL(Name, ScriptName, Def, Flags, Desc) MACRO_CONFIG_INT(Name, ScriptName, Def, 0, 0, Flags, Desc)
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Flags, Desc) \
 	if(CHECKSUM_RECORD(Flags)) \
 	{ \
@@ -4369,6 +4366,7 @@ int CClient::HandleChecksum(int Conn, CUuid Uuid, CUnpacker *pUnpacker)
 #include <engine/shared/config_variables.h>
 #undef CHECKSUM_RECORD
 #undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_INP
 #undef MACRO_CONFIG_COL
 #undef MACRO_CONFIG_STR
 	}

--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -13,6 +13,8 @@
 #include <engine/shared/protocol.h>
 #include <engine/storage.h>
 
+#include <generated/protocol.h>
+
 CConfig g_Config;
 
 // ----------------------- Config Variables
@@ -108,6 +110,48 @@ void SIntConfigVariable::ResetToDefault()
 void SIntConfigVariable::ResetToOld()
 {
 	*m_pVariable = m_OldValue;
+}
+
+// -----
+
+void SInputConfigVariable::CommandCallback(IConsole::IResult *pResult, void *pUserData)
+{
+	SInputConfigVariable *pData = static_cast<SInputConfigVariable *>(pUserData);
+
+	if(pResult->NumArguments())
+	{
+		if(pData->CheckReadOnly())
+			return;
+
+		int Value = pResult->GetInteger(0);
+
+		// do clamping
+		if(Value < 0)
+			Value = 0;
+		if(Value > 1)
+			Value = 1;
+
+		if((*pData->m_pVariable & 1) != Value)
+			*pData->m_pVariable = (*pData->m_pVariable + 1) & INPUT_STATE_MASK;
+		if(pResult->m_ClientId != IConsole::CLIENT_ID_GAME)
+			pData->m_OldValue = Value;
+	}
+	else
+	{
+		char aBuf[32];
+		str_format(aBuf, sizeof(aBuf), "Value: %d", *pData->m_pVariable);
+		pData->m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "config", aBuf);
+	}
+}
+
+void SInputConfigVariable::Register()
+{
+	m_pConsole->Register(m_pScriptName, "?i", m_Flags, CommandCallback, this, m_pHelp);
+}
+
+void SInputConfigVariable::Serialize(char *pOut, size_t Size, int Value) const
+{
+	str_format(pOut, Size, "%s %i", m_pScriptName, Value & 1);
 }
 
 // -----
@@ -294,6 +338,12 @@ void CConfigManager::Init()
 		AddVariable(m_ConfigHeap.Allocate<SIntConfigVariable>(m_pConsole, #ScriptName, SConfigVariable::VAR_INT, Flags, pHelp, &g_Config.m_##Name, Def, Min, Max)); \
 	}
 
+#define MACRO_CONFIG_INP(Name, ScriptName, Flags, Desc) \
+	{ \
+		const char *pHelp = Desc " (default: 0, min: 0, max: 1)"; \
+		AddVariable(m_ConfigHeap.Allocate<SInputConfigVariable>(m_pConsole, #ScriptName, SConfigVariable::VAR_INP, Flags, pHelp, &g_Config.m_##Name)); \
+	}
+
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Flags, Desc) \
 	{ \
 		const size_t HelpSize = (size_t)str_length(Desc) + 32; \
@@ -315,6 +365,7 @@ void CConfigManager::Init()
 #include "config_variables.h"
 
 #undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_INP
 #undef MACRO_CONFIG_COL
 #undef MACRO_CONFIG_STR
 
@@ -497,6 +548,12 @@ void CConfigManager::Con_Toggle(IConsole::IResult *pResult, void *pUserData)
 			const bool EqualToFirst = *pIntVariable->m_pVariable == pResult->GetInteger(1);
 			pIntVariable->SetValue(pResult->GetInteger(EqualToFirst ? 2 : 1));
 		}
+		else if(pVariable->m_Type == SConfigVariable::VAR_INP)
+		{
+			SInputConfigVariable *pInputVariable = static_cast<SInputConfigVariable *>(pVariable);
+			const bool EqualToFirst = *pInputVariable->m_pVariable == (pResult->GetInteger(1) & 1);
+			pInputVariable->SetValue(pResult->GetInteger(EqualToFirst ? 2 : 1));
+		}
 		else if(pVariable->m_Type == SConfigVariable::VAR_COLOR)
 		{
 			SColorConfigVariable *pColorVariable = static_cast<SColorConfigVariable *>(pVariable);
@@ -527,14 +584,22 @@ void CConfigManager::Con_ToggleStroke(IConsole::IResult *pResult, void *pUserDat
 	for(SConfigVariable *pVariable : pConfigManager->m_vpAllVariables)
 	{
 		if((pVariable->m_Flags & pConsole->FlagMask()) == 0 ||
-			pVariable->m_Type != SConfigVariable::VAR_INT ||
+			(pVariable->m_Type != SConfigVariable::VAR_INT && pVariable->m_Type != SConfigVariable::VAR_INP) ||
 			str_comp(pScriptName, pVariable->m_pScriptName) != 0)
 		{
 			continue;
 		}
 
-		SIntConfigVariable *pIntVariable = static_cast<SIntConfigVariable *>(pVariable);
-		pIntVariable->SetValue(pResult->GetInteger(0) == 0 ? pResult->GetInteger(3) : pResult->GetInteger(2));
+		if(pVariable->m_Type == SConfigVariable::VAR_INT)
+		{
+			SIntConfigVariable *pIntVariable = static_cast<SIntConfigVariable *>(pVariable);
+			pIntVariable->SetValue(pResult->GetInteger(0) == 0 ? pResult->GetInteger(3) : pResult->GetInteger(2));
+		}
+		else if(pVariable->m_Type == SConfigVariable::VAR_INP)
+		{
+			SInputConfigVariable *pInputVariable = static_cast<SInputConfigVariable *>(pVariable);
+			pInputVariable->SetValue((pResult->GetInteger(0) & 1) == 0 ? pResult->GetInteger(3) : pResult->GetInteger(2));
+		}
 		return;
 	}
 

--- a/src/engine/shared/config.h
+++ b/src/engine/shared/config.h
@@ -37,6 +37,12 @@ public:
 		Maximum: Max\n \
 		Description: Desc */ \
 	int m_##Name;
+#define MACRO_CONFIG_INP(Name, ScriptName, Flags, Desc) \
+	/** Config variable: ScriptName\n \
+		Type: Input (Integer)\n \
+		Default: Def\n \
+		Description: Desc */ \
+	int m_##Name;
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Flags, Desc) \
 	/** Config variable: ScriptName\n \
 		Type: Color\n \
@@ -52,6 +58,7 @@ public:
 	char m_##Name[Len]; // Flawfinder: ignore
 #include "config_variables.h"
 #undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_INP
 #undef MACRO_CONFIG_COL
 #undef MACRO_CONFIG_STR
 };
@@ -66,6 +73,9 @@ namespace DefaultConfig
 #define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Flags, Desc) \
 	/** Default value of the integer config variable 'ScriptName' (see CConfig::m_##Name). */ \
 	static constexpr int Name = Def;
+#define MACRO_CONFIG_INP(Name, ScriptName, Flags, Desc) \
+	/** Default value of the input config variable 'ScriptName' (see CConfig::m_##Name). */ \
+	static constexpr int Name = 0;
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Flags, Desc) \
 	/** Default value of the color config variable 'ScriptName' (see CConfig::m_##Name). */ \
 	static constexpr unsigned Name = Def;
@@ -74,6 +84,7 @@ namespace DefaultConfig
 	static constexpr const char *const Name = Def;
 #include "config_variables.h"
 #undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_INP
 #undef MACRO_CONFIG_COL
 #undef MACRO_CONFIG_STR
 }
@@ -111,6 +122,7 @@ struct SConfigVariable
 	enum EVariableType
 	{
 		VAR_INT,
+		VAR_INP,
 		VAR_COLOR,
 		VAR_STRING,
 	};
@@ -169,11 +181,27 @@ struct SIntConfigVariable : public SConfigVariable
 	static void CommandCallback(IConsole::IResult *pResult, void *pUserData);
 	void Register() override;
 	bool IsDefault() const override;
-	void Serialize(char *pOut, size_t Size, int Value) const;
-	void Serialize(char *pOut, size_t Size) const override;
 	void SetValue(int Value);
 	void ResetToDefault() override;
 	void ResetToOld() override;
+
+protected:
+	virtual void Serialize(char *pOut, size_t Size, int Value) const;
+	void Serialize(char *pOut, size_t Size) const override;
+};
+
+struct SInputConfigVariable : public SIntConfigVariable
+{
+	SInputConfigVariable(IConsole *pConsole, const char *pScriptName, EVariableType Type, int Flags, const char *pHelp, int *pVariable) :
+		SIntConfigVariable(pConsole, pScriptName, Type, Flags, pHelp, pVariable, 0, 0, 1)
+	{
+	}
+
+	~SInputConfigVariable() override = default;
+
+	static void CommandCallback(IConsole::IResult *pResult, void *pUserData);
+	void Register() override;
+	void Serialize(char *pOut, size_t Size, int Value) const override;
 };
 
 struct SColorConfigVariable : public SConfigVariable

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -6,9 +6,10 @@
 #ifndef MACRO_CONFIG_INT
 #error "The config macros must be defined"
 // This helps IDEs properly syntax highlight the uses of the macro below.
-#define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc)
-#define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc)
-#define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc)
+#define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Flags, Desc)
+#define MACRO_CONFIG_INP(Name, ScriptName, Flags, Desc)
+#define MACRO_CONFIG_COL(Name, ScriptName, Def, Flags, Desc)
+#define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Flags, Desc)
 #endif
 
 // client

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -250,7 +250,7 @@ MACRO_CONFIG_COL(ClDummyColorFeet, dummy_color_feet, 65408, CFGFLAG_CLIENT | CFG
 MACRO_CONFIG_STR(ClDummySkin, dummy_skin, 24, "default", CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Dummy skin")
 MACRO_CONFIG_INT(ClDummyDefaultEyes, dummy_default_eyes, 0, 0, 5, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Dummy eyes when joining server (0 = normal, 1 = pain, 2 = happy, 3 = surprise, 4 = angry, 5 = blink)")
 MACRO_CONFIG_INT(ClDummy, cl_dummy, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Whether you control your player (0) or your dummy (1)")
-MACRO_CONFIG_INT(ClDummyHammer, cl_dummy_hammer, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Whether dummy is hammering for a hammerfly")
+MACRO_CONFIG_INP(ClDummyHammer, cl_dummy_hammer, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Whether dummy is hammering for a hammerfly")
 MACRO_CONFIG_INT(ClDummyResetOnSwitch, cl_dummy_resetonswitch, 0, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Whether dummy or player should stop pressing keys when you switch (0 = off, 1 = dummy, 2 = player)")
 MACRO_CONFIG_INT(ClDummyRestoreWeapon, cl_dummy_restore_weapon, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Whether dummy should switch to last weapon after hammerfly")
 MACRO_CONFIG_INT(ClDummyCopyMoves, cl_dummy_copy_moves, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Whether dummy should copy your moves")
@@ -258,7 +258,7 @@ MACRO_CONFIG_INT(ClDummyCopyMoves, cl_dummy_copy_moves, 0, 0, 1, CFGFLAG_CLIENT 
 // more controllable dummy command
 MACRO_CONFIG_INT(ClDummyControl, cl_dummy_control, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Whether you can control dummy at the same time (cl_dummy_jump, cl_dummy_fire, cl_dummy_hook)")
 MACRO_CONFIG_INT(ClDummyJump, cl_dummy_jump, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Whether dummy is jumping (requires cl_dummy_control 1)")
-MACRO_CONFIG_INT(ClDummyFire, cl_dummy_fire, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Whether dummy is firing (requires cl_dummy_control 1)")
+MACRO_CONFIG_INP(ClDummyFire, cl_dummy_fire, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Whether dummy is firing (requires cl_dummy_control 1)")
 MACRO_CONFIG_INT(ClDummyHook, cl_dummy_hook, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Whether dummy is hooking (requires cl_dummy_control 1)")
 
 // start menu

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -292,14 +292,19 @@ int CControls::SnapInput(int *pData)
 			CNetObj_PlayerInput *pDummyInput = &GameClient()->m_DummyInput;
 			pDummyInput->m_Jump = g_Config.m_ClDummyJump;
 
-			if(g_Config.m_ClDummyFire)
+			if(g_Config.m_ClDummyHammer == (pDummyInput->m_Fire & ~1 & INPUT_STATE_MASK))
+			{
 				pDummyInput->m_Fire = g_Config.m_ClDummyFire;
-			else if((pDummyInput->m_Fire & 1) != 0)
-				pDummyInput->m_Fire++;
+				g_Config.m_ClDummyHammer = (pDummyInput->m_Fire & ~1 & INPUT_STATE_MASK);
+			}
+			else
+				g_Config.m_ClDummyFire = (pDummyInput->m_Fire & ~1 & INPUT_STATE_MASK) | (g_Config.m_ClDummyFire & 1);
 
 			pDummyInput->m_Hook = g_Config.m_ClDummyHook;
 			m_aInputData[!g_Config.m_ClDummy] = *pDummyInput;
 		}
+		else
+			g_Config.m_ClDummyFire = (GameClient()->m_DummyInput.m_Fire & ~1 & INPUT_STATE_MASK) | (g_Config.m_ClDummyFire & 1);
 
 		// stress testing
 		if(g_Config.m_DbgStress)

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1367,7 +1367,7 @@ void CHud::RenderDummyActions()
 	float y = StartY + 2;
 	float x = StartX + 2;
 	Graphics()->SetColor(1.0f, 1.0f, 1.0f, 0.4f);
-	if(g_Config.m_ClDummyHammer)
+	if((g_Config.m_ClDummyHammer & 1) == 1)
 	{
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 	}

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -101,7 +101,7 @@ float CPlayers::GetPlayerTargetAngle(
 {
 	if(GameClient()->PredictDummy() && GameClient()->m_aLocalIds[!g_Config.m_ClDummy] == ClientId)
 	{
-		const CNetObj_PlayerInput &Input = g_Config.m_ClDummyHammer ? GameClient()->m_HammerInput : GameClient()->m_DummyInput;
+		const CNetObj_PlayerInput &Input = g_Config.m_ClDummyHammer != (GameClient()->m_DummyInput.m_Fire & ~1) ? GameClient()->m_HammerInput : GameClient()->m_DummyInput;
 		return angle(vec2(Input.m_TargetX, Input.m_TargetY));
 	}
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -564,11 +564,21 @@ int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
 	}
 	else
 	{
-		// a `+toggle cl_dummy_fire 0 1` bind was pressed and released (or released and pressed)
-		// possibly a debounce issue, but the player will fire this tick
-		// we need to try to fire with the dummy in case the dummy will be unfrozen by the player
-		if(g_Config.m_ClDummyHammer != (m_DummyInput.m_Fire | 1))
-			m_DummyFire = 0;
+		if(!g_Config.m_ClDummyCopyMoves)
+		{
+			// a `+toggle cl_dummy_fire 0 1` bind was pressed and released (or released and pressed)
+			// possibly a debounce issue, but the player will fire this tick
+			// we need to try to fire with the dummy in case the dummy will be unfrozen by the player
+			if(g_Config.m_ClDummyHammer != (m_DummyInput.m_Fire | 1))
+				m_DummyFire = 0;
+		}
+		else if(m_DummyInput.m_Fire == ((g_Config.m_ClDummyHammer + 2) & ~1 & INPUT_STATE_MASK))
+		{
+			// fire done "on the player" was just released
+			// ClDummyHammer should be caught up to keep correct state
+			g_Config.m_ClDummyHammer = (m_DummyInput.m_Fire & ~1 & INPUT_STATE_MASK) | (g_Config.m_ClDummyHammer & 1);
+			return 0;
+		}
 
 		if(m_DummyFire % 25 != 0)
 		{

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -526,6 +526,8 @@ void CGameClient::OnDummySwap()
 	const int PrevDummyFire = m_DummyInput.m_Fire;
 	m_DummyInput = m_Controls.m_aInputData[!g_Config.m_ClDummy];
 	m_Controls.m_aInputData[g_Config.m_ClDummy].m_Fire = PrevDummyFire;
+	g_Config.m_ClDummyHammer = (m_DummyInput.m_Fire & ~1 & INPUT_STATE_MASK) | (g_Config.m_ClDummyHammer & 1);
+	g_Config.m_ClDummyFire = (m_DummyInput.m_Fire & ~1 & INPUT_STATE_MASK) | (g_Config.m_ClDummyFire & 1);
 	m_IsDummySwapping = 1;
 }
 
@@ -540,14 +542,15 @@ int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
 		return 0;
 	}
 
-	if(!g_Config.m_ClDummyHammer)
+	if((m_HammerInput.m_Fire & 1) != 0 && (g_Config.m_ClDummyHammer & 1) == 0)
 	{
-		if(m_DummyFire != 0)
-		{
-			m_DummyInput.m_Fire = (m_HammerInput.m_Fire + 1) & ~1;
-			m_DummyFire = 0;
-		}
-
+		m_HammerInput.m_Fire = (m_HammerInput.m_Fire + 1) & INPUT_STATE_MASK & ~1;
+		m_DummyInput.m_Fire = m_HammerInput.m_Fire;
+		g_Config.m_ClDummyHammer = m_DummyInput.m_Fire;
+		m_DummyFire = 0;
+	}
+	if(g_Config.m_ClDummyHammer == (m_DummyInput.m_Fire & ~1 & INPUT_STATE_MASK))
+	{
 		if(!Force && (!m_DummyInput.m_Direction && !m_DummyInput.m_Jump && !m_DummyInput.m_Hook))
 		{
 			return 0;
@@ -558,6 +561,12 @@ int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
 	}
 	else
 	{
+		// a `+toggle cl_dummy_fire 0 1` bind was pressed and released (or released and pressed)
+		// possibly a debounce issue, but the player will fire this tick
+		// we need to try to fire with the dummy in case the dummy will be unfrozen by the player
+		if(g_Config.m_ClDummyHammer != (m_DummyInput.m_Fire | 1))
+			m_DummyFire = 0;
+
 		if(m_DummyFire % 25 != 0)
 		{
 			m_DummyFire++;
@@ -565,7 +574,10 @@ int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
 		}
 		m_DummyFire++;
 
-		m_HammerInput.m_Fire = (m_HammerInput.m_Fire + 1) | 1;
+		m_HammerInput.m_Fire = ((m_DummyInput.m_Fire + 1) & INPUT_STATE_MASK) | 1;
+		// supporting above conditions
+		m_DummyInput.m_Fire = m_HammerInput.m_Fire;
+		g_Config.m_ClDummyHammer = (m_DummyInput.m_Fire & ~1 & INPUT_STATE_MASK) | (g_Config.m_ClDummyHammer & 1);
 		m_HammerInput.m_WantedWeapon = WEAPON_HAMMER + 1;
 		if(!g_Config.m_ClDummyRestoreWeapon)
 		{
@@ -4827,7 +4839,13 @@ void CGameClient::DummyResetInput()
 		return;
 
 	if((m_DummyInput.m_Fire & 1) != 0)
-		m_DummyInput.m_Fire++;
+	{
+		m_DummyInput.m_Fire = (m_DummyInput.m_Fire + 1) & INPUT_STATE_MASK;
+		// matching existing behavior, ClDummyHammer is still active
+		// don't make it be a full input state wraparound of presses ahead
+		if((g_Config.m_ClDummyHammer & 1) != 0)
+			g_Config.m_ClDummyHammer = (g_Config.m_ClDummyHammer + 2) & INPUT_STATE_MASK;
+	}
 
 	m_Controls.ResetInput(!g_Config.m_ClDummy);
 	m_Controls.m_aInputData[!g_Config.m_ClDummy].m_Hook = 0;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -523,8 +523,11 @@ void CGameClient::OnDummySwap()
 		m_Controls.ResetInput(PlayerOrDummy);
 		m_Controls.m_aInputData[PlayerOrDummy].m_Hook = 0;
 	}
-	const int PrevDummyFire = m_DummyInput.m_Fire;
+	int PrevDummyFire = m_DummyInput.m_Fire;
 	m_DummyInput = m_Controls.m_aInputData[!g_Config.m_ClDummy];
+	// preserve existing behavior - old dummy, now player, should fire immediately upon swap
+	if((g_Config.m_ClDummyHammer & 1) == 1)
+		PrevDummyFire = (PrevDummyFire + 2) & INPUT_STATE_MASK;
 	m_Controls.m_aInputData[g_Config.m_ClDummy].m_Fire = PrevDummyFire;
 	g_Config.m_ClDummyHammer = (m_DummyInput.m_Fire & ~1 & INPUT_STATE_MASK) | (g_Config.m_ClDummyHammer & 1);
 	g_Config.m_ClDummyFire = (m_DummyInput.m_Fire & ~1 & INPUT_STATE_MASK) | (g_Config.m_ClDummyFire & 1);

--- a/src/game/server/teehistorian.cpp
+++ b/src/game/server/teehistorian.cpp
@@ -175,6 +175,8 @@ void CTeeHistorian::WriteHeader(const CGameInfo *pGameInfo)
 		First = false; \
 	}
 
+#define MACRO_CONFIG_INP(Name, ScriptName, Flags, Desc) MACRO_CONFIG_INT(Name, ScriptName, 0, 0, 1, Flags, Desc)
+
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Flags, Desc) MACRO_CONFIG_INT(Name, ScriptName, Def, 0, 0, Flags, Desc)
 
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Flags, Desc) \
@@ -191,6 +193,7 @@ void CTeeHistorian::WriteHeader(const CGameInfo *pGameInfo)
 #include <engine/shared/config_variables.h>
 
 #undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_INP
 #undef MACRO_CONFIG_COL
 #undef MACRO_CONFIG_STR
 

--- a/src/test/teehistorian_test.cpp
+++ b/src/test/teehistorian_test.cpp
@@ -39,15 +39,17 @@ protected:
 	TeeHistorian()
 	{
 		mem_zero(&m_Config, sizeof(m_Config));
-#define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) \
+#define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Flags, Desc) \
 	m_Config.m_##Name = (Def);
+#define MACRO_CONFIG_INP(Name, ScriptName, Flags, Desc) MACRO_CONFIG_INT(Name, ScriptName, 0, 0, 1, Flags, Desc)
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) MACRO_CONFIG_INT(Name, ScriptName, Def, 0, 0, Save, Desc)
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) \
 	str_copy(m_Config.m_##Name, (Def));
 #include <engine/shared/config_variables.h>
-#undef MACRO_CONFIG_STR
-#undef MACRO_CONFIG_COL
 #undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_INP
+#undef MACRO_CONFIG_COL
+#undef MACRO_CONFIG_STR
 
 		RegisterUuids(&m_UuidManager);
 		RegisterTeehistorianUuids(&m_UuidManager);


### PR DESCRIPTION
`cl_dummy_hammer` and `cl_dummy_fire` are applied when a physics tick happens. This is different from how `m_Fire` and switching weapons are handled for the player, where the variable is incremented immediately upon press and release and that state is used to apply the action during physics ticks.

Due to this, if a deepfly bind's fire is (supposedly) pressed and released inbetween physics ticks, only the player will fire. This happens to me [1.4% of the time](https://github.com/ddnet/ddnet/issues/11694#issuecomment-3815117516) on a <1yo controller's bumper. If one's fire key has bad debounce, the dummy's fire could happen a tick later than the player's. Both of these scenarios are problematic when doing things like deepfly.

This PR adds an Input config variable type, which can be used for configs that are directly passed through to things that use `CountInput()`. Setting them to 0 or 1 will update the config in the way the underlying variables usually are, and since these configs are not saved to disk that behavior is transparent.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options **(should have more before merge)**
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps **(goal here is identical behavior)**
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI

## Known issues

- ~Having `cl_dummy_hammer` active and switching to one's dummy does not cause a fire~ Fixed
- ~Firing as the player appears to happen twice on the same tick? (visible with gun stars) - no clue what could cause that at the moment~ Reproducible on master
- Implementation strategy may need discussion, but this was the only clean method I could think of