### PR TITLE
Use `std::optional` for map details instead of separate `bool`, check map size of `NETMSG_MAP_DETAILS` and `NETMSG_MAP_CHANGE`

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1597,7 +1597,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 			m_MapDetails = std::make_optional<CMapDetails>();
 			CMapDetails &MapDetails = m_MapDetails.value();
 			str_copy(MapDetails.m_aName, pMap);
-			(void)MapSize;
+			MapDetails.m_Size = MapSize;
 			MapDetails.m_Crc = MapCrc;
 			MapDetails.m_Sha256 = *pMapSha256;
 			str_copy(MapDetails.m_aUrl, pMapUrl);
@@ -1658,6 +1658,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 			const char *pMapUrl = nullptr;
 			if(MapDetails.has_value() &&
 				str_comp(MapDetails->m_aName, pMap) == 0 &&
+				MapDetails->m_Size == MapSize &&
 				MapDetails->m_Crc == MapCrc)
 			{
 				MapSha256 = MapDetails->m_Sha256;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -160,6 +160,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	{
 	public:
 		char m_aName[256];
+		int m_Size;
 		int m_Crc;
 		SHA256_DIGEST m_Sha256;
 		char m_aUrl[256];


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions