### PR TITLE
Line split clangd array to help forks with git conflicts

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,2 +1,7 @@
 Style:
-  AngledHeaders: ["base/.*", "engine/.*", "game/.*", "generated/.*"]
+  AngledHeaders: [
+    "base/.*",
+    "engine/.*",
+    "game/.*",
+    "generated/.*"
+  ]


### PR DESCRIPTION
As soon as ddnet edits this I will get a inline git conflict from

https://github.com/ddnet-insta/ddnet-insta/commit/dcb7505503fe51b8a63cd94df7c60b6af6c1e33d

which is fiddely. Its nicer to look at conflicts if array elements have their own lines.

## Checklist

- [x] Tested the change in my editor
- [x] I didn't use generative AI to generate more than single-line completions