### PR TITLE
Fix Rust build by reordering libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2292,12 +2292,12 @@ set(LIBS
   ${SQLite3_LIBRARIES}
   ${WEBSOCKETS_LIBRARIES}
   ${ZLIB_LIBRARIES}
+  # Add Rust part of our code.
+  rust_engine_shared
   ${PLATFORM_LIBS}
   # Add pthreads (on non-Windows) at the end, so that other libraries can depend
   # on it.
   ${CMAKE_THREAD_LIBS_INIT}
-  # Add Rust part of our code.
-  rust_engine_shared
 )
 
 # Targets


### PR DESCRIPTION
Windows build:
```
/usr/lib/gcc/x86_64-w64-mingw32/13.1.0/../../../../x86_64-w64-mingw32/bin/ld: x86_64-pc-windows-gnu/release/libddnet_engine_shared.a(std-8984bea53711d8dc.std.822af3e2effa3d17-cgu.0.rcgu.o): in function `std::sys::pal::windows::rand::hashmap_random_keys':
/rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library\std\src\sys\pal\windows/rand.rs:8: undefined reference to `BCryptGenRandom'
```