### PR TITLE
Add `CLayer::IsEnvelopeUsed/IsImageUsed/IsSoundUsed` functions

### DIFF
--- a/src/game/editor/mapitems/layer.h
+++ b/src/game/editor/mapitems/layer.h
@@ -32,6 +32,10 @@ public:
 	virtual void Render(bool Tileset = false) {}
 	virtual CUi::EPopupMenuFunctionResult RenderProperties(CUIRect *pToolbox) { return CUi::POPUP_KEEP_OPEN; }
 
+	virtual bool IsEnvelopeUsed(int EnvelopeIndex) const { return false; }
+	virtual bool IsImageUsed(int ImageIndex) const { return false; }
+	virtual bool IsSoundUsed(int SoundIndex) const { return false; }
+
 	virtual void ModifyImageIndex(const FIndexModifyFunction &IndexModifyFunction) {}
 	virtual void ModifyEnvelopeIndex(const FIndexModifyFunction &IndexModifyFunction) {}
 	virtual void ModifySoundIndex(const FIndexModifyFunction &IndexModifyFunction) {}

--- a/src/game/editor/mapitems/layer_quads.cpp
+++ b/src/game/editor/mapitems/layer_quads.cpp
@@ -226,6 +226,18 @@ CUi::EPopupMenuFunctionResult CLayerQuads::RenderProperties(CUIRect *pToolBox)
 	return CUi::POPUP_KEEP_OPEN;
 }
 
+bool CLayerQuads::IsEnvelopeUsed(int EnvelopeIndex) const
+{
+	return std::any_of(m_vQuads.begin(), m_vQuads.end(), [&](const auto &Quad) {
+		return Quad.m_PosEnv == EnvelopeIndex || Quad.m_ColorEnv == EnvelopeIndex;
+	});
+}
+
+bool CLayerQuads::IsImageUsed(int ImageIndex) const
+{
+	return m_Image == ImageIndex;
+}
+
 void CLayerQuads::ModifyImageIndex(const FIndexModifyFunction &IndexModifyFunction)
 {
 	IndexModifyFunction(&m_Image);

--- a/src/game/editor/mapitems/layer_quads.h
+++ b/src/game/editor/mapitems/layer_quads.h
@@ -23,6 +23,9 @@ public:
 
 	CUi::EPopupMenuFunctionResult RenderProperties(CUIRect *pToolbox) override;
 
+	bool IsEnvelopeUsed(int EnvelopeIndex) const override;
+	bool IsImageUsed(int ImageIndex) const override;
+
 	void ModifyImageIndex(const FIndexModifyFunction &IndexModifyFunction) override;
 	void ModifyEnvelopeIndex(const FIndexModifyFunction &IndexModifyFunction) override;
 

--- a/src/game/editor/mapitems/layer_sounds.cpp
+++ b/src/game/editor/mapitems/layer_sounds.cpp
@@ -186,6 +186,18 @@ CUi::EPopupMenuFunctionResult CLayerSounds::RenderProperties(CUIRect *pToolBox)
 	return CUi::POPUP_KEEP_OPEN;
 }
 
+bool CLayerSounds::IsEnvelopeUsed(int EnvelopeIndex) const
+{
+	return std::any_of(m_vSources.begin(), m_vSources.end(), [&](const auto &Source) {
+		return Source.m_PosEnv == EnvelopeIndex || Source.m_SoundEnv == EnvelopeIndex;
+	});
+}
+
+bool CLayerSounds::IsSoundUsed(int SoundIndex) const
+{
+	return m_Sound == SoundIndex;
+}
+
 void CLayerSounds::ModifySoundIndex(const FIndexModifyFunction &IndexModifyFunction)
 {
 	IndexModifyFunction(&m_Sound);

--- a/src/game/editor/mapitems/layer_sounds.h
+++ b/src/game/editor/mapitems/layer_sounds.h
@@ -19,6 +19,9 @@ public:
 
 	CUi::EPopupMenuFunctionResult RenderProperties(CUIRect *pToolbox) override;
 
+	bool IsEnvelopeUsed(int EnvelopeIndex) const override;
+	bool IsSoundUsed(int SoundIndex) const override;
+
 	void ModifyEnvelopeIndex(const FIndexModifyFunction &IndexModifyFunction) override;
 	void ModifySoundIndex(const FIndexModifyFunction &IndexModifyFunction) override;
 

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -1357,6 +1357,16 @@ void CLayerTiles::FlagModified(int x, int y, int w, int h)
 	}
 }
 
+bool CLayerTiles::IsEnvelopeUsed(int EnvelopeIndex) const
+{
+	return m_ColorEnv == EnvelopeIndex;
+}
+
+bool CLayerTiles::IsImageUsed(int ImageIndex) const
+{
+	return m_Image == ImageIndex;
+}
+
 void CLayerTiles::ModifyImageIndex(const FIndexModifyFunction &IndexModifyFunction)
 {
 	IndexModifyFunction(&m_Image);

--- a/src/game/editor/mapitems/layer_tiles.h
+++ b/src/game/editor/mapitems/layer_tiles.h
@@ -161,6 +161,9 @@ public:
 	};
 	static CUi::EPopupMenuFunctionResult RenderCommonProperties(SCommonPropState &State, CEditorMap *pEditorMap, CUIRect *pToolbox, std::vector<std::shared_ptr<CLayerTiles>> &vpLayers, std::vector<int> &vLayerIndices);
 
+	bool IsEnvelopeUsed(int EnvelopeIndex) const override;
+	bool IsImageUsed(int ImageIndex) const override;
+
 	void ModifyImageIndex(const FIndexModifyFunction &IndexModifyFunction) override;
 	void ModifyEnvelopeIndex(const FIndexModifyFunction &IndexModifyFunction) override;
 

--- a/src/game/editor/mapitems/map.cpp
+++ b/src/game/editor/mapitems/map.cpp
@@ -687,35 +687,9 @@ bool CEditorMap::IsEnvelopeUsed(int EnvelopeIndex) const
 	{
 		for(const auto &pLayer : pGroup->m_vpLayers)
 		{
-			if(pLayer->m_Type == LAYERTYPE_QUADS)
+			if(pLayer->IsEnvelopeUsed(EnvelopeIndex))
 			{
-				std::shared_ptr<CLayerQuads> pLayerQuads = std::static_pointer_cast<CLayerQuads>(pLayer);
-				for(const auto &Quad : pLayerQuads->m_vQuads)
-				{
-					if(Quad.m_PosEnv == EnvelopeIndex || Quad.m_ColorEnv == EnvelopeIndex)
-					{
-						return true;
-					}
-				}
-			}
-			else if(pLayer->m_Type == LAYERTYPE_SOUNDS)
-			{
-				std::shared_ptr<CLayerSounds> pLayerSounds = std::static_pointer_cast<CLayerSounds>(pLayer);
-				for(const auto &Source : pLayerSounds->m_vSources)
-				{
-					if(Source.m_PosEnv == EnvelopeIndex || Source.m_SoundEnv == EnvelopeIndex)
-					{
-						return true;
-					}
-				}
-			}
-			else if(pLayer->m_Type == LAYERTYPE_TILES)
-			{
-				std::shared_ptr<CLayerTiles> pLayerTiles = std::static_pointer_cast<CLayerTiles>(pLayer);
-				if(pLayerTiles->m_ColorEnv == EnvelopeIndex)
-				{
-					return true;
-				}
+				return true;
 			}
 		}
 	}
@@ -956,21 +930,9 @@ bool CEditorMap::IsImageUsed(int ImageIndex) const
 	{
 		for(const auto &pLayer : pGroup->m_vpLayers)
 		{
-			if(pLayer->m_Type == LAYERTYPE_TILES)
+			if(pLayer->IsImageUsed(ImageIndex))
 			{
-				const std::shared_ptr<CLayerTiles> pTiles = std::static_pointer_cast<CLayerTiles>(pLayer);
-				if(pTiles->m_Image == ImageIndex)
-				{
-					return true;
-				}
-			}
-			else if(pLayer->m_Type == LAYERTYPE_QUADS)
-			{
-				const std::shared_ptr<CLayerQuads> pQuads = std::static_pointer_cast<CLayerQuads>(pLayer);
-				if(pQuads->m_Image == ImageIndex)
-				{
-					return true;
-				}
+				return true;
 			}
 		}
 	}
@@ -1050,13 +1012,9 @@ bool CEditorMap::IsSoundUsed(int SoundIndex) const
 	{
 		for(const auto &pLayer : pGroup->m_vpLayers)
 		{
-			if(pLayer->m_Type == LAYERTYPE_SOUNDS)
+			if(pLayer->IsSoundUsed(SoundIndex))
 			{
-				std::shared_ptr<CLayerSounds> pSounds = std::static_pointer_cast<CLayerSounds>(pLayer);
-				if(pSounds->m_Sound == SoundIndex)
-				{
-					return true;
-				}
+				return true;
 			}
 		}
 	}


### PR DESCRIPTION
Instead of casting the editor layers in the `CEditorMap::IsEnvelopeUsed/IsImageUsed/IsSoundUsed` functions, implement the checks for used envelopes/images/sounds individually for each layer with virtual `CLayer::IsEnvelopeUsed/IsImageUsed/IsSoundUsed` functions.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions