### PR TITLE
Use racefinish message to stop demo/ghost recording

### DIFF
--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -620,9 +620,20 @@ void CGhost::OnMessage(int MsgType, void *pRawMsg)
 			int Time = CRaceHelper::TimeFromFinishMessage(pMsg->m_pMessage, aName, sizeof(aName));
 			if(Time > 0 && GameClient()->m_Snap.m_LocalClientId >= 0 && str_comp(aName, GameClient()->m_aClients[GameClient()->m_Snap.m_LocalClientId].m_aName) == 0)
 			{
-				StopRecord(Time);
+				if(m_Recording)
+					StopRecord(Time);
 				StopRender();
 			}
+		}
+	}
+	else if(MsgType == NETMSGTYPE_SV_RACEFINISH)
+	{
+		CNetMsg_Sv_RaceFinish *pMsg = (CNetMsg_Sv_RaceFinish *)pRawMsg;
+		if(m_Recording && pMsg->m_ClientId == GameClient()->m_Snap.m_LocalClientId)
+		{
+			if(m_Recording)
+				StopRecord(pMsg->m_Time);
+			StopRender();
 		}
 	}
 }

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -158,6 +158,16 @@ void CRaceDemo::OnMessage(int MsgType, void *pRawMsg)
 			}
 		}
 	}
+	else if(MsgType == NETMSGTYPE_SV_RACEFINISH)
+	{
+		CNetMsg_Sv_RaceFinish *pMsg = (CNetMsg_Sv_RaceFinish *)pRawMsg;
+		if(m_RaceState == RACE_STARTED && pMsg->m_ClientId == GameClient()->m_Snap.m_LocalClientId)
+		{
+			m_RaceState = RACE_FINISHED;
+			m_RecordStopTick = Client()->GameTick(g_Config.m_ClDummy) + Client()->GameTickSpeed();
+			m_Time = pMsg->m_Time;
+		}
+	}
 }
 
 void CRaceDemo::OnMapLoad()


### PR DESCRIPTION
Axiom servers localized finish chat message without realizing it's parsed by client. With the pr we don't merely rely on parsing finish chat message. The parsing method is kept for compatability.
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
