### PR TITLE
Fix compilation of sphore.cpp on Linux

### DIFF
--- a/src/base/sphore.cpp
+++ b/src/base/sphore.cpp
@@ -17,6 +17,8 @@
 #include <sys/stat.h> // S_* constants
 #elif defined(CONF_FAMILY_UNIX)
 #include "str.h"
+
+#include <cerrno>
 #endif
 
 #if defined(CONF_FAMILY_WINDOWS)


### PR DESCRIPTION
```
/ddnet-source/src/base/sphore.cpp: In function ‘void sphore_wait(SEMAPHORE*)’: /ddnet-source/src/base/sphore.cpp:79:14: error: ‘errno’ was not declared in this scope
   79 |   dbg_assert(errno == EINTR, "sem_wait failure");
      |              ^~~~~
/ddnet-source/src/base/dbg.h:30:8: note: in definition of macro ‘dbg_assert’
   30 |   if(!(test)) \
      |        ^~~~
/ddnet-source/src/base/sphore.cpp:20:1: note: ‘errno’ is defined in header ‘<cerrno>’; did you forget to ‘#include <cerrno>’?
   19 | #include "str.h"
  +++ |+#include <cerrno>
   20 | #endif
In file included from /ddnet-source/src/base/sphore.cpp:6:
/ddnet-source/src/base/sphore.cpp:79:23: error: ‘EINTR’ was not declared in this scope
   79 |   dbg_assert(errno == EINTR, "sem_wait failure");
      |                       ^~~~~
/ddnet-source/src/base/dbg.h:30:8: note: in definition of macro ‘dbg_assert’
   30 |   if(!(test)) \
      |        ^~~~
```
Follow-up to https://github.com/ddnet/ddnet/pull/11770