### PR TITLE
Skip snapping entities with invalid IDs

### DIFF
--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -120,7 +120,8 @@ void CGameWorld::Snap(int SnappingClient)
 	for(CEntity *pEnt = m_apFirstEntityTypes[ENTTYPE_CHARACTER]; pEnt;)
 	{
 		m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
-		pEnt->Snap(SnappingClient);
+		if(pEnt->GetId() >= 0)
+			pEnt->Snap(SnappingClient);
 		pEnt = m_pNextTraverseEntity;
 	}
 
@@ -132,7 +133,8 @@ void CGameWorld::Snap(int SnappingClient)
 		for(CEntity *pEnt = m_apFirstEntityTypes[i]; pEnt;)
 		{
 			m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
-			pEnt->Snap(SnappingClient);
+			if(pEnt->GetId() >= 0)
+				pEnt->Snap(SnappingClient);
 			pEnt = m_pNextTraverseEntity;
 		}
 	}


### PR DESCRIPTION
When the snap ID pool is exhausted (~32K entities), new entities get ID -1. Snapping these causes an assertion crash in CSnapshotBuilder::NewItem. Skip them in CGameWorld::Snap instead.

Fixes #1192, fixes #11909

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
