### PR TITLE
editor: preserve quad art group for undo/redo

### DIFF
--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -1325,27 +1325,26 @@ void CEditorActionTileArt::Redo()
 
 // ---------------------------
 
-CEditorActionQuadArt::CEditorActionQuadArt(CEditorMap *pMap, const CQuadArtParameters &Parameters) :
-	IEditorAction(pMap), m_Parameters(Parameters)
+CEditorActionQuadArt::CEditorActionQuadArt(CEditorMap *pMap, const std::shared_ptr<CLayerGroup> &pGroup) :
+	IEditorAction(pMap), m_pGroup(pGroup)
 {
 	str_copy(m_aDisplayText, "Add quad art");
 }
 
 void CEditorActionQuadArt::Undo()
 {
-	// Delete added group
-	Map()->m_vpGroups.pop_back();
+	// Delete added group (keep pointer for redo)
+	auto &vGroups = Map()->m_vpGroups;
+	auto It = std::find(vGroups.begin(), vGroups.end(), m_pGroup);
+	if(It != vGroups.end())
+		vGroups.erase(It);
 }
 
 void CEditorActionQuadArt::Redo()
 {
-	CImageInfo Image;
-	if(!Graphics()->LoadPng(Image, m_Parameters.m_aFilename, IStorage::TYPE_ALL))
-	{
-		Editor()->ShowFileDialogError("Failed to load image from file '%s'.", m_Parameters.m_aFilename);
-		return;
-	}
-	Map()->AddQuadArt(std::move(Image), m_Parameters, true);
+	auto &vGroups = Map()->m_vpGroups;
+	if(std::find(vGroups.begin(), vGroups.end(), m_pGroup) == vGroups.end())
+		vGroups.push_back(m_pGroup);
 }
 
 // ---------------------------------

--- a/src/game/editor/editor_actions.h
+++ b/src/game/editor/editor_actions.h
@@ -18,6 +18,7 @@
 
 class CEditorMap;
 class IEditorEnvelopeReference;
+class CLayerGroup;
 
 class CEditorActionLayerBase : public IEditorAction
 {
@@ -367,13 +368,13 @@ private:
 class CEditorActionQuadArt : public IEditorAction
 {
 public:
-	CEditorActionQuadArt(CEditorMap *pMap, const CQuadArtParameters &Parameters);
+	CEditorActionQuadArt(CEditorMap *pMap, const std::shared_ptr<CLayerGroup> &pGroup);
 
 	void Undo() override;
 	void Redo() override;
 
 private:
-	CQuadArtParameters m_Parameters;
+	std::shared_ptr<CLayerGroup> m_pGroup;
 };
 
 // ----------------------

--- a/src/game/editor/quad_art.cpp
+++ b/src/game/editor/quad_art.cpp
@@ -190,7 +190,7 @@ void CEditorMap::AddQuadArt(CImageInfo &&Image, const CQuadArtParameters &Parame
 	QuadArt.Create(pLayer);
 
 	if(!IgnoreHistory)
-		m_EditorHistory.RecordAction(std::make_shared<CEditorActionQuadArt>(this, Parameters));
+		m_EditorHistory.RecordAction(std::make_shared<CEditorActionQuadArt>(this, pGroup));
 
 	OnModify();
 }


### PR DESCRIPTION
Store the created group and its original index, so undo removes the correct group even if other groups were added/removed. Redo reinserts the same group at the prior position instead of relying on pop_back behavior.
Fixes #11911 
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions