### PR TITLE
Improve fatal error popups for graphics errors

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -180,16 +180,25 @@ void CGraphicsBackend_Threaded::WaitForIdle()
 
 void CGraphicsBackend_Threaded::ProcessError(const SGfxErrorContainer &Error)
 {
-	std::string VerboseStr = "Graphics Assertion:";
+	m_FatalError = "";
 	for(const auto &ErrStr : Error.m_vErrors)
 	{
-		VerboseStr.append("\n");
+		if(!m_FatalError.empty())
+		{
+			m_FatalError.append("\n");
+		}
 		if(ErrStr.m_RequiresTranslation)
-			VerboseStr.append(m_TranslateFunc(ErrStr.m_Err.c_str(), ""));
+			m_FatalError.append(m_TranslateFunc(ErrStr.m_Err.c_str(), ""));
 		else
-			VerboseStr.append(ErrStr.m_Err);
+			m_FatalError.append(ErrStr.m_Err);
 	}
-	dbg_assert_failed("%s", VerboseStr.c_str());
+	std::string LogMessage = "Graphics Error:\n" + m_FatalError;
+	dbg_assert_failed("%s", LogMessage.c_str());
+}
+
+const char *CGraphicsBackend_Threaded::GetFatalError() const
+{
+	return m_FatalError.c_str();
 }
 
 bool CGraphicsBackend_Threaded::GetWarning(std::vector<std::string> &WarningStrings)

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -46,6 +46,7 @@ class CGraphicsBackend_Threaded : public IGraphicsBackend
 {
 private:
 	TTranslateFunc m_TranslateFunc;
+	std::string m_FatalError;
 	SGfxWarningContainer m_Warning;
 
 public:
@@ -94,6 +95,7 @@ private:
 #endif
 
 public:
+	const char *GetFatalError() const override;
 	bool GetWarning(std::vector<std::string> &WarningStrings) override;
 };
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3104,8 +3104,20 @@ void CClient::Run()
 		if(!Success)
 		{
 			log_error("client", "Failed to initialize the graphics (see details above)");
-			std::string Message = std::string("Failed to initialize the graphics. See details below.\n\n") + MemoryLogger.ConcatenatedLines();
-			ShowMessageBox({.m_pTitle = "Graphics Error", .m_pMessage = Message.c_str()});
+			const std::string Message = std::string(
+							    "Failed to initialize the graphics. See details below.\n\n"
+							    "For detailed troubleshooting instructions please read our Wiki:\n"
+							    "https://wiki.ddnet.org/wiki/GFX_Troubleshooting\n\n") +
+						    MemoryLogger.ConcatenatedLines();
+			const std::vector<IGraphics::CMessageBoxButton> vButtons = {
+				{.m_pLabel = "Show Wiki"},
+				{.m_pLabel = "OK", .m_Confirm = true, .m_Cancel = true},
+			};
+			const std::optional<int> MessageResult = ShowMessageBox({.m_pTitle = "Graphics Initialization Error", .m_pMessage = Message.c_str(), .m_vButtons = vButtons});
+			if(MessageResult && *MessageResult == 0)
+			{
+				ViewLink("https://wiki.ddnet.org/wiki/GFX_Troubleshooting");
+			}
 			return;
 		}
 	}
@@ -4736,22 +4748,58 @@ int main(int argc, const char **argv)
 	dbg_assert_set_handler([MainThreadId, pClient](const char *pMsg) {
 		if(MainThreadId != std::this_thread::get_id())
 			return;
+
+		const char *pGraphicsError = pClient->Graphics() == nullptr ? "" : pClient->Graphics()->GetFatalError();
+		const bool GotGraphicsError = pGraphicsError[0] != '\0';
+		const char *pTitle;
+		const char *pPreamble;
+		const char *pPostamble;
+		if(GotGraphicsError)
+		{
+			pTitle = "Graphics Error";
+			pPreamble =
+				"A graphics error occurred. Please see details and instructions below.\n\n";
+			pPostamble =
+				"For detailed troubleshooting instructions please read our Wiki:\n"
+				"https://wiki.ddnet.org/wiki/GFX_Troubleshooting\n\n"
+				"If this did not resolve the issue, please take a screenshot and report this error.\n"
+				"Please also share the assert log"
+#if defined(CONF_CRASHDUMP)
+				" and crash log"
+#endif
+				" found in the 'dumps' folder in your config directory.\n\n";
+			// This is more human readable and we don't care about the source location here,
+			// because all graphics assertions come from CGraphicsBackend_Threaded::ProcessError
+			// and the original message is also logged separately by the assertion system.
+			pMsg = pGraphicsError;
+		}
+		else
+		{
+			pTitle = "Assertion Error";
+			pPreamble =
+				"An assertion error occurred. Please take a screenshot and report this error.\n"
+				"Please also share the assert log"
+#if defined(CONF_CRASHDUMP)
+				" and crash log"
+#endif
+				" found in the 'dumps' folder in your config directory.\n\n";
+			pPostamble = "";
+		}
+
 		char aOsVersionString[128];
 		if(!os_version_str(aOsVersionString, sizeof(aOsVersionString)))
 		{
 			str_copy(aOsVersionString, "unknown");
 		}
+
 		char aGpuInfo[512];
 		pClient->GetGpuInfoString(aGpuInfo);
+
 		char aMessage[2048];
 		str_format(aMessage, sizeof(aMessage),
-			"An assertion error occurred. Please write down or take a screenshot of the following information and report this error.\n"
-			"Please also share the assert log"
-#if defined(CONF_CRASHDUMP)
-			" and crash log"
-#endif
-			" which you should find in the 'dumps' folder in your config directory.\n\n"
+			"%s"
 			"%s\n\n"
+			"%s"
 			"Platform: %s (%s)\n"
 			"Configuration: base"
 #if defined(CONF_AUTOUPDATE)
@@ -4776,7 +4824,9 @@ int main(int argc, const char **argv)
 			"Game version: %s %s %s\n"
 			"OS version: %s\n\n"
 			"%s", // GPU info
+			pPreamble,
 			pMsg,
+			pPostamble,
 			CONF_PLATFORM_STRING, CONF_ARCH_ENDIAN_STRING,
 			GAME_NAME, GAME_RELEASE_VERSION, GIT_SHORTREV_HASH != nullptr ? GIT_SHORTREV_HASH : "",
 			aOsVersionString,
@@ -4784,6 +4834,10 @@ int main(int argc, const char **argv)
 		// Also log all of this information to the assertion log file
 		log_error("assertion", "%s", aMessage);
 		std::vector<IGraphics::CMessageBoxButton> vButtons;
+		if(GotGraphicsError)
+		{
+			vButtons.push_back({.m_pLabel = "Show Wiki"});
+		}
 		// Storage may not have been initialized yet and viewing files is not supported on Android yet
 #if !defined(CONF_PLATFORM_ANDROID)
 		if(pClient->Storage() != nullptr)
@@ -4792,16 +4846,18 @@ int main(int argc, const char **argv)
 		}
 #endif
 		vButtons.push_back({.m_pLabel = "OK", .m_Confirm = true, .m_Cancel = true});
-		const std::optional<int> MessageResult = pClient->ShowMessageBox({.m_pTitle = "Assertion Error", .m_pMessage = aMessage, .m_vButtons = vButtons});
+		const std::optional<int> MessageResult = pClient->ShowMessageBox({.m_pTitle = pTitle, .m_pMessage = aMessage, .m_vButtons = vButtons});
+		if(GotGraphicsError && MessageResult && *MessageResult == 0)
+		{
+			pClient->ViewLink("https://wiki.ddnet.org/wiki/GFX_Troubleshooting");
+		}
 #if !defined(CONF_PLATFORM_ANDROID)
-		if(pClient->Storage() != nullptr && MessageResult && *MessageResult == 0)
+		if(pClient->Storage() != nullptr && MessageResult && *MessageResult == (GotGraphicsError ? 1 : 0))
 		{
 			char aDumpsPath[IO_MAX_PATH_LENGTH];
 			pClient->Storage()->GetCompletePath(IStorage::TYPE_SAVE, "dumps", aDumpsPath, sizeof(aDumpsPath));
 			pClient->ViewFile(aDumpsPath);
 		}
-#else
-		(void)MessageResult;
 #endif
 		// Client will crash due to assertion, don't call PerformAllCleanup in this inconsistent state
 	});

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -2922,6 +2922,11 @@ const char *CGraphics_Threaded::GetRendererString()
 	return m_pBackend->GetRendererString();
 }
 
+const char *CGraphics_Threaded::GetFatalError() const
+{
+	return m_pBackend == nullptr ? "" : m_pBackend->GetFatalError();
+}
+
 TGLBackendReadPresentedImageData &CGraphics_Threaded::GetReadPresentedImageDataFuncUnsafe()
 {
 	return m_pBackend->GetReadPresentedImageDataFuncUnsafe();

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -730,6 +730,7 @@ public:
 	// be aware that this function should only be called from the graphics thread, and even then you should really know what you are doing
 	virtual TGLBackendReadPresentedImageData &GetReadPresentedImageDataFuncUnsafe() = 0;
 
+	virtual const char *GetFatalError() const = 0;
 	virtual bool GetWarning(std::vector<std::string> &WarningStrings) = 0;
 
 	/**
@@ -1269,6 +1270,7 @@ public:
 	const char *GetVendorString() override;
 	const char *GetVersionString() override;
 	const char *GetRendererString() override;
+	const char *GetFatalError() const override;
 
 	TGLBackendReadPresentedImageData &GetReadPresentedImageDataFuncUnsafe() override;
 };

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -346,6 +346,7 @@ public:
 	virtual const char *GetVendorString() = 0;
 	virtual const char *GetVersionString() = 0;
 	virtual const char *GetRendererString() = 0;
+	virtual const char *GetFatalError() const = 0;
 
 	class CLineItem
 	{


### PR DESCRIPTION
Distinguish the graphics error popup from general popups for assertion errors. Instead of directing the user to report the error, first instruct them to read the error message and follow the troubleshooting instructions on the Wiki. Afterwards, direct them to report the error if the instructions did not help.

Slightly simplify the instructions to share the error by removing the suggestion to write down the error, which was never done by users, in favor of simply taking a screenshot.

Add button to open the Wiki in a browser to the graphics error popup.

Also add a Wiki link and button to open it to the graphics initialization error popup.

To allow the client to determine whether it is crashing due to a graphics error in the assert handler, the graphics and backend now expose the error string when graphics are crashing due to assertion error.

Screenshots:

<img src="https://github.com/user-attachments/assets/eee3b4a4-ff66-42cf-9eb6-ede3b6ada9f1" />

<img src="https://github.com/user-attachments/assets/f968221d-79bd-4118-9fa6-0ac3c4789ee7" />


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options:
   - Vulkan
   - OpenGL: does not use the fatal graphics error system yet, as the error-results of most OpenGL function calls are ignored
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
