### PR TITLE
Start to work on stronger unit tests

### DIFF
--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -368,6 +368,8 @@ public:
 
 	bool CheckReservedSlotAuth(int ClientId, const char *pPassword);
 	void ProcessClientPacket(CNetChunk *pPacket);
+	void OnNetMsgReady(int ClientId);
+	void OnNetMsgEnterGame(int ClientId);
 
 	class CCache
 	{


### PR DESCRIPTION
The test works and it also logs the chat message correctly. As you can see here:

```
$ make testrunner && ./testrunner --gtest_filter=CTestGameWorld.ClientConnect
[  2%] Built target generate_protocol
[  6%] Built target game-shared
[  6%] Built target json
[  8%] Built target rust-bridge-shared
[  8%] Built target rust_engine_shared_target
[ 10%] Built target engine-gfx
[ 48%] Built target engine-shared
[ 48%] Built target antibot
[ 72%] Built target game-server-without-main
[ 72%] Building CXX object CMakeFiles/testrunner.dir/src/test/gameworld_test.cpp.o
[ 72%] Linking CXX executable testrunner
[100%] Built target testrunner
Note: Google Test filter = CTestGameWorld.ClientConnect
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from CTestGameWorld
[ RUN      ] CTestGameWorld.ClientConnect
2026-02-19 17:49:36 I storage: added path 'CTestGameWorld.ClientConnect-170978.tmp'
2026-02-19 17:49:36 I storage: added path '$DATADIR' ('data')
2026-02-19 17:49:36 I storage: added path '$CURRENTDIR' ('/home/chiller/Desktop/gaming/ddnet/build')
2026-02-19 17:49:36 E sixup: couldn't load map maps7/coverage.map
2026-02-19 17:49:36 I sixup: disabling 0.7 compatibility
2026-02-19 17:49:36 I http: libcurl version 8.18.0 (compiled = 8.18.0)
2026-02-19 17:49:36 I antibot: null antibot initialized
2026-02-19 17:49:36 I tuning: gravity in zone 1 changed to 2.00
2026-02-19 17:49:36 I sql: [0] load best time failed on all databases
2026-02-19 17:49:36 I sql: [1] load map info failed on all databases
2026-02-19 17:49:36 I server: Loaded 0 announcements
2026-02-19 17:49:36 I server: Found 19 maps for maplist
2026-02-19 17:49:36 I chat: *** yellow
[       OK ] CTestGameWorld.ClientConnect (113 ms)
[----------] 1 test from CTestGameWorld (113 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (113 ms total)
[  PASSED  ] 1 test.
```

This is still a draft pr because I want to polish this on another day. And would like to merge #11792
 first. I just wanted to show case the current state. And communicate my plan of making the unit tests stronger. So we can soon cover actual new user facing features and config options with unit tests.
 
 ## planned tests
 
 - [ ] run `auth_add` rcon command and try to login the player and verify their authed state
 - [ ] simulate user chat commands such as **/join**  and **/team** and match the error messages printed to chat https://github.com/ddnet/ddnet/pull/11799#issuecomment-3928548070 or the changed state on success