### PR TITLE
Move ready and enter game to own methods

### DIFF
--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -368,6 +368,8 @@ public:
 
 	bool CheckReservedSlotAuth(int ClientId, const char *pPassword);
 	void ProcessClientPacket(CNetChunk *pPacket);
+	void OnNetMsgReady(int ClientId);
+	void OnNetMsgEnterGame(int ClientId);
 
 	class CCache
 	{


### PR DESCRIPTION
Motivation for this is similar to (it uses also the same NetMessage suffix naming scheme)
https://github.com/ddnet/ddnet/pull/7147

Big methods like this can get messy during merge
conflicts for forks. This commit will also cause such conflict but in the future it will be cleaner.

I intentionally did not do all at once to not cause a too overwhelming conflict for forks.

But the primary motivation for this is similar to the creation of `CreatePlayer()` in https://github.com/ddnet/ddnet/pull/10420 so that we can simulate a player connection in unit tests. Right now we can only do the game server side. So adding more unit tests is a huge mine field because the server client slots are not filled.

All the game server and game controller code calls into the server which then throws a "Client slot empty" assert. For example this one:

https://github.com/ddnet/ddnet/blob/66cecc37bcdba21f83210bcf6d9272cb5e7214de/src/engine/server/server.cpp#L524

So to create more powerful unit tests the unit test needs to be able to call a method to init that client slot.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions