### PR TITLE
Move info to own method

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1716,55 +1716,14 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 		}
 		else if(Msg == NETMSG_INFO)
 		{
-			if((m_aClients[ClientId].m_State == CClient::STATE_PREAUTH || m_aClients[ClientId].m_State == CClient::STATE_AUTH))
-			{
-				const char *pVersion = Unpacker.GetString(CUnpacker::SANITIZE_CC);
-				if(Unpacker.Error())
-				{
-					return;
-				}
-				if(str_comp(pVersion, GameServer()->NetVersion()) != 0 && str_comp(pVersion, "0.7 802f1be60a05665f") != 0)
-				{
-					// wrong version
-					char aReason[256];
-					str_format(aReason, sizeof(aReason), "Wrong version. Server is running '%s' and client '%s'", GameServer()->NetVersion(), pVersion);
-					m_NetServer.Drop(ClientId, aReason);
-					return;
-				}
+			const char *pVersion = Unpacker.GetString(CUnpacker::SANITIZE_CC);
+			if(Unpacker.Error())
+				return;
+			const char *pPassword = Unpacker.GetString(CUnpacker::SANITIZE_CC);
+			if(Unpacker.Error())
+				pPassword = nullptr;
 
-				const char *pPassword = Unpacker.GetString(CUnpacker::SANITIZE_CC);
-				if(Unpacker.Error())
-				{
-					return;
-				}
-				if(Config()->m_Password[0] != 0 && str_comp(Config()->m_Password, pPassword) != 0)
-				{
-					// wrong password
-					m_NetServer.Drop(ClientId, "Wrong password");
-					return;
-				}
-
-				int NumConnectedClients = 0;
-				for(int i = 0; i < MaxClients(); ++i)
-				{
-					if(m_aClients[i].m_State != CClient::STATE_EMPTY)
-					{
-						NumConnectedClients++;
-					}
-				}
-
-				// reserved slot
-				if(NumConnectedClients > MaxClients() - Config()->m_SvReservedSlots && !CheckReservedSlotAuth(ClientId, pPassword))
-				{
-					m_NetServer.Drop(ClientId, "This server is full");
-					return;
-				}
-
-				m_aClients[ClientId].m_State = CClient::STATE_CONNECTING;
-				SendRconType(ClientId, m_AuthManager.NumNonDefaultKeys() > 0);
-				SendCapabilities(ClientId);
-				SendMap(ClientId);
-			}
+			OnNetMsgInfo(ClientId, pVersion, pPassword);
 		}
 		else if(Msg == NETMSG_REQUEST_MAP_DATA)
 		{
@@ -1981,6 +1940,53 @@ void CServer::OnNetMsgClientVer(int ClientId, CUuid *pConnectionId, int DDNetVer
 	m_aClients[ClientId].m_DDNetVersionSettled = true;
 	m_aClients[ClientId].m_GotDDNetVersionPacket = true;
 	m_aClients[ClientId].m_State = CClient::STATE_AUTH;
+}
+
+void CServer::OnNetMsgInfo(int ClientId, const char *pVersion, const char *pPasswordOrNullptr)
+{
+	if((m_aClients[ClientId].m_State != CClient::STATE_PREAUTH && m_aClients[ClientId].m_State != CClient::STATE_AUTH))
+		return;
+
+	if(str_comp(pVersion, GameServer()->NetVersion()) != 0 && str_comp(pVersion, "0.7 802f1be60a05665f") != 0)
+	{
+		// wrong version
+		char aReason[256];
+		str_format(aReason, sizeof(aReason), "Wrong version. Server is running '%s' and client '%s'", GameServer()->NetVersion(), pVersion);
+		m_NetServer.Drop(ClientId, aReason);
+		return;
+	}
+
+	const char *pPassword = pPasswordOrNullptr;
+	if(!pPassword)
+		return;
+
+	if(Config()->m_Password[0] != 0 && str_comp(Config()->m_Password, pPassword) != 0)
+	{
+		// wrong password
+		m_NetServer.Drop(ClientId, "Wrong password");
+		return;
+	}
+
+	int NumConnectedClients = 0;
+	for(int i = 0; i < MaxClients(); ++i)
+	{
+		if(m_aClients[i].m_State != CClient::STATE_EMPTY)
+		{
+			NumConnectedClients++;
+		}
+	}
+
+	// reserved slot
+	if(NumConnectedClients > MaxClients() - Config()->m_SvReservedSlots && !CheckReservedSlotAuth(ClientId, pPassword))
+	{
+		m_NetServer.Drop(ClientId, "This server is full");
+		return;
+	}
+
+	m_aClients[ClientId].m_State = CClient::STATE_CONNECTING;
+	SendRconType(ClientId, m_AuthManager.NumNonDefaultKeys() > 0);
+	SendCapabilities(ClientId);
+	SendMap(ClientId);
 }
 
 void CServer::OnNetMsgReady(int ClientId)

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -369,6 +369,7 @@ public:
 	bool CheckReservedSlotAuth(int ClientId, const char *pPassword);
 	void ProcessClientPacket(CNetChunk *pPacket);
 	void OnNetMsgClientVer(int ClientId, CUuid *pConnectionId, int DDNetVersion, const char *pDDNetVersionStr);
+	void OnNetMsgInfo(int ClientId, const char *pVersion, const char *pPasswordOrNullptr);
 	void OnNetMsgReady(int ClientId);
 	void OnNetMsgEnterGame(int ClientId);
 	void OnNetMsgRconCmd(int ClientId, const char *pCmd);


### PR DESCRIPTION
To be consistent with the other code the unpacker step
happens outside of the method. And to not change the protocol
the version check can still return a proper error message
even if the password is missing which for the correct version
will still just silently drop the invalid message.


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions