### PR TITLE
Refactor SendPackMsg to use requires

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -83,7 +83,8 @@ public:
 	virtual int GetClientVersion(int ClientId) const = 0;
 	virtual int SendMsg(CMsgPacker *pMsg, int Flags, int ClientId) = 0;
 
-	template<class T, typename std::enable_if<!protocol7::is_sixup<T>::value, int>::type = 0>
+	template<class T>
+		requires(!protocol7::is_sixup<T>::value)
 	int SendPackMsg(const T *pMsg, int Flags, int ClientId)
 	{
 		int Result = 0;
@@ -100,7 +101,8 @@ public:
 		return Result;
 	}
 
-	template<class T, typename std::enable_if<protocol7::is_sixup<T>::value, int>::type = 1>
+	template<class T>
+		requires(protocol7::is_sixup<T>::value)
 	int SendPackMsg(const T *pMsg, int Flags, int ClientId)
 	{
 		int Result = 0;


### PR DESCRIPTION
`requires` is a C++20 way of doing it. It produces clearer compiler errors and eliminates the dummy template parameter workaround

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
