### PR TITLE
 Improve Emscripten log output in HTML wrapper, parse ANSI colors of log lines

### DIFF
--- a/other/emscripten/minimal.html
+++ b/other/emscripten/minimal.html
@@ -26,6 +26,10 @@
 			overflow: hidden scroll;
 			box-sizing: border-box;
 		}
+		#output .line {
+			border-left: 5px solid;
+			padding-left: 10px;
+		}
 		</style>
 	</head>
 	<body>
@@ -33,11 +37,15 @@
 		<canvas id="canvas" oncontextmenu="event.preventDefault()"></canvas>
 		<script>
 			var output = document.getElementById('output');
-			function appendOutput(message, bold, textColor) {
+			function appendOutput(message, bold, textColor, borderColor) {
 				const span = document.createElement("span");
 				span.textContent = message;
+				span.className = "line";
 				if (textColor) {
 					span.style.color = textColor;
+				}
+				if (borderColor) {
+					span.style.borderColor = borderColor;
 				}
 				if (bold) {
 					span.style.fontWeight = "bold";
@@ -46,10 +54,20 @@
 				output.appendChild(document.createElement("br"));
 				output.scrollTop = output.scrollHeight;
 			}
+			function parseAnsiColorRgb(line) {
+				// Only handles RGB format because our logging system only uses that.
+				const match = line.match(/^\x1b\[38;2;(\d+);(\d+);(\d+)m([\s\S]*?)\x1b\[0m$/);
+				if (!match) {
+					return { color: "black", message: line };
+				}
+				const [, r, g, b, message] = match;
+				return { color: `rgb(${r}, ${g}, ${b})`, message: message };
+			}
 			var Module = {
 				print: function(text) {
-					console.log(text);
-					appendOutput(text);
+					const parsedLine = parseAnsiColorRgb(text);
+					console.log(parsedLine.message);
+					appendOutput(parsedLine.message, false, undefined, parsedLine.color);
 				},
 				printErr: function(text) {
 					console.error(text);


### PR DESCRIPTION
See commit messages.

<img width="912" height="300" alt="image" src="https://github.com/user-attachments/assets/e29716bc-dc97-4e96-8a68-4f34c4cc8356" />

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions: the `parseAnsiColorRgb` function was drafted with ChatGPT