### PR TITLE
Add more assertions for `CSnapshotBuilder`

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -4414,8 +4414,7 @@ void CServer::SnapFreeId(int Id)
 
 void *CServer::SnapNewItem(int Type, int Id, int Size)
 {
-	dbg_assert(Id >= -1 && Id <= 0xffff, "Invalid snap item Id: %d", Id);
-	return Id < 0 ? nullptr : m_SnapshotBuilder.NewItem(Type, Id, Size);
+	return m_SnapshotBuilder.NewItem(Type, Id, Size);
 }
 
 void CServer::SnapSetStaticsize(int ItemType, int Size)

--- a/src/engine/shared/sixup_translate_snapshot.cpp
+++ b/src/engine/shared/sixup_translate_snapshot.cpp
@@ -4,8 +4,11 @@
 
 void CSnapshotBuilder::Init7(const CSnapshot *pSnapshot)
 {
+	dbg_assert(!m_Building, "Snapshot builder is already building snapshot. Call `Finish` for each call to `Init`.");
+
 	// the method is called Init7 because it is only used for 0.7 support
 	// but the snap we are building is a 0.6 snap
+	m_Building = true;
 	m_Sixup = false;
 
 	m_DataSize = pSnapshot->m_DataSize;

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -160,17 +160,16 @@ class CSnapshotBuilder
 	int m_NumItems;
 
 	int m_aExtendedItemTypes[MAX_EXTENDED_ITEM_TYPES];
-	int m_NumExtendedItemTypes;
+	int m_NumExtendedItemTypes = 0;
 
 	bool AddExtendedItemType(int Index);
 	int GetExtendedItemTypeIndex(int TypeId);
 	int GetTypeFromIndex(int Index) const;
 
+	bool m_Building = false;
 	bool m_Sixup = false;
 
 public:
-	CSnapshotBuilder();
-
 	void Init(bool Sixup = false);
 	void Init7(const CSnapshot *pSnapshot);
 


### PR DESCRIPTION
Ensure `CSnapshotBuilder` functions are used in correct order: first `Init`/`Init7`, then `NewItem`/`AddExtendedItemType`, lastly `Finish`.

Ensure snap item ID is valid in `CSnapshotBuilder::NewItem` instead of `CServer::SnapNewItem`. Do not allow passing snap item ID `-1`.

Ensure snap item type and size are valid in `CSnapshotBuilder::NewItem`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions