### PR TITLE
Work around IDs being duplicated in sixup snapshot translation

### DIFF
--- a/src/engine/shared/snapshot/builder.rs
+++ b/src/engine/shared/snapshot/builder.rs
@@ -121,17 +121,23 @@ impl CSnapshotBuilder {
             Some(t) => t,
             None => return true, // dropping items from 0.7 snaps doesn't count as dropping
         };
-        let id: u16 = id.try_into().expect("id must fit into a 16-bit integer");
-        match self.builder.add_item(type_, id, data) {
-            Ok(()) => true,
-            Err(snap::BuilderError::DuplicateKey) => {
-                panic!("duplicate key in snapshot type={type_} id={id}");
-            }
-            Err(snap::BuilderError::TooLongSnap | snap::BuilderError::TooManyItems) => {
-                self.has_dropped_item = true;
-                false
-            }
+        let mut id: u16 = id.try_into().expect("id must fit into a 16-bit integer");
+        for _ in 0..128 {
+            return match self.builder.add_item(type_, id, data) {
+                Ok(()) => true,
+                Err(snap::BuilderError::DuplicateKey) => {
+                    // Work around #12070, try again with higher ID:
+                    id = id.wrapping_add(1);
+                    continue;
+                }
+                Err(snap::BuilderError::TooLongSnap | snap::BuilderError::TooManyItems) => {
+                    self.has_dropped_item = true;
+                    false
+                }
+            };
         }
+        // silently drop the item if there's no ID space
+        true
     }
 
     /// Finishes building the snapshot, erroring if any items were dropped.


### PR DESCRIPTION
`NETEVENTTYPE_SOUNDWORLD` would sometimes get character IDs and sometimes original `NETEVENTTYPE_SOUNDWORLD` IDs. These can overlap.

Works around #12070.
Fixes #12069.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions