### PR TITLE
Don't activate freeze bars on other tees from prediction (supersedes #11860)

### DIFF
--- a/src/game/client/components/freezebars.cpp
+++ b/src/game/client/components/freezebars.cpp
@@ -8,6 +8,11 @@ void CFreezeBars::RenderFreezeBar(const int ClientId)
 	const float FreezeBarHalfWidth = 32.0f;
 	const float FreezeBarHeight = 16.0f;
 
+	const bool LocalPredicted = ClientId == GameClient()->m_Snap.m_LocalClientId || (GameClient()->PredictDummy() && ClientId == GameClient()->m_aLocalIds[!g_Config.m_ClDummy]);
+	const CGameClient::CSnapState::CCharacterInfo &CharacterInfo = GameClient()->m_Snap.m_aCharacters[ClientId];
+	if(!LocalPredicted && CharacterInfo.m_HasExtendedData && CharacterInfo.m_ExtendedData.m_FreezeEnd <= 0)
+		return;
+
 	// pCharacter contains the predicted character for local players or the last snap for players who are spectated
 	CCharacterCore *pCharacter = &GameClient()->m_aClients[ClientId].m_Predicted;
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
Fixes #11775
Supersedes #11860

This fixes freeze bars from activating when tees are mispredicted into freeze but we still use the predicted freeze duration so players can accurately time their gameplay. 

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
