### PR TITLE
Add Selectable Label

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1349,12 +1349,13 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		{
 			const float ExtraTextFontSize = m_Popup == POPUP_FIRST_LAUNCH ? 16.0f : 20.0f;
 
+			static CButtonContainer s_ExtraTextLabel;
 			if(TopAlign)
-				Ui()->DoLabel(&ExtraText, pExtraText, ExtraTextFontSize, TEXTALIGN_TL, {.m_MaxWidth = ExtraText.w});
+				Ui()->DoSelectableLabel(&s_ExtraTextLabel, &ExtraText, pExtraText, ExtraTextFontSize, TEXTALIGN_TL, {.m_MaxWidth = ExtraText.w});
 			else if(TextRender()->TextWidth(ExtraTextFontSize, pExtraText) > ExtraText.w)
-				Ui()->DoLabel(&ExtraText, pExtraText, ExtraTextFontSize, TEXTALIGN_ML, {.m_MaxWidth = ExtraText.w});
+				Ui()->DoSelectableLabel(&s_ExtraTextLabel, &ExtraText, pExtraText, ExtraTextFontSize, TEXTALIGN_ML, {.m_MaxWidth = ExtraText.w});
 			else
-				Ui()->DoLabel(&ExtraText, pExtraText, ExtraTextFontSize, TEXTALIGN_MC);
+				Ui()->DoSelectableLabel(&s_ExtraTextLabel, &ExtraText, pExtraText, ExtraTextFontSize, TEXTALIGN_MC);
 		}
 	}
 

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -260,6 +260,11 @@ void CUi::Update(vec2 MouseWorldPos)
 		m_pHotScrollRegion = nullptr;
 	}
 
+	// Reset selectable label state when it was not rendered for a frame
+	if(!m_SelectableLabelState.m_Rendered)
+		m_SelectableLabelState.Reset();
+	m_SelectableLabelState.m_Rendered = false;
+
 	m_ProgressSpinnerOffset += Client()->RenderFrameTime() * 1.5f;
 	m_ProgressSpinnerOffset = std::fmod(m_ProgressSpinnerOffset, 1.0f);
 }
@@ -806,6 +811,101 @@ CLabelResult CUi::DoLabel(const CUIRect *pRect, const char *pText, float Size, i
 	Cursor.m_vColorSplits = LabelProps.m_vColorSplits;
 	Cursor.m_LineWidth = (float)LabelProps.m_MaxWidth;
 	TextRender()->TextEx(&Cursor, pText, -1);
+	return CLabelResult{.m_Truncated = Cursor.m_Truncated};
+}
+
+CLabelResult CUi::DoSelectableLabel(const void *pId, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps)
+{
+	const bool Inside = MouseHovered(pRect);
+	CSelectableLabelState *pState = &m_SelectableLabelState;
+	const bool IsOwner = pState->m_pActiveId == pId;
+	pState->m_Rendered = true;
+
+	CLineInput::SMouseSelection *pMouseSelection = &pState->m_MouseSelection;
+	if(CheckActiveItem(pId))
+	{
+		if(!MouseButton(0))
+		{
+			SetActiveItem(nullptr);
+			pMouseSelection->m_Selecting = false;
+		}
+	}
+	else if(HotItem() == pId)
+	{
+		if(MouseButton(0))
+		{
+			SetActiveItem(pId);
+			pMouseSelection->m_Selecting = true;
+			pMouseSelection->m_PressMouse = MousePos();
+			pState->m_pActiveId = pId;
+			pState->m_SelectionStart = 0;
+			pState->m_SelectionEnd = 0;
+		}
+	}
+
+	if(Inside && !MouseButton(0))
+		SetHotItem(pId);
+
+	if(pMouseSelection->m_Selecting)
+		pMouseSelection->m_ReleaseMouse = MousePos();
+
+	// Click outside clears selection, only for the label that owns it
+	if(!Inside && MouseButtonClicked(0) && !CheckActiveItem(pId) && IsOwner)
+		pState->Reset();
+
+	// DoLabel logic
+	const int Flags = GetFlagsForLabelProperties(LabelProps, nullptr);
+	const SCursorAndBoundingBox TextBounds = CalcFontSizeCursorHeightAndBoundingBox(TextRender(), pText, Flags, Size, pRect->w, LabelProps);
+	const vec2 CursorPos = CalcAlignedCursorPos(pRect, TextBounds.m_TextSize, Align, TextBounds.m_LineCount == 1 ? &TextBounds.m_BiggestCharacterHeight : nullptr);
+
+	CTextCursor Cursor;
+	Cursor.SetPosition(CursorPos);
+	Cursor.m_FontSize = Size;
+	Cursor.m_Flags |= Flags;
+	Cursor.m_vColorSplits = LabelProps.m_vColorSplits;
+	Cursor.m_LineWidth = (float)LabelProps.m_MaxWidth;
+
+	if(pMouseSelection->m_Selecting && IsOwner)
+	{
+		Cursor.m_CalculateSelectionMode = TEXT_CURSOR_SELECTION_MODE_CALCULATE;
+		Cursor.m_PressMouse = pMouseSelection->m_PressMouse;
+		Cursor.m_ReleaseMouse = pMouseSelection->m_ReleaseMouse;
+	}
+	else if(pState->HasSelection() && IsOwner)
+	{
+		Cursor.m_CalculateSelectionMode = TEXT_CURSOR_SELECTION_MODE_SET;
+		Cursor.m_SelectionStart = pState->m_SelectionStart;
+		Cursor.m_SelectionEnd = pState->m_SelectionEnd;
+	}
+
+	TextRender()->TextEx(&Cursor, pText, -1);
+
+	if(pMouseSelection->m_Selecting && IsOwner)
+	{
+		pState->m_SelectionStart = Cursor.m_SelectionStart;
+		pState->m_SelectionEnd = Cursor.m_SelectionEnd;
+	}
+
+	if((pState->HasSelection() && IsOwner) || Inside)
+	{
+		if(Input()->ModifierIsPressed() && Input()->KeyPress(KEY_A))
+		{
+			pState->m_pActiveId = pId;
+			pState->m_SelectionStart = 0;
+			pState->m_SelectionEnd = Cursor.m_GlyphCount;
+		}
+	}
+
+	if(pState->HasSelection() && IsOwner && Input()->ModifierIsPressed() && Input()->KeyPress(KEY_C))
+	{
+		const int Start = minimum(pState->m_SelectionStart, pState->m_SelectionEnd);
+		const int End = maximum(pState->m_SelectionStart, pState->m_SelectionEnd);
+		const size_t StartBytes = str_utf8_offset_chars_to_bytes(pText, Start);
+		const size_t EndBytes = str_utf8_offset_chars_to_bytes(pText, End);
+		std::string SelectedText(pText + StartBytes, EndBytes - StartBytes);
+		Input()->SetClipboardText(SelectedText.c_str());
+	}
+
 	return CLabelResult{.m_Truncated = Cursor.m_Truncated};
 }
 

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -383,6 +383,27 @@ private:
 	};
 	CDoubleClickState m_DoubleClickState;
 	const void *m_pLastEditingItem = nullptr;
+
+	class CSelectableLabelState
+	{
+	public:
+		CLineInput::SMouseSelection m_MouseSelection;
+		const void *m_pActiveId = nullptr;
+		bool m_Rendered = false;
+		int m_SelectionStart = 0;
+		int m_SelectionEnd = 0;
+
+		bool HasSelection() const { return m_SelectionStart != m_SelectionEnd; }
+		void Reset()
+		{
+			m_MouseSelection.m_Selecting = false;
+			m_pActiveId = nullptr;
+			m_SelectionStart = 0;
+			m_SelectionEnd = 0;
+		}
+	};
+	CSelectableLabelState m_SelectableLabelState;
+
 	const void *m_pLastActiveScrollbar = nullptr;
 	int m_ScrollbarValue = 0;
 	float m_ActiveScrollbarOffset = 0.0f;
@@ -589,6 +610,7 @@ public:
 
 	CLabelResult DoLabel(const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps = {}) const;
 	CLabelResult DoLabel_AutoLineSize(const char *pText, float FontSize, int Align, CUIRect *pRect, float LineSize, const SLabelProperties &LabelProps = {}) const;
+	CLabelResult DoSelectableLabel(const void *pId, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps = {});
 
 	void DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps = {}, int StrLen = -1, const CTextCursor *pReadCursor = nullptr) const;
 	void DoLabelStreamed(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps = {}, int StrLen = -1, const CTextCursor *pReadCursor = nullptr) const;


### PR DESCRIPTION
Closes https://github.com/ddnet/ddnet/issues/12017

Allows selecting, Ctrl+A, Ctrl+C, by checking if mouse is hovered over the text container

<img width="594" height="332" alt="image" src="https://github.com/user-attachments/assets/e682d8ee-778e-4866-8fc7-3984c7b886ff" />



## Checklist

- [x] Tested the change ingame
- [x]  Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
