### PR TITLE
Fix OOB access to particle texture when there are no particles

### DIFF
--- a/src/game/client/components/particles.cpp
+++ b/src/game/client/components/particles.cpp
@@ -270,6 +270,7 @@ void CParticles::RenderGroup(int Group)
 			{
 				if((size_t)CurParticleRenderCount == GRAPHICS_MAX_PARTICLES_RENDER_COUNT || LastColor.r != m_aParticles[i].m_Color.r || LastColor.g != m_aParticles[i].m_Color.g || LastColor.b != m_aParticles[i].m_Color.b || LastColor.a != Alpha || LastQuadOffset != QuadOffset)
 				{
+					dbg_assert(LastQuadOffset >= FirstParticleOffset, "Invalid particle offsets: %d < %d", LastQuadOffset, FirstParticleOffset);
 					Graphics()->TextureSet(aParticles[LastQuadOffset - FirstParticleOffset]);
 					Graphics()->RenderQuadContainerAsSpriteMultiple(ParticleQuadContainerIndex, LastQuadOffset - FirstParticleOffset, CurParticleRenderCount, s_aParticleRenderInfo);
 					CurParticleRenderCount = 0;
@@ -298,8 +299,12 @@ void CParticles::RenderGroup(int Group)
 			i = m_aParticles[i].m_NextPart;
 		}
 
-		Graphics()->TextureSet(aParticles[LastQuadOffset - FirstParticleOffset]);
-		Graphics()->RenderQuadContainerAsSpriteMultiple(ParticleQuadContainerIndex, LastQuadOffset - FirstParticleOffset, CurParticleRenderCount, s_aParticleRenderInfo);
+		if(CurParticleRenderCount > 0)
+		{
+			dbg_assert(LastQuadOffset >= FirstParticleOffset, "Invalid particle offsets: %d < %d", LastQuadOffset, FirstParticleOffset);
+			Graphics()->TextureSet(aParticles[LastQuadOffset - FirstParticleOffset]);
+			Graphics()->RenderQuadContainerAsSpriteMultiple(ParticleQuadContainerIndex, LastQuadOffset - FirstParticleOffset, CurParticleRenderCount, s_aParticleRenderInfo);
+		}
 	}
 	else
 	{


### PR DESCRIPTION
When there are no particles to be rendered in the extra and trail-extra groups, `LastQuadOffset` is set to `0` but `FirstParticleOffset` is set to `SPRITE_PART_SNOWFLAKE` (which is `139`), causing an out-of-bounds access to `aParticles[-139]`.

Found by clang-tidy:

```
[234/380] Building CXX object CMakeFiles/game-client.dir/src/game/client/components/particles.cpp.obj
src/game/client/components/particles.cpp:301:26: warning: Out of bound access to memory preceding the field 'm_aSpriteParticles' [clang-analyzer-security.ArrayBound]
  301 |                 Graphics()->TextureSet(aParticles[LastQuadOffset - FirstParticleOffset]);
      |                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/game/client/components/particles.cpp:214:5: note: Assuming 'Group' is equal to GROUP_EXTRA
  214 |         if(Group == GROUP_EXTRA || Group == GROUP_TRAIL_EXTRA)
      |            ^~~~~~~~~~~~~~~~~~~~
src/game/client/components/particles.cpp:214:26: note: Left side of '||' is true
  214 |         if(Group == GROUP_EXTRA || Group == GROUP_TRAIL_EXTRA)
      |                                 ^
src/game/client/components/particles.cpp:222:5: note: Assuming the condition is true
  222 |         if(Graphics()->IsQuadContainerBufferingEnabled())
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/game/client/components/particles.cpp:222:2: note: Taking true branch
  222 |         if(Graphics()->IsQuadContainerBufferingEnabled())
      |         ^
src/game/client/components/particles.cpp:234:6: note: Assuming the condition is false
  234 |                 if(i != -1)
      |                    ^~~~~~~
src/game/client/components/particles.cpp:234:3: note: Taking false branch
  234 |                 if(i != -1)
      |                 ^
src/game/client/components/particles.cpp:256:3: note: Loop condition is false. Execution continues on line 301
  256 |                 while(i != -1)
      |                 ^
src/game/client/components/particles.cpp:301:26: note: Access of the field 'm_aSpriteParticles' at negative byte offset -556
  301 |                 Graphics()->TextureSet(aParticles[LastQuadOffset - FirstParticleOffset]);
      |                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions