### PR TITLE
Fix client crash connecting to same websockets port after shutdown

### DIFF
--- a/src/engine/shared/websockets.cpp
+++ b/src/engine/shared/websockets.cpp
@@ -140,6 +140,8 @@ static int websocket_protocol_callback(lws *wsi, enum lws_callback_reasons reaso
 		return 0;
 	}
 
+	case LWS_CALLBACK_CLIENT_CLOSED:
+		[[fallthrough]];
 	case LWS_CALLBACK_CLOSED:
 	{
 		char addr_str[NETADDR_MAXSTRSIZE];
@@ -148,6 +150,15 @@ static int websocket_protocol_callback(lws *wsi, enum lws_callback_reasons reaso
 
 		static const unsigned char CLOSE_PACKET[] = {0x10, 0x0e, 0x00, 0x04};
 		receive_chunk(ctx_data, pss, &CLOSE_PACKET, sizeof(CLOSE_PACKET));
+		return 0;
+	}
+
+	case LWS_CALLBACK_WSI_DESTROY:
+	{
+		if(pss == nullptr)
+		{
+			return 0;
+		}
 		pss->wsi = nullptr;
 		ctx_data->port_map.erase(pss->addr);
 		return 0;


### PR DESCRIPTION
Add handling for client websocket connection being closed by the server (e.g. due to shutdown or kick). Fix client crashing when trying to open another websocket connection to the same port after the connection was closed by the server, due to the stale pointer to `pss` (the per-session-data) not being removed from the port map when the session ends.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions