### PR TITLE
Batch tee rendering with skin texture arrays (0.6 path)

### DIFF
--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -699,7 +699,7 @@ void CCommandProcessorFragment_OpenGL::Cmd_Texture_Destroy(const CCommandBuffer:
 	DestroyTexture(pCommand->m_Slot);
 }
 
-void CCommandProcessorFragment_OpenGL::TextureCreate(int Slot, int Width, int Height, int GLFormat, int GLStoreFormat, int Flags, uint8_t *pTexData)
+void CCommandProcessorFragment_OpenGL::TextureCreate(int Slot, int Width, int Height, int GLFormat, int GLStoreFormat, int Flags, uint8_t *pTexData, int GridSplitW, int GridSplitH)
 {
 #ifndef BACKEND_GL_MODERN_API
 
@@ -867,10 +867,10 @@ void CCommandProcessorFragment_OpenGL::TextureCreate(int Slot, int Width, int He
 			int ConvertWidth = Width;
 			int ConvertHeight = Height;
 
-			if(ConvertWidth == 0 || (ConvertWidth % 16) != 0 || ConvertHeight == 0 || (ConvertHeight % 16) != 0)
+			if(ConvertWidth == 0 || (ConvertWidth % GridSplitW) != 0 || ConvertHeight == 0 || (ConvertHeight % GridSplitH) != 0)
 			{
-				int NewWidth = maximum<int>(HighestBit(ConvertWidth), 16);
-				int NewHeight = maximum<int>(HighestBit(ConvertHeight), 16);
+				int NewWidth = maximum<int>(HighestBit(ConvertWidth), GridSplitW);
+				int NewHeight = maximum<int>(HighestBit(ConvertHeight), GridSplitH);
 				uint8_t *pNewTexData = ResizeImage(pTexData, ConvertWidth, ConvertHeight, NewWidth, NewHeight, GLFormatToPixelSize(GLFormat));
 				log_debug("gfx/opengl", "3D/2D array texture was resized");
 
@@ -881,9 +881,9 @@ void CCommandProcessorFragment_OpenGL::TextureCreate(int Slot, int Width, int He
 				pTexData = pNewTexData;
 			}
 
-			if(Texture2DTo3D(pTexData, ConvertWidth, ConvertHeight, PixelSize, 16, 16, pImageData3D, Image3DWidth, Image3DHeight))
+			if(Texture2DTo3D(pTexData, ConvertWidth, ConvertHeight, PixelSize, GridSplitW, GridSplitH, pImageData3D, Image3DWidth, Image3DHeight))
 			{
-				glTexImage3D(Target, 0, GLStoreFormat, Image3DWidth, Image3DHeight, 256, 0, GLFormat, GL_UNSIGNED_BYTE, pImageData3D);
+				glTexImage3D(Target, 0, GLStoreFormat, Image3DWidth, Image3DHeight, GridSplitW * GridSplitH, 0, GLFormat, GL_UNSIGNED_BYTE, pImageData3D);
 			}
 
 			free(pImageData3D);
@@ -909,7 +909,7 @@ void CCommandProcessorFragment_OpenGL::TextureCreate(int Slot, int Width, int He
 
 void CCommandProcessorFragment_OpenGL::Cmd_Texture_Create(const CCommandBuffer::SCommand_Texture_Create *pCommand)
 {
-	TextureCreate(pCommand->m_Slot, pCommand->m_Width, pCommand->m_Height, GL_RGBA, GL_RGBA, pCommand->m_Flags, pCommand->m_pData);
+	TextureCreate(pCommand->m_Slot, pCommand->m_Width, pCommand->m_Height, GL_RGBA, GL_RGBA, pCommand->m_Flags, pCommand->m_pData, pCommand->m_GridSplitW, pCommand->m_GridSplitH);
 }
 
 void CCommandProcessorFragment_OpenGL::Cmd_TextTexture_Update(const CCommandBuffer::SCommand_TextTexture_Update *pCommand)
@@ -925,8 +925,8 @@ void CCommandProcessorFragment_OpenGL::Cmd_TextTextures_Destroy(const CCommandBu
 
 void CCommandProcessorFragment_OpenGL::Cmd_TextTextures_Create(const CCommandBuffer::SCommand_TextTextures_Create *pCommand)
 {
-	TextureCreate(pCommand->m_Slot, pCommand->m_Width, pCommand->m_Height, GL_ALPHA, GL_ALPHA, TextureFlag::NO_MIPMAPS, pCommand->m_pTextData);
-	TextureCreate(pCommand->m_SlotOutline, pCommand->m_Width, pCommand->m_Height, GL_ALPHA, GL_ALPHA, TextureFlag::NO_MIPMAPS, pCommand->m_pTextOutlineData);
+	TextureCreate(pCommand->m_Slot, pCommand->m_Width, pCommand->m_Height, GL_ALPHA, GL_ALPHA, TextureFlag::NO_MIPMAPS, pCommand->m_pTextData, 16, 16);
+	TextureCreate(pCommand->m_SlotOutline, pCommand->m_Width, pCommand->m_Height, GL_ALPHA, GL_ALPHA, TextureFlag::NO_MIPMAPS, pCommand->m_pTextOutlineData, 16, 16);
 }
 
 void CCommandProcessorFragment_OpenGL::Cmd_Clear(const CCommandBuffer::SCommand_Clear *pCommand)

--- a/src/engine/client/backend/opengl/backend_opengl.h
+++ b/src/engine/client/backend/opengl/backend_opengl.h
@@ -84,7 +84,7 @@ protected:
 	static size_t GLFormatToPixelSize(int GLFormat);
 
 	void TextureUpdate(int Slot, int X, int Y, int Width, int Height, int GLFormat, uint8_t *pTexData);
-	void TextureCreate(int Slot, int Width, int Height, int GLFormat, int GLStoreFormat, int Flags, uint8_t *pTexData);
+	void TextureCreate(int Slot, int Width, int Height, int GLFormat, int GLStoreFormat, int Flags, uint8_t *pTexData, int GridSplitW, int GridSplitH);
 
 	virtual bool Cmd_Init(const SCommand_Init *pCommand);
 	virtual void Cmd_Shutdown(const SCommand_Shutdown *pCommand) {}

--- a/src/engine/client/backend/opengl/backend_opengl3.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl3.cpp
@@ -562,7 +562,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Texture_Destroy(const CCommandBuff
 	DestroyTexture(pCommand->m_Slot);
 }
 
-void CCommandProcessorFragment_OpenGL3_3::TextureCreate(int Slot, int Width, int Height, int GLFormat, int GLStoreFormat, int Flags, uint8_t *pTexData)
+void CCommandProcessorFragment_OpenGL3_3::TextureCreate(int Slot, int Width, int Height, int GLFormat, int GLStoreFormat, int Flags, uint8_t *pTexData, int GridSplitW, int GridSplitH)
 {
 	while(Slot >= (int)m_vTextures.size())
 		m_vTextures.resize(m_vTextures.size() * 2);
@@ -661,10 +661,10 @@ void CCommandProcessorFragment_OpenGL3_3::TextureCreate(int Slot, int Width, int
 			int ConvertWidth = Width;
 			int ConvertHeight = Height;
 
-			if(ConvertWidth == 0 || (ConvertWidth % 16) != 0 || ConvertHeight == 0 || (ConvertHeight % 16) != 0)
+			if(ConvertWidth == 0 || (ConvertWidth % GridSplitW) != 0 || ConvertHeight == 0 || (ConvertHeight % GridSplitH) != 0)
 			{
-				int NewWidth = maximum<int>(HighestBit(ConvertWidth), 16);
-				int NewHeight = maximum<int>(HighestBit(ConvertHeight), 16);
+				int NewWidth = maximum<int>(HighestBit(ConvertWidth), GridSplitW);
+				int NewHeight = maximum<int>(HighestBit(ConvertHeight), GridSplitH);
 				uint8_t *pNewTexData = ResizeImage(pTexData, ConvertWidth, ConvertHeight, NewWidth, NewHeight, GLFormatToPixelSize(GLFormat));
 				log_debug("gfx/opengl", "3D/2D array texture was resized");
 
@@ -675,9 +675,9 @@ void CCommandProcessorFragment_OpenGL3_3::TextureCreate(int Slot, int Width, int
 				pTexData = pNewTexData;
 			}
 
-			if(Texture2DTo3D(pTexData, ConvertWidth, ConvertHeight, PixelSize, 16, 16, pImageData3D, Image3DWidth, Image3DHeight))
+			if(Texture2DTo3D(pTexData, ConvertWidth, ConvertHeight, PixelSize, GridSplitW, GridSplitH, pImageData3D, Image3DWidth, Image3DHeight))
 			{
-				glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GLStoreFormat, Image3DWidth, Image3DHeight, 256, 0, GLFormat, GL_UNSIGNED_BYTE, pImageData3D);
+				glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GLStoreFormat, Image3DWidth, Image3DHeight, GridSplitW * GridSplitH, 0, GLFormat, GL_UNSIGNED_BYTE, pImageData3D);
 				glGenerateMipmap(GL_TEXTURE_2D_ARRAY);
 			}
 
@@ -703,7 +703,7 @@ void CCommandProcessorFragment_OpenGL3_3::TextureCreate(int Slot, int Width, int
 
 void CCommandProcessorFragment_OpenGL3_3::Cmd_Texture_Create(const CCommandBuffer::SCommand_Texture_Create *pCommand)
 {
-	TextureCreate(pCommand->m_Slot, pCommand->m_Width, pCommand->m_Height, GL_RGBA, GL_RGBA, pCommand->m_Flags, pCommand->m_pData);
+	TextureCreate(pCommand->m_Slot, pCommand->m_Width, pCommand->m_Height, GL_RGBA, GL_RGBA, pCommand->m_Flags, pCommand->m_pData, pCommand->m_GridSplitW, pCommand->m_GridSplitH);
 }
 
 void CCommandProcessorFragment_OpenGL3_3::Cmd_TextTexture_Update(const CCommandBuffer::SCommand_TextTexture_Update *pCommand)
@@ -719,8 +719,8 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_TextTextures_Destroy(const CComman
 
 void CCommandProcessorFragment_OpenGL3_3::Cmd_TextTextures_Create(const CCommandBuffer::SCommand_TextTextures_Create *pCommand)
 {
-	TextureCreate(pCommand->m_Slot, pCommand->m_Width, pCommand->m_Height, GL_RED, GL_RED, TextureFlag::NO_MIPMAPS, pCommand->m_pTextData);
-	TextureCreate(pCommand->m_SlotOutline, pCommand->m_Width, pCommand->m_Height, GL_RED, GL_RED, TextureFlag::NO_MIPMAPS, pCommand->m_pTextOutlineData);
+	TextureCreate(pCommand->m_Slot, pCommand->m_Width, pCommand->m_Height, GL_RED, GL_RED, TextureFlag::NO_MIPMAPS, pCommand->m_pTextData, 16, 16);
+	TextureCreate(pCommand->m_SlotOutline, pCommand->m_Width, pCommand->m_Height, GL_RED, GL_RED, TextureFlag::NO_MIPMAPS, pCommand->m_pTextOutlineData, 16, 16);
 }
 
 void CCommandProcessorFragment_OpenGL3_3::Cmd_Clear(const CCommandBuffer::SCommand_Clear *pCommand)

--- a/src/engine/client/backend/opengl/backend_opengl3.h
+++ b/src/engine/client/backend/opengl/backend_opengl3.h
@@ -80,7 +80,7 @@ protected:
 	void RenderText(const CCommandBuffer::SState &State, int DrawNum, int TextTextureIndex, int TextOutlineTextureIndex, int TextureSize, const ColorRGBA &TextColor, const ColorRGBA &TextOutlineColor);
 
 	void TextureUpdate(int Slot, int X, int Y, int Width, int Height, int GLFormat, uint8_t *pTexData);
-	void TextureCreate(int Slot, int Width, int Height, int GLFormat, int GLStoreFormat, int Flags, uint8_t *pTexData);
+	void TextureCreate(int Slot, int Width, int Height, int GLFormat, int GLStoreFormat, int Flags, uint8_t *pTexData, int GridSplitW, int GridSplitH);
 
 	bool Cmd_Init(const SCommand_Init *pCommand) override;
 	void Cmd_Shutdown(const SCommand_Shutdown *pCommand) override;

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -2532,7 +2532,9 @@ protected:
 		VkFormat Format,
 		VkFormat StoreFormat,
 		int Flags,
-		uint8_t *&pData)
+		uint8_t *&pData,
+		int GridSplitW,
+		int GridSplitH)
 	{
 		size_t ImageIndex = (size_t)Slot;
 		const size_t PixelSize = VulkanFormatToPixelSize(Format);
@@ -2603,10 +2605,10 @@ protected:
 			int ConvertWidth = Width;
 			int ConvertHeight = Height;
 
-			if(ConvertWidth == 0 || (ConvertWidth % 16) != 0 || ConvertHeight == 0 || (ConvertHeight % 16) != 0)
+			if(ConvertWidth == 0 || (ConvertWidth % GridSplitW) != 0 || ConvertHeight == 0 || (ConvertHeight % GridSplitH) != 0)
 			{
-				int NewWidth = maximum<int>(HighestBit(ConvertWidth), 16);
-				int NewHeight = maximum<int>(HighestBit(ConvertHeight), 16);
+				int NewWidth = maximum<int>(HighestBit(ConvertWidth), GridSplitW);
+				int NewHeight = maximum<int>(HighestBit(ConvertHeight), GridSplitH);
 				uint8_t *pNewTexData = ResizeImage(pData, ConvertWidth, ConvertHeight, NewWidth, NewHeight, PixelSize);
 				if(IsVerbose())
 				{
@@ -2622,7 +2624,7 @@ protected:
 
 			bool Needs3DTexDel = false;
 			uint8_t *pTexData3D = static_cast<uint8_t *>(malloc((size_t)PixelSize * ConvertWidth * ConvertHeight));
-			if(!Texture2DTo3D(pData, ConvertWidth, ConvertHeight, PixelSize, 16, 16, pTexData3D, Image3DWidth, Image3DHeight))
+			if(!Texture2DTo3D(pData, ConvertWidth, ConvertHeight, PixelSize, GridSplitW, GridSplitH, pTexData3D, Image3DWidth, Image3DHeight))
 			{
 				free(pTexData3D);
 				pTexData3D = nullptr;
@@ -2631,7 +2633,7 @@ protected:
 
 			if(pTexData3D != nullptr)
 			{
-				const size_t ImageDepth2DArray = (size_t)16 * 16;
+				const size_t ImageDepth2DArray = (size_t)GridSplitW * GridSplitH;
 				VkExtent3D ImgSize{(uint32_t)Image3DWidth, (uint32_t)Image3DHeight, 1};
 				if(RequiresMipMaps)
 				{
@@ -6657,7 +6659,7 @@ public:
 		int Flags = pCommand->m_Flags;
 		uint8_t *pData = pCommand->m_pData;
 
-		if(!CreateTextureCMD(Slot, Width, Height, VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_R8G8B8A8_UNORM, Flags, pData))
+		if(!CreateTextureCMD(Slot, Width, Height, VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_R8G8B8A8_UNORM, Flags, pData, pCommand->m_GridSplitW, pCommand->m_GridSplitH))
 			return false;
 
 		free(pData);
@@ -6675,9 +6677,9 @@ public:
 		uint8_t *pTmpData = pCommand->m_pTextData;
 		uint8_t *pTmpData2 = pCommand->m_pTextOutlineData;
 
-		if(!CreateTextureCMD(Slot, Width, Height, VK_FORMAT_R8_UNORM, VK_FORMAT_R8_UNORM, TextureFlag::NO_MIPMAPS, pTmpData))
+		if(!CreateTextureCMD(Slot, Width, Height, VK_FORMAT_R8_UNORM, VK_FORMAT_R8_UNORM, TextureFlag::NO_MIPMAPS, pTmpData, 16, 16))
 			return false;
-		if(!CreateTextureCMD(SlotOutline, Width, Height, VK_FORMAT_R8_UNORM, VK_FORMAT_R8_UNORM, TextureFlag::NO_MIPMAPS, pTmpData2))
+		if(!CreateTextureCMD(SlotOutline, Width, Height, VK_FORMAT_R8_UNORM, VK_FORMAT_R8_UNORM, TextureFlag::NO_MIPMAPS, pTmpData2, 16, 16))
 			return false;
 
 		if(!CreateNewTextDescriptorSets(Slot, SlotOutline))

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -394,7 +394,7 @@ void CGraphics_Threaded::LoadTextureAddWarning(size_t Width, size_t Height, int 
 	}
 }
 
-static CCommandBuffer::SCommand_Texture_Create LoadTextureCreateCommand(int TextureId, size_t Width, size_t Height, int Flags)
+static CCommandBuffer::SCommand_Texture_Create LoadTextureCreateCommand(int TextureId, size_t Width, size_t Height, int Flags, int GridSplitW, int GridSplitH)
 {
 	CCommandBuffer::SCommand_Texture_Create Cmd;
 	Cmd.m_Slot = TextureId;
@@ -409,6 +409,9 @@ static CCommandBuffer::SCommand_Texture_Create LoadTextureCreateCommand(int Text
 	if((Flags & IGraphics::TEXLOAD_NO_2D_TEXTURE) != 0)
 		Cmd.m_Flags |= TextureFlag::NO_2D_TEXTURE;
 
+	Cmd.m_GridSplitW = GridSplitW;
+	Cmd.m_GridSplitH = GridSplitH;
+
 	return Cmd;
 }
 
@@ -420,7 +423,7 @@ IGraphics::CTextureHandle CGraphics_Threaded::LoadTextureRaw(const CImageInfo &I
 		return IGraphics::CTextureHandle();
 
 	IGraphics::CTextureHandle TextureHandle = FindFreeTextureIndex();
-	CCommandBuffer::SCommand_Texture_Create Cmd = LoadTextureCreateCommand(TextureHandle.Id(), Image.m_Width, Image.m_Height, Flags);
+	CCommandBuffer::SCommand_Texture_Create Cmd = LoadTextureCreateCommand(TextureHandle.Id(), Image.m_Width, Image.m_Height, Flags, 16, 16);
 
 	// Copy texture data and convert if necessary
 	uint8_t *pTmpData;
@@ -451,10 +454,31 @@ IGraphics::CTextureHandle CGraphics_Threaded::LoadTextureRawMove(CImageInfo &Ima
 		return IGraphics::CTextureHandle();
 
 	IGraphics::CTextureHandle TextureHandle = FindFreeTextureIndex();
-	CCommandBuffer::SCommand_Texture_Create Cmd = LoadTextureCreateCommand(TextureHandle.Id(), Image.m_Width, Image.m_Height, Flags);
+	CCommandBuffer::SCommand_Texture_Create Cmd = LoadTextureCreateCommand(TextureHandle.Id(), Image.m_Width, Image.m_Height, Flags, 16, 16);
 	Cmd.m_pData = Image.m_pData;
 	Image.m_pData = nullptr;
 	Image.Free();
+	AddCmd(Cmd);
+
+	return TextureHandle;
+}
+
+IGraphics::CTextureHandle CGraphics_Threaded::LoadTextureArrayRaw(const CImageInfo &Image, int GridW, int GridH, const char *pTexName)
+{
+	if(Image.m_Width == 0 || Image.m_Height == 0)
+		return IGraphics::CTextureHandle();
+
+	const int Flags = TEXLOAD_TO_2D_ARRAY_TEXTURE | TEXLOAD_NO_2D_TEXTURE;
+	IGraphics::CTextureHandle TextureHandle = FindFreeTextureIndex();
+	CCommandBuffer::SCommand_Texture_Create Cmd = LoadTextureCreateCommand(TextureHandle.Id(), Image.m_Width, Image.m_Height, Flags, GridW, GridH);
+
+	uint8_t *pTmpData;
+	if(!ConvertToRgbaAlloc(pTmpData, Image))
+	{
+		log_warn("graphics", "Converted image '%s' to RGBA, consider making its file format RGBA.", pTexName ? pTexName : "(no name)");
+	}
+	Cmd.m_pData = pTmpData;
+
 	AddCmd(Cmd);
 
 	return TextureHandle;

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -518,6 +518,10 @@ public:
 		int m_Flags;
 		// data must be in RGBA format
 		uint8_t *m_pData; // will be freed by the command processor
+
+		// grid split for 2D array / 3D textures (default 16x16 = 256 layers)
+		int m_GridSplitW = 16;
+		int m_GridSplitH = 16;
 	};
 
 	struct SCommand_Texture_Destroy : public SCommand
@@ -933,6 +937,7 @@ public:
 	void LoadTextureAddWarning(size_t Width, size_t Height, int Flags, const char *pTexName);
 	IGraphics::CTextureHandle LoadTextureRaw(const CImageInfo &Image, int Flags, const char *pTexName = nullptr) override;
 	IGraphics::CTextureHandle LoadTextureRawMove(CImageInfo &Image, int Flags, const char *pTexName = nullptr) override;
+	IGraphics::CTextureHandle LoadTextureArrayRaw(const CImageInfo &Image, int GridW, int GridH, const char *pTexName = nullptr) override;
 
 	bool LoadTextTextures(size_t Width, size_t Height, CTextureHandle &TextTexture, CTextureHandle &TextOutlineTexture, uint8_t *pTextData, uint8_t *pTextOutlineData) override;
 	bool UnloadTextTextures(CTextureHandle &TextTexture, CTextureHandle &TextOutlineTexture) override;

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -291,6 +291,7 @@ public:
 	virtual void UnloadTexture(CTextureHandle *pIndex) = 0;
 	virtual CTextureHandle LoadTextureRaw(const CImageInfo &Image, int Flags, const char *pTexName = nullptr) = 0;
 	virtual CTextureHandle LoadTextureRawMove(CImageInfo &Image, int Flags, const char *pTexName = nullptr) = 0;
+	virtual CTextureHandle LoadTextureArrayRaw(const CImageInfo &Image, int GridW, int GridH, const char *pTexName = nullptr) = 0;
 	virtual CTextureHandle LoadTexture(const char *pFilename, int StorageType, int Flags = 0) = 0;
 	virtual void TextureSet(CTextureHandle Texture) = 0;
 	void TextureClear() { TextureSet(CTextureHandle()); }

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -436,6 +436,67 @@ void CSkins::LoadSkinFinish(CSkinContainer *pSkinContainer, const CSkinLoadData 
 		Skin.m_ColorableSkin.m_aEyes[i] = Graphics()->LoadSpriteTexture(Data.m_InfoGrayscale, &g_pData->m_aSprites[SPRITE_TEE_EYE_NORMAL + i]);
 	}
 
+	// Build texture arrays for batched rendering on modern backends
+	if(Graphics()->Uses2DTextureArrays())
+	{
+		auto BuildSkinTextureArray = [&](const CImageInfo &SrcImage) -> IGraphics::CTextureHandle {
+			// Sprite layout: body is 3x3 grid cells (the largest), so each layer
+			// must be body-sized. We use a 5x2 grid = 10 layers.
+			constexpr int GridW = 5;
+			constexpr int GridH = 2;
+
+			const int GridX = g_pData->m_aSprites[SPRITE_TEE_BODY].m_pSet->m_Gridx;
+			const int GridY = g_pData->m_aSprites[SPRITE_TEE_BODY].m_pSet->m_Gridy;
+			const int CellW = SrcImage.m_Width / GridX;
+			const int CellH = SrcImage.m_Height / GridY;
+
+			// Body is the largest sprite and defines our layer size
+			const int LayerW = CellW * g_pData->m_aSprites[SPRITE_TEE_BODY].m_W;
+			const int LayerH = CellH * g_pData->m_aSprites[SPRITE_TEE_BODY].m_H;
+
+			CImageInfo SynImage;
+			SynImage.m_Width = LayerW * GridW;
+			SynImage.m_Height = LayerH * GridH;
+			SynImage.m_Format = CImageInfo::FORMAT_RGBA;
+			SynImage.m_pData = static_cast<uint8_t *>(calloc(1, SynImage.DataSize()));
+
+			// Blit a sprite into the synthetic image at the given layer index.
+			// Each sprite is placed at (0,0) within its layer cell.
+			auto BlitSprite = [&](int LayerIndex, int SpriteId) {
+				const CDataSprite *pSprite = &g_pData->m_aSprites[SpriteId];
+				const int SrcCellW = SrcImage.m_Width / pSprite->m_pSet->m_Gridx;
+				const int SrcCellH = SrcImage.m_Height / pSprite->m_pSet->m_Gridy;
+				const int SrcX = pSprite->m_X * SrcCellW;
+				const int SrcY = pSprite->m_Y * SrcCellH;
+				const int SrcW = pSprite->m_W * SrcCellW;
+				const int SrcH = pSprite->m_H * SrcCellH;
+
+				const int DstX = (LayerIndex % GridW) * LayerW;
+				const int DstY = (LayerIndex / GridW) * LayerH;
+
+				SynImage.CopyRectFrom(SrcImage, SrcX, SrcY, SrcW, SrcH, DstX, DstY);
+			};
+
+			BlitSprite(CSkin::SKIN_LAYER_BODY, SPRITE_TEE_BODY);
+			BlitSprite(CSkin::SKIN_LAYER_BODY_OUTLINE, SPRITE_TEE_BODY_OUTLINE);
+			BlitSprite(CSkin::SKIN_LAYER_FEET, SPRITE_TEE_FOOT);
+			BlitSprite(CSkin::SKIN_LAYER_FEET_OUTLINE, SPRITE_TEE_FOOT_OUTLINE);
+			BlitSprite(CSkin::SKIN_LAYER_EYE_NORMAL, SPRITE_TEE_EYE_NORMAL);
+			BlitSprite(CSkin::SKIN_LAYER_EYE_ANGRY, SPRITE_TEE_EYE_ANGRY);
+			BlitSprite(CSkin::SKIN_LAYER_EYE_PAIN, SPRITE_TEE_EYE_PAIN);
+			BlitSprite(CSkin::SKIN_LAYER_EYE_HAPPY, SPRITE_TEE_EYE_HAPPY);
+			BlitSprite(CSkin::SKIN_LAYER_EYE_DEAD, SPRITE_TEE_EYE_DEAD);
+			BlitSprite(CSkin::SKIN_LAYER_EYE_SURPRISE, SPRITE_TEE_EYE_SURPRISE);
+
+			IGraphics::CTextureHandle Handle = Graphics()->LoadTextureArrayRaw(SynImage, GridW, GridH, "skin-array");
+			free(SynImage.m_pData);
+			return Handle;
+		};
+
+		Skin.m_OriginalSkin.m_TextureArray = BuildSkinTextureArray(Data.m_Info);
+		Skin.m_ColorableSkin.m_TextureArray = BuildSkinTextureArray(Data.m_InfoGrayscale);
+	}
+
 	Skin.m_Metrics = Data.m_Metrics;
 	Skin.m_BloodColor = Data.m_BloodColor;
 

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -485,10 +485,16 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 
 void CRenderTools::RenderTee6(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha) const
 {
+	const CSkin::CSkinTextures *pSkinTextures = pInfo->m_CustomColoredSkin ? &pInfo->m_ColorableRenderSkin : &pInfo->m_OriginalRenderSkin;
+
+	if(pSkinTextures->m_TextureArray.IsValid())
+	{
+		RenderTee6Batched(pAnim, pInfo, Emote, Dir, Pos, Alpha);
+		return;
+	}
+
 	vec2 Direction = Dir;
 	vec2 Position = Pos;
-
-	const CSkin::CSkinTextures *pSkinTextures = pInfo->m_CustomColoredSkin ? &pInfo->m_ColorableRenderSkin : &pInfo->m_OriginalRenderSkin;
 
 	// first pass we draw the outline
 	// second pass we draw the filling
@@ -583,4 +589,120 @@ void CRenderTools::RenderTee6(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 			Graphics()->RenderQuadContainerAsSprite(m_TeeQuadContainerIndex, QuadOffset, Position.x + pFoot->m_X * AnimScale, Position.y + pFoot->m_Y * AnimScale, w / 64.f, h / 32.f);
 		}
 	}
+}
+
+void CRenderTools::RenderTee6Batched(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha) const
+{
+	const CSkin::CSkinTextures *pSkinTextures = pInfo->m_CustomColoredSkin ? &pInfo->m_ColorableRenderSkin : &pInfo->m_OriginalRenderSkin;
+
+	float AnimScale, BaseSize;
+	GetRenderTeeAnimScaleAndBaseSize(pInfo, AnimScale, BaseSize);
+
+	const vec2 BodyPos = Pos + vec2(pAnim->GetBody()->m_X, pAnim->GetBody()->m_Y) * AnimScale;
+	float BodyScale;
+	GetRenderTeeBodyScale(BaseSize, BodyScale);
+	const float BodySize = 64.0f * BodyScale;
+
+	const bool Indicate = !pInfo->m_GotAirJump && g_Config.m_ClAirjumpindicator;
+	const bool FlipFeet = Dir.x < 0 && pInfo->m_FeetFlipped;
+
+	// UV coordinates within each texture array layer.
+	// Each layer is body-sized (3x3 grid cells). Sprites smaller than
+	// the body occupy the top-left corner of their layer.
+	// Body/BodyOutline: 3x3 cells -> full layer
+	constexpr float BodyU1 = 1.0f;
+	constexpr float BodyV1 = 1.0f;
+	// Feet/FeetOutline: 2x1 cells in a 3x3-cell layer
+	constexpr float FeetU1 = 2.0f / 3.0f;
+	constexpr float FeetV1 = 1.0f / 3.0f;
+	// Eyes: 1x1 cells in a 3x3-cell layer
+	constexpr float EyeU1 = 1.0f / 3.0f;
+	constexpr float EyeV1 = 1.0f / 3.0f;
+
+	auto DrawFoot = [&](const CAnimKeyframe *pFoot, int Layer, float ColorScale) {
+		Graphics()->SetColor(pInfo->m_ColorFeet.r * ColorScale, pInfo->m_ColorFeet.g * ColorScale, pInfo->m_ColorFeet.b * ColorScale, Alpha);
+		Graphics()->QuadsSetRotation(pFoot->m_Angle * pi * 2);
+		if(FlipFeet)
+			Graphics()->QuadsSetSubsetFree(FeetU1, 0, 0, 0, 0, FeetV1, FeetU1, FeetV1, Layer);
+		else
+			Graphics()->QuadsSetSubsetFree(0, 0, FeetU1, 0, FeetU1, FeetV1, 0, FeetV1, Layer);
+		const float FootW = BaseSize;
+		const float FootH = BaseSize / 2;
+		IGraphics::CQuadItem Quad(Pos.x + pFoot->m_X * AnimScale - FootW / 2, Pos.y + pFoot->m_Y * AnimScale - FootH / 2, FootW, FootH);
+		Graphics()->QuadsTex3DDrawTL(&Quad, 1);
+	};
+
+	// Outline pass: back foot outline, body outline, front foot outline
+	Graphics()->TextureSet(pSkinTextures->m_TextureArray);
+	Graphics()->WrapClamp();
+	Graphics()->QuadsTex3DBegin();
+	{
+		DrawFoot(pAnim->GetBackFoot(), CSkin::SKIN_LAYER_FEET_OUTLINE, 1.0f);
+
+		// Body outline
+		Graphics()->SetColor(pInfo->m_ColorBody.r, pInfo->m_ColorBody.g, pInfo->m_ColorBody.b, Alpha);
+		Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle * pi * 2);
+		Graphics()->QuadsSetSubsetFree(0, 0, BodyU1, 0, BodyU1, BodyV1, 0, BodyV1, CSkin::SKIN_LAYER_BODY_OUTLINE);
+		IGraphics::CQuadItem BodyOutlineQuad(BodyPos.x - BodySize / 2, BodyPos.y - BodySize / 2, BodySize, BodySize);
+		Graphics()->QuadsTex3DDrawTL(&BodyOutlineQuad, 1);
+
+		DrawFoot(pAnim->GetFrontFoot(), CSkin::SKIN_LAYER_FEET_OUTLINE, 1.0f);
+	}
+	Graphics()->QuadsTex3DEnd();
+
+	// Fill pass: back foot, body, eyes, front foot
+	Graphics()->QuadsTex3DBegin();
+	{
+		const float FeetColorScale = Indicate ? 0.5f : 1.0f;
+		DrawFoot(pAnim->GetBackFoot(), CSkin::SKIN_LAYER_FEET, FeetColorScale);
+
+		// Body fill
+		Graphics()->SetColor(pInfo->m_ColorBody.r, pInfo->m_ColorBody.g, pInfo->m_ColorBody.b, Alpha);
+		Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle * pi * 2);
+		Graphics()->QuadsSetSubsetFree(0, 0, BodyU1, 0, BodyU1, BodyV1, 0, BodyV1, CSkin::SKIN_LAYER_BODY);
+		IGraphics::CQuadItem BodyFillQuad(BodyPos.x - BodySize / 2, BodyPos.y - BodySize / 2, BodySize, BodySize);
+		Graphics()->QuadsTex3DDrawTL(&BodyFillQuad, 1);
+
+		// Eyes
+		int TeeEye = 0;
+		switch(Emote)
+		{
+		case EMOTE_PAIN:
+			TeeEye = SPRITE_TEE_EYE_PAIN - SPRITE_TEE_EYE_NORMAL;
+			break;
+		case EMOTE_HAPPY:
+			TeeEye = SPRITE_TEE_EYE_HAPPY - SPRITE_TEE_EYE_NORMAL;
+			break;
+		case EMOTE_SURPRISE:
+			TeeEye = SPRITE_TEE_EYE_SURPRISE - SPRITE_TEE_EYE_NORMAL;
+			break;
+		case EMOTE_ANGRY:
+			TeeEye = SPRITE_TEE_EYE_ANGRY - SPRITE_TEE_EYE_NORMAL;
+			break;
+		default:
+			break;
+		}
+
+		const int EyeLayer = CSkin::SKIN_LAYER_EYE_NORMAL + TeeEye;
+		const float EyeScale = BaseSize * 0.40f;
+		const float EyeH = Emote == EMOTE_BLINK ? BaseSize * 0.15f : EyeScale;
+		const float EyeSeparation = (0.075f - 0.010f * absolute(Dir.x)) * BaseSize;
+		const vec2 EyeOffset = vec2(Dir.x * 0.125f, -0.05f + Dir.y * 0.10f) * BaseSize;
+
+		Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle * pi * 2);
+
+		// Left eye
+		Graphics()->QuadsSetSubsetFree(0, 0, EyeU1, 0, EyeU1, EyeV1, 0, EyeV1, EyeLayer);
+		IGraphics::CQuadItem LeftEye(BodyPos.x - EyeSeparation + EyeOffset.x - EyeScale / 2, BodyPos.y + EyeOffset.y - EyeH / 2, EyeScale, EyeH);
+		Graphics()->QuadsTex3DDrawTL(&LeftEye, 1);
+
+		// Right eye (mirrored horizontally)
+		Graphics()->QuadsSetSubsetFree(EyeU1, 0, 0, 0, 0, EyeV1, EyeU1, EyeV1, EyeLayer);
+		IGraphics::CQuadItem RightEye(BodyPos.x + EyeSeparation + EyeOffset.x - EyeScale / 2, BodyPos.y + EyeOffset.y - EyeH / 2, EyeScale, EyeH);
+		Graphics()->QuadsTex3DDrawTL(&RightEye, 1);
+
+		DrawFoot(pAnim->GetFrontFoot(), CSkin::SKIN_LAYER_FEET, FeetColorScale);
+	}
+	Graphics()->QuadsTex3DEnd();
+	Graphics()->WrapNormal();
 }

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -218,6 +218,7 @@ class CRenderTools
 	static void GetRenderTeeFeetScale(float BaseSize, float &FeetScaleWidth, float &FeetScaleHeight);
 
 	void RenderTee6(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha = 1.0f) const;
+	void RenderTee6Batched(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha = 1.0f) const;
 	void RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha = 1.0f) const;
 
 public:

--- a/src/game/client/skin.cpp
+++ b/src/game/client/skin.cpp
@@ -17,6 +17,7 @@ void CSkin::CSkinTextures::Reset()
 	{
 		Eye = IGraphics::CTextureHandle();
 	}
+	m_TextureArray = IGraphics::CTextureHandle();
 }
 
 void CSkin::CSkinTextures::Unload(IGraphics *pGraphics)
@@ -31,6 +32,7 @@ void CSkin::CSkinTextures::Unload(IGraphics *pGraphics)
 	{
 		pGraphics->UnloadTexture(&Eye);
 	}
+	pGraphics->UnloadTexture(&m_TextureArray);
 }
 
 CSkin::CSkinMetricVariableInt::operator int() const

--- a/src/game/client/skin.h
+++ b/src/game/client/skin.h
@@ -26,8 +26,27 @@ public:
 
 		IGraphics::CTextureHandle m_aEyes[6];
 
+		// Texture array for batched rendering (valid on modern backends only)
+		IGraphics::CTextureHandle m_TextureArray;
+
 		void Reset();
 		void Unload(IGraphics *pGraphics);
+	};
+
+	// Layer indices for skin texture arrays
+	enum
+	{
+		SKIN_LAYER_BODY = 0,
+		SKIN_LAYER_BODY_OUTLINE,
+		SKIN_LAYER_FEET,
+		SKIN_LAYER_FEET_OUTLINE,
+		SKIN_LAYER_EYE_NORMAL,
+		SKIN_LAYER_EYE_ANGRY,
+		SKIN_LAYER_EYE_PAIN,
+		SKIN_LAYER_EYE_HAPPY,
+		SKIN_LAYER_EYE_DEAD,
+		SKIN_LAYER_EYE_SURPRISE,
+		NUM_SKIN_LAYERS,
 	};
 
 	CSkinTextures m_OriginalSkin;


### PR DESCRIPTION
Batches `RenderTee6` draw calls using `GL_TEXTURE_2D_ARRAY` on modern backends (OpenGL 3.3+, Vulkan), while keeping the existing per-sprite path for OpenGL 1.

Each skin's body parts (body, body outline, feet, feet outline, 6 eyes = 10 total) are loaded into a 2D texture array with one layer per part. The renderer selects layers via `QuadsTex3DBegin`/`QuadsTex3DDrawTL`/`QuadsTex3DEnd`, drawing all parts in 2 draw calls per tee (outline pass + fill pass) instead of ~8 individual `TextureSet` + `RenderQuadContainerAsSprite` calls.

Unlike a texture atlas, texture arrays have **no texture bleeding** each layer is an independent 2D texture with its own UV space, so bilinear filtering cannot sample across sprite boundaries.

## Perf profile comparison

Profiled with `perf` on a 64-player server with scoreboard open. Percentages are share of **total process CPU samples** from `perf report --children`.

| | Before | After |
|---|---|---|
| `RenderTee` | 5.94% | 2.31% |
| `RenderQuadContainerEx` + `AddCmd` | 6.32% | 0.88% |

61% reduction in `RenderTee` CPU cost.

## Checklist

- [x] Tested the change ingame
- [ ] Added documentation for new user facing features
- [ ] Wrote a unit test, or it's not possible/worth it
- [x] Changed no physics that affect existing maps/runs, or updated [physics_version](https://github.com/ddnet/ddnet/blob/master/src/game/server/gamecontext.cpp#L51)
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Ensured cross-platform compatibility
- [ ] Code was written or reviewed by AI without being checked and understood