### PR TITLE
Remove useless clamp

### DIFF
--- a/src/game/client/sixup_translate_snapshot.cpp
+++ b/src/game/client/sixup_translate_snapshot.cpp
@@ -119,10 +119,10 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 			Info6.m_WarmupTimer = TranslationContext.m_GameStateEndTick7 - GameTick;
 
 		// hack to port 0.7 race timer to ddnet warmup gametimer hack
-		int TimerClientId = std::clamp(TranslationContext.m_aLocalClientId[Conn], 0, (int)MAX_CLIENTS);
+		int TimerClientId = TranslationContext.m_aLocalClientId[Conn];
 		if(SpectatorId >= 0)
 			TimerClientId = SpectatorId;
-		const protocol7::CNetObj_PlayerInfoRace *pRaceInfo = TranslationContext.m_apPlayerInfosRace[TimerClientId];
+		const protocol7::CNetObj_PlayerInfoRace *pRaceInfo = TimerClientId == -1 ? nullptr : TranslationContext.m_apPlayerInfosRace[TimerClientId];
 		if(pRaceInfo)
 		{
 			Info6.m_WarmupTimer = -pRaceInfo->m_RaceStartTick;


### PR DESCRIPTION
The value could not hit the upper bound anyways because it is correctly bounds checked on assignment.
The lower bound can be hit if its "unitialized" to -1. Accessing it at MAX_CLIENTS is not even UB because it should match the array size. But whatever MAX_CLIENTS is never a valid client id so the bounds check however useless it is should ideally still be correct. And matching the other existing code.

https://github.com/ddnet/ddnet/pull/11959#discussion_r2954483104

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions