### PR TITLE
Refactor typedef, use using

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -85,6 +85,7 @@ Checks: >
   modernize-use-override,
   modernize-use-transparent-functors,
   modernize-use-uncaught-exceptions,
+  modernize-use-using,
   readability-*,
   -readability-avoid-nested-conditional-operator,
   -readability-braces-around-statements,
@@ -141,9 +142,9 @@ CheckOptions:
   - key:             readability-identifier-naming.StructPrefix
     value:           S
   - key:             readability-identifier-naming.StructIgnoredRegexp
-    value:           '^((GL_S|[CI])[A-Z](_?[a-zA-Z0-9])*|_json_value|NETADDR)$'
+    value:           '^((GL_S|[CI])[A-Z](_?[a-zA-Z0-9])*|_json_value)$'
   - key:             readability-identifier-naming.ClassIgnoredRegexp
-    value:           '^([CI][A-Z](_?[a-zA-Z0-9])*)$'
+    value:           '^([CI][A-Z](_?[a-zA-Z0-9])*|NETADDR)$'
   - key:             readability-identifier-naming.ParameterCase
     value:           CamelCase
   - key:             readability-identifier-naming.ParameterIgnoredRegexp

--- a/datasrc/seven/compile.py
+++ b/datasrc/seven/compile.py
@@ -110,7 +110,7 @@ def main():
 		print("")
 
 		print("""
-	template<typename... Ts> struct make_void { typedef void type;};
+	template<typename... Ts> struct make_void { using type = void ;};
 	template<typename... Ts> using void_t = typename make_void<Ts...>::type;
 
 	template<typename T, typename = void>

--- a/src/base/dbg.h
+++ b/src/base/dbg.h
@@ -89,7 +89,7 @@ bool dbg_assert_has_failed();
  *
  * @see dbg_assert_set_handler
  */
-typedef std::function<void(const char *message)> DBG_ASSERT_HANDLER;
+using DBG_ASSERT_HANDLER = std::function<void(const char *message)>;
 
 /**
  * Sets a callback function that will be invoked before breaking into the

--- a/src/base/hash_ctxt.h
+++ b/src/base/hash_ctxt.h
@@ -22,7 +22,7 @@ struct SHA256_CTX
 	uint32_t curlen;
 	unsigned char buf[64];
 };
-typedef md5_state_t MD5_CTX;
+using MD5_CTX = md5_state_t;
 #endif
 
 void sha256_init(SHA256_CTX *ctxt);

--- a/src/base/hash_libtomcrypt.cpp
+++ b/src/base/hash_libtomcrypt.cpp
@@ -8,9 +8,9 @@
 #include <cstdint>
 #include <cstring>
 
-typedef uint32_t u32;
-typedef uint64_t u64;
-typedef SHA256_CTX sha256_state;
+using u32 = uint32_t;
+using u64 = uint64_t;
+using sha256_state = SHA256_CTX;
 
 static const u32 K[64] =
 	{

--- a/src/base/logger.h
+++ b/src/base/logger.h
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-typedef void *IOHANDLE;
+using IOHANDLE = void *;
 
 /**
  * @ingroup Log

--- a/src/base/net.cpp
+++ b/src/base/net.cpp
@@ -41,12 +41,13 @@
 #error NOT IMPLEMENTED
 #endif
 
-static NETSTATS network_stats = {0};
+static NETSTATS network_stats = {};
 
 #define VLEN 128
 #define PACKETSIZE 1400
-typedef struct
+class NETSOCKET_BUFFER
 {
+public:
 #ifdef CONF_PLATFORM_LINUX
 	int pos;
 	int size;
@@ -57,7 +58,7 @@ typedef struct
 #else
 	char buf[PACKETSIZE];
 #endif
-} NETSOCKET_BUFFER;
+};
 
 void net_buffer_init(NETSOCKET_BUFFER *buffer)
 {

--- a/src/base/net.h
+++ b/src/base/net.h
@@ -39,12 +39,12 @@ extern const NETADDR NETADDR_ZEROED;
 /**
  * @ingroup Network-Unix-Sockets
  */
-typedef int UNIXSOCKET;
+using UNIXSOCKET = int;
 
 /**
  * @ingroup Network-Unix-Sockets
  */
-typedef struct sockaddr_un UNIXSOCKETADDR;
+using UNIXSOCKETADDR = sockaddr_un;
 #endif
 
 /**

--- a/src/base/rust.h
+++ b/src/base/rust.h
@@ -1,5 +1,5 @@
 #ifndef BASE_RUST_H
 #define BASE_RUST_H
-typedef const char *StrRef;
-typedef void *UserPtr;
+using StrRef = const char *;
+using UserPtr = void *;
 #endif // BASE_RUST_H

--- a/src/base/sphore.h
+++ b/src/base/sphore.h
@@ -18,19 +18,19 @@
 /**
  * @ingroup Semaphore
  */
-typedef void *SEMAPHORE;
+using SEMAPHORE = void *;
 #elif defined(CONF_PLATFORM_MACOS)
 #include <semaphore.h>
 /**
  * @ingroup Semaphore
  */
-typedef sem_t *SEMAPHORE;
+using SEMAPHORE = sem_t *;
 #elif defined(CONF_FAMILY_UNIX)
 #include <semaphore.h>
 /**
  * @ingroup Semaphore
  */
-typedef sem_t SEMAPHORE;
+using SEMAPHORE = sem_t;
 #else
 #error not implemented on this platform
 #endif

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -30,14 +30,14 @@ inline constexpr auto IO_MAX_PATH_LENGTH = 512;
  *
  * @ingroup File-IO
  */
-typedef void *IOHANDLE;
+using IOHANDLE = void *;
 
 /**
  * Wrapper for asynchronously writing to an @link IOHANDLE @endlink.
  *
  * @ingroup File-IO
  */
-typedef struct ASYNCIO ASYNCIO;
+struct ASYNCIO;
 
 /**
  * Callback function type for @link fs_listdir @endlink.
@@ -53,7 +53,7 @@ typedef struct ASYNCIO ASYNCIO;
  *
  * @see fs_listdir
  */
-typedef int (*FS_LISTDIR_CALLBACK)(const char *name, int is_dir, int dir_type, void *user);
+using FS_LISTDIR_CALLBACK = int (*)(const char *name, int is_dir, int dir_type, void *user);
 
 /**
  * Represents a file/folder entry for the @link FS_LISTDIR_CALLBACK_FILEINFO @endlink
@@ -94,7 +94,7 @@ public:
  *
  * @see fs_listdir_fileinfo
  */
-typedef int (*FS_LISTDIR_CALLBACK_FILEINFO)(const CFsFileInfo *info, int is_dir, int dir_type, void *user);
+using FS_LISTDIR_CALLBACK_FILEINFO = int (*)(const CFsFileInfo *info, int is_dir, int dir_type, void *user);
 
 /**
  * The maximum bytes necessary to encode one Unicode codepoint with UTF-8.
@@ -106,7 +106,8 @@ inline constexpr auto UTF8_BYTE_LENGTH = 4;
 /**
  * @ingroup Network-General
  */
-typedef struct NETSOCKET_INTERNAL *NETSOCKET;
+struct NETSOCKET_INTERNAL;
+using NETSOCKET = NETSOCKET_INTERNAL *;
 
 /**
  * @ingroup Network-General
@@ -164,8 +165,9 @@ inline constexpr auto NETADDR_MAXSTRSIZE = 1 + (8 * 4 + 7) + 1 + 1 + 5 + 1; // [
 /**
  * @ingroup Network-Address
  */
-typedef struct NETADDR
+class NETADDR
 {
+public:
 	unsigned int type;
 	unsigned char ip[16];
 	unsigned short port;
@@ -173,7 +175,7 @@ typedef struct NETADDR
 	bool operator==(const NETADDR &other) const;
 	bool operator!=(const NETADDR &other) const;
 	bool operator<(const NETADDR &other) const;
-} NETADDR;
+};
 
 /**
  * @ingroup Network-Address
@@ -187,13 +189,14 @@ struct std::hash<NETADDR>
 /**
  * @ingroup Network-General
  */
-typedef struct NETSTATS
+class NETSTATS
 {
+public:
 	uint64_t sent_packets;
 	uint64_t sent_bytes;
 	uint64_t recv_packets;
 	uint64_t recv_bytes;
-} NETSTATS;
+};
 
 #if defined(CONF_FAMILY_WINDOWS)
 /**
@@ -201,7 +204,7 @@ typedef struct NETSTATS
  *
  * @ingroup Process
  */
-typedef void *PROCESS;
+using PROCESS = void *;
 /**
  * A handle that denotes an invalid process.
  *
@@ -214,7 +217,7 @@ constexpr PROCESS INVALID_PROCESS = nullptr; // NOLINT(misc-misplaced-const)
  *
  * @ingroup Process
  */
-typedef pid_t PROCESS;
+using PROCESS = pid_t;
 /**
  * A handle that denotes an invalid process.
  *

--- a/src/base/vmath.h
+++ b/src/base/vmath.h
@@ -158,9 +158,9 @@ inline vector2_base<float> random_direction()
 	return direction(random_angle());
 }
 
-typedef vector2_base<float> vec2;
-typedef vector2_base<bool> bvec2;
-typedef vector2_base<int> ivec2;
+using vec2 = vector2_base<float>;
+using bvec2 = vector2_base<bool>;
+using ivec2 = vector2_base<int>;
 
 template<Numeric T>
 constexpr bool closest_point_on_line(vector2_base<T> line_pointA, vector2_base<T> line_pointB, vector2_base<T> target_point, vector2_base<T> &out_pos)
@@ -330,9 +330,9 @@ inline vector3_base<float> normalize(const vector3_base<float> &v)
 	return vector3_base<float>(v.x * l, v.y * l, v.z * l);
 }
 
-typedef vector3_base<float> vec3;
-typedef vector3_base<bool> bvec3;
-typedef vector3_base<int> ivec3;
+using vec3 = vector3_base<float>;
+using bvec3 = vector3_base<bool>;
+using ivec3 = vector3_base<int>;
 
 // ------------------------------------
 
@@ -424,9 +424,9 @@ public:
 	constexpr bool operator!=(const vector4_base &vec) const { return x != vec.x || y != vec.y || z != vec.z || w != vec.w; }
 };
 
-typedef vector4_base<float> vec4;
-typedef vector4_base<bool> bvec4;
-typedef vector4_base<int> ivec4;
-typedef vector4_base<uint8_t> ubvec4;
+using vec4 = vector4_base<float>;
+using bvec4 = vector4_base<bool>;
+using ivec4 = vector4_base<int>;
+using ubvec4 = vector4_base<uint8_t>;
 
 #endif

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -35,7 +35,7 @@ enum
 	RECORDER_MAX = 4,
 };
 
-typedef bool (*CLIENTFUNC_FILTER)(const void *pData, int DataSize, void *pUser);
+using CLIENTFUNC_FILTER = bool (*)(const void *pData, int DataSize, void *pUser);
 struct CChecksumData;
 
 class IClient : public IInterface
@@ -80,7 +80,7 @@ public:
 		LOADING_CALLBACK_DETAIL_MAP,
 		LOADING_CALLBACK_DETAIL_DEMO,
 	};
-	typedef std::function<void(ELoadingCallbackDetail Detail)> TLoadingCallback;
+	using TLoadingCallback = std::function<void(ELoadingCallbackDetail Detail)>;
 	CTranslationContext m_TranslationContext;
 
 protected:

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -155,7 +155,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 			}
 		};
 
-		typedef std::multiset<SMemoryHeapQueueElement, std::greater<>> TMemoryHeapQueue;
+		using TMemoryHeapQueue = std::multiset<SMemoryHeapQueueElement, std::greater<>>;
 
 		struct SMemoryHeapElement
 		{
@@ -507,9 +507,9 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 	template<typename TName>
 	struct SStreamMemory
 	{
-		typedef std::vector<std::vector<TName>> TBufferObjectsOfFrame;
-		typedef std::vector<std::vector<VkMappedMemoryRange>> TMemoryMapRangesOfFrame;
-		typedef std::vector<size_t> TStreamUseCount;
+		using TBufferObjectsOfFrame = std::vector<std::vector<TName>>;
+		using TMemoryMapRangesOfFrame = std::vector<std::vector<VkMappedMemoryRange>>;
+		using TStreamUseCount = std::vector<size_t>;
 		TBufferObjectsOfFrame m_vvBufferObjectsOfFrame;
 		TMemoryMapRangesOfFrame m_vvBufferObjectsOfFrameRangeData;
 		TStreamUseCount m_vCurrentUsedCount;
@@ -551,7 +551,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 			m_vCurrentUsedCount.resize(FrameImageCount);
 		}
 
-		typedef std::function<void(size_t, TName &)> TDestroyBufferFunc;
+		using TDestroyBufferFunc = std::function<void(size_t, TName &)>;
 
 		void Destroy(TDestroyBufferFunc &&DestroyBuffer)
 		{
@@ -708,7 +708,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 		float m_TextureSize;
 	};
 
-	typedef vec3 SUniformTextGFragmentOffset;
+	using SUniformTextGFragmentOffset = vec3;
 
 	struct SUniformTextGFragmentConstants
 	{
@@ -732,7 +732,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 		vec2 m_Scale;
 	};
 
-	typedef ColorRGBA SUniformTileGVertColor;
+	using SUniformTileGVertColor = ColorRGBA;
 
 	struct SUniformTileGVertColorAlign
 	{
@@ -750,7 +750,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 		float m_Rotation;
 	};
 
-	typedef ColorRGBA SUniformPrimExGVertColor;
+	using SUniformPrimExGVertColor = ColorRGBA;
 
 	struct SUniformPrimExGVertColorAlign
 	{
@@ -763,7 +763,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 		vec2 m_Center;
 	};
 
-	typedef ColorRGBA SUniformSpriteMultiGVertColor;
+	using SUniformSpriteMultiGVertColor = ColorRGBA;
 
 	struct SUniformSpriteMultiGVertColorAlign
 	{
@@ -782,7 +782,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 		vec4 m_aPSR[1];
 	};
 
-	typedef ColorRGBA SUniformSpriteMultiPushGVertColor;
+	using SUniformSpriteMultiPushGVertColor = ColorRGBA;
 
 	struct SUniformQuadGPosBase
 	{
@@ -1067,14 +1067,14 @@ private:
 		VkRect2D m_Scissor;
 	};
 
-	typedef std::vector<SRenderCommandExecuteBuffer> TCommandList;
-	typedef std::vector<TCommandList> TThreadCommandList;
+	using TCommandList = std::vector<SRenderCommandExecuteBuffer>;
+	using TThreadCommandList = std::vector<TCommandList>;
 
 	TThreadCommandList m_vvThreadCommandLists;
 	std::vector<bool> m_vThreadHelperHadCommands;
 
-	typedef std::function<bool(const CCommandBuffer::SCommand *, SRenderCommandExecuteBuffer &)> TCommandBufferCommandCallback;
-	typedef std::function<void(SRenderCommandExecuteBuffer &, const CCommandBuffer::SCommand *)> TCommandBufferFillExecuteBufferFunc;
+	using TCommandBufferCommandCallback = std::function<bool(const CCommandBuffer::SCommand *, SRenderCommandExecuteBuffer &)>;
+	using TCommandBufferFillExecuteBufferFunc = std::function<void(SRenderCommandExecuteBuffer &, const CCommandBuffer::SCommand *)>;
 
 	struct SCommandCallback
 	{
@@ -6275,7 +6275,7 @@ public:
 	 * STREAM BUFFERS SETUP
 	 ************************/
 
-	typedef std::function<bool(SFrameBuffers &, VkBuffer, VkDeviceSize)> TNewMemFunc;
+	using TNewMemFunc = std::function<bool(SFrameBuffers &, VkBuffer, VkDeviceSize)>;
 
 	// returns true, if the stream memory was just allocated
 	template<typename TStreamMemName, typename TInstanceTypeName, size_t InstanceTypeCount, size_t BufferCreateCount, bool UsesCurrentCountOffset>

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2447,7 +2447,7 @@ void CClient::ResetDDNetInfoTask()
 	}
 }
 
-typedef std::tuple<int, int, int> TVersion;
+using TVersion = std::tuple<int, int, int>;
 static const TVersion gs_InvalidVersion = std::make_tuple(-1, -1, -1);
 
 static TVersion ToVersion(char *pStr)

--- a/src/engine/client/discord.cpp
+++ b/src/engine/client/discord.cpp
@@ -7,7 +7,7 @@
 #if defined(CONF_DISCORD)
 #include <discord_game_sdk.h>
 
-typedef enum EDiscordResult(DISCORD_API *FDiscordCreate)(DiscordVersion, struct DiscordCreateParams *, struct IDiscordCore **);
+using FDiscordCreate = EDiscordResult(DISCORD_API *)(DiscordVersion, DiscordCreateParams *, IDiscordCore **);
 
 #if defined(CONF_DISCORD_DYNAMIC)
 #include <dlfcn.h>

--- a/src/engine/client/graphics_defines.h
+++ b/src/engine/client/graphics_defines.h
@@ -4,9 +4,9 @@
 #include <cstddef>
 #include <cstdint>
 
-typedef uint32_t TWGLuint;
-typedef int32_t TWGLint;
-typedef uint32_t TWGLenum;
-typedef uint8_t TWGLubyte;
+using TWGLuint = uint32_t;
+using TWGLint = int32_t;
+using TWGLenum = uint32_t;
+using TWGLubyte = uint8_t;
 
 #endif

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -171,13 +171,13 @@ public:
 		CMD_COUNT,
 	};
 
-	typedef vec2 SPoint;
-	typedef vec2 STexCoord;
-	typedef GL_SColorf SColorf;
-	typedef GL_SColor SColor;
-	typedef GL_SVertex SVertex;
-	typedef GL_SVertexTex3D SVertexTex3D;
-	typedef GL_SVertexTex3DStream SVertexTex3DStream;
+	using SPoint = vec2;
+	using STexCoord = vec2;
+	using SColorf = GL_SColorf;
+	using SColor = GL_SColor;
+	using SVertex = GL_SVertex;
+	using SVertexTex3D = GL_SVertexTex3D;
+	using SVertexTex3DStream = GL_SVertexTex3DStream;
 
 	struct SCommand
 	{
@@ -1275,7 +1275,7 @@ public:
 	TGLBackendReadPresentedImageData &GetReadPresentedImageDataFuncUnsafe() override;
 };
 
-typedef std::function<const char *(const char *, const char *)> TTranslateFunc;
+using TTranslateFunc = std::function<const char *(const char *, const char *)>;
 extern IGraphicsBackend *CreateGraphicsBackend(TTranslateFunc &&TranslateFunc);
 
 #endif // ENGINE_CLIENT_GRAPHICS_THREADED_H

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -30,7 +30,7 @@
 
 class CSortWrap
 {
-	typedef bool (CServerBrowser::*SortFunc)(int, int) const;
+	using SortFunc = bool (CServerBrowser::*)(int, int) const;
 	SortFunc m_pfnSort;
 	CServerBrowser *m_pThis;
 

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -15,7 +15,8 @@
 #include <optional>
 #include <set>
 
-typedef struct _json_value json_value;
+struct _json_value;
+using json_value = _json_value;
 class CNetClient;
 class IConfigManager;
 class IConsole;

--- a/src/engine/client/serverbrowser_http.cpp
+++ b/src/engine/client/serverbrowser_http.cpp
@@ -50,7 +50,7 @@ static int ClassifyAge(int AgeSeconds)
 class CChooseMaster
 {
 public:
-	typedef bool (*VALIDATOR)(json_value *pJson);
+	using VALIDATOR = bool (*)(json_value *pJson);
 
 	enum
 	{

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -832,7 +832,7 @@ public:
 	}
 };
 
-typedef vector4_base<unsigned char> STextCharQuadVertexColor;
+using STextCharQuadVertexColor = vector4_base<unsigned char>;
 
 struct STextCharQuadVertex
 {

--- a/src/engine/config.h
+++ b/src/engine/config.h
@@ -9,8 +9,8 @@ class IConfigManager : public IInterface
 {
 	MACRO_INTERFACE("config")
 public:
-	typedef void (*SAVECALLBACKFUNC)(IConfigManager *pConfig, void *pUserData);
-	typedef void (*POSSIBLECFGFUNC)(const struct SConfigVariable *, void *pUserData);
+	using SAVECALLBACKFUNC = void (*)(IConfigManager *pConfig, void *pUserData);
+	using POSSIBLECFGFUNC = void (*)(const struct SConfigVariable *, void *pUserData);
 
 	virtual void Init() = 0;
 	virtual void Reset(const char *pScriptName) = 0;

--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -97,12 +97,12 @@ public:
 		virtual EAccessLevel GetAccessLevel() const = 0;
 	};
 
-	typedef void (*FTeeHistorianCommandCallback)(int ClientId, int FlagMask, const char *pCmd, IResult *pResult, void *pUser);
-	typedef void (*FPossibleCallback)(int Index, const char *pCmd, void *pUser);
-	typedef void (*FCommandCallback)(IResult *pResult, void *pUserData);
-	typedef void (*FChainCommandCallback)(IResult *pResult, void *pUserData, FCommandCallback pfnCallback, void *pCallbackUserData);
-	typedef bool (*FUnknownCommandCallback)(const char *pCommand, void *pUser); // returns true if the callback has handled the argument
-	typedef bool (*FCanUseCommandCallback)(int ClientId, const ICommandInfo *pCommand, void *pUser);
+	using FTeeHistorianCommandCallback = void (*)(int ClientId, int FlagMask, const char *pCmd, IResult *pResult, void *pUser);
+	using FPossibleCallback = void (*)(int Index, const char *pCmd, void *pUser);
+	using FCommandCallback = void (*)(IResult *pResult, void *pUserData);
+	using FChainCommandCallback = void (*)(IResult *pResult, void *pUserData, FCommandCallback pfnCallback, void *pCallbackUserData);
+	using FUnknownCommandCallback = bool (*)(const char *pCommand, void *pUser); // returns true if the callback has handled the argument
+	using FCanUseCommandCallback = bool (*)(int ClientId, const ICommandInfo *pCommand, void *pUser);
 
 	static void EmptyPossibleCommandCallback(int Index, const char *pCmd, void *pUser) {}
 	static bool EmptyUnknownCommandCallback(const char *pCommand, void *pUser) { return false; }

--- a/src/engine/demo.h
+++ b/src/engine/demo.h
@@ -24,7 +24,7 @@ static constexpr double DEMO_SPEEDS[] = {0.1, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2
 static constexpr int DEMO_SPEED_INDEX_DEFAULT = 4;
 static_assert(DEMO_SPEEDS[DEMO_SPEED_INDEX_DEFAULT] == 1.0);
 
-typedef bool (*DEMOFUNC_FILTER)(const void *pData, int DataSize, void *pUser);
+using DEMOFUNC_FILTER = bool (*)(const void *pData, int DataSize, void *pUser);
 
 // TODO: Properly extend demo format using uuids
 // "6be6da4a-cebd-380c-9b5b-1289c842d780"

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -81,8 +81,8 @@ public:
 	uint32_t m_Format;
 };
 
-typedef vec2 GL_SPoint;
-typedef vec2 GL_STexCoord;
+using GL_SPoint = vec2;
+using GL_STexCoord = vec2;
 
 struct GL_STexCoord3D
 {
@@ -104,9 +104,9 @@ struct GL_STexCoord3D
 	float u, v, w;
 };
 
-typedef ColorRGBA GL_SColorf;
+using GL_SColorf = ColorRGBA;
 //use normalized color values
-typedef vector4_base<unsigned char> GL_SColor;
+using GL_SColor = vector4_base<unsigned char>;
 
 struct GL_SVertex
 {
@@ -175,12 +175,12 @@ struct STWGraphicGpu
 	STWGraphicGpuItem m_AutoGpu;
 };
 
-typedef STWGraphicGpu TTwGraphicsGpuList;
+using TTwGraphicsGpuList = STWGraphicGpu;
 
-typedef std::function<void()> WINDOW_RESIZE_FUNC;
-typedef std::function<void()> WINDOW_PROPS_CHANGED_FUNC;
+using WINDOW_RESIZE_FUNC = std::function<void()>;
+using WINDOW_PROPS_CHANGED_FUNC = std::function<void()>;
 
-typedef std::function<bool(uint32_t &Width, uint32_t &Height, CImageInfo::EImageFormat &Format, std::vector<uint8_t> &vDstData)> TGLBackendReadPresentedImageData;
+using TGLBackendReadPresentedImageData = std::function<bool(uint32_t &Width, uint32_t &Height, CImageInfo::EImageFormat &Format, std::vector<uint8_t> &vDstData)>;
 
 struct CDataSprite;
 

--- a/src/engine/rust.h
+++ b/src/engine/rust.h
@@ -2,6 +2,6 @@
 #define ENGINE_RUST_H
 #include "console.h"
 
-typedef IConsole::IResult IConsole_IResult;
-typedef IConsole::FCommandCallback IConsole_FCommandCallback;
+using IConsole_IResult = IConsole::IResult;
+using IConsole_FCommandCallback = IConsole::FCommandCallback;
 #endif // ENGINE_RUST_H

--- a/src/engine/server/authmanager.cpp
+++ b/src/engine/server/authmanager.cpp
@@ -196,7 +196,7 @@ void CAuthManager::UpdateKey(int Slot, const char *pPw, const char *pRoleName)
 	UpdateKeyHash(Slot, HashPassword(pPw, aSalt), aSalt, pRoleName);
 }
 
-void CAuthManager::ListKeys(FListCallback pfnListCallback, void *pUser)
+void CAuthManager::ListKeys(const FListCallback &pfnListCallback, void *pUser)
 {
 	for(auto &Key : m_vKeys)
 		pfnListCallback(Key.m_aIdent, Key.m_pRole->Name(), pUser);

--- a/src/engine/server/authmanager.h
+++ b/src/engine/server/authmanager.h
@@ -6,6 +6,7 @@
 
 #include <generated/protocol.h>
 
+#include <functional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -71,7 +72,7 @@ private:
 public:
 	static const char *AuthLevelToRoleName(int AuthLevel);
 
-	typedef void (*FListCallback)(const char *pIdent, const char *pRoleName, void *pUser);
+	using FListCallback = void (*)(const char *pIdent, const char *pRoleName, void *pUser);
 
 	CAuthManager();
 
@@ -92,7 +93,7 @@ public:
 	bool IsValidIdent(const char *pIdent) const;
 	void UpdateKeyHash(int Slot, MD5_DIGEST Hash, const unsigned char *pSalt, const char *pRoleName);
 	void UpdateKey(int Slot, const char *pPw, const char *pRoleName);
-	void ListKeys(FListCallback pfnListCallback, void *pUser);
+	void ListKeys(const FListCallback &pfnListCallback, void *pUser);
 	void AddDefaultKey(const char *pRoleName, const char *pPw);
 	bool IsGenerated() const;
 	int NumNonDefaultKeys() const;

--- a/src/engine/server/databases/connection_pool.h
+++ b/src/engine/server/databases/connection_pool.h
@@ -66,8 +66,8 @@ public:
 	CDbConnectionPool &operator=(const CDbConnectionPool &) = delete;
 
 	// Returns false on success.
-	typedef bool (*FRead)(IDbConnection *, const ISqlData *, char *pError, int ErrorSize);
-	typedef bool (*FWrite)(IDbConnection *, const ISqlData *, Write, char *pError, int ErrorSize);
+	using FRead = bool (*)(IDbConnection *, const ISqlData *, char *pError, int ErrorSize);
+	using FWrite = bool (*)(IDbConnection *, const ISqlData *, Write, char *pError, int ErrorSize);
 
 	enum Mode
 	{

--- a/src/engine/server/databases/mysql.cpp
+++ b/src/engine/server/databases/mysql.cpp
@@ -16,7 +16,7 @@
 
 // MySQL >= 8.0.1 removed my_bool, 8.0.2 accidentally reintroduced it: https://bugs.mysql.com/bug.php?id=87337
 #if !defined(LIBMARIADB) && MYSQL_VERSION_ID >= 80001 && MYSQL_VERSION_ID != 80002
-typedef bool my_bool;
+using my_bool = bool;
 #endif
 
 enum

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -13,7 +13,7 @@
 #include <functional>
 #include <vector>
 
-typedef std::function<void()> TUpdateIntraTimesFunc;
+using TUpdateIntraTimesFunc = std::function<void()>;
 
 class CSnapshotDelta;
 class IConsole;

--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -19,7 +19,8 @@
 #include <optional>
 #include <unordered_map>
 
-typedef struct _json_value json_value;
+struct _json_value;
+using json_value = _json_value;
 class IStorage;
 
 enum class EHttpState

--- a/src/engine/shared/netban.h
+++ b/src/engine/shared/netban.h
@@ -108,7 +108,7 @@ protected:
 	class CBanPool
 	{
 	public:
-		typedef T CDataType;
+		using CDataType = T;
 
 		CBan<CDataType> *Add(const CDataType *pData, const CBanInfo *pInfo, const CNetHash *pNetHash);
 		int Remove(CBan<CDataType> *pBan);
@@ -147,10 +147,10 @@ protected:
 		void InsertUsed(CBan<CDataType> *pBan);
 	};
 
-	typedef CBanPool<NETADDR, 1> CBanAddrPool;
-	typedef CBanPool<CNetRange, 16> CBanRangePool;
-	typedef CBan<NETADDR> CBanAddr;
-	typedef CBan<CNetRange> CBanRange;
+	using CBanAddrPool = CBanPool<NETADDR, 1>;
+	using CBanRangePool = CBanPool<CNetRange, 16>;
+	using CBanAddr = CBan<NETADDR>;
+	using CBanRange = CBan<CNetRange>;
 
 	template<class T>
 	void MakeBanInfo(const CBan<T> *pBan, char *pBuf, unsigned BuffSize, int Type) const;

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -115,8 +115,8 @@ enum
 	NET_TOKENREQUEST_DATASIZE = 512,
 };
 
-typedef int SECURITY_TOKEN;
-typedef unsigned int TOKEN;
+using SECURITY_TOKEN = int;
+using TOKEN = unsigned int;
 
 SECURITY_TOKEN ToSecurityToken(const unsigned char *pData);
 void WriteSecurityToken(unsigned char *pData, SECURITY_TOKEN Token);
@@ -129,11 +129,11 @@ enum
 	NET_SECURITY_TOKEN_UNSUPPORTED = 0,
 };
 
-typedef int (*NETFUNC_DELCLIENT)(int ClientId, const char *pReason, void *pUser);
-typedef int (*NETFUNC_NEWCLIENT_CON)(int ClientId, void *pUser);
-typedef int (*NETFUNC_NEWCLIENT)(int ClientId, void *pUser, bool Sixup);
-typedef int (*NETFUNC_NEWCLIENT_NOAUTH)(int ClientId, void *pUser);
-typedef int (*NETFUNC_CLIENTREJOIN)(int ClientId, void *pUser);
+using NETFUNC_DELCLIENT = int (*)(int ClientId, const char *pReason, void *pUser);
+using NETFUNC_NEWCLIENT_CON = int (*)(int ClientId, void *pUser);
+using NETFUNC_NEWCLIENT = int (*)(int ClientId, void *pUser, bool Sixup);
+using NETFUNC_NEWCLIENT_NOAUTH = int (*)(int ClientId, void *pUser);
+using NETFUNC_CLIENTREJOIN = int (*)(int ClientId, void *pUser);
 
 struct CNetChunk
 {

--- a/src/engine/shared/protocol.h
+++ b/src/engine/shared/protocol.h
@@ -163,6 +163,6 @@ namespace FinishTime
 	inline constexpr int UNSET = -2;
 }
 
-typedef std::bitset<MAX_CLIENTS> CClientMask;
+using CClientMask = std::bitset<MAX_CLIENTS>;
 
 #endif

--- a/src/engine/shared/serverinfo.h
+++ b/src/engine/shared/serverinfo.h
@@ -6,7 +6,8 @@
 #include <engine/map.h>
 #include <engine/serverbrowser.h>
 
-typedef struct _json_value json_value;
+struct _json_value;
+using json_value = _json_value;
 class CServerInfo;
 
 class CServerInfo2

--- a/src/engine/shared/stun.h
+++ b/src/engine/shared/stun.h
@@ -2,7 +2,7 @@
 #define ENGINE_SHARED_STUN_H
 #include <cstddef>
 
-struct NETADDR;
+class NETADDR;
 
 class CStunData
 {

--- a/src/engine/shared/video.h
+++ b/src/engine/shared/video.h
@@ -6,7 +6,7 @@
 #include <cstdint>
 #include <functional>
 
-typedef std::function<void(short *pFinalOut, unsigned Frames)> ISoundMixFunc;
+using ISoundMixFunc = std::function<void(short *pFinalOut, unsigned Frames)>;
 
 class IVideo
 {

--- a/src/engine/shared/websockets.cpp
+++ b/src/engine/shared/websockets.cpp
@@ -30,12 +30,8 @@ struct websocket_chunk
 };
 
 // Client opens two connections for whatever reason
-typedef CStaticRingBuffer<websocket_chunk, (MAX_CLIENTS * 2) * NET_CONN_BUFFERSIZE,
-	CRingBufferBase::FLAG_RECYCLE>
-	TRecvBuffer;
-typedef CStaticRingBuffer<websocket_chunk, NET_CONN_BUFFERSIZE,
-	CRingBufferBase::FLAG_RECYCLE>
-	TSendBuffer;
+using TRecvBuffer = CStaticRingBuffer<websocket_chunk, (MAX_CLIENTS * 2) * NET_CONN_BUFFERSIZE, CRingBufferBase::FLAG_RECYCLE>;
+using TSendBuffer = CStaticRingBuffer<websocket_chunk, NET_CONN_BUFFERSIZE, CRingBufferBase::FLAG_RECYCLE>;
 
 struct per_session_data
 {

--- a/src/engine/sqlite.h
+++ b/src/engine/sqlite.h
@@ -17,8 +17,8 @@ class CSqliteStmtDeleter
 public:
 	void operator()(sqlite3_stmt *pStmt);
 };
-typedef std::unique_ptr<sqlite3, CSqliteDeleter> CSqlite;
-typedef std::unique_ptr<sqlite3_stmt, CSqliteStmtDeleter> CSqliteStmt;
+using CSqlite = std::unique_ptr<sqlite3, CSqliteDeleter>;
+using CSqliteStmt = std::unique_ptr<sqlite3_stmt, CSqliteStmtDeleter>;
 
 int SqliteHandleError(IConsole *pConsole, int Error, sqlite3 *pSqlite, const char *pContext);
 #define SQLITE_HANDLE_ERROR(x) SqliteHandleError(pConsole, x, &*pSqlite, #x)

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -206,7 +206,7 @@ protected:
 	CUIElement m_ConnectButton;
 
 	// generic popups
-	typedef void (CMenus::*FPopupButtonCallback)();
+	using FPopupButtonCallback = void (CMenus::*)();
 	void DefaultButtonCallback()
 	{
 		// do nothing

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -15,7 +15,7 @@
 
 using namespace std::chrono_literals;
 
-typedef std::function<void()> TMenuAssetScanLoadedFunc;
+using TMenuAssetScanLoadedFunc = std::function<void()>;
 
 struct SMenuAssetScanUser
 {

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -226,7 +226,7 @@ public:
 
 	CSkins();
 
-	typedef std::function<void()> TSkinLoadedCallback;
+	using TSkinLoadedCallback = std::function<void()>;
 
 	int Sizeof() const override { return sizeof(*this); }
 	void OnConsoleInit() override;

--- a/src/game/client/components/skins7.h
+++ b/src/game/client/components/skins7.h
@@ -32,7 +32,7 @@ public:
 		HAT_OFFSET_SIDE = 2,
 	};
 
-	typedef std::function<void()> TSkinLoadedCallback;
+	using TSkinLoadedCallback = std::function<void()>;
 
 	class CSkinPart
 	{

--- a/src/game/client/components/touch_controls.h
+++ b/src/game/client/components/touch_controls.h
@@ -18,7 +18,8 @@
 #include <vector>
 
 class CJsonWriter;
-typedef struct _json_value json_value;
+struct _json_value;
+using json_value = _json_value;
 
 class CTouchControls : public CComponent
 {

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -32,9 +32,9 @@ public:
 		vec2 m_Offset = vec2(0.0f, 0.0f);
 	};
 
-	typedef std::function<void(const char *pLine)> FClipboardLineCallback;
-	typedef std::function<const char *(char *pCurrentText, size_t NumChars)> FDisplayTextCallback;
-	typedef std::function<bool()> FCalculateOffsetCallback;
+	using FClipboardLineCallback = std::function<void(const char *pLine)>;
+	using FDisplayTextCallback = std::function<const char *(char *pCurrentText, size_t NumChars)>;
+	using FCalculateOffsetCallback = std::function<bool()>;
 
 private:
 	static IClient *ms_pClient;

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -1736,7 +1736,7 @@ void CUi::RenderPopupMenus()
 
 void CUi::ClosePopupMenu(const SPopupMenuId *pId, bool IncludeDescendants)
 {
-	auto PopupMenuToClose = std::find_if(m_vPopupMenus.begin(), m_vPopupMenus.end(), [pId](const SPopupMenu PopupMenu) { return PopupMenu.m_pId == pId; });
+	auto PopupMenuToClose = std::find_if(m_vPopupMenus.begin(), m_vPopupMenus.end(), [pId](const SPopupMenu &PopupMenu) { return PopupMenu.m_pId == pId; });
 	if(PopupMenuToClose != m_vPopupMenus.end())
 	{
 		if(IncludeDescendants)

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -334,12 +334,12 @@ public:
 	 *
 	 * @return Value from the @link EPopupMenuFunctionResult @endlink enum.
 	 */
-	typedef EPopupMenuFunctionResult (*FPopupMenuFunction)(void *pContext, CUIRect View, bool Active);
+	using FPopupMenuFunction = EPopupMenuFunctionResult (*)(void *pContext, CUIRect View, bool Active);
 
 	/**
 	 * Callback that is called when one or more popups are closed.
 	 */
-	typedef std::function<void()> FPopupMenuClosedCallback;
+	using FPopupMenuClosedCallback = std::function<void()>;
 
 	/**
 	 * Represents the aggregated state of current touch events to control a user interface.

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -28,7 +28,7 @@ enum
 
 vec2 ClampVel(int MoveRestriction, vec2 Vel);
 
-typedef bool (*CALLBACK_SWITCHACTIVE)(int Number, void *pUser);
+using CALLBACK_SWITCHACTIVE = bool (*)(int Number, void *pUser);
 struct CAntibotMapData;
 
 class CCollision

--- a/src/game/editor/editor_server_settings.cpp
+++ b/src/game/editor/editor_server_settings.cpp
@@ -1151,7 +1151,7 @@ void CMapSettingsBackend::LoadPossibleValues(const CSettingValuesBuilder &Builde
 	if(Iter == m_LoaderFunctions.end())
 		return;
 
-	(*Iter->second)(Builder);
+	Iter->second(Builder);
 }
 
 void CMapSettingsBackend::RegisterLoader(const char *pSettingName, const FLoaderFunction &pfnLoader)

--- a/src/game/editor/editor_server_settings.h
+++ b/src/game/editor/editor_server_settings.h
@@ -195,7 +195,7 @@ enum class ECollisionCheckResult
 
 class CMapSettingsBackend : public CEditorComponent
 {
-	typedef void (*FLoaderFunction)(const CSettingValuesBuilder &);
+	using FLoaderFunction = void (*)(const CSettingValuesBuilder &);
 
 public:
 	// General methods

--- a/src/game/editor/file_browser.h
+++ b/src/game/editor/file_browser.h
@@ -22,7 +22,7 @@ public:
 		IMAGE,
 		SOUND,
 	};
-	typedef bool (*FFileDialogOpenCallback)(const char *pFilename, int StorageType, void *pUser);
+	using FFileDialogOpenCallback = bool (*)(const char *pFilename, int StorageType, void *pUser);
 
 	void ShowFileDialog(
 		int StorageType, EFileType FileType,

--- a/src/game/editor/quick_action.h
+++ b/src/game/editor/quick_action.h
@@ -4,10 +4,10 @@
 #include <functional>
 #include <utility>
 
-typedef std::function<void()> FButtonClickCallback;
-typedef std::function<bool()> FButtonDisabledCallback;
-typedef std::function<bool()> FButtonActiveCallback;
-typedef std::function<int()> FButtonColorCallback;
+using FButtonClickCallback = std::function<void()>;
+using FButtonDisabledCallback = std::function<bool()>;
+using FButtonActiveCallback = std::function<bool()>;
+using FButtonColorCallback = std::function<int()>;
 
 class CQuickAction
 {

--- a/src/game/map/render_layer.h
+++ b/src/game/map/render_layer.h
@@ -27,7 +27,7 @@ class CMapItemLayerQuads;
 class IMap;
 class CMapImages;
 
-typedef std::function<void(const char *pCaption, const char *pContent, int IncreaseCounter)> FRenderUploadCallback;
+using FRenderUploadCallback = std::function<void(const char *pCaption, const char *pContent, int IncreaseCounter)>;
 
 constexpr int BorderRenderDistance = 201;
 

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -252,8 +252,8 @@ enum
 static constexpr size_t MAX_MAPIMAGES = 64;
 static constexpr size_t MAX_MAPSOUNDS = 64;
 
-typedef ivec2 CPoint; // 22.10 fixed point
-typedef ivec4 CColor;
+using CPoint = ivec2; // 22.10 fixed point
+using CColor = ivec4;
 
 class CFixedTime
 {
@@ -389,7 +389,7 @@ public:
 	int m_MustBe1;
 };
 
-typedef CMapItemImage_v1 CMapItemImage;
+using CMapItemImage = CMapItemImage_v1;
 
 class CMapItemGroup_v1
 {
@@ -551,7 +551,7 @@ public:
 	int m_Synchronized;
 };
 
-typedef CMapItemEnvelope_v2 CMapItemEnvelope;
+using CMapItemEnvelope = CMapItemEnvelope_v2;
 
 class CSoundShape
 {

--- a/src/game/server/teehistorian.h
+++ b/src/game/server/teehistorian.h
@@ -17,7 +17,7 @@ class CUuidManager;
 class CTeeHistorian
 {
 public:
-	typedef void (*WRITE_CALLBACK)(const void *pData, int DataSize, void *pUser);
+	using WRITE_CALLBACK = void (*)(const void *pData, int DataSize, void *pUser);
 
 	struct CGameInfo
 	{

--- a/src/steam/steam_api_flat.h
+++ b/src/steam/steam_api_flat.h
@@ -11,9 +11,9 @@
 
 extern "C" {
 
-typedef uint64_t CSteamId;
-typedef int32_t HSteamPipe;
-typedef int32_t HSteamUser;
+using CSteamId = uint64_t;
+using HSteamPipe = int32_t;
+using HSteamUser = int32_t;
 
 struct CallbackMsg_t
 {

--- a/src/test/str_test.cpp
+++ b/src/test/str_test.cpp
@@ -10,7 +10,7 @@
 
 #include <limits>
 
-typedef void (*TStringArgumentFunction)(char *pStr);
+using TStringArgumentFunction = void (*)(char *pStr);
 template<TStringArgumentFunction Func>
 static void TestInplace(const char *pInput, const char *pOutput)
 {


### PR DESCRIPTION
`using` is more modern C++, reads better - left to right, works with templates and is cleaner with function pointers

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
