### PR TITLE
Make hammer semi-transparent when hammer hit disabled

### DIFF
--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -663,6 +663,9 @@ void CPlayers::RenderPlayer(
 
 			if(Player.m_Weapon == WEAPON_HAMMER)
 			{
+				if(in_range(ClientId, 0, MAX_CLIENTS - 1) && GameClient()->m_aClients[ClientId].m_HammerHitDisabled)
+					Graphics()->SetColor(1.0f, 1.0f, 1.0f, Alpha * 0.5f);
+
 				// static position for hammer
 				WeaponPosition = Position + vec2(State.GetAttach()->m_X, State.GetAttach()->m_Y);
 				WeaponPosition.y += g_pData->m_Weapons.m_aId[CurrentWeapon].m_Offsety;


### PR DESCRIPTION
Closes #11717
Alternative to #11984

Fully client-sided with minimal changes.
Feels intuitive since semi-transparent players can't be hit 

<img width="631" height="450" alt="image" src="https://github.com/user-attachments/assets/57dbda9b-0fca-4dfe-8245-b146267e398d" />



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
