### PR TITLE
fix visual hook delay

### DIFF
--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -459,7 +459,7 @@ void CPlayers::RenderHook(
 	int ClientId,
 	float Intra)
 {
-	if(pPrevChar->m_HookState <= 0 || pPlayerChar->m_HookState <= 0)
+	if(pPlayerChar->m_HookState <= 0)
 		return;
 
 	CNetObj_Character Prev;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

This PR fixes the hook not being drawn the first tick it is extended. It seemed like this was a bug but if this is the intended behavior please mention it.

This could also be seen as slight input delay reduction as you can technically see your hook directly after hooking instead of waiting 20ms for the hook to appear, although after testing it ingame for a short amount of time I haven't noticed much of a difference with my eyes. But others might.

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

After this PR:

https://github.com/user-attachments/assets/f6a84219-545d-494d-a469-797f7088bd04

Before this PR:

https://github.com/user-attachments/assets/1c5d6032-7a4b-4a2d-bda5-2f530f176115

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
