### PR TITLE
Add Antiping Shadow

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -24,6 +24,8 @@ MACRO_CONFIG_INT(ClAntiPingWeapons, cl_antiping_weapons, 1, 0, 1, CFGFLAG_CLIENT
 MACRO_CONFIG_INT(ClAntiPingSmooth, cl_antiping_smooth, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Make the prediction of other player's movement smoother")
 MACRO_CONFIG_INT(ClAntiPingGunfire, cl_antiping_gunfire, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Predict gunfire and show predicted weapon physics (with cl_antiping_grenade 1 and cl_antiping_weapons 1)")
 MACRO_CONFIG_INT(ClAntiPingPreInput, cl_antiping_preinput, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Predict other players using preinputs for more accurate input prediction")
+MACRO_CONFIG_INT(ClAntipingShadow, cl_antiping_shadow, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show predicted shadow tee (0 = off, 1 = on)")
+MACRO_CONFIG_INT(ClAntipingShadowAlpha, cl_antiping_shadow_alpha, 75, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Alpha % of antiping ghost")
 MACRO_CONFIG_INT(ClPredictionMargin, cl_prediction_margin, 10, 1, 300, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Prediction margin in ms (adds latency, can reduce lag from ping jumps)")
 MACRO_CONFIG_INT(ClSubTickAiming, cl_sub_tick_aiming, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Send aiming data at sub-tick accuracy")
 #if defined(CONF_PLATFORM_ANDROID)

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -881,7 +881,15 @@ void CNamePlates::OnRender()
 		// Only render name plates for active characters
 		if(GameClient()->m_Snap.m_aCharacters[i].m_Active)
 		{
-			const vec2 RenderPos = GameClient()->m_aClients[i].m_RenderPos;
+			vec2 RenderPos = GameClient()->m_aClients[i].m_RenderPos;
+
+			bool Local = GameClient()->m_Snap.m_LocalClientId == i;
+
+			if(!Local && g_Config.m_ClAntipingShadow)
+				RenderPos = mix(
+					vec2(GameClient()->m_Snap.m_aCharacters[i].m_Prev.m_X, GameClient()->m_Snap.m_aCharacters[i].m_Prev.m_Y),
+					vec2(GameClient()->m_Snap.m_aCharacters[i].m_Cur.m_X, GameClient()->m_Snap.m_aCharacters[i].m_Cur.m_Y),
+					Client()->IntraGameTick(g_Config.m_ClDummy));
 			RenderNamePlateGame(RenderPos, pInfo, 1.0f);
 		}
 	}

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -472,6 +472,11 @@ void CPlayers::RenderHook(
 	if(ClientId >= 0)
 		Intra = GameClient()->m_aClients[ClientId].m_IsPredicted ? Client()->PredIntraGameTick(g_Config.m_ClDummy) : Client()->IntraGameTick(g_Config.m_ClDummy);
 
+	bool Local = GameClient()->m_Snap.m_LocalClientId == ClientId;
+
+	if(!Local && g_Config.m_ClAntipingShadow)
+		Intra = Client()->IntraGameTick(g_Config.m_ClDummy);
+
 	bool OtherTeam = GameClient()->IsOtherTeam(ClientId);
 	float Alpha = (OtherTeam || ClientId < 0) ? g_Config.m_ClShowOthersAlpha / 100.0f : 1.0f;
 	if(ClientId == -2) // ghost
@@ -480,7 +485,7 @@ void CPlayers::RenderHook(
 	RenderInfo.m_Size = 64.0f;
 
 	vec2 Position;
-	if(in_range(ClientId, MAX_CLIENTS - 1))
+	if(in_range(ClientId, MAX_CLIENTS - 1) && !(!Local && g_Config.m_ClAntipingShadow))
 		Position = GameClient()->m_aClients[ClientId].m_RenderPos;
 	else
 		Position = mix(vec2(Prev.m_X, Prev.m_Y), vec2(Player.m_X, Player.m_Y), Intra);
@@ -493,7 +498,7 @@ void CPlayers::RenderHook(
 	vec2 Pos = Position;
 	vec2 HookPos;
 
-	if(in_range(pPlayerChar->m_HookedPlayer, MAX_CLIENTS - 1))
+	if(in_range(pPlayerChar->m_HookedPlayer, MAX_CLIENTS - 1) && !(GameClient()->m_Snap.m_LocalClientId != pPlayerChar->m_HookedPlayer && g_Config.m_ClAntipingShadow))
 		HookPos = GameClient()->m_aClients[pPlayerChar->m_HookedPlayer].m_RenderPos;
 	else
 		HookPos = mix(vec2(Prev.m_HookX, Prev.m_HookY), vec2(Player.m_HookX, Player.m_HookY), Intra);
@@ -585,6 +590,14 @@ void CPlayers::RenderPlayer(
 	else
 		Position = mix(vec2(Prev.m_X, Prev.m_Y), vec2(Player.m_X, Player.m_Y), Intra);
 	vec2 Vel = mix(vec2(Prev.m_VelX / 256.0f, Prev.m_VelY / 256.0f), vec2(Player.m_VelX / 256.0f, Player.m_VelY / 256.0f), Intra);
+
+	vec2 PredPosition = Position;
+
+	if(!Local && g_Config.m_ClAntipingShadow)
+		Position = mix(
+			vec2(GameClient()->m_Snap.m_aCharacters[ClientId].m_Prev.m_X, GameClient()->m_Snap.m_aCharacters[ClientId].m_Prev.m_Y),
+			vec2(GameClient()->m_Snap.m_aCharacters[ClientId].m_Cur.m_X, GameClient()->m_Snap.m_aCharacters[ClientId].m_Cur.m_Y),
+			Client()->IntraGameTick(g_Config.m_ClDummy));
 
 	GameClient()->m_Flow.Add(Position, Vel * 100.0f, 10.0f);
 
@@ -832,7 +845,13 @@ void CPlayers::RenderPlayer(
 		RenderTools()->RenderTee(&State, &RenderInfo, Player.m_Emote, Direction, ShadowPosition, g_Config.m_ClUnpredictedShadowAlpha / 100.f); // render ghost
 	}
 
-	RenderTools()->RenderTee(&State, &RenderInfo, Player.m_Emote, Direction, Position, Alpha);
+	if(!Local && g_Config.m_ClAntipingShadow)
+	{
+		RenderTools()->RenderTee(&State, &RenderInfo, Player.m_Emote, Direction, PredPosition, g_Config.m_ClAntipingShadowAlpha * 0.01); // render ghost
+		RenderTools()->RenderTee(&State, &RenderInfo, Player.m_Emote, Direction, Position, Alpha);
+	}
+	else
+		RenderTools()->RenderTee(&State, &RenderInfo, Player.m_Emote, Direction, Position, Alpha);
 
 	float TeeAnimScale, TeeBaseSize;
 	CRenderTools::GetRenderTeeAnimScaleAndBaseSize(&RenderInfo, TeeAnimScale, TeeBaseSize);
@@ -990,7 +1009,11 @@ void CPlayers::OnRender()
 		{
 			continue;
 		}
-		RenderHook(&GameClient()->m_aClients[ClientId].m_RenderPrev, &GameClient()->m_aClients[ClientId].m_RenderCur, &aRenderInfo[ClientId], ClientId);
+
+		if(g_Config.m_ClAntipingShadow)
+			RenderHook(&GameClient()->m_Snap.m_aCharacters[ClientId].m_Prev, &GameClient()->m_Snap.m_aCharacters[ClientId].m_Cur, &aRenderInfo[ClientId], ClientId, Client()->IntraGameTick(g_Config.m_ClDummy));
+		else
+			RenderHook(&GameClient()->m_aClients[ClientId].m_RenderPrev, &GameClient()->m_aClients[ClientId].m_RenderCur, &aRenderInfo[ClientId], ClientId);
 	}
 	if(LocalClientId != -1 && IsPlayerInfoAvailable(LocalClientId))
 	{


### PR DESCRIPTION
A friend of mine with high ping always preferred this old client's antiping implementation.
This is replicating that feature.

https://github.com/user-attachments/assets/d3cb8cac-dd86-4430-8846-a955055c9a0b

Antiping player prediction will show as a partially transparent (adjustable with cl_antiping_shadow_alpha) behind the original non predicted player. The video is a slightly older build, new one moves nameplate and hooks to the non predicted tee as well.

This is heavily preferred by my friend, surely he can't be the only one. I think it probably especially helps with PvP mods, which I know isn't the main focus of DDNet but the change is relatively small and should be easily maintainable.
Basically shows the finer body language thats hard to see with only Antiping shown whilst also showing where to aim.

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
