### PR TITLE
Fail gameworld test if HTTP interface could not be initialized

### DIFF
--- a/src/test/gameworld_test.cpp
+++ b/src/test/gameworld_test.cpp
@@ -104,10 +104,7 @@ public:
 		m_pServer->m_pPersistentData = malloc(GameServer()->PersistentDataSize());
 		EXPECT_NE(m_pServer->LoadMap("coverage"), 0);
 
-		if(!pServer->m_Http.Init(std::chrono::seconds{2}))
-		{
-			log_error("server", "Failed to initialize the HTTP client.");
-		}
+		EXPECT_TRUE(pServer->m_Http.Init(std::chrono::seconds{2})) << "Failed to initialize the HTTP client";
 
 		pServer->m_NetServer.SetCallbacks(
 			CServer::NewClientCallback,


### PR DESCRIPTION
Instead of continuing with the HTTP interface being in an inconsistent state.

## Checklist

- [X] Tested the change
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions