### PR TITLE
Disable CodeQL TRAP caching, update to v4 of CodeQL actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # Disable TRAP caching because this uses a lot of cache storage (>500 MiB) for each push to master
@@ -72,4 +72,4 @@ jobs:
        cmake --build . --config RelWithDebInfo --target everything
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
Disable TRAP caching for the CodeQL workflow because this uses a lot of cache storage (>500 MiB) for each push to master and is mostly pointless because the cache key includes the commit hash. Hence, this cache could only be used for the scheduled runs that happen weekly.

More than half of this [repository's action cache storage](https://github.com/ddnet/ddnet/actions/caches?query=sort%3Asize-desc) is currently used for `codeql-trap-*` entries.

## Checklist

- [X] Tested the change in my repository
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions