### PR TITLE
Multi-stream on a network with a queue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2080,6 +2080,8 @@ set_src(ENGINE_INTERFACE GLOB src/engine
   warning.h
 )
 set_src(ENGINE_SHARED GLOB_RECURSE src/engine/shared
+  AtomicOps.h
+  ReaderWriterQueue.h
   assertion_logger.cpp
   assertion_logger.h
   compression.cpp
@@ -2125,6 +2127,8 @@ set_src(ENGINE_SHARED GLOB_RECURSE src/engine/shared
   masterserver.h
   memheap.cpp
   memheap.h
+  net_io_thread.cpp
+  net_io_thread.h
   netban.cpp
   netban.h
   network.cpp
@@ -2149,11 +2153,15 @@ set_src(ENGINE_SHARED GLOB_RECURSE src/engine/shared
   serverinfo.cpp
   serverinfo.h
   sixup_translate_snapshot.cpp
+  snap_tasks.h
+  snap_threaded.cpp
+  snap_threaded.h
   snapshot.cpp
   snapshot.h
   storage.cpp
   stun.cpp
   stun.h
+  task_processor.h
   teehistorian_ex.cpp
   teehistorian_ex.h
   teehistorian_ex_chunks.h

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -543,6 +543,17 @@ void sphore_signal(SEMAPHORE *sem);
 void sphore_destroy(SEMAPHORE *sem);
 
 /**
+ * Wait on a semaphore until a relative deadline using a high-resolution wait.
+ * Cross-platform: on Windows — WaitableTimer (HIGH_RES) + WaitForMultipleObjects,
+ * on POSIX — sem_timedwait for an absolute deadline.
+ *
+ * @param sem            Semaphore handle.
+ * @param ns_from_now    Relative timeout in nanoseconds. <0 => infinite wait (like sphore_wait).
+ * @return 1 if semaphore signaled before deadline, 0 on timeout.
+ */
+int sphore_wait_deadline_ns(SEMAPHORE *sem, long long ns_from_now);
+
+/**
  * @defgroup Network Networking
  */
 

--- a/src/engine/server/main.cpp
+++ b/src/engine/server/main.cpp
@@ -174,6 +174,7 @@ int main(int argc, const char **argv)
 	pConfigManager->SetReadOnly("sv_port", true);
 	pConfigManager->SetReadOnly("bindaddr", true);
 	pConfigManager->SetReadOnly("logfile", true);
+	pConfigManager->SetReadOnly("sv_net_threaded", true);
 
 	if(g_Config.m_Logfile[0])
 	{

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -16,9 +16,11 @@
 #include <engine/shared/econ.h>
 #include <engine/shared/fifo.h>
 #include <engine/shared/http.h>
+#include <engine/shared/net_io_thread.h>
 #include <engine/shared/netban.h>
 #include <engine/shared/network.h>
 #include <engine/shared/protocol.h>
+#include <engine/shared/snap_threaded.h>
 #include <engine/shared/snapshot.h>
 #include <engine/shared/uuid_manager.h>
 
@@ -215,11 +217,12 @@ public:
 	CSnapshotDelta m_SnapshotDelta;
 	CSnapshotBuilder m_SnapshotBuilder;
 	CSnapIdPool m_IdPool;
-	CNetServer m_NetServer;
+	CNetIOThread m_NetServer;
 	CEcon m_Econ;
 	CFifo m_Fifo;
 	CServerBan m_ServerBan;
 	CHttp m_Http;
+	CSnapThreaded m_SnapThreaded;
 
 	IEngineMap *m_pMap;
 
@@ -331,6 +334,7 @@ public:
 	int DistinctClientCount() const override;
 
 	int GetClientVersion(int ClientId) const override;
+	static bool RepackMsg(const CMsgPacker *pMsg, CPacker &Packer, bool Sixup);
 	int SendMsg(CMsgPacker *pMsg, int Flags, int ClientId) override;
 
 	void DoSnapshot();

--- a/src/engine/shared/AtomicOps.h
+++ b/src/engine/shared/AtomicOps.h
@@ -1,0 +1,830 @@
+// ©2013-2016 Cameron Desrochers.
+// Distributed under the simplified BSD license (see the license file that
+// should have come with this header).
+// Uses Jeff Preshing's semaphore implementation (under the terms of its
+// separate zlib license, embedded below).
+
+// https://github.com/cameron314/readerwriterqueue/blob/master/atomicops.h
+
+#ifndef ENGINE_SHARED_ATOMICOPS_H
+#define ENGINE_SHARED_ATOMICOPS_H
+
+// Provides portable (VC++2010+, Intel ICC 13, GCC 4.7+, and anything C++11 compliant) implementation
+// of low-level memory barriers, plus a few semi-portable utility macros (for inlining and alignment).
+// Also has a basic atomic type (limited to hardware-supported atomics with no memory ordering guarantees).
+// Uses the AE_* prefix for macros (historical reasons), and the "moodycamel" namespace for symbols.
+
+#include <cassert>
+#include <cerrno>
+#include <cstdint>
+#include <ctime>
+#include <type_traits>
+
+// Platform detection
+#if defined(__INTEL_COMPILER)
+#define AE_ICC
+#elif defined(_MSC_VER)
+#define AE_VCPP
+#elif defined(__GNUC__)
+#define AE_GCC
+#endif
+
+#if defined(_M_IA64) || defined(__ia64__)
+#define AE_ARCH_IA64
+#elif defined(_WIN64) || defined(__amd64__) || defined(_M_X64) || defined(__x86_64__)
+#define AE_ARCH_X64
+#elif defined(_M_IX86) || defined(__i386__)
+#define AE_ARCH_X86
+#elif defined(_M_PPC) || defined(__powerpc__)
+#define AE_ARCH_PPC
+#else
+#define AE_ARCH_UNKNOWN
+#endif
+
+// AE_UNUSED
+#define AE_UNUSED(x) ((void)x)
+
+// AE_NO_TSAN/AE_TSAN_ANNOTATE_*
+// For GCC
+#if defined(__SANITIZE_THREAD__)
+#define AE_TSAN_IS_ENABLED
+#endif
+// For clang
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer) && !defined(AE_TSAN_IS_ENABLED)
+#define AE_TSAN_IS_ENABLED
+#endif
+#endif
+
+#ifdef AE_TSAN_IS_ENABLED
+#if __cplusplus >= 201703L // inline variables require C++17
+namespace moodycamel
+{
+	inline int ae_tsan_global;
+}
+#define AE_TSAN_ANNOTATE_RELEASE() AnnotateHappensBefore(__FILE__, __LINE__, (void *)(&::moodycamel::ae_tsan_global))
+#define AE_TSAN_ANNOTATE_ACQUIRE() AnnotateHappensAfter(__FILE__, __LINE__, (void *)(&::moodycamel::ae_tsan_global))
+extern "C" void AnnotateHappensBefore(const char *, int, void *);
+extern "C" void AnnotateHappensAfter(const char *, int, void *);
+#else // when we can't work with tsan, attempt to disable its warnings
+#define AE_NO_TSAN __attribute__((no_sanitize("thread")))
+#endif
+#endif
+
+#ifndef AE_NO_TSAN
+#define AE_NO_TSAN
+#endif
+
+#ifndef AE_TSAN_ANNOTATE_RELEASE
+#define AE_TSAN_ANNOTATE_RELEASE()
+#define AE_TSAN_ANNOTATE_ACQUIRE()
+#endif
+
+// AE_FORCEINLINE
+#if defined(AE_VCPP) || defined(AE_ICC)
+#define AE_FORCEINLINE __forceinline
+#elif defined(AE_GCC)
+//#define AE_FORCEINLINE __attribute__((always_inline))
+#define AE_FORCEINLINE inline
+#else
+#define AE_FORCEINLINE inline
+#endif
+
+// AE_ALIGN
+#if defined(AE_VCPP) || defined(AE_ICC)
+#define AE_ALIGN(x) __declspec(align(x))
+#elif defined(AE_GCC)
+#define AE_ALIGN(x) __attribute__((aligned(x)))
+#else
+// Assume GCC compliant syntax...
+#define AE_ALIGN(x) __attribute__((aligned(x)))
+#endif
+
+// Portable atomic fences implemented below:
+
+// NOLINTBEGIN
+
+namespace moodycamel
+{
+
+	enum memory_order
+	{
+		memory_order_relaxed,
+		memory_order_acquire,
+		memory_order_release,
+		memory_order_acq_rel,
+		memory_order_seq_cst,
+
+		// memory_order_sync: Forces a full sync:
+		// #LoadLoad, #LoadStore, #StoreStore, and most significantly, #StoreLoad
+		memory_order_sync = memory_order_seq_cst
+	};
+
+} // end namespace moodycamel
+
+#if (defined(AE_VCPP) && (_MSC_VER < 1700 || defined(__cplusplus_cli))) || (defined(AE_ICC) && __INTEL_COMPILER < 1600)
+// VS2010 and ICC13 don't support std::atomic_*_fence, implement our own fences
+
+#include <intrin.h>
+
+#if defined(AE_ARCH_X64) || defined(AE_ARCH_X86)
+#define AeFullSync _mm_mfence
+#define AeLiteSync _mm_mfence
+#elif defined(AE_ARCH_IA64)
+#define AeFullSync __mf
+#define AeLiteSync __mf
+#elif defined(AE_ARCH_PPC)
+#include <ppcintrinsics.h>
+#define AeFullSync __sync
+#define AeLiteSync __lwsync
+#endif
+
+#ifdef AE_VCPP
+#pragma warning(push)
+#pragma warning(disable : 4365) // Disable erroneous 'conversion from long to unsigned int, signed/unsigned mismatch' error when using `assert`
+#ifdef __cplusplus_cli
+#pragma managed(push, off)
+#endif
+#endif
+
+namespace moodycamel
+{
+
+	AE_FORCEINLINE void compiler_fence(memory_order order) AE_NO_TSAN
+	{
+		switch(order)
+		{
+		case memory_order_relaxed: break;
+		case memory_order_acquire: _ReadBarrier(); break;
+		case memory_order_release: _WriteBarrier(); break;
+		case memory_order_acq_rel: _ReadWriteBarrier(); break;
+		case memory_order_seq_cst: _ReadWriteBarrier(); break;
+		default: assert(false);
+		}
+	}
+
+// x86/x64 have a strong memory model -- all loads and stores have
+// acquire and release semantics automatically (so only need compiler
+// barriers for those).
+#if defined(AE_ARCH_X86) || defined(AE_ARCH_X64)
+	AE_FORCEINLINE void fence(memory_order order) AE_NO_TSAN
+	{
+		switch(order)
+		{
+		case memory_order_relaxed: break;
+		case memory_order_acquire: _ReadBarrier(); break;
+		case memory_order_release: _WriteBarrier(); break;
+		case memory_order_acq_rel: _ReadWriteBarrier(); break;
+		case memory_order_seq_cst:
+			_ReadWriteBarrier();
+			AeFullSync();
+			_ReadWriteBarrier();
+			break;
+		default: assert(false);
+		}
+	}
+#else
+	AE_FORCEINLINE void fence(memory_order order) AE_NO_TSAN
+	{
+		// Non-specialized arch, use heavier memory barriers everywhere just in case :-(
+		switch(order)
+		{
+		case memory_order_relaxed:
+			break;
+		case memory_order_acquire:
+			_ReadBarrier();
+			AeLiteSync();
+			_ReadBarrier();
+			break;
+		case memory_order_release:
+			_WriteBarrier();
+			AeLiteSync();
+			_WriteBarrier();
+			break;
+		case memory_order_acq_rel:
+			_ReadWriteBarrier();
+			AeLiteSync();
+			_ReadWriteBarrier();
+			break;
+		case memory_order_seq_cst:
+			_ReadWriteBarrier();
+			AeFullSync();
+			_ReadWriteBarrier();
+			break;
+		default: assert(false);
+		}
+	}
+#endif
+} // end namespace moodycamel
+#else
+// Use standard library of atomics
+#include <atomic>
+
+namespace moodycamel
+{
+
+	AE_FORCEINLINE void compiler_fence(memory_order order) AE_NO_TSAN
+	{
+		switch(order)
+		{
+		case memory_order_relaxed: break;
+		case memory_order_acquire: std::atomic_signal_fence(std::memory_order_acquire); break;
+		case memory_order_release: std::atomic_signal_fence(std::memory_order_release); break;
+		case memory_order_acq_rel: std::atomic_signal_fence(std::memory_order_acq_rel); break;
+		case memory_order_seq_cst: std::atomic_signal_fence(std::memory_order_seq_cst); break;
+		default: assert(false);
+		}
+	}
+
+	AE_FORCEINLINE void fence(memory_order order) AE_NO_TSAN
+	{
+		switch(order)
+		{
+		case memory_order_relaxed: break;
+		case memory_order_acquire:
+			AE_TSAN_ANNOTATE_ACQUIRE();
+			std::atomic_thread_fence(std::memory_order_acquire);
+			break;
+		case memory_order_release:
+			AE_TSAN_ANNOTATE_RELEASE();
+			std::atomic_thread_fence(std::memory_order_release);
+			break;
+		case memory_order_acq_rel:
+			AE_TSAN_ANNOTATE_ACQUIRE();
+			AE_TSAN_ANNOTATE_RELEASE();
+			std::atomic_thread_fence(std::memory_order_acq_rel);
+			break;
+		case memory_order_seq_cst:
+			AE_TSAN_ANNOTATE_ACQUIRE();
+			AE_TSAN_ANNOTATE_RELEASE();
+			std::atomic_thread_fence(std::memory_order_seq_cst);
+			break;
+		default: assert(false);
+		}
+	}
+
+} // end namespace moodycamel
+
+#endif
+
+#if !defined(AE_VCPP) || (_MSC_VER >= 1700 && !defined(__cplusplus_cli))
+#define AE_USE_STD_ATOMIC_FOR_WEAK_ATOMIC
+#endif
+
+#ifdef AE_USE_STD_ATOMIC_FOR_WEAK_ATOMIC
+#include <atomic>
+#endif
+#include <utility>
+
+// WARNING: *NOT* A REPLACEMENT FOR std::atomic. READ CAREFULLY:
+// Provides basic support for atomic variables -- no memory ordering guarantees are provided.
+// The guarantee of atomicity is only made for types that already have atomic load and store guarantees
+// at the hardware level -- on most platforms this generally means aligned pointers and integers (only).
+namespace moodycamel
+{
+	template<typename T>
+	class weak_atomic
+	{
+	public:
+		AE_NO_TSAN weak_atomic() :
+			value() {}
+#ifdef AE_VCPP
+#pragma warning(push)
+#pragma warning(disable : 4100) // Get rid of (erroneous) 'unreferenced formal parameter' warning
+#endif
+		template<typename U>
+		AE_NO_TSAN weak_atomic(U &&x) :
+			value(std::forward<U>(x))
+		{
+		}
+#ifdef __cplusplus_cli
+		// Work around bug with universal reference/nullptr combination that only appears when /clr is on
+		AE_NO_TSAN weak_atomic(nullptr_t) :
+			value(nullptr) {}
+#endif
+		AE_NO_TSAN weak_atomic(weak_atomic const &other) :
+			value(other.load()) {}
+		AE_NO_TSAN weak_atomic(weak_atomic &&other) :
+			value(std::move(other.load())) {}
+#ifdef AE_VCPP
+#pragma warning(pop)
+#endif
+
+		AE_FORCEINLINE operator T() const AE_NO_TSAN { return load(); }
+
+#ifndef AE_USE_STD_ATOMIC_FOR_WEAK_ATOMIC
+		template<typename U>
+		AE_FORCEINLINE weak_atomic const &operator=(U &&x) AE_NO_TSAN
+		{
+			value = std::forward<U>(x);
+			return *this;
+		}
+		AE_FORCEINLINE weak_atomic const &operator=(weak_atomic const &other) AE_NO_TSAN
+		{
+			value = other.value;
+			return *this;
+		}
+
+		AE_FORCEINLINE T load() const AE_NO_TSAN { return value; }
+
+		AE_FORCEINLINE T fetch_add_acquire(T increment) AE_NO_TSAN
+		{
+#if defined(AE_ARCH_X64) || defined(AE_ARCH_X86)
+			if(sizeof(T) == 4)
+				return _InterlockedExchangeAdd((long volatile *)&value, (long)increment);
+#if defined(_M_AMD64)
+			else if(sizeof(T) == 8)
+				return _InterlockedExchangeAdd64((long long volatile *)&value, (long long)increment);
+#endif
+#else
+#error Unsupported platform
+#endif
+			assert(false && "T must be either a 32 or 64 bit type");
+			return value;
+		}
+
+		AE_FORCEINLINE T fetch_add_release(T increment) AE_NO_TSAN
+		{
+#if defined(AE_ARCH_X64) || defined(AE_ARCH_X86)
+			if(sizeof(T) == 4)
+				return _InterlockedExchangeAdd((long volatile *)&value, (long)increment);
+#if defined(_M_AMD64)
+			else if(sizeof(T) == 8)
+				return _InterlockedExchangeAdd64((long long volatile *)&value, (long long)increment);
+#endif
+#else
+#error Unsupported platform
+#endif
+			assert(false && "T must be either a 32 or 64 bit type");
+			return value;
+		}
+#else
+		template<typename U>
+		AE_FORCEINLINE weak_atomic const &operator=(U &&x) AE_NO_TSAN
+		{
+			value.store(std::forward<U>(x), std::memory_order_relaxed);
+			return *this;
+		}
+
+		AE_FORCEINLINE weak_atomic const &operator=(weak_atomic const &other) AE_NO_TSAN
+		{
+			value.store(other.value.load(std::memory_order_relaxed), std::memory_order_relaxed);
+			return *this;
+		}
+
+		AE_FORCEINLINE T load() const AE_NO_TSAN { return value.load(std::memory_order_relaxed); }
+
+		AE_FORCEINLINE T fetch_add_acquire(T increment) AE_NO_TSAN
+		{
+			return value.fetch_add(increment, std::memory_order_acquire);
+		}
+
+		AE_FORCEINLINE T fetch_add_release(T increment) AE_NO_TSAN
+		{
+			return value.fetch_add(increment, std::memory_order_release);
+		}
+#endif
+
+	private:
+#ifndef AE_USE_STD_ATOMIC_FOR_WEAK_ATOMIC
+		// No std::atomic support, but still need to circumvent compiler optimizations.
+		// `volatile` will make memory access slow, but is guaranteed to be reliable.
+		volatile T value;
+#else
+		std::atomic<T> value;
+#endif
+	};
+
+} // end namespace moodycamel
+
+// Portable single-producer, single-consumer semaphore below:
+
+#if defined(_WIN32)
+// Avoid including windows.h in a header; we only need a handful of
+// items, so we'll redeclare them here (this is relatively safe since
+// the API generally has to remain stable between Windows versions).
+// I know this is an ugly hack but it still beats polluting the global
+// namespace with thousands of generic names or adding a .cpp for nothing.
+extern "C" {
+struct _SECURITY_ATTRIBUTES;
+__declspec(dllimport) void *__stdcall CreateSemaphoreW(_SECURITY_ATTRIBUTES *lpSemaphoreAttributes, long lInitialCount, long lMaximumCount, const wchar_t *lpName);
+__declspec(dllimport) int __stdcall CloseHandle(void *hObject);
+__declspec(dllimport) unsigned long __stdcall WaitForSingleObject(void *hHandle, unsigned long dwMilliseconds);
+__declspec(dllimport) int __stdcall ReleaseSemaphore(void *hSemaphore, long lReleaseCount, long *lpPreviousCount);
+}
+#elif defined(__MACH__)
+#include <mach/mach.h>
+#elif defined(__unix__)
+#include <semaphore.h>
+#elif defined(FREERTOS)
+#include <FreeRTOS.h>
+#include <semphr.h>
+#include <task.h>
+#endif
+
+namespace moodycamel
+{
+	// Code in the spsc_sema namespace below is an adaptation of Jeff Preshing's
+	// portable + lightweight semaphore implementations, originally from
+	// https://github.com/preshing/cpp11-on-multicore/blob/master/common/sema.h
+	// LICENSE:
+	// Copyright (c) 2015 Jeff Preshing
+	//
+	// This software is provided 'as-is', without any express or implied
+	// warranty. In no event will the authors be held liable for any damages
+	// arising from the use of this software.
+	//
+	// Permission is granted to anyone to use this software for any purpose,
+	// including commercial applications, and to alter it and redistribute it
+	// freely, subject to the following restrictions:
+	//
+	// 1. The origin of this software must not be misrepresented; you must not
+	//    claim that you wrote the original software. If you use this software
+	//    in a product, an acknowledgement in the product documentation would be
+	//    appreciated but is not required.
+	// 2. Altered source versions must be plainly marked as such, and must not be
+	//    misrepresented as being the original software.
+	// 3. This notice may not be removed or altered from any source distribution.
+	namespace spsc_sema
+	{
+#if defined(_WIN32)
+		class Semaphore
+		{
+		private:
+			void *m_hSema;
+
+			Semaphore(const Semaphore &other);
+			Semaphore &operator=(const Semaphore &other);
+
+		public:
+			AE_NO_TSAN Semaphore(int initialCount = 0) :
+				m_hSema()
+			{
+				assert(initialCount >= 0);
+				const long maxLong = 0x7fffffff;
+				m_hSema = CreateSemaphoreW(nullptr, initialCount, maxLong, nullptr);
+				assert(m_hSema);
+			}
+
+			AE_NO_TSAN ~Semaphore()
+			{
+				CloseHandle(m_hSema);
+			}
+
+			bool wait() AE_NO_TSAN
+			{
+				const unsigned long infinite = 0xffffffff;
+				return WaitForSingleObject(m_hSema, infinite) == 0;
+			}
+
+			bool try_wait() AE_NO_TSAN
+			{
+				return WaitForSingleObject(m_hSema, 0) == 0;
+			}
+
+			bool timed_wait(std::uint64_t usecs) AE_NO_TSAN
+			{
+				return WaitForSingleObject(m_hSema, (unsigned long)(usecs / 1000)) == 0;
+			}
+
+			void signal(int count = 1) AE_NO_TSAN
+			{
+				while(!ReleaseSemaphore(m_hSema, count, nullptr))
+					;
+			}
+		};
+#elif defined(__MACH__)
+		//---------------------------------------------------------
+		// Semaphore (Apple iOS and OSX)
+		// Can't use POSIX semaphores due to http://lists.apple.com/archives/darwin-kernel/2009/Apr/msg00010.html
+		//---------------------------------------------------------
+		class Semaphore
+		{
+		private:
+			semaphore_t m_sema;
+
+			Semaphore(const Semaphore &other);
+			Semaphore &operator=(const Semaphore &other);
+
+		public:
+			AE_NO_TSAN Semaphore(int initialCount = 0) :
+				m_sema()
+			{
+				assert(initialCount >= 0);
+				kern_return_t rc = semaphore_create(mach_task_self(), &m_sema, SYNC_POLICY_FIFO, initialCount);
+				assert(rc == KERN_SUCCESS);
+				AE_UNUSED(rc);
+			}
+
+			AE_NO_TSAN ~Semaphore()
+			{
+				semaphore_destroy(mach_task_self(), m_sema);
+			}
+
+			bool wait() AE_NO_TSAN
+			{
+				return semaphore_wait(m_sema) == KERN_SUCCESS;
+			}
+
+			bool try_wait() AE_NO_TSAN
+			{
+				return timed_wait(0);
+			}
+
+			bool timed_wait(std::uint64_t timeout_usecs) AE_NO_TSAN
+			{
+				mach_timespec_t ts;
+				ts.tv_sec = static_cast<unsigned int>(timeout_usecs / 1000000);
+				ts.tv_nsec = static_cast<int>((timeout_usecs % 1000000) * 1000);
+
+				// added in OSX 10.10: https://developer.apple.com/library/prerelease/mac/documentation/General/Reference/APIDiffsMacOSX10_10SeedDiff/modules/Darwin.html
+				kern_return_t rc = semaphore_timedwait(m_sema, ts);
+				return rc == KERN_SUCCESS;
+			}
+
+			void signal() AE_NO_TSAN
+			{
+				while(semaphore_signal(m_sema) != KERN_SUCCESS)
+					;
+			}
+
+			void signal(int count) AE_NO_TSAN
+			{
+				while(count-- > 0)
+				{
+					while(semaphore_signal(m_sema) != KERN_SUCCESS)
+						;
+				}
+			}
+		};
+#elif defined(__unix__)
+		//---------------------------------------------------------
+		// Semaphore (POSIX, Linux)
+		//---------------------------------------------------------
+		class Semaphore
+		{
+		private:
+			sem_t m_sema;
+
+			Semaphore(const Semaphore &other);
+			Semaphore &operator=(const Semaphore &other);
+
+		public:
+			AE_NO_TSAN Semaphore(int initialCount = 0) :
+				m_sema()
+			{
+				assert(initialCount >= 0);
+				int rc = sem_init(&m_sema, 0, static_cast<unsigned int>(initialCount));
+				assert(rc == 0);
+				AE_UNUSED(rc);
+			}
+
+			AE_NO_TSAN ~Semaphore()
+			{
+				sem_destroy(&m_sema);
+			}
+
+			bool wait() AE_NO_TSAN
+			{
+				// http://stackoverflow.com/questions/2013181/gdb-causes-sem-wait-to-fail-with-eintr-error
+				int rc;
+				do
+				{
+					rc = sem_wait(&m_sema);
+				} while(rc == -1 && errno == EINTR);
+				return rc == 0;
+			}
+
+			bool try_wait() AE_NO_TSAN
+			{
+				int rc;
+				do
+				{
+					rc = sem_trywait(&m_sema);
+				} while(rc == -1 && errno == EINTR);
+				return rc == 0;
+			}
+
+			bool timed_wait(std::uint64_t usecs) AE_NO_TSAN
+			{
+				struct timespec ts;
+				const int usecs_in_1_sec = 1000000;
+				const int nsecs_in_1_sec = 1000000000;
+				clock_gettime(CLOCK_REALTIME, &ts);
+				ts.tv_sec += static_cast<time_t>(usecs / usecs_in_1_sec);
+				ts.tv_nsec += static_cast<long>(usecs % usecs_in_1_sec) * 1000;
+				// sem_timedwait bombs if you have more than 1e9 in tv_nsec
+				// so we have to clean things up before passing it in
+				if(ts.tv_nsec >= nsecs_in_1_sec)
+				{
+					ts.tv_nsec -= nsecs_in_1_sec;
+					++ts.tv_sec;
+				}
+
+				int rc;
+				do
+				{
+					rc = sem_timedwait(&m_sema, &ts);
+				} while(rc == -1 && errno == EINTR);
+				return rc == 0;
+			}
+
+			void signal() AE_NO_TSAN
+			{
+				while(sem_post(&m_sema) == -1)
+					;
+			}
+
+			void signal(int count) AE_NO_TSAN
+			{
+				while(count-- > 0)
+				{
+					while(sem_post(&m_sema) == -1)
+						;
+				}
+			}
+		};
+#elif defined(FREERTOS)
+		//---------------------------------------------------------
+		// Semaphore (FreeRTOS)
+		//---------------------------------------------------------
+		class Semaphore
+		{
+		private:
+			SemaphoreHandle_t m_sema;
+
+			Semaphore(const Semaphore &other);
+			Semaphore &operator=(const Semaphore &other);
+
+		public:
+			AE_NO_TSAN Semaphore(int initialCount = 0) :
+				m_sema()
+			{
+				assert(initialCount >= 0);
+				m_sema = xSemaphoreCreateCounting(static_cast<UBaseType_t>(~0ull), static_cast<UBaseType_t>(initialCount));
+				assert(m_sema);
+			}
+
+			AE_NO_TSAN ~Semaphore()
+			{
+				vSemaphoreDelete(m_sema);
+			}
+
+			bool wait() AE_NO_TSAN
+			{
+				return xSemaphoreTake(m_sema, portMAX_DELAY) == pdTRUE;
+			}
+
+			bool try_wait() AE_NO_TSAN
+			{
+				// Note: In an ISR context, if this causes a task to unblock,
+				// the caller won't know about it
+				if(xPortIsInsideInterrupt())
+					return xSemaphoreTakeFromISR(m_sema, NULL) == pdTRUE;
+				return xSemaphoreTake(m_sema, 0) == pdTRUE;
+			}
+
+			bool timed_wait(std::uint64_t usecs) AE_NO_TSAN
+			{
+				std::uint64_t msecs = usecs / 1000;
+				TickType_t ticks = static_cast<TickType_t>(msecs / portTICK_PERIOD_MS);
+				if(ticks == 0)
+					return try_wait();
+				return xSemaphoreTake(m_sema, ticks) == pdTRUE;
+			}
+
+			void signal() AE_NO_TSAN
+			{
+				// Note: In an ISR context, if this causes a task to unblock,
+				// the caller won't know about it
+				BaseType_t rc;
+				if(xPortIsInsideInterrupt())
+					rc = xSemaphoreGiveFromISR(m_sema, NULL);
+				else
+					rc = xSemaphoreGive(m_sema);
+				assert(rc == pdTRUE);
+				AE_UNUSED(rc);
+			}
+
+			void signal(int count) AE_NO_TSAN
+			{
+				while(count-- > 0)
+					signal();
+			}
+		};
+#else
+#error Unsupported platform! (No semaphore wrapper available)
+#endif
+
+		//---------------------------------------------------------
+		// LightweightSemaphore
+		//---------------------------------------------------------
+		class LightweightSemaphore
+		{
+		public:
+			typedef std::make_signed<std::size_t>::type ssize_t;
+
+		private:
+			weak_atomic<ssize_t> m_count;
+			Semaphore m_sema;
+
+			bool waitWithPartialSpinning(std::int64_t timeout_usecs = -1) AE_NO_TSAN
+			{
+				ssize_t oldCount;
+				// Is there a better way to set the initial spin count?
+				// If we lower it to 1000, testBenaphore becomes 15x slower on my Core i7-5930K Windows PC,
+				// as threads start hitting the kernel semaphore.
+				int spin = 1024;
+				while(--spin >= 0)
+				{
+					if(m_count.load() > 0)
+					{
+						m_count.fetch_add_acquire(-1);
+						return true;
+					}
+					compiler_fence(memory_order_acquire); // Prevent the compiler from collapsing the loop.
+				}
+				oldCount = m_count.fetch_add_acquire(-1);
+				if(oldCount > 0)
+					return true;
+				if(timeout_usecs < 0)
+				{
+					if(m_sema.wait())
+						return true;
+				}
+				if(timeout_usecs > 0 && m_sema.timed_wait(static_cast<uint64_t>(timeout_usecs)))
+					return true;
+				// At this point, we've timed out waiting for the semaphore, but the
+				// count is still decremented indicating we may still be waiting on
+				// it. So we have to re-adjust the count, but only if the semaphore
+				// wasn't signaled enough times for us too since then. If it was, we
+				// need to release the semaphore too.
+				while(true)
+				{
+					oldCount = m_count.fetch_add_release(1);
+					if(oldCount < 0)
+						return false; // successfully restored things to the way they were
+					// Oh, the producer thread just signaled the semaphore after all. Try again:
+					oldCount = m_count.fetch_add_acquire(-1);
+					if(oldCount > 0 && m_sema.try_wait())
+						return true;
+				}
+			}
+
+		public:
+			AE_NO_TSAN LightweightSemaphore(ssize_t initialCount = 0) :
+				m_count(initialCount), m_sema()
+			{
+				assert(initialCount >= 0);
+			}
+
+			bool tryWait() AE_NO_TSAN
+			{
+				if(m_count.load() > 0)
+				{
+					m_count.fetch_add_acquire(-1);
+					return true;
+				}
+				return false;
+			}
+
+			bool wait() AE_NO_TSAN
+			{
+				return tryWait() || waitWithPartialSpinning();
+			}
+
+			bool wait(std::int64_t timeout_usecs) AE_NO_TSAN
+			{
+				return tryWait() || waitWithPartialSpinning(timeout_usecs);
+			}
+
+			void signal(ssize_t count = 1) AE_NO_TSAN
+			{
+				assert(count >= 0);
+				ssize_t oldCount = m_count.fetch_add_release(count);
+				assert(oldCount >= -1);
+				if(oldCount < 0)
+				{
+					m_sema.signal(1);
+				}
+			}
+
+			std::size_t availableApprox() const AE_NO_TSAN
+			{
+				ssize_t count = m_count.load();
+				return count > 0 ? static_cast<std::size_t>(count) : 0;
+			}
+		};
+	} // end namespace spsc_sema
+} // end namespace moodycamel
+
+// NOLINTEND
+
+#if defined(AE_VCPP) && (_MSC_VER < 1700 || defined(__cplusplus_cli))
+#pragma warning(pop)
+#ifdef __cplusplus_cli
+#pragma managed(pop)
+#endif
+#endif
+
+#endif

--- a/src/engine/shared/ReaderWriterQueue.h
+++ b/src/engine/shared/ReaderWriterQueue.h
@@ -1,0 +1,1028 @@
+// ©2013-2020 Cameron Desrochers.
+// Distributed under the simplified BSD license (see the license file that
+// should have come with this header).
+
+// https://github.com/cameron314/readerwriterqueue/blob/master/readerwriterqueue.h
+
+#ifndef ENGINE_SHARED_READERWRITERQUEUE_H
+#define ENGINE_SHARED_READERWRITERQUEUE_H
+
+#include "AtomicOps.h"
+
+#include <cassert>
+#include <cstdint>
+#include <cstdlib> // For malloc/free/abort & size_t
+#include <memory>
+#include <new>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#if __cplusplus > 199711L || _MSC_VER >= 1700 // C++11 or VS2012
+#include <chrono>
+#endif
+
+// A lock-free queue for a single-consumer, single-producer architecture.
+// The queue is also wait-free in the common path (except if more memory
+// needs to be allocated, in which case malloc is called).
+// Allocates memory sparingly, and only once if the original maximum size
+// estimate is never exceeded.
+// Tested on x86/x64 processors, but semantics should be correct for all
+// architectures (given the right implementations in atomicops.h), provided
+// that aligned integer and pointer accesses are naturally atomic.
+// Note that there should only be one consumer thread and producer thread;
+// Switching roles of the threads, or using multiple consecutive threads for
+// one role, is not safe unless properly synchronized.
+// Using the queue exclusively from one thread is fine, though a bit silly.
+
+#ifndef MOODYCAMEL_CACHE_LINE_SIZE
+#define MOODYCAMEL_CACHE_LINE_SIZE 64
+#endif
+
+#ifndef MOODYCAMEL_EXCEPTIONS_ENABLED
+#if (defined(_MSC_VER) && defined(_CPPUNWIND)) || (defined(__GNUC__) && defined(__EXCEPTIONS)) || (!defined(_MSC_VER) && !defined(__GNUC__))
+#define MOODYCAMEL_EXCEPTIONS_ENABLED
+#endif
+#endif
+
+#ifndef MOODYCAMEL_HAS_EMPLACE
+#if !defined(_MSC_VER) || _MSC_VER >= 1800 // variadic templates: either a non-MS compiler or VS >= 2013
+#define MOODYCAMEL_HAS_EMPLACE 1
+#endif
+#endif
+
+#ifndef MOODYCAMEL_MAYBE_ALIGN_TO_CACHELINE
+#if defined(__APPLE__) && defined(__MACH__) && __cplusplus >= 201703L
+// This is required to find out what deployment target we are using
+#include <AvailabilityMacros.h>
+#if !defined(MAC_OS_X_VERSION_MIN_REQUIRED) || !defined(MAC_OS_X_VERSION_10_14) || MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_14
+// C++17 new(size_t, align_val_t) is not backwards-compatible with older versions of macOS, so we can't support over-alignment in this case
+#define MOODYCAMEL_MAYBE_ALIGN_TO_CACHELINE
+#endif
+#endif
+#endif
+
+#ifndef MOODYCAMEL_MAYBE_ALIGN_TO_CACHELINE
+#define MOODYCAMEL_MAYBE_ALIGN_TO_CACHELINE AE_ALIGN(MOODYCAMEL_CACHE_LINE_SIZE)
+#endif
+
+#ifdef AE_VCPP
+#pragma warning(push)
+#pragma warning(disable : 4324) // structure was padded due to __declspec(align())
+#pragma warning(disable : 4820) // padding was added
+#pragma warning(disable : 4127) // conditional expression is constant
+#endif
+
+// NOLINTBEGIN
+
+namespace moodycamel
+{
+
+	template<typename T, size_t MAX_BLOCK_SIZE = 512>
+	class MOODYCAMEL_MAYBE_ALIGN_TO_CACHELINE ReaderWriterQueue
+	{
+		// Design: Based on a queue-of-queues. The low-level queues are just
+		// circular buffers with front and tail indices indicating where the
+		// next element to dequeue is and where the next element can be enqueued,
+		// respectively. Each low-level queue is called a "block". Each block
+		// wastes exactly one element's worth of space to keep the design simple
+		// (if front == tail then the queue is empty, and can't be full).
+		// The high-level queue is a circular linked list of blocks; again there
+		// is a front and tail, but this time they are pointers to the blocks.
+		// The front block is where the next element to be dequeued is, provided
+		// the block is not empty. The back block is where elements are to be
+		// enqueued, provided the block is not full.
+		// The producer thread owns all the tail indices/pointers. The consumer
+		// thread owns all the front indices/pointers. Both threads read each
+		// other's variables, but only the owning thread updates them. E.g. After
+		// the consumer reads the producer's tail, the tail may change before the
+		// consumer is done dequeuing an object, but the consumer knows the tail
+		// will never go backwards, only forwards.
+		// If there is no room to enqueue an object, an additional block (of
+		// equal size to the last block) is added. Blocks are never removed.
+
+	public:
+		typedef T value_type;
+
+		// Constructs a queue that can hold at least `size` elements without further
+		// allocations. If more than MAX_BLOCK_SIZE elements are requested,
+		// then several blocks of MAX_BLOCK_SIZE each are reserved (including
+		// at least one extra buffer block).
+		AE_NO_TSAN explicit ReaderWriterQueue(size_t size = 15)
+#ifndef NDEBUG
+			:
+			enqueuing(false), dequeuing(false)
+#endif
+		{
+			assert(MAX_BLOCK_SIZE == ceilToPow2(MAX_BLOCK_SIZE) && "MAX_BLOCK_SIZE must be a power of 2");
+			assert(MAX_BLOCK_SIZE >= 2 && "MAX_BLOCK_SIZE must be at least 2");
+
+			Block *firstBlock = nullptr;
+
+			largestBlockSize = ceilToPow2(size + 1); // We need a spare slot to fit size elements in the block
+			if(largestBlockSize > MAX_BLOCK_SIZE * 2)
+			{
+				// We need a spare block in case the producer is writing to a different block the consumer is reading from, and
+				// wants to enqueue the maximum number of elements. We also need a spare element in each block to avoid the ambiguity
+				// between front == tail meaning "empty" and "full".
+				// So the effective number of slots that are guaranteed to be usable at any time is the block size - 1 times the
+				// number of blocks - 1. Solving for size and applying a ceiling to the division gives us (after simplifying):
+				size_t initialBlockCount = (size + MAX_BLOCK_SIZE * 2 - 3) / (MAX_BLOCK_SIZE - 1);
+				largestBlockSize = MAX_BLOCK_SIZE;
+				Block *lastBlock = nullptr;
+				for(size_t i = 0; i != initialBlockCount; ++i)
+				{
+					auto block = make_block(largestBlockSize);
+					if(block == nullptr)
+					{
+#ifdef MOODYCAMEL_EXCEPTIONS_ENABLED
+						throw std::bad_alloc();
+#else
+						abort();
+#endif
+					}
+					if(firstBlock == nullptr)
+					{
+						firstBlock = block;
+					}
+					else
+					{
+						lastBlock->next = block;
+					}
+					lastBlock = block;
+					block->next = firstBlock;
+				}
+			}
+			else
+			{
+				firstBlock = make_block(largestBlockSize);
+				if(firstBlock == nullptr)
+				{
+#ifdef MOODYCAMEL_EXCEPTIONS_ENABLED
+					throw std::bad_alloc();
+#else
+					abort();
+#endif
+				}
+				firstBlock->next = firstBlock;
+			}
+			frontBlock = firstBlock;
+			tailBlock = firstBlock;
+
+			// Make sure the reader/writer threads will have the initialized memory setup above:
+			fence(memory_order_sync);
+		}
+
+		// Note: The queue should not be accessed concurrently while it's
+		// being moved. It's up to the user to synchronize this.
+		AE_NO_TSAN ReaderWriterQueue(ReaderWriterQueue &&other) :
+			frontBlock(other.frontBlock.load()),
+			tailBlock(other.tailBlock.load()),
+			largestBlockSize(other.largestBlockSize)
+#ifndef NDEBUG
+			,
+			enqueuing(false),
+			dequeuing(false)
+#endif
+		{
+			other.largestBlockSize = 32;
+			Block *b = other.make_block(other.largestBlockSize);
+			if(b == nullptr)
+			{
+#ifdef MOODYCAMEL_EXCEPTIONS_ENABLED
+				throw std::bad_alloc();
+#else
+				abort();
+#endif
+			}
+			b->next = b;
+			other.frontBlock = b;
+			other.tailBlock = b;
+		}
+
+		// Note: The queue should not be accessed concurrently while it's
+		// being moved. It's up to the user to synchronize this.
+		ReaderWriterQueue &operator=(ReaderWriterQueue &&other) AE_NO_TSAN
+		{
+			Block *b = frontBlock.load();
+			frontBlock = other.frontBlock.load();
+			other.frontBlock = b;
+			b = tailBlock.load();
+			tailBlock = other.tailBlock.load();
+			other.tailBlock = b;
+			std::swap(largestBlockSize, other.largestBlockSize);
+			return *this;
+		}
+
+		// Note: The queue should not be accessed concurrently while it's
+		// being deleted. It's up to the user to synchronize this.
+		AE_NO_TSAN ~ReaderWriterQueue()
+		{
+			// Make sure we get the latest version of all variables from other CPUs:
+			fence(memory_order_sync);
+
+			// Destroy any remaining objects in queue and free memory
+			Block *frontBlock_ = frontBlock;
+			Block *block = frontBlock_;
+			do
+			{
+				Block *nextBlock = block->next;
+				size_t blockFront = block->front;
+				size_t blockTail = block->tail;
+
+				for(size_t i = blockFront; i != blockTail; i = (i + 1) & block->sizeMask)
+				{
+					auto element = reinterpret_cast<T *>(block->data + i * sizeof(T));
+					element->~T();
+					(void)element;
+				}
+
+				auto rawBlock = block->rawThis;
+				block->~Block();
+				std::free(rawBlock);
+				block = nextBlock;
+			} while(block != frontBlock_);
+		}
+
+		// Enqueues a copy of element if there is room in the queue.
+		// Returns true if the element was enqueued, false otherwise.
+		// Does not allocate memory.
+		AE_FORCEINLINE bool try_enqueue(T const &element) AE_NO_TSAN
+		{
+			return inner_enqueue<CannotAlloc>(element);
+		}
+
+		// Enqueues a moved copy of element if there is room in the queue.
+		// Returns true if the element was enqueued, false otherwise.
+		// Does not allocate memory.
+		AE_FORCEINLINE bool try_enqueue(T &&element) AE_NO_TSAN
+		{
+			return inner_enqueue<CannotAlloc>(std::forward<T>(element));
+		}
+
+#if MOODYCAMEL_HAS_EMPLACE
+		// Like try_enqueue() but with emplace semantics (i.e. construct-in-place).
+		template<typename... Args>
+		AE_FORCEINLINE bool try_emplace(Args &&...args) AE_NO_TSAN
+		{
+			return inner_enqueue<CannotAlloc>(std::forward<Args>(args)...);
+		}
+#endif
+
+		// Enqueues a copy of element on the queue.
+		// Allocates an additional block of memory if needed.
+		// Only fails (returns false) if memory allocation fails.
+		AE_FORCEINLINE bool enqueue(T const &element) AE_NO_TSAN
+		{
+			return inner_enqueue<CanAlloc>(element);
+		}
+
+		// Enqueues a moved copy of element on the queue.
+		// Allocates an additional block of memory if needed.
+		// Only fails (returns false) if memory allocation fails.
+		AE_FORCEINLINE bool enqueue(T &&element) AE_NO_TSAN
+		{
+			return inner_enqueue<CanAlloc>(std::forward<T>(element));
+		}
+
+#if MOODYCAMEL_HAS_EMPLACE
+		// Like enqueue() but with emplace semantics (i.e. construct-in-place).
+		template<typename... Args>
+		AE_FORCEINLINE bool emplace(Args &&...args) AE_NO_TSAN
+		{
+			return inner_enqueue<CanAlloc>(std::forward<Args>(args)...);
+		}
+#endif
+
+		// Attempts to dequeue an element; if the queue is empty,
+		// returns false instead. If the queue has at least one element,
+		// moves front to result using operator=, then returns true.
+		template<typename U>
+		bool try_dequeue(U &result) AE_NO_TSAN
+		{
+#ifndef NDEBUG
+			ReentrantGuard guard(this->dequeuing);
+#endif
+
+			// High-level pseudocode:
+			// Remember where the tail block is
+			// If the front block has an element in it, dequeue it
+			// Else
+			//     If front block was the tail block when we entered the function, return false
+			//     Else advance to next block and dequeue the item there
+
+			// Note that we have to use the value of the tail block from before we check if the front
+			// block is full or not, in case the front block is empty and then, before we check if the
+			// tail block is at the front block or not, the producer fills up the front block *and
+			// moves on*, which would make us skip a filled block. Seems unlikely, but was consistently
+			// reproducible in practice.
+			// In order to avoid overhead in the common case, though, we do a double-checked pattern
+			// where we have the fast path if the front block is not empty, then read the tail block,
+			// then re-read the front block and check if it's not empty again, then check if the tail
+			// block has advanced.
+
+			Block *frontBlock_ = frontBlock.load();
+			size_t blockTail = frontBlock_->localTail;
+			size_t blockFront = frontBlock_->front.load();
+
+			if(blockFront != blockTail || blockFront != (frontBlock_->localTail = frontBlock_->tail.load()))
+			{
+				fence(memory_order_acquire);
+
+			non_empty_front_block:
+				// Front block not empty, dequeue from here
+				auto element = reinterpret_cast<T *>(frontBlock_->data + blockFront * sizeof(T));
+				result = std::move(*element);
+				element->~T();
+
+				blockFront = (blockFront + 1) & frontBlock_->sizeMask;
+
+				fence(memory_order_release);
+				frontBlock_->front = blockFront;
+			}
+			else if(frontBlock_ != tailBlock.load())
+			{
+				fence(memory_order_acquire);
+
+				frontBlock_ = frontBlock.load();
+				blockTail = frontBlock_->localTail = frontBlock_->tail.load();
+				blockFront = frontBlock_->front.load();
+				fence(memory_order_acquire);
+
+				if(blockFront != blockTail)
+				{
+					// Oh look, the front block isn't empty after all
+					goto non_empty_front_block;
+				}
+
+				// Front block is empty but there's another block ahead, advance to it
+				Block *nextBlock = frontBlock_->next;
+				// Don't need an acquire fence here since next can only ever be set on the tailBlock,
+				// and we're not the tailBlock, and we did an acquire earlier after reading tailBlock which
+				// ensures next is up-to-date on this CPU in case we recently were at tailBlock.
+
+				size_t nextBlockFront = nextBlock->front.load();
+				size_t nextBlockTail = nextBlock->localTail = nextBlock->tail.load();
+				fence(memory_order_acquire);
+
+				// Since the tailBlock is only ever advanced after being written to,
+				// we know there's for sure an element to dequeue on it
+				assert(nextBlockFront != nextBlockTail);
+				AE_UNUSED(nextBlockTail);
+
+				// We're done with this block, let the producer use it if it needs
+				fence(memory_order_release); // Expose possibly pending changes to frontBlock->front from last dequeue
+				frontBlock = frontBlock_ = nextBlock;
+
+				compiler_fence(memory_order_release); // Not strictly needed
+
+				auto element = reinterpret_cast<T *>(frontBlock_->data + nextBlockFront * sizeof(T));
+
+				result = std::move(*element);
+				element->~T();
+
+				nextBlockFront = (nextBlockFront + 1) & frontBlock_->sizeMask;
+
+				fence(memory_order_release);
+				frontBlock_->front = nextBlockFront;
+			}
+			else
+			{
+				// No elements in current block and no other block to advance to
+				return false;
+			}
+
+			return true;
+		}
+
+		// Returns a pointer to the front element in the queue (the one that
+		// would be removed next by a call to `try_dequeue` or `pop`). If the
+		// queue appears empty at the time the method is called, nullptr is
+		// returned instead.
+		// Must be called only from the consumer thread.
+		T *peek() const AE_NO_TSAN
+		{
+#ifndef NDEBUG
+			ReentrantGuard guard(this->dequeuing);
+#endif
+			// See try_dequeue() for reasoning
+
+			Block *frontBlock_ = frontBlock.load();
+			size_t blockTail = frontBlock_->localTail;
+			size_t blockFront = frontBlock_->front.load();
+
+			if(blockFront != blockTail || blockFront != (frontBlock_->localTail = frontBlock_->tail.load()))
+			{
+				fence(memory_order_acquire);
+			non_empty_front_block:
+				return reinterpret_cast<T *>(frontBlock_->data + blockFront * sizeof(T));
+			}
+			else if(frontBlock_ != tailBlock.load())
+			{
+				fence(memory_order_acquire);
+				frontBlock_ = frontBlock.load();
+				blockTail = frontBlock_->localTail = frontBlock_->tail.load();
+				blockFront = frontBlock_->front.load();
+				fence(memory_order_acquire);
+
+				if(blockFront != blockTail)
+				{
+					goto non_empty_front_block;
+				}
+
+				Block *nextBlock = frontBlock_->next;
+
+				size_t nextBlockFront = nextBlock->front.load();
+				fence(memory_order_acquire);
+
+				assert(nextBlockFront != nextBlock->tail.load());
+				return reinterpret_cast<T *>(nextBlock->data + nextBlockFront * sizeof(T));
+			}
+
+			return nullptr;
+		}
+
+		// Removes the front element from the queue, if any, without returning it.
+		// Returns true on success, or false if the queue appeared empty at the time
+		// `pop` was called.
+		bool pop() AE_NO_TSAN
+		{
+#ifndef NDEBUG
+			ReentrantGuard guard(this->dequeuing);
+#endif
+			// See try_dequeue() for reasoning
+
+			Block *frontBlock_ = frontBlock.load();
+			size_t blockTail = frontBlock_->localTail;
+			size_t blockFront = frontBlock_->front.load();
+
+			if(blockFront != blockTail || blockFront != (frontBlock_->localTail = frontBlock_->tail.load()))
+			{
+				fence(memory_order_acquire);
+
+			non_empty_front_block:
+				auto element = reinterpret_cast<T *>(frontBlock_->data + blockFront * sizeof(T));
+				element->~T();
+
+				blockFront = (blockFront + 1) & frontBlock_->sizeMask;
+
+				fence(memory_order_release);
+				frontBlock_->front = blockFront;
+			}
+			else if(frontBlock_ != tailBlock.load())
+			{
+				fence(memory_order_acquire);
+				frontBlock_ = frontBlock.load();
+				blockTail = frontBlock_->localTail = frontBlock_->tail.load();
+				blockFront = frontBlock_->front.load();
+				fence(memory_order_acquire);
+
+				if(blockFront != blockTail)
+				{
+					goto non_empty_front_block;
+				}
+
+				// Front block is empty but there's another block ahead, advance to it
+				Block *nextBlock = frontBlock_->next;
+
+				size_t nextBlockFront = nextBlock->front.load();
+				size_t nextBlockTail = nextBlock->localTail = nextBlock->tail.load();
+				fence(memory_order_acquire);
+
+				assert(nextBlockFront != nextBlockTail);
+				AE_UNUSED(nextBlockTail);
+
+				fence(memory_order_release);
+				frontBlock = frontBlock_ = nextBlock;
+
+				compiler_fence(memory_order_release);
+
+				auto element = reinterpret_cast<T *>(frontBlock_->data + nextBlockFront * sizeof(T));
+				element->~T();
+
+				nextBlockFront = (nextBlockFront + 1) & frontBlock_->sizeMask;
+
+				fence(memory_order_release);
+				frontBlock_->front = nextBlockFront;
+			}
+			else
+			{
+				// No elements in current block and no other block to advance to
+				return false;
+			}
+
+			return true;
+		}
+
+		// Returns the approximate number of items currently in the queue.
+		// Safe to call from both the producer and consumer threads.
+		inline size_t size_approx() const AE_NO_TSAN
+		{
+			size_t result = 0;
+			Block *frontBlock_ = frontBlock.load();
+			Block *block = frontBlock_;
+			do
+			{
+				fence(memory_order_acquire);
+				size_t blockFront = block->front.load();
+				size_t blockTail = block->tail.load();
+				result += (blockTail - blockFront) & block->sizeMask;
+				block = block->next.load();
+			} while(block != frontBlock_);
+			return result;
+		}
+
+		// Returns the total number of items that could be enqueued without incurring
+		// an allocation when this queue is empty.
+		// Safe to call from both the producer and consumer threads.
+		//
+		// NOTE: The actual capacity during usage may be different depending on the consumer.
+		//       If the consumer is removing elements concurrently, the producer cannot add to
+		//       the block the consumer is removing from until it's completely empty, except in
+		//       the case where the producer was writing to the same block the consumer was
+		//       reading from the whole time.
+		inline size_t max_capacity() const
+		{
+			size_t result = 0;
+			Block *frontBlock_ = frontBlock.load();
+			Block *block = frontBlock_;
+			do
+			{
+				fence(memory_order_acquire);
+				result += block->sizeMask;
+				block = block->next.load();
+			} while(block != frontBlock_);
+			return result;
+		}
+
+	private:
+		enum AllocationMode
+		{
+			CanAlloc,
+			CannotAlloc
+		};
+
+#if MOODYCAMEL_HAS_EMPLACE
+		template<AllocationMode canAlloc, typename... Args>
+		bool inner_enqueue(Args &&...args) AE_NO_TSAN
+#else
+		template<AllocationMode canAlloc, typename U>
+		bool inner_enqueue(U &&element) AE_NO_TSAN
+#endif
+		{
+#ifndef NDEBUG
+			ReentrantGuard guard(this->enqueuing);
+#endif
+
+			// High-level pseudocode (assuming we're allowed to alloc a new block):
+			// If room in tail block, add to tail
+			// Else check next block
+			//     If next block is not the head block, enqueue on next block
+			//     Else create a new block and enqueue there
+			//     Advance tail to the block we just enqueued to
+
+			Block *tailBlock_ = tailBlock.load();
+			size_t blockFront = tailBlock_->localFront;
+			size_t blockTail = tailBlock_->tail.load();
+
+			size_t nextBlockTail = (blockTail + 1) & tailBlock_->sizeMask;
+			if(nextBlockTail != blockFront || nextBlockTail != (tailBlock_->localFront = tailBlock_->front.load()))
+			{
+				fence(memory_order_acquire);
+				// This block has room for at least one more element
+				char *location = tailBlock_->data + blockTail * sizeof(T);
+#if MOODYCAMEL_HAS_EMPLACE
+				new(location) T(std::forward<Args>(args)...);
+#else
+				new(location) T(std::forward<U>(element));
+#endif
+
+				fence(memory_order_release);
+				tailBlock_->tail = nextBlockTail;
+			}
+			else
+			{
+				fence(memory_order_acquire);
+				if(tailBlock_->next.load() != frontBlock)
+				{
+					// Note that the reason we can't advance to the frontBlock and start adding new entries there
+					// is because if we did, then dequeue would stay in that block, eventually reading the new values,
+					// instead of advancing to the next full block (whose values were enqueued first and so should be
+					// consumed first).
+
+					fence(memory_order_acquire); // Ensure we get latest writes if we got the latest frontBlock
+
+					// tailBlock is full, but there's a free block ahead, use it
+					Block *tailBlockNext = tailBlock_->next.load();
+					size_t nextBlockFront = tailBlockNext->localFront = tailBlockNext->front.load();
+					nextBlockTail = tailBlockNext->tail.load();
+					fence(memory_order_acquire);
+
+					// This block must be empty since it's not the head block and we
+					// go through the blocks in a circle
+					assert(nextBlockFront == nextBlockTail);
+					tailBlockNext->localFront = nextBlockFront;
+
+					char *location = tailBlockNext->data + nextBlockTail * sizeof(T);
+#if MOODYCAMEL_HAS_EMPLACE
+					new(location) T(std::forward<Args>(args)...);
+#else
+					new(location) T(std::forward<U>(element));
+#endif
+
+					tailBlockNext->tail = (nextBlockTail + 1) & tailBlockNext->sizeMask;
+
+					fence(memory_order_release);
+					tailBlock = tailBlockNext;
+				}
+				else if(canAlloc == CanAlloc)
+				{
+					// tailBlock is full and there's no free block ahead; create a new block
+					auto newBlockSize = largestBlockSize >= MAX_BLOCK_SIZE ? largestBlockSize : largestBlockSize * 2;
+					auto newBlock = make_block(newBlockSize);
+					if(newBlock == nullptr)
+					{
+						// Could not allocate a block!
+						return false;
+					}
+					largestBlockSize = newBlockSize;
+
+#if MOODYCAMEL_HAS_EMPLACE
+					new(newBlock->data) T(std::forward<Args>(args)...);
+#else
+					new(newBlock->data) T(std::forward<U>(element));
+#endif
+					assert(newBlock->front == 0);
+					newBlock->tail = newBlock->localTail = 1;
+
+					newBlock->next = tailBlock_->next.load();
+					tailBlock_->next = newBlock;
+
+					// Might be possible for the dequeue thread to see the new tailBlock->next
+					// *without* seeing the new tailBlock value, but this is OK since it can't
+					// advance to the next block until tailBlock is set anyway (because the only
+					// case where it could try to read the next is if it's already at the tailBlock,
+					// and it won't advance past tailBlock in any circumstance).
+
+					fence(memory_order_release);
+					tailBlock = newBlock;
+				}
+				else if(canAlloc == CannotAlloc)
+				{
+					// Would have had to allocate a new block to enqueue, but not allowed
+					return false;
+				}
+				else
+				{
+					assert(false && "Should be unreachable code");
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		// Disable copying
+		ReaderWriterQueue(ReaderWriterQueue const &) {}
+
+		// Disable assignment
+		ReaderWriterQueue &operator=(ReaderWriterQueue const &) {}
+
+		AE_FORCEINLINE static size_t ceilToPow2(size_t x)
+		{
+			// From http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+			--x;
+			x |= x >> 1;
+			x |= x >> 2;
+			x |= x >> 4;
+			for(size_t i = 1; i < sizeof(size_t); i <<= 1)
+			{
+				x |= x >> (i << 3);
+			}
+			++x;
+			return x;
+		}
+
+		template<typename U>
+		static AE_FORCEINLINE char *align_for(char *ptr) AE_NO_TSAN
+		{
+			const std::size_t alignment = std::alignment_of<U>::value;
+			return ptr + (alignment - (reinterpret_cast<std::uintptr_t>(ptr) % alignment)) % alignment;
+		}
+
+	private:
+#ifndef NDEBUG
+		struct ReentrantGuard
+		{
+			AE_NO_TSAN ReentrantGuard(weak_atomic<bool> &_inSection) :
+				inSection(_inSection)
+			{
+				assert(!inSection && "Concurrent (or re-entrant) enqueue or dequeue operation detected (only one thread at a time may hold the producer or consumer role)");
+				inSection = true;
+			}
+
+			AE_NO_TSAN ~ReentrantGuard() { inSection = false; }
+
+		private:
+			ReentrantGuard &operator=(ReentrantGuard const &);
+
+		private:
+			weak_atomic<bool> &inSection;
+		};
+#endif
+
+		struct Block
+		{
+			// Avoid false-sharing by putting highly contended variables on their own cache lines
+			weak_atomic<size_t> front; // (Atomic) Elements are read from here
+			size_t localTail; // An uncontended shadow copy of tail, owned by the consumer
+
+			char cachelineFiller0[MOODYCAMEL_CACHE_LINE_SIZE - sizeof(weak_atomic<size_t>) - sizeof(size_t)];
+			weak_atomic<size_t> tail; // (Atomic) Elements are enqueued here
+			size_t localFront;
+
+			char cachelineFiller1[MOODYCAMEL_CACHE_LINE_SIZE - sizeof(weak_atomic<size_t>) - sizeof(size_t)]; // next isn't very contended, but we don't want it on the same cache line as tail (which is)
+			weak_atomic<Block *> next; // (Atomic)
+
+			char *data; // Contents (on heap) are aligned to T's alignment
+
+			const size_t sizeMask;
+
+			// size must be a power of two (and greater than 0)
+			AE_NO_TSAN Block(size_t const &_size, char *_rawThis, char *_data) :
+				front(0UL), localTail(0), tail(0UL), localFront(0), next(nullptr), data(_data), sizeMask(_size - 1), rawThis(_rawThis)
+			{
+			}
+
+		private:
+			// C4512 - Assignment operator could not be generated
+			Block &operator=(Block const &);
+
+		public:
+			char *rawThis;
+		};
+
+		static Block *make_block(size_t capacity) AE_NO_TSAN
+		{
+			// Allocate enough memory for the block itself, as well as all the elements it will contain
+			auto size = sizeof(Block) + std::alignment_of<Block>::value - 1;
+			size += sizeof(T) * capacity + std::alignment_of<T>::value - 1;
+			auto newBlockRaw = static_cast<char *>(std::malloc(size));
+			if(newBlockRaw == nullptr)
+			{
+				return nullptr;
+			}
+
+			auto newBlockAligned = align_for<Block>(newBlockRaw);
+			auto newBlockData = align_for<T>(newBlockAligned + sizeof(Block));
+			return new(newBlockAligned) Block(capacity, newBlockRaw, newBlockData);
+		}
+
+	private:
+		weak_atomic<Block *> frontBlock; // (Atomic) Elements are dequeued from this block
+
+		char cachelineFiller[MOODYCAMEL_CACHE_LINE_SIZE - sizeof(weak_atomic<Block *>)];
+		weak_atomic<Block *> tailBlock; // (Atomic) Elements are enqueued to this block
+
+		size_t largestBlockSize;
+
+#ifndef NDEBUG
+		weak_atomic<bool> enqueuing;
+		mutable weak_atomic<bool> dequeuing;
+#endif
+	};
+
+	// Like ReaderWriterQueue, but also providees blocking operations
+	template<typename T, size_t MAX_BLOCK_SIZE = 512>
+	class BlockingReaderWriterQueue
+	{
+	private:
+		typedef ::moodycamel::ReaderWriterQueue<T, MAX_BLOCK_SIZE> ReaderWriterQueue;
+
+	public:
+		explicit BlockingReaderWriterQueue(size_t size = 15) AE_NO_TSAN
+			: inner(size),
+			  sema(new spsc_sema::LightweightSemaphore())
+		{
+		}
+
+		BlockingReaderWriterQueue(BlockingReaderWriterQueue &&other) AE_NO_TSAN
+			: inner(std::move(other.inner)),
+			  sema(std::move(other.sema))
+		{
+		}
+
+		BlockingReaderWriterQueue &operator=(BlockingReaderWriterQueue &&other) AE_NO_TSAN
+		{
+			std::swap(sema, other.sema);
+			std::swap(inner, other.inner);
+			return *this;
+		}
+
+		// Enqueues a copy of element if there is room in the queue.
+		// Returns true if the element was enqueued, false otherwise.
+		// Does not allocate memory.
+		AE_FORCEINLINE bool try_enqueue(T const &element) AE_NO_TSAN
+		{
+			if(inner.try_enqueue(element))
+			{
+				sema->signal();
+				return true;
+			}
+			return false;
+		}
+
+		// Enqueues a moved copy of element if there is room in the queue.
+		// Returns true if the element was enqueued, false otherwise.
+		// Does not allocate memory.
+		AE_FORCEINLINE bool try_enqueue(T &&element) AE_NO_TSAN
+		{
+			if(inner.try_enqueue(std::forward<T>(element)))
+			{
+				sema->signal();
+				return true;
+			}
+			return false;
+		}
+
+#if MOODYCAMEL_HAS_EMPLACE
+		// Like try_enqueue() but with emplace semantics (i.e. construct-in-place).
+		template<typename... Args>
+		AE_FORCEINLINE bool try_emplace(Args &&...args) AE_NO_TSAN
+		{
+			if(inner.try_emplace(std::forward<Args>(args)...))
+			{
+				sema->signal();
+				return true;
+			}
+			return false;
+		}
+#endif
+
+		// Enqueues a copy of element on the queue.
+		// Allocates an additional block of memory if needed.
+		// Only fails (returns false) if memory allocation fails.
+		AE_FORCEINLINE bool enqueue(T const &element) AE_NO_TSAN
+		{
+			if(inner.enqueue(element))
+			{
+				sema->signal();
+				return true;
+			}
+			return false;
+		}
+
+		// Enqueues a moved copy of element on the queue.
+		// Allocates an additional block of memory if needed.
+		// Only fails (returns false) if memory allocation fails.
+		AE_FORCEINLINE bool enqueue(T &&element) AE_NO_TSAN
+		{
+			if(inner.enqueue(std::forward<T>(element)))
+			{
+				sema->signal();
+				return true;
+			}
+			return false;
+		}
+
+#if MOODYCAMEL_HAS_EMPLACE
+		// Like enqueue() but with emplace semantics (i.e. construct-in-place).
+		template<typename... Args>
+		AE_FORCEINLINE bool emplace(Args &&...args) AE_NO_TSAN
+		{
+			if(inner.emplace(std::forward<Args>(args)...))
+			{
+				sema->signal();
+				return true;
+			}
+			return false;
+		}
+#endif
+
+		// Attempts to dequeue an element; if the queue is empty,
+		// returns false instead. If the queue has at least one element,
+		// moves front to result using operator=, then returns true.
+		template<typename U>
+		bool try_dequeue(U &result) AE_NO_TSAN
+		{
+			if(sema->tryWait())
+			{
+				bool success = inner.try_dequeue(result);
+				assert(success);
+				AE_UNUSED(success);
+				return true;
+			}
+			return false;
+		}
+
+		// Attempts to dequeue an element; if the queue is empty,
+		// waits until an element is available, then dequeues it.
+		template<typename U>
+		void wait_dequeue(U &result) AE_NO_TSAN
+		{
+			while(!sema->wait())
+				;
+			bool success = inner.try_dequeue(result);
+			AE_UNUSED(result);
+			assert(success);
+			AE_UNUSED(success);
+		}
+
+		// Attempts to dequeue an element; if the queue is empty,
+		// waits until an element is available up to the specified timeout,
+		// then dequeues it and returns true, or returns false if the timeout
+		// expires before an element can be dequeued.
+		// Using a negative timeout indicates an indefinite timeout,
+		// and is thus functionally equivalent to calling wait_dequeue.
+		template<typename U>
+		bool wait_dequeue_timed(U &result, std::int64_t timeout_usecs) AE_NO_TSAN
+		{
+			if(!sema->wait(timeout_usecs))
+			{
+				return false;
+			}
+			bool success = inner.try_dequeue(result);
+			AE_UNUSED(result);
+			assert(success);
+			AE_UNUSED(success);
+			return true;
+		}
+
+#if __cplusplus > 199711L || _MSC_VER >= 1700
+		// Attempts to dequeue an element; if the queue is empty,
+		// waits until an element is available up to the specified timeout,
+		// then dequeues it and returns true, or returns false if the timeout
+		// expires before an element can be dequeued.
+		// Using a negative timeout indicates an indefinite timeout,
+		// and is thus functionally equivalent to calling wait_dequeue.
+		template<typename U, typename Rep, typename Period>
+		inline bool wait_dequeue_timed(U &result, std::chrono::duration<Rep, Period> const &timeout) AE_NO_TSAN
+		{
+			return wait_dequeue_timed(result, std::chrono::duration_cast<std::chrono::microseconds>(timeout).count());
+		}
+#endif
+
+		// Returns a pointer to the front element in the queue (the one that
+		// would be removed next by a call to `try_dequeue` or `pop`). If the
+		// queue appears empty at the time the method is called, nullptr is
+		// returned instead.
+		// Must be called only from the consumer thread.
+		AE_FORCEINLINE T *peek() const AE_NO_TSAN
+		{
+			return inner.peek();
+		}
+
+		// Removes the front element from the queue, if any, without returning it.
+		// Returns true on success, or false if the queue appeared empty at the time
+		// `pop` was called.
+		AE_FORCEINLINE bool pop() AE_NO_TSAN
+		{
+			if(sema->tryWait())
+			{
+				bool result = inner.pop();
+				assert(result);
+				AE_UNUSED(result);
+				return true;
+			}
+			return false;
+		}
+
+		// Returns the approximate number of items currently in the queue.
+		// Safe to call from both the producer and consumer threads.
+		AE_FORCEINLINE size_t size_approx() const AE_NO_TSAN
+		{
+			return sema->availableApprox();
+		}
+
+		// Returns the total number of items that could be enqueued without incurring
+		// an allocation when this queue is empty.
+		// Safe to call from both the producer and consumer threads.
+		//
+		// NOTE: The actual capacity during usage may be different depending on the consumer.
+		//       If the consumer is removing elements concurrently, the producer cannot add to
+		//       the block the consumer is removing from until it's completely empty, except in
+		//       the case where the producer was writing to the same block the consumer was
+		//       reading from the whole time.
+		AE_FORCEINLINE size_t max_capacity() const
+		{
+			return inner.max_capacity();
+		}
+
+	private:
+		// Disable copying & assignment
+		BlockingReaderWriterQueue(BlockingReaderWriterQueue const &) {}
+		BlockingReaderWriterQueue &operator=(BlockingReaderWriterQueue const &) {}
+
+	private:
+		ReaderWriterQueue inner;
+		std::unique_ptr<spsc_sema::LightweightSemaphore> sema;
+	};
+
+} // end namespace moodycamel
+
+// NOLINTEND
+
+#ifdef AE_VCPP
+#pragma warning(pop)
+#endif
+
+#endif

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -705,6 +705,12 @@ MACRO_CONFIG_INT(SvConnlimitTime, sv_connlimit_time, 20, 0, 1000, CFGFLAG_SERVER
 MACRO_CONFIG_STR(SvConnLoggingServer, sv_conn_logging_server, 128, "", CFGFLAG_SERVER, "Unix socket server for IP address logging (Unix only)")
 #endif
 
+// Network
+MACRO_CONFIG_INT(SvNetThreaded, sv_net_threaded, 0, 0, 1, CFGFLAG_SERVER, "Run network I/O in dedicated thread")
+MACRO_CONFIG_INT(SvSnapThreaded, sv_snap_threaded, 1, 0, 1, CFGFLAG_SERVER, "Move part of snap handling to thread(required: sv_net_threaded)")
+MACRO_CONFIG_INT(SvNetWait, sv_net_wait, 1, 0, 1, CFGFLAG_SERVER, "Waiting for incoming network data")
+MACRO_CONFIG_INT(SvNetWaitMin, sv_net_wait_min, 500000, 0, 0x7FFFFFFF, CFGFLAG_SERVER, "Minimal waiting delay for incoming network data")
+
 MACRO_CONFIG_INT(ClUnpredictedShadow, cl_unpredicted_shadow, 0, -1, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show unpredicted shadow tee (0 = off, 1 = on, -1 = don't even show in debug mode)")
 MACRO_CONFIG_INT(ClPredictFreeze, cl_predict_freeze, 1, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Predict freeze tiles (0 = off, 1 = on, 2 = partial (allow a small amount of movement in freeze)")
 MACRO_CONFIG_INT(ClShowNinja, cl_show_ninja, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ninja skin")

--- a/src/engine/shared/net_io_thread.cpp
+++ b/src/engine/shared/net_io_thread.cpp
@@ -1,0 +1,852 @@
+#include "net_io_thread.h"
+
+#include <base/system.h>
+
+#include <engine/shared/config.h>
+
+int CNetIOThread::NewClientTrampoline(int ClientId, void *pUser, bool Sixup)
+{
+	auto *pSelf = static_cast<CNetIOThread *>(pUser);
+	if(!pSelf->m_pfnNewClient)
+		return 0;
+
+	if(!g_Config.m_SvNetThreaded)
+		return pSelf->m_pfnNewClient(ClientId, pSelf->m_pCallbackUser, Sixup);
+
+	auto pEvent = std::make_unique<CEventNewClient>();
+	pEvent->m_ClientId = ClientId;
+	pEvent->m_Sixup = Sixup;
+	const NETADDR *pAddr = pSelf->m_Server.ClientAddr(ClientId);
+	if(pAddr)
+		pEvent->m_Addr = *pAddr;
+	pEvent->m_aAddrStr = pSelf->m_Server.ClientAddrString(ClientId, true);
+	pEvent->m_aAddrStrNoPort = pSelf->m_Server.ClientAddrString(ClientId, false);
+	pSelf->EnqueueEvent(std::move(pEvent));
+	return 0;
+}
+
+int CNetIOThread::NewClientNoAuthTrampoline(int ClientId, void *pUser)
+{
+	auto *pSelf = static_cast<CNetIOThread *>(pUser);
+	if(!pSelf->m_pfnNewClientNoAuth)
+		return 0;
+
+	if(!g_Config.m_SvNetThreaded)
+		return pSelf->m_pfnNewClientNoAuth(ClientId, pSelf->m_pCallbackUser);
+
+	auto pEvent = std::make_unique<CEventNewClientNoAuth>();
+	pEvent->m_ClientId = ClientId;
+	const NETADDR *pAddr = pSelf->m_Server.ClientAddr(ClientId);
+	if(pAddr)
+		pEvent->m_Addr = *pAddr;
+	pEvent->m_aAddrStr = pSelf->m_Server.ClientAddrString(ClientId, true);
+	pEvent->m_aAddrStrNoPort = pSelf->m_Server.ClientAddrString(ClientId, false);
+	pSelf->EnqueueEvent(std::move(pEvent));
+	return 0;
+}
+
+int CNetIOThread::ClientRejoinTrampoline(int ClientId, void *pUser)
+{
+	auto *pSelf = static_cast<CNetIOThread *>(pUser);
+	if(!pSelf->m_pfnClientRejoin)
+		return 0;
+
+	if(!g_Config.m_SvNetThreaded)
+		return pSelf->m_pfnClientRejoin(ClientId, pSelf->m_pCallbackUser);
+
+	auto pEvent = std::make_unique<CEventClientRejoin>();
+	pEvent->m_ClientId = ClientId;
+	const NETADDR *pAddr = pSelf->m_Server.ClientAddr(ClientId);
+	if(pAddr)
+		pEvent->m_Addr = *pAddr;
+	pEvent->m_aAddrStr = pSelf->m_Server.ClientAddrString(ClientId, true);
+	pEvent->m_aAddrStrNoPort = pSelf->m_Server.ClientAddrString(ClientId, false);
+	pSelf->EnqueueEvent(std::move(pEvent));
+	return 0;
+}
+
+int CNetIOThread::DelClientTrampoline(int ClientId, const char *pReason, void *pUser)
+{
+	auto *pSelf = static_cast<CNetIOThread *>(pUser);
+	if(!pSelf->m_pfnDelClient)
+		return 0;
+
+	if(!g_Config.m_SvNetThreaded)
+		return pSelf->m_pfnDelClient(ClientId, pReason, pSelf->m_pCallbackUser);
+
+	auto pEvent = std::make_unique<CEventDelClient>();
+	pEvent->m_ClientId = ClientId;
+	const NETADDR *pAddr = pSelf->m_Server.ClientAddr(ClientId);
+	if(pAddr)
+		pEvent->m_Addr = *pAddr;
+	pEvent->m_aAddrStr = pSelf->m_Server.ClientAddrString(ClientId, true);
+	pEvent->m_aAddrStrNoPort = pSelf->m_Server.ClientAddrString(ClientId, false);
+	str_copy(pEvent->m_aReason, pReason ? pReason : "", sizeof(pEvent->m_aReason));
+	pSelf->EnqueueEvent(std::move(pEvent));
+	return 0;
+}
+
+void CNetIOThread::Run(void *pUser)
+{
+	CNetIOThread *pSelf = static_cast<CNetIOThread *>(pUser);
+
+	while(pSelf->m_Running.load(std::memory_order_acquire))
+	{
+		pSelf->ProcessCommands();
+		pSelf->ProcessSnap();
+		pSelf->PumpNetwork();
+		if(!pSelf->HasPendingCommands())
+		{
+			if(pSelf->m_Server.NumOnlineClients() > 0)
+				pSelf->m_Server.NetWaitActive();
+			else
+				pSelf->m_Server.NetWaitNonActive();
+		}
+	}
+}
+
+void CNetIOThread::StartWorker()
+{
+	if(m_Running.exchange(true))
+		return;
+
+	dbg_assert(m_WorkSemInitialized, "work semaphore not initialized");
+
+	m_Server.SetConnDirtyObserver(
+		[](int ClientId, const CNetConnection::CConnStateDelta &Delta, void *pUser) {
+			auto *pSelf = static_cast<CNetIOThread *>(pUser);
+			auto State = std::make_unique<CEventClientState>();
+			State->m_ClientId = ClientId;
+			CClientRuntimeState StateCached = pSelf->m_aClientRuntimeThreadCache[ClientId];
+			if(Delta.m_StateChanged)
+				StateCached.m_State = Delta.m_State;
+			if(Delta.m_SecurityTokenChanged)
+				StateCached.m_SecurityToken = Delta.m_SecurityToken;
+			if(Delta.m_ErrorChanged)
+				str_copy(StateCached.m_aErrorString, Delta.m_aErrorString);
+			if(Delta.m_TimeoutProtectedChanged)
+				StateCached.m_TimeoutProtected = Delta.m_TimeoutProtected;
+			if(Delta.m_TimeoutSituationChanged)
+				StateCached.m_TimeoutSituation = Delta.m_TimeoutSituation;
+
+			pSelf->m_aClientRuntimeThreadCache[ClientId] = StateCached;
+			State->m_State = StateCached;
+			pSelf->EnqueueEvent(std::move(State));
+		},
+		this);
+
+	m_pThread = thread_init(Run, this, "net io thread");
+}
+
+void CNetIOThread::StopWorker()
+{
+	if(!m_Running.exchange(false))
+		return;
+	if(m_pThread)
+		thread_wait(m_pThread);
+	m_pThread = nullptr;
+}
+
+void CNetIOThread::ProcessCommands()
+{
+	std::unique_ptr<CCommand> pCmd;
+	while(m_CommandQueue.try_dequeue(pCmd))
+	{
+		switch(pCmd->m_Type)
+		{
+		case CCommand::CMD_CLOSE:
+			m_Server.Close();
+			break;
+		case CCommand::CMD_DROP:
+		{
+			auto *p = static_cast<CCmdDrop *>(pCmd.get());
+			m_Server.Drop(p->m_ClientId, p->m_aReason);
+			break;
+		}
+		case CCommand::CMD_SEND_PACKET_CONNLESS_WITH_TOKEN7:
+		{
+			auto *p = static_cast<CCmdSendPacketConnlessWithToken7 *>(pCmd.get());
+			NETADDR Addr = p->m_Addr;
+			const void *pData = p->m_DataSize > 0 ? static_cast<const void *>(p->m_aData) : nullptr;
+			m_Server.SendPacketConnlessWithToken7(&Addr, pData, p->m_DataSize, p->m_Token, p->m_ResponseToken);
+			break;
+		}
+		case CCommand::CMD_SEND_TOKEN_SIXUP:
+		{
+			auto *p = static_cast<CCmdSendTokenSixup *>(pCmd.get());
+			m_Server.SendTokenSixup(p->m_Addr, p->m_Token);
+			break;
+		}
+		case CCommand::CMD_SET_MAX_CLIENTS_PER_IP:
+		{
+			auto *p = static_cast<CCmdSetMaxClientsPerIp *>(pCmd.get());
+			m_Server.SetMaxClientsPerIp(p->m_Max);
+			break;
+		}
+		case CCommand::CMD_SET_TIMEOUT_PROTECTED:
+		{
+			auto *p = static_cast<CCmdSetTimeoutProtected *>(pCmd.get());
+			m_Server.ResumeOldConnectionProtected(p->m_ClientId);
+			break;
+		}
+		case CCommand::CMD_IGNORE_TIMEOUTS:
+		{
+			auto *p = static_cast<CCmdIgnoreTimeouts *>(pCmd.get());
+			m_Server.IgnoreTimeouts(p->m_ClientId);
+			break;
+		}
+		case CCommand::CMD_SET_ACCEPTING_NEW_CONNECTIONS:
+		{
+			auto *p = static_cast<CCmdSetAcceptingNewConnections *>(pCmd.get());
+			m_Server.SetAcceptingNewConnections(p->m_Value);
+			break;
+		}
+		case CCommand::CMD_RESET_ERROR_STRING:
+		{
+			auto *p = static_cast<CCmdResetErrorString *>(pCmd.get());
+			m_Server.ResetErrorString(p->m_ClientId);
+			break;
+		}
+		case CCommand::CMD_SET_TIMED_OUT:
+		{
+			auto *p = static_cast<CCmdSetTimedOut *>(pCmd.get());
+			m_Server.ResumeOldConnection(p->m_ClientId, p->m_OrigId);
+			break;
+		}
+		case CCommand::CMD_GET_GLOBAL_TOKEN:
+		{
+			auto *p = static_cast<CCmdGetGlobalToken *>(pCmd.get());
+			p->m_Promise.set_value(m_Server.GetGlobalToken());
+			break;
+		}
+		case CCommand::CMD_GET_TOKEN:
+		{
+			auto *p = static_cast<CCmdGetToken *>(pCmd.get());
+			p->m_Promise.set_value(m_Server.GetToken(p->m_Addr));
+			break;
+		}
+		case CCommand::CMD_GET_VANILLA_TOKEN:
+		{
+			auto *p = static_cast<CCmdGetVanillaToken *>(pCmd.get());
+			p->m_Promise.set_value(m_Server.GetVanillaToken(p->m_Addr));
+			break;
+		}
+		case CCommand::CMD_SEND:
+		{
+			auto *p = static_cast<CCmdSend *>(pCmd.get());
+			(void)m_Server.Send(&p->m_Chunk);
+			break;
+		}
+		case CCommand::CMD_BAN_ADDRESS:
+		{
+			auto *p = static_cast<CCmdBanAddress *>(pCmd.get());
+			m_Server.BanAddr(&p->m_Addr, p->m_Seconds, p->m_aReason, p->m_VerbatimReason);
+			break;
+		}
+		case CCommand::CMD_BAN_RANGE:
+		{
+			auto *p = static_cast<CCmdBanRange *>(pCmd.get());
+			m_Server.BanRange(&p->m_Range, p->m_Seconds, p->m_aReason);
+			break;
+		}
+		default: break;
+		}
+	}
+}
+
+void CNetIOThread::PumpNetwork()
+{
+	m_Server.Update();
+
+	SECURITY_TOKEN Token = NET_SECURITY_TOKEN_UNKNOWN;
+
+	for(;;)
+	{
+		CEventRecv Ev;
+		if(!m_Server.Recv(&Ev.m_Chunk, &Token))
+			break;
+
+		if(Ev.m_Chunk.m_DataSize > NET_MAX_PACKETSIZE)
+			Ev.m_Chunk.m_DataSize = NET_MAX_PACKETSIZE;
+
+		if(Ev.m_Chunk.m_DataSize > 0 && Ev.m_Chunk.m_pData)
+		{
+			mem_copy(Ev.m_aData, Ev.m_Chunk.m_pData, Ev.m_Chunk.m_DataSize);
+			Ev.m_Chunk.m_pData = Ev.m_aData;
+		}
+		else
+		{
+			Ev.m_Chunk.m_pData = nullptr;
+		}
+
+		Ev.m_Token = Token;
+		Token = NET_SECURITY_TOKEN_UNKNOWN;
+
+		m_RecvQueue.enqueue(std::make_unique<CEventRecv>(Ev));
+		NotifyWorkAvailable();
+	}
+}
+
+void CNetIOThread::ProcessPendingEvents()
+{
+	if(!m_EventQueue.peek())
+		return;
+	std::unique_ptr<CEvent> pEvBase;
+	while(m_EventQueue.try_dequeue(pEvBase))
+	{
+		switch(pEvBase->m_Type)
+		{
+		case CEvent::EV_NEWCLIENT:
+		{
+			auto *pEvent = static_cast<CEventNewClient *>(pEvBase.get());
+			UpdateClientPublicState(pEvent->m_ClientId, pEvent->m_Addr, pEvent->m_aAddrStr, pEvent->m_aAddrStrNoPort);
+			if(m_pfnNewClient)
+				m_pfnNewClient(pEvent->m_ClientId, m_pCallbackUser, pEvent->m_Sixup);
+			break;
+		}
+		case CEvent::EV_NEWCLIENT_NOAUTH:
+		{
+			auto *pEvent = static_cast<CEventNewClientNoAuth *>(pEvBase.get());
+			UpdateClientPublicState(pEvent->m_ClientId, pEvent->m_Addr, pEvent->m_aAddrStr, pEvent->m_aAddrStrNoPort);
+			if(m_pfnNewClientNoAuth)
+				m_pfnNewClientNoAuth(pEvent->m_ClientId, m_pCallbackUser);
+			break;
+		}
+		case CEvent::EV_CLIENTREJOIN:
+		{
+			auto *pEvent = static_cast<CEventClientRejoin *>(pEvBase.get());
+			UpdateClientPublicState(pEvent->m_ClientId, pEvent->m_Addr, pEvent->m_aAddrStr, pEvent->m_aAddrStrNoPort);
+			if(m_pfnClientRejoin)
+				m_pfnClientRejoin(pEvent->m_ClientId, m_pCallbackUser);
+			break;
+		}
+		case CEvent::EV_DELCLIENT:
+		{
+			auto *pEvent = static_cast<CEventDelClient *>(pEvBase.get());
+			UpdateClientPublicState(pEvent->m_ClientId, pEvent->m_Addr, pEvent->m_aAddrStr, pEvent->m_aAddrStrNoPort);
+			if(m_pfnDelClient)
+				m_pfnDelClient(pEvent->m_ClientId, pEvent->m_aReason, m_pCallbackUser);
+			break;
+		}
+		case CEvent::EV_CLIENT_STATE:
+		{
+			auto *pEvent = static_cast<CEventClientState *>(pEvBase.get());
+			if(pEvent->m_ClientId >= 0 && pEvent->m_ClientId < (int)m_aClientRuntimeState.size())
+				m_aClientRuntimeState[pEvent->m_ClientId] = pEvent->m_State;
+			break;
+		}
+		default: break;
+		}
+	}
+}
+
+void CNetIOThread::UpdateClientPublicState(int ClientId, const NETADDR &Addr, const std::array<char, NETADDR_MAXSTRSIZE> &AddrStrWithPort, const std::array<char, NETADDR_MAXSTRSIZE> &AddrStrWithoutPort)
+{
+	m_aClientPublicState[ClientId].m_Addr = Addr;
+	m_aClientPublicState[ClientId].m_aAddrStr = AddrStrWithPort;
+	m_aClientPublicState[ClientId].m_aAddrStrNoPort = AddrStrWithoutPort;
+}
+
+bool CNetIOThread::HasPendingEvents() const
+{
+	const auto *pEvent = m_RecvQueue.peek();
+	if(pEvent && pEvent->get())
+		return true;
+
+	const auto *pRecv = m_EventQueue.peek();
+	return pRecv && pRecv->get();
+}
+
+bool CNetIOThread::HasPendingCommands() const
+{
+	const auto *pCmd = m_CommandQueue.peek();
+	return pCmd && pCmd->get();
+}
+
+void CNetIOThread::NotifyWorkAvailable()
+{
+	m_WorkGen.fetch_add(1, std::memory_order_release);
+	if(m_WorkSemInitialized)
+		sphore_signal(&m_WorkSem);
+}
+
+void CNetIOThread::EnqueueEvent(std::unique_ptr<CEvent> pEvent)
+{
+	if(!pEvent)
+		return;
+
+	m_EventQueue.enqueue(std::move(pEvent));
+	NotifyWorkAvailable();
+}
+
+void CNetIOThread::EnqueueCommand(std::unique_ptr<CCommand> pCmd)
+{
+	if(!pCmd)
+		return;
+
+	m_CommandQueue.enqueue(std::move(pCmd));
+}
+
+int CNetIOThread::SetCallbacks(NETFUNC_NEWCLIENT pfnNewClient,
+	NETFUNC_NEWCLIENT_NOAUTH pfnNewClientNoAuth,
+	NETFUNC_CLIENTREJOIN pfnClientRejoin,
+	NETFUNC_DELCLIENT pfnDelClient,
+	void *pUser)
+{
+	m_pfnNewClient = pfnNewClient;
+	m_pfnNewClientNoAuth = pfnNewClientNoAuth;
+	m_pfnClientRejoin = pfnClientRejoin;
+	m_pfnDelClient = pfnDelClient;
+	m_pCallbackUser = pUser;
+
+	int Result = m_Server.SetCallbacks(NewClientTrampoline, NewClientNoAuthTrampoline, ClientRejoinTrampoline, DelClientTrampoline, this);
+
+	if(g_Config.m_SvNetThreaded)
+		StartWorker();
+
+	return Result;
+}
+
+bool CNetIOThread::Open(NETADDR BindAddr, CNetBan *pNetBan, int MaxClients, int MaxClientsPerIp, CSnapThreaded *pSnapThreaded)
+{
+	if(g_Config.m_SvNetThreaded && !m_WorkSemInitialized)
+	{
+		sphore_init(&m_WorkSem);
+		m_WorkSemInitialized = true;
+	}
+
+	bool Ok = m_Server.Open(BindAddr, pNetBan, MaxClients, MaxClientsPerIp, pSnapThreaded);
+	if(Ok)
+	{
+		m_AddressCache = m_Server.Address();
+		m_NetTypeCache.store(m_Server.NetType(), std::memory_order_relaxed);
+		m_MaxClientsCache.store(m_Server.MaxClients(), std::memory_order_relaxed);
+	}
+	else
+	{
+		m_AddressCache = NETADDR{};
+		m_NetTypeCache.store(NETTYPE_INVALID, std::memory_order_relaxed);
+		m_MaxClientsCache.store(0, std::memory_order_relaxed);
+		if(m_WorkSemInitialized)
+		{
+			sphore_destroy(&m_WorkSem);
+			m_WorkSemInitialized = false;
+		}
+	}
+	return Ok;
+}
+
+void CNetIOThread::Close()
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		m_Server.Close();
+		return;
+	}
+
+	if(m_Running.load(std::memory_order_acquire))
+	{
+		EnqueueCommand(std::make_unique<CCmdClose>());
+		StopWorker();
+	}
+	else
+	{
+		m_Server.Close();
+	}
+
+	m_AddressCache = NETADDR{};
+	m_NetTypeCache.store(NETTYPE_INVALID, std::memory_order_relaxed);
+	m_MaxClientsCache.store(0, std::memory_order_relaxed);
+
+	if(m_WorkSemInitialized)
+	{
+		sphore_destroy(&m_WorkSem);
+		m_WorkSemInitialized = false;
+	}
+}
+
+int CNetIOThread::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken)
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		return m_Server.Recv(pChunk, pResponseToken);
+	}
+
+	ProcessPendingEvents();
+
+	std::unique_ptr<CEventRecv> pEv;
+	if(!m_RecvQueue.try_dequeue(pEv))
+		return 0;
+
+	*pChunk = pEv->m_Chunk;
+	if(pEv->m_Chunk.m_DataSize > 0)
+	{
+		mem_copy(m_aRecvStorage, pEv->m_aData, pEv->m_Chunk.m_DataSize);
+		pChunk->m_pData = m_aRecvStorage;
+	}
+	else
+	{
+		pChunk->m_pData = nullptr;
+	}
+	if(pResponseToken)
+		*pResponseToken = pEv->m_Token;
+
+	return 1;
+}
+
+int CNetIOThread::Send(CNetChunk *pChunk)
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		return m_Server.Send(pChunk);
+	}
+
+	auto Cmd = std::make_unique<CCmdSend>();
+	Cmd->m_Chunk = *pChunk;
+
+	if(Cmd->m_Chunk.m_DataSize > NET_MAX_PACKETSIZE)
+		Cmd->m_Chunk.m_DataSize = NET_MAX_PACKETSIZE;
+
+	if(Cmd->m_Chunk.m_DataSize > 0 && Cmd->m_Chunk.m_pData)
+	{
+		mem_copy(Cmd->m_aData, Cmd->m_Chunk.m_pData, Cmd->m_Chunk.m_DataSize);
+		Cmd->m_Chunk.m_pData = Cmd->m_aData;
+	}
+	else
+	{
+		Cmd->m_Chunk.m_pData = nullptr;
+	}
+
+	EnqueueCommand(std::move(Cmd));
+	return 0;
+}
+
+void CNetIOThread::Update()
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		m_Server.Update();
+		return;
+	}
+
+	ProcessPendingEvents();
+}
+
+void CNetIOThread::Drop(int ClientId, const char *pReason)
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		m_Server.Drop(ClientId, pReason);
+		return;
+	}
+
+	auto Cmd = std::make_unique<CCmdDrop>();
+	Cmd->m_ClientId = ClientId;
+	str_copy(Cmd->m_aReason, pReason ? pReason : "", sizeof(Cmd->m_aReason));
+	EnqueueCommand(std::move(Cmd));
+}
+
+const NETADDR *CNetIOThread::ClientAddr(int ClientId) const
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		return m_Server.ClientAddr(ClientId);
+	}
+	return &m_aClientPublicState[ClientId].m_Addr;
+}
+
+const std::array<char, NETADDR_MAXSTRSIZE> &CNetIOThread::ClientAddrString(int ClientId, bool IncludePort) const
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		return m_Server.ClientAddrString(ClientId, IncludePort);
+	}
+	return IncludePort ? m_aClientPublicState[ClientId].m_aAddrStr : m_aClientPublicState[ClientId].m_aAddrStrNoPort;
+}
+
+bool CNetIOThread::HasSecurityToken(int ClientId) const
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		return m_Server.HasSecurityToken(ClientId);
+	}
+	int SecurityToken = m_aClientRuntimeState[ClientId].m_SecurityToken;
+	return SecurityToken != NET_SECURITY_TOKEN_UNKNOWN && SecurityToken != NET_SECURITY_TOKEN_UNSUPPORTED;
+}
+
+int CNetIOThread::NumOnlineClients()
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		return m_Server.NumOnlineClients();
+	}
+
+	int Found = 0;
+	for(int i = 0; i < MaxClients(); ++i)
+	{
+		if(m_aClientRuntimeState[i].m_State != CNetConnection::EState::ONLINE)
+			continue;
+		Found++;
+	}
+	return Found;
+}
+
+void CNetIOThread::SendTokenSixup(NETADDR &Addr, SECURITY_TOKEN Token)
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		m_Server.SendTokenSixup(Addr, Token);
+		return;
+	}
+
+	auto Cmd = std::make_unique<CCmdSendTokenSixup>();
+	Cmd->m_Addr = Addr;
+	Cmd->m_Token = Token;
+	EnqueueCommand(std::move(Cmd));
+}
+
+void CNetIOThread::SetMaxClientsPerIp(int Max)
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		m_Server.SetMaxClientsPerIp(Max);
+		return;
+	}
+
+	auto Cmd = std::make_unique<CCmdSetMaxClientsPerIp>();
+	Cmd->m_Max = Max;
+	m_CommandQueue.enqueue(std::move(Cmd)); // without EnqueueCommand wrapper as executed before open
+}
+
+bool CNetIOThread::HasErrored(int ClientId)
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		return m_Server.HasErrored(ClientId);
+	}
+
+	return m_aClientRuntimeState[ClientId].m_State == CNetConnection::EState::ERROR;
+}
+
+void CNetIOThread::ResumeOldConnectionProtected(int ClientId)
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		m_Server.ResumeOldConnectionProtected(ClientId);
+		return;
+	}
+
+	auto Cmd = std::make_unique<CCmdSetTimeoutProtected>();
+	Cmd->m_ClientId = ClientId;
+	EnqueueCommand(std::move(Cmd));
+}
+
+void CNetIOThread::IgnoreTimeouts(int ClientId)
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		m_Server.IgnoreTimeouts(ClientId);
+		return;
+	}
+
+	auto Cmd = std::make_unique<CCmdIgnoreTimeouts>();
+	Cmd->m_ClientId = ClientId;
+	EnqueueCommand(std::move(Cmd));
+}
+
+void CNetIOThread::SetAcceptingNewConnections(bool Value)
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		m_Server.SetAcceptingNewConnections(Value);
+		return;
+	}
+
+	auto Cmd = std::make_unique<CCmdSetAcceptingNewConnections>();
+	Cmd->m_Value = Value;
+	EnqueueCommand(std::move(Cmd));
+}
+
+void CNetIOThread::ResetErrorString(int ClientId)
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		m_Server.ResetErrorString(ClientId);
+		return;
+	}
+
+	auto Cmd = std::make_unique<CCmdResetErrorString>();
+	Cmd->m_ClientId = ClientId;
+	EnqueueCommand(std::move(Cmd));
+}
+
+const char *CNetIOThread::ErrorString(int ClientId)
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		return m_Server.ErrorString(ClientId);
+	}
+	return m_aClientRuntimeState[ClientId].m_aErrorString;
+}
+
+void CNetIOThread::ResumeOldConnection(int ClientId, int OrigId)
+{
+	if(!g_Config.m_SvNetThreaded || !m_Running.load(std::memory_order_acquire))
+	{
+		m_Server.ResumeOldConnection(ClientId, OrigId);
+		return;
+	}
+
+	auto Cmd = std::make_unique<CCmdSetTimedOut>();
+	Cmd->m_ClientId = ClientId;
+	Cmd->m_OrigId = OrigId;
+	EnqueueCommand(std::move(Cmd));
+}
+
+SECURITY_TOKEN CNetIOThread::GetGlobalToken()
+{
+	if(!g_Config.m_SvNetThreaded || !m_Running.load(std::memory_order_acquire))
+	{
+		return m_Server.GetGlobalToken();
+	}
+
+	auto Cmd = std::make_unique<CCmdGetGlobalToken>();
+	auto Future = Cmd->m_Promise.get_future();
+	EnqueueCommand(std::move(Cmd));
+	return Future.get();
+}
+
+SECURITY_TOKEN CNetIOThread::GetToken(const NETADDR &Addr)
+{
+	if(!g_Config.m_SvNetThreaded || !m_Running.load(std::memory_order_acquire))
+	{
+		return m_Server.GetToken(Addr);
+	}
+
+	auto Cmd = std::make_unique<CCmdGetToken>();
+	Cmd->m_Addr = Addr;
+	auto Future = Cmd->m_Promise.get_future();
+	EnqueueCommand(std::move(Cmd));
+	return Future.get();
+}
+
+SECURITY_TOKEN CNetIOThread::GetVanillaToken(const NETADDR &Addr)
+{
+	if(!g_Config.m_SvNetThreaded || !m_Running.load(std::memory_order_acquire))
+	{
+		return m_Server.GetVanillaToken(Addr);
+	}
+
+	auto Cmd = std::make_unique<CCmdGetVanillaToken>();
+	Cmd->m_Addr = Addr;
+	auto Future = Cmd->m_Promise.get_future();
+	EnqueueCommand(std::move(Cmd));
+	return Future.get();
+}
+
+CNetConnection::EState CNetIOThread::State(int ClientId)
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		return m_Server.State(ClientId);
+	}
+	return m_aClientRuntimeState[ClientId].m_State;
+}
+
+void CNetIOThread::BanAddr(const NETADDR *pAddr, int Seconds, const char *pReason, bool VerbatimReason)
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		m_Server.BanAddr(pAddr, Seconds, pReason, VerbatimReason);
+		return;
+	}
+
+	auto Cmd = std::make_unique<CCmdBanAddress>();
+	if(pAddr)
+		Cmd->m_Addr = *pAddr;
+	Cmd->m_Seconds = Seconds;
+	str_copy(Cmd->m_aReason, pReason ? pReason : "", sizeof(Cmd->m_aReason));
+	Cmd->m_VerbatimReason = VerbatimReason;
+	EnqueueCommand(std::move(Cmd));
+}
+
+void CNetIOThread::BanRange(const CNetRange *pRange, int Seconds, const char *pReason)
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		m_Server.BanRange(pRange, Seconds, pReason);
+		return;
+	}
+
+	auto Cmd = std::make_unique<CCmdBanRange>();
+	if(pRange)
+		Cmd->m_Range = *pRange;
+	Cmd->m_Seconds = Seconds;
+	str_copy(Cmd->m_aReason, pReason ? pReason : "", sizeof(Cmd->m_aReason));
+	EnqueueCommand(std::move(Cmd));
+}
+
+bool CNetIOThread::NetWait(int64_t TimeToTick)
+{
+	if(!g_Config.m_SvNetThreaded)
+		return m_Server.NetWait(TimeToTick);
+
+	if(HasPendingEvents())
+		return true;
+
+	if(!m_WorkSemInitialized)
+		return HasPendingEvents();
+
+	if(TimeToTick > 0)
+	{
+		const uint64_t GenBefore = m_WorkGen.load(std::memory_order_acquire);
+		sphore_wait_deadline_ns(&m_WorkSem, TimeToTick);
+		if(m_WorkGen.load(std::memory_order_acquire) != GenBefore)
+			return true;
+		return HasPendingEvents();
+	}
+
+	return false;
+}
+
+bool CNetIOThread::NetWaitActive()
+{
+	if(!g_Config.m_SvNetThreaded)
+		return m_Server.NetWaitActive();
+	return NetWait(500000);
+}
+
+bool CNetIOThread::NetWaitNonActive()
+{
+	if(!g_Config.m_SvNetThreaded)
+		return m_Server.NetWaitNonActive();
+	return NetWait(1000000000);
+}
+
+void CNetIOThread::SendPacketConnlessWithToken7(NETADDR *pAddr, const void *pData, int DataSize, SECURITY_TOKEN Token, SECURITY_TOKEN ResponseToken)
+{
+	if(!g_Config.m_SvNetThreaded)
+	{
+		m_Server.SendPacketConnlessWithToken7(pAddr, pData, DataSize, Token, ResponseToken);
+		return;
+	}
+
+	auto Cmd = std::make_unique<CCmdSendPacketConnlessWithToken7>();
+	if(pAddr)
+		Cmd->m_Addr = *pAddr;
+
+	if(DataSize > NET_MAX_PACKETSIZE)
+		DataSize = NET_MAX_PACKETSIZE;
+	Cmd->m_DataSize = DataSize > 0 ? DataSize : 0;
+	if(Cmd->m_DataSize > 0 && pData)
+		mem_copy(Cmd->m_aData, pData, Cmd->m_DataSize);
+
+	Cmd->m_Token = Token;
+	Cmd->m_ResponseToken = ResponseToken;
+	EnqueueCommand(std::move(Cmd));
+}
+
+void CNetIOThread::ProcessSnap()
+{
+	m_Server.ProcessSnap();
+}

--- a/src/engine/shared/net_io_thread.h
+++ b/src/engine/shared/net_io_thread.h
@@ -1,0 +1,352 @@
+#ifndef ENGINE_SHARED_NET_IO_THREAD_H
+#define ENGINE_SHARED_NET_IO_THREAD_H
+
+#include <engine/shared/ReaderWriterQueue.h>
+#include <engine/shared/netban.h>
+#include <engine/shared/network.h>
+
+#include <array>
+#include <atomic>
+#include <condition_variable>
+#include <future>
+#include <memory>
+#include <mutex>
+
+class CNetRange;
+
+struct CEvent
+{
+	virtual ~CEvent() = default;
+	enum EType
+	{
+		EV_RECV,
+		EV_NEWCLIENT,
+		EV_NEWCLIENT_NOAUTH,
+		EV_CLIENTREJOIN,
+		EV_DELCLIENT,
+		EV_CLIENT_STATE,
+	} m_Type;
+};
+
+struct CEventRecv final : CEvent
+{
+	CEventRecv() { m_Type = EV_RECV; }
+	CNetChunk m_Chunk{};
+	SECURITY_TOKEN m_Token{};
+	unsigned char m_aData[NET_MAX_PACKETSIZE]{};
+};
+
+struct CEventClientBase : CEvent
+{
+	int m_ClientId{};
+	NETADDR m_Addr{};
+	std::array<char, NETADDR_MAXSTRSIZE> m_aAddrStr{};
+	std::array<char, NETADDR_MAXSTRSIZE> m_aAddrStrNoPort{};
+};
+
+struct CEventNewClient final : CEventClientBase
+{
+	CEventNewClient()
+	{
+		m_Type = EV_NEWCLIENT;
+	}
+	bool m_Sixup{};
+};
+
+struct CEventNewClientNoAuth final : CEventClientBase
+{
+	CEventNewClientNoAuth()
+	{
+		m_Type = EV_NEWCLIENT_NOAUTH;
+	}
+};
+
+struct CEventClientRejoin final : CEventClientBase
+{
+	CEventClientRejoin()
+	{
+		m_Type = EV_CLIENTREJOIN;
+	}
+};
+
+struct CEventDelClient final : CEventClientBase
+{
+	CEventDelClient()
+	{
+		m_Type = EV_DELCLIENT;
+	}
+	char m_aReason[256]{};
+};
+
+struct CClientRuntimeState
+{
+	CNetConnection::EState m_State = CNetConnection::EState::OFFLINE;
+	int m_SecurityToken = NET_SECURITY_TOKEN_UNKNOWN;
+	char m_aErrorString[256]{};
+	bool m_TimeoutProtected = false;
+	bool m_TimeoutSituation = false;
+};
+
+struct CEventClientState final : CEvent
+{
+	CEventClientState()
+	{
+		m_Type = EV_CLIENT_STATE;
+	}
+	int m_ClientId{};
+	CClientRuntimeState m_State{};
+};
+
+struct CCommand
+{
+	virtual ~CCommand() = default;
+	enum EType
+	{
+		CMD_CLOSE,
+		CMD_DROP,
+		CMD_SEND_PACKET_CONNLESS_WITH_TOKEN7,
+		CMD_SEND_TOKEN_SIXUP,
+		CMD_SET_MAX_CLIENTS_PER_IP,
+		CMD_SET_TIMED_OUT,
+		CMD_SET_TIMEOUT_PROTECTED,
+		CMD_IGNORE_TIMEOUTS,
+		CMD_SET_ACCEPTING_NEW_CONNECTIONS,
+		CMD_RESET_ERROR_STRING,
+		CMD_GET_GLOBAL_TOKEN,
+		CMD_GET_TOKEN,
+		CMD_GET_VANILLA_TOKEN,
+		CMD_SEND,
+		CMD_BAN_ADDRESS,
+		CMD_BAN_RANGE,
+	} m_Type;
+};
+
+struct CCmdClose final : CCommand
+{
+	CCmdClose() { m_Type = CMD_CLOSE; }
+};
+
+struct CCmdDrop final : CCommand
+{
+	CCmdDrop() { m_Type = CMD_DROP; }
+	int m_ClientId{};
+	char m_aReason[256]{};
+};
+
+struct CCmdSendPacketConnlessWithToken7 final : CCommand
+{
+	CCmdSendPacketConnlessWithToken7() { m_Type = CMD_SEND_PACKET_CONNLESS_WITH_TOKEN7; }
+	NETADDR m_Addr{};
+	int m_DataSize{};
+	unsigned char m_aData[NET_MAX_PACKETSIZE]{};
+	SECURITY_TOKEN m_Token{};
+	SECURITY_TOKEN m_ResponseToken{};
+};
+
+struct CCmdSendTokenSixup final : CCommand
+{
+	CCmdSendTokenSixup() { m_Type = CMD_SEND_TOKEN_SIXUP; }
+	NETADDR m_Addr{};
+	SECURITY_TOKEN m_Token{};
+};
+
+struct CCmdSetMaxClientsPerIp final : CCommand
+{
+	CCmdSetMaxClientsPerIp() { m_Type = CMD_SET_MAX_CLIENTS_PER_IP; }
+	int m_Max{};
+};
+
+struct CCmdSetTimeoutProtected final : CCommand
+{
+	CCmdSetTimeoutProtected() { m_Type = CMD_SET_TIMEOUT_PROTECTED; }
+	int m_ClientId{};
+};
+
+struct CCmdIgnoreTimeouts final : CCommand
+{
+	CCmdIgnoreTimeouts() { m_Type = CMD_IGNORE_TIMEOUTS; }
+	int m_ClientId{};
+};
+
+struct CCmdSetAcceptingNewConnections final : CCommand
+{
+	CCmdSetAcceptingNewConnections() { m_Type = CMD_SET_ACCEPTING_NEW_CONNECTIONS; }
+	bool m_Value{};
+};
+
+struct CCmdResetErrorString final : CCommand
+{
+	CCmdResetErrorString() { m_Type = CMD_RESET_ERROR_STRING; }
+	int m_ClientId{};
+};
+
+struct CCmdSetTimedOut final : CCommand
+{
+	CCmdSetTimedOut() { m_Type = CMD_SET_TIMED_OUT; }
+	int m_ClientId{};
+	int m_OrigId{};
+	std::promise<bool> m_Promise;
+};
+
+struct CCmdGetGlobalToken final : CCommand
+{
+	CCmdGetGlobalToken() { m_Type = CMD_GET_GLOBAL_TOKEN; }
+	std::promise<SECURITY_TOKEN> m_Promise;
+};
+
+struct CCmdGetToken final : CCommand
+{
+	CCmdGetToken() { m_Type = CMD_GET_TOKEN; }
+	NETADDR m_Addr{};
+	std::promise<SECURITY_TOKEN> m_Promise;
+};
+
+struct CCmdGetVanillaToken final : CCommand
+{
+	CCmdGetVanillaToken() { m_Type = CMD_GET_VANILLA_TOKEN; }
+	NETADDR m_Addr{};
+	std::promise<SECURITY_TOKEN> m_Promise;
+};
+
+struct CCmdSend final : CCommand
+{
+	CCmdSend() { m_Type = CMD_SEND; }
+	CNetChunk m_Chunk{};
+	unsigned char m_aData[NET_MAX_PACKETSIZE]{};
+};
+
+struct CCmdBanAddress final : CCommand
+{
+	CCmdBanAddress() { m_Type = CMD_BAN_ADDRESS; }
+	NETADDR m_Addr{};
+	int m_Seconds{};
+	char m_aReason[128]{};
+	bool m_VerbatimReason{};
+};
+
+struct CCmdBanRange final : CCommand
+{
+	CCmdBanRange() { m_Type = CMD_BAN_RANGE; }
+	CNetRange m_Range{};
+	int m_Seconds{};
+	char m_aReason[128]{};
+};
+
+class CNetIOThread : public INetServer
+{
+	std::atomic_bool m_Running{false};
+	void *m_pThread{nullptr};
+
+	CNetServer m_Server;
+
+	NETADDR m_AddressCache{};
+	std::atomic<int> m_NetTypeCache{NETTYPE_INVALID};
+	std::atomic<int> m_MaxClientsCache{0};
+
+	struct CClientPublicState
+	{
+		NETADDR m_Addr{};
+		std::array<char, NETADDR_MAXSTRSIZE> m_aAddrStr{};
+		std::array<char, NETADDR_MAXSTRSIZE> m_aAddrStrNoPort{};
+	};
+
+	std::array<CClientPublicState, NET_MAX_CLIENTS> m_aClientPublicState{};
+	std::array<CClientRuntimeState, NET_MAX_CLIENTS> m_aClientRuntimeState{};
+	std::array<CClientRuntimeState, NET_MAX_CLIENTS> m_aClientRuntimeThreadCache{};
+
+	moodycamel::ReaderWriterQueue<std::unique_ptr<CCommand>> m_CommandQueue;
+	moodycamel::ReaderWriterQueue<std::unique_ptr<CEvent>> m_EventQueue;
+	moodycamel::ReaderWriterQueue<std::unique_ptr<CEventRecv>> m_RecvQueue;
+
+	unsigned char m_aRecvStorage[NET_MAX_PACKETSIZE]{};
+
+	SEMAPHORE m_WorkSem{};
+	bool m_WorkSemInitialized = false;
+	std::atomic<uint64_t> m_WorkGen{0};
+
+	static void Run(void *pUser);
+
+	NETFUNC_NEWCLIENT m_pfnNewClient{};
+	NETFUNC_NEWCLIENT_NOAUTH m_pfnNewClientNoAuth{};
+	NETFUNC_CLIENTREJOIN m_pfnClientRejoin{};
+	NETFUNC_DELCLIENT m_pfnDelClient{};
+	CNetConnection::NETFUNC_CONN_DIRTY m_pfnConnDirty = nullptr;
+	void *m_pCallbackUser{};
+
+	void StartWorker();
+	void StopWorker();
+	void ProcessCommands();
+	void PumpNetwork();
+	void ProcessPendingEvents();
+	void UpdateClientPublicState(int ClientId, const NETADDR &Addr, const std::array<char, NETADDR_MAXSTRSIZE> &AddrStrWithPort, const std::array<char, NETADDR_MAXSTRSIZE> &AddrStrWithoutPort);
+	bool HasPendingEvents() const;
+	bool HasPendingCommands() const;
+	void NotifyWorkAvailable();
+	void EnqueueEvent(std::unique_ptr<CEvent> pEvent);
+	void EnqueueCommand(std::unique_ptr<CCommand> pCmd);
+	int SendMsg(CMsgPacker *pMsg, int Flags, int ClientId, bool SixUp);
+	void ProcessSnap();
+
+	CSnapThreaded *m_pSnapThreaded = nullptr;
+	void *m_pConnDirtyUser = nullptr;
+
+	static int NewClientTrampoline(int ClientId, void *pUser, bool Sixup);
+	static int NewClientNoAuthTrampoline(int ClientId, void *pUser);
+	static int ClientRejoinTrampoline(int ClientId, void *pUser);
+	static int DelClientTrampoline(int ClientId, const char *pReason, void *pUser);
+
+public:
+	CNetIOThread() = default;
+	~CNetIOThread() override { CNetIOThread::Close(); }
+
+	int SetCallbacks(NETFUNC_NEWCLIENT pfnNewClient, NETFUNC_NEWCLIENT_NOAUTH pfnNewClientNoAuth, NETFUNC_CLIENTREJOIN pfnClientRejoin, NETFUNC_DELCLIENT pfnDelClient, void *pUser) override;
+
+	bool Open(NETADDR BindAddr, CNetBan *pNetBan, int MaxClients, int MaxClientsPerIp, CSnapThreaded *pSnapThreaded) override;
+	void Close() override;
+
+	int Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken) override;
+	int Send(CNetChunk *pChunk) override;
+
+	void Update() override;
+
+	void Drop(int ClientId, const char *pReason) override;
+
+	const NETADDR *ClientAddr(int ClientId) const override;
+	const std::array<char, NETADDR_MAXSTRSIZE> &ClientAddrString(int ClientId, bool IncludePort) const override;
+	bool HasSecurityToken(int ClientId) const override;
+	int NumOnlineClients() override;
+	NETADDR Address() const override { return m_AddressCache; }
+	int NetType() const override { return m_NetTypeCache.load(std::memory_order_relaxed); }
+	int MaxClients() const override { return m_MaxClientsCache.load(std::memory_order_relaxed); }
+
+	void SendTokenSixup(NETADDR &Addr, SECURITY_TOKEN Token) override;
+	void SetMaxClientsPerIp(int Max) override;
+	bool HasErrored(int ClientId) override;
+	void ResumeOldConnection(int ClientId, int OrigId) override;
+	void ResumeOldConnectionProtected(int ClientId) override;
+	void IgnoreTimeouts(int ClientId) override;
+	void SetAcceptingNewConnections(bool Value) override;
+
+	void ResetErrorString(int ClientId) override;
+	const char *ErrorString(int ClientId) override;
+
+	SECURITY_TOKEN GetGlobalToken() override;
+	SECURITY_TOKEN GetToken(const NETADDR &Addr) override;
+	SECURITY_TOKEN GetVanillaToken(const NETADDR &Addr) override;
+
+	CNetConnection::EState State(int ClientId) override;
+
+	void BanAddr(const NETADDR *pAddr, int Seconds, const char *pReason, bool VerbatimReason = false) override;
+	void BanRange(const CNetRange *pRange, int Seconds, const char *pReason) override;
+
+	bool NetWait(int64_t TimeToTick) override;
+	bool NetWaitActive() override;
+	bool NetWaitNonActive() override;
+
+	void SendPacketConnlessWithToken7(NETADDR *pAddr, const void *pData, int DataSize, SECURITY_TOKEN Token, SECURITY_TOKEN ResponseToken) override;
+
+	NETSOCKET Socket() const override { return m_Server.Socket(); }
+	CNetBan *NetBan() const override { return m_Server.NetBan(); }
+};
+
+#endif

--- a/src/engine/shared/snap_tasks.h
+++ b/src/engine/shared/snap_tasks.h
@@ -1,0 +1,78 @@
+#ifndef ENGINE_SHARED_SNAP_TASKS_H
+#define ENGINE_SHARED_SNAP_TASKS_H
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+enum class ESnapTaskType : uint8_t
+{
+	SNAPSHOT,
+	RESET_STORAGE,
+};
+
+struct CSnapTask
+{
+	virtual ~CSnapTask() = default;
+	ESnapTaskType m_Type;
+};
+
+struct CSnapshotTask : CSnapTask
+{
+	CSnapshotTask()
+	{
+		m_Type = ESnapTaskType::SNAPSHOT;
+	}
+
+	int m_ClientId{-1};
+	int m_Tick{-1};
+	bool m_Sixup{false};
+	int m_LastAckedTick{-1};
+	std::unique_ptr<uint8_t[]> m_Data;
+	int m_Size{0};
+};
+
+struct CResetStorageTask : CSnapTask
+{
+	CResetStorageTask()
+	{
+		m_Type = ESnapTaskType::RESET_STORAGE;
+	}
+
+	int m_ClientId{-1};
+};
+
+// Result structure
+struct SSnapSendResult
+{
+	int m_ClientId{-1};
+	int m_SixUp{false};
+	int m_Tick{-1};
+	int m_DeltaTick{-1}; // -1 if base wasn't found
+	int m_Crc{0};
+	bool m_Empty{false}; // true => send NETMSG_SNAPEMPTY (ignore buffer/slices)
+
+	// Single owned buffer with concatenated compressed payload for all packets.
+	// Slices point into this buffer.
+	std::shared_ptr<std::vector<uint8_t>> m_Buffer;
+
+	struct Slice
+	{
+		int m_Offset{0}; // offset into m_Buffer
+		int m_Size{0}; // bytes in this packet
+	};
+	std::vector<Slice> m_Slices; // size == number of packets
+
+	// Convenience:
+	int NumPackets() const { return m_Empty ? 0 : (int)m_Slices.size(); }
+	bool IsValid() const { return m_ClientId >= 0 && m_Tick >= 0; }
+};
+
+// Wrapper for result to match CTaskProcessor interface
+struct CSnapResult
+{
+	virtual ~CSnapResult() = default;
+	SSnapSendResult m_Result;
+};
+
+#endif

--- a/src/engine/shared/snap_threaded.cpp
+++ b/src/engine/shared/snap_threaded.cpp
@@ -1,0 +1,239 @@
+#include "snap_threaded.h"
+
+#include <engine/server/server.h>
+#include <engine/shared/compression.h>
+#include <engine/shared/protocol.h>
+#include <engine/shared/snapshot.h>
+
+#include <algorithm>
+
+CSnapThreaded::CSnapThreaded() :
+	m_TaskProcessor(*this)
+{
+}
+
+CSnapThreaded::~CSnapThreaded()
+{
+	Stop();
+}
+
+void CSnapThreaded::SetServer(CServer *pServer)
+{
+	m_pServer = pServer;
+}
+
+void CSnapThreaded::Start()
+{
+	m_DeltaBuf.resize(CSnapshot::MAX_SIZE);
+	m_CompBuf.resize(CSnapshot::MAX_SIZE);
+	m_TaskProcessor.Start("snap thread");
+}
+
+void CSnapThreaded::Stop()
+{
+	m_TaskProcessor.Stop();
+}
+
+void CSnapThreaded::EnqueueRawSnapshot(int ClientId, int Tick, bool Sixup, int LastAckedTick, std::unique_ptr<uint8_t[]> pSnapshotBytes, int SnapshotSize)
+{
+	auto pTask = std::make_unique<CSnapshotTask>();
+	pTask->m_ClientId = ClientId;
+	pTask->m_Tick = Tick;
+	pTask->m_Sixup = Sixup;
+	pTask->m_LastAckedTick = LastAckedTick;
+	pTask->m_Data = std::move(pSnapshotBytes);
+	pTask->m_Size = SnapshotSize;
+	m_TaskProcessor.EnqueueTask(std::move(pTask));
+}
+
+void CSnapThreaded::ResetStorage(int ClientId)
+{
+	auto pTask = std::make_unique<CResetStorageTask>();
+	pTask->m_ClientId = ClientId;
+	m_TaskProcessor.EnqueueTask(std::move(pTask));
+}
+
+bool CSnapThreaded::TryPopResult(SSnapSendResult &Out)
+{
+	std::unique_ptr<CSnapResult> pResult;
+	if(m_TaskProcessor.TryDequeueResult(pResult))
+	{
+		Out = std::move(pResult->m_Result);
+		return true;
+	}
+	return false;
+}
+
+void CSnapThreaded::SetStaticsize(int ItemType, int Size)
+{
+	m_Delta.SetStaticsize(ItemType, Size);
+}
+
+bool CSnapThreaded::TryGetTagTime(int ClientId, int Tick, int64_t &OutTagTime) const
+{
+	if(ClientId < 0 || ClientId >= MAX_CLIENTS)
+		return false;
+	return m_Clients[ClientId].m_TagTimes.TryGet(Tick, OutTagTime);
+}
+
+std::unique_ptr<CSnapResult> CSnapThreaded::ProcessTask(CSnapTask &Task)
+{
+	switch(Task.m_Type)
+	{
+	case ESnapTaskType::SNAPSHOT:
+		return ProcessSnapshotTask(dynamic_cast<CSnapshotTask *>(&Task));
+	case ESnapTaskType::RESET_STORAGE:
+		ProcessResetStorageTask(dynamic_cast<CResetStorageTask *>(&Task));
+		return nullptr;
+	default:
+		return nullptr;
+	}
+}
+
+void CSnapThreaded::ProcessResetStorageTask(CResetStorageTask *pTask)
+{
+	const int ClientId = pTask->m_ClientId;
+	if(ClientId < 0 || ClientId >= MAX_CLIENTS)
+		return;
+
+	SClientState &State = m_Clients[ClientId];
+	State.m_Storage.PurgeAll();
+}
+
+std::unique_ptr<CSnapResult> CSnapThreaded::EmitEmpty(int ClientId, int Tick, int DeltaTick, bool SixUp)
+{
+	auto pResult = std::make_unique<CSnapResult>();
+	pResult->m_Result.m_ClientId = ClientId;
+	pResult->m_Result.m_SixUp = SixUp;
+	pResult->m_Result.m_Tick = Tick;
+	pResult->m_Result.m_DeltaTick = DeltaTick;
+	pResult->m_Result.m_Crc = 0;
+	pResult->m_Result.m_Empty = true;
+	return pResult;
+}
+
+std::unique_ptr<CSnapResult> CSnapThreaded::EmitCompressed(int ClientId, int Tick, int DeltaTick, int Crc, const uint8_t *pComp, int CompSize, bool SixUp)
+{
+	// Split into packets of size MAX_SNAPSHOT_PACKSIZE.
+	const int MaxSize = MAX_SNAPSHOT_PACKSIZE;
+	const int NumPackets = (CompSize + MaxSize - 1) / MaxSize;
+
+	auto Buf = std::make_shared<std::vector<uint8_t>>();
+	Buf->resize(CompSize);
+	mem_copy(Buf->data(), pComp, CompSize);
+
+	auto pResult = std::make_unique<CSnapResult>();
+	pResult->m_Result.m_ClientId = ClientId;
+	pResult->m_Result.m_SixUp = SixUp;
+	pResult->m_Result.m_Tick = Tick;
+	pResult->m_Result.m_DeltaTick = DeltaTick;
+	pResult->m_Result.m_Crc = Crc;
+	pResult->m_Result.m_Empty = false;
+	pResult->m_Result.m_Buffer = std::move(Buf);
+	pResult->m_Result.m_Slices.reserve(NumPackets);
+
+	int Left = CompSize;
+	int Offset = 0;
+	while(Left > 0)
+	{
+		const int Chunk = Left < MaxSize ? Left : MaxSize;
+		pResult->m_Result.m_Slices.push_back({Offset, Chunk});
+		Offset += Chunk;
+		Left -= Chunk;
+	}
+
+	return pResult;
+}
+
+std::unique_ptr<CSnapResult> CSnapThreaded::ProcessSnapshotTask(CSnapshotTask *pTask)
+{
+	const int ClientId = pTask->m_ClientId;
+	if(ClientId < 0 || ClientId >= MAX_CLIENTS || pTask->m_Size <= 0 || pTask->m_Data == nullptr)
+		return nullptr;
+
+	// Prepare delta tables per 0.7/0.6 flavor.
+	m_Delta.SetStaticsize(protocol7::NETEVENTTYPE_SOUNDWORLD, pTask->m_Sixup);
+	m_Delta.SetStaticsize(protocol7::NETEVENTTYPE_DAMAGE, pTask->m_Sixup);
+
+	// Interpret bytes as CSnapshot
+	CSnapshot *pSnap = reinterpret_cast<CSnapshot *>(pTask->m_Data.get());
+
+	if(pTask->m_Size > CSnapshot::MAX_SIZE || !pSnap->IsValid(pTask->m_Size))
+	{
+		return EmitEmpty(ClientId, pTask->m_Tick, -1, pTask->m_Sixup);
+	}
+
+	SClientState &State = m_Clients[ClientId];
+
+	// Add to storage, prune old (keep ~3 seconds), resolve base
+	{
+		const int64_t Now = time_get();
+		const int KeepTicks = (m_pServer ? m_pServer->TickSpeed() : 50) * 3;
+		State.m_Storage.PurgeUntil(pTask->m_Tick - KeepTicks);
+		State.m_Storage.Add(pTask->m_Tick, Now, pTask->m_Size, pSnap, 0, nullptr);
+		State.m_TagTimes.Push(pTask->m_Tick, Now);
+	}
+
+	int DeltaTick = -1;
+	const CSnapshot *pBase = CSnapshot::EmptySnapshot();
+	{
+		int64_t DummyTagTime = 0;
+		const CSnapshot *pFound = nullptr;
+		const int BaseSize = State.m_Storage.Get(pTask->m_LastAckedTick, &DummyTagTime, &pFound, nullptr);
+		if(BaseSize >= 0 && pFound && pFound->IsValid(BaseSize))
+		{
+			pBase = pFound;
+			DeltaTick = pTask->m_LastAckedTick;
+		}
+	}
+
+	// Compute CRC of full snapshot (for headers).
+	const int Crc = pSnap->Crc();
+
+	// Create delta
+	const int DeltaSize = m_Delta.CreateDelta(pBase, pSnap, (char *)m_DeltaBuf.data());
+
+	if(DeltaSize == 0)
+	{
+		// Nothing to send this tick to that client -> NETMSG_SNAPEMPTY
+		return EmitEmpty(ClientId, pTask->m_Tick, DeltaTick, pTask->m_Sixup);
+	}
+
+	// Compress
+	const int CompSize = CVariableInt::Compress((char *)m_DeltaBuf.data(), DeltaSize, (char *)m_CompBuf.data(), (int)m_CompBuf.size());
+
+	return EmitCompressed(ClientId, pTask->m_Tick, DeltaTick, Crc, m_CompBuf.data(), CompSize, pTask->m_Sixup);
+}
+
+void CSnapThreaded::STagRing::Push(int Tick, int64_t TagTime)
+{
+	uint32_t WriteIdx = m_WriteIdx.fetch_add(1, std::memory_order_relaxed);
+	SSlot &Slot = m_Slots[WriteIdx % K_CAP];
+	uint32_t Seq0 = Slot.m_Seq.load(std::memory_order_relaxed);
+	Slot.m_Seq.store(Seq0 + 1, std::memory_order_release); // odd => write begin
+	Slot.m_Tick = Tick;
+	Slot.m_TagTime = TagTime;
+	Slot.m_Seq.store(Seq0 + 2, std::memory_order_release); // even => write end
+}
+
+bool CSnapThreaded::STagRing::TryGet(int Tick, int64_t &OutTagTime) const
+{
+	for(const auto &Slot : m_Slots)
+	{
+		uint32_t Seq1 = Slot.m_Seq.load(std::memory_order_acquire);
+		if((Seq1 & 1u) != 0) // in write
+			continue;
+		int t = Slot.m_Tick;
+		int64_t TagTime = Slot.m_TagTime;
+		uint32_t Seq2 = Slot.m_Seq.load(std::memory_order_acquire);
+		if(Seq1 == Seq2 && (Seq2 & 1u) == 0)
+		{
+			if(t == Tick)
+			{
+				OutTagTime = TagTime;
+				return true;
+			}
+		}
+	}
+	return false;
+}

--- a/src/engine/shared/snap_threaded.h
+++ b/src/engine/shared/snap_threaded.h
@@ -1,0 +1,112 @@
+#ifndef ENGINE_SHARED_SNAP_THREADED_H
+#define ENGINE_SHARED_SNAP_THREADED_H
+
+#include <engine/shared/protocol.h>
+#include <engine/shared/snap_tasks.h>
+#include <engine/shared/snapshot.h>
+#include <engine/shared/task_processor.h>
+
+#include <array>
+#include <atomic>
+#include <memory>
+#include <vector>
+
+class CServer;
+class CSnapshot;
+
+// NOLINTBEGIN(portability-template-virtual-member-function)
+
+// Threaded snapshot delta/compress worker.
+class CSnapThreaded final : public ITaskProcessor<CSnapTask, CSnapResult>
+{
+public:
+	CSnapThreaded();
+	~CSnapThreaded() override;
+
+	// Called once early (e.g. in CServer ctor) so we can query TickSpeed(), logging, etc.
+	void SetServer(CServer *pServer);
+
+	// Optional: start/stop worker thread (automatically stops in dtor).
+	void Start();
+	void Stop();
+
+	// --- Task API (enqueued onto a single queue to preserve order) ---
+
+	// Enqueue a raw snapshot for a specific client.
+	// Ownership of pSnapshotBytes is transferred.
+	// - ClientId: 0..MaxClients-1
+	// - Tick: current game tick
+	// - Sixup: whether 0.7 packing rules apply for that client
+	// - LastAckedTick: last acked snapshot tick reported by that client (or -1)
+	// - pSnapshotBytes + SnapshotSize: bytes returned by CSnapshotBuilder::Finish(...)
+	void EnqueueRawSnapshot(int ClientId, int Tick, bool Sixup, int LastAckedTick, std::unique_ptr<uint8_t[]> pSnapshotBytes, int SnapshotSize);
+
+	// Request to purge in-memory snapshot storage for a client (queued; order-safe).
+	void ResetStorage(int ClientId);
+
+	// The network thread (single consumer) should call this frequently and send the packets.
+	// Returns true if a result was popped and filled into out.
+	bool TryPopResult(SSnapSendResult &Out);
+
+	// Optional tweak: static sizes for forced statics in delta
+	void SetStaticsize(int ItemType, int Size);
+
+	// For latency calculation on the main thread when both net and snap are threaded.
+	bool TryGetTagTime(int ClientId, int Tick, int64_t &OutTagTime) const;
+
+	// ITaskProcessor implementation
+	std::unique_ptr<CSnapResult> ProcessTask(CSnapTask &Task) override;
+
+private:
+	// Tiny lock-free ring with seqlock slots to expose (tick -> tag time) to readers.
+	struct STagRing
+	{
+		static constexpr int K_CAP = 64;
+		struct SSlot
+		{
+			std::atomic<uint32_t> m_Seq{0}; // seqlock
+			int m_Tick{-1};
+			int64_t m_TagTime{0};
+		};
+		SSlot m_Slots[K_CAP];
+		std::atomic<uint32_t> m_WriteIdx{0};
+
+		void Push(int Tick, int64_t TagTime);
+
+		// lock-free consistent read; returns true if Tick is found
+		bool TryGet(int Tick, int64_t &OutTagTime) const;
+	};
+
+	struct SClientState
+	{
+		CSnapshotStorage m_Storage;
+		STagRing m_TagTimes;
+	};
+
+	// We keep a single delta helper in the worker thread (not shared with main).
+	CSnapshotDelta m_Delta;
+
+	std::vector<uint8_t> m_DeltaBuf;
+	std::vector<uint8_t> m_CompBuf;
+
+	// Task processors
+	std::unique_ptr<CSnapResult> ProcessSnapshotTask(CSnapshotTask *pTask);
+	void ProcessResetStorageTask(CResetStorageTask *pTask);
+
+	// Emitters into result queue
+	std::unique_ptr<CSnapResult> EmitEmpty(int ClientId, int Tick, int DeltaTick, bool SixUp);
+	std::unique_ptr<CSnapResult> EmitCompressed(int ClientId, int Tick, int DeltaTick, int Crc, const uint8_t *pComp, int CompSize, bool SixUp);
+
+	// Environment
+	CServer *m_pServer{nullptr};
+
+	// Task processor
+	CTaskProcessor<CSnapTask, CSnapResult> m_TaskProcessor;
+
+	// Per-client state.
+	std::array<SClientState, MAX_CLIENTS> m_Clients{};
+};
+
+// NOLINTEND(portability-template-virtual-member-function)
+
+#endif

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -8,6 +8,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 
 // CSnapshot
 
@@ -74,6 +75,19 @@ public:
 
 // CSnapshotDelta
 
+enum
+{
+	HASHLIST_SIZE = 256,
+	HASHLIST_BUCKET_SIZE = 64,
+};
+
+struct CItemList
+{
+	int m_Num;
+	int m_aKeys[HASHLIST_BUCKET_SIZE];
+	int m_aIndex[HASHLIST_BUCKET_SIZE];
+};
+
 class CSnapshotDelta
 {
 public:
@@ -96,8 +110,11 @@ private:
 	uint64_t m_aSnapshotDataRate[CSnapshot::MAX_TYPE + 1];
 	uint64_t m_aSnapshotDataUpdates[CSnapshot::MAX_TYPE + 1];
 	CData m_Empty;
+	std::unique_ptr<CItemList[]> m_Hashlist;
 
 	static void UndiffItem(const int *pPast, const int *pDiff, int *pOut, int Size, uint64_t *pDataRate);
+
+	CItemList *AcquireHashlist();
 
 public:
 	static int DiffItem(const int *pPast, const int *pCurrent, int *pOut, int Size);
@@ -180,6 +197,7 @@ public:
 	int *GetItemData(int Key);
 
 	int Finish(void *pSnapdata);
+	bool IsSixup() const { return m_Sixup; }
 };
 
-#endif // ENGINE_SNAPSHOT_H
+#endif // ENGINE_SHARED_SNAPSHOT_H

--- a/src/engine/shared/task_processor.h
+++ b/src/engine/shared/task_processor.h
@@ -1,0 +1,111 @@
+#ifndef ENGINE_SHARED_TASK_PROCESSOR_H
+#define ENGINE_SHARED_TASK_PROCESSOR_H
+
+#include <base/system.h>
+#include <base/tl/threading.h>
+
+#include <engine/shared/ReaderWriterQueue.h>
+
+#include <atomic>
+#include <memory>
+
+template<typename TTask, typename TResult>
+class ITaskProcessor
+{
+public:
+	virtual ~ITaskProcessor() = default;
+	virtual std::unique_ptr<TResult> ProcessTask(TTask &Task) = 0; // NOLINT(portability-template-virtual-member-function)
+};
+
+template<typename TTask, typename TResult>
+class CTaskProcessor
+{
+public:
+	using TaskType = TTask;
+	using ResultType = TResult;
+	using ProcessorType = ITaskProcessor<TaskType, ResultType>;
+
+	explicit CTaskProcessor(ProcessorType &Processor) :
+		m_Processor(Processor) {}
+	~CTaskProcessor()
+	{
+		Stop();
+	}
+
+	void Start(const char *pThreadName)
+	{
+		if(m_pThread)
+			return;
+
+		m_Active.store(true, std::memory_order_release);
+		m_pThread = thread_init(WorkerThread, this, pThreadName);
+	}
+
+	void Stop()
+	{
+		if(!m_pThread)
+			return;
+
+		m_Active.store(false, std::memory_order_release);
+		m_Semaphore.Signal();
+		thread_wait(m_pThread);
+		m_pThread = nullptr;
+	}
+
+	void EnqueueTask(std::unique_ptr<TaskType> pTask)
+	{
+		if(!pTask)
+			return;
+
+		m_TaskQueue.enqueue(std::move(pTask));
+		m_Semaphore.Signal();
+	}
+
+	void EnqueueResult(std::unique_ptr<ResultType> pResult)
+	{
+		if(!pResult)
+			return;
+
+		m_ResultQueue.enqueue(std::move(pResult));
+	}
+
+	bool TryDequeueResult(std::unique_ptr<ResultType> &pResult)
+	{
+		return m_ResultQueue.try_dequeue(pResult);
+	}
+
+private:
+	static void WorkerThread(void *pUserData)
+	{
+		auto *pSelf = static_cast<CTaskProcessor *>(pUserData);
+		pSelf->RunWorker();
+	}
+
+	void RunWorker()
+	{
+		while(true)
+		{
+			m_Semaphore.Wait();
+
+			std::unique_ptr<TaskType> pTask;
+			while(m_TaskQueue.try_dequeue(pTask))
+			{
+				auto pResult = m_Processor.ProcessTask(*pTask);
+				if(pResult)
+					m_ResultQueue.enqueue(std::move(pResult));
+			}
+
+			if(!m_Active.load(std::memory_order_acquire))
+				break;
+		}
+	}
+
+	ProcessorType &m_Processor;
+	CSemaphore m_Semaphore;
+	std::atomic_bool m_Active{false};
+	void *m_pThread{};
+	moodycamel::ReaderWriterQueue<std::unique_ptr<TaskType>> m_TaskQueue;
+	moodycamel::ReaderWriterQueue<std::unique_ptr<ResultType>> m_ResultQueue;
+};
+
+#endif


### PR DESCRIPTION
These pull requests improve network performance by queuing with a separate network thread.
This allows the network load to be handled on a different core, which is very helpful for servers with a large online players.

Why draft? Because a lot of things still need to be changed. I just ask that you share your ideas on how to improve the code.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

I didn't use AI, but the person I got the code from did. I can't go into detail about which parts were created with AI.

Please note that the `ReaderWriterQueue.h` and `AtomicOps.h` files contain NOLINTBEGIN and NOLINTEND. This is because the code was pulled from another repository! This part of the code may be modified once all the details have been worked out and it is ready for deployment.

I'm asking for help fixing src/base/system.cpp for Windows and MacOS, since I don't have either one. (I'd also like an estimate of how well it will work on those systems.)
