### PR TITLE
Assert that the connection tests actually use 0.6/0.7 connections

### DIFF
--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -647,7 +647,7 @@ def client_can_connect_7(test_env):
 	client = test_env.client()
 	server = test_env.server()
 	wait_for_startup([client, server])
-	client.command(f"connect tw-0.7+udp://localhost:{server.port}")
+	client.command(f"connect tw-0.7+udp://127.0.0.1:{server.port}") # FIXME(#11693): Work around missing domain support.
 	join = server.wait_for_log_prefix("server: player has entered the game", timeout=10).line
 	if "sixup=1" not in join:
 		raise AssertionError(f"sixup=0 not found in {join!r}")


### PR DESCRIPTION
Also work around #11693.

CC #11954 

## Checklist

- [x] Tested the change ~ingame~
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions