### PR TITLE
Improve documentation for thread-safety of aborted jobs, fix potential thread-safety issue in community icon loading

### DIFF
--- a/src/engine/shared/jobs.h
+++ b/src/engine/shared/jobs.h
@@ -12,7 +12,15 @@
 #include <vector>
 
 /**
+ * Jobs and job pool.
+ *
+ * @defgroup Jobs Jobs
+ */
+
+/**
  * A job which runs in a worker thread of a job pool.
+ *
+ * @ingroup Jobs
  *
  * @see CJobPool
  */
@@ -125,6 +133,8 @@ public:
 
 /**
  * A job pool which runs jobs in one or more worker threads.
+ *
+ * @ingroup Jobs
  *
  * @see IJob
  */

--- a/src/engine/shared/jobs.h
+++ b/src/engine/shared/jobs.h
@@ -81,18 +81,22 @@ public:
 	 * Returns the state of the job.
 	 *
 	 * @remark Accessing jobs in any other way that with the base functions of `IJob`
-	 * is generally not thread-safe unless the job is in @link STATE_DONE @endlink
-	 * or has not been enqueued yet.
+	 * is generally not thread-safe unless the job is in `STATE_DONE` or has not been
+	 * enqueued yet.
 	 *
 	 * @return State of the job.
 	 */
 	EJobState State() const;
 
 	/**
-	 * Returns whether the job was completed, i.e. whether it's not still queued
-	 * or running.
+	 * Returns whether the job was completed or aborted, i.e. whether it's not still
+	 * queued or running.
 	 *
 	 * @return `true` if the job is done, `false` otherwise.
+	 *
+	 * @remark This function also considers aborted jobs to be done, but aborted jobs
+	 * may still be running until the cancelation is accepted. Ensure the job's state
+	 * is `STATE_DONE` before accessing any results of the job.
 	 */
 	bool Done() const;
 

--- a/src/game/client/components/community_icons.cpp
+++ b/src/game/client/components/community_icons.cpp
@@ -148,7 +148,7 @@ void CCommunityIcons::Update()
 		std::shared_ptr<CCommunityIconLoadJob> pJob = m_CommunityIconLoadJobs.front();
 		if(pJob->Done())
 		{
-			if(pJob->Success())
+			if(pJob->State() == IJob::STATE_DONE && pJob->Success())
 			{
 				LoadFinish(pJob->CommunityId(), pJob->ImageInfo(), pJob->ImageInfoGrayscale(), pJob->Sha256());
 			}


### PR DESCRIPTION
See commit messages.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions