### PR TITLE
Use gtest logging instead of `dbg_msg` in editor test

### DIFF
--- a/src/test/editor_test.cpp
+++ b/src/test/editor_test.cpp
@@ -1,4 +1,4 @@
-#include <base/system.h>
+#include <base/str.h>
 
 #include <gtest/gtest.h>
 
@@ -78,13 +78,7 @@ bool IsValidEditorTooltip(const char *pTooltip, char *pErrorMsg, int ErrorMsgSiz
 void AssertTooltip(const char *pTooltip)
 {
 	char aError[512];
-	bool IsValid = IsValidEditorTooltip(pTooltip, aError, sizeof(aError));
-	if(!IsValid)
-	{
-		dbg_msg("test", "Invalid tooltip: %s", pTooltip);
-		dbg_msg("test", "ERROR: %s", aError);
-	}
-	EXPECT_TRUE(IsValid);
+	EXPECT_TRUE(IsValidEditorTooltip(pTooltip, aError, sizeof(aError))) << "Invalid tooltip: " << pTooltip << "\nError: " << aError;
 }
 
 TEST(Editor, QuickActionNames)


### PR DESCRIPTION
```
ddnet/src/test/editor_test.cpp:81: Failure
Value of: IsValidEditorTooltip(pTooltip, aError, sizeof(aError))
  Actual: false
Expected: true
Invalid tooltip: [Ctrl+Q] Add a new sound source.
Error: expected character 'r' at index 3 to be upper case
```

## Checklist

- [X] Tested the change
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
