### PR TITLE
Fix: Image format name for RGB and RGBA are swapped

### DIFF
--- a/src/engine/gfx/image.cpp
+++ b/src/engine/gfx/image.cpp
@@ -38,7 +38,7 @@ size_t CImageInfo::PixelSize(EImageFormat Format)
 
 const char *CImageInfo::FormatName(EImageFormat Format)
 {
-	static const char *s_apNames[] = {"UNDEFINED", "RGBA", "RGB", "R", "RA"};
+	static const char *s_apNames[] = {"UNDEFINED", "RGB", "RGBA", "R", "RA"};
 	return s_apNames[(int)Format + 1];
 }
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

See https://github.com/ddnet/ddnet/blob/e728c58f84795389484196e249b4063c5e7a6e53/src/engine/image.h#L17

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
