### PR TITLE
Fix editor map not being saved if editor is quit before job is done

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -7288,24 +7288,12 @@ void CEditor::HandleWriterFinishJobs()
 		return;
 	m_WriterFinishJobs.pop_front();
 
-	char aBuf[2 * IO_MAX_PATH_LENGTH + 128];
-	if(!Storage()->RemoveFile(pJob->GetRealFilename(), IStorage::TYPE_SAVE))
+	const char *pErrorMessage = pJob->ErrorMessage();
+	if(pErrorMessage[0] != '\0')
 	{
-		str_format(aBuf, sizeof(aBuf), "Saving failed: Could not remove old map file '%s'.", pJob->GetRealFilename());
-		ShowFileDialogError("%s", aBuf);
-		log_error("editor/save", "%s", aBuf);
+		ShowFileDialogError("%s", pErrorMessage);
 		return;
 	}
-
-	if(!Storage()->RenameFile(pJob->GetTempFilename(), pJob->GetRealFilename(), IStorage::TYPE_SAVE))
-	{
-		str_format(aBuf, sizeof(aBuf), "Saving failed: Could not move temporary map file '%s' to '%s'.", pJob->GetTempFilename(), pJob->GetRealFilename());
-		ShowFileDialogError("%s", aBuf);
-		log_error("editor/save", "%s", aBuf);
-		return;
-	}
-
-	log_trace("editor/save", "Saved map to '%s'.", pJob->GetRealFilename());
 
 	// send rcon.. if we can
 	if(Client()->RconAuthed() && g_Config.m_EdAutoMapReload)
@@ -7315,8 +7303,8 @@ void CEditor::HandleWriterFinishJobs()
 
 		if(net_addr_is_local(&Client()->ServerAddress()))
 		{
-			char aMapName[128];
-			IStorage::StripPathAndExtension(pJob->GetRealFilename(), aMapName, sizeof(aMapName));
+			char aMapName[MAX_MAP_LENGTH];
+			IStorage::StripPathAndExtension(pJob->RealFilename(), aMapName, sizeof(aMapName));
 			if(!str_comp(aMapName, CurrentServerInfo.m_aMap))
 				Client()->Rcon("hot_reload");
 		}
@@ -7470,8 +7458,12 @@ void CEditor::LoadCurrentMap()
 bool CEditor::Save(const char *pFilename)
 {
 	// Check if file with this name is already being saved at the moment
-	if(std::any_of(std::begin(m_WriterFinishJobs), std::end(m_WriterFinishJobs), [pFilename](const std::shared_ptr<CDataFileWriterFinishJob> &Job) { return str_comp(pFilename, Job->GetRealFilename()) == 0; }))
+	if(std::any_of(std::begin(m_WriterFinishJobs), std::end(m_WriterFinishJobs), [pFilename](const std::shared_ptr<CDataFileWriterFinishJob> &Job) {
+		   return str_comp(pFilename, Job->RealFilename()) == 0;
+	   }))
+	{
 		return false;
+	}
 
 	const auto &&ErrorHandler = [this](const char *pErrorMessage) {
 		ShowFileDialogError("%s", pErrorMessage);

--- a/src/game/editor/mapitems/map.h
+++ b/src/game/editor/mapitems/map.h
@@ -35,16 +35,18 @@ class IEditorEnvelopeReference;
 
 class CDataFileWriterFinishJob : public IJob
 {
+	IStorage *m_pStorage;
 	char m_aRealFilename[IO_MAX_PATH_LENGTH];
 	char m_aTempFilename[IO_MAX_PATH_LENGTH];
+	char m_aErrorMessage[2 * IO_MAX_PATH_LENGTH + 128];
 	CDataFileWriter m_Writer;
 
 	void Run() override;
 
 public:
-	CDataFileWriterFinishJob(const char *pRealFilename, const char *pTempFilename, CDataFileWriter &&Writer);
-	const char *GetRealFilename() const { return m_aRealFilename; }
-	const char *GetTempFilename() const { return m_aTempFilename; }
+	CDataFileWriterFinishJob(IStorage *pStorage, const char *pRealFilename, const char *pTempFilename, CDataFileWriter &&Writer);
+	const char *RealFilename() const { return m_aRealFilename; }
+	const char *ErrorMessage() const { return m_aErrorMessage; }
 };
 
 using FErrorHandler = std::function<void(const char *pErrorMessage)>;

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -36,13 +36,31 @@ public:
 void CDataFileWriterFinishJob::Run()
 {
 	m_Writer.Finish();
+
+	if(!m_pStorage->RemoveFile(m_aRealFilename, IStorage::TYPE_SAVE))
+	{
+		str_format(m_aErrorMessage, sizeof(m_aErrorMessage), "Saving failed: Could not remove old map file '%s'.", m_aRealFilename);
+		log_error("editor/save", "%s", m_aErrorMessage);
+		return;
+	}
+
+	if(!m_pStorage->RenameFile(m_aTempFilename, m_aRealFilename, IStorage::TYPE_SAVE))
+	{
+		str_format(m_aErrorMessage, sizeof(m_aErrorMessage), "Saving failed: Could not move temporary map file '%s' to '%s'.", m_aTempFilename, m_aRealFilename);
+		log_error("editor/save", "%s", m_aErrorMessage);
+		return;
+	}
+
+	log_trace("editor/save", "Saved map to '%s'.", m_aRealFilename);
 }
 
-CDataFileWriterFinishJob::CDataFileWriterFinishJob(const char *pRealFilename, const char *pTempFilename, CDataFileWriter &&Writer) :
+CDataFileWriterFinishJob::CDataFileWriterFinishJob(IStorage *pStorage, const char *pRealFilename, const char *pTempFilename, CDataFileWriter &&Writer) :
+	m_pStorage(pStorage),
 	m_Writer(std::move(Writer))
 {
 	str_copy(m_aRealFilename, pRealFilename);
 	str_copy(m_aTempFilename, pTempFilename);
+	m_aErrorMessage[0] = '\0';
 }
 
 bool CEditorMap::Save(const char *pFilename, const FErrorHandler &ErrorHandler)
@@ -413,7 +431,7 @@ bool CEditorMap::Save(const char *pFilename, const FErrorHandler &ErrorHandler)
 	}
 
 	// finish the data file
-	std::shared_ptr<CDataFileWriterFinishJob> pWriterFinishJob = std::make_shared<CDataFileWriterFinishJob>(pFilename, aFilenameTmp, std::move(Writer));
+	std::shared_ptr<CDataFileWriterFinishJob> pWriterFinishJob = std::make_shared<CDataFileWriterFinishJob>(m_pEditor->Storage(), pFilename, aFilenameTmp, std::move(Writer));
 	m_pEditor->Engine()->AddJob(pWriterFinishJob);
 	m_pEditor->m_WriterFinishJobs.push_back(pWriterFinishJob);
 


### PR DESCRIPTION
The final renaming of the editor map was only performed while the editor is open, so if the editor or client is closed before the datafile writer job is done, the file would not be renamed to its final filename.

This is fixed by also renaming the file within the job and storing the error message so it can be shown with a popup from the main thread in the editor. If the client is quit while a datafile writer job is running, the client will wait for the job to complete, as this job cannot be aborted.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions