### PR TITLE
Remove virtual method `OnRender` from `CEditorComponent`

### DIFF
--- a/src/game/editor/component.cpp
+++ b/src/game/editor/component.cpp
@@ -32,10 +32,6 @@ void CEditorComponent::OnUpdate()
 {
 }
 
-void CEditorComponent::OnRender(CUIRect View)
-{
-}
-
 void CEditorComponent::InitSubComponents()
 {
 	for(CEditorComponent &Component : m_vSubComponents)

--- a/src/game/editor/component.h
+++ b/src/game/editor/component.h
@@ -24,14 +24,11 @@ public:
 	virtual void OnMapLoad();
 
 	/**
-	 * Gets called before @link OnRender @endlink. Should return `true`
-	 * if the event was consumed.
+	 * Should return `true` if the event was consumed.
 	 */
 	virtual bool OnInput(const IInput::CEvent &Event);
 
 	virtual void OnUpdate();
-
-	virtual void OnRender(CUIRect View);
 
 	/**
 	 * Initialize all registered subcomponents.

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2477,7 +2477,7 @@ void CEditor::DoMapEditor(CUIRect View)
 		}
 
 		MapView()->RenderGroupBorder();
-		MapView()->MapGrid()->OnRender(View);
+		MapView()->MapGrid()->Render();
 	}
 
 	const bool ShouldPan = Ui()->HotItem() == &m_MapEditorId && ((Input()->ModifierIsPressed() && Ui()->MouseButton(0)) || Ui()->MouseButton(2));
@@ -6582,8 +6582,9 @@ void CEditor::Render()
 		}
 	}
 
-	for(CEditorComponent &Component : m_vComponents)
-		Component.OnRender(View);
+	m_FileBrowser.Render();
+	m_Prompt.Render();
+	m_FontTyper.Render();
 
 	MapView()->UpdateZoom();
 

--- a/src/game/editor/file_browser.cpp
+++ b/src/game/editor/file_browser.cpp
@@ -79,7 +79,7 @@ void CFileBrowser::ShowFileDialog(
 	Editor()->m_Dialog = DIALOG_FILE;
 }
 
-void CFileBrowser::OnRender(CUIRect _)
+void CFileBrowser::Render()
 {
 	if(Editor()->m_Dialog != DIALOG_FILE)
 	{

--- a/src/game/editor/file_browser.h
+++ b/src/game/editor/file_browser.h
@@ -29,7 +29,7 @@ public:
 		const char *pTitle, const char *pButtonText,
 		const char *pInitialPath, const char *pInitialFilename,
 		FFileDialogOpenCallback pfnOpenCallback, void *pOpenCallbackUser);
-	void OnRender(CUIRect _) override;
+	void Render();
 	bool IsValidSaveFilename() const;
 
 	void OnEditorClose();

--- a/src/game/editor/font_typer.cpp
+++ b/src/game/editor/font_typer.cpp
@@ -196,7 +196,7 @@ void CFontTyper::SetCursor()
 	m_CursorRenderTime = time_get_nanoseconds() - 501ms;
 }
 
-void CFontTyper::OnRender(CUIRect View)
+void CFontTyper::Render()
 {
 	if(m_ConfirmActivatePopupContext.m_Result == CUi::SConfirmPopupContext::CONFIRMED)
 	{

--- a/src/game/editor/font_typer.h
+++ b/src/game/editor/font_typer.h
@@ -37,7 +37,7 @@ class CFontTyper : public CEditorComponent
 	void SetTile(ivec2 Pos, unsigned char Index, const std::shared_ptr<CLayerTiles> &pLayer);
 
 public:
-	void OnRender(CUIRect View) override;
+	void Render();
 	bool OnInput(const IInput::CEvent &Event) override;
 	void OnInit(CEditor *pEditor) override;
 

--- a/src/game/editor/map_grid.cpp
+++ b/src/game/editor/map_grid.cpp
@@ -13,7 +13,7 @@ void CMapGrid::OnReset()
 	m_GridFactor = 1;
 }
 
-void CMapGrid::OnRender(CUIRect View)
+void CMapGrid::Render()
 {
 	if(!m_GridActive)
 	{

--- a/src/game/editor/map_grid.h
+++ b/src/game/editor/map_grid.h
@@ -9,7 +9,7 @@ class CMapGrid : public CEditorComponent
 {
 public:
 	void OnReset() override;
-	void OnRender(CUIRect View) override;
+	void Render();
 
 	void SnapToGrid(vec2 &Position) const;
 	int GridLineDistance() const;

--- a/src/game/editor/prompt.cpp
+++ b/src/game/editor/prompt.cpp
@@ -66,7 +66,7 @@ void CPrompt::OnInit(CEditor *pEditor)
 #undef REGISTER_QUICK_ACTION
 }
 
-void CPrompt::OnRender(CUIRect _)
+void CPrompt::Render()
 {
 	if(!IsActive())
 		return;

--- a/src/game/editor/prompt.h
+++ b/src/game/editor/prompt.h
@@ -21,7 +21,7 @@ class CPrompt : public CEditorComponent
 public:
 	void OnInit(CEditor *pEditor) override;
 	bool OnInput(const IInput::CEvent &Event) override;
-	void OnRender(CUIRect _) override;
+	void Render();
 	bool IsActive();
 	void SetActive();
 	void SetInactive();


### PR DESCRIPTION
Some components do not render anything, some do not need a view
and if they do, they likely need different ones. So there is no
point in having a virtual method for it.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
