### PR TITLE
Improve Emscripten error handling and quitting behavior

### DIFF
--- a/cmake/toolchains/Emscripten.toolchain
+++ b/cmake/toolchains/Emscripten.toolchain
@@ -16,6 +16,9 @@ set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s PTHREAD_POOL_SIZE_STRICT=2")
 # Bad, but we sometimes need to block on the main thread because PROXY_TO_PTHREAD is not supported yet.
 set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s ALLOW_BLOCKING_ON_MAIN_THREAD=1")
 
+# Ensure execution ends after main() returns, so global destructors and Module.onExit are invoked.
+set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s EXIT_RUNTIME=1")
+
 # Filesystem support for loading files with C API functions.
 set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s FILESYSTEM=1 -s FORCE_FILESYSTEM=1")
 
@@ -29,7 +32,7 @@ set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s FULL_ES3=1")
 
 # Make sure C callback functions are available to JS.
 set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=[\\$autoResumeAudioContext,\\$dynCall]")
-set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s EXPORTED_FUNCTIONS=_main,_EmscriptenCallbackDropFile")
+set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s EXPORTED_FUNCTIONS=_main,_EmscriptenCallbackDropFile,_EmscriptenCallbackQuit")
 set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s EXPORTED_RUNTIME_METHODS=ccall")
 
 # Very important: use same stack size that other platforms have, as the default of 64 KiB that Emscripten uses is too small for our code and causes stack overflows.

--- a/other/emscripten/minimal.html
+++ b/other/emscripten/minimal.html
@@ -34,7 +34,7 @@
 	</head>
 	<body>
 		<div id="output"></div>
-		<canvas id="canvas" oncontextmenu="event.preventDefault()"></canvas>
+		<canvas id="canvas">Canvas not supported.</canvas>
 		<script>
 			var output = document.getElementById('output');
 			function appendOutput(message, bold, textColor, borderColor) {
@@ -73,16 +73,36 @@
 					console.error(text);
 					appendOutput(text, false, "red");
 				},
-				onAbort: function() {
-					// Game over. Hide the canvas. The error will already be logged by printErr.
+				onExit: function() {
+					// After client quits, hide the canvas and reset the cursor, as the canvas
+					// will be entirely black, also blocking the view of the console output.
 					Module['canvas'].style.display = "none";
+					// Make sure to reset cursor because it sometimes does not become visible.
+					Module['canvas'].style.cursor = "default";
+					appendOutput("Client closed. Reload the page to restart.", true);
+					const restartButton = document.createElement("button");
+					restartButton.textContent = "Reload page";
+					restartButton.style.marginTop = "10px";
+					restartButton.style.padding = "5px";
+					restartButton.addEventListener('click', e => location.reload());
+					output.appendChild(restartButton);
+					output.scrollTop = output.scrollHeight;
 				},
 				canvas: document.getElementById('canvas')
 			};
 			window.onerror = function(text) {
 				appendOutput(text, true, "red");
-				Module['canvas'].style.display = "none";
 			};
+			Module['canvas'].addEventListener('contextmenu', e => e.preventDefault());
+			Module['canvas'].addEventListener('webglcontextcreationerror', e => {
+				appendOutput(`Failed to create WebGL context: ${e.statusMessage || "Unknown error"}`, true, "red");
+			});
+			Module['canvas'].addEventListener('webglcontextlost', e => {
+				// The client cannot currently recover from GL context loss, because it
+				// would require reloading all textures, framebuffers etc.
+				appendOutput(`The WebGL context was lost: ${e.statusMessage || "Unknown error"}`, true, "red");
+				Module.ccall('EmscriptenCallbackQuit', null, [], []);
+			});
 			Module['canvas'].addEventListener('dragover', e => {
 				e.preventDefault();
 				e.dataTransfer.dropEffect = "none";

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -64,8 +64,6 @@
 
 #if defined(CONF_PLATFORM_ANDROID)
 #include <android/android_main.h>
-#elif defined(CONF_PLATFORM_EMSCRIPTEN)
-#include <emscripten/emscripten.h>
 #endif
 
 #include "SDL.h"
@@ -4705,12 +4703,6 @@ int main(int argc, const char **argv)
 		//       ignores the activity lifecycle entirely, which may cause issues if
 		//       we ever used any global resources like the camera.
 		std::exit(0);
-#elif defined(CONF_PLATFORM_EMSCRIPTEN)
-		// Hide canvas after client quit as it will be entirely black without visible
-		// cursor, also blocking view of the console.
-		EM_ASM({
-			document.querySelector('#canvas').style.display = 'none';
-		});
 #endif
 	};
 	std::function<void()> PerformAllCleanup = [PerformCleanup, PerformFinalCleanup]() mutable {

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -686,6 +686,18 @@ static int TranslateMouseWheelEventKey(const SDL_MouseWheelEvent &MouseWheelEven
 	}
 }
 
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+extern "C" {
+
+// This will be called from Emscripten JS code
+bool EmscriptenQuit = false;
+void EmscriptenCallbackQuit()
+{
+	EmscriptenQuit = true;
+}
+}
+#endif
+
 int CInput::Update()
 {
 	const int64_t Now = time_get();
@@ -708,6 +720,13 @@ int CInput::Update()
 			AddKeyEvent(Key, Flags);
 		}
 	};
+
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+	if(EmscriptenQuit)
+	{
+		return 1;
+	}
+#endif
 
 	while(SDL_PollEvent(&Event))
 	{


### PR DESCRIPTION
Handle Emscripten client being quit or aborted in the HTML wrapper by hiding the canvas, instead of doing this in the client only on successful exit. Also reset the canvas' cursor to ensure it becomes visible again.

On client quit, print a log output indicating that the client can be restarted by reloading the page. Add button for convenience to reload page.

Handle WebGL context lost event by quitting the client and logging an error message. The client cannot currently recover from GL context loss, because it would require reloading all textures, framebuffers etc.

Handle WebGL context creation error event by logging a more detailed error message. The client already handles the failed context creation.

<img width="596" height="130" alt="image" src="https://github.com/user-attachments/assets/b1f1890e-eaa8-47fc-ad23-48c34bfea816" />

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options:
   - With WebGL disabled in browser to test context creation error
   - WebGL context loss simulated using `document.getElementById("canvas").getContext("webgl2").getExtension("WEBGL_lose_context").loseContext();`
   - Assertion crash to test that `onAbort` is unnecessary and that `onerror` does not need to hide the canvas because `onExit` will always be called
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions