### PR TITLE
Fix: Prevent mispredicted freeze bars on other players (#11775)

### DIFF
--- a/src/game/client/components/freezebars.cpp
+++ b/src/game/client/components/freezebars.cpp
@@ -8,27 +8,45 @@ void CFreezeBars::RenderFreezeBar(const int ClientId)
 	const float FreezeBarHalfWidth = 32.0f;
 	const float FreezeBarHeight = 16.0f;
 
-	// pCharacter contains the predicted character for local players or the last snap for players who are spectated
-	CCharacterCore *pCharacter = &GameClient()->m_aClients[ClientId].m_Predicted;
+	const auto &CharSnap = GameClient()->m_Snap.m_aCharacters[ClientId];
+	if(!CharSnap.m_Active)
+		return;
 
-	if(pCharacter->m_FreezeEnd <= 0 || pCharacter->m_FreezeStart == 0 || pCharacter->m_FreezeEnd <= pCharacter->m_FreezeStart || !GameClient()->m_Snap.m_aCharacters[ClientId].m_HasExtendedDisplayInfo || (pCharacter->m_IsInFreeze && g_Config.m_ClFreezeBarsAlphaInsideFreeze == 0))
+	const bool IsLocal = (ClientId == GameClient()->m_aLocalIds[0] || ClientId == GameClient()->m_aLocalIds[1]);
+	const bool IsSpec = (GameClient()->m_Snap.m_SpecInfo.m_Active && ClientId == GameClient()->m_Snap.m_SpecInfo.m_SpectatorId);
+	int FreezeStart;
+	int FreezeEnd;
+	bool IsInFreeze;
+	if(IsLocal || IsSpec)
+	{
+		const CCharacterCore &Predicted = GameClient()->m_aClients[ClientId].m_Predicted;
+		FreezeStart = Predicted.m_FreezeStart;
+		FreezeEnd = Predicted.m_FreezeEnd;
+		IsInFreeze = Predicted.m_IsInFreeze;
+	}
+	else
+	{
+		FreezeStart = CharSnap.m_HasExtendedData ? CharSnap.m_ExtendedData.m_FreezeStart : 0;
+		FreezeEnd = CharSnap.m_HasExtendedData ? CharSnap.m_ExtendedData.m_FreezeEnd : 0;
+		IsInFreeze = CharSnap.m_HasExtendedData && (CharSnap.m_ExtendedData.m_Flags & CHARACTERFLAG_IN_FREEZE) != 0;
+	}
+
+	if(FreezeEnd <= 0 || FreezeStart == 0 || FreezeEnd <= FreezeStart || !CharSnap.m_HasExtendedDisplayInfo || (IsInFreeze && g_Config.m_ClFreezeBarsAlphaInsideFreeze == 0))
 	{
 		return;
 	}
 
-	const int Max = pCharacter->m_FreezeEnd - pCharacter->m_FreezeStart;
-	float FreezeProgress = std::clamp(Max - (Client()->GameTick(g_Config.m_ClDummy) - pCharacter->m_FreezeStart), 0, Max) / (float)Max;
+	const int Max = FreezeEnd - FreezeStart;
+	float FreezeProgress = std::clamp(Max - (Client()->GameTick(g_Config.m_ClDummy) - FreezeStart), 0, Max) / (float)Max;
 	if(FreezeProgress <= 0.0f)
-	{
 		return;
-	}
 
 	vec2 Position = GameClient()->m_aClients[ClientId].m_RenderPos;
 	Position.x -= FreezeBarHalfWidth;
 	Position.y += 32;
 
 	float Alpha = GameClient()->IsOtherTeam(ClientId) ? g_Config.m_ClShowOthersAlpha / 100.0f : 1.0f;
-	if(pCharacter->m_IsInFreeze)
+	if(IsInFreeze)
 	{
 		Alpha *= g_Config.m_ClFreezeBarsAlphaInsideFreeze / 100.0f;
 	}


### PR DESCRIPTION
Reopened as clean branch without merge commit:
Prevents freeze bars from appearing on other players when they are mispredicted into freeze on high-latency connections.
Fixes #11775

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
