### PR TITLE
Ensure strict-weak ordering in `CFileBrowser::CompareCommon`

### DIFF
--- a/src/game/editor/file_browser.cpp
+++ b/src/game/editor/file_browser.cpp
@@ -816,13 +816,13 @@ int CFileBrowser::DirectoryListingCallback(const CFsFileInfo *pInfo, int IsDir, 
 
 std::optional<bool> CFileBrowser::CompareCommon(const CFilelistItem *pLhs, const CFilelistItem *pRhs)
 {
-	if(str_comp(pLhs->m_aFilename, "..") == 0)
-	{
-		return true;
-	}
 	if(str_comp(pRhs->m_aFilename, "..") == 0)
 	{
 		return false;
+	}
+	if(str_comp(pLhs->m_aFilename, "..") == 0)
+	{
+		return true;
 	}
 	if(pLhs->m_IsLink != pRhs->m_IsLink)
 	{


### PR DESCRIPTION
The client was crashing when opening the editor file browser to add an image due to additional STL assertions from #11851.

CC #11940. Manually checked all occurrences of `".."` to ensure that there are no further instances of this incorrect filename comparison.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions