### PR TITLE
Don't explicitly add default "smooth" qualifier when "noperspective" is not supported

### DIFF
--- a/src/engine/client/backend/glsl_shader_compiler.cpp
+++ b/src/engine/client/backend/glsl_shader_compiler.cpp
@@ -182,7 +182,7 @@ void CGLSLCompiler::ParseLine(std::string &Line, const char *pReadLine, EGLSLSha
 
 					if(str_comp(aTmpStr, "noperspective") == 0)
 					{
-						Line.append("smooth");
+						// GLES does not support noperspective. Drop it to use the default (smooth) inexplicitly because shaders fail to compile on iOS otherwise.
 						Line.append(pBuff);
 						return;
 					}


### PR DESCRIPTION
https://github.com/ddnet/ddnet/issues/11921#issuecomment-4060310093
With "smooth" is added, the shader won't compile on iOS, even though it should. But "smooth" is the default behavior so nothing should change even when it's removed.


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

AI proposed the fix and I tested on iOS device
<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
```
`UIScene` lifecycle will soon be required. Failure to adopt will result in an assert in the future.
2026-03-13 20:42:27 I ios: Changed current directory to '/Users/pioooooo/Library/Developer/CoreSimulator/Devices/85EE15BE-4F0F-4864-9027-43881915F4AB/data/Containers/Bundle/Application/088FA1CF-73D9-479B-8310-4D4A0CAB70C5/DDNet.app/'
2026-03-13 20:42:27 I engine: running on unix-ios-arm64
2026-03-13 20:42:27 I engine: arch is little endian
2026-03-13 20:42:27 I engine: operating system version: Darwin 25.2.0 (arm64, Darwin Kernel Version 25.2.0: Tue Nov 18 21:09:55 PST 2025; root:xnu-12377.61.12~1/RELEASE_ARM64_T8103)
2026-03-13 20:42:27 E storage: couldn't open storage.cfg
2026-03-13 20:42:27 I storage: using standard paths
2026-03-13 20:42:27 I storage: added path '$USERDIR' ('/Users/pioooooo/Library/Developer/CoreSimulator/Devices/85EE15BE-4F0F-4864-9027-43881915F4AB/data/Containers/Data/Application/AEED6E76-C79E-4B19-A6C5-02E678D9FBF8/Library/Application Support/DDNet')
2026-03-13 20:42:27 I storage: added path '$DATADIR' ('data')
2026-03-13 20:42:27 I storage: added path '$CURRENTDIR' ('/Users/pioooooo/Library/Developer/CoreSimulator/Devices/85EE15BE-4F0F-4864-9027-43881915F4AB/data/Containers/Bundle/Application/088FA1CF-73D9-479B-8310-4D4A0CAB70C5/DDNet.app')
You need UIApplicationSupportsIndirectInputEvents in your Info.plist for mouse support
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound f1 = toggle_local_console[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound f2 = toggle_remote_console[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound tab = +scoreboard[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound equals = +statboard[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound f10 = screenshot[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound a = +left[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound d = +right[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound space = +jump[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound mouse1 = +fire[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound mouse2 = +hook[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound lshift = +emote[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound return = +show_chat; chat all[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound right = spectate_next[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound left = spectate_previous[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound rshift = +spectate[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound 1 = +weapon1[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound 2 = +weapon2[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound 3 = +weapon3[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound 4 = +weapon4[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound 5 = +weapon5[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound mousewheelup = +prevweapon[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound mousewheeldown = +nextweapon[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound t = +show_chat; chat all[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound y = +show_chat; chat team[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound u = +show_chat[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound i = +show_chat; chat all /c [0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound f3 = vote yes[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound f4 = vote no[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound k = kill[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound q = say /spec[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound p = say /pause[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound kp_plus = zoom+[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound kp_minus = zoom-[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound kp_multiply = zoom[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound pause = say /pause[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound up = +jump[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound left = +left[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound right = +right[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound leftbracket = +prevweapon[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound rightbracket = +nextweapon[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound c = say /rank[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound v = say /info[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound b = say /top5[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound s = +showhookcoll[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound x = toggle cl_dummy 0 1[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound h = toggle cl_dummy_hammer 0 1[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound slash = +show_chat; chat all /[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound kp_0 = say /emote normal 999999[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound kp_1 = say /emote happy 999999[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound kp_2 = say /emote angry 999999[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound kp_3 = say /emote pain 999999[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound kp_4 = say /emote surprise 999999[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound kp_5 = say /emote blink 999999[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound minus = spectate_previous[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound equals = spectate_next[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound mouse3 = toggle_scoreboard_cursor; +spectate[0m
[38;2;255;255;204m2026-03-13 20:42:27 I binds: bound lalt = toggle_scoreboard_cursor[0m
2026-03-13 20:42:27 E net: Setting IP_TOS on IPv6 failed (22 'Invalid argument')
2026-03-13 20:42:27 E net: Setting IP_TOS on IPv6 failed (22 'Invalid argument')
2026-03-13 20:42:27 E net: Setting IP_TOS on IPv6 failed (22 'Invalid argument')
2026-03-13 20:42:27 I http: libcurl version 8.8.0-DEV (compiled = 8.8.0)
2026-03-13 20:42:27 I sdl: SDL version 2.32.10 (compiled = 2.32.10)
2026-03-13 20:42:28 I gfx: Created OpenGL ES 3.0 context
2026-03-13 20:42:29 I gfx/opengl: Vendor string: Apple Inc.
2026-03-13 20:42:29 I gfx/opengl: Version string: OpenGL ES 3.0 APPLE-22.0.12
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/prim.vert'. The compiler returned:
ERROR: 0:8: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/prim.frag'. The compiler returned:
ERROR: 0:12: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to link shader program '1'. The linker returned:
ERROR: OpenGL ES requires exactly one vertex and one fragment shader to validly link.
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/prim.vert'. The compiler returned:
ERROR: 0:9: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/prim.frag'. The compiler returned:
ERROR: 0:13: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to link shader program '2'. The linker returned:
ERROR: OpenGL ES requires exactly one vertex and one fragment shader to validly link.
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/pipeline.vert'. The compiler returned:
ERROR: 0:15: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/pipeline.frag'. The compiler returned:
ERROR: 0:23: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to link shader program '3'. The linker returned:
ERROR: OpenGL ES requires exactly one vertex and one fragment shader to validly link.
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/pipeline.vert'. The compiler returned:
ERROR: 0:14: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/pipeline.frag'. The compiler returned:
ERROR: 0:22: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to link shader program '4'. The linker returned:
ERROR: OpenGL ES requires exactly one vertex and one fragment shader to validly link.
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/tile.vert'. The compiler returned:
ERROR: 0:11: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/tile.frag'. The compiler returned:
ERROR: 0:22: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to link shader program '5'. The linker returned:
ERROR: OpenGL ES requires exactly one vertex and one fragment shader to validly link.
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/tile_border.vert'. The compiler returned:
ERROR: 0:14: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/tile_border.frag'. The compiler returned:
ERROR: 0:22: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to link shader program '6'. The linker returned:
ERROR: OpenGL ES requires exactly one vertex and one fragment shader to validly link.
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/quad.vert'. The compiler returned:
ERROR: 0:21: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/quad.frag'. The compiler returned:
ERROR: 0:21: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to link shader program '8'. The linker returned:
ERROR: OpenGL ES requires exactly one vertex and one fragment shader to validly link.
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/quad.vert'. The compiler returned:
ERROR: 0:22: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/quad.frag'. The compiler returned:
ERROR: 0:22: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to link shader program '10'. The linker returned:
ERROR: OpenGL ES requires exactly one vertex and one fragment shader to validly link.
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/quad.vert'. The compiler returned:
ERROR: 0:21: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/quad.frag'. The compiler returned:
ERROR: 0:21: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to link shader program '11'. The linker returned:
ERROR: OpenGL ES requires exactly one vertex and one fragment shader to validly link.
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/quad.vert'. The compiler returned:
ERROR: 0:22: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/quad.frag'. The compiler returned:
ERROR: 0:22: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to link shader program '12'. The linker returned:
ERROR: OpenGL ES requires exactly one vertex and one fragment shader to validly link.
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/text.vert'. The compiler returned:
ERROR: 0:9: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/text.frag'. The compiler returned:
ERROR: 0:16: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to link shader program '13'. The linker returned:
ERROR: OpenGL ES requires exactly one vertex and one fragment shader to validly link.
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/primex.vert'. The compiler returned:
ERROR: 0:13: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/primex.frag'. The compiler returned:
ERROR: 0:16: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to link shader program '14'. The linker returned:
ERROR: OpenGL ES requires exactly one vertex and one fragment shader to validly link.
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/primex.vert'. The compiler returned:
ERROR: 0:14: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/primex.frag'. The compiler returned:
ERROR: 0:17: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to link shader program '15'. The linker returned:
ERROR: OpenGL ES requires exactly one vertex and one fragment shader to validly link.
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/primex.vert'. The compiler returned:
ERROR: 0:14: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/primex.frag'. The compiler returned:
ERROR: 0:17: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to link shader program '16'. The linker returned:
ERROR: OpenGL ES requires exactly one vertex and one fragment shader to validly link.
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/primex.vert'. The compiler returned:
ERROR: 0:15: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/primex.frag'. The compiler returned:
ERROR: 0:18: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to link shader program '17'. The linker returned:
ERROR: OpenGL ES requires exactly one vertex and one fragment shader to validly link.
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/spritemulti.vert'. The compiler returned:
ERROR: 0:11: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to compile shader file 'shader/spritemulti.frag'. The compiler returned:
ERROR: 0:14: 'smooth' : syntax error: syntax error
2026-03-13 20:42:29 E gfx/opengl/shader: Failed to link shader program '18'. The linker returned:
ERROR: OpenGL ES requires exactly one vertex and one fragment shader to validly link.
[38;2;153;127;255m2026-03-13 20:42:29 I gfx: GPU vendor: Apple Inc.[0m
[38;2;153;127;255m2026-03-13 20:42:29 I gfx: GPU renderer: Apple Software Renderer[0m
[38;2;153;127;255m2026-03-13 20:42:29 I gfx: GPU version: OpenGL ES 3.0 APPLE-22.0.12[0m
2026-03-13 20:42:29 I localization: Choosing default language based on user locale 'en-CN'
AddInstanceForFactory: No factory registered for id <CFUUID 0x60000024ae00> F8BB1C28-BAE8-11D6-9C31-00039315CD46
       LoudnessManager.mm:1755  ReadPListFile: unable to open stream for LoudnessManager plist
       LoudnessManager.mm:1261  GetHardwarePlatformKey: cannot get acoustic ID
       LoudnessManager.mm:1215  IsHardwareSupported: no plist loaded, returning false
       LoudnessManager.mm:1215  IsHardwareSupported: no plist loaded, returning false
2026-03-13 20:42:29 I sound: sound init successful using audio driver 'coreaudio'
2026-03-13 20:42:29 I textrender: Freetype version 2.13.2 (compiled = 2.13.2)
2026-03-13 20:42:29 I joystick: 1 joystick(s) found
2026-03-13 20:42:29 I joystick: Opened joystick 0 'iOS Accelerometer' (3 axes, 0 buttons, 0 balls, 0 hats)
2026-03-13 20:42:29 E http: https://master3.ddnet.org/ddnet/15/servers.json failed. libcurl error (1): Protocol "https" not supported
2026-03-13 20:42:29 E http: https://master4.ddnet.org/ddnet/15/servers.json failed. libcurl error (1): Protocol "https" not supported
2026-03-13 20:42:29 E http: https://master1.ddnet.org/ddnet/15/servers.json failed. libcurl error (1): Protocol "https" not supported
2026-03-13 20:42:29 E http: https://master2.ddnet.org/ddnet/15/servers.json failed. libcurl error (1): Protocol "https" not supported
2026-03-13 20:42:29 E serverbrowser_http: WARNING: no usable masters found
2026-03-13 20:42:29 I joystick: Opened joystick 1 'Gamepad' (19 axes, 15 buttons, 0 balls, 0 hats)
[38;2;178;178;255m2026-03-13 20:42:30 I client: version 19.8 on ios arm64[0m
[38;2;178;178;255m2026-03-13 20:42:30 I client: git revision hash: 4dd20cc2f4c3566a[0m
2026-03-13 20:42:30 E serverbrowser_http: no working serverlist URL found
2026-03-13 20:42:30 E http: https://info.ddnet.org/info?name=nameless%20tee failed. libcurl error (1): Protocol "https" not supported
2026-03-13 20:42:30 E http: https://master2.ddnet.org/ddnet/15/servers.json failed. libcurl error (1): Protocol "https" not supported
2026-03-13 20:42:30 E http: https://master4.ddnet.org/ddnet/15/servers.json failed. libcurl error (1): Protocol "https" not supported
2026-03-13 20:42:30 E http: https://master1.ddnet.org/ddnet/15/servers.json failed. libcurl error (1): Protocol "https" not supported
2026-03-13 20:42:30 E http: https://master3.ddnet.org/ddnet/15/servers.json failed. libcurl error (1): Protocol "https" not supported
2026-03-13 20:42:30 E serverbrowser_http: WARNING: no usable masters found
2026-03-13 20:42:30 E serverbrowser_http: no working serverlist URL found
2026-03-13 20:42:55 I localization: loaded 'languages/danish.txt'
Message from debugger: Terminated due to signal 9
Program ended with exit code: 9
```
