### PR TITLE
Improve and consolidate server join/leave logging

### DIFF
--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -632,7 +632,7 @@ def client_can_connect(test_env):
 	server = test_env.server()
 	wait_for_startup([client, server])
 	client.command(f"connect localhost:{server.port}")
-	server.wait_for_log_prefix("server: player has entered the game", timeout=10)
+	server.wait_for_log_prefix("server: player has entered the game.", timeout=10)
 	server.exit()
 	client.wait_for_log_exact("client: offline error='Server shutdown'")
 	client.exit()
@@ -646,7 +646,7 @@ def client_can_connect_7(test_env):
 	server = test_env.server()
 	wait_for_startup([client, server])
 	client.command(f"connect tw-0.7+udp://localhost:{server.port}")
-	server.wait_for_log_prefix("server: player has entered the game", timeout=10)
+	server.wait_for_log_prefix("server: player has entered the game.", timeout=10)
 	server.exit()
 	client.wait_for_log_exact("client: offline error='Server shutdown'")
 	client.exit()
@@ -677,14 +677,14 @@ def smoke_test(test_env):
 	client1.command("debug 1")
 	client1.command("stdout_output_level 2; loglevel 2")
 	client1.command(f"connect localhost:{server.port}")
-	server.wait_for_log_prefix("server: player has entered the game", timeout=10)
+	server.wait_for_log_prefix("server: player has entered the game.", timeout=10)
 	client1.wait_for_log_exact("client: state change. last=2 current=3", timeout=15)
 	client1.command("stdout_output_level 0; loglevel 0")
 	client1.command("debug 0")
 	client1.command("record client1")
 
 	client2.command(f"connect localhost:{server.port}")
-	server.wait_for_log_prefix("server: player has entered the game", timeout=10)
+	server.wait_for_log_prefix("server: player has entered the game.", timeout=10)
 	for _ in range(5):
 		server.wait_for_log(
 			lambda l: l.line.startswith("chat: *** client1 finished in:") or l.line.startswith("chat: *** client2 finished in:"),
@@ -746,7 +746,7 @@ def smoke_test(test_env):
 	client1.command("rcon sv_map Tutorial")
 
 	for _ in range(2):
-		server.wait_for_log_prefix("server: player has entered the game", timeout=10)
+		server.wait_for_log_prefix("server: player has entered the game.", timeout=10)
 
 	client1.clear_events()
 	client2.clear_events()

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -296,13 +296,13 @@ const char *CServer::DnsblStateStr(EDnsblState State)
 	switch(State)
 	{
 	case EDnsblState::NONE:
-		return "n/a";
+		return "none";
 	case EDnsblState::PENDING:
 		return "pending";
 	case EDnsblState::BLACKLISTED:
-		return "black";
+		return "blacklisted";
 	case EDnsblState::WHITELISTED:
-		return "white";
+		return "whitelisted";
 	}
 
 	dbg_assert_failed("Invalid dnsbl State: %d", static_cast<int>(State));
@@ -2013,12 +2013,17 @@ void CServer::OnNetMsgEnterGame(int ClientId)
 	if(!GameServer()->IsClientReady(ClientId))
 		return;
 
+	const char *pProtocol = IsSixup(ClientId) ? "0.7" : "0.6";
+	const int Version = m_aClients[ClientId].m_DDNetVersion >= 0 ? m_aClients[ClientId].m_DDNetVersion : VERSION_VANILLA;
+	const char *pName = m_aClients[ClientId].m_aName[0] != '\0' ? m_aClients[ClientId].m_aName : "(connecting)";
 	log_info(
 		"server",
-		"player has entered the game. ClientId=%d addr=<{%s}> sixup=%d",
+		"player has entered the game. ClientId=%d name='%s' addr=<{%s}> protocol=%s version=%d",
 		ClientId,
+		pName,
 		ClientAddrString(ClientId, true),
-		IsSixup(ClientId));
+		pProtocol,
+		Version);
 	m_aClients[ClientId].m_State = CClient::STATE_INGAME;
 	if(!IsSixup(ClientId))
 	{

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1865,6 +1865,18 @@ void CGameContext::OnClientDrop(int ClientId, const char *pReason)
 {
 	LogEvent("Disconnect", ClientId);
 
+	if(Server()->ClientIngame(ClientId))
+	{
+		const char *pLeaveReason = pReason != nullptr ? pReason : "";
+		log_info(
+			"server",
+			"player has left the game. ClientId=%d name='%s' addr=<{%s}> reason='%s'",
+			ClientId,
+			Server()->ClientName(ClientId),
+			Server()->ClientAddrString(ClientId, true),
+			pLeaveReason);
+	}
+
 	AbortVoteKickOnDisconnect(ClientId);
 	m_pController->OnPlayerDisconnect(m_apPlayers[ClientId], pReason);
 	delete m_apPlayers[ClientId];
@@ -1979,7 +1991,6 @@ bool CGameContext::OnClientDDNetVersionKnown(int ClientId)
 	IServer::CClientInfo Info;
 	dbg_assert(Server()->GetClientInfo(ClientId, &Info), "failed to get client info");
 	int ClientVersion = Info.m_DDNetVersion;
-	dbg_msg("ddnet", "cid=%d version=%d", ClientId, ClientVersion);
 
 	if(m_TeeHistorianActive)
 	{

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -444,9 +444,6 @@ void IGameController::OnPlayerDisconnect(class CPlayer *pPlayer, const char *pRe
 		else
 			str_format(aBuf, sizeof(aBuf), "'%s' has left the game", Server()->ClientName(ClientId));
 		GameServer()->SendChat(-1, TEAM_ALL, aBuf, -1, CGameContext::FLAG_SIX);
-
-		str_format(aBuf, sizeof(aBuf), "leave player='%d:%s'", ClientId, Server()->ClientName(ClientId));
-		GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "game", aBuf);
 	}
 }
 


### PR DESCRIPTION
This continues the logging work from #11318 and addresses more of #11317.

What I changed:

- Added a structured join log line in the server log: `server: player has entered the game. ClientId=... name='...' addr=<{...}> protocol=... version=...`
- Added a structured leave log line in the server log: `server: player has left the game. ClientId=... name='...' addr=<{...}> reason='...'`
- Replaced protocol output (sixup=0/1) with more explicit protocol values (protocol=0.6/0.7) in join logging.
- Normalized DNSBL state strings to explicit values (none, pending, blacklisted, whitelisted) where DNSBL state is logged.
I also removed redundant/duplicate join and leave log lines from the old locations, so each event is logged once in the intended place.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions