### PR TITLE
Document MSRV in Cargo.toml of crates involved in server/client

### DIFF
--- a/src/base/Cargo.toml
+++ b/src/base/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ddnet-base"
 version = "0.0.1"
 edition = "2021"
+rust-version = "1.63"
 publish = false
 license = "Zlib"
 

--- a/src/engine/Cargo.toml
+++ b/src/engine/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ddnet-engine"
 version = "0.0.1"
 edition = "2021"
+rust-version = "1.63"
 publish = false
 license = "Zlib"
 

--- a/src/engine/shared/Cargo.toml
+++ b/src/engine/shared/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ddnet-engine-shared"
 version = "0.0.1"
 edition = "2021"
+rust-version = "1.63"
 publish = false
 license = "Zlib"
 

--- a/src/rust-bridge/test/Cargo.toml
+++ b/src/rust-bridge/test/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ddnet-test"
 version = "0.0.1"
 edition = "2021"
+rust-version = "1.63"
 publish = false
 license = "Zlib"
 


### PR DESCRIPTION
Cargo.toml has a field for the minimum supported Rust version. Specify that as it helps other Rust tools to not make changes that are only available on newer Rust versions.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions