### PR TITLE
Move remaining `str_*` functions to `base/str.cpp/h`

### DIFF
--- a/src/base/dbg.cpp
+++ b/src/base/dbg.cpp
@@ -4,7 +4,7 @@
 #include "dbg.h"
 
 #include "logger.h"
-#include "system.h" // TODO: replace with str.h after moving str_format
+#include "str.h"
 
 #include <atomic>
 #include <cstdarg>

--- a/src/base/fs.cpp
+++ b/src/base/fs.cpp
@@ -1,9 +1,11 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
+#include <base/dbg.h>
 #include <base/fs.h>
 #include <base/log.h>
-#include <base/system.h>
+#include <base/secure.h>
+#include <base/str.h>
 #include <base/types.h>
 #include <base/windows.h>
 
@@ -15,6 +17,9 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <cctype> // tolower
+#include <cstdio> // rename
+#include <cstdlib> // getenv
 #elif defined(CONF_FAMILY_WINDOWS)
 #include <io.h>
 #include <shlobj.h> // SHGetKnownFolderPath

--- a/src/base/hash.cpp
+++ b/src/base/hash.cpp
@@ -1,7 +1,8 @@
 #include "hash.h"
 
 #include "hash_ctxt.h"
-#include "system.h"
+#include "mem.h"
+#include "str.h"
 
 static void digest_str(const unsigned char *digest, size_t digest_len, char *str, size_t max_len)
 {

--- a/src/base/sphore.cpp
+++ b/src/base/sphore.cpp
@@ -10,12 +10,14 @@
 
 #include <limits>
 #elif defined(CONF_PLATFORM_MACOS)
-#include "system.h" // TODO: replace with str.h after moving str_format
+#include "str.h"
+#include "system.h" // pid
 
 #include <fcntl.h> // O_* constants
 #include <sys/stat.h> // S_* constants
 #elif defined(CONF_FAMILY_UNIX)
-#include "system.h" // TODO: replace with str.h after moving str_format
+#include "str.h"
+#include "system.h" // pid
 #endif
 
 #if defined(CONF_FAMILY_WINDOWS)

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -11,13 +11,8 @@
 #include <sys/types.h>
 
 #include <atomic>
-#include <cctype>
-#include <charconv>
 #include <chrono>
-#include <cinttypes>
 #include <cmath>
-#include <cstdarg>
-#include <cstdio>
 #include <cstring>
 #include <iterator> // std::size
 #include <mutex>
@@ -1759,127 +1754,6 @@ int net_socket_read_wait(NETSOCKET sock, std::chrono::nanoseconds nanoseconds)
 	}
 #endif
 	return 0;
-}
-
-int str_format_v(char *buffer, int buffer_size, const char *format, va_list args)
-{
-#if defined(CONF_FAMILY_WINDOWS)
-	_vsprintf_p(buffer, buffer_size, format, args);
-	buffer[buffer_size - 1] = 0; /* assure null termination */
-#else
-	vsnprintf(buffer, buffer_size, format, args);
-	/* null termination is assured by definition of vsnprintf */
-#endif
-	return str_utf8_fix_truncation(buffer);
-}
-
-#if !defined(CONF_DEBUG)
-int str_format_int(char *buffer, size_t buffer_size, int value)
-{
-	buffer[0] = '\0'; // Fix false positive clang-analyzer-core.UndefinedBinaryOperatorResult when using result
-	auto result = std::to_chars(buffer, buffer + buffer_size - 1, value);
-	result.ptr[0] = '\0';
-	return result.ptr - buffer;
-}
-#endif
-
-#undef str_format
-int str_format(char *buffer, int buffer_size, const char *format, ...)
-{
-	va_list args;
-	va_start(args, format);
-	int length = str_format_v(buffer, buffer_size, format, args);
-	va_end(args);
-	return length;
-}
-#if !defined(CONF_DEBUG)
-#define str_format str_format_opt
-#endif
-
-static int min3(int a, int b, int c)
-{
-	int min = a;
-	if(b < min)
-		min = b;
-	if(c < min)
-		min = c;
-	return min;
-}
-
-int str_utf8_dist(const char *a, const char *b)
-{
-	int buf_len = 2 * (str_length(a) + 1 + str_length(b) + 1);
-	int *buf = (int *)calloc(buf_len, sizeof(*buf));
-	int result = str_utf8_dist_buffer(a, b, buf, buf_len);
-	free(buf);
-	return result;
-}
-
-static int str_to_utf32_unchecked(const char *str, int **out)
-{
-	int out_len = 0;
-	while((**out = str_utf8_decode(&str)))
-	{
-		(*out)++;
-		out_len++;
-	}
-	return out_len;
-}
-
-int str_utf32_dist_buffer(const int *a, int a_len, const int *b, int b_len, int *buf, int buf_len)
-{
-	int i, j;
-	dbg_assert(buf_len >= (a_len + 1) + (b_len + 1), "buffer too small");
-	if(a_len > b_len)
-	{
-		int tmp1 = a_len;
-		const int *tmp2 = a;
-
-		a_len = b_len;
-		a = b;
-
-		b_len = tmp1;
-		b = tmp2;
-	}
-#define B(i, j) buf[((j) & 1) * (a_len + 1) + (i)]
-	for(i = 0; i <= a_len; i++)
-	{
-		B(i, 0) = i;
-	}
-	for(j = 1; j <= b_len; j++)
-	{
-		B(0, j) = j;
-		for(i = 1; i <= a_len; i++)
-		{
-			int subst = (a[i - 1] != b[j - 1]);
-			B(i, j) = min3(
-				B(i - 1, j) + 1,
-				B(i, j - 1) + 1,
-				B(i - 1, j - 1) + subst);
-		}
-	}
-	return B(a_len, b_len);
-#undef B
-}
-
-int str_utf8_dist_buffer(const char *a_utf8, const char *b_utf8, int *buf, int buf_len)
-{
-	int a_utf8_len = str_length(a_utf8);
-	int b_utf8_len = str_length(b_utf8);
-	int *a, *b; // UTF-32
-	int a_len, b_len; // UTF-32 length
-	dbg_assert(buf_len >= 2 * (a_utf8_len + 1 + b_utf8_len + 1), "buffer too small");
-	if(a_utf8_len > b_utf8_len)
-	{
-		const char *tmp2 = a_utf8;
-		a_utf8 = b_utf8;
-		b_utf8 = tmp2;
-	}
-	a = buf;
-	a_len = str_to_utf32_unchecked(a_utf8, &buf);
-	b = buf;
-	b_len = str_to_utf32_unchecked(b_utf8, &buf);
-	return str_utf32_dist_buffer(a, a_len, b, b_len, buf, buf_len - b_len - a_len);
 }
 
 void net_stats(NETSTATS *stats_inout)

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -19,27 +19,12 @@
 #include "types.h"
 
 #include <chrono>
-#include <cinttypes>
-#include <cstdarg>
 #include <cstdint>
-#include <cstring>
 #include <ctime>
 #include <functional>
 #include <mutex>
 #include <optional>
 #include <string>
-
-#ifdef __MINGW32__
-#undef PRId64
-#undef PRIu64
-#undef PRIX64
-#define PRId64 "I64d"
-#define PRIu64 "I64u"
-#define PRIX64 "I64X"
-#define PRIzu "Iu"
-#else
-#define PRIzu "zu"
-#endif
 
 #ifdef CONF_FAMILY_UNIX
 #include <sys/un.h>
@@ -591,124 +576,6 @@ void net_unix_close(UNIXSOCKET sock);
 #endif
 
 /**
- * String related functions.
- *
- * @defgroup Strings Strings
- */
-
-/**
- * Performs printf formatting into a buffer.
- *
- * @ingroup Strings
- *
- * @param buffer Pointer to the buffer to receive the formatted string.
- * @param buffer_size Size of the buffer.
- * @param format printf formatting string.
- * @param args The variable argument list.
- *
- * @return Length of written string, even if it has been truncated.
- *
- * @remark See the C manual for syntax for the printf formatting string.
- * @remark The strings are treated as null-terminated strings.
- * @remark Guarantees that buffer string will contain null-termination.
- */
-[[gnu::format(printf, 3, 0)]] int str_format_v(char *buffer, int buffer_size, const char *format, va_list args);
-
-/**
- * Performs printf formatting into a buffer.
- *
- * @ingroup Strings
- *
- * @param buffer Pointer to the buffer to receive the formatted string.
- * @param buffer_size Size of the buffer.
- * @param format printf formatting string.
- * @param ... Parameters for the formatting.
- *
- * @return Length of written string, even if it has been truncated.
- *
- * @remark See the C manual for syntax for the printf formatting string.
- * @remark The strings are treated as null-terminated strings.
- * @remark Guarantees that buffer string will contain null-termination.
- */
-[[gnu::format(printf, 3, 4)]] int str_format(char *buffer, int buffer_size, const char *format, ...);
-
-#if !defined(CONF_DEBUG)
-int str_format_int(char *buffer, size_t buffer_size, int value);
-
-template<typename... Args>
-int str_format_opt(char *buffer, int buffer_size, const char *format, Args... args)
-{
-	static_assert(sizeof...(args) > 0, "Use str_copy instead of str_format without format arguments");
-	return str_format(buffer, buffer_size, format, args...);
-}
-
-template<>
-inline int str_format_opt(char *buffer, int buffer_size, const char *format, int val) // NOLINT(readability-inconsistent-declaration-parameter-name)
-{
-	if(strcmp(format, "%d") == 0)
-	{
-		return str_format_int(buffer, buffer_size, val);
-	}
-	else
-	{
-		return str_format(buffer, buffer_size, format, val);
-	}
-}
-
-#define str_format str_format_opt
-#endif
-
-/**
- * Computes the edit distance between two strings.
- *
- * @param a First string for the edit distance.
- * @param b Second string for the edit distance.
- *
- * @return The edit distance between the both strings.
- *
- * @remark The strings are treated as null-terminated strings.
- */
-int str_utf8_dist(const char *a, const char *b);
-
-/**
- * Computes the edit distance between two strings, allows buffers
- * to be passed in.
- *
- * @ingroup Strings
- *
- * @param a First string for the edit distance.
- * @param b Second string for the edit distance.
- * @param buf Buffer for the function.
- * @param buf_len Length of the buffer, must be at least as long as
- *                twice the length of both strings combined plus two.
- *
- * @return The edit distance between the both strings.
- *
- * @remark The strings are treated as null-terminated strings.
- */
-int str_utf8_dist_buffer(const char *a, const char *b, int *buf, int buf_len);
-
-/**
- * Computes the edit distance between two strings, allows buffers
- * to be passed in.
- *
- * @ingroup Strings
- *
- * @param a First string for the edit distance.
- * @param a_len Length of the first string.
- * @param b Second string for the edit distance.
- * @param b_len Length of the second string.
- * @param buf Buffer for the function.
- * @param buf_len Length of the buffer, must be at least as long as
- *                the length of both strings combined plus two.
- *
- * @return The edit distance between the both strings.
- *
- * @remark The strings are treated as null-terminated strings.
- */
-int str_utf32_dist_buffer(const int *a, int a_len, const int *b, int b_len, int *buf, int buf_len);
-
-/**
  * Swaps the endianness of data. Each element is swapped individually by reversing its bytes.
  *
  * @param data Pointer to data to be swapped.
@@ -720,31 +587,6 @@ int str_utf32_dist_buffer(const int *a, int a_len, const int *b, int b_len, int 
 void swap_endian(void *data, unsigned elem_size, unsigned num);
 
 void net_stats(NETSTATS *stats);
-
-int str_utf8_to_skeleton(const char *str, int *buf, int buf_len);
-
-/**
- * Checks if two strings only differ by confusable characters.
- *
- * @ingroup Strings
- *
- * @param str1 String to compare.
- * @param str2 String to compare.
- *
- * @return `0` if the strings are confusables.
- */
-int str_utf8_comp_confusable(const char *str1, const char *str2);
-
-/**
- * Converts the given Unicode codepoint to lowercase (locale insensitive).
- *
- * @ingroup Strings
- *
- * @param code Unicode codepoint to convert.
- *
- * @return Lowercase codepoint, or the original codepoint if there is no lowercase version.
- */
-int str_utf8_tolower_codepoint(int code);
 
 /**
  * Packs 4 big endian bytes into an unsigned.

--- a/src/base/time.cpp
+++ b/src/base/time.cpp
@@ -4,7 +4,8 @@
 #include "time.h"
 
 #include "dbg.h"
-#include "system.h" // TODO: replace with str.h after moving str_format
+#include "detect.h"
+#include "str.h"
 
 #include <cmath>
 #include <iomanip> // std::get_time

--- a/src/base/unicode/confusables.cpp
+++ b/src/base/unicode/confusables.cpp
@@ -1,6 +1,6 @@
 #include "confusables.h"
 
-#include <base/system.h>
+#include <base/str.h>
 
 #include <cstddef>
 

--- a/src/base/windows.cpp
+++ b/src/base/windows.cpp
@@ -5,7 +5,8 @@
 
 #if defined(CONF_FAMILY_WINDOWS)
 
-#include "system.h"
+#include "dbg.h"
+#include "str.h"
 
 #include <shlobj.h> // SHChangeNotify
 #include <windows.h>

--- a/src/engine/server/databases/connection.cpp
+++ b/src/engine/server/databases/connection.cpp
@@ -1,6 +1,6 @@
 #include "connection.h"
 
-#include <base/system.h> // TODO: replace with str.h after moving str_format
+#include <base/str.h>
 
 IDbConnection::IDbConnection(const char *pPrefix)
 {

--- a/src/engine/server/databases/sqlite.cpp
+++ b/src/engine/server/databases/sqlite.cpp
@@ -1,7 +1,9 @@
 #include "connection.h"
 
+#include <base/dbg.h>
 #include <base/math.h>
-#include <base/system.h> // TODO: replace with str.h after moving str_format
+#include <base/mem.h>
+#include <base/str.h>
 
 #include <engine/console.h>
 

--- a/src/engine/shared/jobs.cpp
+++ b/src/engine/shared/jobs.cpp
@@ -3,7 +3,7 @@
 #include "jobs.h"
 
 #include <base/dbg.h>
-#include <base/system.h> // TODO: replace with str.h after moving str_format
+#include <base/str.h>
 #include <base/thread.h>
 
 #include <algorithm>

--- a/src/test/score_test.cpp
+++ b/src/test/score_test.cpp
@@ -1,5 +1,5 @@
 #include <base/detect.h>
-#include <base/system.h> // TODO: replace with str.h after moving str_format
+#include <base/str.h>
 #include <base/time.h>
 
 #include <engine/server/databases/connection.h>

--- a/src/test/str_test.cpp
+++ b/src/test/str_test.cpp
@@ -1,4 +1,5 @@
-#include <base/system.h>
+#include <base/mem.h>
+#include <base/str.h>
 #include <base/windows.h>
 
 #include <engine/server/server.h>


### PR DESCRIPTION
Also move the `#include <cinttypes>` and the string format constants `PRIzu` etc. to `str.h` as it seems like the most appropriate location for them.

CC #10093.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions