### PR TITLE
Feature: Shrink tile layer clips for unbuffered backends

### DIFF
--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -903,7 +903,48 @@ void CRenderLayerTile::OnInit(IGraphics *pGraphics, ITextRender *pTextRender, CR
 {
 	CRenderLayer::OnInit(pGraphics, pTextRender, pRenderMap, pEnvelopeManager, pMap, pMapImages, FRenderUploadCallbackOptional);
 	InitTileData();
-	m_LayerClip = CClipRegion(0.0f, 0.0f, m_pLayerTilemap->m_Width * 32.0f, m_pLayerTilemap->m_Height * 32.0f);
+
+	// set clip region
+	if(!Graphics()->IsTileBufferingEnabled())
+	{
+		// shrink clip region, this is done in `UploadTileData` for buffered backends
+		int MinX = m_pLayerTilemap->m_Width;
+		int MaxX = 0;
+		int MinY = m_pLayerTilemap->m_Height;
+		int MaxY = 0;
+		for(int TileY = 0; TileY < m_pLayerTilemap->m_Height; ++TileY)
+		{
+			for(int TileX = 0; TileX < m_pLayerTilemap->m_Width; ++TileX)
+			{
+				unsigned char Index = 0;
+				unsigned char Flags = 0;
+				int Angle = 0;
+				GetTileData(&Index, &Flags, &Angle, static_cast<unsigned int>(TileX), static_cast<unsigned int>(TileY), 0);
+
+				if(Index > 0)
+				{
+					MinX = std::min(TileX, MinX);
+					MaxX = std::max(TileX, MaxX);
+					MinY = std::min(TileY, MinY);
+					MaxY = std::max(TileY, MaxY);
+				}
+			}
+		}
+
+		if(MinX > MaxX || MinY > MaxY)
+		{
+			// layer is empty
+			m_LayerClip = CClipRegion(0.0f, 0.0f, 0.0f, 0.0f);
+		}
+		else
+		{
+			m_LayerClip = CClipRegion(MinX * 32.0f, MinY * 32.0f, (MaxX - MinX + 1) * 32.0f, (MaxY - MinY + 1) * 32.0f);
+		}
+	}
+	else
+	{
+		m_LayerClip = CClipRegion(0.0f, 0.0f, m_pLayerTilemap->m_Width * 32.0f, m_pLayerTilemap->m_Height * 32.0f);
+	}
 }
 
 void CRenderLayerTile::InitTileData()


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Currently for unbuffered backends i.e. opengl 1 the tile layer clip regions are not shrunk, but just kept at the size of the tile layer, even if it just contains nothing (AIR). This is the case, because the shrinking of the layer requires to iterate across the tilelayer which is done in `UploadTileData` for buffered backends, but not at all for unbuffered ones, because they don't upload to the GPU (yes, that's the meaning of unbuffered).

This is the followup of #11174 and uses the same map:

**After:**
<img width="2560" height="1440" alt="screenshot_2026-03-14_12-57-19" src="https://github.com/user-attachments/assets/36b8a655-bf1f-44f0-ac91-322fd96e966e" />


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
