### PR TITLE
Fix editor brush selection rectangle being rendered multiple times

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2652,8 +2652,10 @@ void CEditor::DoMapEditor(CUIRect View)
 					}
 					else
 					{
-						for(size_t k = 0; k < NumEditLayers; k++)
-							apEditLayers[k].second->BrushSelecting(r);
+						if(NumEditLayers > 0)
+						{
+							apEditLayers[0].second->BrushSelecting(r);
+						}
 						Ui()->MapScreen();
 					}
 				}
@@ -2674,8 +2676,10 @@ void CEditor::DoMapEditor(CUIRect View)
 					}
 					else
 					{
-						for(size_t k = 0; k < NumEditLayers; k++)
-							apEditLayers[k].second->BrushSelecting(r);
+						if(NumEditLayers > 0)
+						{
+							apEditLayers[0].second->BrushSelecting(r);
+						}
 						Ui()->MapScreen();
 					}
 				}

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -270,13 +270,10 @@ bool CLayerTiles::IsEmpty() const
 
 void CLayerTiles::BrushSelecting(CUIRect Rect)
 {
-	Graphics()->TextureClear();
-	Graphics()->QuadsBegin();
-	Graphics()->SetColor(1.0f, 1.0f, 1.0f, 0.4f);
 	Snap(&Rect);
-	IGraphics::CQuadItem QuadItem(Rect.x, Rect.y, Rect.w, Rect.h);
-	Graphics()->QuadsDrawTL(&QuadItem, 1);
-	Graphics()->QuadsEnd();
+
+	Rect.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.4f), IGraphics::CORNER_NONE, 0.0f);
+
 	char aBuf[16];
 	str_format(aBuf, sizeof(aBuf), "%d⨯%d", ConvertX(Rect.w), ConvertY(Rect.h));
 	TextRender()->Text(Rect.x + 3.0f, Rect.y + 3.0f, Editor()->m_ShowPicker ? 15.0f : Editor()->MapView()->ScaleLength(15.0f), aBuf, -1.0f);


### PR DESCRIPTION
The brush selection rectangle was rendered multiple times, once for each selected layer, causing the rectangle to decrease in transparency because the size of the selection rectangle is identical for all selected layers.

Now, the selection rectangle is only rendered for the first selected layer. Only either tiles layers or quads layers can be added to the `apEditLayers` array at the same time, so it is never necessary to render the selection rectangle for tiles and quad layers at the same time.

Screenshots:
- Before: <img src="https://github.com/user-attachments/assets/09d19dc3-e3f4-4d00-8d6c-3d847d283c99" />
- After: <img src="https://github.com/user-attachments/assets/472b0fd1-213b-4b28-88ab-077e7defa4ad" />


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing: `NumEditLayers == 0` is possible, for example if you delete the selected layer/group
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions