### PR TITLE
Fix: airjump beeing detected if you only have 1 jump

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2363,7 +2363,22 @@ void CGameClient::OnNewSnapshot()
 				if(IsOtherTeam(i))
 					Alpha = g_Config.m_ClShowOthersAlpha / 100.0f;
 				const float Volume = 1.0f; // TODO snd_game_volume_others
-				m_Effects.AirJump(Pos, Alpha, Volume);
+
+				bool Grounded = false;
+				if(Collision()->CheckPoint(m_Snap.m_aCharacters[i].m_Prev.m_X + CCharacterCore::PhysicalSize() / 2,
+					   m_Snap.m_aCharacters[i].m_Prev.m_Y + CCharacterCore::PhysicalSize() / 2 + 5))
+				{
+					Grounded = true;
+				}
+				if(Collision()->CheckPoint(m_Snap.m_aCharacters[i].m_Prev.m_X - CCharacterCore::PhysicalSize() / 2,
+					   m_Snap.m_aCharacters[i].m_Prev.m_Y + CCharacterCore::PhysicalSize() / 2 + 5))
+				{
+					Grounded = true;
+				}
+				if(!Grounded)
+				{
+					m_Effects.AirJump(Pos, Alpha, Volume);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

If you spectate a player who only has one jump or have a demo of a player who only has one jump, you can have false AIR_JUMP particles. This PR adds a ground jump detection. Unfortunately you can't have this info from the `m_Jumped` flag alone. I tested this ingame and in a demo, I attached the demo file. At first I was working with the interpolated position, but turns out we need to use the PREV position here, as the Tee is starting to move upwards after a groundjump.

[KingsLeap-Benchmark.zip](https://github.com/user-attachments/files/25872471/KingsLeap-Benchmark.zip)

closes #4656
is maybe unopening #4356
related #5568

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
