### PR TITLE
Use DoLabelStreamed for scoreboard in server browser info

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -526,6 +526,7 @@ protected:
 	};
 	static CUi::EPopupMenuFunctionResult PopupCountrySelection(void *pContext, CUIRect View, bool Active);
 	void RenderServerbrowserInfo(CUIRect View);
+	std::vector<CUIElement *> m_vpScoreboardUiElements;
 	void RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *pSelectedServer);
 	void RenderServerbrowserFriends(CUIRect View);
 	void FriendlistOnUpdate();

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1291,6 +1291,18 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 {
 	const float FontSize = 10.0f;
 
+	enum
+	{
+		UI_ELEM_SCORE = 0,
+		UI_ELEM_NAME_1,
+		UI_ELEM_NAME_2,
+		UI_ELEM_NAME_3,
+		UI_ELEM_CLAN_1,
+		UI_ELEM_CLAN_2,
+		UI_ELEM_CLAN_3,
+		NUM_UI_ELEMS,
+	};
+
 	static CListBox s_ListBox;
 	View.VSplitLeft(5.0f, nullptr, &View);
 	s_ListBox.DoAutoSpacing(2.0f);
@@ -1298,10 +1310,20 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 	s_ListBox.SetScrollbarMargin(5.0f);
 	s_ListBox.DoStart(25.0f, pSelectedServer->m_NumReceivedClients, 1, 3, -1, &View, false, IGraphics::CORNER_NONE, true);
 
+	if(m_vpScoreboardUiElements.size() < (size_t)pSelectedServer->m_NumReceivedClients)
+		m_vpScoreboardUiElements.resize(pSelectedServer->m_NumReceivedClients, nullptr);
+
 	for(int i = 0; i < pSelectedServer->m_NumReceivedClients; i++)
 	{
 		const CServerInfo::CClient &CurrentClient = pSelectedServer->m_aClients[i];
 		const CListboxItem Item = s_ListBox.DoNextItem(&CurrentClient);
+
+		if(m_vpScoreboardUiElements[i] == nullptr)
+		{
+			m_vpScoreboardUiElements[i] = Ui()->GetNewUIElement(NUM_UI_ELEMS);
+		}
+		CUIElement *pUiElement = m_vpScoreboardUiElements[i];
+
 		if(!Item.m_Visible)
 			continue;
 
@@ -1354,7 +1376,7 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 			}
 		}
 
-		Ui()->DoLabel(&Score, aTemp, FontSize, TEXTALIGN_ML);
+		Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_SCORE), &Score, aTemp, FontSize, TEXTALIGN_ML);
 
 		// render tee if available
 		if(CurrentClient.m_aSkin[0] != '\0')
@@ -1385,42 +1407,44 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 		}
 
 		// name
-		CTextCursor NameCursor;
-		NameCursor.SetPosition(vec2(Name.x, Name.y + (Name.h - (FontSize - 1.0f)) / 2.0f));
-		NameCursor.m_FontSize = FontSize - 1.0f;
-		NameCursor.m_Flags |= TEXTFLAG_STOP_AT_END;
-		NameCursor.m_LineWidth = Name.w;
-		const char *pName = CurrentClient.m_aName;
-		bool Printed = false;
-		if(g_Config.m_BrFilterString[0])
-			Printed = PrintHighlighted(pName, [&](const char *pFilteredStr, const int FilterLen) {
-				TextRender()->TextEx(&NameCursor, pName, (int)(pFilteredStr - pName));
-				TextRender()->TextColor(HIGHLIGHTED_TEXT_COLOR);
-				TextRender()->TextEx(&NameCursor, pFilteredStr, FilterLen);
-				TextRender()->TextColor(TextRender()->DefaultTextColor());
-				TextRender()->TextEx(&NameCursor, pFilteredStr + FilterLen, -1);
-			});
-		if(!Printed)
-			TextRender()->TextEx(&NameCursor, pName, -1);
+		{
+			SLabelProperties Props;
+			Props.m_MaxWidth = Name.w;
+			Props.m_StopAtEnd = true;
+			Props.m_EnableWidthCheck = false;
+			const char *pName = CurrentClient.m_aName;
+			bool Printed = false;
+			if(g_Config.m_BrFilterString[0])
+				Printed = PrintHighlighted(pName, [&](const char *pFilteredStr, const int FilterLen) {
+					Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_NAME_1), &Name, pName, FontSize - 1.0f, TEXTALIGN_ML, Props, (int)(pFilteredStr - pName));
+					TextRender()->TextColor(HIGHLIGHTED_TEXT_COLOR);
+					Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_NAME_2), &Name, pFilteredStr, FontSize - 1.0f, TEXTALIGN_ML, Props, FilterLen, &pUiElement->Rect(UI_ELEM_NAME_1)->m_Cursor);
+					TextRender()->TextColor(TextRender()->DefaultTextColor());
+					Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_NAME_3), &Name, pFilteredStr + FilterLen, FontSize - 1.0f, TEXTALIGN_ML, Props, -1, &pUiElement->Rect(UI_ELEM_NAME_2)->m_Cursor);
+				});
+			if(!Printed)
+				Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_NAME_1), &Name, pName, FontSize - 1.0f, TEXTALIGN_ML, Props);
+		}
 
 		// clan
-		CTextCursor ClanCursor;
-		ClanCursor.SetPosition(vec2(Clan.x, Clan.y + (Clan.h - (FontSize - 2.0f)) / 2.0f));
-		ClanCursor.m_FontSize = FontSize - 2.0f;
-		ClanCursor.m_Flags |= TEXTFLAG_STOP_AT_END;
-		ClanCursor.m_LineWidth = Clan.w;
-		const char *pClan = CurrentClient.m_aClan;
-		Printed = false;
-		if(g_Config.m_BrFilterString[0])
-			Printed = PrintHighlighted(pClan, [&](const char *pFilteredStr, const int FilterLen) {
-				TextRender()->TextEx(&ClanCursor, pClan, (int)(pFilteredStr - pClan));
-				TextRender()->TextColor(0.4f, 0.4f, 1.0f, 1.0f);
-				TextRender()->TextEx(&ClanCursor, pFilteredStr, FilterLen);
-				TextRender()->TextColor(TextRender()->DefaultTextColor());
-				TextRender()->TextEx(&ClanCursor, pFilteredStr + FilterLen, -1);
-			});
-		if(!Printed)
-			TextRender()->TextEx(&ClanCursor, pClan, -1);
+		{
+			SLabelProperties Props;
+			Props.m_MaxWidth = Clan.w;
+			Props.m_StopAtEnd = true;
+			Props.m_EnableWidthCheck = false;
+			const char *pClan = CurrentClient.m_aClan;
+			bool Printed = false;
+			if(g_Config.m_BrFilterString[0])
+				Printed = PrintHighlighted(pClan, [&](const char *pFilteredStr, const int FilterLen) {
+					Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_CLAN_1), &Clan, pClan, FontSize - 2.0f, TEXTALIGN_ML, Props, (int)(pFilteredStr - pClan));
+					TextRender()->TextColor(0.4f, 0.4f, 1.0f, 1.0f);
+					Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_CLAN_2), &Clan, pFilteredStr, FontSize - 2.0f, TEXTALIGN_ML, Props, FilterLen, &pUiElement->Rect(UI_ELEM_CLAN_1)->m_Cursor);
+					TextRender()->TextColor(TextRender()->DefaultTextColor());
+					Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_CLAN_3), &Clan, pFilteredStr + FilterLen, FontSize - 2.0f, TEXTALIGN_ML, Props, -1, &pUiElement->Rect(UI_ELEM_CLAN_2)->m_Cursor);
+				});
+			if(!Printed)
+				Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_CLAN_1), &Clan, pClan, FontSize - 2.0f, TEXTALIGN_ML, Props);
+		}
 
 		// flag
 		GameClient()->m_CountryFlags.Render(CurrentClient.m_Country, ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f), Flag.x, Flag.y, Flag.w, Flag.h);


### PR DESCRIPTION
Replace per-frame `DoLabel`/`TextEx` calls with cached `DoLabelStreamed` in `RenderServerbrowserInfoScoreboard`. This avoids recreating text containers every frame for score, name, and clan columns.

Follows the same `CUIElement` pattern already used in `RenderServerbrowserServerList`.

## Perf profile comparison

Normalized to absolute cycles (master: 12.8B total, patched: 13.0B total):

| Function | master (Mcycles) | patched (Mcycles) | diff |
|---|---|---|---|
| `AppendTextContainer` | 401 | 231 | -170 |
| `SGlyph map operator[]` | 328 | 145 | -182 |
| `CreateTextContainer` | 81 | ~19 | -62 |
| `DoLabelStreamed` | 116 | 182 | +66 |
| `GetTextContainer` | 77 | 144 | +67 |
| `RenderTextContainer` | 0 | 127 | +127 |
| **Total** | **1,002** | **849** | **-153 (-15.3%)** |

Net savings of ~153M cycles (~1.2% of total CPU). Modest since the scoreboard only renders players for one selected server.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

AI was used to profile, identify the hotspot, and implement the caching conversion.