### PR TITLE
Optimize editor ingame entities, render entities in switch layer

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -40,6 +40,7 @@
 #include <chrono>
 #include <iterator>
 #include <limits>
+#include <tuple>
 #include <type_traits>
 
 static const char *VANILLA_IMAGES[] = {
@@ -6768,81 +6769,138 @@ void CEditor::RenderMousePointer()
 	}
 }
 
-void CEditor::RenderGameEntities(const std::shared_ptr<CLayerTiles> &pTiles)
+void CEditor::RenderIngameEntities(const CLayerGroup &Group, const CLayerTiles &TilesLayer)
 {
 	const CGameClient *pGameClient = (CGameClient *)Kernel()->RequestInterface<IGameClient>();
 	const float TileSize = 32.f;
 
-	for(int y = 0; y < pTiles->m_Height; y++)
+	const bool DDNetOrCustomEntities = std::find_if(std::begin(gs_apModEntitiesNames), std::end(gs_apModEntitiesNames),
+						   [&](const char *pEntitiesName) { return str_comp_nocase(m_SelectEntitiesImage.c_str(), pEntitiesName) == 0 &&
+											   str_comp_nocase(pEntitiesName, "ddnet") != 0; }) == std::end(gs_apModEntitiesNames);
+
+	const bool IsSwitch = TilesLayer.m_HasSwitch;
+	std::function<std::tuple<unsigned char, unsigned char>(int, int)> GetTile;
+	std::function<unsigned char(int, int)> GetIndexChecked;
+	if(IsSwitch)
 	{
-		for(int x = 0; x < pTiles->m_Width; x++)
+		const CLayerSwitch &SwitchLayer = static_cast<const CLayerSwitch &>(TilesLayer);
+		GetTile = [&](int x, int y) -> std::tuple<unsigned char, unsigned char> {
+			const CSwitchTile Tile = SwitchLayer.m_pSwitchTile[y * SwitchLayer.m_Width + x];
+			return {Tile.m_Type - ENTITY_OFFSET, Tile.m_Flags};
+		};
+		GetIndexChecked = [&](int x, int y) -> unsigned char {
+			if(x < 0 || y < 0 || x >= SwitchLayer.m_Width || y >= SwitchLayer.m_Height)
+			{
+				return 0;
+			}
+			return SwitchLayer.m_pSwitchTile[y * SwitchLayer.m_Width + x].m_Type - ENTITY_OFFSET;
+		};
+	}
+	else
+	{
+		GetTile = [&](int x, int y) -> std::tuple<unsigned char, unsigned char> {
+			const CTile Tile = TilesLayer.m_pTiles[y * TilesLayer.m_Width + x];
+			return {Tile.m_Index - ENTITY_OFFSET, Tile.m_Flags};
+		};
+		GetIndexChecked = [&](int x, int y) -> unsigned char {
+			if(x < 0 || y < 0 || x >= TilesLayer.m_Width || y >= TilesLayer.m_Height)
+			{
+				return 0;
+			}
+			return TilesLayer.m_pTiles[y * TilesLayer.m_Width + x].m_Index - ENTITY_OFFSET;
+		};
+	}
+
+	static const ivec2 DOOR_OFFSETS[] = {{1, 0}, {1, 1}, {0, 1}, {-1, 1}, {-1, 0}, {-1, -1}, {0, -1}, {1, -1}};
+	const ColorRGBA DoorOuterColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClLaserDoorOutlineColor));
+	const ColorRGBA DoorInnerColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClLaserDoorInnerColor));
+
+	float aPoints[4];
+	Group.Mapping(aPoints);
+	const int ExtraBorder = 9; // doors extend beyond the tile on which they are placed
+	const int StartX = std::max<int>(0, std::floor(aPoints[0] / TileSize) - ExtraBorder);
+	const int EndX = std::min<int>(TilesLayer.m_Width, std::ceil(aPoints[2] / TileSize) + ExtraBorder);
+	const int StartY = std::max<int>(0, std::floor(aPoints[1] / TileSize) - ExtraBorder);
+	const int EndY = std::min<int>(TilesLayer.m_Height, std::ceil(aPoints[3] / TileSize) + ExtraBorder);
+	for(int y = StartY; y < EndY; y++)
+	{
+		for(int x = StartX; x < EndX; x++)
 		{
-			const unsigned char Index = pTiles->m_pTiles[y * pTiles->m_Width + x].m_Index - ENTITY_OFFSET;
-			if(!((Index >= ENTITY_FLAGSTAND_RED && Index <= ENTITY_WEAPON_LASER) ||
-				   (Index >= ENTITY_ARMOR_SHOTGUN && Index <= ENTITY_ARMOR_LASER)))
-				continue;
+			const auto [Index, Flags] = GetTile(x, y);
 
-			const bool DDNetOrCustomEntities = std::find_if(std::begin(gs_apModEntitiesNames), std::end(gs_apModEntitiesNames),
-								   [&](const char *pEntitiesName) { return str_comp_nocase(m_SelectEntitiesImage.c_str(), pEntitiesName) == 0 &&
-													   str_comp_nocase(pEntitiesName, "ddnet") != 0; }) == std::end(gs_apModEntitiesNames);
+			if(Index == ENTITY_DOOR)
+			{
+				for(const ivec2 Offset : DOOR_OFFSETS)
+				{
+					const unsigned char IndexDoorLength = GetIndexChecked(x + Offset.x, y + Offset.y);
+					if(IndexDoorLength >= ENTITY_LASER_SHORT && IndexDoorLength <= ENTITY_LASER_LONG)
+					{
+						const int Length = (IndexDoorLength - ENTITY_LASER_SHORT + 1) * 3;
+						const vec2 Pos = vec2(x + 0.5f, y + 0.5f);
+						const vec2 To = Pos + normalize(vec2(Offset.x, Offset.y)) * Length;
+						pGameClient->m_Items.RenderLaser(To * TileSize, Pos * TileSize, DoorOuterColor, DoorInnerColor, 0.0f, 0.0f, LASERTYPE_DOOR);
+					}
+				}
+			}
+			else if((!IsSwitch && Index >= ENTITY_FLAGSTAND_RED && Index <= ENTITY_FLAGSTAND_BLUE) ||
+				(Index >= ENTITY_ARMOR_1 && Index <= ENTITY_WEAPON_LASER) ||
+				(DDNetOrCustomEntities && Index >= ENTITY_ARMOR_SHOTGUN && Index <= ENTITY_ARMOR_LASER))
+			{
+				vec2 Pos = vec2(x, y) * TileSize;
+				vec2 Scale;
+				int VisualSize;
 
-			vec2 Pos(x * TileSize, y * TileSize);
-			vec2 Scale;
-			int VisualSize;
-
-			if(Index == ENTITY_FLAGSTAND_RED)
-			{
-				Graphics()->TextureSet(pGameClient->m_GameSkin.m_SpriteFlagRed);
-				Scale = vec2(42, 84);
-				VisualSize = 1;
-				Pos.y -= (Scale.y / 2.f) * 0.75f;
-			}
-			else if(Index == ENTITY_FLAGSTAND_BLUE)
-			{
-				Graphics()->TextureSet(pGameClient->m_GameSkin.m_SpriteFlagBlue);
-				Scale = vec2(42, 84);
-				VisualSize = 1;
-				Pos.y -= (Scale.y / 2.f) * 0.75f;
-			}
-			else if(Index == ENTITY_ARMOR_1)
-			{
-				Graphics()->TextureSet(pGameClient->m_GameSkin.m_SpritePickupArmor);
-				Graphics()->GetSpriteScale(SPRITE_PICKUP_HEALTH, Scale.x, Scale.y);
-				VisualSize = 64;
-			}
-			else if(Index == ENTITY_HEALTH_1)
-			{
-				Graphics()->TextureSet(pGameClient->m_GameSkin.m_SpritePickupHealth);
-				Graphics()->GetSpriteScale(SPRITE_PICKUP_HEALTH, Scale.x, Scale.y);
-				VisualSize = 64;
-			}
-			else if(Index == ENTITY_WEAPON_SHOTGUN)
-			{
-				Graphics()->TextureSet(pGameClient->m_GameSkin.m_aSpritePickupWeapons[WEAPON_SHOTGUN]);
-				Graphics()->GetSpriteScale(SPRITE_PICKUP_SHOTGUN, Scale.x, Scale.y);
-				VisualSize = g_pData->m_Weapons.m_aId[WEAPON_SHOTGUN].m_VisualSize;
-			}
-			else if(Index == ENTITY_WEAPON_GRENADE)
-			{
-				Graphics()->TextureSet(pGameClient->m_GameSkin.m_aSpritePickupWeapons[WEAPON_GRENADE]);
-				Graphics()->GetSpriteScale(SPRITE_PICKUP_GRENADE, Scale.x, Scale.y);
-				VisualSize = g_pData->m_Weapons.m_aId[WEAPON_GRENADE].m_VisualSize;
-			}
-			else if(Index == ENTITY_WEAPON_LASER)
-			{
-				Graphics()->TextureSet(pGameClient->m_GameSkin.m_aSpritePickupWeapons[WEAPON_LASER]);
-				Graphics()->GetSpriteScale(SPRITE_PICKUP_LASER, Scale.x, Scale.y);
-				VisualSize = g_pData->m_Weapons.m_aId[WEAPON_LASER].m_VisualSize;
-			}
-			else if(Index == ENTITY_POWERUP_NINJA)
-			{
-				Graphics()->TextureSet(pGameClient->m_GameSkin.m_aSpritePickupWeapons[WEAPON_NINJA]);
-				Graphics()->GetSpriteScale(SPRITE_PICKUP_NINJA, Scale.x, Scale.y);
-				VisualSize = 128;
-			}
-			else if(DDNetOrCustomEntities)
-			{
-				if(Index == ENTITY_ARMOR_SHOTGUN)
+				if(Index == ENTITY_FLAGSTAND_RED)
+				{
+					Graphics()->TextureSet(pGameClient->m_GameSkin.m_SpriteFlagRed);
+					Scale = vec2(42, 84);
+					VisualSize = 1;
+					Pos.y -= (Scale.y / 2.f) * 0.75f;
+				}
+				else if(Index == ENTITY_FLAGSTAND_BLUE)
+				{
+					Graphics()->TextureSet(pGameClient->m_GameSkin.m_SpriteFlagBlue);
+					Scale = vec2(42, 84);
+					VisualSize = 1;
+					Pos.y -= (Scale.y / 2.f) * 0.75f;
+				}
+				else if(Index == ENTITY_ARMOR_1)
+				{
+					Graphics()->TextureSet(pGameClient->m_GameSkin.m_SpritePickupArmor);
+					Graphics()->GetSpriteScale(SPRITE_PICKUP_HEALTH, Scale.x, Scale.y);
+					VisualSize = 64;
+				}
+				else if(Index == ENTITY_HEALTH_1)
+				{
+					Graphics()->TextureSet(pGameClient->m_GameSkin.m_SpritePickupHealth);
+					Graphics()->GetSpriteScale(SPRITE_PICKUP_HEALTH, Scale.x, Scale.y);
+					VisualSize = 64;
+				}
+				else if(Index == ENTITY_WEAPON_SHOTGUN)
+				{
+					Graphics()->TextureSet(pGameClient->m_GameSkin.m_aSpritePickupWeapons[WEAPON_SHOTGUN]);
+					Graphics()->GetSpriteScale(SPRITE_PICKUP_SHOTGUN, Scale.x, Scale.y);
+					VisualSize = g_pData->m_Weapons.m_aId[WEAPON_SHOTGUN].m_VisualSize;
+				}
+				else if(Index == ENTITY_WEAPON_GRENADE)
+				{
+					Graphics()->TextureSet(pGameClient->m_GameSkin.m_aSpritePickupWeapons[WEAPON_GRENADE]);
+					Graphics()->GetSpriteScale(SPRITE_PICKUP_GRENADE, Scale.x, Scale.y);
+					VisualSize = g_pData->m_Weapons.m_aId[WEAPON_GRENADE].m_VisualSize;
+				}
+				else if(Index == ENTITY_POWERUP_NINJA)
+				{
+					Graphics()->TextureSet(pGameClient->m_GameSkin.m_aSpritePickupWeapons[WEAPON_NINJA]);
+					Graphics()->GetSpriteScale(SPRITE_PICKUP_NINJA, Scale.x, Scale.y);
+					VisualSize = 128;
+				}
+				else if(Index == ENTITY_WEAPON_LASER)
+				{
+					Graphics()->TextureSet(pGameClient->m_GameSkin.m_aSpritePickupWeapons[WEAPON_LASER]);
+					Graphics()->GetSpriteScale(SPRITE_PICKUP_LASER, Scale.x, Scale.y);
+					VisualSize = g_pData->m_Weapons.m_aId[WEAPON_LASER].m_VisualSize;
+				}
+				else if(Index == ENTITY_ARMOR_SHOTGUN)
 				{
 					Graphics()->TextureSet(pGameClient->m_GameSkin.m_SpritePickupArmorShotgun);
 					Graphics()->GetSpriteScale(SPRITE_PICKUP_ARMOR_SHOTGUN, Scale.x, Scale.y);
@@ -6867,113 +6925,50 @@ void CEditor::RenderGameEntities(const std::shared_ptr<CLayerTiles> &pTiles)
 					VisualSize = 64;
 				}
 				else
-					continue;
-			}
-			else
-				continue;
-
-			Graphics()->QuadsBegin();
-
-			if(Index != ENTITY_FLAGSTAND_RED && Index != ENTITY_FLAGSTAND_BLUE)
-			{
-				const unsigned char Flags = pTiles->m_pTiles[y * pTiles->m_Width + x].m_Flags;
-
-				if(Flags & TILEFLAG_XFLIP)
-					Scale.x = -Scale.x;
-
-				if(Flags & TILEFLAG_YFLIP)
-					Scale.y = -Scale.y;
-
-				if(Flags & TILEFLAG_ROTATE)
 				{
-					Graphics()->QuadsSetRotation(90.f * (pi / 180));
+					dbg_assert_failed("Unhandled ingame entities index: %d", Index);
+				}
 
-					if(Index == ENTITY_POWERUP_NINJA)
+				Graphics()->QuadsBegin();
+
+				if(Index != ENTITY_FLAGSTAND_RED &&
+					Index != ENTITY_FLAGSTAND_BLUE)
+				{
+					if(Flags & TILEFLAG_XFLIP)
 					{
-						if(Flags & TILEFLAG_XFLIP)
-							Pos.y += 10.0f;
-						else
-							Pos.y -= 10.0f;
+						Scale.x = -Scale.x;
+					}
+
+					if(Flags & TILEFLAG_YFLIP)
+					{
+						Scale.y = -Scale.y;
+					}
+
+					if(Flags & TILEFLAG_ROTATE)
+					{
+						Graphics()->QuadsSetRotation(90.f * (pi / 180));
+
+						if(Index == ENTITY_POWERUP_NINJA)
+						{
+							Pos.y += (Flags & TILEFLAG_XFLIP) ? 10.0f : -10.0f;
+						}
+					}
+					else
+					{
+						if(Index == ENTITY_POWERUP_NINJA)
+						{
+							Pos.x += (Flags & TILEFLAG_XFLIP) ? 10.0f : -10.0f;
+						}
 					}
 				}
-				else
-				{
-					if(Index == ENTITY_POWERUP_NINJA)
-					{
-						if(Flags & TILEFLAG_XFLIP)
-							Pos.x += 10.0f;
-						else
-							Pos.x -= 10.0f;
-					}
-				}
-			}
 
-			Scale *= VisualSize;
-			Pos -= vec2((Scale.x - TileSize) / 2.f, (Scale.y - TileSize) / 2.f);
-			Pos += direction(Client()->GlobalTime() * 2.0f + x + y) * 2.5f;
+				Scale *= VisualSize;
+				Pos -= (Scale - vec2(TileSize, TileSize)) / 2.0f;
+				Pos += direction(Client()->GlobalTime() * 2.0f + x + y) * 2.5f;
 
-			IGraphics::CQuadItem Quad(Pos.x, Pos.y, Scale.x, Scale.y);
-			Graphics()->QuadsDrawTL(&Quad, 1);
-			Graphics()->QuadsEnd();
-		}
-	}
-}
-
-void CEditor::RenderSwitchEntities(const std::shared_ptr<CLayerTiles> &pTiles)
-{
-	const CGameClient *pGameClient = (CGameClient *)Kernel()->RequestInterface<IGameClient>();
-	const float TileSize = 32.f;
-
-	std::function<unsigned char(int, int, unsigned char &)> GetIndex;
-	if(pTiles->m_HasSwitch)
-	{
-		CLayerSwitch *pSwitchLayer = ((CLayerSwitch *)(pTiles.get()));
-		GetIndex = [pSwitchLayer](int y, int x, unsigned char &Number) -> unsigned char {
-			if(x < 0 || y < 0 || x >= pSwitchLayer->m_Width || y >= pSwitchLayer->m_Height)
-				return 0;
-			Number = pSwitchLayer->m_pSwitchTile[y * pSwitchLayer->m_Width + x].m_Number;
-			return pSwitchLayer->m_pSwitchTile[y * pSwitchLayer->m_Width + x].m_Type - ENTITY_OFFSET;
-		};
-	}
-	else
-	{
-		GetIndex = [pTiles](int y, int x, unsigned char &Number) -> unsigned char {
-			if(x < 0 || y < 0 || x >= pTiles->m_Width || y >= pTiles->m_Height)
-				return 0;
-			Number = 0;
-			return pTiles->m_pTiles[y * pTiles->m_Width + x].m_Index - ENTITY_OFFSET;
-		};
-	}
-
-	ivec2 aOffsets[] = {{1, 0}, {1, 1}, {0, 1}, {-1, 1}, {-1, 0}, {-1, -1}, {0, -1}, {1, -1}};
-
-	const ColorRGBA OuterColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClLaserDoorOutlineColor));
-	const ColorRGBA InnerColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClLaserDoorInnerColor));
-	const float TicksHead = Client()->GlobalTime() * Client()->GameTickSpeed();
-
-	for(int y = 0; y < pTiles->m_Height; y++)
-	{
-		for(int x = 0; x < pTiles->m_Width; x++)
-		{
-			unsigned char Number = 0;
-			const unsigned char Index = GetIndex(y, x, Number);
-
-			if(Index == ENTITY_DOOR)
-			{
-				for(size_t i = 0; i < sizeof(aOffsets) / sizeof(ivec2); ++i)
-				{
-					unsigned char NumberDoorLength = 0;
-					unsigned char IndexDoorLength = GetIndex(y + aOffsets[i].y, x + aOffsets[i].x, NumberDoorLength);
-					if(IndexDoorLength >= ENTITY_LASER_SHORT && IndexDoorLength <= ENTITY_LASER_LONG)
-					{
-						float XOff = std::cos(i * pi / 4.0f);
-						float YOff = std::sin(i * pi / 4.0f);
-						int Length = (IndexDoorLength - ENTITY_LASER_SHORT + 1) * 3;
-						vec2 Pos(x + 0.5f, y + 0.5f);
-						vec2 To(x + XOff * Length + 0.5f, y + YOff * Length + 0.5f);
-						pGameClient->m_Items.RenderLaser(To * TileSize, Pos * TileSize, OuterColor, InnerColor, 1.0f, TicksHead, (int)LASERTYPE_DOOR);
-					}
-				}
+				IGraphics::CQuadItem Quad(Pos.x, Pos.y, Scale.x, Scale.y);
+				Graphics()->QuadsDrawTL(&Quad, 1);
+				Graphics()->QuadsEnd();
 			}
 		}
 	}

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -343,8 +343,7 @@ public:
 	void FreeDynamicPopupMenus();
 	void UpdateColorPipette();
 	void RenderMousePointer();
-	void RenderGameEntities(const std::shared_ptr<CLayerTiles> &pTiles);
-	void RenderSwitchEntities(const std::shared_ptr<CLayerTiles> &pTiles);
+	void RenderIngameEntities(const CLayerGroup &Group, const CLayerTiles &TilesLayer);
 
 	template<typename E>
 	SEditResult<E> DoPropertiesWithState(CUIRect *pToolbox, CProperty *pProps, int *pIds, int *pNewVal, const std::vector<ColorRGBA> &vColors = {});

--- a/src/game/editor/mapitems/layer_group.cpp
+++ b/src/game/editor/mapitems/layer_group.cpp
@@ -98,12 +98,9 @@ void CLayerGroup::Render()
 				std::shared_ptr<CLayerTiles> pTiles = std::static_pointer_cast<CLayerTiles>(pLayer);
 
 				if(g_Config.m_EdShowIngameEntities &&
-					pLayer->IsEntitiesLayer() &&
 					(pLayer == Map()->m_pGameLayer || pLayer == Map()->m_pFrontLayer || pLayer == Map()->m_pSwitchLayer))
 				{
-					if(pLayer != Map()->m_pSwitchLayer)
-						Editor()->RenderGameEntities(pTiles);
-					Editor()->RenderSwitchEntities(pTiles);
+					Editor()->RenderIngameEntities(*this, *pTiles);
 				}
 
 				if(pTiles->m_HasGame || pTiles->m_HasFront || pTiles->m_HasTele || pTiles->m_HasSpeedup || pTiles->m_HasTune || pTiles->m_HasSwitch)


### PR DESCRIPTION
Only render ingame entities within the viewport instead of iterating over all game, front and switch tiles. This significantly improves performance on large maps on lower to medium zoom levels.

Combine the `RenderGameEntities` and `RenderSwitchEntities` functions into the `RenderIngameEntities` function to avoid iterating over all game/front tiles twice. Also render the ingame entities for supported game tiles placed in the switch layer (i.e., all except red and blue flags).

Avoid performing several `str_comp`s for every game/front entity to determine whether a custom entities image is being used, by moving this outside the loops.

Check for `DDNetOrCustomEntities` early to avoid nested `if`. Assert that all entity indices are handled afterwards.

Remove unnecessary `IsEntitiesLayer` check, which is already included in the more specific checks for game, front and switch layers.

Refactoring:

- Set door laser ticks to zero instead of emulating tick value, as doors are not affected by the tick value.
- Return `std::tuple` instead of using output parameter.
- Simplify `vec2` math.

FPS graphs with various maps for comparison:

- dm1:
    - Before: <img width="1920" height="1080" alt="dm1 old" src="https://github.com/user-attachments/assets/f3e8642d-f985-403a-9290-813d5f24e880" />
    - After: <img width="1920" height="1080" alt="dm1 new" src="https://github.com/user-attachments/assets/f6813db0-442a-470c-8a38-ced7b3153f2a" />
- ctf1:
    - Before: <img width="1920" height="1080" alt="ctf1 old" src="https://github.com/user-attachments/assets/4817f1d9-501f-41a6-ad6f-f0cc9e41c454" />
    - After: <img width="1920" height="1080" alt="ctf1 new" src="https://github.com/user-attachments/assets/6e718bed-2f17-4945-b59f-2b220585a89e" />
- Chacruna:
    - Before: <img width="1920" height="1080" alt="Chacruna old" src="https://github.com/user-attachments/assets/fbcfe216-1019-4f21-8772-9bc2d308dbf1" />
    - After: <img width="1920" height="1080" alt="Chacrune new" src="https://github.com/user-attachments/assets/0da60edb-76bb-4076-9be2-ca1bb2e9c866" />
- ChillBlock5:
    - Before: <img width="1920" height="1080" alt="ChillBlock5 old" src="https://github.com/user-attachments/assets/c361a352-6c87-4ccb-8f5c-b66d0b759226" />
    - After: <img width="1920" height="1080" alt="ChillBlock5 new" src="https://github.com/user-attachments/assets/6f50803c-8421-45c9-adaa-c7ac12d3827e" />
- Until Draw:
    - Before: <img width="1920" height="1080" alt="Until Draw old" src="https://github.com/user-attachments/assets/7c2c618b-8a54-4218-9200-987f0fe30c29" />
    - After: <img width="1920" height="1080" alt="Until Dawn new" src="https://github.com/user-attachments/assets/1866bbe3-61a3-4c95-8b99-c10d8e93de41" />


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
