### PR TITLE
Fix default graphics blend mode with OpenGL 1

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -110,7 +110,7 @@ CGraphics_Threaded::CGraphics_Threaded()
 	m_State.m_ClipW = 0;
 	m_State.m_ClipH = 0;
 	m_State.m_Texture = -1;
-	m_State.m_BlendMode = EBlendMode::NONE;
+	m_State.m_BlendMode = EBlendMode::ALPHA;
 	m_State.m_WrapMode = EWrapMode::REPEAT;
 
 	m_CurrentCommandBuffer = 0;


### PR DESCRIPTION
The blend mode was previously initialized to `NONE` (`BlendNone`) in the `CGraphics_Threaded` constructor but immediately set to `ALPHA` (`BlendNormal`) when rendering the loading screen.

The call to `BlendNormal` when rendering the loading screen was deemed unnecessary in #11938, which causes the blend mode to be incorrect with OpenGL 1, because it initializes its blend mode to `ALPHA`:

https://github.com/ddnet/ddnet/blob/f4e30bd321c3882193e2a0d1c8bb07252db9042d/src/engine/client/backend/opengl/backend_opengl.cpp#L614

Other backends are unaffected, as they apparently do not need this anymore:

https://github.com/ddnet/ddnet/blob/f4e30bd321c3882193e2a0d1c8bb07252db9042d/src/engine/client/backend/opengl/backend_opengl.cpp#L1133-L1136

Fixes this: <img width="1920" height="1080" alt="screenshot_2026-03-15_11-24-19" src="https://github.com/user-attachments/assets/38b4043f-3c8e-4547-b771-9901bd74256e" />


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions