### PR TITLE
Move crashdump function declaration to `base/crashdump.h`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2010,6 +2010,7 @@ set_src(BASE GLOB_RECURSE src/base
   color.cpp
   color.h
   crashdump.cpp
+  crashdump.h
   dbg.cpp
   dbg.h
   detect.h

--- a/src/base/crashdump.cpp
+++ b/src/base/crashdump.cpp
@@ -1,3 +1,5 @@
+#include "crashdump.h"
+
 #include "detect.h"
 
 #if defined(CONF_CRASHDUMP)
@@ -6,7 +8,6 @@
 #else
 
 #include "log.h"
-#include "system.h"
 #include "windows.h"
 
 #include <windows.h>

--- a/src/base/crashdump.h
+++ b/src/base/crashdump.h
@@ -1,0 +1,18 @@
+#ifndef BASE_CRASHDUMP_H
+#define BASE_CRASHDUMP_H
+
+/**
+ * @defgroup Crash-Dumping Crash Dumping
+ */
+
+/**
+ * Initializes the crash dumper and sets the filename to write the crash dump
+ * to, if support for crash logging was compiled in. Otherwise does nothing.
+ *
+ * @ingroup Crash-Dumping
+ *
+ * @param log_file_path Absolute path to which crash log file should be written.
+ */
+void crashdump_init_if_available(const char *log_file_path);
+
+#endif

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -580,20 +580,6 @@ bool os_version_str(char *version, size_t length);
 void os_locale_str(char *locale, size_t length);
 
 /**
- * @defgroup Crash-Dumping Crash Dumping
- */
-
-/**
- * Initializes the crash dumper and sets the filename to write the crash dump
- * to, if support for crash logging was compiled in. Otherwise does nothing.
- *
- * @ingroup Crash-Dumping
- *
- * @param log_file_path Absolute path to which crash log file should be written.
- */
-void crashdump_init_if_available(const char *log_file_path);
-
-/**
  * Fixes the command line arguments to be encoded in UTF-8 on all systems.
  * This is a RAII wrapper for @link cmdline_fix @endlink and @link cmdline_free @endlink.
  *

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -7,6 +7,7 @@
 #include "friends.h"
 #include "serverbrowser.h"
 
+#include <base/crashdump.h>
 #include <base/hash.h>
 #include <base/hash_ctxt.h>
 #include <base/log.h>

--- a/src/engine/server/main.cpp
+++ b/src/engine/server/main.cpp
@@ -1,3 +1,4 @@
+#include <base/crashdump.h>
 #include <base/detect.h>
 #include <base/logger.h>
 #include <base/process.h>


### PR DESCRIPTION
CC #10093.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions