### PR TITLE
Clipboard callback: execute each line separately (#11788)

### DIFF
--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -112,6 +112,10 @@ class CGameConsole : public CComponent
 		void Reset();
 
 		void ExecuteLine(const char *pLine);
+		void ExecuteLinesFromString(const char *pStr);
+		/**
+		 * Execute each line separately
+		 */
 
 		bool OnInput(const IInput::CEvent &Event);
 		void PrintLine(const char *pLine, int Len, ColorRGBA PrintColor) REQUIRES(!m_BacklogPendingLock);


### PR DESCRIPTION
- Fixed clipboard callback to execute each line separately
- Addresses issue #11788

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
