### PR TITLE
 Cleanup the main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,30 +32,6 @@ To clone this repository when you have the necessary libraries on your system al
 git clone --depth 1 https://github.com/ddnet/ddnet
 ```
 
-To clone this repository with external libraries and full history (~1 GiB):
-
-```sh
-git clone --recursive https://github.com/ddnet/ddnet
-```
-
-To clone this repository when you have the necessary libraries on your system already with full history (~450 MiB):
-
-```sh
-git clone https://github.com/ddnet/ddnet
-```
-
-To clone this repository since we moved the libraries to https://github.com/ddnet/ddnet-libs with history (~250 MiB):
-
-```sh
-git clone --shallow-exclude=included-libs https://github.com/ddnet/ddnet
-```
-
-To clone the libraries if you have previously cloned DDNet without them, or if you require the ddnet-libs history instead of a shallow clone:
-
-```sh
-git submodule update --init --recursive
-```
-
 ## Dependencies on Linux / macOS
 
 You can install the required libraries on your system, `touch CMakeLists.txt` and CMake will use the system-wide libraries by default. You can install all required dependencies and CMake on Debian or Ubuntu like this:
@@ -203,27 +179,3 @@ Detailed instructions can be found in [`docs/DATABASE.md`](docs/DATABASE.md).
 ## Debugging
 
 Detailed instructions can be found in [`docs/DEBUGGING.md`](docs/DEBUGGING.md).
-
-## Better Git Blame
-
-First, use a better tool than `git blame` itself, e.g. [`tig`](https://jonas.github.io/tig/). There's probably a good UI for Windows, too. Alternatively, use the GitHub UI, click "Blame" in any file view.
-
-For `tig`, use `tig blame path/to/file.cpp` to open the blame view, you can navigate with arrow keys or kj, press comma to go to the previous revision of the current line, q to quit.
-
-Only then you could also set up git to ignore specific formatting revisions:
-
-```sh
-git config blame.ignoreRevsFile formatting-revs.txt
-```
-
-## (Neo)Vim Syntax Highlighting for config files
-
-Copy the file detection and syntax files to your vim config folder:
-
-```sh
-# vim
-cp -R other/vim/* ~/.vim/
-
-# neovim
-cp -R other/vim/* ~/.config/nvim/
-```

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -380,3 +380,27 @@ Maintainers will update the translation files for releases based on the translat
 ## Commit messages
 
 Describe the change your contribution is making for the player/user instead of talking about what you did in a technical sense. Your PR messages will ideally be in a format that can directly be used in the [change log](https://ddnet.org/downloads/).
+
+## Better Git Blame
+
+First, use a better tool than `git blame` itself, e.g. [`tig`](https://jonas.github.io/tig/). There's probably a good UI for Windows, too. Alternatively, use the GitHub UI, click "Blame" in any file view.
+
+For `tig`, use `tig blame path/to/file.cpp` to open the blame view, you can navigate with arrow keys or kj, press comma to go to the previous revision of the current line, q to quit.
+
+Only then you could also set up git to ignore specific formatting revisions:
+
+```sh
+git config blame.ignoreRevsFile formatting-revs.txt
+```
+
+## (Neo)Vim Syntax Highlighting for config files
+
+Copy the file detection and syntax files to your vim config folder:
+
+```sh
+# vim
+cp -R other/vim/* ~/.vim/
+
+# neovim
+cp -R other/vim/* ~/.config/nvim/
+```


### PR DESCRIPTION
I don't like how there is still 10 ways to clone the repo. If someone isn't tech-savvy they probably just need 1 way e.g. depth 1 with submodules. If someone knows a difference between them, they most likely don't need the guide.

Also, the `Better Git Blame` section doesn't seem to contribute much. It's not related to the ddnet repo, we don't need to advertise `tig` that doesn't even work on windows. The github web version is good enough and is known

Same goes for the neo vim, I don't think most people use that particular editor. This seems like a personal preference rather than something related to ddnet. If this is really important to someone, this could be added to the `CONTRIBUTING.md` instead

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
