### PR TITLE
Add floating back button

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -31,6 +31,9 @@ MACRO_CONFIG_INT(ClTouchControls, cl_touch_controls, 1, 0, 1, CFGFLAG_CLIENT | C
 #else
 MACRO_CONFIG_INT(ClTouchControls, cl_touch_controls, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable ingame touch controls")
 #endif
+MACRO_CONFIG_INT(ClBackButton, cl_back_button, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show draggable virtual back button")
+MACRO_CONFIG_INT(ClBackButtonX, cl_back_button_x, 5000, 0, 1000000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Relative X position of the draggable back button")
+MACRO_CONFIG_INT(ClBackButtonY, cl_back_button_y, 5000, 0, 1000000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Relative Y position of the draggable back button")
 
 MACRO_CONFIG_INT(ClNamePlates, cl_nameplates, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show name plates")
 MACRO_CONFIG_INT(ClNamePlatesAlways, cl_nameplates_always, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Always show name plates regardless of distance")

--- a/src/game/client/components/key_binder.cpp
+++ b/src/game/client/components/key_binder.cpp
@@ -97,3 +97,12 @@ bool CKeyBinder::IsActive() const
 {
 	return m_TakeKey;
 }
+
+bool CKeyBinder::AbortPendingKey()
+{
+	if(m_pKeyReaderId == nullptr)
+		return false;
+	m_Key = CBindSlot(KEY_ESCAPE, KeyModifier::NONE);
+	m_TakeKey = false;
+	return true;
+}

--- a/src/game/client/components/key_binder.h
+++ b/src/game/client/components/key_binder.h
@@ -22,6 +22,8 @@ public:
 	};
 	CKeyReaderResult DoKeyReader(CButtonContainer *pReaderButton, CButtonContainer *pClearButton, const CUIRect *pRect, const CBindSlot &CurrentBind, bool Activate);
 	bool IsActive() const;
+	bool HasPendingKeyReader() const { return m_pKeyReaderId != nullptr; }
+	bool AbortPendingKey();
 
 private:
 	const CButtonContainer *m_pKeyReaderId = nullptr;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2522,10 +2522,14 @@ void CMenus::OnRender()
 
 	Ui()->Update();
 
+	if(IsActive())
+		Ui()->DoBackButton();
+
 	Render();
 
 	if(IsActive())
 	{
+		Ui()->RenderBackButton();
 		RenderTools()->RenderCursor(Ui()->MousePos(), 24.0f);
 	}
 

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2518,10 +2518,14 @@ void CMenus::OnRender()
 
 	Ui()->Update();
 
+	if(IsActive())
+		Ui()->DoBackButton();
+
 	Render();
 
 	if(IsActive())
 	{
+		Ui()->RenderBackButton();
 		RenderTools()->RenderCursor(Ui()->MousePos(), 24.0f);
 	}
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -342,6 +342,24 @@ void CGameClient::OnInit()
 
 	// propagate pointers
 	m_UI.Init(Kernel());
+	m_UI.SetOnBackButtonPressedCallback([this]() {
+		m_BackButtonHandledKeyBind = m_KeyBinder.HasPendingKeyReader();
+		if(m_BackButtonHandledKeyBind)
+			m_KeyBinder.AbortPendingKey();
+	});
+	m_UI.SetDispatchInputCallback([this](const IInput::CEvent &Event) {
+		if(m_BackButtonHandledKeyBind)
+		{
+			if(Event.m_Flags & IInput::FLAG_RELEASE)
+				m_BackButtonHandledKeyBind = false;
+			return;
+		}
+		for(auto &pComponent : m_vpInput)
+		{
+			if(pComponent->OnInput(Event) && (Event.m_Flags & ~IInput::FLAG_RELEASE) != 0)
+				break;
+		}
+	});
 	m_RenderTools.Init(Graphics(), TextRender());
 	m_RenderMap.Init(Graphics(), TextRender());
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -342,6 +342,20 @@ void CGameClient::OnInit()
 
 	// propagate pointers
 	m_UI.Init(Kernel());
+	m_UI.SetOnBackButtonPressedCallback([this]() {
+		m_BackButtonHandledKeyBind = m_KeyBinder.HasPendingKeyReader();
+		if(m_BackButtonHandledKeyBind)
+			m_KeyBinder.AbortPendingKey();
+	});
+	m_UI.SetDispatchInputCallback([this](const IInput::CEvent &Event) {
+		if(m_BackButtonHandledKeyBind)
+		{
+			if(Event.m_Flags & IInput::FLAG_RELEASE)
+				m_BackButtonHandledKeyBind = false;
+			return;
+		}
+		OnInput(Event);
+	});
 	m_RenderTools.Init(Graphics(), TextRender());
 	m_RenderMap.Init(Graphics(), TextRender());
 
@@ -492,13 +506,7 @@ void CGameClient::OnUpdate()
 
 	// handle key presses
 	Input()->ConsumeEvents([&](const IInput::CEvent &Event) {
-		for(auto &pComponent : m_vpInput)
-		{
-			// Events with flag `FLAG_RELEASE` must always be forwarded to all components so keys being
-			// released can be handled in all components also after some components have been disabled.
-			if(pComponent->OnInput(Event) && (Event.m_Flags & ~IInput::FLAG_RELEASE) != 0)
-				break;
-		}
+		OnInput(Event);
 	});
 
 	if(g_Config.m_ClSubTickAiming && m_Binds.m_MouseOnAction)
@@ -510,6 +518,17 @@ void CGameClient::OnUpdate()
 	for(auto &pComponent : m_vpAll)
 	{
 		pComponent->OnUpdate();
+	}
+}
+
+void CGameClient::OnInput(const IInput::CEvent &Event)
+{
+	for(auto &pComponent : m_vpInput)
+	{
+		// Events with flag `FLAG_RELEASE` must always be forwarded to all components so keys being
+		// released can be handled in all components also after some components have been disabled.
+		if(pComponent->OnInput(Event) && (Event.m_Flags & ~IInput::FLAG_RELEASE) != 0)
+			break;
 	}
 }
 

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -584,6 +584,8 @@ public:
 	CRenderTools m_RenderTools;
 	CRenderMap m_RenderMap;
 
+	bool m_BackButtonHandledKeyBind = false;
+
 	void OnReset();
 
 	size_t ComponentCount() const { return m_vpAll.size(); }

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -584,6 +584,8 @@ public:
 	CRenderTools m_RenderTools;
 	CRenderMap m_RenderMap;
 
+	bool m_BackButtonHandledKeyBind = false;
+
 	void OnReset();
 
 	size_t ComponentCount() const { return m_vpAll.size(); }
@@ -917,6 +919,8 @@ private:
 	void UpdateSpectatorCursor();
 	void UpdateRenderedCharacters();
 	void HandlePredictedEvents(int Tick);
+
+	void OnInput(const IInput::CEvent &Event);
 
 	int m_aLastUpdateTick[MAX_CLIENTS] = {0};
 	void DetectStrongHook();

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -1662,6 +1662,104 @@ void CUi::RenderProgressSpinner(vec2 Center, float OuterRadius, const SProgressS
 	Graphics()->QuadsEnd();
 }
 
+void CUi::DoBackButton()
+{
+	if(!g_Config.m_ClBackButton)
+		return;
+
+	MapScreen();
+	const CUIRect *pScreen = Screen();
+	const float Size = pScreen->h * 0.1f;
+	constexpr float PositionScale = 1000000.0f;
+	const auto ClampPos = [&](vec2 Pos) {
+		Pos.x = std::clamp(Pos.x, 0.0f, pScreen->w - Size);
+		Pos.y = std::clamp(Pos.y, 0.0f, pScreen->h - Size);
+		return Pos;
+	};
+
+	vec2 ButtonPos = ClampPos({g_Config.m_ClBackButtonX / PositionScale * pScreen->w, g_Config.m_ClBackButtonY / PositionScale * pScreen->h});
+	CUIRect ButtonRect{ButtonPos.x, ButtonPos.y, Size, Size};
+
+	bool Clicked = false;
+	bool Abrupted = false;
+	const int Result = DoDraggableButtonLogic(&m_BackButtonId, 0, &ButtonRect, &Clicked, &Abrupted);
+
+	// Detect the press transition. DoDraggableButtonLogic sets the active item on the
+	// press frame but returns 0 there, so check CheckActiveItem to catch it.
+	if(m_BackButtonOp == EBackButtonOp::NONE && CheckActiveItem(&m_BackButtonId))
+	{
+		m_BackButtonInitialMouse = MousePos();
+		m_BackButtonDragOffset = ButtonPos - MousePos();
+		m_BackButtonOp = EBackButtonOp::CLICKED;
+		if(m_pfnOnBackButtonPressed)
+			m_pfnOnBackButtonPressed();
+	}
+
+	if(m_BackButtonOp == EBackButtonOp::CLICKED && length(MousePos() - m_BackButtonInitialMouse) > 5.0f)
+	{
+		m_BackButtonOp = EBackButtonOp::DRAGGING;
+	}
+
+	if(m_BackButtonOp == EBackButtonOp::DRAGGING)
+	{
+		ButtonPos = ClampPos(MousePos() + m_BackButtonDragOffset);
+		g_Config.m_ClBackButtonX = round_to_int(ButtonPos.x / pScreen->w * PositionScale);
+		g_Config.m_ClBackButtonY = round_to_int(ButtonPos.y / pScreen->h * PositionScale);
+		ButtonRect.x = ButtonPos.x;
+		ButtonRect.y = ButtonPos.y;
+	}
+
+	if(Result && Clicked)
+	{
+		if(m_BackButtonOp == EBackButtonOp::CLICKED && m_pfnDispatchInput)
+		{
+			IInput::CEvent Event;
+			Event.m_Key = KEY_ESCAPE;
+			Event.m_InputCount = 0;
+			Event.m_aText[0] = '\0';
+			Event.m_Flags = IInput::FLAG_PRESS;
+			m_pfnDispatchInput(Event);
+			Event.m_Flags = IInput::FLAG_RELEASE;
+			m_pfnDispatchInput(Event);
+		}
+		m_BackButtonOp = EBackButtonOp::NONE;
+	}
+	else if(Result && Abrupted)
+	{
+		m_BackButtonOp = EBackButtonOp::NONE;
+	}
+
+	m_BackButtonRect = ButtonRect;
+}
+
+void CUi::RenderBackButton()
+{
+	if(!g_Config.m_ClBackButton)
+		return;
+
+	MapScreen();
+
+	// Override hot/active claims made by UI rendered between DoBackButton and RenderBackButton.
+	if(m_BackButtonOp != EBackButtonOp::NONE)
+		SetActiveItem(&m_BackButtonId);
+	else if(MouseHovered(&m_BackButtonRect) && !MouseButton(0) && !MouseButton(1) && !MouseButton(2))
+		SetHotItem(&m_BackButtonId);
+
+	const bool Pressed = m_BackButtonOp != EBackButtonOp::NONE;
+	const bool Hovered = !Pressed && HotItem() == &m_BackButtonId;
+	const float Alpha = Pressed ? 0.9f : (Hovered ? 0.35f : 0.5f);
+	const ColorRGBA BackgroundColor{0.0f, 0.0f, 0.0f, Alpha};
+	m_BackButtonRect.Draw(BackgroundColor, IGraphics::CORNER_ALL, 12.0f);
+
+	TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
+	TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH |
+				     ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING |
+				     ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING);
+	DoLabel(&m_BackButtonRect, FontIcon::CHEVRON_LEFT, m_BackButtonRect.w * 0.5f, TEXTALIGN_MC);
+	TextRender()->SetRenderFlags(0);
+	TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
+}
+
 void CUi::DoPopupMenu(const SPopupMenuId *pId, float X, float Y, float Width, float Height, void *pContext, FPopupMenuFunction pfnFunc, const SPopupMenuProperties &Props)
 {
 	constexpr float Margin = SPopupMenu::POPUP_BORDER + SPopupMenu::POPUP_MARGIN;

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -1666,6 +1666,103 @@ void CUi::RenderProgressSpinner(vec2 Center, float OuterRadius, const SProgressS
 	Graphics()->QuadsEnd();
 }
 
+void CUi::DoBackButton()
+{
+	if(!g_Config.m_ClBackButton)
+		return;
+
+	MapScreen();
+	const CUIRect *pScreen = Screen();
+	const float Size = pScreen->h * 0.1f;
+	constexpr float PositionScale = 1000000.0f;
+	const auto ClampPos = [&](vec2 Pos) {
+		Pos.x = std::clamp(Pos.x, 0.0f, pScreen->w - Size);
+		Pos.y = std::clamp(Pos.y, 0.0f, pScreen->h - Size);
+		return Pos;
+	};
+
+	vec2 ButtonPos = ClampPos({g_Config.m_ClBackButtonX / PositionScale * pScreen->w, g_Config.m_ClBackButtonY / PositionScale * pScreen->h});
+	CUIRect ButtonRect{ButtonPos.x, ButtonPos.y, Size, Size};
+
+	bool Clicked = false;
+	bool Abrupted = false;
+	const int Result = DoDraggableButtonLogic(&m_BackButtonId, 0, &ButtonRect, &Clicked, &Abrupted);
+
+	// Detect the press transition. DoDraggableButtonLogic sets the active item on the
+	// press frame but returns 0 there, so check CheckActiveItem to catch it.
+	if(m_BackButtonOp == EBackButtonOp::NONE && CheckActiveItem(&m_BackButtonId))
+	{
+		m_BackButtonInitialMouse = MousePos();
+		m_BackButtonDragOffset = ButtonPos - MousePos();
+		m_BackButtonOp = EBackButtonOp::CLICKED;
+		if(m_OnBackButtonPressedFunction)
+			m_OnBackButtonPressedFunction();
+	}
+
+	if(m_BackButtonOp == EBackButtonOp::CLICKED && length(MousePos() - m_BackButtonInitialMouse) > 5.0f)
+	{
+		m_BackButtonOp = EBackButtonOp::DRAGGING;
+	}
+
+	if(m_BackButtonOp == EBackButtonOp::DRAGGING)
+	{
+		ButtonPos = ClampPos(MousePos() + m_BackButtonDragOffset);
+		g_Config.m_ClBackButtonX = round_to_int(ButtonPos.x / pScreen->w * PositionScale);
+		g_Config.m_ClBackButtonY = round_to_int(ButtonPos.y / pScreen->h * PositionScale);
+		ButtonRect.x = ButtonPos.x;
+		ButtonRect.y = ButtonPos.y;
+	}
+
+	if(Result && Clicked)
+	{
+		if(m_BackButtonOp == EBackButtonOp::CLICKED && m_DispatchInputFunction)
+		{
+			IInput::CEvent Event;
+			Event.m_Key = KEY_ESCAPE;
+			Event.m_InputCount = 0;
+			Event.m_aText[0] = '\0';
+			Event.m_Flags = IInput::FLAG_PRESS;
+			m_DispatchInputFunction(Event);
+			Event.m_Flags = IInput::FLAG_RELEASE;
+			m_DispatchInputFunction(Event);
+		}
+		m_BackButtonOp = EBackButtonOp::NONE;
+	}
+	else if(Result && Abrupted)
+	{
+		m_BackButtonOp = EBackButtonOp::NONE;
+	}
+
+	m_BackButtonRect = ButtonRect;
+}
+
+void CUi::RenderBackButton()
+{
+	if(!g_Config.m_ClBackButton)
+		return;
+
+	MapScreen();
+
+	// Override hot/active claims made by UI rendered between DoBackButton and RenderBackButton.
+	if(m_BackButtonOp != EBackButtonOp::NONE)
+		SetActiveItem(&m_BackButtonId);
+	else if(MouseHovered(&m_BackButtonRect) && !MouseButton(0) && !MouseButton(1) && !MouseButton(2))
+		SetHotItem(&m_BackButtonId);
+
+	const bool Pressed = m_BackButtonOp != EBackButtonOp::NONE;
+	const bool Hovered = !Pressed && HotItem() == &m_BackButtonId;
+	const float Alpha = Pressed ? 0.9f : (Hovered ? 0.35f : 0.5f);
+	m_BackButtonRect.Draw({0.0f, 0.0f, 0.0f, Alpha}, IGraphics::CORNER_ALL, 12.0f);
+
+	TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
+	TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH |
+				     ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING |
+				     ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING);
+	DoLabel(&m_BackButtonRect, FontIcon::CHEVRON_LEFT, m_BackButtonRect.w * 0.5f, TEXTALIGN_MC);
+	TextRender()->SetRenderFlags(0);
+	TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
+}
+
 void CUi::DoPopupMenu(const SPopupMenuId *pId, float X, float Y, float Width, float Height, void *pContext, FPopupMenuFunction pfnFunc, const SPopupMenuProperties &Props)
 {
 	constexpr float Margin = SPopupMenu::POPUP_BORDER + SPopupMenu::POPUP_MARGIN;

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -413,6 +413,21 @@ private:
 
 	unsigned m_HotkeysPressed = 0;
 
+	enum class EBackButtonOp
+	{
+		NONE,
+		CLICKED,
+		DRAGGING,
+	};
+	EBackButtonOp m_BackButtonOp = EBackButtonOp::NONE;
+	vec2 m_BackButtonDragOffset = vec2(0.0f, 0.0f);
+	vec2 m_BackButtonInitialMouse = vec2(0.0f, 0.0f);
+	CUIRect m_BackButtonRect = {0.0f, 0.0f, 0.0f, 0.0f};
+	char m_BackButtonId = 0;
+
+	std::function<void(const IInput::CEvent &Event)> m_pfnDispatchInput;
+	std::function<void()> m_pfnOnBackButtonPressed;
+
 	CUIRect m_Screen;
 
 	std::vector<CUIRect> m_vClips;
@@ -676,6 +691,13 @@ public:
 
 	// progress spinner
 	void RenderProgressSpinner(vec2 Center, float OuterRadius, const SProgressSpinnerProperties &Props = {}) const;
+
+	// virtual back button
+	void DoBackButton();
+	void RenderBackButton();
+	void SetDispatchInputCallback(std::function<void(const IInput::CEvent &Event)> pfnCallback) { m_pfnDispatchInput = std::move(pfnCallback); }
+	// Fired the moment the back button transitions to active (mouse-down inside it).
+	void SetOnBackButtonPressedCallback(std::function<void()> pfnCallback) { m_pfnOnBackButtonPressed = std::move(pfnCallback); }
 
 	// popup menu
 	void DoPopupMenu(const SPopupMenuId *pId, float X, float Y, float Width, float Height, void *pContext, FPopupMenuFunction pfnFunc, const SPopupMenuProperties &Props = {});

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -412,6 +412,21 @@ private:
 
 	unsigned m_HotkeysPressed = 0;
 
+	enum class EBackButtonOp
+	{
+		NONE,
+		CLICKED,
+		DRAGGING,
+	};
+	EBackButtonOp m_BackButtonOp = EBackButtonOp::NONE;
+	vec2 m_BackButtonDragOffset = vec2(0.0f, 0.0f);
+	vec2 m_BackButtonInitialMouse = vec2(0.0f, 0.0f);
+	CUIRect m_BackButtonRect = {0.0f, 0.0f, 0.0f, 0.0f};
+	const char m_BackButtonId = 0;
+
+	std::function<void(const IInput::CEvent &Event)> m_DispatchInputFunction;
+	std::function<void()> m_OnBackButtonPressedFunction;
+
 	CUIRect m_Screen;
 
 	std::vector<CUIRect> m_vClips;
@@ -672,6 +687,13 @@ public:
 
 	// progress spinner
 	void RenderProgressSpinner(vec2 Center, float OuterRadius, const SProgressSpinnerProperties &Props = {}) const;
+
+	// virtual back button
+	void DoBackButton();
+	void RenderBackButton();
+	void SetDispatchInputCallback(std::function<void(const IInput::CEvent &Event)> pfnCallback) { m_DispatchInputFunction = std::move(pfnCallback); }
+	// Fired the moment the back button transitions to active (mouse-down inside it).
+	void SetOnBackButtonPressedCallback(std::function<void()> pfnCallback) { m_OnBackButtonPressedFunction = std::move(pfnCallback); }
 
 	// popup menu
 	void DoPopupMenu(const SPopupMenuId *pId, float X, float Y, float Width, float Height, void *pContext, FPopupMenuFunction pfnFunc, const SPopupMenuProperties &Props = {});

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6608,6 +6608,7 @@ void CEditor::Render()
 	if(m_GuiActive)
 		RenderTooltip(TooltipRect);
 
+	Ui()->RenderBackButton();
 	RenderMousePointer();
 }
 
@@ -7070,6 +7071,14 @@ void CEditor::Init()
 	m_UI.SetPopupMenuClosedCallback([this]() {
 		m_PopupEventWasActivated = false;
 	});
+	m_UI.SetDispatchInputCallback([this](const IInput::CEvent &Event) {
+		for(CEditorComponent &Component : m_vComponents)
+		{
+			if(Component.OnInput(Event) && (Event.m_Flags & ~IInput::FLAG_RELEASE) != 0)
+				return;
+		}
+		m_UI.OnInput(Event);
+	});
 	m_RenderMap.Init(m_pGraphics, m_pTextRender);
 	m_ZoomEnvelopeX.OnInit(this);
 	m_ZoomEnvelopeY.OnInit(this);
@@ -7379,6 +7388,8 @@ void CEditor::OnRender()
 	Ui()->StartCheck();
 
 	Ui()->Update(m_MouseWorldPos);
+
+	Ui()->DoBackButton();
 
 	Render();
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4121,6 +4121,7 @@ void CEditor::Render()
 	if(m_GuiActive)
 		RenderTooltip(TooltipRect);
 
+	Ui()->RenderBackButton();
 	RenderMousePointer();
 }
 
@@ -4614,6 +4615,9 @@ void CEditor::Init()
 	m_UI.SetPopupMenuClosedCallback([this]() {
 		m_PopupEventWasActivated = false;
 	});
+	m_UI.SetDispatchInputCallback([this](const IInput::CEvent &Event) {
+		OnInput(Event);
+	});
 	m_RenderMap.Init(m_pGraphics, m_pTextRender);
 	m_ZoomEnvelopeX.OnInit(this);
 	m_ZoomEnvelopeY.OnInit(this);
@@ -4779,26 +4783,7 @@ void CEditor::OnUpdate()
 
 	// handle key presses
 	Input()->ConsumeEvents([&](const IInput::CEvent &Event) {
-		if(m_Dialog == DIALOG_NONE &&
-			CLineInput::GetActiveInput() == nullptr &&
-			Event.m_Key == KEY_F1)
-		{
-			if((Event.m_Flags & IInput::FLAG_PRESS) != 0 &&
-				(Event.m_Flags & IInput::FLAG_REPEAT) == 0)
-			{
-				m_QuickActionShowHelp.Call();
-			}
-			return;
-		}
-
-		for(CEditorComponent &Component : m_vComponents)
-		{
-			// Events with flag `FLAG_RELEASE` must always be forwarded to all components so keys being
-			// released can be handled in all components also after some components have been disabled.
-			if(Component.OnInput(Event) && (Event.m_Flags & ~IInput::FLAG_RELEASE) != 0)
-				return;
-		}
-		Ui()->OnInput(Event);
+		OnInput(Event);
 	});
 
 	MapView()->UpdateMouseWorld();
@@ -4808,6 +4793,27 @@ void CEditor::OnUpdate()
 
 	for(CEditorComponent &Component : m_vComponents)
 		Component.OnUpdate();
+}
+
+void CEditor::OnInput(const IInput::CEvent &Event)
+{
+	if(m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && Event.m_Key == KEY_F1)
+	{
+		if((Event.m_Flags & IInput::FLAG_PRESS) != 0 && (Event.m_Flags & IInput::FLAG_REPEAT) == 0)
+		{
+			m_QuickActionShowHelp.Call();
+		}
+		return;
+	}
+
+	for(CEditorComponent &Component : m_vComponents)
+	{
+		// Events with flag `FLAG_RELEASE` must always be forwarded to all components so keys being
+		// released can be handled in all components also after some components have been disabled.
+		if(Component.OnInput(Event) && (Event.m_Flags & ~IInput::FLAG_RELEASE) != 0)
+			return;
+	}
+	Ui()->OnInput(Event);
 }
 
 void CEditor::OnRender()
@@ -4830,6 +4836,8 @@ void CEditor::OnRender()
 	Ui()->StartCheck();
 
 	Ui()->Update();
+
+	Ui()->DoBackButton();
 
 	Render();
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -281,6 +281,7 @@ public:
 	void ResetIngameMoved() override { m_IngameMoved = false; }
 
 	void HandleCursorMovement();
+	void OnInput(const IInput::CEvent &Event);
 	void MouseAxisLock(vec2 &CursorRel);
 	vec2 m_MouseAxisInitialPos = vec2(0.0f, 0.0f);
 	enum class EAxisLock


### PR DESCRIPTION
Part of #11935.
<img width="2772" height="1240" alt="Screenshot_2026-04-22-01-58-43-56_39a5dfb0fae685d" src="https://github.com/user-attachments/assets/fd3f1b47-7cdb-48f9-bafe-762c415c14f9" />

- Tap on it will add an `esc` key press event for one frame and an `esc` key release event the next frame
- Long press on it will move the button with your finger
- Enable with `cl_touch_controls 1; cl_touch_back_button 1`. Its top left coordinate is stored as config variables `cl_touch_back_button_x` and `cl_touch_back_button_y`, 0-10000 mapping to relative position 0-1 on screen

Tested the android apk in workflow and iOS application in my other branch

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
AI coded most, I tested and reviewed and coded smaller portion when my free tokens are used up...