### PR TITLE
Feature: Activate quad clipping for unbuffered backends

### DIFF
--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -1037,7 +1037,22 @@ void CRenderLayerQuads::Init()
 		m_TextureHandle.Invalidate();
 
 	if(!Graphics()->IsQuadBufferingEnabled())
+	{
+		// create clip region for unbuffered backends
+		CQuadCluster QuadCluster;
+		QuadCluster.m_Grouped = false;
+		QuadCluster.m_StartIndex = 0;
+		QuadCluster.m_NumQuads = m_pLayerQuads->m_NumQuads;
+
+		// unused, because cluster is not grouped
+		QuadCluster.m_PosEnv = -1;
+		QuadCluster.m_PosEnvOffset = 0;
+		QuadCluster.m_ColorEnv = -1;
+		QuadCluster.m_ColorEnvOffset = 0;
+
+		CalculateClipping(QuadCluster);
 		return;
+	}
 
 	std::vector<CTmpQuad> vTmpQuads;
 	std::vector<CTmpQuadTextured> vTmpQuadsTextured;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Currently the quad clipping for unbuffered backends like opengl 1 is skipped. We should enable this, because it can hide some huge quadarts:

**Before:**

Mona lisa is almost crashing the client
<img width="2560" height="1440" alt="screenshot_2026-03-14_12-20-01" src="https://github.com/user-attachments/assets/2b554aeb-ca90-403d-b6bd-a7e7bde11dca" />

Even outside of the viewscreen the mona is just pure spite
<img width="2560" height="1440" alt="screenshot_2026-03-14_12-20-12" src="https://github.com/user-attachments/assets/d7ec20dc-7db3-4ed3-bcca-58b5a754a76c" />

**After:**

Mona still hates us:
<img width="2560" height="1440" alt="screenshot_2026-03-14_12-27-28" src="https://github.com/user-attachments/assets/644eaba6-0022-4b55-9fed-022e7652f164" />

But at least the game keeps working if she is outside of viewrange
<img width="2560" height="1440" alt="screenshot_2026-03-14_12-27-08" src="https://github.com/user-attachments/assets/ed043ca2-4d3a-4e2f-a3d4-bd131a6ad98c" />

**Map:**

(Warning might explode your PC if you are running this game on a potato)
[mona-lisa3-noclip3.zip](https://github.com/user-attachments/files/25995027/mona-lisa3-noclip3.zip)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
