### PR TITLE
Fix death tests getting stuck

### DIFF
--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -142,6 +142,7 @@ int main(int argc, const char **argv)
 	CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 	::testing::InitGoogleTest(&argc, const_cast<char **>(argv));
+	GTEST_FLAG_SET(death_test_style, "threadsafe");
 	net_init();
 	return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Closed #11807

https://github.com/google/googletest/blob/main/docs/advanced.md#death-tests-and-threads

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Used https://duck.ai/ for https://github.com/ddnet/ddnet/pull/11809#issuecomment-3935537620