### PR TITLE
Add `CEditorObject::Map` getter function

### DIFF
--- a/src/game/editor/editor_object.cpp
+++ b/src/game/editor/editor_object.cpp
@@ -9,6 +9,8 @@ void CEditorObject::OnInit(CEditor *pEditor)
 
 CEditor *CEditorObject::Editor() { return m_pEditor; }
 const CEditor *CEditorObject::Editor() const { return m_pEditor; }
+CEditorMap *CEditorObject::Map() { return m_pEditor->Map(); }
+const CEditorMap *CEditorObject::Map() const { return m_pEditor->Map(); }
 IInput *CEditorObject::Input() { return m_pEditor->Input(); }
 const IInput *CEditorObject::Input() const { return m_pEditor->Input(); }
 IClient *CEditorObject::Client() { return m_pEditor->Client(); }

--- a/src/game/editor/editor_object.h
+++ b/src/game/editor/editor_object.h
@@ -2,6 +2,7 @@
 #define GAME_EDITOR_EDITOR_OBJECT_H
 
 class CEditor;
+class CEditorMap;
 class IInput;
 class IClient;
 class CConfig;
@@ -27,6 +28,8 @@ public:
 
 	CEditor *Editor();
 	const CEditor *Editor() const;
+	CEditorMap *Map();
+	const CEditorMap *Map() const;
 	IInput *Input();
 	const IInput *Input() const;
 	IClient *Client();

--- a/src/game/editor/editor_server_settings.cpp
+++ b/src/game/editor/editor_server_settings.cpp
@@ -1838,7 +1838,7 @@ void CMapSettingsBackend::CContext::ColorArguments(std::vector<STextColorSplit> 
 
 int CMapSettingsBackend::CContext::CheckCollision(ECollisionCheckResult &Result) const
 {
-	return CheckCollision(m_pBackend->Editor()->Map()->m_vSettings, Result);
+	return CheckCollision(m_pBackend->Map()->m_vSettings, Result);
 }
 
 int CMapSettingsBackend::CContext::CheckCollision(const std::vector<CEditorMapSetting> &vSettings, ECollisionCheckResult &Result) const
@@ -2088,7 +2088,7 @@ void CMapSettingsBackend::OnMapLoad()
 	// Load & validate all map settings
 	m_LoadedMapSettings.Reset();
 
-	auto &vLoadedMapSettings = Editor()->Map()->m_vSettings;
+	auto &vLoadedMapSettings = Map()->m_vSettings;
 
 	// Keep a vector of valid map settings, to check collision against: m_vValidLoadedMapSettings
 

--- a/src/game/editor/font_typer.cpp
+++ b/src/game/editor/font_typer.cpp
@@ -34,7 +34,7 @@ void CFontTyper::SetTile(ivec2 Pos, unsigned char Index, const std::shared_ptr<C
 
 bool CFontTyper::OnInput(const IInput::CEvent &Event)
 {
-	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Editor()->Map()->SelectedLayerType(0, LAYERTYPE_TILES));
+	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Map()->SelectedLayerType(0, LAYERTYPE_TILES));
 	if(!pLayer)
 	{
 		if(IsActive())
@@ -161,7 +161,7 @@ bool CFontTyper::OnInput(const IInput::CEvent &Event)
 
 void CFontTyper::TextModeOn()
 {
-	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Editor()->Map()->SelectedLayerType(0, LAYERTYPE_TILES));
+	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Map()->SelectedLayerType(0, LAYERTYPE_TILES));
 	if(!pLayer)
 		return;
 	if(pLayer->m_Image == -1)
@@ -181,7 +181,7 @@ void CFontTyper::TextModeOff()
 	if(Editor()->m_Dialog == DIALOG_PSEUDO_FONT_TYPER)
 		Editor()->m_Dialog = DIALOG_NONE;
 	if(m_TilesPlacedSinceActivate)
-		Editor()->Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorBrushDrawAction>(Editor()->Map(), Editor()->Map()->m_SelectedGroup), "Font typer");
+		Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorBrushDrawAction>(Map(), Map()->m_SelectedGroup), "Font typer");
 	m_TilesPlacedSinceActivate = 0;
 	m_Active = false;
 	m_pLastLayer = nullptr;
@@ -212,7 +212,7 @@ void CFontTyper::OnRender(CUIRect View)
 		TextModeOff();
 	str_copy(Editor()->m_aTooltip, "Type on your keyboard to insert letters and numbers. Press Escape to end text mode.");
 
-	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Editor()->Map()->SelectedLayerType(0, LAYERTYPE_TILES));
+	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Map()->SelectedLayerType(0, LAYERTYPE_TILES));
 	if(!pLayer)
 		return;
 
@@ -238,7 +238,7 @@ void CFontTyper::OnRender(CUIRect View)
 		m_CursorRenderTime = time_get_nanoseconds();
 	if((CurTime - m_CursorRenderTime) > 500ms)
 	{
-		std::shared_ptr<CLayerGroup> pGroup = Editor()->Map()->SelectedGroup();
+		std::shared_ptr<CLayerGroup> pGroup = Map()->SelectedGroup();
 		pGroup->MapScreen();
 		Graphics()->WrapClamp();
 		Graphics()->TextureSet(m_CursorTextTexture);

--- a/src/game/editor/layer_selector.cpp
+++ b/src/game/editor/layer_selector.cpp
@@ -27,8 +27,8 @@ bool CLayerSelector::SelectByTile()
 	bool IsFound = false;
 	for(const auto &HoverTile : Editor()->HoverTiles())
 	{
-		if(!Editor()->Map()->m_vpGroups[HoverTile.m_Group]->m_Visible ||
-			!Editor()->Map()->m_vpGroups[HoverTile.m_Group]->m_vpLayers[HoverTile.m_Layer]->m_Visible)
+		if(!Map()->m_vpGroups[HoverTile.m_Group]->m_Visible ||
+			!Map()->m_vpGroups[HoverTile.m_Group]->m_vpLayers[HoverTile.m_Layer]->m_Visible)
 			continue;
 
 		if(MatchedGroup == -1)
@@ -49,7 +49,7 @@ bool CLayerSelector::SelectByTile()
 	{
 		if(!IsFound)
 			m_SelectionOffset = 1;
-		Editor()->Map()->SelectLayer(MatchedLayer, MatchedGroup);
+		Map()->SelectLayer(MatchedLayer, MatchedGroup);
 		return true;
 	}
 	return false;

--- a/src/game/editor/map_grid.cpp
+++ b/src/game/editor/map_grid.cpp
@@ -20,7 +20,7 @@ void CMapGrid::OnRender(CUIRect View)
 		return;
 	}
 
-	std::shared_ptr<CLayerGroup> pGroup = Editor()->Map()->SelectedGroup();
+	std::shared_ptr<CLayerGroup> pGroup = Map()->SelectedGroup();
 	if(!pGroup)
 	{
 		return;

--- a/src/game/editor/map_view.cpp
+++ b/src/game/editor/map_view.cpp
@@ -51,14 +51,14 @@ void CMapView::Focus()
 
 void CMapView::RenderGroupBorder()
 {
-	std::shared_ptr<CLayerGroup> pGroup = Editor()->Map()->SelectedGroup();
+	std::shared_ptr<CLayerGroup> pGroup = Map()->SelectedGroup();
 	if(pGroup)
 	{
 		pGroup->MapScreen();
 
-		for(size_t i = 0; i < Editor()->Map()->m_vSelectedLayers.size(); i++)
+		for(size_t i = 0; i < Map()->m_vSelectedLayers.size(); i++)
 		{
-			std::shared_ptr<CLayer> pLayer = Editor()->Map()->SelectedLayerType(i, LAYERTYPE_TILES);
+			std::shared_ptr<CLayer> pLayer = Map()->SelectedLayerType(i, LAYERTYPE_TILES);
 			if(pLayer)
 			{
 				CUIRect BorderRect;
@@ -76,46 +76,46 @@ void CMapView::RenderEditorMap()
 	if(Editor()->m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && Input()->ShiftIsPressed() && !Input()->ModifierIsPressed() && Input()->KeyPress(KEY_G))
 	{
 		const bool AnyHidden =
-			!Editor()->Map()->m_pGameLayer->m_Visible ||
-			(Editor()->Map()->m_pFrontLayer && !Editor()->Map()->m_pFrontLayer->m_Visible) ||
-			(Editor()->Map()->m_pTeleLayer && !Editor()->Map()->m_pTeleLayer->m_Visible) ||
-			(Editor()->Map()->m_pSpeedupLayer && !Editor()->Map()->m_pSpeedupLayer->m_Visible) ||
-			(Editor()->Map()->m_pTuneLayer && !Editor()->Map()->m_pTuneLayer->m_Visible) ||
-			(Editor()->Map()->m_pSwitchLayer && !Editor()->Map()->m_pSwitchLayer->m_Visible);
-		Editor()->Map()->m_pGameLayer->m_Visible = AnyHidden;
-		if(Editor()->Map()->m_pFrontLayer)
-			Editor()->Map()->m_pFrontLayer->m_Visible = AnyHidden;
-		if(Editor()->Map()->m_pTeleLayer)
-			Editor()->Map()->m_pTeleLayer->m_Visible = AnyHidden;
-		if(Editor()->Map()->m_pSpeedupLayer)
-			Editor()->Map()->m_pSpeedupLayer->m_Visible = AnyHidden;
-		if(Editor()->Map()->m_pTuneLayer)
-			Editor()->Map()->m_pTuneLayer->m_Visible = AnyHidden;
-		if(Editor()->Map()->m_pSwitchLayer)
-			Editor()->Map()->m_pSwitchLayer->m_Visible = AnyHidden;
+			!Map()->m_pGameLayer->m_Visible ||
+			(Map()->m_pFrontLayer && !Map()->m_pFrontLayer->m_Visible) ||
+			(Map()->m_pTeleLayer && !Map()->m_pTeleLayer->m_Visible) ||
+			(Map()->m_pSpeedupLayer && !Map()->m_pSpeedupLayer->m_Visible) ||
+			(Map()->m_pTuneLayer && !Map()->m_pTuneLayer->m_Visible) ||
+			(Map()->m_pSwitchLayer && !Map()->m_pSwitchLayer->m_Visible);
+		Map()->m_pGameLayer->m_Visible = AnyHidden;
+		if(Map()->m_pFrontLayer)
+			Map()->m_pFrontLayer->m_Visible = AnyHidden;
+		if(Map()->m_pTeleLayer)
+			Map()->m_pTeleLayer->m_Visible = AnyHidden;
+		if(Map()->m_pSpeedupLayer)
+			Map()->m_pSpeedupLayer->m_Visible = AnyHidden;
+		if(Map()->m_pTuneLayer)
+			Map()->m_pTuneLayer->m_Visible = AnyHidden;
+		if(Map()->m_pSwitchLayer)
+			Map()->m_pSwitchLayer->m_Visible = AnyHidden;
 	}
 
-	for(auto &pGroup : Editor()->Map()->m_vpGroups)
+	for(auto &pGroup : Map()->m_vpGroups)
 	{
 		if(pGroup->m_Visible)
 			pGroup->Render();
 	}
 
 	// render the game, tele, speedup, front, tune and switch above everything else
-	if(Editor()->Map()->m_pGameGroup->m_Visible)
+	if(Map()->m_pGameGroup->m_Visible)
 	{
-		Editor()->Map()->m_pGameGroup->MapScreen();
-		for(auto &pLayer : Editor()->Map()->m_pGameGroup->m_vpLayers)
+		Map()->m_pGameGroup->MapScreen();
+		for(auto &pLayer : Map()->m_pGameGroup->m_vpLayers)
 		{
 			if(pLayer->m_Visible && pLayer->IsEntitiesLayer())
 				pLayer->Render();
 		}
 	}
 
-	std::shared_ptr<CLayerTiles> pSelectedTilesLayer = std::static_pointer_cast<CLayerTiles>(Editor()->Map()->SelectedLayerType(0, LAYERTYPE_TILES));
+	std::shared_ptr<CLayerTiles> pSelectedTilesLayer = std::static_pointer_cast<CLayerTiles>(Map()->SelectedLayerType(0, LAYERTYPE_TILES));
 	if(Editor()->m_ShowTileInfo != CEditor::SHOW_TILE_OFF && pSelectedTilesLayer && pSelectedTilesLayer->m_Visible && m_Zoom.GetValue() <= 300.0f)
 	{
-		Editor()->Map()->SelectedGroup()->MapScreen();
+		Map()->SelectedGroup()->MapScreen();
 		pSelectedTilesLayer->ShowInfo();
 	}
 }

--- a/src/game/editor/proof_mode.cpp
+++ b/src/game/editor/proof_mode.cpp
@@ -60,13 +60,13 @@ void CProofMode::ResetMenuBackgroundPositions()
 	std::array<vec2, CMenuBackground::NUM_POS> aBackgroundPositions = GenerateMenuBackgroundPositions();
 	m_vMenuBackgroundPositions.assign(aBackgroundPositions.begin(), aBackgroundPositions.end());
 
-	if(Editor()->Map()->m_pGameLayer)
+	if(Map()->m_pGameLayer)
 	{
-		for(int y = 0; y < Editor()->Map()->m_pGameLayer->m_Height; ++y)
+		for(int y = 0; y < Map()->m_pGameLayer->m_Height; ++y)
 		{
-			for(int x = 0; x < Editor()->Map()->m_pGameLayer->m_Width; ++x)
+			for(int x = 0; x < Map()->m_pGameLayer->m_Width; ++x)
 			{
-				CTile Tile = Editor()->Map()->m_pGameLayer->GetTile(x, y);
+				CTile Tile = Map()->m_pGameLayer->GetTile(x, y);
 				if(Tile.m_Index >= TILE_TIME_CHECKPOINT_FIRST && Tile.m_Index <= TILE_TIME_CHECKPOINT_LAST)
 				{
 					int ArrayIndex = std::clamp<int>((Tile.m_Index - TILE_TIME_CHECKPOINT_FIRST), 0, CMenuBackground::NUM_POS);
@@ -97,7 +97,7 @@ void CProofMode::RenderScreenSizes()
 	// render screen sizes
 	if(m_ProofBorders != PROOF_BORDER_OFF)
 	{
-		std::shared_ptr<CLayerGroup> pGameGroup = Editor()->Map()->m_pGameGroup;
+		std::shared_ptr<CLayerGroup> pGameGroup = Map()->m_pGameGroup;
 		pGameGroup->MapScreen();
 
 		Graphics()->TextureClear();


### PR DESCRIPTION
Preparation for supporting multiple editor maps to reduce future code differences.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions