### PR TITLE
Feature: Make CImageInfo handle memory automatically

### DIFF
--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -9,6 +9,8 @@
 #include <engine/client/backend_sdl.h>
 #include <engine/graphics.h>
 
+#include <cstdint>
+
 #if defined(BACKEND_AS_OPENGL_ES) || !defined(CONF_BACKEND_OPENGL_ES)
 
 #include <engine/client/backend/glsl_shader_compiler.h>
@@ -1006,9 +1008,16 @@ void CCommandProcessorFragment_OpenGL::Cmd_Screenshot(const CCommandBuffer::SCom
 	int w = aViewport[2];
 	int h = aViewport[3];
 
-	// we allocate one more row to use when we are flipping the texture
-	unsigned char *pPixelData = (unsigned char *)malloc((size_t)w * (h + 1) * 4);
-	unsigned char *pTempRow = pPixelData + w * h * 4;
+	pCommand->m_pImage->m_Width = w;
+	pCommand->m_pImage->m_Height = h;
+	pCommand->m_pImage->m_Format = CImageInfo::FORMAT_RGBA;
+	pCommand->m_pImage->Allocate();
+
+	uint8_t *pPixelData = pCommand->m_pImage->m_pData;
+
+	// we create a tmp row to use when we are flipping the texture
+	std::vector<uint8_t> vTmpRow(w * 4);
+	uint8_t *pTempRow = vTmpRow.data();
 
 	// fetch the pixels
 	GLint Alignment;
@@ -1029,12 +1038,6 @@ void CCommandProcessorFragment_OpenGL::Cmd_Screenshot(const CCommandBuffer::SCom
 			pPixelData[(h - y - 1) * w * 4 + x * 4 + 3] = 255;
 		}
 	}
-
-	// fill in the information
-	pCommand->m_pImage->m_Width = w;
-	pCommand->m_pImage->m_Height = h;
-	pCommand->m_pImage->m_Format = CImageInfo::FORMAT_RGBA;
-	pCommand->m_pImage->m_pData = pPixelData;
 }
 
 CCommandProcessorFragment_OpenGL::CCommandProcessorFragment_OpenGL()

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -6808,19 +6808,22 @@ public:
 		uint32_t Width;
 		uint32_t Height;
 		CImageInfo::EImageFormat Format;
+
 		if(GetPresentedImageDataImpl(Width, Height, Format, m_vScreenshotHelper, true, {}))
 		{
-			const size_t ImgSize = (size_t)Width * (size_t)Height * CImageInfo::PixelSize(Format);
-			pCommand->m_pImage->m_pData = static_cast<uint8_t *>(malloc(ImgSize));
-			mem_copy(pCommand->m_pImage->m_pData, m_vScreenshotHelper.data(), ImgSize);
+			pCommand->m_pImage->m_Width = (int)Width;
+			pCommand->m_pImage->m_Height = (int)Height;
+			pCommand->m_pImage->m_Format = Format;
+			pCommand->m_pImage->Allocate();
+			mem_copy(pCommand->m_pImage->m_pData, m_vScreenshotHelper.data(), pCommand->m_pImage->DataSize());
 		}
 		else
 		{
+			pCommand->m_pImage->m_Width = 0;
+			pCommand->m_pImage->m_Height = 0;
+			pCommand->m_pImage->m_Format = CImageInfo::FORMAT_UNDEFINED;
 			pCommand->m_pImage->m_pData = nullptr;
 		}
-		pCommand->m_pImage->m_Width = (int)Width;
-		pCommand->m_pImage->m_Height = (int)Height;
-		pCommand->m_pImage->m_Format = Format;
 
 		return true;
 	}

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -346,7 +346,7 @@ IGraphics::CTextureHandle CGraphics_Threaded::LoadSpriteTexture(const CImageInfo
 	SpriteInfo.m_Width = w;
 	SpriteInfo.m_Height = h;
 	SpriteInfo.m_Format = FromImageInfo.m_Format;
-	SpriteInfo.m_pData = static_cast<uint8_t *>(malloc(SpriteInfo.DataSize()));
+	SpriteInfo.Allocate();
 	SpriteInfo.CopyRectFrom(FromImageInfo, x, y, w, h, 0, 0);
 	return LoadTextureRawMove(SpriteInfo, 0, pSprite->m_pName);
 }

--- a/src/engine/gfx/image.cpp
+++ b/src/engine/gfx/image.cpp
@@ -1,4 +1,5 @@
 #include <base/dbg.h>
+#include <base/log.h>
 #include <base/mem.h>
 
 #include <engine/image.h>
@@ -16,20 +17,50 @@ CImageInfo &CImageInfo::operator=(CImageInfo &&Other)
 	m_Height = Other.m_Height;
 	m_Format = Other.m_Format;
 	m_pData = Other.m_pData;
+	m_IsAllocated = Other.m_IsAllocated;
 	Other.m_Width = 0;
 	Other.m_Height = 0;
 	Other.m_Format = FORMAT_UNDEFINED;
 	Other.m_pData = nullptr;
+	Other.m_IsAllocated = false;
 	return *this;
+}
+
+CImageInfo::~CImageInfo()
+{
+	if(m_IsAllocated)
+		Free();
+}
+
+void CImageInfo::Allocate()
+{
+	dbg_assert(m_pData == nullptr && !m_IsAllocated, "Image data already allocated");
+	// format is asserted in pixel size
+	m_pData = static_cast<uint8_t *>(malloc(DataSize()));
+	m_IsAllocated = true;
+}
+
+void CImageInfo::AllocateFillZero()
+{
+	dbg_assert(m_pData == nullptr && !m_IsAllocated, "Image data already allocated");
+	// format is asserted in pixel size
+	m_pData = static_cast<uint8_t *>(calloc(DataSize(), sizeof(uint8_t)));
+	m_IsAllocated = true;
 }
 
 void CImageInfo::Free()
 {
+	if(m_pData != nullptr)
+	{
+		if(!m_IsAllocated)
+			log_warn("graphics", "Image free without calling 'Allocate'");
+		free(m_pData);
+		m_pData = nullptr;
+	}
+	m_IsAllocated = false;
 	m_Width = 0;
 	m_Height = 0;
 	m_Format = FORMAT_UNDEFINED;
-	free(m_pData);
-	m_pData = nullptr;
 }
 
 size_t CImageInfo::PixelSize(EImageFormat Format)
@@ -148,7 +179,7 @@ CImageInfo CImageInfo::DeepCopy() const
 	Copy.m_Width = m_Width;
 	Copy.m_Height = m_Height;
 	Copy.m_Format = m_Format;
-	Copy.m_pData = static_cast<uint8_t *>(malloc(Size));
+	Copy.Allocate();
 	mem_copy(Copy.m_pData, m_pData, Size);
 	return Copy;
 }

--- a/src/engine/gfx/image_loader.cpp
+++ b/src/engine/gfx/image_loader.cpp
@@ -260,7 +260,7 @@ bool CImageLoader::LoadPng(CByteBufferReader &Reader, const char *pContextName, 
 		Image.m_Width = Width;
 		Image.m_Height = Height;
 		Image.m_Format = ImageFormatFromChannelCount(ColorChannelCount);
-		Image.m_pData = static_cast<uint8_t *>(malloc(Image.DataSize()));
+		Image.Allocate();
 		for(int y = 0; y < Height; ++y)
 		{
 			mem_copy(&Image.m_pData[y * BytesInRow], pRowPointers[y], BytesInRow);

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -10,6 +10,9 @@
  */
 class CImageInfo
 {
+private:
+	bool m_IsAllocated = false;
+
 public:
 	/**
 	 * Defines the format of image data.
@@ -36,6 +39,21 @@ public:
 	CImageInfo(CImageInfo &&Other);
 
 	/**
+	 * Forbid copies.
+	 */
+	CImageInfo(const CImageInfo &) = delete;
+
+	/**
+	 * Forbid copies.
+	 */
+	CImageInfo &operator=(const CImageInfo &) = delete;
+
+	/**
+	 * Destructor, which automatically frees memory.
+	 */
+	~CImageInfo();
+
+	/**
 	 * Width of the image.
 	 */
 	size_t m_Width = 0;
@@ -56,6 +74,16 @@ public:
 	 * Pointer to the image data.
 	 */
 	uint8_t *m_pData = nullptr;
+
+	/**
+	 * Creates the image data, does not zero it.
+	 */
+	void Allocate();
+
+	/**
+	 * Creates the image data and fills it with zero.
+	 */
+	void AllocateFillZero();
 
 	/**
 	 * Frees the image data and clears all info.

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -287,7 +287,7 @@ IGraphics::CTextureHandle CMapImages::GetEntities(EMapImageEntityLayerType Entit
 			BuildImageInfo.m_Width = ImgInfo.m_Width;
 			BuildImageInfo.m_Height = ImgInfo.m_Height;
 			BuildImageInfo.m_Format = ImgInfo.m_Format;
-			BuildImageInfo.m_pData = static_cast<uint8_t *>(malloc(BuildImageInfo.DataSize()));
+			BuildImageInfo.Allocate();
 
 			// build game layer
 			for(int LayerType = 0; LayerType < MAP_IMAGE_ENTITY_LAYER_TYPE_COUNT; ++LayerType)
@@ -413,7 +413,7 @@ IGraphics::CTextureHandle CMapImages::UploadEntityLayerText(int TextureSize, int
 	TextImage.m_Width = 1024;
 	TextImage.m_Height = 1024;
 	TextImage.m_Format = CImageInfo::FORMAT_RGBA;
-	TextImage.m_pData = static_cast<uint8_t *>(calloc(TextImage.DataSize(), sizeof(uint8_t)));
+	TextImage.AllocateFillZero();
 
 	UpdateEntityLayerText(TextImage, TextureSize, MaxWidth, YOffset, 0);
 	UpdateEntityLayerText(TextImage, TextureSize, MaxWidth, YOffset, 1);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3765,10 +3765,7 @@ bool CEditor::ReplaceImage(const char *pFilename, int StorageType, bool CheckDup
 
 	std::shared_ptr<CEditorImage> pImg = Map()->SelectedImage();
 	pImg->CEditorImage::Free();
-	pImg->m_Width = ImgInfo.m_Width;
-	pImg->m_Height = ImgInfo.m_Height;
-	pImg->m_Format = ImgInfo.m_Format;
-	pImg->m_pData = ImgInfo.m_pData;
+	*pImg = std::move(ImgInfo);
 	str_copy(pImg->m_aName, aBuf);
 	pImg->m_External = IsVanillaImage(pImg->m_aName);
 
@@ -3823,10 +3820,8 @@ bool CEditor::AddImage(const char *pFilename, int StorageType, void *pUser)
 	}
 
 	std::shared_ptr<CEditorImage> pImg = std::make_shared<CEditorImage>(pEditor->Map());
-	pImg->m_Width = ImgInfo.m_Width;
-	pImg->m_Height = ImgInfo.m_Height;
-	pImg->m_Format = ImgInfo.m_Format;
-	pImg->m_pData = ImgInfo.m_pData;
+	*pImg = std::move(ImgInfo);
+
 	pImg->m_External = IsVanillaImage(aBuf);
 
 	ConvertToRgba(*pImg);

--- a/src/game/editor/mapitems/image.cpp
+++ b/src/game/editor/mapitems/image.cpp
@@ -12,8 +12,6 @@ CEditorImage::CEditorImage(CEditorMap *pMap) :
 CEditorImage::~CEditorImage()
 {
 	Graphics()->UnloadTexture(&m_Texture);
-	free(m_pData);
-	m_pData = nullptr;
 }
 
 void CEditorImage::OnAttach(CEditorMap *pMap)
@@ -57,4 +55,11 @@ void CEditorImage::Free()
 	Graphics()->UnloadTexture(&m_Texture);
 	m_AutoMapper.Unload();
 	CImageInfo::Free();
+}
+
+CEditorImage &CEditorImage::operator=(CImageInfo &&Other)
+{
+	CImageInfo *pThis = this;
+	*pThis = std::move(Other);
+	return *this;
 }

--- a/src/game/editor/mapitems/image.h
+++ b/src/game/editor/mapitems/image.h
@@ -18,6 +18,8 @@ public:
 	void AnalyseTileFlags();
 	void Free();
 
+	CEditorImage &operator=(CImageInfo &&Other);
+
 	IGraphics::CTextureHandle m_Texture;
 	int m_External = 0;
 	char m_aName[IO_MAX_PATH_LENGTH] = "";

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -567,13 +567,8 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 				str_format(aBuf, sizeof(aBuf), "mapres/%s.png", pImg->m_aName);
 
 				// load external
-				CImageInfo ImgInfo;
-				if(m_pEditor->Graphics()->LoadPng(ImgInfo, aBuf, IStorage::TYPE_ALL))
+				if(m_pEditor->Graphics()->LoadPng(*pImg, aBuf, IStorage::TYPE_ALL))
 				{
-					pImg->m_Width = ImgInfo.m_Width;
-					pImg->m_Height = ImgInfo.m_Height;
-					pImg->m_Format = ImgInfo.m_Format;
-					pImg->m_pData = ImgInfo.m_pData;
 					ConvertToRgba(*pImg);
 
 					int TextureLoadFlag = m_pEditor->Graphics()->Uses2DTextureArrays() ? IGraphics::TEXLOAD_TO_2D_ARRAY_TEXTURE : IGraphics::TEXLOAD_TO_3D_TEXTURE;
@@ -593,12 +588,11 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 				pImg->m_Width = pItem->m_Width;
 				pImg->m_Height = pItem->m_Height;
 				pImg->m_Format = CImageInfo::FORMAT_RGBA;
+				pImg->Allocate();
 
 				// copy image data
 				void *pData = pMap->GetData(pItem->m_ImageData);
-				const size_t DataSize = pImg->DataSize();
-				pImg->m_pData = static_cast<uint8_t *>(malloc(DataSize));
-				mem_copy(pImg->m_pData, pData, DataSize);
+				mem_copy(pImg->m_pData, pData, pImg->DataSize());
 				int TextureLoadFlag = m_pEditor->Graphics()->Uses2DTextureArrays() ? IGraphics::TEXLOAD_TO_2D_ARRAY_TEXTURE : IGraphics::TEXLOAD_TO_3D_TEXTURE;
 				if(pImg->m_Width % 16 != 0 || pImg->m_Height % 16 != 0)
 					TextureLoadFlag = 0;

--- a/src/game/editor/tile_art.cpp
+++ b/src/game/editor/tile_art.cpp
@@ -76,7 +76,7 @@ static CImageInfo ColorGroupToImage(const std::array<ColorRGBA, NumTiles> &aColo
 	Image.m_Width = NumTilesRow * TileSize;
 	Image.m_Height = NumTilesColumn * TileSize;
 	Image.m_Format = CImageInfo::FORMAT_RGBA;
-	Image.m_pData = static_cast<uint8_t *>(malloc(Image.DataSize()));
+	Image.Allocate();
 
 	for(int y = 0; y < NumTilesColumn; y++)
 	{
@@ -100,28 +100,25 @@ static std::vector<CImageInfo> ColorGroupsToImages(const std::vector<std::array<
 	return vImages;
 }
 
-static std::shared_ptr<CEditorImage> ImageInfoToEditorImage(CEditorMap *pMap, const CImageInfo &Image, const char *pName)
+static std::shared_ptr<CEditorImage> ImageInfoToEditorImage(CEditorMap *pMap, CImageInfo &Image, const char *pName)
 {
 	std::shared_ptr<CEditorImage> pEditorImage = std::make_shared<CEditorImage>(pMap);
-	pEditorImage->m_Width = Image.m_Width;
-	pEditorImage->m_Height = Image.m_Height;
-	pEditorImage->m_Format = Image.m_Format;
-	pEditorImage->m_pData = Image.m_pData;
+	*pEditorImage = std::move(Image);
 
 	int TextureLoadFlag = pMap->Editor()->Graphics()->Uses2DTextureArrays() ? IGraphics::TEXLOAD_TO_2D_ARRAY_TEXTURE : IGraphics::TEXLOAD_TO_3D_TEXTURE;
-	pEditorImage->m_Texture = pMap->Editor()->Graphics()->LoadTextureRaw(Image, TextureLoadFlag, pName);
+	pEditorImage->m_Texture = pMap->Editor()->Graphics()->LoadTextureRaw(*pEditorImage, TextureLoadFlag, pName);
 	pEditorImage->m_External = 0;
 	str_copy(pEditorImage->m_aName, pName);
 
 	return pEditorImage;
 }
 
-static std::shared_ptr<CLayerTiles> AddLayerWithImage(CEditorMap *pMap, const std::shared_ptr<CLayerGroup> &pGroup, int Width, int Height, const CImageInfo &Image, const char *pName)
+static std::shared_ptr<CLayerTiles> AddLayerWithImage(CEditorMap *pMap, const std::shared_ptr<CLayerGroup> &pGroup, CImageInfo &Image, const char *pName)
 {
 	std::shared_ptr<CEditorImage> pEditorImage = ImageInfoToEditorImage(pMap, Image, pName);
 	pMap->m_vpImages.push_back(pEditorImage);
 
-	std::shared_ptr<CLayerTiles> pLayer = std::make_shared<CLayerTiles>(pMap, Width, Height);
+	std::shared_ptr<CLayerTiles> pLayer = std::make_shared<CLayerTiles>(pMap, pEditorImage->m_Width, pEditorImage->m_Height);
 	str_copy(pLayer->m_aName, pName);
 	pLayer->m_Image = pMap->m_vpImages.size() - 1;
 	pGroup->AddLayer(pLayer);
@@ -155,7 +152,7 @@ void CEditorMap::AddTileArt(CImageInfo &&Image, const char *pFilename, bool Igno
 	for(size_t i = 0; i < vColorImages.size(); i++)
 	{
 		str_format(aImageName, sizeof(aImageName), "%s %" PRIzu, aTileArtFilename, i + 1);
-		std::shared_ptr<CLayerTiles> pLayer = AddLayerWithImage(this, pGroup, Image.m_Width, Image.m_Height, vColorImages[i], aImageName);
+		std::shared_ptr<CLayerTiles> pLayer = AddLayerWithImage(this, pGroup, vColorImages[i], aImageName);
 		SetTilelayerIndices(pLayer, vaColorGroups[i], Image);
 	}
 	auto IndexMap = SortImages();


### PR DESCRIPTION
This PR moves memory allocation into the CImageInfo class and wraps memory allocation. It makes it handle freeing its data automatically, which ensures memory is freed and makes it easier to use this class, as you don't need to care about memory management. It also centralizes the memory management, which is desirable

I tested this a lot ingame:
- [x] screenshots, especially opengl
- [x] pixel art tools (both)
- [x] png loading, map loading
- [x] ingame sprites

This PR also deletes the CImageInfo copy constructor and assign operator and makes use out of the move constructor and operator.

If you need to copy an image, you need to explicitly call `DeepCopy`.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
