### PR TITLE
Fix: Stop forcing predicted events onto older ddrace servers

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1575,7 +1575,7 @@ static CGameInfo GetGameInfo(const CNetObj_GameInfoEx *pInfoEx, int InfoExSize, 
 	Info.m_NoWeakHookAndBounce = false;
 	Info.m_NoSkinChangeForFrozen = false;
 	Info.m_DDRaceTeam = false;
-	Info.m_PredictEvents = DDRace || Vanilla;
+	Info.m_PredictEvents = Vanilla;
 
 	if(Version >= 0)
 	{


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

DDRace is not necessarily DDNet in terms of server flags. Even other mods use the server flag in order to enable ddnet gamplay features and prediction.
If a server wants to enable this prediction, it should send the flag for it and this should be respected, not forced by gametype. The only exception I can life with is vanilla, since _I guess_ we explicitly support the prediction for it.

We can't ensure that the event prediction is properly working for these cases:

```
	DDRace = Flags & GAMEINFOFLAG_GAMETYPE_DDRACE;
	DDNet = Flags & GAMEINFOFLAG_GAMETYPE_DDNET;
	FDDrace = Version >= 6 && Flags2 & GAMEINFOFLAG2_GAMETYPE_FDDRACE;
```
because they are merged togheter into one 

```
DDRace = DDRace || DDNet || FDDrace;
```

Which is then forcing the prediction **on**: (old code)

```
Info.m_PredictEvents = DDRace || Vanilla;
```

Why can we not check for the `DDNet` gametype flag? Because it's unfortunately not atomic. A lot of features are controlled by this flag often in combination with others.

closes #11764 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
