### PR TITLE
Fix iterator usage due to input events cleared in input callback

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -524,7 +524,6 @@ void CChat::EnableMode(int Team)
 		else
 			m_Mode = MODE_ALL;
 
-		Input()->Clear();
 		m_CompletionChosen = -1;
 		m_CompletionUsed = false;
 		m_Input.Activate(EInputPriority::CHAT);


### PR DESCRIPTION
In the `CInput::ConsumeEvents` function we iterate over all input events with `for(const CEvent &Event : m_vInputEvents)`, which then call the `OnInput` function of the components. The `CChat::OnInput` function calls the `CChat::EnableMode` function when the chat is activated, which then calls `Input()->Clear()` which clears `m_vInputEvents` and invalidates the iterator of the `for`-loop. This was caught by the additional STL assertions from #11851.

This is fixed by removing the stray call to `Input()->Clear()` entirely. The call does not seem to have any effect (anymore). Opening the chat works. There are no input events being incorrectly handled after opening the chat. Holding binds when opening the chat also works as before.

The call to `Input()->Clear()` was previously `Input()->ClearEvents()`. Before that it was `inp_clear_events()`, which was introduced in dfe499248f1b1236487156b28e4a535d7963fe35.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options: `gfx_asyncrender_old 0` and `gfx_asyncrender_old 1`
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions