### PR TITLE
Fix bugged dummy jump when quickly spectating

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -518,6 +518,7 @@ void CGameClient::OnDummySwap()
 	}
 	const int PrevDummyFire = m_DummyInput.m_Fire;
 	m_DummyInput = m_Controls.m_aInputData[!g_Config.m_ClDummy];
+	m_DummyInput.m_PlayerFlags &= ~PLAYERFLAG_SPEC_CAM;
 	m_Controls.m_aInputData[g_Config.m_ClDummy].m_Fire = PrevDummyFire;
 	m_IsDummySwapping = 1;
 }


### PR DESCRIPTION
When quickly switching to dummy and spectating `bind m "+toggle cl_dummy 1 0;say /spec"` the `SPEC_CAM` flag is missed because it's based on current player's camera type.

https://github.com/ddnet/ddnet/blob/f054384a3278530cafddf29d6826421d2aeb5236/src/game/client/components/controls.cpp#L200-L201

So the client would think the dummy is still in spec and send the `SPEC_CAM` flag to the server. Therefore, the server was ignoring its inputs when it was controlled with `cl_dummy_control`

https://github.com/ddnet/ddnet/blob/f054384a3278530cafddf29d6826421d2aeb5236/src/game/server/player.cpp#L597-L598

Video of the bug:
https://discord.com/channels/252358080522747904/757720336274948198/1483507363481653530


Clearing it when swapping doesn't break anything, because the flag is only used for view pos, and the dummy can't independently control the spec camera anyway.

https://github.com/ddnet/ddnet/blob/f054384a3278530cafddf29d6826421d2aeb5236/src/game/server/player.cpp#L566-L567

Steps to reproduce:
1. Connect dummy
2. Use this bind twice `bind m "+toggle cl_dummy 1 0;say /spec"`. So the dummy goes into spec and out of it
3. When it's out of spec try `bind w "+toggle cl_dummy_jump 1 0"`, it will jump in place (client-server mismatch)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
