### PR TITLE
Reduce server demo size

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -86,7 +86,17 @@ public:
 	template<class T, typename std::enable_if<!protocol7::is_sixup<T>::value, int>::type = 0>
 	int SendPackMsg(const T *pMsg, int Flags, int ClientId)
 	{
+		if(ClientId == SERVER_DEMO_CLIENT)
+			return RecordServerDemoMsg(pMsg, Flags);
+
 		int Result = 0;
+		if(ClientId == -1)
+		{
+			Result = RecordServerDemoMsg(pMsg, Flags);
+			if(Result < 0)
+				return Result;
+		}
+
 		if(ClientId == -1)
 		{
 			for(int i = 0; i < MaxClients(); i++)
@@ -103,6 +113,10 @@ public:
 	template<class T, typename std::enable_if<protocol7::is_sixup<T>::value, int>::type = 1>
 	int SendPackMsg(const T *pMsg, int Flags, int ClientId)
 	{
+		// Sixup messages are never recorded to server demos (0.6 format only).
+		if(ClientId == SERVER_DEMO_CLIENT)
+			return 0;
+
 		int Result = 0;
 		if(ClientId == -1)
 		{
@@ -114,6 +128,18 @@ public:
 			Result = SendPackMsgOne(pMsg, Flags, ClientId);
 
 		return Result;
+	}
+
+	template<class T>
+	int RecordServerDemoMsg(const T *pMsg, int Flags)
+	{
+		if(Flags & MSGFLAG_NORECORD)
+			return 0;
+
+		CMsgPacker Packer(T::ms_MsgId, false, protocol7::is_sixup<T>::value);
+		if(pMsg->Pack(&Packer))
+			return -1;
+		return RecordServerDemo(&Packer);
 	}
 
 	template<class T>
@@ -191,6 +217,8 @@ public:
 			return -1;
 		return SendMsg(&Packer, Flags, ClientId);
 	}
+
+	virtual int RecordServerDemo(CMsgPacker *pMsg) = 0;
 
 	bool Translate(int &Target, int Client)
 	{

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -902,6 +902,24 @@ static inline bool RepackMsg(const CMsgPacker *pMsg, CPacker &Packer, bool Sixup
 	return true;
 }
 
+int CServer::RecordServerDemo(CMsgPacker *pMsg)
+{
+	if(pMsg->m_System)
+		return 0;
+	if(!m_aDemoRecorder[RECORDER_MANUAL].IsRecording() && !m_aDemoRecorder[RECORDER_AUTO].IsRecording())
+		return 0;
+
+	CPacker Pack;
+	if(!RepackMsg(pMsg, Pack, false))
+		return -1;
+
+	if(m_aDemoRecorder[RECORDER_MANUAL].IsRecording())
+		m_aDemoRecorder[RECORDER_MANUAL].RecordMessage(Pack.Data(), Pack.Size());
+	if(m_aDemoRecorder[RECORDER_AUTO].IsRecording())
+		m_aDemoRecorder[RECORDER_AUTO].RecordMessage(Pack.Data(), Pack.Size());
+	return 0;
+}
+
 int CServer::SendMsg(CMsgPacker *pMsg, int Flags, int ClientId)
 {
 	CNetChunk Packet;
@@ -910,6 +928,13 @@ int CServer::SendMsg(CMsgPacker *pMsg, int Flags, int ClientId)
 		Packet.m_Flags |= NETSENDFLAG_VITAL;
 	if(Flags & MSGFLAG_FLUSH)
 		Packet.m_Flags |= NETSENDFLAG_FLUSH;
+
+	if(ClientId == SERVER_DEMO_CLIENT)
+	{
+		if(Flags & MSGFLAG_NORECORD)
+			return 0;
+		return RecordServerDemo(pMsg);
+	}
 
 	if(ClientId < 0)
 	{
@@ -922,9 +947,18 @@ int CServer::SendMsg(CMsgPacker *pMsg, int Flags, int ClientId)
 		// write message to demo recorders
 		if(!(Flags & MSGFLAG_NORECORD))
 		{
-			for(auto &Recorder : m_aDemoRecorder)
-				if(Recorder.IsRecording())
-					Recorder.RecordMessage(Pack6.Data(), Pack6.Size());
+			for(int i = 0; i < MAX_CLIENTS; ++i)
+			{
+				if(m_aDemoRecorder[i].IsRecording())
+					m_aDemoRecorder[i].RecordMessage(Pack6.Data(), Pack6.Size());
+			}
+			if(!pMsg->m_System)
+			{
+				if(m_aDemoRecorder[RECORDER_MANUAL].IsRecording())
+					m_aDemoRecorder[RECORDER_MANUAL].RecordMessage(Pack6.Data(), Pack6.Size());
+				if(m_aDemoRecorder[RECORDER_AUTO].IsRecording())
+					m_aDemoRecorder[RECORDER_AUTO].RecordMessage(Pack6.Data(), Pack6.Size());
+			}
 		}
 
 		if(!(Flags & MSGFLAG_NOSEND))
@@ -966,10 +1000,6 @@ int CServer::SendMsg(CMsgPacker *pMsg, int Flags, int ClientId)
 		{
 			if(m_aDemoRecorder[ClientId].IsRecording())
 				m_aDemoRecorder[ClientId].RecordMessage(Pack.Data(), Pack.Size());
-			if(m_aDemoRecorder[RECORDER_MANUAL].IsRecording())
-				m_aDemoRecorder[RECORDER_MANUAL].RecordMessage(Pack.Data(), Pack.Size());
-			if(m_aDemoRecorder[RECORDER_AUTO].IsRecording())
-				m_aDemoRecorder[RECORDER_AUTO].RecordMessage(Pack.Data(), Pack.Size());
 		}
 
 		if(!(Flags & MSGFLAG_NOSEND))
@@ -1107,7 +1137,7 @@ void CServer::DoSnapshot()
 						Msg.AddInt(Crc);
 						Msg.AddInt(Chunk);
 						Msg.AddRaw(&aCompData[n * MaxSize], Chunk);
-						SendMsg(&Msg, MSGFLAG_FLUSH, i);
+						SendMsg(&Msg, MSGFLAG_FLUSH | MSGFLAG_NORECORD, i);
 					}
 					else
 					{
@@ -1119,7 +1149,7 @@ void CServer::DoSnapshot()
 						Msg.AddInt(Crc);
 						Msg.AddInt(Chunk);
 						Msg.AddRaw(&aCompData[n * MaxSize], Chunk);
-						SendMsg(&Msg, MSGFLAG_FLUSH, i);
+						SendMsg(&Msg, MSGFLAG_FLUSH | MSGFLAG_NORECORD, i);
 					}
 				}
 			}
@@ -1128,7 +1158,7 @@ void CServer::DoSnapshot()
 				CMsgPacker Msg(NETMSG_SNAPEMPTY, true);
 				Msg.AddInt(m_CurrentGameTick);
 				Msg.AddInt(m_CurrentGameTick - DeltaTick);
-				SendMsg(&Msg, MSGFLAG_FLUSH, i);
+				SendMsg(&Msg, MSGFLAG_FLUSH | MSGFLAG_NORECORD, i);
 			}
 		}
 	}
@@ -1320,7 +1350,7 @@ void CServer::SendRconType(int ClientId, bool UsernameReq)
 {
 	CMsgPacker Msg(NETMSG_RCONTYPE, true);
 	Msg.AddInt(UsernameReq);
-	SendMsg(&Msg, MSGFLAG_VITAL, ClientId);
+	SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 }
 
 void CServer::SendCapabilities(int ClientId)
@@ -1328,7 +1358,7 @@ void CServer::SendCapabilities(int ClientId)
 	CMsgPacker Msg(NETMSG_CAPABILITIES, true);
 	Msg.AddInt(SERVERCAP_CURVERSION); // version
 	Msg.AddInt(SERVERCAPFLAG_DDNET | SERVERCAPFLAG_CHATTIMEOUTCODE | SERVERCAPFLAG_ANYPLAYERFLAG | SERVERCAPFLAG_PINGEX | SERVERCAPFLAG_ALLOWDUMMY | SERVERCAPFLAG_SYNCWEAPONINPUT); // flags
-	SendMsg(&Msg, MSGFLAG_VITAL, ClientId);
+	SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 }
 
 void CServer::SendMap(int ClientId)
@@ -1348,7 +1378,7 @@ void CServer::SendMap(int ClientId)
 		{
 			Msg.AddString("", 0);
 		}
-		SendMsg(&Msg, MSGFLAG_VITAL, ClientId);
+		SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 	}
 	{
 		CMsgPacker Msg(NETMSG_MAP_CHANGE, true);
@@ -1361,7 +1391,7 @@ void CServer::SendMap(int ClientId)
 			Msg.AddInt(NET_MAX_CHUNK_SIZE - 128);
 			Msg.AddRaw(m_aCurrentMapSha256[MapType].data, sizeof(m_aCurrentMapSha256[MapType].data));
 		}
-		SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_FLUSH, ClientId);
+		SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_FLUSH | MSGFLAG_NORECORD, ClientId);
 	}
 
 	m_aClients[ClientId].m_NextMapChunk = 0;
@@ -1393,7 +1423,7 @@ void CServer::SendMapData(int ClientId, int Chunk)
 		Msg.AddInt(ChunkSize);
 	}
 	Msg.AddRaw(&m_apCurrentMapData[MapType][Offset], ChunkSize);
-	SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_FLUSH, ClientId);
+	SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_FLUSH | MSGFLAG_NORECORD, ClientId);
 
 	if(Config()->m_Debug)
 	{
@@ -1406,20 +1436,20 @@ void CServer::SendMapData(int ClientId, int Chunk)
 void CServer::SendMapReload(int ClientId)
 {
 	CMsgPacker Msg(NETMSG_MAP_RELOAD, true);
-	SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_FLUSH, ClientId);
+	SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_FLUSH | MSGFLAG_NORECORD, ClientId);
 }
 
 void CServer::SendConnectionReady(int ClientId)
 {
 	CMsgPacker Msg(NETMSG_CON_READY, true);
-	SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_FLUSH, ClientId);
+	SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_FLUSH | MSGFLAG_NORECORD, ClientId);
 }
 
 void CServer::SendRconLine(int ClientId, const char *pLine)
 {
 	CMsgPacker Msg(NETMSG_RCON_LINE, true);
 	Msg.AddString(pLine, 512);
-	SendMsg(&Msg, MSGFLAG_VITAL, ClientId);
+	SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 }
 
 void CServer::SendRconLogLine(int ClientId, const CLogMessage *pMessage)
@@ -1449,27 +1479,27 @@ void CServer::SendRconCmdAdd(const IConsole::ICommandInfo *pCommandInfo, int Cli
 	Msg.AddString(pCommandInfo->Name(), IConsole::TEMPCMD_NAME_LENGTH);
 	Msg.AddString(pCommandInfo->Help(), IConsole::TEMPCMD_HELP_LENGTH);
 	Msg.AddString(pCommandInfo->Params(), IConsole::TEMPCMD_PARAMS_LENGTH);
-	SendMsg(&Msg, MSGFLAG_VITAL, ClientId);
+	SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 }
 
 void CServer::SendRconCmdRem(const IConsole::ICommandInfo *pCommandInfo, int ClientId)
 {
 	CMsgPacker Msg(NETMSG_RCON_CMD_REM, true);
 	Msg.AddString(pCommandInfo->Name(), IConsole::TEMPCMD_NAME_LENGTH);
-	SendMsg(&Msg, MSGFLAG_VITAL, ClientId);
+	SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 }
 
 void CServer::SendRconCmdGroupStart(int ClientId)
 {
 	CMsgPacker Msg(NETMSG_RCON_CMD_GROUP_START, true);
 	Msg.AddInt(NumRconCommands(ClientId));
-	SendMsg(&Msg, MSGFLAG_VITAL, ClientId);
+	SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 }
 
 void CServer::SendRconCmdGroupEnd(int ClientId)
 {
 	CMsgPacker Msg(NETMSG_RCON_CMD_GROUP_END, true);
-	SendMsg(&Msg, MSGFLAG_VITAL, ClientId);
+	SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 }
 
 int CServer::NumRconCommands(int ClientId)
@@ -1518,13 +1548,13 @@ void CServer::SendMaplistGroupStart(int ClientId)
 {
 	CMsgPacker Msg(NETMSG_MAPLIST_GROUP_START, true);
 	Msg.AddInt(m_vMaplistEntries.size());
-	SendMsg(&Msg, MSGFLAG_VITAL, ClientId);
+	SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 }
 
 void CServer::SendMaplistGroupEnd(int ClientId)
 {
 	CMsgPacker Msg(NETMSG_MAPLIST_GROUP_END, true);
-	SendMsg(&Msg, MSGFLAG_VITAL, ClientId);
+	SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 }
 
 void CServer::UpdateClientMaplistEntries(int ClientId)
@@ -1581,7 +1611,7 @@ void CServer::UpdateClientMaplistEntries(int ClientId)
 			}
 			++Client.m_MaplistEntryToSend;
 		}
-		SendMsg(&Msg, MSGFLAG_VITAL, ClientId);
+		SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 	}
 
 	if((size_t)Client.m_MaplistEntryToSend >= m_vMaplistEntries.size())
@@ -1680,7 +1710,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 
 	if(Result == UNPACKMESSAGE_ANSWER)
 	{
-		SendMsg(&Packer, MSGFLAG_VITAL, ClientId);
+		SendMsg(&Packer, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 	}
 
 	{
@@ -1836,7 +1866,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 				CMsgPacker Msgp(NETMSG_INPUTTIMING, true);
 				Msgp.AddInt(IntendedTick);
 				Msgp.AddInt(TimeLeft);
-				SendMsg(&Msgp, 0, ClientId);
+				SendMsg(&Msgp, MSGFLAG_NORECORD, ClientId);
 			}
 
 			m_aClients[ClientId].m_LastInputTick = IntendedTick;
@@ -1932,7 +1962,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 		{
 			CMsgPacker Msgp(NETMSG_PING_REPLY, true);
 			int Vital = (pPacket->m_Flags & NET_CHUNKFLAG_VITAL) != 0 ? MSGFLAG_VITAL : 0;
-			SendMsg(&Msgp, MSGFLAG_FLUSH | Vital, ClientId);
+			SendMsg(&Msgp, MSGFLAG_FLUSH | Vital | MSGFLAG_NORECORD, ClientId);
 		}
 		else if(Msg == NETMSG_PINGEX)
 		{
@@ -1944,7 +1974,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 			CMsgPacker Msgp(NETMSG_PONGEX, true);
 			Msgp.AddRaw(pId, sizeof(*pId));
 			int Vital = (pPacket->m_Flags & NET_CHUNKFLAG_VITAL) != 0 ? MSGFLAG_VITAL : 0;
-			SendMsg(&Msgp, MSGFLAG_FLUSH | Vital, ClientId);
+			SendMsg(&Msgp, MSGFLAG_FLUSH | Vital | MSGFLAG_NORECORD, ClientId);
 		}
 		else
 		{
@@ -2031,7 +2061,7 @@ void CServer::OnNetMsgEnterGame(int ClientId)
 	{
 		CMsgPacker ServerInfoMessage(protocol7::NETMSG_SERVERINFO, true, true);
 		GetServerInfoSixup(&ServerInfoMessage, false);
-		SendMsg(&ServerInfoMessage, MSGFLAG_VITAL | MSGFLAG_FLUSH, ClientId);
+		SendMsg(&ServerInfoMessage, MSGFLAG_VITAL | MSGFLAG_FLUSH | MSGFLAG_NORECORD, ClientId);
 	}
 	GameServer()->OnClientEnter(ClientId);
 }
@@ -2787,7 +2817,7 @@ void CServer::UpdateServerInfo(bool Resend)
 				{
 					CMsgPacker ServerInfoMessage(protocol7::NETMSG_SERVERINFO, true, true);
 					GetServerInfoSixup(&ServerInfoMessage, false);
-					SendMsg(&ServerInfoMessage, MSGFLAG_VITAL | MSGFLAG_FLUSH, i);
+					SendMsg(&ServerInfoMessage, MSGFLAG_VITAL | MSGFLAG_FLUSH | MSGFLAG_NORECORD, i);
 				}
 			}
 		}
@@ -4186,12 +4216,12 @@ void CServer::LogoutClient(int ClientId, const char *pReason)
 		CMsgPacker Msg(NETMSG_RCON_AUTH_STATUS, true);
 		Msg.AddInt(0); //authed
 		Msg.AddInt(0); //cmdlist
-		SendMsg(&Msg, MSGFLAG_VITAL, ClientId);
+		SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 	}
 	else
 	{
 		CMsgPacker Msg(protocol7::NETMSG_RCON_AUTH_OFF, true, true);
-		SendMsg(&Msg, MSGFLAG_VITAL, ClientId);
+		SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 	}
 
 	m_aClients[ClientId].m_AuthTries = 0;

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -326,6 +326,7 @@ public:
 
 	int GetClientVersion(int ClientId) const override;
 	int SendMsg(CMsgPacker *pMsg, int Flags, int ClientId) override;
+	int RecordServerDemo(CMsgPacker *pMsg) override;
 
 	void DoSnapshot();
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -603,7 +603,7 @@ void CGameContext::SendChatTarget(int To, const char *pText, int VersionFlags) c
 	Msg.m_ClientId = -1;
 	Msg.m_pMessage = pText;
 
-	if(g_Config.m_SvDemoChat)
+	if(g_Config.m_SvDemoChat && To == -1)
 		Server()->SendPackMsg(&Msg, MSGFLAG_NOSEND, SERVER_DEMO_CLIENT);
 
 	if(To == -1)
@@ -790,7 +790,7 @@ void CGameContext::SendServerAlert(const char *pMessage)
 	//       otherwise the message is recorded multiple times.
 	CNetMsg_Sv_ServerAlert Msg;
 	Msg.m_pMessage = pMessage;
-	Server()->SendPackMsg(&Msg, MSGFLAG_NOSEND, 0);
+	Server()->SendPackMsg(&Msg, MSGFLAG_NOSEND, SERVER_DEMO_CLIENT);
 }
 
 void CGameContext::SendModeratorAlert(const char *pMessage, int ToClientId)


### PR DESCRIPTION
Reduce server demo size by skipping unnecessary traffic and deduping repeated messages.

Server demos were larger than necessary because global messages were recorded during per-client fan-out, and system/setup packets that are not used in demo playback were also stored. This change records global game messages once at the SendPackMsg layer instead of once per client, while excluding system messages from manual/auto server demos. The result is smaller server demos.

Closes #11144 
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions