### PR TITLE
Use resize-H/V cursors in editor while using axis lock

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6724,6 +6724,15 @@ void CEditor::RenderMousePointer()
 	if(!m_ShowMousePointer)
 		return;
 
+	if(m_MouseAxisLockState == EAxisLock::HORIZONTAL)
+	{
+		m_CursorType = CURSOR_RESIZE_H;
+	}
+	else if(m_MouseAxisLockState == EAxisLock::VERTICAL)
+	{
+		m_CursorType = CURSOR_RESIZE_V;
+	}
+
 	constexpr float CursorSize = 16.0f;
 
 	// Cursor


### PR DESCRIPTION
<img width="111" height="461" alt="image" src="https://github.com/user-attachments/assets/fb9531aa-c34a-40b1-909b-dd7ce9b5b2e9" />

<img width="388" height="107" alt="image" src="https://github.com/user-attachments/assets/7c3d8854-efba-46e9-978e-95ac20aac8bf" />

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
