### PR TITLE
fix Hook Line Tip Preview not affected by ClHookCollAlpha

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2426,9 +2426,11 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		auto DoHookCollision = [this](const vec2 &Pos, const float &Length, const int &Size, const ColorRGBA &Color, const ColorRGBA &TipColor, const bool &Invert) {
 			ColorRGBA ColorModified = Color;
+			ColorRGBA TipColorModified = TipColor;
 			if(Invert)
 				ColorModified = color_invert(ColorModified);
 			ColorModified = ColorModified.WithAlpha((float)g_Config.m_ClHookCollAlpha / 100);
+			TipColorModified = TipColor.WithMultipliedAlpha((float)g_Config.m_ClHookCollAlpha / 100);
 			Graphics()->TextureClear();
 			if(Size > 0)
 			{
@@ -2439,7 +2441,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 				Graphics()->QuadsDrawTL(&QuadItem, 1);
 				if(TipColor.a > 0.0f)
 				{
-					Graphics()->SetColor(TipColor);
+					Graphics()->SetColor(TipColorModified);
 					IGraphics::CQuadItem TipQuadItem(Pos.x + Length, Pos.y - LineWidth, 15.f, LineWidth * 2.f);
 					Graphics()->QuadsDrawTL(&TipQuadItem, 1);
 				}
@@ -2453,7 +2455,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 				Graphics()->LinesDraw(&LineItem, 1);
 				if(TipColor.a > 0.0f)
 				{
-					Graphics()->SetColor(TipColor);
+					Graphics()->SetColor(TipColorModified);
 					IGraphics::CLineItem TipLineItem(Pos.x + Length, Pos.y, Pos.x + Length + 15.f, Pos.y);
 					Graphics()->LinesDraw(&TipLineItem, 1);
 				}


### PR DESCRIPTION
🙈
<img width="1920" height="1080" alt="screenshot_2026-02-18_10-22-35" src="https://github.com/user-attachments/assets/dcd3aa79-fdf3-48a1-9f26-9044fec4b4e8" />

## Checklist
- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
