### PR TITLE
Improve `CClient::GetGpuInfoString` for headless client

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -5414,6 +5414,19 @@ std::optional<int> CClient::ShowMessageBox(const IGraphics::CMessageBox &Message
 
 void CClient::GetGpuInfoString(char (&aGpuInfo)[512])
 {
+#if defined(CONF_HEADLESS_CLIENT)
+	if(m_pGraphics == nullptr || !m_pGraphics->IsBackendInitialized())
+	{
+		str_format(aGpuInfo, std::size(aGpuInfo),
+			"Configured graphics backend: headless\n"
+			"Graphics %s not yet initialized.",
+			m_pGraphics == nullptr ? "were" : "backend was");
+	}
+	else
+	{
+		str_copy(aGpuInfo, "Configured graphics backend: headless");
+	}
+#else
 	if(m_pGraphics == nullptr || !m_pGraphics->IsBackendInitialized())
 	{
 		str_format(aGpuInfo, std::size(aGpuInfo),
@@ -5438,6 +5451,7 @@ void CClient::GetGpuInfoString(char (&aGpuInfo)[512])
 			m_pGraphics->StreamedMemoryUsage() / 1024.0 / 1024.0,
 			m_pGraphics->StagingMemoryUsage() / 1024.0 / 1024.0);
 	}
+#endif
 }
 
 void CClient::SetLoggers(std::shared_ptr<ILogger> &&pFileLogger, std::shared_ptr<ILogger> &&pStdoutLogger)


### PR DESCRIPTION
The assertion error previously showed incorrect/zeroed graphics information for the headless client.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions