### PR TITLE
Add editor button, quick action and hotkey to toggle brush picker, minor fixes

### DIFF
--- a/src/engine/font_icons.h
+++ b/src/engine/font_icons.h
@@ -18,6 +18,7 @@ namespace FontIcon
 	inline const char *const BAN = "\uF05E";
 	inline const char *const BOOKMARK = "\uF02E";
 	inline const char *const BORDER_ALL = "\uF84C";
+	inline const char *const BRUSH = "\uF55D";
 	inline const char *const CAMERA = "\uF030";
 	inline const char *const CHEVRON_DOWN = "\uF078";
 	inline const char *const CHEVRON_LEFT = "\uF053";

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -608,6 +608,17 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 			ToolbarBottom.VSplitLeft(5.0f, nullptr, &ToolbarBottom);
 		}
 
+		// brush picker button
+		{
+			ToolbarBottom.VSplitLeft(25.0f, &Button, &ToolbarBottom);
+			const int Checked = m_QuickActionBrushPicker.Disabled() ? -1 : (m_ShowPicker ? 1 : 0);
+			if(DoButton_FontIcon(&m_QuickActionBrushPicker, FontIcon::BRUSH, Checked, &Button, BUTTONFLAG_LEFT, m_QuickActionBrushPicker.Description(), IGraphics::CORNER_ALL))
+			{
+				m_QuickActionBrushPicker.Call();
+			}
+			ToolbarBottom.VSplitLeft(5.0f, nullptr, &ToolbarBottom);
+		}
+
 		// tile manipulation
 		{
 			// do tele/tune/switch/speedup button
@@ -2415,6 +2426,8 @@ void CEditor::DoMapEditor(CUIRect View)
 
 			if(m_ShowTileInfo != SHOW_TILE_OFF)
 				m_pTilesetPicker->ShowInfo();
+
+			str_copy(m_aTooltip, "Click or drag left mouse button to create a brush. Hover individual tiles for explanation.");
 		}
 		else
 		{
@@ -2646,6 +2659,7 @@ void CEditor::DoMapEditor(CUIRect View)
 							if(Grabs == 0)
 								m_pBrush->Clear();
 
+							m_ShowPickerToggle = false; // Close the tile picker after grabbing brush if it was toggled open
 							Map()->DeselectQuads();
 							Map()->DeselectQuadPoints();
 						}
@@ -6298,15 +6312,9 @@ void CEditor::Render()
 	// render checker
 	RenderBackground(View, m_CheckerTexture, 32.0f, 1.0f);
 
-	CUIRect MenuBar, ModeBar, ToolBar, StatusBar, ExtraEditor, ToolBox;
-	m_ShowPicker = m_Mode == MODE_LAYERS &&
-		       m_Dialog == DIALOG_NONE &&
-		       CLineInput::GetActiveInput() == nullptr &&
-		       Map()->m_vSelectedLayers.size() == 1 &&
-			   Map()->SelectedLayer(0) != nullptr &&
-			   (Map()->SelectedLayer(0)->m_Type == LAYERTYPE_TILES || Map()->SelectedLayer(0)->m_Type == LAYERTYPE_QUADS) &&
-		       Input()->KeyIsPressed(KEY_SPACE);
+	UpdateBrushPicker();
 
+	CUIRect MenuBar, ModeBar, ToolBar, StatusBar, ExtraEditor, ToolBox;
 	if(m_GuiActive)
 	{
 		View.HSplitTop(16.0f, &MenuBar, &View);
@@ -6615,6 +6623,37 @@ void CEditor::Render()
 		RenderTooltip(TooltipRect);
 
 	RenderMousePointer();
+}
+
+void CEditor::UpdateBrushPicker()
+{
+	if(!m_QuickActionBrushPicker.Disabled() &&
+		m_Dialog == DIALOG_NONE &&
+		CLineInput::GetActiveInput() == nullptr)
+	{
+		if(Input()->ModifierIsPressed())
+		{
+			if(Input()->KeyPress(KEY_SPACE))
+			{
+				m_ShowPickerToggle = !m_ShowPickerToggle;
+			}
+			m_ShowPicker = m_ShowPickerToggle;
+		}
+		else
+		{
+			const bool SpacePressed = Input()->KeyIsPressed(KEY_SPACE);
+			m_ShowPicker = m_ShowPickerToggle || SpacePressed;
+			if(SpacePressed)
+			{
+				m_ShowPickerToggle = false;
+			}
+		}
+	}
+	else
+	{
+		m_ShowPicker = false;
+		m_ShowPickerToggle = false;
+	}
 }
 
 void CEditor::RenderPressedKeys(CUIRect View)

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6299,7 +6299,13 @@ void CEditor::Render()
 	RenderBackground(View, m_CheckerTexture, 32.0f, 1.0f);
 
 	CUIRect MenuBar, ModeBar, ToolBar, StatusBar, ExtraEditor, ToolBox;
-	m_ShowPicker = Input()->KeyIsPressed(KEY_SPACE) && m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && Map()->m_vSelectedLayers.size() == 1;
+	m_ShowPicker = m_Mode == MODE_LAYERS &&
+		       m_Dialog == DIALOG_NONE &&
+		       CLineInput::GetActiveInput() == nullptr &&
+		       Map()->m_vSelectedLayers.size() == 1 &&
+			   Map()->SelectedLayer(0) != nullptr &&
+			   (Map()->SelectedLayer(0)->m_Type == LAYERTYPE_TILES || Map()->SelectedLayer(0)->m_Type == LAYERTYPE_QUADS) &&
+		       Input()->KeyIsPressed(KEY_SPACE);
 
 	if(m_GuiActive)
 	{

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -336,6 +336,7 @@ public:
 	void LoadCurrentMap();
 	void Render();
 
+	void UpdateBrushPicker();
 	void RenderPressedKeys(CUIRect View);
 	void RenderSavingIndicator(CUIRect View);
 	void FreeDynamicPopupMenus();
@@ -474,7 +475,8 @@ public:
 	};
 	EQuadEnvelopePointOperation m_QuadEnvelopePointOperation = EQuadEnvelopePointOperation::NONE;
 
-	bool m_ShowPicker;
+	bool m_ShowPicker = false;
+	bool m_ShowPickerToggle = false;
 
 	// Color palette and pipette
 	ColorRGBA m_aSavedColors[8];

--- a/src/game/editor/prompt.cpp
+++ b/src/game/editor/prompt.cpp
@@ -42,9 +42,12 @@ void CPrompt::SetInactive()
 {
 	m_ResetFilterResults = true;
 	m_PromptInput.Clear();
+
 	if(Editor()->m_Dialog == DIALOG_QUICK_PROMPT)
 	{
 		Editor()->OnDialogClose();
+		m_PromptInput.Deactivate();
+		Ui()->SetActiveItem(nullptr);
 	}
 }
 

--- a/src/game/editor/quick_actions.h
+++ b/src/game/editor/quick_actions.h
@@ -17,6 +17,19 @@ REGISTER_QUICK_ACTION(
 	DEFAULT_BTN,
 	"[F1] Open the DDNet Wiki page for the map editor in a web browser.")
 REGISTER_QUICK_ACTION(
+	BrushPicker,
+	"Brush picker",
+	[&]() { m_ShowPickerToggle = !m_ShowPickerToggle; },
+	[&]() -> bool {
+		return m_Mode != MODE_LAYERS ||
+		       Map()->m_vSelectedLayers.size() != 1 ||
+		       Map()->SelectedLayer(0) == nullptr ||
+		       (Map()->SelectedLayer(0)->m_Type != LAYERTYPE_TILES && Map()->SelectedLayer(0)->m_Type != LAYERTYPE_QUADS);
+	},
+	[&]() -> bool { return m_ShowPickerToggle; },
+	DEFAULT_BTN,
+	"[Ctrl+Space, Hold Space] Toggle brush picker.")
+REGISTER_QUICK_ACTION(
 	ToggleGrid,
 	"Toggle grid",
 	[&]() { MapView()->MapGrid()->Toggle(); },


### PR DESCRIPTION
See commit messages.

<img width="1920" height="1080" alt="screenshot_2026-04-18_16-21-38" src="https://github.com/user-attachments/assets/bc28958a-02f2-4893-ba2c-0ebbbf5716a8" />

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions