### PR TITLE
Only print log messages for failed unit tests by default

### DIFF
--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -47,16 +47,7 @@ void log_global_logger_finish()
 
 void log_set_global_logger_default()
 {
-	std::unique_ptr<ILogger> logger;
-#if defined(CONF_PLATFORM_ANDROID)
-	logger = log_logger_android();
-#else
-	logger = log_logger_stdout();
-#endif
-	if(logger)
-	{
-		log_set_global_logger(logger.release());
-	}
+	log_set_global_logger(log_logger_default().release());
 }
 
 ILogger *log_get_scope_logger()
@@ -216,6 +207,16 @@ public:
 std::unique_ptr<ILogger> log_logger_collection(std::vector<std::shared_ptr<ILogger>> &&vpLoggers)
 {
 	return std::make_unique<CLoggerCollection>(std::move(vpLoggers));
+}
+
+std::unique_ptr<ILogger> log_logger_default()
+{
+#if defined(CONF_PLATFORM_ANDROID)
+	std::unique_ptr<ILogger> logger = log_logger_android();
+#else
+	std::unique_ptr<ILogger> logger = log_logger_stdout();
+#endif
+	return logger == nullptr ? log_logger_noop() : std::move(logger);
 }
 
 class CLoggerAsync : public ILogger

--- a/src/base/logger.h
+++ b/src/base/logger.h
@@ -199,6 +199,8 @@ std::unique_ptr<ILogger> log_logger_file(IOHANDLE file);
  * @ingroup Log
  *
  * Logger for writing logs to the standard output (stdout).
+ *
+ * @remark This function can return `nullptr` if the standard output is not available.
  */
 std::unique_ptr<ILogger> log_logger_stdout();
 

--- a/src/base/logger.h
+++ b/src/base/logger.h
@@ -131,9 +131,10 @@ void log_set_global_logger(ILogger *logger);
  * threads.
  *
  * This is logging to stdout on most platforms and to the system log on
- * Android.
+ * Android. Discards log messages if stdout is not available.
  *
  * @see log_set_global_logger
+ * @see log_logger_default
  */
 void log_set_global_logger_default();
 
@@ -185,6 +186,14 @@ std::unique_ptr<ILogger> log_logger_android();
  * Logger combining a vector of other loggers.
  */
 std::unique_ptr<ILogger> log_logger_collection(std::vector<std::shared_ptr<ILogger>> &&vpLoggers);
+
+/**
+ * @ingroup Log
+ *
+ * Sane default logger. This is logging to stdout on most platforms and to the
+ * system log on Android. Discards log messages if stdout is not available.
+ */
+std::unique_ptr<ILogger> log_logger_default();
 
 /**
  * @ingroup Log

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -1,5 +1,6 @@
 #include "test.h"
 
+#include <base/dbg.h>
 #include <base/fs.h>
 #include <base/logger.h>
 #include <base/net.h>
@@ -12,6 +13,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <mutex>
 
 CTestInfo::CTestInfo()
 {
@@ -141,13 +143,118 @@ CTestInfo::~CTestInfo()
 	}
 }
 
+class CTestLogger : public ILogger
+{
+	friend class CTestLogListener;
+
+	std::unique_ptr<ILogger> m_pGlobalLogger;
+	std::unique_ptr<CMemoryLogger> m_pMemoryLogger;
+	std::mutex m_Lock;
+
+public:
+	CTestLogger(std::unique_ptr<ILogger> &&pGlobalLogger) :
+		m_pGlobalLogger(std::move(pGlobalLogger))
+	{
+	}
+
+	void Log(const CLogMessage *pMessage) override
+	{
+		if(m_Filter.Filters(pMessage))
+		{
+			return;
+		}
+		const std::unique_lock Lock(m_Lock);
+		if(m_pMemoryLogger != nullptr)
+		{
+			m_pMemoryLogger->Log(pMessage);
+		}
+		else
+		{
+			m_pGlobalLogger->Log(pMessage);
+		}
+	}
+
+	void GlobalFinish() override
+	{
+		dbg_assert(m_pMemoryLogger == nullptr, "Memory logger should be unset when test logger finishes");
+		m_pGlobalLogger->GlobalFinish();
+	}
+};
+
+class CTestLogListener : public testing::EmptyTestEventListener
+{
+	CTestLogger *m_pTestLogger;
+	bool m_CaptureOutput;
+
+public:
+	CTestLogListener(CTestLogger *pTestLogger, bool CaptureOutput) :
+		m_pTestLogger(pTestLogger),
+		m_CaptureOutput(CaptureOutput)
+	{
+	}
+
+	void OnTestStart(const testing::TestInfo &TestInfo) override
+	{
+		if(!m_CaptureOutput)
+		{
+			return;
+		}
+
+		const std::unique_lock Lock(m_pTestLogger->m_Lock);
+		m_pTestLogger->m_pMemoryLogger = std::make_unique<CMemoryLogger>();
+	}
+
+	void OnTestEnd(const testing::TestInfo &TestInfo) override
+	{
+		if(!m_CaptureOutput)
+		{
+			return;
+		}
+
+		const std::unique_lock Lock(m_pTestLogger->m_Lock);
+		if(TestInfo.result()->Failed())
+		{
+			for(const CLogMessage &Line : m_pTestLogger->m_pMemoryLogger->Lines())
+			{
+				m_pTestLogger->m_pGlobalLogger->Log(&Line);
+			}
+		}
+		m_pTestLogger->m_pMemoryLogger = nullptr;
+	}
+};
+
 int main(int argc, const char **argv)
 {
+	CTestLogger *pTestLogger = std::make_unique<CTestLogger>(log_logger_default()).release();
+	log_set_global_logger(pTestLogger);
+
 	CCmdlineFix CmdlineFix(&argc, &argv);
-	log_set_global_logger_default();
+
 	::testing::InitGoogleTest(&argc, const_cast<char **>(argv));
 	GTEST_FLAG_SET(death_test_style, "threadsafe");
+
+	bool CaptureOutput = true;
+	if(argc >= 2)
+	{
+		for(int Argument = 1; Argument < argc; ++Argument)
+		{
+			if(str_comp(argv[Argument], "--no-capture") == 0)
+			{
+				CaptureOutput = false;
+			}
+			else
+			{
+				log_error("testrunner", "Unknown argument: %s", argv[Argument]);
+				return -1;
+			}
+		}
+	}
+
+	testing::TestEventListeners &Listeners = testing::UnitTest::GetInstance()->listeners();
+	Listeners.Append(new CTestLogListener(pTestLogger, CaptureOutput));
+
 	net_init();
+
 	return RUN_ALL_TESTS();
 }
 


### PR DESCRIPTION
Set a custom global logger that switches between forwarding log messages to a regular global logger and storing the log messages in a memory logger. Use a gtest `::testing::TestEventListener` to listen for the start and end of tests. On test start, set the memory logger to capture the log messages. On test end, if the test failed, forward the stored log messages to the global logger, i.e., log them to stdout.

Add the optional parameter `--no-capture` to the testrunner to always log the output also for passed tests as before.

Use a custom global logger instead of a scope logger, as scope loggers are thread local, so they cannot be used to capture the output of other threads in the gameworld tests.

Closes #8361.

## Checklist

- [X] Tested the change
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions