### PR TITLE
Make sure to not use the internal item type of snaps

### DIFF
--- a/datasrc/compile.py
+++ b/datasrc/compile.py
@@ -271,10 +271,8 @@ void CNetObjHandler::DebugDumpSnapshot(const CSnapshot *pSnap) const
 		const CSnapshotItem *pItem = pSnap->GetItem(i);
 		int Size = pSnap->GetItemSize(i);
 		int Type = pSnap->GetItemType(i);
-		const char *pName = GetObjName(pItem->Type());
-		if(Type > OFFSET_UUID && Type < g_UuidManager.NumUuids() + OFFSET_UUID)
-			pName = g_UuidManager.GetName(Type);
-		dbg_msg("snapshot", "\\t%s type=%d id=%d size=%d", pName, pItem->Type(), pItem->Id(), Size);
+		const char *pName = GetObjName(Type);
+		dbg_msg("snapshot", "\\t%s type=%d id=%d size=%d", pName, pItem->InternalType(), pItem->Id(), Size);
 		if(!DumpObj(Type, pItem->Data(), Size))
 			continue;
 

--- a/datasrc/seven/compile.py
+++ b/datasrc/seven/compile.py
@@ -285,10 +285,8 @@ void CNetObjHandler::DebugDumpSnapshot(const ::CSnapshot *pSnap) const
 		const CSnapshotItem *pItem = pSnap->GetItem(i);
 		int Size = pSnap->GetItemSize(i);
 		int Type = pSnap->GetItemType(i);
-		const char *pName = GetObjName(pItem->Type());
-		if(Type > OFFSET_UUID && Type < g_UuidManager.NumUuids() + OFFSET_UUID)
-			pName = g_UuidManager.GetName(Type);
-		dbg_msg("snapshot", "\\t%s type=%d id=%d size=%d", pName, pItem->Type(), pItem->Id(), Size);
+		const char *pName = GetObjName(Type);
+		dbg_msg("snapshot", "\\t%s type=%d id=%d size=%d", pName, pItem->InternalType(), pItem->Id(), Size);
 		if(!DumpObj(Type, pItem->Data(), Size))
 			continue;
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2336,6 +2336,15 @@ int CClient::UnpackAndValidateSnapshot(CSnapshot *pFrom, CSnapshot *pTo)
 		const void *pData = pFromItem->Data();
 		Unpacker.Reset(pData, FromItemSize);
 
+		if(ItemType <= 0)
+		{
+			// Don't add extended item type descriptions, they get
+			// added implicitly (== 0).
+			//
+			// Don't add items of unknown item types either (< 0).
+			continue;
+		}
+
 		void *pRawObj = pNetObjHandler->SecureUnpackObj(ItemType, &Unpacker);
 		if(!pRawObj)
 		{
@@ -2349,7 +2358,7 @@ int CClient::UnpackAndValidateSnapshot(CSnapshot *pFrom, CSnapshot *pTo)
 		}
 		const int ItemSize = pNetObjHandler->GetUnpackedObjSize(ItemType);
 
-		void *pObj = Builder.NewItem(pFromItem->Type(), pFromItem->Id(), ItemSize);
+		void *pObj = Builder.NewItem(ItemType, pFromItem->Id(), ItemSize);
 		if(!pObj)
 			return -4;
 

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -35,7 +35,7 @@ int CSnapshot::GetItemSize(int Index) const
 
 int CSnapshot::GetItemType(int Index) const
 {
-	int InternalType = GetItem(Index)->Type();
+	int InternalType = GetItem(Index)->InternalType();
 	return GetExternalItemType(InternalType);
 }
 
@@ -49,7 +49,7 @@ int CSnapshot::GetExternalItemType(int InternalType) const
 	int TypeItemIndex = GetItemIndex(InternalType); // NETOBJTYPE_EX
 	if(TypeItemIndex == -1 || GetItemSize(TypeItemIndex) < (int)sizeof(CUuid))
 	{
-		return InternalType;
+		return -1;
 	}
 	const CSnapshotItem *pTypeItem = GetItem(TypeItemIndex);
 	CUuid Uuid;
@@ -89,7 +89,7 @@ const void *CSnapshot::FindItem(int Type, int Id) const
 		for(int i = 0; i < m_NumItems; i++)
 		{
 			const CSnapshotItem *pItem = GetItem(i);
-			if(pItem->Type() == 0 && pItem->Id() >= OFFSET_UUID_TYPE) // NETOBJTYPE_EX
+			if(pItem->InternalType() == 0 && pItem->Id() >= OFFSET_UUID_TYPE) // NETOBJTYPE_EX
 			{
 				if(mem_comp(pItem->Data(), aTypeUuidItem, sizeof(CUuid)) == 0)
 				{
@@ -130,7 +130,7 @@ void CSnapshot::DebugDump() const
 	{
 		const CSnapshotItem *pItem = GetItem(i);
 		int Size = GetItemSize(i);
-		dbg_msg("snapshot", "\ttype=%d id=%d", pItem->Type(), pItem->Id());
+		dbg_msg("snapshot", "\ttype=%d id=%d", pItem->InternalType(), pItem->Id());
 		for(size_t b = 0; b < Size / sizeof(int32_t); b++)
 			dbg_msg("snapshot", "\t\t%3d %12d\t%08x", (int)b, pItem->Data()[b], pItem->Data()[b]);
 	}
@@ -338,7 +338,7 @@ int CSnapshotDelta::CreateDelta(const CSnapshot *pFrom, const CSnapshot *pTo, vo
 		const int ItemSize = pTo->GetItemSize(i); // O(1) .. O(n)
 		const CSnapshotItem *pCurItem = pTo->GetItem(i); // O(1) .. O(n)
 		const int PastIndex = aPastIndices[i];
-		const bool IncludeSize = pCurItem->Type() >= MAX_NETOBJSIZES || !m_aItemSizes[pCurItem->Type()];
+		const bool IncludeSize = pCurItem->InternalType() >= MAX_NETOBJSIZES || !m_aItemSizes[pCurItem->InternalType()];
 
 		if(PastIndex != -1)
 		{
@@ -351,7 +351,7 @@ int CSnapshotDelta::CreateDelta(const CSnapshot *pFrom, const CSnapshot *pTo, vo
 
 			if(DiffItem(pPastItem->Data(), pCurItem->Data(), pItemDataDst, ItemSize / sizeof(int32_t)))
 			{
-				*pData++ = pCurItem->Type();
+				*pData++ = pCurItem->InternalType();
 				*pData++ = pCurItem->Id();
 				if(IncludeSize)
 					*pData++ = ItemSize / sizeof(int32_t);
@@ -361,7 +361,7 @@ int CSnapshotDelta::CreateDelta(const CSnapshot *pFrom, const CSnapshot *pTo, vo
 		}
 		else
 		{
-			*pData++ = pCurItem->Type();
+			*pData++ = pCurItem->InternalType();
 			*pData++ = pCurItem->Id();
 			if(IncludeSize)
 				*pData++ = ItemSize / sizeof(int32_t);
@@ -544,7 +544,7 @@ int CSnapshotDelta::UnpackDelta(const CSnapshot *pFrom, CSnapshot *pTo, const vo
 
 		if(Keep)
 		{
-			void *pObj = Builder.NewItem(pFromItem->Type(), pFromItem->Id(), ItemSize);
+			void *pObj = Builder.NewItem(pFromItem->InternalType(), pFromItem->Id(), ItemSize);
 			if(!pObj)
 				return -301;
 

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -21,7 +21,7 @@ public:
 	int m_TypeAndId;
 
 	const int *Data() const { return (int *)(this + 1); }
-	int Type() const { return m_TypeAndId >> 16; }
+	int InternalType() const { return m_TypeAndId >> 16; }
 	int Id() const { return m_TypeAndId & 0xffff; }
 	int Key() const { return m_TypeAndId; }
 	void Invalidate() { m_TypeAndId = -1; }

--- a/src/game/client/sixup_translate_snapshot.cpp
+++ b/src/game/client/sixup_translate_snapshot.cpp
@@ -26,8 +26,17 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 		const int Size = pSnapSrcSeven->GetItemSize(i);
 		const int ItemType = pSnapSrcSeven->GetItemType(i);
 
+		if(ItemType <= 0)
+		{
+			// Don't add extended item type descriptions, they get
+			// added implicitly (== 0).
+			//
+			// Don't add items of unknown item types either (< 0).
+			continue;
+		}
+
 		// ddnet ex snap items
-		if((ItemType > __NETOBJTYPE_UUID_HELPER && ItemType < OFFSET_NETMSGTYPE_UUID) || pItem7->Type() == NETOBJTYPE_EX)
+		if(ItemType >= OFFSET_UUID)
 		{
 			CUnpacker Unpacker;
 			Unpacker.Reset(pItem7->Data(), Size);
@@ -41,7 +50,7 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 			}
 			const int ItemSize = GetNetObjHandler()->GetUnpackedObjSize(ItemType);
 
-			void *pObj = Builder.NewItem(pItem7->Type(), pItem7->Id(), ItemSize);
+			void *pObj = Builder.NewItem(ItemType, pItem7->Id(), ItemSize);
 			if(!pObj)
 				return -17;
 
@@ -49,23 +58,20 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 			continue;
 		}
 
-		if(GetNetObjHandler7()->ValidateObj(pItem7->Type(), pItem7->Data(), Size) != 0)
+		if(GetNetObjHandler7()->ValidateObj(ItemType, pItem7->Data(), Size) != 0)
 		{
-			if(pItem7->Type() > 0 && pItem7->Type() < CSnapshot::OFFSET_UUID_TYPE)
-			{
-				dbg_msg(
-					"sixup",
-					"invalidated index=%d type=%d (%s) size=%d id=%d",
-					i,
-					pItem7->Type(),
-					GetNetObjHandler7()->GetObjName(pItem7->Type()),
-					Size,
-					pItem7->Id());
-			}
+			dbg_msg(
+				"sixup",
+				"invalidated index=%d type=%d (%s) size=%d id=%d",
+				i,
+				ItemType,
+				GetNetObjHandler7()->GetObjName(ItemType),
+				Size,
+				pItem7->Id());
 			pSnapSrcSeven->InvalidateItem(i);
 		}
 
-		if(pItem7->Type() == protocol7::NETOBJTYPE_PLAYERINFORACE)
+		if(ItemType == protocol7::NETOBJTYPE_PLAYERINFORACE)
 		{
 			const protocol7::CNetObj_PlayerInfoRace *pInfo = (const protocol7::CNetObj_PlayerInfoRace *)pItem7->Data();
 			int ClientId = pItem7->Id();
@@ -74,7 +80,7 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 				TranslationContext.m_apPlayerInfosRace[ClientId] = pInfo;
 			}
 		}
-		else if(pItem7->Type() == protocol7::NETOBJTYPE_SPECTATORINFO)
+		else if(ItemType == protocol7::NETOBJTYPE_SPECTATORINFO)
 		{
 			const protocol7::CNetObj_SpectatorInfo *pSpec7 = (const protocol7::CNetObj_SpectatorInfo *)pItem7->Data();
 			SpectatorId = pSpec7->m_SpectatorId;
@@ -163,20 +169,21 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 	for(int i = 0; i < pSnapSrcSeven->NumItems(); i++)
 	{
 		const CSnapshotItem *pItem7 = pSnapSrcSeven->GetItem(i);
+		const int ItemType = pSnapSrcSeven->GetItemType(i);
 		const int Size = pSnapSrcSeven->GetItemSize(i);
 		// the first few items are a full match
 		// no translation needed
-		if(pItem7->Type() == protocol7::NETOBJTYPE_PROJECTILE ||
-			pItem7->Type() == protocol7::NETOBJTYPE_LASER ||
-			pItem7->Type() == protocol7::NETOBJTYPE_FLAG)
+		if(ItemType == protocol7::NETOBJTYPE_PROJECTILE ||
+			ItemType == protocol7::NETOBJTYPE_LASER ||
+			ItemType == protocol7::NETOBJTYPE_FLAG)
 		{
-			void *pObj = Builder.NewItem(pItem7->Type(), pItem7->Id(), Size);
+			void *pObj = Builder.NewItem(ItemType, pItem7->Id(), Size);
 			if(!pObj)
 				return -4;
 
 			mem_copy(pObj, pItem7->Data(), Size);
 		}
-		else if(pItem7->Type() == protocol7::NETOBJTYPE_PICKUP)
+		else if(ItemType == protocol7::NETOBJTYPE_PICKUP)
 		{
 			void *pObj = Builder.NewItem(NETOBJTYPE_PICKUP, pItem7->Id(), sizeof(CNetObj_Pickup));
 			if(!pObj)
@@ -190,14 +197,14 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 
 			mem_copy(pObj, &Pickup6, sizeof(CNetObj_Pickup));
 		}
-		else if(pItem7->Type() == protocol7::NETOBJTYPE_GAMEDATA)
+		else if(ItemType == protocol7::NETOBJTYPE_GAMEDATA)
 		{
 			const protocol7::CNetObj_GameData *pGameData = (const protocol7::CNetObj_GameData *)pItem7->Data();
 			TranslationContext.m_GameStateFlags7 = pGameData->m_GameStateFlags;
 			TranslationContext.m_GameStartTick7 = pGameData->m_GameStartTick;
 			TranslationContext.m_GameStateEndTick7 = pGameData->m_GameStateEndTick;
 		}
-		else if(pItem7->Type() == protocol7::NETOBJTYPE_GAMEDATATEAM)
+		else if(ItemType == protocol7::NETOBJTYPE_GAMEDATATEAM)
 		{
 			// 0.7 added GameDataTeam and GameDataFlag
 			// both items merged together have all fields of the 0.6 GameData
@@ -209,7 +216,7 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 			TranslationContext.m_TeamscoreBlue = pTeam7->m_TeamscoreBlue;
 			NewGameData = true;
 		}
-		else if(pItem7->Type() == protocol7::NETOBJTYPE_GAMEDATAFLAG)
+		else if(ItemType == protocol7::NETOBJTYPE_GAMEDATAFLAG)
 		{
 			const protocol7::CNetObj_GameDataFlag *pFlag7 = (const protocol7::CNetObj_GameDataFlag *)pItem7->Data();
 
@@ -223,7 +230,7 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 			// pFlag7->m_FlagDropTickRed;
 			// pFlag7->m_FlagDropTickBlue;
 		}
-		else if(pItem7->Type() == protocol7::NETOBJTYPE_CHARACTER)
+		else if(ItemType == protocol7::NETOBJTYPE_CHARACTER)
 		{
 			void *pObj = Builder.NewItem(NETOBJTYPE_CHARACTER, pItem7->Id(), sizeof(CNetObj_Character));
 			if(!pObj)
@@ -300,7 +307,7 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 
 			mem_copy(pObj, &Char6, sizeof(CNetObj_Character));
 		}
-		else if(pItem7->Type() == protocol7::NETOBJTYPE_PLAYERINFO)
+		else if(ItemType == protocol7::NETOBJTYPE_PLAYERINFO)
 		{
 			void *pObj = Builder.NewItem(NETOBJTYPE_PLAYERINFO, pItem7->Id(), sizeof(CNetObj_PlayerInfo));
 			if(!pObj)
@@ -320,7 +327,7 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 			Info6.m_Latency = pInfo7->m_Latency;
 			mem_copy(pObj, &Info6, sizeof(CNetObj_PlayerInfo));
 		}
-		else if(pItem7->Type() == protocol7::NETOBJTYPE_SPECTATORINFO)
+		else if(ItemType == protocol7::NETOBJTYPE_SPECTATORINFO)
 		{
 			void *pObj = Builder.NewItem(NETOBJTYPE_SPECTATORINFO, pItem7->Id(), sizeof(CNetObj_SpectatorInfo));
 			if(!pObj)
@@ -335,7 +342,7 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 			Spec6.m_Y = pSpec7->m_Y;
 			mem_copy(pObj, &Spec6, sizeof(CNetObj_SpectatorInfo));
 		}
-		else if(pItem7->Type() == protocol7::NETEVENTTYPE_EXPLOSION)
+		else if(ItemType == protocol7::NETEVENTTYPE_EXPLOSION)
 		{
 			void *pEvent = Builder.NewItem(NETEVENTTYPE_EXPLOSION, pItem7->Id(), sizeof(CNetEvent_Explosion));
 			if(!pEvent)
@@ -347,7 +354,7 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 			Explosion6.m_Y = pExplosion7->m_Y;
 			mem_copy(pEvent, &Explosion6, sizeof(CNetEvent_Explosion));
 		}
-		else if(pItem7->Type() == protocol7::NETEVENTTYPE_SPAWN)
+		else if(ItemType == protocol7::NETEVENTTYPE_SPAWN)
 		{
 			void *pEvent = Builder.NewItem(NETEVENTTYPE_SPAWN, pItem7->Id(), sizeof(CNetEvent_Spawn));
 			if(!pEvent)
@@ -359,7 +366,7 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 			Spawn6.m_Y = pSpawn7->m_Y;
 			mem_copy(pEvent, &Spawn6, sizeof(CNetEvent_Spawn));
 		}
-		else if(pItem7->Type() == protocol7::NETEVENTTYPE_HAMMERHIT)
+		else if(ItemType == protocol7::NETEVENTTYPE_HAMMERHIT)
 		{
 			void *pEvent = Builder.NewItem(NETEVENTTYPE_HAMMERHIT, pItem7->Id(), sizeof(CNetEvent_HammerHit));
 			if(!pEvent)
@@ -371,7 +378,7 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 			HammerHit6.m_Y = pHammerHit7->m_Y;
 			mem_copy(pEvent, &HammerHit6, sizeof(CNetEvent_HammerHit));
 		}
-		else if(pItem7->Type() == protocol7::NETEVENTTYPE_DEATH)
+		else if(ItemType == protocol7::NETEVENTTYPE_DEATH)
 		{
 			void *pEvent = Builder.NewItem(NETEVENTTYPE_DEATH, pItem7->Id(), sizeof(CNetEvent_Death));
 			if(!pEvent)
@@ -384,7 +391,7 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 			Death6.m_ClientId = pDeath7->m_ClientId;
 			mem_copy(pEvent, &Death6, sizeof(CNetEvent_Death));
 		}
-		else if(pItem7->Type() == protocol7::NETEVENTTYPE_SOUNDWORLD)
+		else if(ItemType == protocol7::NETEVENTTYPE_SOUNDWORLD)
 		{
 			void *pEvent = Builder.NewItem(NETEVENTTYPE_SOUNDWORLD, pItem7->Id(), sizeof(CNetEvent_SoundWorld));
 			if(!pEvent)
@@ -397,7 +404,7 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 			SoundWorld6.m_SoundId = pSoundWorld7->m_SoundId;
 			mem_copy(pEvent, &SoundWorld6, sizeof(CNetEvent_SoundWorld));
 		}
-		else if(pItem7->Type() == protocol7::NETEVENTTYPE_DAMAGE)
+		else if(ItemType == protocol7::NETEVENTTYPE_DAMAGE)
 		{
 			// 0.7 introduced amount for damage indicators
 			// so for one 0.7 item we might create multiple 0.6 ones
@@ -445,7 +452,7 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 				mem_copy(pEvent, &Dmg6, sizeof(CNetEvent_DamageInd));
 			}
 		}
-		else if(pItem7->Type() == protocol7::NETOBJTYPE_DE_CLIENTINFO)
+		else if(ItemType == protocol7::NETOBJTYPE_DE_CLIENTINFO)
 		{
 			const protocol7::CNetObj_De_ClientInfo *pInfo = (const protocol7::CNetObj_De_ClientInfo *)pItem7->Data();
 
@@ -470,7 +477,7 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 
 			ApplySkin7InfoFromSnapObj(pInfo, ClientId);
 		}
-		else if(pItem7->Type() == protocol7::NETOBJTYPE_DE_GAMEINFO)
+		else if(ItemType == protocol7::NETOBJTYPE_DE_GAMEINFO)
 		{
 			const protocol7::CNetObj_De_GameInfo *pInfo = (const protocol7::CNetObj_De_GameInfo *)pItem7->Data();
 

--- a/src/tools/demo_extract_chat.cpp
+++ b/src/tools/demo_extract_chat.cpp
@@ -51,6 +51,16 @@ public:
 			const int FromItemSize = pFrom->GetItemSize(Index);
 			const int ItemType = pFrom->GetItemType(Index);
 			const void *pData = pFromItem->Data();
+
+			if(ItemType <= 0)
+			{
+				// Don't add extended item type descriptions, they get
+				// added implicitly (== 0).
+				//
+				// Don't add items of unknown item types either (< 0).
+				continue;
+			}
+
 			Unpacker.Reset(pData, FromItemSize);
 
 			void *pRawObj = NetObjHandler.SecureUnpackObj(ItemType, &Unpacker);
@@ -58,7 +68,7 @@ public:
 				continue;
 
 			const int ItemSize = NetObjHandler.GetUnpackedObjSize(ItemType);
-			void *pObj = Builder.NewItem(pFromItem->Type(), pFromItem->Id(), ItemSize);
+			void *pObj = Builder.NewItem(ItemType, pFromItem->Id(), ItemSize);
 			if(!pObj)
 				return -4;
 


### PR DESCRIPTION
Rename the relevant method so it's less likely to get used in places where it shouldn't.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completion