### PR TITLE
Track last-bound descriptor sets to avoid redundant Vulkan calls

### DIFF
--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -1028,7 +1028,7 @@ private:
 	SPipelineContainer m_QuadGroupedPipeline;
 
 	std::vector<VkPipeline> m_vLastPipeline;
-	std::vector<std::array<VkDescriptorSet, 2>> m_vvLastDescriptorSets;
+	std::vector<VkDescriptorSet> m_vLastDescriptorSet;
 
 	std::vector<VkCommandPool> m_vCommandPools;
 
@@ -2176,7 +2176,7 @@ protected:
 					std::unique_lock<std::mutex> Lock(pRenderThread->m_Mutex);
 					pRenderThread->m_Cond.wait(Lock, [&pRenderThread] { return !pRenderThread->m_IsRendering; });
 					m_vLastPipeline[ThreadIndex + 1] = VK_NULL_HANDLE;
-					m_vvLastDescriptorSets[ThreadIndex + 1] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
+					m_vLastDescriptorSet[ThreadIndex + 1] = VK_NULL_HANDLE;
 				}
 			}
 		}
@@ -2425,8 +2425,8 @@ protected:
 
 		for(auto &LastPipe : m_vLastPipeline)
 			LastPipe = VK_NULL_HANDLE;
-		for(auto &LastDescrSets : m_vvLastDescriptorSets)
-			LastDescrSets = {VK_NULL_HANDLE, VK_NULL_HANDLE};
+		for(auto &LastDescrSet : m_vLastDescriptorSet)
+			LastDescrSet = VK_NULL_HANDLE;
 
 		return true;
 	}
@@ -3328,6 +3328,15 @@ protected:
 		}
 	}
 
+	void BindDescriptorSets(size_t RenderThreadIndex, VkCommandBuffer &CommandBuffer, VkPipelineLayout PipeLayout, VkDescriptorSet Descriptor)
+	{
+		if(m_vLastDescriptorSet[RenderThreadIndex] != Descriptor)
+		{
+			vkCmdBindDescriptorSets(CommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, PipeLayout, 0, 1, &Descriptor, 0, nullptr);
+			m_vLastDescriptorSet[RenderThreadIndex] = Descriptor;
+		}
+	}
+
 	/**************************
 	 * RENDERING IMPLEMENTATION
 	 ***************************/
@@ -3379,11 +3388,7 @@ protected:
 
 		if(IsTextured)
 		{
-			if(m_vvLastDescriptorSets[ExecBuffer.m_ThreadIndex][0] != ExecBuffer.m_aDescriptors[0].m_Descriptor)
-			{
-				vkCmdBindDescriptorSets(CommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, PipeLayout, 0, 1, &ExecBuffer.m_aDescriptors[0].m_Descriptor, 0, nullptr);
-				m_vvLastDescriptorSets[ExecBuffer.m_ThreadIndex][0] = ExecBuffer.m_aDescriptors[0].m_Descriptor;
-			}
+			BindDescriptorSets(ExecBuffer.m_ThreadIndex, CommandBuffer, PipeLayout, ExecBuffer.m_aDescriptors[0].m_Descriptor);
 		}
 
 		SUniformTileGPosBorder VertexPushConstants;
@@ -3466,11 +3471,7 @@ protected:
 
 		if(IsTextured)
 		{
-			if(m_vvLastDescriptorSets[ExecBuffer.m_ThreadIndex][0] != ExecBuffer.m_aDescriptors[0].m_Descriptor)
-			{
-				vkCmdBindDescriptorSets(CommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, PipeLayout, 0, 1, &ExecBuffer.m_aDescriptors[0].m_Descriptor, 0, nullptr);
-				m_vvLastDescriptorSets[ExecBuffer.m_ThreadIndex][0] = ExecBuffer.m_aDescriptors[0].m_Descriptor;
-			}
+			BindDescriptorSets(ExecBuffer.m_ThreadIndex, CommandBuffer, PipeLayout, ExecBuffer.m_aDescriptors[0].m_Descriptor);
 		}
 
 		vkCmdPushConstants(CommandBuffer, PipeLayout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(SUniformGPos), m.data());
@@ -5485,7 +5486,7 @@ public:
 		m_vImageLastFrameCheck.clear();
 
 		m_vLastPipeline.clear();
-		m_vvLastDescriptorSets.clear();
+		m_vLastDescriptorSet.clear();
 
 		for(size_t i = 0; i < m_ThreadCount; ++i)
 		{
@@ -6186,7 +6187,7 @@ public:
 		}
 
 		m_vLastPipeline.resize(m_ThreadCount, VK_NULL_HANDLE);
-		m_vvLastDescriptorSets.resize(m_ThreadCount, {VK_NULL_HANDLE, VK_NULL_HANDLE});
+		m_vLastDescriptorSet.resize(m_ThreadCount, VK_NULL_HANDLE);
 
 		m_vvFrameDelayedBufferCleanup.resize(m_SwapChainImageCount);
 		m_vvFrameDelayedTextureCleanup.resize(m_SwapChainImageCount);
@@ -7159,11 +7160,7 @@ public:
 
 		if(IsTextured)
 		{
-			if(m_vvLastDescriptorSets[ExecBuffer.m_ThreadIndex][0] != ExecBuffer.m_aDescriptors[0].m_Descriptor)
-			{
-				vkCmdBindDescriptorSets(CommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, PipeLayout, 0, 1, &ExecBuffer.m_aDescriptors[0].m_Descriptor, 0, nullptr);
-				m_vvLastDescriptorSets[ExecBuffer.m_ThreadIndex][0] = ExecBuffer.m_aDescriptors[0].m_Descriptor;
-			}
+			BindDescriptorSets(ExecBuffer.m_ThreadIndex, CommandBuffer, PipeLayout, ExecBuffer.m_aDescriptors[0].m_Descriptor);
 		}
 
 		uint32_t DrawCount = (uint32_t)pCommand->m_QuadNum;
@@ -7259,11 +7256,7 @@ public:
 
 		vkCmdBindIndexBuffer(CommandBuffer, ExecBuffer.m_IndexBuffer, 0, VK_INDEX_TYPE_UINT32);
 
-		if(m_vvLastDescriptorSets[ExecBuffer.m_ThreadIndex][0] != ExecBuffer.m_aDescriptors[0].m_Descriptor)
-		{
-			vkCmdBindDescriptorSets(CommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, PipeLayout, 0, 1, &ExecBuffer.m_aDescriptors[0].m_Descriptor, 0, nullptr);
-			m_vvLastDescriptorSets[ExecBuffer.m_ThreadIndex][0] = ExecBuffer.m_aDescriptors[0].m_Descriptor;
-		}
+		BindDescriptorSets(ExecBuffer.m_ThreadIndex, CommandBuffer, PipeLayout, ExecBuffer.m_aDescriptors[0].m_Descriptor);
 
 		SUniformGTextPos PosTexSizeConstant;
 		mem_copy(PosTexSizeConstant.m_aPos, m.data(), m.size() * sizeof(float));
@@ -7339,11 +7332,7 @@ public:
 
 		if(IsTextured)
 		{
-			if(m_vvLastDescriptorSets[ExecBuffer.m_ThreadIndex][0] != ExecBuffer.m_aDescriptors[0].m_Descriptor)
-			{
-				vkCmdBindDescriptorSets(CommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, PipeLayout, 0, 1, &ExecBuffer.m_aDescriptors[0].m_Descriptor, 0, nullptr);
-				m_vvLastDescriptorSets[ExecBuffer.m_ThreadIndex][0] = ExecBuffer.m_aDescriptors[0].m_Descriptor;
-			}
+			BindDescriptorSets(ExecBuffer.m_ThreadIndex, CommandBuffer, PipeLayout, ExecBuffer.m_aDescriptors[0].m_Descriptor);
 		}
 
 		vkCmdPushConstants(CommandBuffer, PipeLayout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(SUniformGPos), m.data());
@@ -7389,11 +7378,7 @@ public:
 
 		if(IsTextured)
 		{
-			if(m_vvLastDescriptorSets[ExecBuffer.m_ThreadIndex][0] != ExecBuffer.m_aDescriptors[0].m_Descriptor)
-			{
-				vkCmdBindDescriptorSets(CommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, PipeLayout, 0, 1, &ExecBuffer.m_aDescriptors[0].m_Descriptor, 0, nullptr);
-				m_vvLastDescriptorSets[ExecBuffer.m_ThreadIndex][0] = ExecBuffer.m_aDescriptors[0].m_Descriptor;
-			}
+			BindDescriptorSets(ExecBuffer.m_ThreadIndex, CommandBuffer, PipeLayout, ExecBuffer.m_aDescriptors[0].m_Descriptor);
 		}
 
 		SUniformPrimExGVertColor PushConstantColor;
@@ -7455,11 +7440,7 @@ public:
 		VkDeviceSize IndexOffset = (VkDeviceSize)((ptrdiff_t)pCommand->m_pOffset);
 		vkCmdBindIndexBuffer(CommandBuffer, ExecBuffer.m_IndexBuffer, IndexOffset, VK_INDEX_TYPE_UINT32);
 
-		if(m_vvLastDescriptorSets[ExecBuffer.m_ThreadIndex][0] != ExecBuffer.m_aDescriptors[0].m_Descriptor)
-		{
-			vkCmdBindDescriptorSets(CommandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, PipeLayout, 0, 1, &ExecBuffer.m_aDescriptors[0].m_Descriptor, 0, nullptr);
-			m_vvLastDescriptorSets[ExecBuffer.m_ThreadIndex][0] = ExecBuffer.m_aDescriptors[0].m_Descriptor;
-		}
+		BindDescriptorSets(ExecBuffer.m_ThreadIndex, CommandBuffer, PipeLayout, ExecBuffer.m_aDescriptors[0].m_Descriptor);
 
 		if(CanBePushed)
 		{


### PR DESCRIPTION
 Same idea as the existing m_vLastPipeline tracking - remember what's bound and don't re-bind it.

Adds per-thread tracking for slot 0 (texture descriptors). Slot 1 (uniforms) changes every draw call so there's nothing to skip there.

  ---

### What this does 

  Before drawing anything, we have to tell the GPU which texture to use. Previously we'd do this before every draw call, even if we're using the same texture as the last call.

  Now we remember what's already bound and skip the call if nothing changed. Same thing we already do for pipelines.

  Helps when drawing lots of stuff with the same texture (tiles, UI, etc.) - fewer API calls, less work for the driver.


Made with AI in its entirety

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
