### PR TITLE
Replace websocket chunk checks with assertions

### DIFF
--- a/src/engine/shared/websockets.cpp
+++ b/src/engine/shared/websockets.cpp
@@ -64,19 +64,14 @@ static lws_context *websocket_context(int socket)
 	return context;
 }
 
-static int receive_chunk(context_data *ctx_data, per_session_data *pss, const void *in, size_t len)
+static void receive_chunk(context_data *ctx_data, per_session_data *pss, const void *in, size_t len)
 {
 	websocket_chunk *chunk = ctx_data->recv_buffer.Allocate(len + sizeof(websocket_chunk));
-	if(chunk == nullptr)
-	{
-		return 1;
-	}
-
+	dbg_assert(chunk != nullptr, "failed to allocate websocket receive buffer chunk of size %" PRIzu, len);
 	chunk->size = len;
 	chunk->read = 0;
 	chunk->addr = pss->addr;
 	mem_copy(&chunk->data[0], in, len);
-	return 0;
 }
 
 static void sockaddr_to_netaddr_websocket(const sockaddr *src, socklen_t src_len, NETADDR *dst)
@@ -185,7 +180,8 @@ static int websocket_protocol_callback(lws *wsi, enum lws_callback_reasons reaso
 	case LWS_CALLBACK_CLIENT_RECEIVE:
 		[[fallthrough]];
 	case LWS_CALLBACK_RECEIVE:
-		return receive_chunk(ctx_data, pss, in, len);
+		receive_chunk(ctx_data, pss, in, len);
+		return 0;
 
 	default:
 		return 0;
@@ -357,12 +353,8 @@ int websocket_send(int socket, const unsigned char *data, size_t size, const NET
 
 	const size_t chunk_size = size + sizeof(websocket_chunk) + LWS_SEND_BUFFER_PRE_PADDING + LWS_SEND_BUFFER_POST_PADDING;
 	websocket_chunk *chunk = pss->send_buffer.Allocate(chunk_size);
+	dbg_assert(chunk != nullptr, "failed to allocate websocket send buffer chunk of size %" PRIzu, size);
 	mem_zero(chunk, chunk_size);
-	if(chunk == nullptr)
-	{
-		return -1;
-	}
-
 	chunk->size = size;
 	chunk->read = 0;
 	chunk->addr = pss->addr;


### PR DESCRIPTION
The websocket send/receive ringbuffers use `FLAG_RECYCLE`, so allocating should always return a chunk and not `nullptr`, unless the chunk size exceeds the size of the ringbuffer, which should never happen.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions