### PR TITLE
Fix headless segfault in SDL3's `SetWindowGrab()`

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1715,6 +1715,10 @@ int CGraphicsBackend_SDL_GL::WindowOpen()
 
 void CGraphicsBackend_SDL_GL::SetWindowGrab(bool Grab)
 {
+	// Works around https://github.com/libsdl-org/sdl2-compat/issues/578.
+	if(!m_pWindow)
+		return;
+
 	SDL_SetWindowGrab(m_pWindow, Grab ? SDL_TRUE : SDL_FALSE);
 }
 


### PR DESCRIPTION
On archlinux by default sdl2 is replaced by sdl2-compat which uses sdl3 under the hood. And a recent update of it caused a segfault during launch of the headless client for me.

```
$ uname -a
Linux archlinux 6.18.9-arch1-2 #1 SMP PREEMPT_DYNAMIC Mon, 09 Feb 2026 17:16:33 +0000 x86_64 GNU/Linux

$ pacman -Q | grep sdl
qemu-audio-sdl 10.2.0-3
qemu-ui-sdl 10.2.0-3
sdl12-compat 1.2.68-2
sdl2-compat 2.32.64-1
sdl2_image 2.8.8-1
sdl3 3.4.0-4
```

```
cmake .. -DCMAKE_BUILD_TYPE=Debug -DHEALDESS_CLIENT=ON
make
gdb ./DDNet
```

causes this segfault directly on start:

```
2026-02-19 10:52:00 I sound: sound init successful using audio driver 'pipewire'
2026-02-19 10:52:00 I textrender: Freetype version 2.14.1 (compiled = 2.14.1)

Thread 1 "DDNet" received signal SIGSEGV, Segmentation fault.
0x00007fffe214bf6b in ?? () from /usr/lib/libSDL3.so.0
(gdb) bt
#0  0x00007fffe214bf6b in ??? () at /usr/lib/libSDL3.so.0
#1  0x00007ffff7d72e7b in ??? () at /usr/lib/libSDL2-2.0.so.0
#2  0x00007ffff7d72f46 in ??? () at /usr/lib/libSDL2-2.0.so.0
#3  0x0000555555955ea8 in CGraphicsBackend_SDL_GL::SetWindowGrab (this=0x555556212bd0, Grab=true) at /home/chiller/Desktop/git/ddnet/src/engine/client/backend_sdl.cpp:1718
#4  0x00005555559a0676 in CGraphics_Threaded::SetWindowGrab (this=0x7fffb4e99010, Grab=true) at /home/chiller/Desktop/git/ddnet/src/engine/client/graphics_threaded.cpp:2746
#5  0x00005555559b7d23 in CInput::MouseModeRelative (this=0x5555560c23b0) at /home/chiller/Desktop/git/ddnet/src/engine/client/input.cpp:296
#6  0x00005555559b7090 in CInput::Init (this=0x5555560c23b0) at /home/chiller/Desktop/git/ddnet/src/engine/client/input.cpp:100
#7  0x0000555555969fc4 in CClient::Run (this=0x7fffe15da010) at /home/chiller/Desktop/git/ddnet/src/engine/client/client.cpp:3130
#8  0x0000555555973aa5 in main (argc=1, argv=0x7fffffffccd8) at /home/chiller/Desktop/git/ddnet/src/engine/client/client.cpp:5002
```

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
