### PR TITLE
Enable STL debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ option(STEAM "Build the Steam release version" OFF)
 option(DISCORD "Enable Discord rich presence support" OFF)
 option(DISCORD_DYNAMIC "Enable discovering Discord rich presence libraries at runtime (Linux only)" OFF)
 option(PREFER_BUNDLED_LIBS "Prefer bundled libraries over system libraries" ${AUTO_DEPENDENCIES_DEFAULT})
-option(DEV "Don't generate stuff necessary for packaging" OFF)
+option(DEV "Don't generate stuff necessary for packaging, don't strip absolute paths from debug info, enable additional assertions" OFF)
 option(VULKAN "Enable the vulkan backend" ${AUTO_VULKAN_BACKEND})
 
 option(EXCEPTION_HANDLING "Enable crashdumps (only works with Windows)" OFF)
@@ -301,11 +301,15 @@ if(NOT MSVC AND NOT HAIKU)
   # special characters will be displayed incorrectly on servers.
   add_cxx_compiler_flag_if_supported(OUR_FLAGS -fsigned-char)
 
+  # Support more sections in object files, because the limit is exceeded for some files in debug mode.
+  add_cxx_compiler_flag_if_supported(OUR_FLAGS -Wa,-mbig-obj)
+
   # Don't insert timestamps into PEs to keep the build reproducible.
   if(TARGET_OS STREQUAL "windows")
     add_cxx_compiler_flag_if_supported(OUR_FLAGS_LINK -Wl,--no-insert-timestamp)
   endif()
 
+  # Strip absolute build paths from debug info. Prevent adding compiler name and version metadata.
   if(NOT CMAKE_BUILD_TYPE STREQUAL Debug AND NOT DEV)
     add_cxx_compiler_flag_if_supported(OUR_FLAGS -ffile-prefix-map=${CMAKE_SOURCE_DIR}=/${CMAKE_PROJECT_NAME})
     add_cxx_compiler_flag_if_supported(OUR_FLAGS -ffile-prefix-map=${PROJECT_BINARY_DIR}=/${CMAKE_PROJECT_NAME})
@@ -803,15 +807,27 @@ if(NOT(GTEST_FOUND) AND DOWNLOAD_GTEST)
         EXCLUDE_FROM_ALL
       )
 
-      if(MSVC)
-        foreach(target gtest gmock)
+      foreach(target gtest gmock)
+        # Enable additional assertions. See:
+        # - https://gcc.gnu.org/wiki/LibstdcxxDebugMode
+        # - https://releases.llvm.org/12.0.0/projects/libcxx/docs/DesignDocs/DebugMode.html
+        if(CMAKE_BUILD_TYPE STREQUAL Debug)
+          # Enable heavier checks that catch more errors.
+          target_compile_definitions(${target} PRIVATE _GLIBCXX_DEBUG) # This also enables _GLIBCXX_ASSERTIONS.
+          target_compile_definitions(${target} PRIVATE _LIBCPP_DEBUG=1)
+        else()
+          # Enable lighter checks that do not change the complexity of operations.
+          target_compile_definitions(${target} PRIVATE _GLIBCXX_ASSERTIONS)
+          target_compile_definitions(${target} PRIVATE _LIBCPP_DEBUG=0)
+        endif()
+        if(MSVC)
           set_property(TARGET ${target} PROPERTY MSVC_RUNTIME_LIBRARY MultiThreaded$<${DBG}:Debug>)
           # `/w` disables all warnings. This is needed because `gtest` enables
           # `/WX` (equivalent of `-Werror`) for some reason, breaking builds
           # when MSVS adds new warnings.
           target_compile_options(${target} PRIVATE /w)
-        endforeach()
-      endif()
+        endif()
+      endforeach()
 
       set(GTEST_LIBRARIES gtest gmock)
       set(GTEST_INCLUDE_DIRS)
@@ -3676,6 +3692,7 @@ foreach(target ${TARGETS})
     target_compile_options(${target} PRIVATE /GS) # Protect the stack pointer.
     target_compile_options(${target} PRIVATE /wd4996) # Use of non-_s functions.
     target_compile_options(${target} PRIVATE /utf-8) # Use UTF-8 for source files.
+    target_compile_options(${target} PRIVATE /bigobj) # Support more sections in object files, because the limit is exceeded for some files in debug mode.
     # Enable Edit & Continue (Hot Reload) support
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.25)
       set_property(TARGET ${target} PROPERTY MSVC_DEBUG_INFORMATION_FORMAT $<IF:$<CONFIG:Debug>,EditAndContinue,Embedded>)
@@ -3753,6 +3770,20 @@ foreach(target ${TARGETS_OWN})
   target_include_directories(${target} SYSTEM PRIVATE ${CURL_INCLUDE_DIRS} ${SQLite3_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS})
   target_compile_definitions(${target} PRIVATE GLEW_STATIC)
   target_compile_definitions(${target} PRIVATE _FILE_OFFSET_BITS=64) # Ensure off_t is 64 bit for ftello and fseeko functions
+
+  # Enable additional assertions. See:
+  # - https://gcc.gnu.org/wiki/LibstdcxxDebugMode
+  # - https://releases.llvm.org/12.0.0/projects/libcxx/docs/DesignDocs/DebugMode.html
+  if(CMAKE_BUILD_TYPE STREQUAL Debug)
+    # Enable heavier checks that catch more errors.
+    target_compile_definitions(${target} PRIVATE _GLIBCXX_DEBUG) # This also enables _GLIBCXX_ASSERTIONS.
+    target_compile_definitions(${target} PRIVATE _LIBCPP_DEBUG=1)
+  else()
+    # Enable lighter checks that do not change the complexity of operations.
+    target_compile_definitions(${target} PRIVATE _GLIBCXX_ASSERTIONS)
+    target_compile_definitions(${target} PRIVATE _LIBCPP_DEBUG=0)
+  endif()
+
   if(CRYPTO_FOUND)
     target_compile_definitions(${target} PRIVATE CONF_OPENSSL)
     target_include_directories(${target} SYSTEM PRIVATE ${CRYPTO_INCLUDE_DIRS})

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -485,7 +485,7 @@ private:
 	PartsVector m_vpParts;
 	void RenderLine(CGameClient &This,
 		vec2 Pos, vec2 Size,
-		PartsVector::iterator Start, PartsVector::iterator End)
+		const PartsVector::iterator &Start, const PartsVector::iterator &End)
 	{
 		Pos.x -= Size.x / 2.0f;
 		for(auto PartIt = Start; PartIt != End; ++PartIt)


### PR DESCRIPTION
Enable full STL debug mode (`_GLIBCXX_DEBUG`, `_LIBCPP_DEBUG=1`) when building in Debug mode to catch more errors at the cost of potentially increased time complexity for STL operations.

Enable light STL debug mode (`_GLIBCXX_ASSERTIONS`, `_LIBCPP_DEBUG=0`) when building in Release mode to catch some errors without influencing the time complexity of operations.

This is enabled for Libstdc++ and libc++:

- https://gcc.gnu.org/wiki/LibstdcxxDebugMode
- https://releases.llvm.org/12.0.0/projects/libcxx/docs/DesignDocs/DebugMode.html

Light debug mode is already enabled when building with some compilers, e.g. with the GNU toolchain installed from MSYS2 on Windows, which made some crashes hard to reproduce that only happen with light debug mode enabled.

Using `_GLIBCXX_DEBUG` requires the `/bigobj` or `-Wa,-mbig-obj` compiler flag, because the maximum number of sections in object files is otherwise exceeded when compiling large files like `backend_vulkan.cpp`.

The `_GLIBCXX_DEBUG` flag must also be set when compiling gtest/gmock because it changes the ABI. The `_GLIBCXX_ASSERTIONS` flag is also set for completeness and consistency.

Closes ddnet#11838.

Co-authored-by: MilkeeyCat <milkeeycat@gmail.com>

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions