### PR TITLE
Color tune regions by tune zone number

### DIFF
--- a/src/base/math.h
+++ b/src/base/math.h
@@ -12,6 +12,7 @@ template<typename T>
 concept Numeric = std::integral<T> || std::floating_point<T>;
 
 constexpr float pi = 3.1415926535897932384626433f;
+constexpr float normalized_golden_angle = 137.50776f / 360.0f;
 
 constexpr int round_to_int(float f)
 {

--- a/src/engine/gfx/image_manipulation.cpp
+++ b/src/engine/gfx/image_manipulation.cpp
@@ -1,8 +1,11 @@
 #include "image_manipulation.h"
 
+#include <base/color.h>
 #include <base/dbg.h>
 #include <base/math.h>
 #include <base/mem.h>
+
+#include <engine/image.h>
 
 #include <cstdlib>
 
@@ -71,22 +74,73 @@ bool ConvertToRgba(CImageInfo &Image)
 	return false;
 }
 
+static inline void ConvertToGrayscalePixel(const CImageInfo &Image, size_t PixelIndex, size_t Step)
+{
+	const uint8_t R = Image.m_pData[PixelIndex * Step];
+	const uint8_t G = Image.m_pData[PixelIndex * Step + 1];
+	const uint8_t B = Image.m_pData[PixelIndex * Step + 2];
+	const uint8_t Luma = (uint8_t)(0.2126f * R + 0.7152f * G + 0.0722f * B);
+
+	Image.m_pData[PixelIndex * Step] = Luma;
+	Image.m_pData[PixelIndex * Step + 1] = Luma;
+	Image.m_pData[PixelIndex * Step + 2] = Luma;
+}
+
 void ConvertToGrayscale(const CImageInfo &Image)
 {
 	if(Image.m_Format == CImageInfo::FORMAT_R || Image.m_Format == CImageInfo::FORMAT_RA)
 		return;
 
 	const size_t Step = Image.PixelSize();
-	for(size_t i = 0; i < Image.m_Width * Image.m_Height; ++i)
+	for(size_t PixelIndex = 0; PixelIndex < Image.m_Width * Image.m_Height; ++PixelIndex)
 	{
-		const uint8_t R = Image.m_pData[i * Step];
-		const uint8_t G = Image.m_pData[i * Step + 1];
-		const uint8_t B = Image.m_pData[i * Step + 2];
-		const uint8_t Luma = (uint8_t)(0.2126f * R + 0.7152f * G + 0.0722f * B);
+		ConvertToGrayscalePixel(Image, PixelIndex, Step);
+	}
+}
 
-		Image.m_pData[i * Step] = Luma;
-		Image.m_pData[i * Step + 1] = Luma;
-		Image.m_pData[i * Step + 2] = Luma;
+void ConvertToGrayscaleRect(const CImageInfo &Image, size_t StartX, size_t StartY, size_t Width, size_t Height)
+{
+	if(Image.m_Format == CImageInfo::FORMAT_R || Image.m_Format == CImageInfo::FORMAT_RA)
+		return;
+
+	const size_t Step = Image.PixelSize();
+	for(size_t PixelY = StartY; PixelY < StartY + Height; ++PixelY)
+	{
+		for(size_t PixelX = StartX; PixelX < StartX + Width; ++PixelX)
+		{
+			const size_t PixelIndex = PixelY * Image.m_Width + PixelX;
+			ConvertToGrayscalePixel(Image, PixelIndex, Step);
+		}
+	}
+}
+
+void ColorizeWithHueRect(CImageInfo &Image, float Hue, float Sat, size_t StartX, size_t StartY, size_t Width, size_t Height)
+{
+	dbg_assert(Hue >= 0.0f && Hue <= 1.0f, "Invalid hue");
+	dbg_assert(Sat >= 0.0f && Sat <= 1.0f, "Invalid saturation");
+	dbg_assert(Image.m_Format == CImageInfo::FORMAT_RGB || Image.m_Format == CImageInfo::FORMAT_RGBA, "Invalid image format");
+	dbg_assert(StartX + Width <= Image.m_Width && StartY + Height <= Image.m_Height, "Image rect is out of range");
+
+	const size_t Step = Image.PixelSize();
+	for(size_t PixelY = StartY; PixelY < StartY + Height; ++PixelY)
+	{
+		for(size_t PixelX = StartX; PixelX < StartX + Width; ++PixelX)
+		{
+			const size_t PixelIndex = PixelY * Image.m_Width + PixelX;
+			uint8_t &R = Image.m_pData[PixelIndex * Step];
+			uint8_t &G = Image.m_pData[PixelIndex * Step + 1];
+			uint8_t &B = Image.m_pData[PixelIndex * Step + 2];
+
+			ColorRGBA PixelColor(R / 255.0f, G / 255.0f, B / 255.0f, 1.0f);
+			ColorHSLA PixelColorHSLA = color_cast<ColorHSLA>(PixelColor);
+			PixelColorHSLA.h = Hue;
+			PixelColorHSLA.s = Sat;
+			PixelColor = color_cast<ColorRGBA>(PixelColorHSLA);
+
+			R = static_cast<uint8_t>(PixelColor.r * 255.0f);
+			G = static_cast<uint8_t>(PixelColor.g * 255.0f);
+			B = static_cast<uint8_t>(PixelColor.b * 255.0f);
+		}
 	}
 }
 

--- a/src/engine/gfx/image_manipulation.h
+++ b/src/engine/gfx/image_manipulation.h
@@ -14,6 +14,10 @@ bool ConvertToRgba(CImageInfo &Image);
 
 // Changes the image data (not the format)
 void ConvertToGrayscale(const CImageInfo &Image);
+void ConvertToGrayscaleRect(const CImageInfo &Image, size_t StartX, size_t StartY, size_t Width, size_t Height);
+
+// Color a rectangle inside an image with hue and saturation
+void ColorizeWithHueRect(CImageInfo &Image, float Hue, float Sat, size_t StartX, size_t StartY, size_t Width, size_t Height);
 
 // These functions assume that the image data is 4 bytes per pixel RGBA
 void DilateImage(uint8_t *pImageBuff, int w, int h);

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -3,7 +3,9 @@
 #include "mapimages.h"
 
 #include <base/log.h>
+#include <base/math.h>
 
+#include <engine/gfx/image_manipulation.h>
 #include <engine/graphics.h>
 #include <engine/map.h>
 #include <engine/storage.h>
@@ -21,6 +23,7 @@ CMapImages::CMapImages()
 	m_Count = 0;
 	std::fill(std::begin(m_aEntitiesIsLoaded), std::end(m_aEntitiesIsLoaded), false);
 	m_SpeedupArrowIsLoaded = false;
+	m_TuneColorsIsLoaded = false;
 
 	str_copy(m_aEntitiesPath, "editor/entities_clear");
 
@@ -287,15 +290,24 @@ IGraphics::CTextureHandle CMapImages::GetEntities(EMapImageEntityLayerType Entit
 			BuildImageInfo.m_Width = ImgInfo.m_Width;
 			BuildImageInfo.m_Height = ImgInfo.m_Height;
 			BuildImageInfo.m_Format = ImgInfo.m_Format;
-			BuildImageInfo.Allocate();
+			BuildImageInfo.AllocateFillZero(); // allocate already transparent image
+
+			// convert tune tile to gray
+			const size_t CopyWidth = ImgInfo.m_Width / 16;
+			const size_t CopyHeight = ImgInfo.m_Height / 16;
+			const size_t TuneTileX = static_cast<size_t>(TILE_TUNE % 16) * CopyWidth;
+			const size_t TuneTileY = static_cast<size_t>(TILE_TUNE / 16) * CopyHeight;
+
+			ConvertToGrayscaleRect(ImgInfo, TuneTileX, TuneTileY, CopyWidth, CopyHeight);
 
 			// build game layer
 			for(int LayerType = 0; LayerType < MAP_IMAGE_ENTITY_LAYER_TYPE_COUNT; ++LayerType)
 			{
 				dbg_assert(!m_aaEntitiesTextures[(EntitiesModType * 2) + (int)EntitiesAreMasked][LayerType].IsValid(), "entities texture already loaded when it should not be");
 
-				// set everything transparent
-				mem_zero(BuildImageInfo.m_pData, BuildImageInfo.DataSize());
+				// reset everything transparent
+				if(LayerType > 0)
+					mem_zero(BuildImageInfo.m_pData, BuildImageInfo.DataSize());
 
 				for(int i = 0; i < 256; ++i)
 				{
@@ -307,8 +319,6 @@ IGraphics::CTextureHandle CMapImages::GetEntities(EMapImageEntityLayerType Entit
 							TileIndex = 8;
 						}
 
-						const size_t CopyWidth = ImgInfo.m_Width / 16;
-						const size_t CopyHeight = ImgInfo.m_Height / 16;
 						const size_t OffsetX = (size_t)(TileIndex % 16) * CopyWidth;
 						const size_t OffsetY = (size_t)(TileIndex / 16) * CopyHeight;
 						BuildImageInfo.CopyRectFrom(ImgInfo, OffsetX, OffsetY, CopyWidth, CopyHeight, OffsetX, OffsetY);
@@ -319,6 +329,29 @@ IGraphics::CTextureHandle CMapImages::GetEntities(EMapImageEntityLayerType Entit
 			}
 
 			BuildImageInfo.Free();
+
+			// build tune map from the tune tile
+			if(Graphics()->HasTextureArraysSupport())
+			{
+				CImageInfo TuneMapInfo;
+				TuneMapInfo.m_Width = ImgInfo.m_Width;
+				TuneMapInfo.m_Height = ImgInfo.m_Height;
+				TuneMapInfo.m_Format = ImgInfo.m_Format;
+				TuneMapInfo.AllocateFillZero();
+
+				for(int TileIndex = 1; TileIndex < 256; ++TileIndex)
+				{
+					size_t StartX = CopyWidth * (TileIndex % 16);
+					size_t StartY = CopyHeight * (TileIndex / 16);
+					TuneMapInfo.CopyRectFrom(ImgInfo, TuneTileX, TuneTileY, CopyWidth, CopyHeight, StartX, StartY);
+					float Hue = std::fmod((TileIndex - 1) * normalized_golden_angle, 1.0f);
+					ColorizeWithHueRect(TuneMapInfo, Hue, 1.0f, StartX, StartY, CopyWidth, CopyHeight);
+				}
+				m_TuneColorMapTexture = Graphics()->LoadTextureRaw(TuneMapInfo, TextureLoadFlag);
+				m_TuneColorsIsLoaded = true;
+				TuneMapInfo.Free();
+			}
+
 			ImgInfo.Free();
 		}
 	}
@@ -335,6 +368,24 @@ IGraphics::CTextureHandle CMapImages::GetSpeedupArrow()
 		m_SpeedupArrowIsLoaded = true;
 	}
 	return m_SpeedupArrowTexture;
+}
+
+IGraphics::CTextureHandle CMapImages::GetTuneColors()
+{
+	if(Graphics()->HasTextureArraysSupport())
+	{
+		if(!m_TuneColorsIsLoaded)
+		{
+			// load entities, this also loads the tune map
+			GetEntities(EMapImageEntityLayerType::MAP_IMAGE_ENTITY_LAYER_TYPE_ALL_EXCEPT_SWITCH);
+			dbg_assert(m_TuneColorsIsLoaded, "Entities did not load the tune color map");
+		}
+		return m_TuneColorMapTexture;
+	}
+	else
+	{
+		return GetEntities(MAP_IMAGE_ENTITY_LAYER_TYPE_ALL_EXCEPT_SWITCH);
+	}
 }
 
 IGraphics::CTextureHandle CMapImages::GetOverlayBottom()

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -4,8 +4,10 @@
 
 #include <base/dbg.h>
 #include <base/log.h>
+#include <base/math.h>
 #include <base/mem.h>
 
+#include <engine/gfx/image_manipulation.h>
 #include <engine/graphics.h>
 #include <engine/map.h>
 #include <engine/storage.h>
@@ -23,6 +25,7 @@ CMapImages::CMapImages()
 	m_Count = 0;
 	std::fill(std::begin(m_aEntitiesIsLoaded), std::end(m_aEntitiesIsLoaded), false);
 	m_SpeedupArrowIsLoaded = false;
+	m_TuneColorsIsLoaded = false;
 
 	str_copy(m_aEntitiesPath, "editor/entities_clear");
 
@@ -287,7 +290,15 @@ IGraphics::CTextureHandle CMapImages::GetEntities(EMapImageEntityLayerType Entit
 			BuildImageInfo.m_Width = ImgInfo.m_Width;
 			BuildImageInfo.m_Height = ImgInfo.m_Height;
 			BuildImageInfo.m_Format = ImgInfo.m_Format;
-			BuildImageInfo.Allocate();
+			BuildImageInfo.Allocate(); // allocate already transparent image
+
+			// convert tune tile to gray
+			const size_t CopyWidth = ImgInfo.m_Width / 16;
+			const size_t CopyHeight = ImgInfo.m_Height / 16;
+			const size_t TuneTileX = static_cast<size_t>(TILE_TUNE % 16) * CopyWidth;
+			const size_t TuneTileY = static_cast<size_t>(TILE_TUNE / 16) * CopyHeight;
+
+			ConvertToGrayscaleRect(ImgInfo, TuneTileX, TuneTileY, CopyWidth, CopyHeight);
 
 			// build game layer
 			for(int LayerType = 0; LayerType < MAP_IMAGE_ENTITY_LAYER_TYPE_COUNT; ++LayerType)
@@ -307,8 +318,6 @@ IGraphics::CTextureHandle CMapImages::GetEntities(EMapImageEntityLayerType Entit
 							TileIndex = 8;
 						}
 
-						const size_t CopyWidth = ImgInfo.m_Width / 16;
-						const size_t CopyHeight = ImgInfo.m_Height / 16;
 						const size_t OffsetX = (size_t)(TileIndex % 16) * CopyWidth;
 						const size_t OffsetY = (size_t)(TileIndex / 16) * CopyHeight;
 						BuildImageInfo.CopyRectFrom(ImgInfo, OffsetX, OffsetY, CopyWidth, CopyHeight, OffsetX, OffsetY);
@@ -319,6 +328,28 @@ IGraphics::CTextureHandle CMapImages::GetEntities(EMapImageEntityLayerType Entit
 			}
 
 			BuildImageInfo.Free();
+
+			// build tune map from the tune tile
+			if(Graphics()->HasTextureArraysSupport())
+			{
+				CImageInfo TuneMapInfo;
+				TuneMapInfo.m_Width = ImgInfo.m_Width;
+				TuneMapInfo.m_Height = ImgInfo.m_Height;
+				TuneMapInfo.m_Format = ImgInfo.m_Format;
+				TuneMapInfo.AllocateFillZero();
+
+				for(int TileIndex = 1; TileIndex < 256; ++TileIndex)
+				{
+					size_t StartX = CopyWidth * (TileIndex % 16);
+					size_t StartY = CopyHeight * (TileIndex / 16);
+					TuneMapInfo.CopyRectFrom(ImgInfo, TuneTileX, TuneTileY, CopyWidth, CopyHeight, StartX, StartY);
+					float Hue = std::fmod((TileIndex - 1) * normalized_golden_angle, 1.0f);
+					ColorizeWithHueRect(TuneMapInfo, Hue, 0.75f, StartX, StartY, CopyWidth, CopyHeight);
+				}
+				m_TuneColorMapTexture = Graphics()->LoadTextureRawMove(TuneMapInfo, TextureLoadFlag);
+				m_TuneColorsIsLoaded = true;
+			}
+
 			ImgInfo.Free();
 		}
 	}
@@ -335,6 +366,24 @@ IGraphics::CTextureHandle CMapImages::GetSpeedupArrow()
 		m_SpeedupArrowIsLoaded = true;
 	}
 	return m_SpeedupArrowTexture;
+}
+
+IGraphics::CTextureHandle CMapImages::GetTuneColors()
+{
+	if(Graphics()->HasTextureArraysSupport())
+	{
+		if(!m_TuneColorsIsLoaded)
+		{
+			// load entities, this also loads the tune map
+			GetEntities(EMapImageEntityLayerType::MAP_IMAGE_ENTITY_LAYER_TYPE_ALL_EXCEPT_SWITCH);
+			dbg_assert(m_TuneColorsIsLoaded, "Entities did not load the tune color map");
+		}
+		return m_TuneColorMapTexture;
+	}
+	else
+	{
+		return GetEntities(MAP_IMAGE_ENTITY_LAYER_TYPE_ALL_EXCEPT_SWITCH);
+	}
 }
 
 IGraphics::CTextureHandle CMapImages::GetOverlayBottom()

--- a/src/game/client/components/mapimages.h
+++ b/src/game/client/components/mapimages.h
@@ -59,6 +59,7 @@ public:
 	// DDRace
 	IGraphics::CTextureHandle GetEntities(EMapImageEntityLayerType EntityLayerType) override;
 	IGraphics::CTextureHandle GetSpeedupArrow() override;
+	IGraphics::CTextureHandle GetTuneColors() override;
 
 	IGraphics::CTextureHandle GetOverlayBottom() override;
 	IGraphics::CTextureHandle GetOverlayTop() override;
@@ -72,8 +73,10 @@ public:
 private:
 	bool m_aEntitiesIsLoaded[MAP_IMAGE_MOD_TYPE_COUNT * 2];
 	bool m_SpeedupArrowIsLoaded;
+	bool m_TuneColorsIsLoaded;
 	IGraphics::CTextureHandle m_aaEntitiesTextures[MAP_IMAGE_MOD_TYPE_COUNT * 2][MAP_IMAGE_ENTITY_LAYER_TYPE_COUNT];
 	IGraphics::CTextureHandle m_SpeedupArrowTexture;
+	IGraphics::CTextureHandle m_TuneColorMapTexture;
 	IGraphics::CTextureHandle m_OverlayBottomTexture;
 	IGraphics::CTextureHandle m_OverlayTopTexture;
 	IGraphics::CTextureHandle m_OverlayCenterTexture;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1034,7 +1034,7 @@ ColorRGBA CGameClient::GetDDTeamColor(int DDTeam, float Lightness) const
 {
 	// Use golden angle to generate unique colors with distinct adjacent colors.
 	// The first DDTeam (team 1) gets angle 0°, i.e. red hue.
-	const float Hue = std::fmod((DDTeam - 1) * (137.50776f / 360.0f), 1.0f);
+	const float Hue = std::fmod((DDTeam - 1) * normalized_golden_angle, 1.0f);
 	return color_cast<ColorRGBA>(ColorHSLA(Hue, 1.0f, Lightness));
 }
 

--- a/src/game/map/render_component.h
+++ b/src/game/map/render_component.h
@@ -14,6 +14,7 @@ public:
 	const IGraphics *Graphics() const { return m_pGraphics; }
 	ITextRender *TextRender() { return m_pTextRender; }
 	CRenderMap *RenderMap() { return m_pRenderMap; }
+	const CRenderMap *RenderMap() const { return m_pRenderMap; }
 
 	void OnInit(IGraphics *pGraphics, ITextRender *pTextRender, CRenderMap *pRenderMap);
 	void OnInit(CRenderComponent *pRenderComponent);

--- a/src/game/map/render_interfaces.h
+++ b/src/game/map/render_interfaces.h
@@ -35,6 +35,7 @@ public:
 	// DDRace
 	virtual IGraphics::CTextureHandle GetEntities(EMapImageEntityLayerType EntityLayerType) = 0;
 	virtual IGraphics::CTextureHandle GetSpeedupArrow() = 0;
+	virtual IGraphics::CTextureHandle GetTuneColors() = 0;
 
 	virtual IGraphics::CTextureHandle GetOverlayBottom() = 0;
 	virtual IGraphics::CTextureHandle GetOverlayTop() = 0;

--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -15,7 +15,7 @@
 #include <game/mapitems.h>
 
 #include <array>
-#include <chrono>
+#include <cmath>
 
 /************************
  * Render Buffer Helper *
@@ -1706,10 +1706,30 @@ void CRenderLayerEntitySwitch::RenderTileLayerNoTileBuffer(const ColorRGBA &Colo
 CRenderLayerEntityTune::CRenderLayerEntityTune(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap) :
 	CRenderLayerEntityBase(GroupId, LayerId, Flags, pLayerTilemap) {}
 
+IGraphics::CTextureHandle CRenderLayerEntityTune::GetTexture() const
+{
+	return m_pMapImages->GetTuneColors();
+}
+
 void CRenderLayerEntityTune::GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const
 {
-	*pIndex = m_pTuneTiles[y * m_pLayerTilemap->m_Width + x].m_Type;
+	const unsigned char Number = m_pTuneTiles[y * m_pLayerTilemap->m_Width + x].m_Number;
+	unsigned char Index = 0;
+
+	if(Number != 0)
+	{
+		// assign color index instead of tune number for higher color distance
+		Index = RenderMap()->TuneColorMapper()->GetTuneColorIndex(Number);
+	}
+
+	*pIndex = Index;
 	*pFlags = 0;
+}
+
+void CRenderLayerEntityTune::Init()
+{
+	RenderMap()->TuneColorMapper()->Reset();
+	CRenderLayerTile::Init();
 }
 
 int CRenderLayerEntityTune::GetDataIndex(unsigned int &TileSize) const

--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -15,7 +15,7 @@
 #include <game/mapitems.h>
 
 #include <array>
-#include <chrono>
+#include <cmath>
 
 /************************
  * Render Buffer Helper *
@@ -1706,10 +1706,30 @@ void CRenderLayerEntitySwitch::RenderTileLayerNoTileBuffer(const ColorRGBA &Colo
 CRenderLayerEntityTune::CRenderLayerEntityTune(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap) :
 	CRenderLayerEntityBase(GroupId, LayerId, Flags, pLayerTilemap) {}
 
+IGraphics::CTextureHandle CRenderLayerEntityTune::GetTexture() const
+{
+	return m_pMapImages->GetTuneColors();
+}
+
 void CRenderLayerEntityTune::GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const
 {
-	*pIndex = m_pTuneTiles[y * m_pLayerTilemap->m_Width + x].m_Type;
+	const unsigned char Number = m_pTuneTiles[y * m_pLayerTilemap->m_Width + x].m_Number;
+	unsigned char Index = 0;
+
+	if(Number != 0)
+	{
+		// assign color index instead of tune number for higher color distance
+		Index = m_TuneColorMapper.TuneNumberToColorIndex(Number);
+	}
+
+	*pIndex = Index;
 	*pFlags = 0;
+}
+
+void CRenderLayerEntityTune::Init()
+{
+	m_TuneColorMapper.Reset();
+	CRenderLayerTile::Init();
 }
 
 int CRenderLayerEntityTune::GetDataIndex(unsigned int &TileSize) const
@@ -1726,7 +1746,7 @@ void CRenderLayerEntityTune::InitTileData()
 void CRenderLayerEntityTune::RenderTileLayerNoTileBuffer(const ColorRGBA &Color, const CRenderLayerParams &Params)
 {
 	Graphics()->BlendNone();
-	RenderMap()->RenderTunemap(m_pTuneTiles, m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height, 32.0f, Color, (Params.m_RenderTileBorder ? TILERENDERFLAG_EXTEND : 0) | LAYERRENDERFLAG_OPAQUE);
+	RenderMap()->RenderTunemap(m_pTuneTiles, m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height, 32.0f, Color, (Params.m_RenderTileBorder ? TILERENDERFLAG_EXTEND : 0) | LAYERRENDERFLAG_OPAQUE, &m_TuneColorMapper);
 	Graphics()->BlendNormal();
-	RenderMap()->RenderTunemap(m_pTuneTiles, m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height, 32.0f, Color, (Params.m_RenderTileBorder ? TILERENDERFLAG_EXTEND : 0) | LAYERRENDERFLAG_TRANSPARENT);
+	RenderMap()->RenderTunemap(m_pTuneTiles, m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height, 32.0f, Color, (Params.m_RenderTileBorder ? TILERENDERFLAG_EXTEND : 0) | LAYERRENDERFLAG_TRANSPARENT, &m_TuneColorMapper);
 }

--- a/src/game/map/render_layer.h
+++ b/src/game/map/render_layer.h
@@ -378,11 +378,13 @@ class CRenderLayerEntityTune final : public CRenderLayerEntityBase
 public:
 	CRenderLayerEntityTune(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
 	int GetDataIndex(unsigned int &TileSize) const override;
+	void Init() override;
 	void InitTileData() override;
 
 protected:
 	void RenderTileLayerNoTileBuffer(const ColorRGBA &Color, const CRenderLayerParams &Params) override;
 	void GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const override;
+	IGraphics::CTextureHandle GetTexture() const override;
 
 private:
 	CTuneTile *m_pTuneTiles;

--- a/src/game/map/render_layer.h
+++ b/src/game/map/render_layer.h
@@ -378,13 +378,16 @@ class CRenderLayerEntityTune final : public CRenderLayerEntityBase
 public:
 	CRenderLayerEntityTune(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
 	int GetDataIndex(unsigned int &TileSize) const override;
+	void Init() override;
 	void InitTileData() override;
 
 protected:
 	void RenderTileLayerNoTileBuffer(const ColorRGBA &Color, const CRenderLayerParams &Params) override;
 	void GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const override;
+	IGraphics::CTextureHandle GetTexture() const override;
 
 private:
 	CTuneTile *m_pTuneTiles;
+	mutable CTuneColorMapper m_TuneColorMapper;
 };
 #endif

--- a/src/game/map/render_map.cpp
+++ b/src/game/map/render_map.cpp
@@ -17,6 +17,7 @@
 #include <game/mapitems.h>
 #include <game/mapitems_ex.h>
 
+#include <array>
 #include <chrono>
 #include <cmath>
 
@@ -243,6 +244,7 @@ void CRenderMap::Init(IGraphics *pGraphics, ITextRender *pTextRender)
 {
 	m_pGraphics = pGraphics;
 	m_pTextRender = pTextRender;
+	m_pTuneColorMapper = std::make_shared<CTuneColorMapper>();
 }
 
 void CRenderMap::RenderEvalEnvelope(const IEnvelopePointAccess *pPoints, std::chrono::nanoseconds TimeNanos, ColorRGBA &Result, size_t Channels)
@@ -1343,7 +1345,8 @@ void CRenderMap::RenderTunemap(CTuneTile *pTune, int w, int h, float Scale, Colo
 
 			int c = mx + my * w;
 
-			unsigned char Index = pTune[c].m_Type;
+			const unsigned char Index = pTune[c].m_Type;
+
 			if(Index)
 			{
 				bool Render = false;
@@ -1352,6 +1355,10 @@ void CRenderMap::RenderTunemap(CTuneTile *pTune, int w, int h, float Scale, Colo
 
 				if(Render)
 				{
+					const unsigned char Number = pTune[c].m_Number;
+					uint8_t ColorIndex = TuneColorMapper()->GetTuneColorIndex(Number);
+					Graphics()->SetColor(Number == 0 ? Color : TuneColorMapper()->GetTuneIndexColor(ColorIndex).Multiply(Color));
+
 					int tx = Index % 16;
 					int ty = Index / 16;
 					int Px0 = tx * (1024 / 16);
@@ -1422,4 +1429,38 @@ void CRenderMap::RenderDebugClip(float ClipX, float ClipY, float ClipW, float Cl
 	// clamp zoom and set line width, because otherwise the text can be partially clipped out
 	TextRender()->Text(ClipX, ClipY, std::min(12.0f * Zoom, 20.0f), pLabel, ClipW);
 	TextRender()->TextColor(TextRender()->DefaultTextColor());
+}
+
+CTuneColorMapper::CTuneColorMapper()
+{
+	Reset();
+}
+
+uint8_t CTuneColorMapper::GetTuneColorIndex(uint8_t TuneNumber)
+{
+	if(TuneNumber == 0)
+		return 0;
+
+	uint8_t &TuneColorIndex = m_aTuneNumberToColorIndex[TuneNumber - 1];
+	if(TuneColorIndex == 0)
+	{
+		TuneColorIndex = m_NextTuneNumberIndex + 1;
+		++m_NextTuneNumberIndex;
+	}
+	return TuneColorIndex;
+}
+
+ColorRGBA CTuneColorMapper::GetTuneIndexColor(uint8_t TuneColorIndex) const
+{
+	if(TuneColorIndex == 0)
+		return ColorRGBA(1.0f, 1.0f, 1.0f);
+
+	float Hue = std::fmod((TuneColorIndex - 1) * normalized_golden_angle, 1.0f);
+	return color_cast<ColorRGBA>(ColorHSLA(Hue, 1.0f, 0.5f, 1.0f));
+}
+
+void CTuneColorMapper::Reset()
+{
+	m_aTuneNumberToColorIndex.fill(0);
+	m_NextTuneNumberIndex = 0;
 }

--- a/src/game/map/render_map.cpp
+++ b/src/game/map/render_map.cpp
@@ -17,6 +17,7 @@
 #include <game/mapitems.h>
 #include <game/mapitems_ex.h>
 
+#include <array>
 #include <chrono>
 #include <cmath>
 
@@ -1286,7 +1287,7 @@ void CRenderMap::RenderSwitchmap(CSwitchTile *pSwitchTile, int w, int h, float S
 	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 }
 
-void CRenderMap::RenderTunemap(CTuneTile *pTune, int w, int h, float Scale, ColorRGBA Color, int RenderFlags)
+void CRenderMap::RenderTunemap(CTuneTile *pTune, int w, int h, float Scale, ColorRGBA Color, int RenderFlags, CTuneColorMapper *pTuneColorMapper)
 {
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
 	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
@@ -1343,7 +1344,8 @@ void CRenderMap::RenderTunemap(CTuneTile *pTune, int w, int h, float Scale, Colo
 
 			int c = mx + my * w;
 
-			unsigned char Index = pTune[c].m_Type;
+			const unsigned char Index = pTune[c].m_Type;
+
 			if(Index)
 			{
 				bool Render = false;
@@ -1352,6 +1354,16 @@ void CRenderMap::RenderTunemap(CTuneTile *pTune, int w, int h, float Scale, Colo
 
 				if(Render)
 				{
+					const unsigned char Number = pTune[c].m_Number;
+
+					if(Number == 0 || pTuneColorMapper == nullptr)
+						Graphics()->SetColor(Color);
+					else
+					{
+						uint8_t ColorIndex = pTuneColorMapper->TuneNumberToColorIndex(Number);
+						Graphics()->SetColor(pTuneColorMapper->TuneColorIndexToColor(ColorIndex).Multiply(Color));
+					}
+
 					int tx = Index % 16;
 					int ty = Index / 16;
 					int Px0 = tx * (1024 / 16);
@@ -1422,4 +1434,38 @@ void CRenderMap::RenderDebugClip(float ClipX, float ClipY, float ClipW, float Cl
 	// clamp zoom and set line width, because otherwise the text can be partially clipped out
 	TextRender()->Text(ClipX, ClipY, std::min(12.0f * Zoom, 20.0f), pLabel, ClipW);
 	TextRender()->TextColor(TextRender()->DefaultTextColor());
+}
+
+CTuneColorMapper::CTuneColorMapper()
+{
+	Reset();
+}
+
+uint8_t CTuneColorMapper::TuneNumberToColorIndex(uint8_t TuneNumber)
+{
+	if(TuneNumber == 0)
+		return 0;
+
+	uint8_t &TuneColorIndex = m_aTuneNumberToColorIndex[TuneNumber - 1];
+	if(TuneColorIndex == 0)
+	{
+		TuneColorIndex = m_NextTuneNumberIndex + 1;
+		++m_NextTuneNumberIndex;
+	}
+	return TuneColorIndex;
+}
+
+ColorRGBA CTuneColorMapper::TuneColorIndexToColor(uint8_t TuneColorIndex) const
+{
+	if(TuneColorIndex == 0)
+		return ColorRGBA(1.0f, 1.0f, 1.0f);
+
+	float Hue = std::fmod((TuneColorIndex - 1) * normalized_golden_angle, 1.0f);
+	return color_cast<ColorRGBA>(ColorHSLA(Hue, 0.75f, 0.5f, 1.0f));
+}
+
+void CTuneColorMapper::Reset()
+{
+	m_aTuneNumberToColorIndex.fill(0);
+	m_NextTuneNumberIndex = 0;
 }

--- a/src/game/map/render_map.h
+++ b/src/game/map/render_map.h
@@ -6,7 +6,9 @@
 #include <game/map/render_interfaces.h>
 #include <game/mapitems.h>
 
+#include <array>
 #include <chrono>
+#include <memory>
 
 enum
 {
@@ -51,15 +53,30 @@ public:
 class IGraphics;
 class ITextRender;
 
+class CTuneColorMapper
+{
+public:
+	CTuneColorMapper();
+	ColorRGBA GetTuneIndexColor(uint8_t TuneColorIndex) const;
+	uint8_t GetTuneColorIndex(uint8_t TuneNumber);
+	void Reset();
+
+private:
+	std::array<uint8_t, 255> m_aTuneNumberToColorIndex;
+	uint8_t m_NextTuneNumberIndex = 0;
+};
+
 class CRenderMap
 {
 	IGraphics *m_pGraphics;
 	ITextRender *m_pTextRender;
+	std::shared_ptr<CTuneColorMapper> m_pTuneColorMapper;
 
 public:
 	void Init(IGraphics *pGraphics, ITextRender *pTextRender);
 	IGraphics *Graphics() { return m_pGraphics; }
 	ITextRender *TextRender() { return m_pTextRender; }
+	std::shared_ptr<CTuneColorMapper> TuneColorMapper() const { return m_pTuneColorMapper; }
 
 	// map render methods (render_map.cpp)
 	static void RenderEvalEnvelope(const IEnvelopePointAccess *pPoints, std::chrono::nanoseconds TimeNanos, ColorRGBA &Result, size_t Channels);

--- a/src/game/map/render_map.h
+++ b/src/game/map/render_map.h
@@ -6,7 +6,9 @@
 #include <game/map/render_interfaces.h>
 #include <game/mapitems.h>
 
+#include <array>
 #include <chrono>
+#include <memory>
 
 enum
 {
@@ -51,6 +53,19 @@ public:
 class IGraphics;
 class ITextRender;
 
+class CTuneColorMapper
+{
+public:
+	CTuneColorMapper();
+	uint8_t TuneNumberToColorIndex(uint8_t TuneNumber);
+	ColorRGBA TuneColorIndexToColor(uint8_t TuneColorIndex) const;
+	void Reset();
+
+private:
+	std::array<uint8_t, 255> m_aTuneNumberToColorIndex;
+	uint8_t m_NextTuneNumberIndex = 0;
+};
+
 class CRenderMap
 {
 	IGraphics *m_pGraphics;
@@ -78,7 +93,7 @@ public:
 	void RenderTuneOverlay(CTuneTile *pTune, int w, int h, float Scale, int OverlayRenderFlags, float Alpha = 1.0f);
 	void RenderTelemap(CTeleTile *pTele, int w, int h, float Scale, ColorRGBA Color, int RenderFlags);
 	void RenderSwitchmap(CSwitchTile *pSwitch, int w, int h, float Scale, ColorRGBA Color, int RenderFlags);
-	void RenderTunemap(CTuneTile *pTune, int w, int h, float Scale, ColorRGBA Color, int RenderFlags);
+	void RenderTunemap(CTuneTile *pTune, int w, int h, float Scale, ColorRGBA Color, int RenderFlags, CTuneColorMapper *pTuneColorMapper);
 
 	void RenderDebugClip(float ClipX, float ClipY, float ClipW, float ClipH, ColorRGBA Color, float Zoom, const char *pLabel);
 };


### PR DESCRIPTION
This PR colors each tune zone individually, so it's easier to differentiate between different tune zones

<img width="2560" height="1440" alt="screenshot_2026-04-03_01-39-38" src="https://github.com/user-attachments/assets/3a614aec-4996-4231-a568-0e5dfec717ce" />

<img width="2560" height="1440" alt="screenshot_2026-04-03_01-40-04" src="https://github.com/user-attachments/assets/79e53324-24d7-48dd-b996-0d735b85d67c" />

_Description updated by @AssassinTee_

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
