### PR TITLE
Fix `clang-analyzer-security.ArrayBound` by adding assertions

### DIFF
--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -242,8 +242,7 @@ static const CMenus::SCustomItem *GetCustomItem(int CurTab, size_t Index)
 		return gs_vpSearchHudList[Index];
 	else if(CurTab == ASSETS_TAB_EXTRAS)
 		return gs_vpSearchExtrasList[Index];
-
-	return nullptr;
+	dbg_assert_failed("Invalid CurTab: %d", CurTab);
 }
 
 template<typename TName>
@@ -306,6 +305,10 @@ void CMenus::ClearCustomItems(int CurTab)
 
 		// reload current DDNet particles skin
 		GameClient()->LoadExtrasSkin(g_Config.m_ClAssetExtras);
+	}
+	else
+	{
+		dbg_assert_failed("Invalid CurTab: %d", CurTab);
 	}
 	gs_aInitCustomList[CurTab] = true;
 }
@@ -414,6 +417,10 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 	else if(s_CurCustomTab == ASSETS_TAB_EXTRAS)
 	{
 		InitAssetList(m_vExtrasList, "assets/extras", "extras", ExtrasScan, Graphics(), Storage(), &User);
+	}
+	else
+	{
+		dbg_assert_failed("Invalid s_CurCustomTab: %d", s_CurCustomTab);
 	}
 
 	MainView.HSplitTop(10.0f, nullptr, &MainView);


### PR DESCRIPTION
Clang-tidy detects a potential OOB access that could only happen if the current asset settings menu tab has an unexpected value.

```
[246/380] Building CXX object CMakeFiles/game-client.dir/src/game/client/components/menus_settings_assets.cpp.obj
src/game/client/components/menus_settings_assets.cpp:310:2: warning: Out of bound access to memory around 'gs_aInitCustomList' [clang-analyzer-security.ArrayBound]
  310 |         gs_aInitCustomList[CurTab] = true;
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~
src/game/client/components/menus_settings_assets.cpp:261:5: note: Assuming 'CurTab' is not equal to ASSETS_TAB_ENTITIES
  261 |         if(CurTab == ASSETS_TAB_ENTITIES)
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/game/client/components/menus_settings_assets.cpp:261:2: note: Taking false branch
  261 |         if(CurTab == ASSETS_TAB_ENTITIES)
      |         ^
src/game/client/components/menus_settings_assets.cpp:275:10: note: Assuming 'CurTab' is not equal to ASSETS_TAB_GAME
  275 |         else if(CurTab == ASSETS_TAB_GAME)
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
src/game/client/components/menus_settings_assets.cpp:275:7: note: Taking false branch
  275 |         else if(CurTab == ASSETS_TAB_GAME)
      |              ^
src/game/client/components/menus_settings_assets.cpp:282:10: note: Assuming 'CurTab' is not equal to ASSETS_TAB_EMOTICONS
  282 |         else if(CurTab == ASSETS_TAB_EMOTICONS)
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/game/client/components/menus_settings_assets.cpp:282:7: note: Taking false branch
  282 |         else if(CurTab == ASSETS_TAB_EMOTICONS)
      |              ^
src/game/client/components/menus_settings_assets.cpp:289:10: note: Assuming 'CurTab' is not equal to ASSETS_TAB_PARTICLES
  289 |         else if(CurTab == ASSETS_TAB_PARTICLES)
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/game/client/components/menus_settings_assets.cpp:289:7: note: Taking false branch
  289 |         else if(CurTab == ASSETS_TAB_PARTICLES)
      |              ^
src/game/client/components/menus_settings_assets.cpp:296:10: note: Assuming 'CurTab' is not equal to ASSETS_TAB_HUD
  296 |         else if(CurTab == ASSETS_TAB_HUD)
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~
src/game/client/components/menus_settings_assets.cpp:296:7: note: Taking false branch
  296 |         else if(CurTab == ASSETS_TAB_HUD)
      |              ^
src/game/client/components/menus_settings_assets.cpp:303:10: note: Assuming 'CurTab' is not equal to ASSETS_TAB_EXTRAS
  303 |         else if(CurTab == ASSETS_TAB_EXTRAS)
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/game/client/components/menus_settings_assets.cpp:303:7: note: Taking false branch
  303 |         else if(CurTab == ASSETS_TAB_EXTRAS)
      |              ^
src/game/client/components/menus_settings_assets.cpp:310:2: note: Access of 'gs_aInitCustomList' at a negative or overflowing index, while it holds only 6 '_Bool' elements
  310 |         gs_aInitCustomList[CurTab] = true;
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions