### PR TITLE
feat: Add frametime overlay modes (cl_showfps 2 | 3 | 4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3089,6 +3089,7 @@ if((GTEST_FOUND OR DOWNLOAD_GTEST) AND SERVER)
     csv_test.cpp
     datafile_test.cpp
     editor_test.cpp
+    frametime_stats_test.cpp
     fs_test.cpp
     gameworld_test.cpp
     git_revision_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3131,11 +3131,13 @@ if((GTEST_FOUND OR DOWNLOAD_GTEST) AND SERVER)
     windows_test.cpp
   )
   set(TESTS_EXTRA
-    src/engine/client/blocklist_driver.cpp
-    src/engine/client/blocklist_driver.h
-    src/engine/client/serverbrowser.cpp
-    src/engine/client/serverbrowser.h
-    src/engine/client/serverbrowser_http.cpp
+      src/engine/client/blocklist_driver.cpp
+      src/engine/client/blocklist_driver.h
+      src/engine/client/graph.cpp
+      src/engine/client/graph.h
+      src/engine/client/serverbrowser.cpp
+      src/engine/client/serverbrowser.h
+      src/engine/client/serverbrowser_http.cpp
     src/engine/client/serverbrowser_http.h
     src/engine/client/serverbrowser_ping_cache.cpp
     src/engine/client/serverbrowser_ping_cache.h

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -2,6 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef ENGINE_CLIENT_H
 #define ENGINE_CLIENT_H
+
 #include "graphics.h"
 #include "kernel.h"
 #include "message.h"
@@ -18,8 +19,8 @@
 #include <array>
 #include <cmath>
 #include <cstddef>
-#include <limits>
 #include <functional>
+#include <limits>
 #include <optional>
 
 #define CONNECTLINK_DOUBLE_SLASH "ddnet://"

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -15,6 +15,10 @@
 #include <generated/protocol.h>
 #include <generated/protocol7.h>
 
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <limits>
 #include <functional>
 #include <optional>
 
@@ -183,10 +187,23 @@ public:
 
 	// Render statistics.
 
+	class SFrameTimeStats
+	{
+	public:
+		int m_NumSamples = 0;
+		float m_Min = 0.0f;
+		float m_Avg = 0.0f;
+		float m_Deviation = 0.0f;
+		float m_Max = 0.0f;
+
+		bool IsValid() const { return m_NumSamples > 0; }
+	};
+
 	// Duration in seconds of the previous render cycle.
 	float RenderFrameTime() const { return m_RenderFrameTime; }
 	// Exponentially weighted average of frame times.
 	float FrameTimeAverage() const { return m_FrameTimeAverage; }
+	virtual SFrameTimeStats FrameTimeWindowStats(size_t NumFrames) const = 0;
 
 	// actions
 	virtual void Connect(const char *pAddress, const char *pPassword = nullptr) = 0;
@@ -425,6 +442,77 @@ public:
 	virtual void InitializeLanguage() = 0;
 
 	virtual void ForceUpdateConsoleRemoteCompletionSuggestions() = 0;
+};
+
+class CFrameTimeHistory
+{
+public:
+	static constexpr size_t MAX_SAMPLES = 1000;
+
+	class SStats
+	{
+	public:
+		size_t m_NumSamples = 0;
+		float m_Min = 0.0f;
+		float m_Avg = 0.0f;
+		float m_Deviation = 0.0f;
+		float m_Max = 0.0f;
+
+		bool IsValid() const
+		{
+			return m_NumSamples > 0;
+		}
+	};
+
+	void Add(float FrameTime)
+	{
+		m_aFrameTimes[m_NextIndex] = FrameTime;
+		m_NextIndex = (m_NextIndex + 1) % MAX_SAMPLES;
+		m_NumSamples = m_NumSamples < MAX_SAMPLES ? m_NumSamples + 1 : MAX_SAMPLES;
+	}
+
+	SStats GetStats(size_t WindowSize) const
+	{
+		const size_t NumSamples = WindowSize < m_NumSamples ? WindowSize : m_NumSamples;
+		if(NumSamples == 0)
+		{
+			return {};
+		}
+
+		const size_t StartIndex = (m_NextIndex + MAX_SAMPLES - NumSamples) % MAX_SAMPLES;
+		float Min = std::numeric_limits<float>::max();
+		float Max = std::numeric_limits<float>::lowest();
+		float Sum = 0.0f;
+		for(size_t i = 0; i < NumSamples; ++i)
+		{
+			const float FrameTime = m_aFrameTimes[(StartIndex + i) % MAX_SAMPLES];
+			if(FrameTime < Min)
+				Min = FrameTime;
+			if(FrameTime > Max)
+				Max = FrameTime;
+			Sum += FrameTime;
+		}
+		const float Avg = Sum / NumSamples;
+		float VarianceSum = 0.0f;
+		for(size_t i = 0; i < NumSamples; ++i)
+		{
+			const float FrameTime = m_aFrameTimes[(StartIndex + i) % MAX_SAMPLES];
+			const float Delta = FrameTime - Avg;
+			VarianceSum += Delta * Delta;
+		}
+
+		return {NumSamples, Min, Avg, std::sqrt(VarianceSum / NumSamples), Max};
+	}
+
+	size_t NumSamples() const
+	{
+		return m_NumSamples;
+	}
+
+private:
+	std::array<float, MAX_SAMPLES> m_aFrameTimes{};
+	size_t m_NextIndex = 0;
+	size_t m_NumSamples = 0;
 };
 
 extern IGameClient *CreateGameClient();

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -16,11 +16,8 @@
 #include <generated/protocol.h>
 #include <generated/protocol7.h>
 
-#include <array>
-#include <cmath>
 #include <cstddef>
 #include <functional>
-#include <limits>
 #include <optional>
 
 #define CONNECTLINK_DOUBLE_SLASH "ddnet://"
@@ -188,9 +185,8 @@ public:
 
 	// Render statistics.
 
-	class SFrameTimeStats
+	struct SFrameTimeStats
 	{
-	public:
 		int m_NumSamples = 0;
 		float m_Min = 0.0f;
 		float m_Avg = 0.0f;
@@ -443,77 +439,6 @@ public:
 	virtual void InitializeLanguage() = 0;
 
 	virtual void ForceUpdateConsoleRemoteCompletionSuggestions() = 0;
-};
-
-class CFrameTimeHistory
-{
-public:
-	static constexpr size_t MAX_SAMPLES = 1000;
-
-	class SStats
-	{
-	public:
-		size_t m_NumSamples = 0;
-		float m_Min = 0.0f;
-		float m_Avg = 0.0f;
-		float m_Deviation = 0.0f;
-		float m_Max = 0.0f;
-
-		bool IsValid() const
-		{
-			return m_NumSamples > 0;
-		}
-	};
-
-	void Add(float FrameTime)
-	{
-		m_aFrameTimes[m_NextIndex] = FrameTime;
-		m_NextIndex = (m_NextIndex + 1) % MAX_SAMPLES;
-		m_NumSamples = m_NumSamples < MAX_SAMPLES ? m_NumSamples + 1 : MAX_SAMPLES;
-	}
-
-	SStats GetStats(size_t WindowSize) const
-	{
-		const size_t NumSamples = WindowSize < m_NumSamples ? WindowSize : m_NumSamples;
-		if(NumSamples == 0)
-		{
-			return {};
-		}
-
-		const size_t StartIndex = (m_NextIndex + MAX_SAMPLES - NumSamples) % MAX_SAMPLES;
-		float Min = std::numeric_limits<float>::max();
-		float Max = std::numeric_limits<float>::lowest();
-		float Sum = 0.0f;
-		for(size_t i = 0; i < NumSamples; ++i)
-		{
-			const float FrameTime = m_aFrameTimes[(StartIndex + i) % MAX_SAMPLES];
-			if(FrameTime < Min)
-				Min = FrameTime;
-			if(FrameTime > Max)
-				Max = FrameTime;
-			Sum += FrameTime;
-		}
-		const float Avg = Sum / NumSamples;
-		float VarianceSum = 0.0f;
-		for(size_t i = 0; i < NumSamples; ++i)
-		{
-			const float FrameTime = m_aFrameTimes[(StartIndex + i) % MAX_SAMPLES];
-			const float Delta = FrameTime - Avg;
-			VarianceSum += Delta * Delta;
-		}
-
-		return {NumSamples, Min, Avg, std::sqrt(VarianceSum / NumSamples), Max};
-	}
-
-	size_t NumSamples() const
-	{
-		return m_NumSamples;
-	}
-
-private:
-	std::array<float, MAX_SAMPLES> m_aFrameTimes{};
-	size_t m_NextIndex = 0;
-	size_t m_NumSamples = 0;
 };
 
 extern IGameClient *CreateGameClient();

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -100,7 +100,7 @@ CSnapshotDelta *CClient::SnapshotDelta()
 
 IClient::SFrameTimeStats CClient::FrameTimeWindowStats(size_t NumFrames) const
 {
-	const CFrameTimeHistory::SStats Stats = m_FrameTimeHistory.GetStats(NumFrames);
+	const CGraph::SSummaryStats Stats = m_FrameTimeGraph.SummaryStats(NumFrames);
 	return {(int)Stats.m_NumSamples, Stats.m_Min, Stats.m_Avg, Stats.m_Deviation, Stats.m_Max};
 }
 
@@ -108,7 +108,8 @@ CClient::CClient() :
 	m_DemoPlayer(&m_SnapshotDelta, &m_SnapshotDeltaSixup, true, [&]() { UpdateDemoIntraTimers(); }),
 	m_InputtimeMarginGraph(128, 2, true),
 	m_aGametimeMarginGraphs{{128, 2, true}, {128, 2, true}},
-	m_FpsGraph(4096, 0, true)
+	m_FpsGraph(4096, 0, true),
+	m_FrameTimeGraph(4096, 2, true)
 {
 	m_StateStartTime = time_get();
 	for(auto &DemoRecorder : m_aDemoRecorder)
@@ -3202,6 +3203,7 @@ void CClient::Run()
 
 	//
 	m_FpsGraph.Init(0.0f, 120.0f);
+	m_FrameTimeGraph.Init(0.0f, 20.0f);
 
 	// never start with the editor
 	g_Config.m_ClEditor = 0;
@@ -3345,8 +3347,8 @@ void CClient::Run()
 			{
 				// update frametime
 				m_RenderFrameTime = (Now - m_LastRenderTime) / (float)time_freq();
-				m_FrameTimeHistory.Add(m_RenderFrameTime);
 				m_FpsGraph.Add(1.0f / m_RenderFrameTime);
+				m_FrameTimeGraph.Add(m_RenderFrameTime * 1000.0f);
 
 				if(m_BenchmarkFile)
 				{

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -98,6 +98,12 @@ CSnapshotDelta *CClient::SnapshotDelta()
 	return &m_SnapshotDelta;
 }
 
+IClient::SFrameTimeStats CClient::FrameTimeWindowStats(size_t NumFrames) const
+{
+	const CFrameTimeHistory::SStats Stats = m_FrameTimeHistory.GetStats(NumFrames);
+	return {(int)Stats.m_NumSamples, Stats.m_Min, Stats.m_Avg, Stats.m_Deviation, Stats.m_Max};
+}
+
 CClient::CClient() :
 	m_DemoPlayer(&m_SnapshotDelta, &m_SnapshotDeltaSixup, true, [&]() { UpdateDemoIntraTimers(); }),
 	m_InputtimeMarginGraph(128, 2, true),
@@ -3339,6 +3345,7 @@ void CClient::Run()
 			{
 				// update frametime
 				m_RenderFrameTime = (Now - m_LastRenderTime) / (float)time_freq();
+				m_FrameTimeHistory.Add(m_RenderFrameTime);
 				m_FpsGraph.Add(1.0f / m_RenderFrameTime);
 
 				if(m_BenchmarkFile)

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -192,6 +192,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	CGraph m_InputtimeMarginGraph;
 	CGraph m_aGametimeMarginGraphs[NUM_DUMMIES];
 	CGraph m_FpsGraph;
+	CFrameTimeHistory m_FrameTimeHistory;
 
 	// the game snapshots are modifiable by the game
 	CSnapshotStorage m_aSnapshotStorage[NUM_DUMMIES];
@@ -354,6 +355,7 @@ public:
 	// ---
 
 	int GetPredictionTime() override;
+	SFrameTimeStats FrameTimeWindowStats(size_t NumFrames) const override;
 	CSnapItem SnapGetItem(int SnapId, int Index) const override;
 	int GetPredictionTick() override;
 	const void *SnapFindItem(int SnapId, int Type, int Id) const override;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -192,7 +192,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	CGraph m_InputtimeMarginGraph;
 	CGraph m_aGametimeMarginGraphs[NUM_DUMMIES];
 	CGraph m_FpsGraph;
-	CFrameTimeHistory m_FrameTimeHistory;
+	CGraph m_FrameTimeGraph;
 
 	// the game snapshots are modifiable by the game
 	CSnapshotStorage m_aSnapshotStorage[NUM_DUMMIES];

--- a/src/engine/client/graph.cpp
+++ b/src/engine/client/graph.cpp
@@ -9,6 +9,7 @@
 #include <engine/graphics.h>
 #include <engine/textrender.h>
 
+#include <cmath>
 #include <limits>
 
 CGraph::CGraph(int MaxEntries, int Precision, bool SummaryStats) :
@@ -128,6 +129,41 @@ void CGraph::Scale(int64_t WantedTotalTime)
 	{
 		m_Average /= NumValues;
 	}
+}
+
+CGraph::SSummaryStats CGraph::SummaryStats(size_t MaxEntries) const
+{
+	const CEntry *pEntry = m_Entries.Last();
+	if(pEntry == nullptr || MaxEntries == 0)
+	{
+		return {};
+	}
+
+	float Min = std::numeric_limits<float>::max();
+	float Max = std::numeric_limits<float>::lowest();
+	float Sum = 0.0f;
+	size_t NumSamples = 0;
+	for(; pEntry != nullptr && NumSamples < MaxEntries; pEntry = m_Entries.Prev(pEntry))
+	{
+		const float Value = pEntry->m_Value;
+		if(Value < Min)
+			Min = Value;
+		if(Value > Max)
+			Max = Value;
+		Sum += Value;
+		++NumSamples;
+	}
+
+	const float Avg = Sum / NumSamples;
+	float VarianceSum = 0.0f;
+	pEntry = m_Entries.Last();
+	for(size_t i = 0; pEntry != nullptr && i < NumSamples; pEntry = m_Entries.Prev(pEntry), ++i)
+	{
+		const float Delta = pEntry->m_Value - Avg;
+		VarianceSum += Delta * Delta;
+	}
+
+	return {NumSamples, Min, Avg, std::sqrt(VarianceSum / NumSamples), Max};
 }
 
 void CGraph::Add(float Value, ColorRGBA Color)

--- a/src/engine/client/graph.h
+++ b/src/engine/client/graph.h
@@ -8,6 +8,7 @@
 
 #include <engine/shared/ringbuffer.h>
 
+#include <cstddef>
 #include <cstdint>
 
 class IGraphics;
@@ -37,6 +38,17 @@ private:
 	void RenderDataLines(IGraphics *pGraphics, float x, float y, float w, float h);
 
 public:
+	struct SSummaryStats
+	{
+		size_t m_NumSamples = 0;
+		float m_Min = 0.0f;
+		float m_Avg = 0.0f;
+		float m_Deviation = 0.0f;
+		float m_Max = 0.0f;
+
+		bool IsValid() const { return m_NumSamples > 0; }
+	};
+
 	CGraph(int MaxEntries, int Precision, bool SummaryStats);
 
 	void Init(float Min, float Max);
@@ -44,6 +56,7 @@ public:
 	void SetMax(float Max);
 
 	void Scale(int64_t WantedTotalTime);
+	SSummaryStats SummaryStats(size_t MaxEntries) const;
 	void Add(float Value, ColorRGBA Color = ColorRGBA(1.0f, 1.0f, 1.0f, 0.75f));
 	void InsertAt(int64_t Time, float Value, ColorRGBA Color = ColorRGBA(1.0f, 1.0f, 1.0f, 0.75f));
 	void Render(IGraphics *pGraphics, ITextRender *pTextRender, float x, float y, float w, float h, const char *pDescription);

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -87,7 +87,7 @@ MACRO_CONFIG_INT(ClShowKillMessages, cl_showkillmessages, 1, 0, 1, CFGFLAG_CLIEN
 MACRO_CONFIG_INT(ClShowFinishMessages, cl_show_finish_messages, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show finish messages")
 MACRO_CONFIG_INT(ClShowVotesAfterVoting, cl_show_votes_after_voting, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show votes window after voting")
 MACRO_CONFIG_INT(ClShowLocalTimeAlways, cl_show_local_time_always, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Always show local time")
-MACRO_CONFIG_INT(ClShowfps, cl_showfps, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame FPS counter")
+MACRO_CONFIG_INT(ClShowfps, cl_showfps, 0, 0, 4, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame FPS counter (0 = off, 1 = FPS, 2 = FPS + frametimes over 360 frames, 3 = FPS + frametimes over 1000 frames, 4 = FPS + frametimes over 360 and 1000 frames)")
 MACRO_CONFIG_INT(ClShowpred, cl_showpred, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame prediction time in milliseconds")
 MACRO_CONFIG_INT(ClEyeWheel, cl_eye_wheel, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show eye wheel along together with emotes")
 MACRO_CONFIG_INT(ClEyeDuration, cl_eye_duration, 999999, 1, 999999, CFGFLAG_CLIENT | CFGFLAG_SAVE, "How long the eyes emotes last")

--- a/src/engine/shared/ringbuffer.h
+++ b/src/engine/shared/ringbuffer.h
@@ -38,9 +38,13 @@ protected:
 	void *Allocate(int Size);
 
 	void *Prev(void *pCurrent);
+	const void *Prev(const void *pCurrent) const { return const_cast<CRingBufferBase *>(this)->Prev((void *)pCurrent); }
 	void *Next(void *pCurrent);
+	const void *Next(const void *pCurrent) const { return const_cast<CRingBufferBase *>(this)->Next((void *)pCurrent); }
 	void *First();
+	const void *First() const { return const_cast<CRingBufferBase *>(this)->First(); }
 	void *Last();
+	const void *Last() const { return const_cast<CRingBufferBase *>(this)->Last(); }
 
 	void Init(void *pMemory, int Size, int Flags);
 	int PopFirst();
@@ -71,9 +75,13 @@ public:
 	}
 
 	T *Prev(T *pCurrent) { return (T *)CRingBufferBase::Prev(pCurrent); }
+	const T *Prev(const T *pCurrent) const { return (const T *)CRingBufferBase::Prev(pCurrent); }
 	T *Next(T *pCurrent) { return (T *)CRingBufferBase::Next(pCurrent); }
+	const T *Next(const T *pCurrent) const { return (const T *)CRingBufferBase::Next(pCurrent); }
 	T *First() { return (T *)CRingBufferBase::First(); }
+	const T *First() const { return (const T *)CRingBufferBase::First(); }
 	T *Last() { return (T *)CRingBufferBase::Last(); }
+	const T *Last() const { return (const T *)CRingBufferBase::Last(); }
 };
 
 template<typename T, int TSIZE, int TFLAGS = 0>

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -29,16 +29,16 @@
 
 namespace
 {
-float ShowFpsPredictionOffset(int Showfps)
-{
-	if(Showfps == 4)
-		return 40.0f;
-	if(Showfps >= 2)
-		return 30.0f;
-	if(Showfps == 1)
-		return 20.0f;
-	return 5.0f;
-}
+	float ShowFpsPredictionOffset(int Showfps)
+	{
+		if(Showfps == 4)
+			return 40.0f;
+		if(Showfps >= 2)
+			return 30.0f;
+		if(Showfps == 1)
+			return 20.0f;
+		return 5.0f;
+	}
 }
 
 CHud::CHud()

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -27,6 +27,20 @@
 
 #include <cmath>
 
+namespace
+{
+float ShowFpsPredictionOffset(int Showfps)
+{
+	if(Showfps == 4)
+		return 40.0f;
+	if(Showfps >= 2)
+		return 30.0f;
+	if(Showfps == 1)
+		return 20.0f;
+	return 5.0f;
+}
+}
+
 CHud::CHud()
 {
 	m_FPSTextContainerIndex.Reset();
@@ -536,39 +550,104 @@ void CHud::RenderTextInfo()
 #endif
 	if(Showfps)
 	{
-		char aBuf[16];
 		const int FramesPerSecond = round_to_int(1.0f / Client()->FrameTimeAverage());
-		str_format(aBuf, sizeof(aBuf), "%d", FramesPerSecond);
-
-		static float s_TextWidth0 = TextRender()->TextWidth(12.f, "0", -1, -1.0f);
-		static float s_TextWidth00 = TextRender()->TextWidth(12.f, "00", -1, -1.0f);
-		static float s_TextWidth000 = TextRender()->TextWidth(12.f, "000", -1, -1.0f);
-		static float s_TextWidth0000 = TextRender()->TextWidth(12.f, "0000", -1, -1.0f);
-		static float s_TextWidth00000 = TextRender()->TextWidth(12.f, "00000", -1, -1.0f);
-		static const float s_aTextWidth[5] = {s_TextWidth0, s_TextWidth00, s_TextWidth000, s_TextWidth0000, s_TextWidth00000};
-
-		int DigitIndex = GetDigitsIndex(FramesPerSecond, 4);
-
-		CTextCursor Cursor;
-		Cursor.SetPosition(vec2(m_Width - 10 - s_aTextWidth[DigitIndex], 5));
-		Cursor.m_FontSize = 12.0f;
-		auto OldFlags = TextRender()->GetRenderFlags();
-		TextRender()->SetRenderFlags(OldFlags | TEXT_RENDER_FLAG_ONE_TIME_USE);
-		if(m_FPSTextContainerIndex.Valid())
-			TextRender()->RecreateTextContainerSoft(m_FPSTextContainerIndex, &Cursor, aBuf);
-		else
-			TextRender()->CreateTextContainer(m_FPSTextContainerIndex, &Cursor, "0");
-		TextRender()->SetRenderFlags(OldFlags);
-		if(m_FPSTextContainerIndex.Valid())
+		if(Showfps == 1)
 		{
-			TextRender()->RenderTextContainer(m_FPSTextContainerIndex, TextRender()->DefaultTextColor(), TextRender()->DefaultTextOutlineColor());
+			char aBuf[16];
+			str_format(aBuf, sizeof(aBuf), "%d", FramesPerSecond);
+
+			static float s_TextWidth0 = TextRender()->TextWidth(12.f, "0", -1, -1.0f);
+			static float s_TextWidth00 = TextRender()->TextWidth(12.f, "00", -1, -1.0f);
+			static float s_TextWidth000 = TextRender()->TextWidth(12.f, "000", -1, -1.0f);
+			static float s_TextWidth0000 = TextRender()->TextWidth(12.f, "0000", -1, -1.0f);
+			static float s_TextWidth00000 = TextRender()->TextWidth(12.f, "00000", -1, -1.0f);
+			static const float s_aTextWidth[5] = {s_TextWidth0, s_TextWidth00, s_TextWidth000, s_TextWidth0000, s_TextWidth00000};
+
+			int DigitIndex = GetDigitsIndex(FramesPerSecond, 4);
+
+			CTextCursor Cursor;
+			Cursor.SetPosition(vec2(m_Width - 10 - s_aTextWidth[DigitIndex], 5));
+			Cursor.m_FontSize = 12.0f;
+			auto OldFlags = TextRender()->GetRenderFlags();
+			TextRender()->SetRenderFlags(OldFlags | TEXT_RENDER_FLAG_ONE_TIME_USE);
+			if(m_FPSTextContainerIndex.Valid())
+				TextRender()->RecreateTextContainerSoft(m_FPSTextContainerIndex, &Cursor, aBuf);
+			else
+				TextRender()->CreateTextContainer(m_FPSTextContainerIndex, &Cursor, "0");
+			TextRender()->SetRenderFlags(OldFlags);
+			if(m_FPSTextContainerIndex.Valid())
+			{
+				TextRender()->RenderTextContainer(m_FPSTextContainerIndex, TextRender()->DefaultTextColor(), TextRender()->DefaultTextOutlineColor());
+			}
+		}
+		else
+		{
+			const float FpsFontSize = 12.0f;
+			const float StatsFontSize = 9.0f;
+			const float RightMargin = 10.0f;
+			const float TopMargin = 5.0f;
+			const float StatsLineSpacing = 10.0f;
+			const ColorRGBA StatsColor = ColorRGBA(1.0f, 0.35f, 0.35f, 1.0f);
+			const float ColumnGap = 4.0f;
+			char aBuf[64];
+			const float FpsTextWidth = TextRender()->TextWidth(FpsFontSize, "FPS: 0000", -1, -1.0f);
+			const float LabelWidth = TextRender()->TextWidth(StatsFontSize, "1000 frames:", -1, -1.0f);
+			const float AvgWidth = TextRender()->TextWidth(StatsFontSize, "avg 000.00 ms +/- 000.00", -1, -1.0f);
+			const float MinWidth = TextRender()->TextWidth(StatsFontSize, "min 000.00 ms", -1, -1.0f);
+			const float MaxWidth = TextRender()->TextWidth(StatsFontSize, "max 000.00 ms", -1, -1.0f);
+			const float SeparatorWidth = TextRender()->TextWidth(StatsFontSize, "|", -1, -1.0f);
+			const float StatsTextWidth = LabelWidth + ColumnGap + AvgWidth + ColumnGap + SeparatorWidth + ColumnGap + MinWidth + ColumnGap + SeparatorWidth + ColumnGap + MaxWidth;
+			const float StatsStartX = m_Width - RightMargin - StatsTextWidth;
+
+			str_format(aBuf, sizeof(aBuf), "FPS: %d", FramesPerSecond);
+			TextRender()->Text(m_Width - RightMargin - FpsTextWidth, TopMargin, FpsFontSize, aBuf, -1.0f);
+
+			const size_t aWindowSizes[2] = {360, 1000};
+			const int NumWindows = Showfps == 4 ? 2 : 1;
+			const int WindowIndexOffset = Showfps == 3 ? 1 : 0;
+			TextRender()->TextColor(StatsColor);
+			for(int i = 0; i < NumWindows; ++i)
+			{
+				const size_t WindowSize = aWindowSizes[WindowIndexOffset + i];
+				const IClient::SFrameTimeStats Stats = Client()->FrameTimeWindowStats(WindowSize);
+				const float y = TopMargin + 12.0f + StatsLineSpacing * i;
+				const float AvgX = StatsStartX + LabelWidth + ColumnGap;
+				const float Separator1X = AvgX + AvgWidth + ColumnGap;
+				const float MinX = Separator1X + SeparatorWidth + ColumnGap;
+				const float Separator2X = MinX + MinWidth + ColumnGap;
+				const float MaxX = Separator2X + SeparatorWidth + ColumnGap;
+
+				str_format(aBuf, sizeof(aBuf), "%d frames:", (int)WindowSize);
+				TextRender()->Text(StatsStartX, y, StatsFontSize, aBuf, -1.0f);
+				if(Stats.IsValid())
+				{
+					str_format(aBuf, sizeof(aBuf), "avg %.2f ms +/- %.2f", Stats.m_Avg * 1000.0f, Stats.m_Deviation * 1000.0f);
+					TextRender()->Text(AvgX, y, StatsFontSize, aBuf, -1.0f);
+					TextRender()->Text(Separator1X, y, StatsFontSize, "|", -1.0f);
+					str_format(aBuf, sizeof(aBuf), "min %.2f ms", Stats.m_Min * 1000.0f);
+					TextRender()->Text(MinX, y, StatsFontSize, aBuf, -1.0f);
+					TextRender()->Text(Separator2X, y, StatsFontSize, "|", -1.0f);
+					str_format(aBuf, sizeof(aBuf), "max %.2f ms", Stats.m_Max * 1000.0f);
+					TextRender()->Text(MaxX, y, StatsFontSize, aBuf, -1.0f);
+				}
+				else
+				{
+					TextRender()->Text(AvgX, y, StatsFontSize, "avg - ms +/- -", -1.0f);
+					TextRender()->Text(Separator1X, y, StatsFontSize, "|", -1.0f);
+					TextRender()->Text(MinX, y, StatsFontSize, "min - ms", -1.0f);
+					TextRender()->Text(Separator2X, y, StatsFontSize, "|", -1.0f);
+					TextRender()->Text(MaxX, y, StatsFontSize, "max - ms", -1.0f);
+				}
+			}
+			TextRender()->TextColor(TextRender()->DefaultTextColor());
 		}
 	}
 	if(g_Config.m_ClShowpred && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 	{
 		char aBuf[64];
 		str_format(aBuf, sizeof(aBuf), "%d", Client()->GetPredictionTime());
-		TextRender()->Text(m_Width - 10 - TextRender()->TextWidth(12, aBuf, -1, -1.0f), Showfps ? 20 : 5, 12, aBuf, -1.0f);
+		const float PredictionOffset = ShowFpsPredictionOffset(Showfps);
+		TextRender()->Text(m_Width - 10 - TextRender()->TextWidth(12, aBuf, -1, -1.0f), PredictionOffset, 12, aBuf, -1.0f);
 	}
 }
 

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -589,17 +589,37 @@ void CHud::RenderTextInfo()
 			const float StatsLineSpacing = 10.0f;
 			const ColorRGBA StatsColor = ColorRGBA(1.0f, 0.35f, 0.35f, 1.0f);
 			const float ColumnGap = 4.0f;
-			char aBuf[64];
-			const float FpsTextWidth = TextRender()->TextWidth(FpsFontSize, "FPS: 0000", -1, -1.0f);
-			const float LabelWidth = TextRender()->TextWidth(StatsFontSize, "1000 frames:", -1, -1.0f);
-			const float AvgWidth = TextRender()->TextWidth(StatsFontSize, "avg 000.00 ms +/- 000.00", -1, -1.0f);
-			const float MinWidth = TextRender()->TextWidth(StatsFontSize, "min 000.00 ms", -1, -1.0f);
-			const float MaxWidth = TextRender()->TextWidth(StatsFontSize, "max 000.00 ms", -1, -1.0f);
+			char aBuf[128];
+			const char *pFpsLabel = Localize("FPS", "Frametime overlay");
+			const char *pFramesLabel = Localize("frames:", "Frametime overlay");
+			const char *pAvgLabel = Localize("avg", "Frametime overlay");
+			const char *pMinLabel = Localize("min", "Frametime overlay");
+			const char *pMaxLabel = Localize("max", "Frametime overlay");
+
+			str_format(aBuf, sizeof(aBuf), "%s: %d", pFpsLabel, 1000);
+			const float FpsTextWidth = TextRender()->TextWidth(FpsFontSize, aBuf, -1, -1.0f);
+			str_format(aBuf, sizeof(aBuf), "%d %s", 1000, pFramesLabel);
+			const float LabelWidth = TextRender()->TextWidth(StatsFontSize, aBuf, -1, -1.0f);
+			str_format(aBuf, sizeof(aBuf), "%s %.2f ms +/- %.2f", pAvgLabel, 1000.0f, 1000.0f);
+			float AvgWidth = TextRender()->TextWidth(StatsFontSize, aBuf, -1, -1.0f);
+			str_format(aBuf, sizeof(aBuf), "%s - ms +/- -", pAvgLabel);
+			if(const float EmptyAvgWidth = TextRender()->TextWidth(StatsFontSize, aBuf, -1, -1.0f); EmptyAvgWidth > AvgWidth)
+				AvgWidth = EmptyAvgWidth;
+			str_format(aBuf, sizeof(aBuf), "%s %.2f ms", pMinLabel, 1000.0f);
+			float MinWidth = TextRender()->TextWidth(StatsFontSize, aBuf, -1, -1.0f);
+			str_format(aBuf, sizeof(aBuf), "%s - ms", pMinLabel);
+			if(const float EmptyMinWidth = TextRender()->TextWidth(StatsFontSize, aBuf, -1, -1.0f); EmptyMinWidth > MinWidth)
+				MinWidth = EmptyMinWidth;
+			str_format(aBuf, sizeof(aBuf), "%s %.2f ms", pMaxLabel, 1000.0f);
+			float MaxWidth = TextRender()->TextWidth(StatsFontSize, aBuf, -1, -1.0f);
+			str_format(aBuf, sizeof(aBuf), "%s - ms", pMaxLabel);
+			if(const float EmptyMaxWidth = TextRender()->TextWidth(StatsFontSize, aBuf, -1, -1.0f); EmptyMaxWidth > MaxWidth)
+				MaxWidth = EmptyMaxWidth;
 			const float SeparatorWidth = TextRender()->TextWidth(StatsFontSize, "|", -1, -1.0f);
 			const float StatsTextWidth = LabelWidth + ColumnGap + AvgWidth + ColumnGap + SeparatorWidth + ColumnGap + MinWidth + ColumnGap + SeparatorWidth + ColumnGap + MaxWidth;
 			const float StatsStartX = m_Width - RightMargin - StatsTextWidth;
 
-			str_format(aBuf, sizeof(aBuf), "FPS: %d", FramesPerSecond);
+			str_format(aBuf, sizeof(aBuf), "%s: %d", pFpsLabel, FramesPerSecond);
 			TextRender()->Text(m_Width - RightMargin - FpsTextWidth, TopMargin, FpsFontSize, aBuf, -1.0f);
 
 			const size_t aWindowSizes[2] = {360, 1000};
@@ -610,33 +630,36 @@ void CHud::RenderTextInfo()
 			{
 				const size_t WindowSize = aWindowSizes[WindowIndexOffset + i];
 				const IClient::SFrameTimeStats Stats = Client()->FrameTimeWindowStats(WindowSize);
-				const float y = TopMargin + 12.0f + StatsLineSpacing * i;
+				const float Y = TopMargin + 12.0f + StatsLineSpacing * i;
 				const float AvgX = StatsStartX + LabelWidth + ColumnGap;
 				const float Separator1X = AvgX + AvgWidth + ColumnGap;
 				const float MinX = Separator1X + SeparatorWidth + ColumnGap;
 				const float Separator2X = MinX + MinWidth + ColumnGap;
 				const float MaxX = Separator2X + SeparatorWidth + ColumnGap;
 
-				str_format(aBuf, sizeof(aBuf), "%d frames:", (int)WindowSize);
-				TextRender()->Text(StatsStartX, y, StatsFontSize, aBuf, -1.0f);
+				str_format(aBuf, sizeof(aBuf), "%d %s", Stats.m_NumSamples, pFramesLabel);
+				TextRender()->Text(StatsStartX, Y, StatsFontSize, aBuf, -1.0f);
 				if(Stats.IsValid())
 				{
-					str_format(aBuf, sizeof(aBuf), "avg %.2f ms +/- %.2f", Stats.m_Avg * 1000.0f, Stats.m_Deviation * 1000.0f);
-					TextRender()->Text(AvgX, y, StatsFontSize, aBuf, -1.0f);
-					TextRender()->Text(Separator1X, y, StatsFontSize, "|", -1.0f);
-					str_format(aBuf, sizeof(aBuf), "min %.2f ms", Stats.m_Min * 1000.0f);
-					TextRender()->Text(MinX, y, StatsFontSize, aBuf, -1.0f);
-					TextRender()->Text(Separator2X, y, StatsFontSize, "|", -1.0f);
-					str_format(aBuf, sizeof(aBuf), "max %.2f ms", Stats.m_Max * 1000.0f);
-					TextRender()->Text(MaxX, y, StatsFontSize, aBuf, -1.0f);
+					str_format(aBuf, sizeof(aBuf), "%s %.2f ms +/- %.2f", pAvgLabel, Stats.m_Avg, Stats.m_Deviation);
+					TextRender()->Text(AvgX, Y, StatsFontSize, aBuf, -1.0f);
+					TextRender()->Text(Separator1X, Y, StatsFontSize, "|", -1.0f);
+					str_format(aBuf, sizeof(aBuf), "%s %.2f ms", pMinLabel, Stats.m_Min);
+					TextRender()->Text(MinX, Y, StatsFontSize, aBuf, -1.0f);
+					TextRender()->Text(Separator2X, Y, StatsFontSize, "|", -1.0f);
+					str_format(aBuf, sizeof(aBuf), "%s %.2f ms", pMaxLabel, Stats.m_Max);
+					TextRender()->Text(MaxX, Y, StatsFontSize, aBuf, -1.0f);
 				}
 				else
 				{
-					TextRender()->Text(AvgX, y, StatsFontSize, "avg - ms +/- -", -1.0f);
-					TextRender()->Text(Separator1X, y, StatsFontSize, "|", -1.0f);
-					TextRender()->Text(MinX, y, StatsFontSize, "min - ms", -1.0f);
-					TextRender()->Text(Separator2X, y, StatsFontSize, "|", -1.0f);
-					TextRender()->Text(MaxX, y, StatsFontSize, "max - ms", -1.0f);
+					str_format(aBuf, sizeof(aBuf), "%s - ms +/- -", pAvgLabel);
+					TextRender()->Text(AvgX, Y, StatsFontSize, aBuf, -1.0f);
+					TextRender()->Text(Separator1X, Y, StatsFontSize, "|", -1.0f);
+					str_format(aBuf, sizeof(aBuf), "%s - ms", pMinLabel);
+					TextRender()->Text(MinX, Y, StatsFontSize, aBuf, -1.0f);
+					TextRender()->Text(Separator2X, Y, StatsFontSize, "|", -1.0f);
+					str_format(aBuf, sizeof(aBuf), "%s - ms", pMaxLabel);
+					TextRender()->Text(MaxX, Y, StatsFontSize, aBuf, -1.0f);
 				}
 			}
 			TextRender()->TextColor(TextRender()->DefaultTextColor());

--- a/src/game/client/components/infomessages.cpp
+++ b/src/game/client/components/infomessages.cpp
@@ -459,7 +459,8 @@ void CInfoMessages::OnRender()
 		Showfps = 0;
 #endif
 	const float StartX = Width - 10.0f;
-	const float StartY = 30.0f + (Showfps ? 100.0f : 0.0f) + (g_Config.m_ClShowpred && Client()->State() != IClient::STATE_DEMOPLAYBACK ? 100.0f : 0.0f);
+	const float ShowFpsOffset = Showfps == 4 ? 150.0f : (Showfps >= 2 ? 125.0f : (Showfps ? 100.0f : 0.0f));
+	const float StartY = 30.0f + ShowFpsOffset + (g_Config.m_ClShowpred && Client()->State() != IClient::STATE_DEMOPLAYBACK ? 100.0f : 0.0f);
 
 	float y = StartY;
 	for(int i = 1; i <= MAX_INFOMSGS; i++)

--- a/src/game/client/components/infomessages.cpp
+++ b/src/game/client/components/infomessages.cpp
@@ -454,12 +454,16 @@ void CInfoMessages::OnRender()
 	Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 
 	int Showfps = g_Config.m_ClShowfps;
+	bool ShowHud = g_Config.m_ClShowhud;
 #if defined(CONF_VIDEORECORDER)
 	if(IVideo::Current())
+	{
 		Showfps = 0;
+		ShowHud = g_Config.m_ClVideoShowhud;
+	}
 #endif
 	const float StartX = Width - 10.0f;
-	const float ShowFpsOffset = Showfps == 4 ? 150.0f : (Showfps >= 2 ? 125.0f : (Showfps ? 100.0f : 0.0f));
+	const float ShowFpsOffset = ShowHud ? (Showfps == 4 ? 150.0f : (Showfps >= 2 ? 125.0f : (Showfps ? 100.0f : 0.0f))) : 0.0f;
 	const float StartY = 30.0f + ShowFpsOffset + (g_Config.m_ClShowpred && Client()->State() != IClient::STATE_DEMOPLAYBACK ? 100.0f : 0.0f);
 
 	float y = StartY;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1034,9 +1034,18 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	GameClient()->m_Tooltips.DoToolTip(&g_Config.m_GfxHighDetail, &Button, Localize("Allows maps to render with more detail"));
 
 	MainView.HSplitTop(20.0f, &Button, &MainView);
-	if(DoButton_CheckBox(&g_Config.m_ClShowfps, Localize("Show FPS"), g_Config.m_ClShowfps, &Button))
-		g_Config.m_ClShowfps ^= 1;
-	GameClient()->m_Tooltips.DoToolTip(&g_Config.m_ClShowfps, &Button, Localize("Renders your frame rate in the top right"));
+	const char *apShowFpsModes[] = {
+		Localize("Off", "Show FPS mode"),
+		Localize("FPS", "Show FPS mode"),
+		Localize("FPS + Frametimes (last 360 frames)", "Show FPS mode"),
+		Localize("FPS + Frametimes (last 1000 frames)", "Show FPS mode"),
+		Localize("FPS + Frametimes (last 360 + 1000 frames)", "Show FPS mode"),
+	};
+	static CUi::SDropDownState s_ShowFpsDropDownState;
+	static CScrollRegion s_ShowFpsDropDownScrollRegion;
+	s_ShowFpsDropDownState.m_SelectionPopupContext.m_pScrollRegion = &s_ShowFpsDropDownScrollRegion;
+	g_Config.m_ClShowfps = Ui()->DoDropDown(&Button, g_Config.m_ClShowfps, apShowFpsModes, std::size(apShowFpsModes), s_ShowFpsDropDownState);
+	GameClient()->m_Tooltips.DoToolTip(&g_Config.m_ClShowfps, &Button, Localize("Renders your frame rate in the top right, optionally with frametime stats over 360 and 1000 frames"));
 
 	MainView.HSplitTop(20.0f, &Button, &MainView);
 	str_copy(aBuf, " ");

--- a/src/test/frametime_stats_test.cpp
+++ b/src/test/frametime_stats_test.cpp
@@ -1,0 +1,115 @@
+#include <engine/client.h>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+TEST(FrameTimeHistory, EmptyWindow)
+{
+	CFrameTimeHistory History;
+
+	const auto Stats = History.GetStats(360);
+	EXPECT_FALSE(Stats.IsValid());
+	EXPECT_EQ(Stats.m_NumSamples, 0u);
+}
+
+TEST(FrameTimeHistory, PartialWindow)
+{
+	CFrameTimeHistory History;
+	History.Add(0.001f);
+	History.Add(0.003f);
+	History.Add(0.002f);
+
+	const auto Stats = History.GetStats(360);
+	ASSERT_TRUE(Stats.IsValid());
+	EXPECT_EQ(Stats.m_NumSamples, 3u);
+	EXPECT_FLOAT_EQ(Stats.m_Min, 0.001f);
+	EXPECT_NEAR(Stats.m_Avg, 0.002f, 1e-6f);
+	EXPECT_NEAR(Stats.m_Deviation, std::sqrt(2.0f / 3.0f) * 0.001f, 1e-6f);
+	EXPECT_FLOAT_EQ(Stats.m_Max, 0.003f);
+}
+
+TEST(FrameTimeHistory, Exact360FrameWindow)
+{
+	CFrameTimeHistory History;
+	for(int i = 1; i <= 360; ++i)
+	{
+		History.Add(i / 1000000.0f);
+	}
+
+	const auto Stats = History.GetStats(360);
+	ASSERT_TRUE(Stats.IsValid());
+	EXPECT_EQ(Stats.m_NumSamples, 360u);
+	EXPECT_FLOAT_EQ(Stats.m_Min, 0.000001f);
+	EXPECT_FLOAT_EQ(Stats.m_Max, 0.000360f);
+	EXPECT_NEAR(Stats.m_Avg, 0.0001805f, 1e-6f);
+	EXPECT_NEAR(Stats.m_Deviation, 0.0001039226f, 1e-6f);
+}
+
+TEST(FrameTimeHistory, Exact1000FrameWindow)
+{
+	CFrameTimeHistory History;
+	for(int i = 1; i <= 1000; ++i)
+	{
+		History.Add(i / 1000000.0f);
+	}
+
+	const auto Stats = History.GetStats(1000);
+	ASSERT_TRUE(Stats.IsValid());
+	EXPECT_EQ(Stats.m_NumSamples, 1000u);
+	EXPECT_FLOAT_EQ(Stats.m_Min, 0.000001f);
+	EXPECT_FLOAT_EQ(Stats.m_Max, 0.001000f);
+	EXPECT_NEAR(Stats.m_Avg, 0.0005005f, 1e-6f);
+	EXPECT_NEAR(Stats.m_Deviation, 0.00028867499f, 1e-6f);
+}
+
+TEST(FrameTimeHistory, RolloverKeepsLatestSamples)
+{
+	CFrameTimeHistory History;
+	for(int i = 1; i <= 1200; ++i)
+	{
+		History.Add(i / 1000000.0f);
+	}
+
+	const auto Stats360 = History.GetStats(360);
+	ASSERT_TRUE(Stats360.IsValid());
+	EXPECT_EQ(Stats360.m_NumSamples, 360u);
+	EXPECT_FLOAT_EQ(Stats360.m_Min, 0.000841f);
+	EXPECT_FLOAT_EQ(Stats360.m_Max, 0.001200f);
+	EXPECT_NEAR(Stats360.m_Avg, 0.0010205f, 1e-6f);
+	EXPECT_NEAR(Stats360.m_Deviation, 0.0001039226f, 1e-6f);
+
+	const auto Stats1000 = History.GetStats(1000);
+	ASSERT_TRUE(Stats1000.IsValid());
+	EXPECT_EQ(Stats1000.m_NumSamples, 1000u);
+	EXPECT_FLOAT_EQ(Stats1000.m_Min, 0.000201f);
+	EXPECT_FLOAT_EQ(Stats1000.m_Max, 0.001200f);
+	EXPECT_NEAR(Stats1000.m_Avg, 0.0007005f, 1e-6f);
+	EXPECT_NEAR(Stats1000.m_Deviation, 0.00028867499f, 1e-6f);
+}
+
+TEST(FrameTimeHistory, OldSpikeAgesOut)
+{
+	CFrameTimeHistory History;
+	History.Add(0.100f);
+	for(int i = 0; i < 999; ++i)
+	{
+		History.Add(0.001f);
+	}
+
+	const auto StatsWithSpike = History.GetStats(1000);
+	ASSERT_TRUE(StatsWithSpike.IsValid());
+	EXPECT_FLOAT_EQ(StatsWithSpike.m_Min, 0.001f);
+	EXPECT_FLOAT_EQ(StatsWithSpike.m_Max, 0.100f);
+	EXPECT_NEAR(StatsWithSpike.m_Avg, 0.001099f, 1e-6f);
+	EXPECT_NEAR(StatsWithSpike.m_Deviation, 0.0031299679f, 1e-6f);
+
+	History.Add(0.002f);
+
+	const auto StatsWithoutSpike = History.GetStats(1000);
+	ASSERT_TRUE(StatsWithoutSpike.IsValid());
+	EXPECT_FLOAT_EQ(StatsWithoutSpike.m_Min, 0.001f);
+	EXPECT_FLOAT_EQ(StatsWithoutSpike.m_Max, 0.002f);
+	EXPECT_NEAR(StatsWithoutSpike.m_Avg, 0.001001f, 1e-6f);
+	EXPECT_NEAR(StatsWithoutSpike.m_Deviation, 0.0000316070f, 1e-6f);
+}

--- a/src/test/frametime_stats_test.cpp
+++ b/src/test/frametime_stats_test.cpp
@@ -1,26 +1,26 @@
-#include <engine/client.h>
+#include <engine/client/graph.h>
 
 #include <gtest/gtest.h>
 
 #include <cmath>
 
-TEST(FrameTimeHistory, EmptyWindow)
+TEST(GraphSummaryStats, EmptyWindow)
 {
-	CFrameTimeHistory History;
+	CGraph Graph(1000, 2, true);
 
-	const auto Stats = History.GetStats(360);
+	const auto Stats = Graph.SummaryStats(360);
 	EXPECT_FALSE(Stats.IsValid());
 	EXPECT_EQ(Stats.m_NumSamples, 0u);
 }
 
-TEST(FrameTimeHistory, PartialWindow)
+TEST(GraphSummaryStats, PartialWindow)
 {
-	CFrameTimeHistory History;
-	History.Add(0.001f);
-	History.Add(0.003f);
-	History.Add(0.002f);
+	CGraph Graph(1000, 2, true);
+	Graph.InsertAt(1, 0.001f);
+	Graph.InsertAt(2, 0.003f);
+	Graph.InsertAt(3, 0.002f);
 
-	const auto Stats = History.GetStats(360);
+	const auto Stats = Graph.SummaryStats(360);
 	ASSERT_TRUE(Stats.IsValid());
 	EXPECT_EQ(Stats.m_NumSamples, 3u);
 	EXPECT_FLOAT_EQ(Stats.m_Min, 0.001f);
@@ -29,15 +29,15 @@ TEST(FrameTimeHistory, PartialWindow)
 	EXPECT_FLOAT_EQ(Stats.m_Max, 0.003f);
 }
 
-TEST(FrameTimeHistory, Exact360FrameWindow)
+TEST(GraphSummaryStats, Exact360FrameWindow)
 {
-	CFrameTimeHistory History;
+	CGraph Graph(1000, 2, true);
 	for(int i = 1; i <= 360; ++i)
 	{
-		History.Add(i / 1000000.0f);
+		Graph.InsertAt(i, i / 1000000.0f);
 	}
 
-	const auto Stats = History.GetStats(360);
+	const auto Stats = Graph.SummaryStats(360);
 	ASSERT_TRUE(Stats.IsValid());
 	EXPECT_EQ(Stats.m_NumSamples, 360u);
 	EXPECT_FLOAT_EQ(Stats.m_Min, 0.000001f);
@@ -46,15 +46,15 @@ TEST(FrameTimeHistory, Exact360FrameWindow)
 	EXPECT_NEAR(Stats.m_Deviation, 0.0001039226f, 1e-6f);
 }
 
-TEST(FrameTimeHistory, Exact1000FrameWindow)
+TEST(GraphSummaryStats, Exact1000FrameWindow)
 {
-	CFrameTimeHistory History;
+	CGraph Graph(1000, 2, true);
 	for(int i = 1; i <= 1000; ++i)
 	{
-		History.Add(i / 1000000.0f);
+		Graph.InsertAt(i, i / 1000000.0f);
 	}
 
-	const auto Stats = History.GetStats(1000);
+	const auto Stats = Graph.SummaryStats(1000);
 	ASSERT_TRUE(Stats.IsValid());
 	EXPECT_EQ(Stats.m_NumSamples, 1000u);
 	EXPECT_FLOAT_EQ(Stats.m_Min, 0.000001f);
@@ -63,15 +63,15 @@ TEST(FrameTimeHistory, Exact1000FrameWindow)
 	EXPECT_NEAR(Stats.m_Deviation, 0.00028867499f, 1e-6f);
 }
 
-TEST(FrameTimeHistory, RolloverKeepsLatestSamples)
+TEST(GraphSummaryStats, RolloverKeepsLatestSamples)
 {
-	CFrameTimeHistory History;
+	CGraph Graph(1000, 2, true);
 	for(int i = 1; i <= 1200; ++i)
 	{
-		History.Add(i / 1000000.0f);
+		Graph.InsertAt(i, i / 1000000.0f);
 	}
 
-	const auto Stats360 = History.GetStats(360);
+	const auto Stats360 = Graph.SummaryStats(360);
 	ASSERT_TRUE(Stats360.IsValid());
 	EXPECT_EQ(Stats360.m_NumSamples, 360u);
 	EXPECT_FLOAT_EQ(Stats360.m_Min, 0.000841f);
@@ -79,7 +79,7 @@ TEST(FrameTimeHistory, RolloverKeepsLatestSamples)
 	EXPECT_NEAR(Stats360.m_Avg, 0.0010205f, 1e-6f);
 	EXPECT_NEAR(Stats360.m_Deviation, 0.0001039226f, 1e-6f);
 
-	const auto Stats1000 = History.GetStats(1000);
+	const auto Stats1000 = Graph.SummaryStats(1000);
 	ASSERT_TRUE(Stats1000.IsValid());
 	EXPECT_EQ(Stats1000.m_NumSamples, 1000u);
 	EXPECT_FLOAT_EQ(Stats1000.m_Min, 0.000201f);
@@ -88,25 +88,25 @@ TEST(FrameTimeHistory, RolloverKeepsLatestSamples)
 	EXPECT_NEAR(Stats1000.m_Deviation, 0.00028867499f, 1e-6f);
 }
 
-TEST(FrameTimeHistory, OldSpikeAgesOut)
+TEST(GraphSummaryStats, OldSpikeAgesOut)
 {
-	CFrameTimeHistory History;
-	History.Add(0.100f);
+	CGraph Graph(1000, 2, true);
+	Graph.InsertAt(1, 0.100f);
 	for(int i = 0; i < 999; ++i)
 	{
-		History.Add(0.001f);
+		Graph.InsertAt(i + 2, 0.001f);
 	}
 
-	const auto StatsWithSpike = History.GetStats(1000);
+	const auto StatsWithSpike = Graph.SummaryStats(1000);
 	ASSERT_TRUE(StatsWithSpike.IsValid());
 	EXPECT_FLOAT_EQ(StatsWithSpike.m_Min, 0.001f);
 	EXPECT_FLOAT_EQ(StatsWithSpike.m_Max, 0.100f);
 	EXPECT_NEAR(StatsWithSpike.m_Avg, 0.001099f, 1e-6f);
 	EXPECT_NEAR(StatsWithSpike.m_Deviation, 0.0031299679f, 1e-6f);
 
-	History.Add(0.002f);
+	Graph.InsertAt(1001, 0.002f);
 
-	const auto StatsWithoutSpike = History.GetStats(1000);
+	const auto StatsWithoutSpike = Graph.SummaryStats(1000);
 	ASSERT_TRUE(StatsWithoutSpike.IsValid());
 	EXPECT_FLOAT_EQ(StatsWithoutSpike.m_Min, 0.001f);
 	EXPECT_FLOAT_EQ(StatsWithoutSpike.m_Max, 0.002f);


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Closes #11742 


https://github.com/user-attachments/assets/de33f214-a5df-4633-be6c-157b59953e69

Adds cl_showfps frametime modes for FPS-only, 360-frame stats, 1000-frame stats, and both windows. Includes UI dropdown support, HUD rendering, and unit tests.

(opinion, it would be nicer if the FPS counter was in the top left, because then the frametimes would fit nicer to the screen)

used ai for code review
## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
