### PR TITLE
Add clan tags to scoreboard, various layout improvements

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -431,7 +431,10 @@ void CScoreboard::RenderSpectators(CUIRect Spectators)
 	}
 }
 
-void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart, int CountEnd, CScoreboardRenderState &State)
+static const int MAX_COLUMNS = 3;
+static const int MAX_PLAYERS_PER_COLUMN = std::ceil(128.0f / MAX_COLUMNS);
+
+void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart, int CountEnd, int NumColumns, CScoreboardRenderState &State)
 {
 	dbg_assert(Team == TEAM_RED || Team == TEAM_BLUE, "Team invalid");
 
@@ -441,87 +444,126 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 	const bool MillisecondScore = GameClient()->m_ReceivedDDNetPlayerFinishTimes;
 	const bool TrueMilliseconds = GameClient()->m_ReceivedDDNetPlayerFinishTimesMillis;
 	const int NumPlayers = CountEnd - CountStart;
-	const bool LowScoreboardWidth = Scoreboard.w < 350.0f;
-
-	bool Race7 = Client()->IsSixup() && pGameInfoObj && pGameInfoObj->m_GameFlags & protocol7::GAMEFLAG_RACE;
-
+	const bool ShortTeamDisplay = NumPlayers > 8;
+	const bool Race7 = Client()->IsSixup() && pGameInfoObj && pGameInfoObj->m_GameFlags & protocol7::GAMEFLAG_RACE;
 	const bool UseTime = Race7 || TimeScore || MillisecondScore;
 
 	// calculate measurements
 	float LineHeight;
 	float TeeSizeMod;
-	float Spacing;
+	float SpacingW;
+	float SpacingH;
+	float MarginSides;
 	float RoundRadius;
+	float RoundRadiusSmall;
 	float FontSize;
+	float FontSizeSmall;
 	if(NumPlayers <= 8)
 	{
 		LineHeight = 30.0f;
 		TeeSizeMod = 0.5f;
-		Spacing = 8.0f;
+		SpacingW = 4.0f;
+		SpacingH = 8.0f;
+		MarginSides = 5.0f;
 		RoundRadius = 5.0f;
+		RoundRadiusSmall = 2.5f;
 		FontSize = 12.0f;
+		FontSizeSmall = 9.0f;
 	}
 	else if(NumPlayers <= 12)
 	{
 		LineHeight = 25.0f;
 		TeeSizeMod = 0.45f;
-		Spacing = 2.5f;
+		SpacingW = 4.0f;
+		SpacingH = 2.0f;
+		MarginSides = 5.0f;
 		RoundRadius = 5.0f;
-		FontSize = 12.0f;
+		RoundRadiusSmall = 2.5f;
+		if(NumColumns == 1)
+		{
+			FontSize = 12.0f;
+			FontSizeSmall = 9.0f;
+		}
+		else
+		{
+			FontSize = 11.0f;
+			FontSizeSmall = 8.0f;
+		}
 	}
 	else if(NumPlayers <= 16)
 	{
 		LineHeight = 20.0f;
 		TeeSizeMod = 0.4f;
-		Spacing = 0.0f;
+		SpacingW = 4.0f;
+		SpacingH = 0.0f;
+		MarginSides = 5.0f;
 		RoundRadius = 2.5f;
-		FontSize = 12.0f;
+		RoundRadiusSmall = 2.5f;
+		if(NumColumns == 1)
+		{
+			FontSize = 12.0f;
+			FontSizeSmall = 9.0f;
+		}
+		else
+		{
+			FontSize = 11.0f;
+			FontSizeSmall = 8.0f;
+		}
 	}
 	else if(NumPlayers <= 24)
 	{
 		LineHeight = 13.5f;
 		TeeSizeMod = 0.3f;
-		Spacing = 0.0f;
+		SpacingW = 3.0f;
+		SpacingH = 0.0f;
+		MarginSides = 5.0f;
 		RoundRadius = 2.5f;
+		RoundRadiusSmall = 2.5f;
 		FontSize = 10.0f;
+		FontSizeSmall = 8.0f;
 	}
 	else if(NumPlayers <= 32)
 	{
 		LineHeight = 10.0f;
 		TeeSizeMod = 0.2f;
-		Spacing = 0.0f;
+		SpacingW = 3.0f;
+		SpacingH = 0.0f;
+		MarginSides = 5.0f;
 		RoundRadius = 2.5f;
-		FontSize = 8.0f;
+		RoundRadiusSmall = 1.5f;
+		FontSize = 8.5f;
+		FontSizeSmall = 6.5f;
 	}
-	else if(LowScoreboardWidth)
+	else if(NumPlayers <= MAX_PLAYERS_PER_COLUMN)
 	{
 		LineHeight = 7.5f;
 		TeeSizeMod = 0.125f;
-		Spacing = 0.0f;
-		RoundRadius = 1.0f;
+		SpacingW = 2.0f;
+		SpacingH = 0.0f;
+		MarginSides = 5.0f;
+		RoundRadius = 1.5f;
+		RoundRadiusSmall = 1.5f;
 		FontSize = 7.0f;
+		FontSizeSmall = 5.0f;
 	}
 	else
 	{
-		LineHeight = 5.0f;
-		TeeSizeMod = 0.1f;
-		Spacing = 0.0f;
-		RoundRadius = 1.0f;
-		FontSize = 5.0f;
+		dbg_assert_failed("Cannot render %d players per scoreboard column", NumPlayers);
 	}
 
-	const float ScoreOffset = Scoreboard.x + 20.0f;
+	const float TeamsLength = GameClient()->m_GameInfo.m_DDRaceTeam && ShortTeamDisplay ? FontSize * 2.0f + 10.0f : 0.0f;
+	const float ScoreOffset = Scoreboard.x + MarginSides + TeamsLength;
 	const float ScoreLength = TextRender()->TextWidth(FontSize, UseTime ? "00:00:00" : "99999");
-	const float TeeOffset = ScoreOffset + ScoreLength + 20.0f;
-	const float TeeLength = 60.0f * TeeSizeMod;
-	const float NameOffset = TeeOffset + TeeLength;
-	const float NameLength = (LowScoreboardWidth ? 90.0f : 150.0f) - TeeLength;
-	const float CountryLength = (LineHeight - Spacing - TeeSizeMod * 5.0f) * 2.0f;
-	const float PingLength = 27.5f;
-	const float PingOffset = Scoreboard.x + Scoreboard.w - PingLength - 10.0f;
+	const float TeeOffset = ScoreOffset + ScoreLength + 5.0f;
+	const float TeeLength = LineHeight;
+	const float CountryHeight = 0.8f * LineHeight;
+	const float CountryLength = 2.0f * CountryHeight;
+	const float PingLength = TextRender()->TextWidth(FontSize, "999");
+	const float PingOffset = Scoreboard.x + Scoreboard.w - PingLength - SpacingW - MarginSides;
 	const float CountryOffset = PingOffset - CountryLength;
-	const float ClanOffset = NameOffset + NameLength + 2.5f;
-	const float ClanLength = CountryOffset - ClanOffset - 2.5f;
+	const float NameOffset = TeeOffset + TeeLength;
+	const float NameLengthWithClan = CountryOffset - NameOffset - 4.0f * SpacingW;
+	const float NameLengthWithoutClan = 0.7f * NameLengthWithClan;
 
 	// render headlines
 	const float HeadlineFontsize = 11.0f;
@@ -531,8 +573,6 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 	const char *pScore = UseTime ? Localize("Time") : Localize("Score");
 	TextRender()->Text(ScoreOffset + ScoreLength - TextRender()->TextWidth(HeadlineFontsize, pScore), HeadlineY, HeadlineFontsize, pScore);
 	TextRender()->Text(NameOffset, HeadlineY, HeadlineFontsize, Localize("Name"));
-	const char *pClanLabel = Localize("Clan");
-	TextRender()->Text(ClanOffset + (ClanLength - TextRender()->TextWidth(HeadlineFontsize, pClanLabel)) / 2.0f, HeadlineY, HeadlineFontsize, pClanLabel);
 	const char *pPingLabel = Localize("Ping");
 	TextRender()->Text(PingOffset + PingLength - TextRender()->TextWidth(HeadlineFontsize, pPingLabel), HeadlineY, HeadlineFontsize, pPingLabel);
 
@@ -562,11 +602,6 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 
 			int DDTeam = GameClient()->m_Teams.Team(pInfo->m_ClientId);
 			int NextDDTeam = 0;
-
-			ColorRGBA TextColor = TextRender()->DefaultTextColor();
-			TextColor.a = RenderDead ? 0.5f : 1.0f;
-			TextRender()->TextColor(TextColor);
-
 			for(int j = i + 1; j < MAX_CLIENTS; j++)
 			{
 				const CNetObj_PlayerInfo *pInfoNext = GameClient()->m_Snap.m_apInfoByDDTeamScore[j];
@@ -576,7 +611,6 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 				NextDDTeam = GameClient()->m_Teams.Team(pInfoNext->m_ClientId);
 				break;
 			}
-
 			if(PrevDDTeam == -1)
 			{
 				for(int j = i - 1; j >= 0; j--)
@@ -591,8 +625,11 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 			}
 
 			CUIRect RowAndSpacing, Row;
-			Scoreboard.HSplitTop(LineHeight + Spacing, &RowAndSpacing, &Scoreboard);
+			Scoreboard.HSplitTop(LineHeight + SpacingH, &RowAndSpacing, &Scoreboard);
 			RowAndSpacing.HSplitTop(LineHeight, &Row, nullptr);
+
+			const ColorRGBA TextColor = TextRender()->DefaultTextColor().WithAlpha(RenderDead ? 0.5f : 1.0f);
+			TextRender()->TextColor(TextColor);
 
 			// team background
 			if(DDTeam != TEAM_FLOCK)
@@ -615,7 +652,7 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 				{
 					const float TeamFontSize = FontSize / 1.5f;
 
-					if(NumPlayers > 8)
+					if(ShortTeamDisplay)
 					{
 						if(DDTeam == TEAM_SUPER)
 							str_copy(aBuf, Localize("Super"));
@@ -623,7 +660,7 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 							str_format(aBuf, sizeof(aBuf), "%d", DDTeam);
 						else
 							str_format(aBuf, sizeof(aBuf), Localize("%d\n(%d/%d)", "Team and size"), DDTeam, CurrentDDTeamSize, MaxTeamSize);
-						TextRender()->Text(State.m_TeamStartX, maximum(State.m_TeamStartY + Row.h / 2.0f - TeamFontSize, State.m_TeamStartY + 1.5f /* padding top */), TeamFontSize, aBuf);
+						TextRender()->Text(State.m_TeamStartX + 1.5f, maximum(State.m_TeamStartY + Row.h / 2.0f - TeamFontSize, State.m_TeamStartY + 1.5f), TeamFontSize, aBuf);
 					}
 					else
 					{
@@ -705,7 +742,7 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 				Graphics()->TextureSet(pGameDataObj->m_FlagCarrierBlue == pInfo->m_ClientId ? GameClient()->m_GameSkin.m_SpriteFlagBlue : GameClient()->m_GameSkin.m_SpriteFlagRed);
 				Graphics()->QuadsBegin();
 				Graphics()->QuadsSetSubset(1.0f, 0.0f, 0.0f, 1.0f);
-				IGraphics::CQuadItem QuadItem(TeeOffset, Row.y - 2.5f - Spacing / 2.0f, Row.h / 2.0f, Row.h);
+				IGraphics::CQuadItem QuadItem(TeeOffset, Row.y - 2.5f - SpacingH / 2.0f, Row.h / 2.0f, Row.h);
 				Graphics()->QuadsDrawTL(&QuadItem, 1);
 				Graphics()->QuadsEnd();
 			}
@@ -736,12 +773,13 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 			}
 
 			// name
+			float NameEndX;
 			{
 				CTextCursor Cursor;
 				Cursor.SetPosition(vec2(NameOffset, Row.y + (Row.h - FontSize) / 2.0f));
 				Cursor.m_FontSize = FontSize;
 				Cursor.m_Flags |= TEXTFLAG_ELLIPSIS_AT_END;
-				Cursor.m_LineWidth = NameLength;
+				Cursor.m_LineWidth = ClientData.m_aClan[0] != '\0' ? NameLengthWithoutClan : NameLengthWithClan;
 				if(ClientData.m_AuthLevel)
 				{
 					TextRender()->TextColor(color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClAuthedPlayerColor)));
@@ -758,31 +796,55 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 				if(Client()->IsSixup() && Client()->m_TranslationContext.m_aClients[pInfo->m_ClientId].m_PlayerFlags7 & protocol7::PLAYERFLAG_READY)
 				{
 					TextRender()->TextColor(0.1f, 1.0f, 0.1f, TextColor.a);
-					TextRender()->TextEx(&Cursor, "✓");
+					TextRender()->TextEx(&Cursor, " ✓");
 				}
+				NameEndX = Cursor.m_X;
 			}
 
 			// clan
+			if(ClientData.m_aClan[0] != '\0')
 			{
-				if(GameClient()->m_aLocalIds[g_Config.m_ClDummy] >= 0 && str_comp(ClientData.m_aClan, GameClient()->m_aClients[GameClient()->m_aLocalIds[g_Config.m_ClDummy]].m_aClan) == 0)
-				{
-					TextRender()->TextColor(color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClSameClanColor)));
-				}
-				else
-				{
-					TextRender()->TextColor(TextColor);
-				}
+				const float ClanOffset = NameEndX + 2.0f * SpacingW;
+				const float MaxClanLength = CountryOffset - ClanOffset - 2.0f * SpacingW;
+
 				CTextCursor Cursor;
-				Cursor.SetPosition(vec2(ClanOffset + (ClanLength - minimum(TextRender()->TextWidth(FontSize, ClientData.m_aClan), ClanLength)) / 2.0f, Row.y + (Row.h - FontSize) / 2.0f));
-				Cursor.m_FontSize = FontSize;
+				Cursor.m_FontSize = FontSizeSmall;
 				Cursor.m_Flags |= TEXTFLAG_ELLIPSIS_AT_END;
-				Cursor.m_LineWidth = ClanLength;
-				TextRender()->TextEx(&Cursor, ClientData.m_aClan);
+				Cursor.m_LineWidth = MaxClanLength;
+
+				const unsigned OldRenderFlags = TextRender()->GetRenderFlags();
+				TextRender()->SetRenderFlags(OldRenderFlags | TEXT_RENDER_FLAG_ONE_TIME_USE);
+				STextContainerIndex ClanTextContainer;
+				TextRender()->CreateTextContainer(ClanTextContainer, &Cursor, ClientData.m_aClan);
+				TextRender()->SetRenderFlags(OldRenderFlags);
+				if(ClanTextContainer.Valid())
+				{
+					CUIRect ClanBackground = {
+						.x = ClanOffset,
+						.y = Row.y + (Row.h - FontSizeSmall - 1.0f) / 2.0f,
+						.w = TextRender()->GetBoundingBoxTextContainer(ClanTextContainer).m_W + 3.0f * SpacingW,
+						.h = FontSizeSmall + 1.0f};
+					ClanBackground.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.25f), IGraphics::CORNER_ALL, RoundRadiusSmall);
+
+					ColorRGBA ClanColor;
+					if(GameClient()->m_aLocalIds[g_Config.m_ClDummy] >= 0 &&
+						str_comp(ClientData.m_aClan, GameClient()->m_aClients[GameClient()->m_aLocalIds[g_Config.m_ClDummy]].m_aClan) == 0)
+					{
+						ClanColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClSameClanColor));
+					}
+					else
+					{
+						ClanColor = TextColor;
+					}
+					TextRender()->RenderTextContainer(ClanTextContainer, ClanColor, TextRender()->DefaultTextOutlineColor(),
+						ClanBackground.x + SpacingW, ClanBackground.y + (ClanBackground.h - FontSizeSmall) / 2.0f);
+					TextRender()->DeleteTextContainer(ClanTextContainer);
+				}
 			}
 
 			// country flag
 			GameClient()->m_CountryFlags.Render(ClientData.m_Country, ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f),
-				CountryOffset, Row.y + (Spacing + TeeSizeMod * 5.0f) / 2.0f, CountryLength, Row.h - Spacing - TeeSizeMod * 5.0f);
+				CountryOffset, Row.y + (Row.h - CountryHeight) / 2.0f, CountryLength, CountryHeight);
 
 			// ping
 			if(g_Config.m_ClEnablePingColor)
@@ -795,7 +857,6 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 			}
 			str_format(aBuf, sizeof(aBuf), "%d", std::clamp(pInfo->m_Latency, 0, 999));
 			TextRender()->Text(PingOffset + PingLength - TextRender()->TextWidth(FontSize, aBuf), Row.y + (Row.h - FontSize) / 2.0f, FontSize, aBuf);
-			TextRender()->TextColor(TextRender()->DefaultTextColor());
 
 			if(CountRendered == CountEnd)
 				break;
@@ -803,6 +864,8 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 		if(CountRendered == CountEnd)
 			break;
 	}
+
+	TextRender()->TextColor(TextRender()->DefaultTextColor());
 }
 
 void CScoreboard::RenderRecordingNotification(float x)
@@ -878,7 +941,7 @@ void CScoreboard::OnRender()
 	const auto &aTeamSize = GameClient()->m_Snap.m_aTeamSize;
 	const int NumPlayers = Teams ? maximum(aTeamSize[TEAM_RED], aTeamSize[TEAM_BLUE]) : aTeamSize[TEAM_RED];
 
-	const float ScoreboardSmallWidth = 375.0f + 10.0f;
+	const float ScoreboardSmallWidth = 500.0f;
 	const float ScoreboardWidth = !Teams && NumPlayers <= 16 ? ScoreboardSmallWidth : 750.0f;
 	const float TitleHeight = 30.0f;
 
@@ -943,8 +1006,8 @@ void CScoreboard::OnRender()
 
 		RenderTitleBar(RedTitle, TEAM_RED, pRedTeamName == nullptr ? Localize("Red team") : pRedTeamName);
 		RenderTitleBar(BlueTitle, TEAM_BLUE, pBlueTeamName == nullptr ? Localize("Blue team") : pBlueTeamName);
-		RenderScoreboard(RedScoreboard, TEAM_RED, 0, NumPlayers, RenderState);
-		RenderScoreboard(BlueScoreboard, TEAM_BLUE, 0, NumPlayers, RenderState);
+		RenderScoreboard(RedScoreboard, TEAM_RED, 0, NumPlayers, 2, RenderState);
+		RenderScoreboard(BlueScoreboard, TEAM_BLUE, 0, NumPlayers, 2, RenderState);
 	}
 	else
 	{
@@ -966,9 +1029,9 @@ void CScoreboard::OnRender()
 
 		if(NumPlayers <= 16)
 		{
-			RenderScoreboard(Scoreboard, TEAM_GAME, 0, NumPlayers, RenderState);
+			RenderScoreboard(Scoreboard, TEAM_GAME, 0, NumPlayers, 1, RenderState);
 		}
-		else if(NumPlayers <= 64)
+		else if(NumPlayers <= 2 * MAX_PLAYERS_PER_COLUMN)
 		{
 			int PlayersPerSide;
 			if(NumPlayers <= 24)
@@ -977,24 +1040,24 @@ void CScoreboard::OnRender()
 				PlayersPerSide = 16;
 			else if(NumPlayers <= 48)
 				PlayersPerSide = 24;
-			else
+			else if(NumPlayers <= 64)
 				PlayersPerSide = 32;
+			else
+				PlayersPerSide = MAX_PLAYERS_PER_COLUMN;
 
 			CUIRect LeftScoreboard, RightScoreboard;
 			Scoreboard.VSplitMid(&LeftScoreboard, &RightScoreboard);
-			RenderScoreboard(LeftScoreboard, TEAM_GAME, 0, PlayersPerSide, RenderState);
-			RenderScoreboard(RightScoreboard, TEAM_GAME, PlayersPerSide, 2 * PlayersPerSide, RenderState);
+			RenderScoreboard(LeftScoreboard, TEAM_GAME, 0, PlayersPerSide, 2, RenderState);
+			RenderScoreboard(RightScoreboard, TEAM_GAME, PlayersPerSide, 2 * PlayersPerSide, 2, RenderState);
 		}
 		else
 		{
-			const int NumColumns = 3;
-			const int PlayersPerColumn = std::ceil(128.0f / NumColumns);
 			CUIRect RemainingScoreboard = Scoreboard;
-			for(int i = 0; i < NumColumns; ++i)
+			for(int i = 0; i < MAX_COLUMNS; ++i)
 			{
 				CUIRect Column;
-				RemainingScoreboard.VSplitLeft(Scoreboard.w / NumColumns, &Column, &RemainingScoreboard);
-				RenderScoreboard(Column, TEAM_GAME, i * PlayersPerColumn, (i + 1) * PlayersPerColumn, RenderState);
+				RemainingScoreboard.VSplitLeft(Scoreboard.w / MAX_COLUMNS, &Column, &RemainingScoreboard);
+				RenderScoreboard(Column, TEAM_GAME, i * MAX_PLAYERS_PER_COLUMN, (i + 1) * MAX_PLAYERS_PER_COLUMN, 3, RenderState);
 			}
 		}
 	}

--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -27,7 +27,7 @@ class CScoreboard : public CComponent
 	void RenderTitleBar(CUIRect TitleBar, int Team, const char *pTitle);
 	void RenderGoals(CUIRect Goals);
 	void RenderSpectators(CUIRect Spectators);
-	void RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart, int CountEnd, CScoreboardRenderState &State);
+	void RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart, int CountEnd, int NumColumns, CScoreboardRenderState &State);
 	void RenderRecordingNotification(float x);
 
 	static void ConKeyScoreboard(IConsole::IResult *pResult, void *pUserData);


### PR DESCRIPTION
Replace the separate column for clans in the scoreboard with clan tags that are positioned directly after the player name. Clan tags are rendered with a round rectangle background and a slightly smaller font size than the player name. This uses less width than dedicating an entire column to the clan, which allows rendering longer names and clans.

Improve the scoreboard layout with 64-86 players by splitting the players between 2 columns of 43 players instead of using the 3 column layout with the last column being empty.

Increase the overall scoreboard width for 1 column layouts, i.e. with 0-16 players.

Increase space for DDRace teams left of the score/time to avoid overlap. However, avoid adding this unused space on servers that do not use DDRace teams.

Decrease unnecessary margin between score/time and skin.

Slightly decrease the height of some scoreboard layouts to avoid the team background slightly overlapping the bottom edge of the scoreboard background.

Screenshots:

- 8 players:
    - Before: <img width="1920" height="1080" alt="8 old" src="https://github.com/user-attachments/assets/2a1e797a-ac1b-400f-8f49-728306ed6346" />
    - After: <img width="1920" height="1080" alt="8 new" src="https://github.com/user-attachments/assets/09be1a19-eb2c-4d57-a18a-bd890bc24c5c" />
- 12 players:
    - Before: <img width="1920" height="1080" alt="12 old" src="https://github.com/user-attachments/assets/fb99719c-d9fa-460b-b6aa-44b4e42b0201" />
    - After: <img width="1920" height="1080" alt="12 new" src="https://github.com/user-attachments/assets/7023b7bb-23d1-4158-a10f-8f15026419ff" />
- 16 players:
    - Before: <img width="1920" height="1080" alt="16 old" src="https://github.com/user-attachments/assets/903452e9-e36a-400f-9355-d6ebbba56490" />
    - After: <img width="1920" height="1080" alt="16 new" src="https://github.com/user-attachments/assets/33f5d8d7-d1b5-40d7-b4fc-3a3dfbd3b2ea" />
- 24 players:
    - Before: <img width="1920" height="1080" alt="24 old" src="https://github.com/user-attachments/assets/e507c302-fd2d-46ac-8930-29d81c9602d3" />
    - After: <img width="1920" height="1080" alt="24 new" src="https://github.com/user-attachments/assets/bec95d2f-8fe6-4872-b8a9-0aefdfd43817" />
- 32 players:
    - Before: <img width="1920" height="1080" alt="32 old" src="https://github.com/user-attachments/assets/bc60c684-bbc7-4eb6-8e9d-eb2bc491f59d" />
    - After: <img width="1920" height="1080" alt="32 new" src="https://github.com/user-attachments/assets/48f1e3eb-de9a-426d-810b-78664bce9623" />
- 48 players:
    - Before: <img width="1920" height="1080" alt="48 old" src="https://github.com/user-attachments/assets/58022f2b-0501-4e25-89f6-1947a4815874" />
    - After: <img width="1920" height="1080" alt="48 new" src="https://github.com/user-attachments/assets/ec57bb82-c86a-44ee-a8f5-e69cae6b792e" />
- 64 players:
    - Before: <img width="1920" height="1080" alt="64 old" src="https://github.com/user-attachments/assets/9435875e-bcd9-44fe-b3ea-853d39db630b" />
    - After: <img width="1920" height="1080" alt="64 new" src="https://github.com/user-attachments/assets/bd153f9c-d0fd-4fcc-951b-4fab0c04f2dc" />
- 86 players:
    - Before: <img width="1920" height="1080" alt="86 old" src="https://github.com/user-attachments/assets/43cb1762-94f6-4774-a7a3-2669e955cf17" />
    - After: <img width="1920" height="1080" alt="86 new" src="https://github.com/user-attachments/assets/5488f79d-0193-4e07-94eb-044249ad977b" />
- 128 players:
    - Before: <img width="1920" height="1080" alt="128 old" src="https://github.com/user-attachments/assets/d81b17f1-ebbf-429e-aa9e-ae44e979f0a0" />
    - After: <img width="1920" height="1080" alt="128 new" src="https://github.com/user-attachments/assets/e2569173-f23e-4760-ae8c-7adbf81b2d11" />
- 8 players (DDRace teams):
    - Before: <img width="1920" height="1080" alt="teams-8 old" src="https://github.com/user-attachments/assets/116a7484-67ad-4c22-9dd3-fbeddac051da" />
    - After: <img width="1920" height="1080" alt="teams-8 new" src="https://github.com/user-attachments/assets/2587d6c4-1bab-4fb2-a75a-ec6d23e76c56" />
- 48 players (DDRace teams):
    - Before: <img width="1920" height="1080" alt="teams-48 old" src="https://github.com/user-attachments/assets/d9bb389b-9c00-4768-8666-7eefe465d79d" />
    - After: <img width="1920" height="1080" alt="teams-48 new" src="https://github.com/user-attachments/assets/9be89eea-3e21-4eec-b6bd-c8e346e442ef" />
- 128 players (DDRace teams):
    - Before: <img width="1920" height="1080" alt="teams-128 old" src="https://github.com/user-attachments/assets/397ade50-3c83-4ec3-9183-5a29716047ee" />
    - After: <img width="1920" height="1080" alt="teams-128 new" src="https://github.com/user-attachments/assets/35b2c7bc-7593-4401-b3de-06c31cb0c0ce" />
- Vanilla teams:
    - Before: <img width="1920" height="1080" alt="vanilla-teams old" src="https://github.com/user-attachments/assets/56b5f86b-3503-4c31-9fd5-f2d670caaa6c" />
    - After: <img width="1920" height="1080" alt="vanilla-teams new" src="https://github.com/user-attachments/assets/81fcb309-2e14-4c36-aea2-f2c5915ff7ea" />

Tested with these binds:

```
bind kp_0 "rcon dbg_dummies 0"
bind kp_1 "rcon dbg_dummies 7"
bind kp_2 "rcon dbg_dummies 11"
bind kp_3 "rcon dbg_dummies 15"
bind kp_4 "rcon dbg_dummies 23"
bind kp_5 "rcon dbg_dummies 31"
bind kp_6 "rcon dbg_dummies 47"
bind kp_7 "rcon dbg_dummies 63"
bind kp_8 "rcon dbg_dummies 85"
bind kp_9 "rcon dbg_dummies 127"
```

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions