### PR TITLE
Feature: Add secret value to finish times for sv_hide_score

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -264,7 +264,7 @@ Objects = [
 	NetObjectEx("DDNetPlayer", "player@netobj.ddnet.tw", [
 		NetIntAny("m_Flags"),
 		NetIntRange("m_AuthLevel", "AUTHED_NO", "AUTHED_ADMIN"),
-		NetIntRange("m_FinishTimeSeconds", 'FinishTime::UNSET', 'max_int', default='FinishTime::UNSET'),
+		NetIntRange("m_FinishTimeSeconds", 'FinishTime::SECRET', 'max_int', default='FinishTime::UNSET'),
 		NetIntRange("m_FinishTimeMillis", 0, 999, default=0),
 	]),
 
@@ -393,7 +393,7 @@ Objects = [
 
  	# the current best time in the server
 	NetObjectEx("MapBestTime", "map-best-time@netobj.ddnet.org", [
-			NetIntRange("m_MapBestTimeSeconds", 'FinishTime::NOT_FINISHED_MILLIS', 'max_int'),
+			NetIntRange("m_MapBestTimeSeconds", 'FinishTime::SECRET', 'max_int'),
 			NetIntRange("m_MapBestTimeMillis", 0, 999),
 	]),
 

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -264,7 +264,7 @@ Objects = [
 	NetObjectEx("DDNetPlayer", "player@netobj.ddnet.tw", [
 		NetIntAny("m_Flags"),
 		NetIntRange("m_AuthLevel", "AUTHED_NO", "AUTHED_ADMIN"),
-		NetIntRange("m_FinishTimeSeconds", 'FinishTime::UNSET', 'max_int', default='FinishTime::UNSET'),
+		NetIntRange("m_FinishTimeSeconds", 'FinishTime::SECRET', 'max_int', default='FinishTime::UNSET'),
 		NetIntRange("m_FinishTimeMillis", 0, 999, default=0),
 	]),
 
@@ -396,7 +396,7 @@ Objects = [
 
  	# the current best time in the server
 	NetObjectEx("MapBestTime", "map-best-time@netobj.ddnet.org", [
-			NetIntRange("m_MapBestTimeSeconds", 'FinishTime::NOT_FINISHED_MILLIS', 'max_int'),
+			NetIntRange("m_MapBestTimeSeconds", 'FinishTime::SECRET', 'max_int'),
 			NetIntRange("m_MapBestTimeMillis", 0, 999),
 	]),
 

--- a/src/engine/shared/protocol.h
+++ b/src/engine/shared/protocol.h
@@ -148,6 +148,7 @@ enum
 	VERSION_DDNET_SAVE_CODE = 19060,
 	VERSION_DDNET_IMPORTANT_ALERT = 19060,
 	VERSION_DDNET_MAP_BESTTIME = 19070,
+	VERSION_DDNET_TIME_SECRET = 19090,
 };
 
 namespace TuneZone
@@ -161,6 +162,7 @@ namespace FinishTime
 	inline constexpr int NOT_FINISHED_TIMESCORE = -9999;
 	inline constexpr int NOT_FINISHED_MILLIS = -1;
 	inline constexpr int UNSET = -2;
+	inline constexpr int SECRET = -3;
 }
 
 typedef std::bitset<MAX_CLIENTS> CClientMask;

--- a/src/engine/shared/protocol.h
+++ b/src/engine/shared/protocol.h
@@ -157,6 +157,7 @@ enum
 	VERSION_DDNET_SAVE_CODE = 19060,
 	VERSION_DDNET_IMPORTANT_ALERT = 19060,
 	VERSION_DDNET_MAP_BESTTIME = 19070,
+	VERSION_DDNET_TIME_SECRET = 20000,
 };
 
 namespace TuneZone
@@ -170,6 +171,7 @@ namespace FinishTime
 	inline constexpr int NOT_FINISHED_TIMESCORE = -9999;
 	inline constexpr int NOT_FINISHED_MILLIS = -1;
 	inline constexpr int UNSET = -2;
+	inline constexpr int SECRET = -3;
 }
 
 typedef std::bitset<MAX_CLIENTS> CClientMask;

--- a/src/engine/shared/protocol.h
+++ b/src/engine/shared/protocol.h
@@ -166,6 +166,7 @@ enum
 	VERSION_DDNET_MAP_BESTTIME = 19070,
 	VERSION_DDNET_128_TEAMS = 20000,
 	VERSION_DDNET_PICKUP_FREEZE = 20010,
+	VERSION_DDNET_TIME_SECRET = 20010,
 };
 
 /**
@@ -189,6 +190,7 @@ namespace FinishTime
 	inline constexpr int NOT_FINISHED_TIMESCORE = -9999;
 	inline constexpr int NOT_FINISHED_MILLIS = -1;
 	inline constexpr int UNSET = -2;
+	inline constexpr int SECRET = -3;
 }
 
 typedef std::bitset<MAX_CLIENTS> CClientMask;

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -13,6 +13,7 @@
 #include <engine/font_icons.h>
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
+#include <engine/shared/protocol.h>
 #include <engine/textrender.h>
 
 #include <generated/client_data.h>
@@ -338,7 +339,7 @@ void CHud::RenderScoreHud()
 					}
 				}
 			}
-			char aScore[2][16];
+			char aScore[2][16] = {{'\0'}, {'\0'}};
 			for(int t = 0; t < 2; ++t)
 			{
 				if(apPlayerInfo[t])
@@ -348,25 +349,24 @@ void CHud::RenderScoreHud()
 					else if(GameClient()->m_GameInfo.m_TimeScore)
 					{
 						CGameClient::CClientData &ClientData = GameClient()->m_aClients[apPlayerInfo[t]->m_ClientId];
-						if(GameClient()->m_ReceivedDDNetPlayerFinishTimes && ClientData.m_FinishTimeSeconds != FinishTime::NOT_FINISHED_MILLIS)
+						if(GameClient()->m_ReceivedDDNetPlayerFinishTimes)
 						{
-							int64_t TimeSeconds = static_cast<int64_t>(absolute(ClientData.m_FinishTimeSeconds));
-							int64_t TimeMillis = TimeSeconds * 1000 + (absolute(ClientData.m_FinishTimeMillis) % 1000);
+							if(ClientData.m_FinishTimeSeconds >= 0)
+							{
+								int64_t TimeSeconds = static_cast<int64_t>(absolute(ClientData.m_FinishTimeSeconds));
+								int64_t TimeMillis = TimeSeconds * 1000 + (absolute(ClientData.m_FinishTimeMillis) % 1000);
 
-							str_time(TimeMillis / 10, ETimeFormat::HOURS, aScore[t], sizeof(aScore[t]));
+								str_time(TimeMillis / 10, ETimeFormat::HOURS, aScore[t], sizeof(aScore[t]));
+							}
 						}
 						else if(apPlayerInfo[t]->m_Score != FinishTime::NOT_FINISHED_TIMESCORE)
 						{
 							str_time((int64_t)absolute(apPlayerInfo[t]->m_Score) * 100, ETimeFormat::HOURS, aScore[t], sizeof(aScore[t]));
 						}
-						else
-							aScore[t][0] = 0;
 					}
 					else
 						str_format(aScore[t], sizeof(aScore[t]), "%d", apPlayerInfo[t]->m_Score);
 				}
-				else
-					aScore[t][0] = 0;
 			}
 
 			bool RecreateScores = str_comp(aScore[0], m_aScoreInfo[0].m_aScoreText) != 0 || str_comp(aScore[1], m_aScoreInfo[1].m_aScoreText) != 0 || m_LastLocalClientId != GameClient()->m_Snap.m_LocalClientId;
@@ -1885,9 +1885,16 @@ void CHud::RenderRecord()
 		char aBuf[64];
 		TextRender()->Text(5, 75, 6, Localize("Server best:"), -1.0f);
 		char aTime[32];
-		int64_t TimeCentiseconds = static_cast<int64_t>(GameClient()->m_MapBestTimeSeconds) * 100 + static_cast<int64_t>(GameClient()->m_MapBestTimeMillis) / 10;
-		str_time(TimeCentiseconds, ETimeFormat::HOURS_CENTISECS, aTime, sizeof(aTime));
-		str_format(aBuf, sizeof(aBuf), "%s%s", GameClient()->m_MapBestTimeSeconds > 3600 ? "" : "   ", aTime);
+		if(GameClient()->m_MapBestTimeSeconds == FinishTime::SECRET)
+		{
+			str_format(aBuf, sizeof(aBuf), "%s", Localize("Secret"));
+		}
+		else
+		{
+			int64_t TimeCentiseconds = static_cast<int64_t>(GameClient()->m_MapBestTimeSeconds) * 100 + static_cast<int64_t>(GameClient()->m_MapBestTimeMillis) / 10;
+			str_time(TimeCentiseconds, ETimeFormat::HOURS_CENTISECS, aTime, sizeof(aTime));
+			str_format(aBuf, sizeof(aBuf), "%s%s", GameClient()->m_MapBestTimeSeconds > 3600 ? "" : "   ", aTime);
+		}
 		TextRender()->Text(53, 75, 6, aBuf, -1.0f);
 	}
 

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -2,7 +2,6 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "hud.h"
 
-#include "binds.h"
 #include "camera.h"
 #include "controls.h"
 #include "voting.h"
@@ -13,6 +12,7 @@
 #include <engine/font_icons.h>
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
+#include <engine/shared/protocol.h>
 #include <engine/textrender.h>
 
 #include <generated/client_data.h>
@@ -340,7 +340,7 @@ void CHud::RenderScoreHud()
 					}
 				}
 			}
-			char aScore[2][16];
+			char aScore[2][16] = {{'\0'}, {'\0'}};
 			for(int t = 0; t < 2; ++t)
 			{
 				if(apPlayerInfo[t])
@@ -352,12 +352,15 @@ void CHud::RenderScoreHud()
 					else if(GameClient()->m_GameInfo.m_TimeScore)
 					{
 						CGameClient::CClientData &ClientData = GameClient()->m_aClients[apPlayerInfo[t]->m_ClientId];
-						if(GameClient()->m_ReceivedDDNetPlayerFinishTimes && ClientData.m_FinishTimeSeconds != FinishTime::NOT_FINISHED_MILLIS)
+						if(GameClient()->m_ReceivedDDNetPlayerFinishTimes)
 						{
-							int64_t TimeSeconds = static_cast<int64_t>(absolute(ClientData.m_FinishTimeSeconds));
-							int64_t TimeMillis = TimeSeconds * 1000 + (absolute(ClientData.m_FinishTimeMillis) % 1000);
+							if(ClientData.m_FinishTimeSeconds >= 0)
+							{
+								int64_t TimeSeconds = static_cast<int64_t>(absolute(ClientData.m_FinishTimeSeconds));
+								int64_t TimeMillis = TimeSeconds * 1000 + (absolute(ClientData.m_FinishTimeMillis) % 1000);
 
-							str_time(TimeMillis / 10, ETimeFormat::HOURS, aScore[t], sizeof(aScore[t]));
+								str_time(TimeMillis / 10, ETimeFormat::HOURS, aScore[t], sizeof(aScore[t]));
+							}
 						}
 						else if(apPlayerInfo[t]->m_Score != FinishTime::NOT_FINISHED_TIMESCORE)
 						{
@@ -1895,9 +1898,16 @@ void CHud::RenderRecord()
 		char aBuf[64];
 		TextRender()->Text(5, 75, 6, Localize("Server best:"), -1.0f);
 		char aTime[32];
-		int64_t TimeCentiseconds = static_cast<int64_t>(GameClient()->m_MapBestTimeSeconds) * 100 + static_cast<int64_t>(GameClient()->m_MapBestTimeMillis) / 10;
-		str_time(TimeCentiseconds, ETimeFormat::HOURS_CENTISECS, aTime, sizeof(aTime));
-		str_format(aBuf, sizeof(aBuf), "%s%s", GameClient()->m_MapBestTimeSeconds > 3600 ? "" : "   ", aTime);
+		if(GameClient()->m_MapBestTimeSeconds == FinishTime::SECRET)
+		{
+			str_format(aBuf, sizeof(aBuf), "%s", Localize("Secret"));
+		}
+		else
+		{
+			int64_t TimeCentiseconds = static_cast<int64_t>(GameClient()->m_MapBestTimeSeconds) * 100 + static_cast<int64_t>(GameClient()->m_MapBestTimeMillis) / 10;
+			str_time(TimeCentiseconds, ETimeFormat::HOURS_CENTISECS, aTime, sizeof(aTime));
+			str_format(aBuf, sizeof(aBuf), "%s%s", GameClient()->m_MapBestTimeSeconds > 3600 ? "" : "   ", aTime);
+		}
 		TextRender()->Text(53, 75, 6, aBuf, -1.0f);
 	}
 

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -2,7 +2,6 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "hud.h"
 
-#include "binds.h"
 #include "camera.h"
 #include "controls.h"
 #include "voting.h"
@@ -13,6 +12,7 @@
 #include <engine/font_icons.h>
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
+#include <engine/shared/protocol.h>
 #include <engine/textrender.h>
 
 #include <generated/client_data.h>
@@ -340,7 +340,7 @@ void CHud::RenderScoreHud()
 					}
 				}
 			}
-			char aScore[2][16];
+			char aScore[2][16] = {{'\0'}, {'\0'}};
 			for(int t = 0; t < 2; ++t)
 			{
 				if(apPlayerInfo[t])
@@ -351,11 +351,16 @@ void CHud::RenderScoreHud()
 					}
 					else if(GameClient()->m_GameInfo.m_TimeScore)
 					{
-						const CGameClient::CClientData &ClientData = GameClient()->m_aClients[apPlayerInfo[t]->m_ClientId];
-						if(GameClient()->m_ReceivedDDNetPlayerFinishTimes && ClientData.m_FinishTimeSeconds != FinishTime::NOT_FINISHED_MILLIS)
+						CGameClient::CClientData &ClientData = GameClient()->m_aClients[apPlayerInfo[t]->m_ClientId];
+						if(GameClient()->m_ReceivedDDNetPlayerFinishTimes)
 						{
-							const int64_t TimeMillis = static_cast<int64_t>(ClientData.m_FinishTimeSeconds) * 1000 + ClientData.m_FinishTimeMillis % 1000;
-							str_time(TimeMillis / 10, ETimeFormat::HOURS, aScore[t], sizeof(aScore[t]));
+							if(ClientData.m_FinishTimeSeconds >= 0)
+							{
+								int64_t TimeSeconds = static_cast<int64_t>(absolute(ClientData.m_FinishTimeSeconds));
+								int64_t TimeMillis = TimeSeconds * 1000 + (absolute(ClientData.m_FinishTimeMillis) % 1000);
+
+								str_time(TimeMillis / 10, ETimeFormat::HOURS, aScore[t], sizeof(aScore[t]));
+							}
 						}
 						else if(apPlayerInfo[t]->m_Score != FinishTime::NOT_FINISHED_TIMESCORE)
 						{
@@ -1895,9 +1900,16 @@ void CHud::RenderRecord()
 		char aBuf[64];
 		TextRender()->Text(5, 75, 6, Localize("Server best:"), -1.0f);
 		char aTime[32];
-		int64_t TimeCentiseconds = static_cast<int64_t>(GameClient()->m_MapBestTimeSeconds) * 100 + static_cast<int64_t>(GameClient()->m_MapBestTimeMillis) / 10;
-		str_time(TimeCentiseconds, ETimeFormat::HOURS_CENTISECS, aTime, sizeof(aTime));
-		str_format(aBuf, sizeof(aBuf), "%s%s", GameClient()->m_MapBestTimeSeconds > 3600 ? "" : "   ", aTime);
+		if(GameClient()->m_MapBestTimeSeconds == FinishTime::SECRET)
+		{
+			str_format(aBuf, sizeof(aBuf), "%s", Localize("Secret"));
+		}
+		else
+		{
+			int64_t TimeCentiseconds = static_cast<int64_t>(GameClient()->m_MapBestTimeSeconds) * 100 + static_cast<int64_t>(GameClient()->m_MapBestTimeMillis) / 10;
+			str_time(TimeCentiseconds, ETimeFormat::HOURS_CENTISECS, aTime, sizeof(aTime));
+			str_format(aBuf, sizeof(aBuf), "%s%s", GameClient()->m_MapBestTimeSeconds > 3600 ? "" : "   ", aTime);
+		}
 		TextRender()->Text(53, 75, 6, aBuf, -1.0f);
 	}
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -65,6 +65,7 @@
 #include <engine/serverbrowser.h>
 #include <engine/shared/config.h>
 #include <engine/shared/csv.h>
+#include <engine/shared/protocol.h>
 #include <engine/sound.h>
 #include <engine/storage.h>
 #include <engine/textrender.h>
@@ -2526,9 +2527,18 @@ std::function<bool(int, int, int, int)> CGameClient::GetScoreComparator(bool Tim
 	}
 
 	// long precise times, smallest value first, subsorting by milliseconds
-	auto CompareTimeMillis = [](int TimeSeconds1, int TimeSeconds2, int TimeMillis1, int TimeMillis2) {
-		TimeSeconds1 = TimeSeconds1 == FinishTime::NOT_FINISHED_MILLIS ? std::numeric_limits<int>::max() : TimeSeconds1;
-		TimeSeconds2 = TimeSeconds2 == FinishTime::NOT_FINISHED_MILLIS ? std::numeric_limits<int>::max() : TimeSeconds2;
+	auto CompareTimeMillis = [](int TimeSeconds1, int TimeSeconds2, int TimeMillis1, int TimeMillis2) -> bool {
+		auto HandleFinishTimeSpecialValues = [](int TimeSeconds) -> int {
+			// unfinished is last
+			if(TimeSeconds == FinishTime::NOT_FINISHED_MILLIS)
+				return std::numeric_limits<int>::max();
+			// secret is better than unfinished
+			else if(TimeSeconds == FinishTime::SECRET)
+				return std::numeric_limits<int>::max() - 1;
+			return TimeSeconds;
+		};
+		TimeSeconds1 = HandleFinishTimeSpecialValues(TimeSeconds1);
+		TimeSeconds2 = HandleFinishTimeSpecialValues(TimeSeconds2);
 		if(TimeSeconds1 == TimeSeconds2)
 			return TimeMillis1 < TimeMillis2;
 		return TimeSeconds1 < TimeSeconds2;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -65,6 +65,7 @@
 #include <engine/serverbrowser.h>
 #include <engine/shared/config.h>
 #include <engine/shared/csv.h>
+#include <engine/shared/protocol.h>
 #include <engine/sound.h>
 #include <engine/storage.h>
 #include <engine/textrender.h>
@@ -2543,9 +2544,18 @@ std::function<bool(int, int, int, int)> CGameClient::GetScoreComparator(bool Tim
 	}
 
 	// long precise times, smallest value first, subsorting by milliseconds
-	auto CompareTimeMillis = [](int TimeSeconds1, int TimeSeconds2, int TimeMillis1, int TimeMillis2) {
-		TimeSeconds1 = TimeSeconds1 == FinishTime::NOT_FINISHED_MILLIS ? std::numeric_limits<int>::max() : TimeSeconds1;
-		TimeSeconds2 = TimeSeconds2 == FinishTime::NOT_FINISHED_MILLIS ? std::numeric_limits<int>::max() : TimeSeconds2;
+	auto CompareTimeMillis = [](int TimeSeconds1, int TimeSeconds2, int TimeMillis1, int TimeMillis2) -> bool {
+		auto HandleFinishTimeSpecialValues = [](int TimeSeconds) -> int {
+			// unfinished is last
+			if(TimeSeconds == FinishTime::NOT_FINISHED_MILLIS)
+				return std::numeric_limits<int>::max();
+			// secret is better than unfinished
+			else if(TimeSeconds == FinishTime::SECRET)
+				return std::numeric_limits<int>::max() - 1;
+			return TimeSeconds;
+		};
+		TimeSeconds1 = HandleFinishTimeSpecialValues(TimeSeconds1);
+		TimeSeconds2 = HandleFinishTimeSpecialValues(TimeSeconds2);
 		if(TimeSeconds1 == TimeSeconds2)
 			return TimeMillis1 < TimeMillis2;
 		return TimeSeconds1 < TimeSeconds2;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -65,6 +65,7 @@
 #include <engine/serverbrowser.h>
 #include <engine/shared/config.h>
 #include <engine/shared/csv.h>
+#include <engine/shared/protocol.h>
 #include <engine/sound.h>
 #include <engine/storage.h>
 #include <engine/textrender.h>
@@ -2542,9 +2543,18 @@ std::function<bool(int, int, int, int)> CGameClient::GetScoreComparator(bool Tim
 	}
 
 	// long precise times, smallest value first, subsorting by milliseconds
-	auto CompareTimeMillis = [](int TimeSeconds1, int TimeSeconds2, int TimeMillis1, int TimeMillis2) {
-		TimeSeconds1 = TimeSeconds1 == FinishTime::NOT_FINISHED_MILLIS ? std::numeric_limits<int>::max() : TimeSeconds1;
-		TimeSeconds2 = TimeSeconds2 == FinishTime::NOT_FINISHED_MILLIS ? std::numeric_limits<int>::max() : TimeSeconds2;
+	auto CompareTimeMillis = [](int TimeSeconds1, int TimeSeconds2, int TimeMillis1, int TimeMillis2) -> bool {
+		auto HandleFinishTimeSpecialValues = [](int TimeSeconds) -> int {
+			// unfinished is last
+			if(TimeSeconds == FinishTime::NOT_FINISHED_MILLIS)
+				return std::numeric_limits<int>::max();
+			// secret is better than unfinished
+			else if(TimeSeconds == FinishTime::SECRET)
+				return std::numeric_limits<int>::max() - 1;
+			return TimeSeconds;
+		};
+		TimeSeconds1 = HandleFinishTimeSpecialValues(TimeSeconds1);
+		TimeSeconds2 = HandleFinishTimeSpecialValues(TimeSeconds2);
 		if(TimeSeconds1 == TimeSeconds2)
 			return TimeMillis1 < TimeMillis2;
 		return TimeSeconds1 < TimeSeconds2;

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -15,6 +15,7 @@
 #include <engine/input.h>
 #include <engine/keys.h>
 #include <engine/shared/config.h>
+#include <engine/shared/protocol.h>
 
 #include <game/localization.h>
 
@@ -1574,15 +1575,26 @@ void CUi::RenderTime(CUIRect TimeRect, float FontSize, int Seconds, bool NotFini
 
 	char aBuf[128];
 
-	str_time(((int64_t)absolute(Seconds)) * 100, ETimeFormat::HOURS, aBuf, sizeof(aBuf));
-
 	// align in vertical middle
 	vec2 Cursor = TimeRect.TopLeft();
+
 	float TextHeight = 0.0f;
 	float SecondsMaxHeight = 0.0f;
 	STextSizeProperties TextSizeProps{};
 	TextSizeProps.m_pMaxCharacterHeightInLine = &SecondsMaxHeight;
 	TextSizeProps.m_pHeight = &TextHeight;
+
+	if(Seconds == FinishTime::SECRET)
+	{
+		str_format(aBuf, sizeof(aBuf), "%s", Localize("Secret"));
+		float TextWidth = std::min(TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f, 0, TextSizeProps), TimeRect.w);
+		Cursor.x += TimeRect.w - TextWidth; // align right
+		Cursor.y += ((TimeRect.h - SecondsMaxHeight) / 2.0f - (FontSize - SecondsMaxHeight));
+		TextRender()->Text(Cursor.x, Cursor.y, FontSize, aBuf);
+		return;
+	}
+
+	str_time(((int64_t)absolute(Seconds)) * 100, ETimeFormat::HOURS, aBuf, sizeof(aBuf));
 
 	float SecondsWidth = std::min(TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f, 0, TextSizeProps), TimeRect.w);
 	Cursor.x += TimeRect.w - SecondsWidth; // align right

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -15,6 +15,7 @@
 #include <engine/input.h>
 #include <engine/keys.h>
 #include <engine/shared/config.h>
+#include <engine/shared/protocol.h>
 
 #include <game/localization.h>
 
@@ -1585,15 +1586,26 @@ void CUi::RenderTime(CUIRect TimeRect, float FontSize, int Seconds, bool NotFini
 
 	char aBuf[128];
 
-	str_time(((int64_t)absolute(Seconds)) * 100, ETimeFormat::HOURS, aBuf, sizeof(aBuf));
-
 	// align in vertical middle
 	vec2 Cursor = TimeRect.TopLeft();
+
 	float TextHeight = 0.0f;
 	float SecondsMaxHeight = 0.0f;
 	STextSizeProperties TextSizeProps{};
 	TextSizeProps.m_pMaxCharacterHeightInLine = &SecondsMaxHeight;
 	TextSizeProps.m_pHeight = &TextHeight;
+
+	if(Seconds == FinishTime::SECRET)
+	{
+		str_format(aBuf, sizeof(aBuf), "%s", Localize("Secret"));
+		float TextWidth = std::min(TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f, 0, TextSizeProps), TimeRect.w);
+		Cursor.x += TimeRect.w - TextWidth; // align right
+		Cursor.y += ((TimeRect.h - SecondsMaxHeight) / 2.0f - (FontSize - SecondsMaxHeight));
+		TextRender()->Text(Cursor.x, Cursor.y, FontSize, aBuf);
+		return;
+	}
+
+	str_time(((int64_t)absolute(Seconds)) * 100, ETimeFormat::HOURS, aBuf, sizeof(aBuf));
 
 	float SecondsWidth = std::min(TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f, 0, TextSizeProps), TimeRect.w);
 	Cursor.x += TimeRect.w - SecondsWidth; // align right

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -15,6 +15,7 @@
 #include <engine/input.h>
 #include <engine/keys.h>
 #include <engine/shared/config.h>
+#include <engine/shared/protocol.h>
 
 #include <game/localization.h>
 
@@ -1643,11 +1644,23 @@ void CUi::RenderTime(CUIRect TimeRect, float FontSize, int Seconds, bool NotFini
 		return;
 
 	char aBuf[128];
+	vec2 Cursor = TimeRect.TopLeft();
+
+	if(Seconds == FinishTime::SECRET)
+	{
+		str_format(aBuf, sizeof(aBuf), "%s", Localize("Secret"));
+
+		float TextWidth = std::min(TextRender()->TextWidth(FontSize, aBuf), TimeRect.w);
+		Cursor.x += TimeRect.w - TextWidth; // align right
+		Cursor.y += ((TimeRect.h - SecondsText.MaxCharacterHeight()) / 2.0f - (FontSize - SecondsText.MaxCharacterHeight()));
+		TextRender()->Text(Cursor.x, Cursor.y, FontSize, aBuf);
+		return;
+	}
+
 	str_time(absolute(static_cast<int64_t>(Seconds)) * 100, ETimeFormat::HOURS, aBuf, sizeof(aBuf));
 	SecondsText.Update(TextRender(), aBuf, FontSize);
 
 	// align in vertical middle
-	vec2 Cursor = TimeRect.TopLeft();
 	const float SecondsWidth = std::min(SecondsText.Width(), TimeRect.w);
 	Cursor.x += TimeRect.w - SecondsWidth; // align right
 	Cursor.y += ((TimeRect.h - SecondsText.MaxCharacterHeight()) / 2.0f - (FontSize - SecondsText.MaxCharacterHeight()));

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -171,6 +171,7 @@ public:
 
 		static CFinishTime Unset() { return CFinishTime(FinishTime::UNSET); }
 		static CFinishTime NotFinished() { return CFinishTime(FinishTime::NOT_FINISHED_MILLIS); }
+		static CFinishTime Secret() { return CFinishTime(FinishTime::SECRET); }
 
 	private:
 		CFinishTime(int Type)

--- a/src/game/server/gamemodes/ddnet.cpp
+++ b/src/game/server/gamemodes/ddnet.cpp
@@ -156,8 +156,12 @@ int CGameControllerDDNet::SnapPlayerScore(int SnappingClient, CPlayer *pPlayer)
 IGameController::CFinishTime CGameControllerDDNet::SnapPlayerTime(int SnappingClient, CPlayer *pPlayer)
 {
 	std::optional<float> BestTime = GameServer()->Score()->PlayerData(pPlayer->GetCid())->m_BestTime;
-	if(BestTime.has_value() && (!g_Config.m_SvHideScore || SnappingClient == pPlayer->GetCid()))
+	bool HideScore = g_Config.m_SvHideScore && SnappingClient != pPlayer->GetCid();
+	if(BestTime.has_value())
 	{
+		if(HideScore)
+			return Server()->GetClientVersion(SnappingClient) < VERSION_DDNET_TIME_SECRET ? CFinishTime::NotFinished() : CFinishTime::Secret();
+
 		// same as in str_time_float
 		int64_t TimeMilliseconds = time_milliseconds_from_seconds(BestTime.value());
 		int Seconds = static_cast<int>(TimeMilliseconds / 1000);
@@ -169,8 +173,11 @@ IGameController::CFinishTime CGameControllerDDNet::SnapPlayerTime(int SnappingCl
 
 IGameController::CFinishTime CGameControllerDDNet::SnapMapBestTime(int SnappingClient)
 {
-	if(m_CurrentRecord.has_value() && !g_Config.m_SvHideScore)
+	if(m_CurrentRecord.has_value())
 	{
+		if(g_Config.m_SvHideScore)
+			return Server()->GetClientVersion(SnappingClient) < VERSION_DDNET_TIME_SECRET ? CFinishTime::NotFinished() : CFinishTime::Secret();
+
 		// same as in str_time_float
 		int64_t TimeMilliseconds = time_milliseconds_from_seconds(m_CurrentRecord.value());
 		int Seconds = static_cast<int>(TimeMilliseconds / 1000);


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This PR adds a secret value to the map finish time and the player finish times if `sv_hide_score` is enabled. This allows you to see if a player finished a map at all without telling you the time or rank. Older clients still see nothing instead in order to be backwards compatible.

<img width="2560" height="1440" alt="screenshot_2026-04-20_23-14-55" src="https://github.com/user-attachments/assets/64503628-3263-456a-a66f-e968883f9faa" />

Players still see their own times
<img width="2560" height="1440" alt="screenshot_2026-04-20_23-14-47" src="https://github.com/user-attachments/assets/7ce6a227-4738-4d43-b833-705b5b00f264" />

Disclaimer: I want that feature, because I want to host "weekly shorts" similar to trackmania in the future. The mod already exists and we have everything in place for it (except a host), but without much problems you could easily port it into ddnet if wanted, since you can just set the right settings and name the mod to "Shorts" or something and you can already do this in current ddnet but without showing "Secret" for players who already finished.

closes #12043 

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
