### PR TITLE
browser: fold string fields into search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2390,6 +2390,7 @@ if(CLIENT)
     notifications.h
     serverbrowser.cpp
     serverbrowser.h
+    serverbrowser_filter.h
     serverbrowser_http.cpp
     serverbrowser_http.h
     serverbrowser_ping_cache.cpp
@@ -3162,6 +3163,7 @@ if((GTEST_FOUND OR DOWNLOAD_GTEST) AND SERVER)
     src/engine/client/blocklist_driver.h
     src/engine/client/serverbrowser.cpp
     src/engine/client/serverbrowser.h
+    src/engine/client/serverbrowser_filter.h
     src/engine/client/serverbrowser_http.cpp
     src/engine/client/serverbrowser_http.h
     src/engine/client/serverbrowser_ping_cache.cpp

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4583,10 +4583,7 @@ void CClient::RegisterCommands()
 	m_pConsole->Chain("br_filter_country", ConchainServerBrowserUpdate, this);
 	m_pConsole->Chain("br_filter_country_index", ConchainServerBrowserUpdate, this);
 	m_pConsole->Chain("br_filter_pw", ConchainServerBrowserUpdate, this);
-	m_pConsole->Chain("br_filter_gametype", ConchainServerBrowserUpdate, this);
-	m_pConsole->Chain("br_filter_gametype_strict", ConchainServerBrowserUpdate, this);
 	m_pConsole->Chain("br_filter_connecting_players", ConchainServerBrowserUpdate, this);
-	m_pConsole->Chain("br_filter_serveraddress", ConchainServerBrowserUpdate, this);
 	m_pConsole->Chain("br_filter_unfinished_map", ConchainServerBrowserUpdate, this);
 	m_pConsole->Chain("br_filter_login", ConchainServerBrowserUpdate, this);
 	m_pConsole->Chain("add_favorite", ConchainServerBrowserUpdate, this);

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -456,12 +456,6 @@ void CServerBrowser::Filter()
 			Filtered = true;
 		else if(g_Config.m_BrFilterPw && Info.m_Flags & SERVER_FLAG_PASSWORD)
 			Filtered = true;
-		else if(g_Config.m_BrFilterServerAddress[0] && !str_find_nocase(Info.m_aAddress, g_Config.m_BrFilterServerAddress))
-			Filtered = true;
-		else if(g_Config.m_BrFilterGametypeStrict && g_Config.m_BrFilterGametype[0] && str_comp_nocase(Info.m_aGameType, g_Config.m_BrFilterGametype))
-			Filtered = true;
-		else if(!g_Config.m_BrFilterGametypeStrict && g_Config.m_BrFilterGametype[0] && !str_utf8_find_nocase(Info.m_aGameType, g_Config.m_BrFilterGametype))
-			Filtered = true;
 		else if(g_Config.m_BrFilterUnfinishedMap && Info.m_HasRank == CServerInfo::RANK_RANKED)
 			Filtered = true;
 		else if(g_Config.m_BrFilterLogin && Info.m_RequiresLogin)
@@ -547,6 +541,18 @@ void CServerBrowser::Filter()
 					if(MatchesFn(Info.m_aMap, aFilterStrTrimmed))
 					{
 						Info.m_QuickSearchHit |= IServerBrowser::QUICK_MAPNAME;
+					}
+
+					// match against game type
+					if(MatchesFn(Info.m_aGameType, aFilterStrTrimmed))
+					{
+						Info.m_QuickSearchHit |= IServerBrowser::QUICK_GAMETYPE;
+					}
+
+					// match against server address
+					if(MatchesFn(Info.m_aAddress, aFilterStrTrimmed))
+					{
+						Info.m_QuickSearchHit |= IServerBrowser::QUICK_ADDRESS;
 					}
 				}
 
@@ -637,7 +643,6 @@ int CServerBrowser::SortHash() const
 	i |= g_Config.m_BrFilterFriends << 7;
 	i |= g_Config.m_BrFilterPw << 8;
 	i |= g_Config.m_BrSortOrder << 9;
-	i |= g_Config.m_BrFilterGametypeStrict << 12;
 	i |= g_Config.m_BrFilterUnfinishedMap << 13;
 	i |= g_Config.m_BrFilterCountry << 14;
 	i |= g_Config.m_BrFilterConnectingPlayers << 15;

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -2,6 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "serverbrowser.h"
 
+#include "serverbrowser_filter.h"
 #include "serverbrowser_http.h"
 #include "serverbrowser_ping_cache.h"
 
@@ -44,14 +45,76 @@ public:
 	bool operator()(int a, int b) { return (g_Config.m_BrSortOrder ? (m_pThis->*m_pfnSort)(b, a) : (m_pThis->*m_pfnSort)(a, b)); }
 };
 
-static bool MatchesPart(const char *a, const char *b)
+serverbrowser_filter::SFilterToken serverbrowser_filter::ParseFilterToken(char *pToken)
 {
-	return str_utf8_find_nocase(a, b) != nullptr;
+	static const struct
+	{
+		const char *m_pPrefix;
+		EFilterField m_Field;
+	} s_aKeys[] = {
+		{"map:", EFilterField::MAP},
+		{"type:", EFilterField::TYPE},
+		{"addr:", EFilterField::ADDR},
+		{"name:", EFilterField::NAME},
+		{"player:", EFilterField::PLAYER},
+	};
+
+	SFilterToken Result;
+	Result.m_Field = EFilterField::ALL;
+	Result.m_Exact = false;
+
+	for(const auto &Key : s_aKeys)
+	{
+		const int PrefixLen = str_length(Key.m_pPrefix);
+		if(str_comp_nocase_num(pToken, Key.m_pPrefix, PrefixLen) == 0)
+		{
+			Result.m_Field = Key.m_Field;
+			pToken += PrefixLen;
+			break;
+		}
+	}
+
+	const int Len = str_length(pToken);
+	if(Len >= 2 && pToken[0] == '"' && pToken[Len - 1] == '"')
+	{
+		pToken[Len - 1] = '\0';
+		pToken += 1;
+		Result.m_Exact = true;
+	}
+
+	Result.m_pValue = pToken;
+	return Result;
 }
 
-static bool MatchesExactly(const char *a, const char *b)
+const char *serverbrowser_filter::NextWhitespaceToken(const char *pStr, char *pBuffer, int BufferSize)
 {
-	return str_comp(a, &b[1]) == 0;
+	pStr = str_utf8_skip_whitespaces(pStr);
+	if(*pStr == '\0')
+		return nullptr;
+
+	char *pOut = pBuffer;
+	char *pEnd = pBuffer + BufferSize - 1;
+	bool InQuotes = false;
+	while(*pStr != '\0' && pOut < pEnd)
+	{
+		const char *pNext = pStr;
+		const int Code = str_utf8_decode(&pNext);
+		if(!InQuotes && str_utf8_isspace(Code))
+			break;
+		if(Code == '"')
+			InQuotes = !InQuotes;
+		while(pStr < pNext && pOut < pEnd)
+			*pOut++ = *pStr++;
+	}
+	*pOut = '\0';
+	return pStr;
+}
+
+bool serverbrowser_filter::TokenMatches(const char *pField, const SFilterToken &Token)
+{
+	if(Token.m_Exact)
+		return str_comp(pField, Token.m_pValue) == 0;
+	return str_utf8_find_nocase(pField, Token.m_pValue) != nullptr;
 }
 
 static NETADDR CommunityAddressKey(const NETADDR &Addr)
@@ -494,114 +557,119 @@ void CServerBrowser::Filter()
 			{
 				Info.m_QuickSearchHit = 0;
 
-				const char *pStr = g_Config.m_BrFilterString;
-				char aFilterStr[sizeof(g_Config.m_BrFilterString)];
-				char aFilterStrTrimmed[sizeof(g_Config.m_BrFilterString)];
-				while((pStr = str_next_token(pStr, IServerBrowser::SEARCH_EXCLUDE_TOKEN, aFilterStr, sizeof(aFilterStr))))
-				{
-					str_copy(aFilterStrTrimmed, str_utf8_skip_whitespaces(aFilterStr));
-					str_utf8_trim_right(aFilterStrTrimmed);
-
-					if(aFilterStrTrimmed[0] == '\0')
+				// match fields <-> token & set QUICK bits
+				auto SearchTokenHits = [&Info](const serverbrowser_filter::SFilterToken &Token) -> int {
+					int Hits = 0;
+					if((Token.m_Field == serverbrowser_filter::EFilterField::ALL || Token.m_Field == serverbrowser_filter::EFilterField::NAME) && serverbrowser_filter::TokenMatches(Info.m_aName, Token))
+						Hits |= IServerBrowser::QUICK_SERVERNAME;
+					if(Token.m_Field == serverbrowser_filter::EFilterField::ALL || Token.m_Field == serverbrowser_filter::EFilterField::PLAYER)
 					{
-						continue;
-					}
-					auto MatchesFn = MatchesPart;
-					const int FilterLen = str_length(aFilterStrTrimmed);
-					if(aFilterStrTrimmed[0] == '"' && aFilterStrTrimmed[FilterLen - 1] == '"')
-					{
-						aFilterStrTrimmed[FilterLen - 1] = '\0';
-						MatchesFn = MatchesExactly;
-					}
-
-					// match against server name
-					if(MatchesFn(Info.m_aName, aFilterStrTrimmed))
-					{
-						Info.m_QuickSearchHit |= IServerBrowser::QUICK_SERVERNAME;
-					}
-
-					// match against players
-					for(int p = 0; p < minimum(Info.m_NumClients, (int)MAX_CLIENTS); p++)
-					{
-						if(MatchesFn(Info.m_aClients[p].m_aName, aFilterStrTrimmed) ||
-							MatchesFn(Info.m_aClients[p].m_aClan, aFilterStrTrimmed))
+						for(int p = 0; p < minimum(Info.m_NumClients, (int)MAX_CLIENTS); p++)
 						{
-							if(g_Config.m_BrFilterConnectingPlayers &&
-								str_comp(Info.m_aClients[p].m_aName, "(connecting)") == 0 &&
-								Info.m_aClients[p].m_aClan[0] == '\0')
+							if(serverbrowser_filter::TokenMatches(Info.m_aClients[p].m_aName, Token) ||
+								serverbrowser_filter::TokenMatches(Info.m_aClients[p].m_aClan, Token))
 							{
-								continue;
+								if(g_Config.m_BrFilterConnectingPlayers &&
+									str_comp(Info.m_aClients[p].m_aName, "(connecting)") == 0 &&
+									Info.m_aClients[p].m_aClan[0] == '\0')
+								{
+									continue;
+								}
+								Hits |= IServerBrowser::QUICK_PLAYER;
+								break;
 							}
-							Info.m_QuickSearchHit |= IServerBrowser::QUICK_PLAYER;
-							break;
 						}
 					}
+					if((Token.m_Field == serverbrowser_filter::EFilterField::ALL || Token.m_Field == serverbrowser_filter::EFilterField::MAP) && serverbrowser_filter::TokenMatches(Info.m_aMap, Token))
+						Hits |= IServerBrowser::QUICK_MAPNAME;
+					if((Token.m_Field == serverbrowser_filter::EFilterField::ALL || Token.m_Field == serverbrowser_filter::EFilterField::TYPE) && serverbrowser_filter::TokenMatches(Info.m_aGameType, Token))
+						Hits |= IServerBrowser::QUICK_GAMETYPE;
+					if((Token.m_Field == serverbrowser_filter::EFilterField::ALL || Token.m_Field == serverbrowser_filter::EFilterField::ADDR) && serverbrowser_filter::TokenMatches(Info.m_aAddress, Token))
+						Hits |= IServerBrowser::QUICK_ADDRESS;
+					return Hits;
+				};
 
-					// match against map
-					if(MatchesFn(Info.m_aMap, aFilterStrTrimmed))
+				bool AnyGroupMatched = false;
+				const char *pStr = g_Config.m_BrFilterString;
+				char aGroup[sizeof(g_Config.m_BrFilterString)];
+				while((pStr = str_next_token(pStr, IServerBrowser::SEARCH_EXCLUDE_TOKEN, aGroup, sizeof(aGroup))))
+				{
+					const char *pGroupCursor = aGroup;
+					char aTokenBuf[sizeof(g_Config.m_BrFilterString)];
+					bool GroupMatched = true;
+					bool GroupHasToken = false;
+					int GroupHits = 0;
+					while((pGroupCursor = serverbrowser_filter::NextWhitespaceToken(pGroupCursor, aTokenBuf, sizeof(aTokenBuf))))
 					{
-						Info.m_QuickSearchHit |= IServerBrowser::QUICK_MAPNAME;
+						const serverbrowser_filter::SFilterToken Token = serverbrowser_filter::ParseFilterToken(aTokenBuf);
+						if(Token.m_pValue[0] == '\0')
+							continue;
+						GroupHasToken = true;
+						const int TokenHits = SearchTokenHits(Token);
+						if(!TokenHits)
+						{
+							GroupMatched = false;
+							break;
+						}
+						GroupHits |= TokenHits;
 					}
-
-					// match against game type
-					if(MatchesFn(Info.m_aGameType, aFilterStrTrimmed))
+					if(GroupHasToken && GroupMatched)
 					{
-						Info.m_QuickSearchHit |= IServerBrowser::QUICK_GAMETYPE;
-					}
-
-					// match against server address
-					if(MatchesFn(Info.m_aAddress, aFilterStrTrimmed))
-					{
-						Info.m_QuickSearchHit |= IServerBrowser::QUICK_ADDRESS;
+						AnyGroupMatched = true;
+						Info.m_QuickSearchHit |= GroupHits;
 					}
 				}
 
-				if(!Info.m_QuickSearchHit)
+				if(!AnyGroupMatched)
 					Filtered = true;
 			}
 
 			if(!Filtered && g_Config.m_BrExcludeString[0] != '\0')
 			{
+				// unscoped exclude tokens only consider name/map/type
+				auto ExcludeTokenMatches = [&Info](const serverbrowser_filter::SFilterToken &Token) -> bool {
+					if((Token.m_Field == serverbrowser_filter::EFilterField::ALL || Token.m_Field == serverbrowser_filter::EFilterField::NAME) && serverbrowser_filter::TokenMatches(Info.m_aName, Token))
+						return true;
+					if((Token.m_Field == serverbrowser_filter::EFilterField::ALL || Token.m_Field == serverbrowser_filter::EFilterField::MAP) && serverbrowser_filter::TokenMatches(Info.m_aMap, Token))
+						return true;
+					if((Token.m_Field == serverbrowser_filter::EFilterField::ALL || Token.m_Field == serverbrowser_filter::EFilterField::TYPE) && serverbrowser_filter::TokenMatches(Info.m_aGameType, Token))
+						return true;
+					if(Token.m_Field == serverbrowser_filter::EFilterField::ADDR && serverbrowser_filter::TokenMatches(Info.m_aAddress, Token))
+						return true;
+					if(Token.m_Field == serverbrowser_filter::EFilterField::PLAYER)
+					{
+						for(int p = 0; p < minimum(Info.m_NumClients, (int)MAX_CLIENTS); p++)
+						{
+							if(serverbrowser_filter::TokenMatches(Info.m_aClients[p].m_aName, Token) ||
+								serverbrowser_filter::TokenMatches(Info.m_aClients[p].m_aClan, Token))
+								return true;
+						}
+					}
+					return false;
+				};
+
 				const char *pStr = g_Config.m_BrExcludeString;
-				char aExcludeStr[sizeof(g_Config.m_BrExcludeString)];
-				char aExcludeStrTrimmed[sizeof(g_Config.m_BrExcludeString)];
-				while((pStr = str_next_token(pStr, IServerBrowser::SEARCH_EXCLUDE_TOKEN, aExcludeStr, sizeof(aExcludeStr))))
+				char aGroup[sizeof(g_Config.m_BrExcludeString)];
+				while(!Filtered && (pStr = str_next_token(pStr, IServerBrowser::SEARCH_EXCLUDE_TOKEN, aGroup, sizeof(aGroup))))
 				{
-					str_copy(aExcludeStrTrimmed, str_utf8_skip_whitespaces(aExcludeStr));
-					str_utf8_trim_right(aExcludeStrTrimmed);
-
-					if(aExcludeStrTrimmed[0] == '\0')
+					const char *pGroupCursor = aGroup;
+					char aTokenBuf[sizeof(g_Config.m_BrExcludeString)];
+					bool GroupMatched = true;
+					bool GroupHasToken = false;
+					while((pGroupCursor = serverbrowser_filter::NextWhitespaceToken(pGroupCursor, aTokenBuf, sizeof(aTokenBuf))))
 					{
-						continue;
+						const serverbrowser_filter::SFilterToken Token = serverbrowser_filter::ParseFilterToken(aTokenBuf);
+						if(Token.m_pValue[0] == '\0')
+							continue;
+						GroupHasToken = true;
+						if(!ExcludeTokenMatches(Token))
+						{
+							GroupMatched = false;
+							break;
+						}
 					}
-					auto MatchesFn = MatchesPart;
-					const int FilterLen = str_length(aExcludeStrTrimmed);
-					if(aExcludeStrTrimmed[0] == '"' && aExcludeStrTrimmed[FilterLen - 1] == '"')
-					{
-						aExcludeStrTrimmed[FilterLen - 1] = '\0';
-						MatchesFn = MatchesExactly;
-					}
-
-					// match against server name
-					if(MatchesFn(Info.m_aName, aExcludeStrTrimmed))
-					{
+					if(GroupHasToken && GroupMatched)
 						Filtered = true;
-						break;
-					}
-
-					// match against map
-					if(MatchesFn(Info.m_aMap, aExcludeStrTrimmed))
-					{
-						Filtered = true;
-						break;
-					}
-
-					// match against gametype
-					if(MatchesFn(Info.m_aGameType, aExcludeStrTrimmed))
-					{
-						Filtered = true;
-						break;
-					}
 				}
 			}
 		}

--- a/src/engine/client/serverbrowser_filter.h
+++ b/src/engine/client/serverbrowser_filter.h
@@ -1,0 +1,36 @@
+#ifndef ENGINE_CLIENT_SERVERBROWSER_FILTER_H
+#define ENGINE_CLIENT_SERVERBROWSER_FILTER_H
+
+namespace serverbrowser_filter
+{
+
+	enum class EFilterField
+	{
+		ALL,
+		NAME,
+		PLAYER,
+		MAP,
+		TYPE,
+		ADDR,
+	};
+
+	struct SFilterToken
+	{
+		EFilterField m_Field;
+		const char *m_pValue;
+		bool m_Exact;
+	};
+
+	// Parses a single trimmed filter token. Recognizes a closed set of `key:`
+	// mutates pToken.
+	SFilterToken ParseFilterToken(char *pToken);
+
+	// Reads the next whitespace-separated token from pStr, respescting double quotes
+	// Returns the position past the token, or nullptr when no token remains.
+	const char *NextWhitespaceToken(const char *pStr, char *pBuffer, int BufferSize);
+
+	bool TokenMatches(const char *pField, const SFilterToken &Token);
+
+}
+
+#endif

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -300,6 +300,8 @@ public:
 		QUICK_SERVERNAME = 1,
 		QUICK_PLAYER = 2,
 		QUICK_MAPNAME = 4,
+		QUICK_GAMETYPE = 8,
+		QUICK_ADDRESS = 16,
 	};
 
 	enum

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -364,10 +364,7 @@ MACRO_CONFIG_INT(BrFilterFriends, br_filter_friends, 0, 0, 1, CFGFLAG_SAVE | CFG
 MACRO_CONFIG_INT(BrFilterCountry, br_filter_country, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Filter out servers with non-matching player country (ISO 3166-1 numeric)")
 MACRO_CONFIG_INT(BrFilterCountryIndex, br_filter_country_index, -1, -1, 999, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Player country to filter by in the server browser (ISO 3166-1 numeric)")
 MACRO_CONFIG_INT(BrFilterPw, br_filter_pw, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Filter out password protected servers in browser")
-MACRO_CONFIG_STR(BrFilterGametype, br_filter_gametype, 128, "", CFGFLAG_SAVE | CFGFLAG_CLIENT, "Game types to filter")
-MACRO_CONFIG_INT(BrFilterGametypeStrict, br_filter_gametype_strict, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Strict gametype filter")
 MACRO_CONFIG_INT(BrFilterConnectingPlayers, br_filter_connecting_players, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Filter connecting players")
-MACRO_CONFIG_STR(BrFilterServerAddress, br_filter_serveraddress, 128, "", CFGFLAG_SAVE | CFGFLAG_CLIENT, "Server address to filter")
 MACRO_CONFIG_INT(BrFilterUnfinishedMap, br_filter_unfinished_map, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show only servers with unfinished maps")
 MACRO_CONFIG_INT(BrFilterLogin, br_filter_login, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Filter out servers that require login")
 

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -672,7 +672,6 @@ void CMenus::PopupConfirmSwitchServer()
 void CMenus::RenderServerbrowserFilters(CUIRect View)
 {
 	const float RowHeight = 18.0f;
-	const float FontSize = (RowHeight - 4.0f) * CUi::ms_FontmodHeight; // based on DoButton_CheckBox
 
 	View.Margin(5.0f, &View);
 
@@ -703,28 +702,6 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 	View.HSplitTop(RowHeight, &Button, &View);
 	if(DoButton_CheckBox(&g_Config.m_BrFilterLogin, Localize("No login required"), g_Config.m_BrFilterLogin, &Button))
 		g_Config.m_BrFilterLogin ^= 1;
-
-	View.HSplitTop(RowHeight, &Button, &View);
-	if(DoButton_CheckBox(&g_Config.m_BrFilterGametypeStrict, Localize("Strict gametype filter"), g_Config.m_BrFilterGametypeStrict, &Button))
-		g_Config.m_BrFilterGametypeStrict ^= 1;
-
-	View.HSplitTop(3.0f, nullptr, &View);
-	View.HSplitTop(RowHeight, &Button, &View);
-	Ui()->DoLabel(&Button, Localize("Game types:"), FontSize, TEXTALIGN_ML);
-	Button.VSplitRight(60.0f, nullptr, &Button);
-	static CLineInput s_GametypeInput(g_Config.m_BrFilterGametype, sizeof(g_Config.m_BrFilterGametype));
-	if(Ui()->DoEditBox(&s_GametypeInput, &Button, FontSize))
-		Client()->ServerBrowserUpdate();
-
-	// server address
-	View.HSplitTop(6.0f, nullptr, &View);
-	View.HSplitTop(RowHeight, &Button, &View);
-	View.HSplitTop(6.0f, nullptr, &View);
-	Ui()->DoLabel(&Button, Localize("Server address:"), FontSize, TEXTALIGN_ML);
-	Button.VSplitRight(60.0f, nullptr, &Button);
-	static CLineInput s_FilterServerAddressInput(g_Config.m_BrFilterServerAddress, sizeof(g_Config.m_BrFilterServerAddress));
-	if(Ui()->DoEditBox(&s_FilterServerAddressInput, &Button, FontSize))
-		Client()->ServerBrowserUpdate();
 
 	// player country
 	{
@@ -837,10 +814,7 @@ void CMenus::ResetServerbrowserFilters()
 	g_Config.m_BrFilterCountry = 0;
 	g_Config.m_BrFilterCountryIndex = -1;
 	g_Config.m_BrFilterPw = 0;
-	g_Config.m_BrFilterGametype[0] = '\0';
-	g_Config.m_BrFilterGametypeStrict = 0;
 	g_Config.m_BrFilterConnectingPlayers = 1;
-	g_Config.m_BrFilterServerAddress[0] = '\0';
 	g_Config.m_BrFilterLogin = true;
 
 	if(g_Config.m_UiPage != PAGE_LAN)

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -24,6 +24,57 @@
 #include <game/localization.h>
 
 static constexpr ColorRGBA HIGHLIGHTED_TEXT_COLOR = ColorRGBA(0.4f, 0.4f, 1.0f, 1.0f);
+static constexpr ColorRGBA FILTERED_TEXT_COLOR = ColorRGBA(0.8f, 0.9f, 1.0f, 1.0f);
+
+static std::vector<STextColorSplit> BuildFilterColorSplits(const char *pStr)
+{
+	static const char *const s_apKeys[] = {"map:", "type:", "addr:", "name:", "player:"};
+
+	std::vector<STextColorSplit> Splits;
+	const char *pCursor = pStr;
+	while(*pCursor != '\0')
+	{
+		// Skip separators
+		while(*pCursor != '\0')
+		{
+			const char *pNext = pCursor;
+			const int Code = str_utf8_decode(&pNext);
+			if(Code != ';' && !str_utf8_isspace(Code))
+				break;
+			pCursor = pNext;
+		}
+		if(*pCursor == '\0')
+			break;
+
+		// check a single token
+		const char *pTokenStart = pCursor;
+		bool InQuotes = false;
+		while(*pCursor != '\0')
+		{
+			const char *pNext = pCursor;
+			const int Code = str_utf8_decode(&pNext);
+			if(!InQuotes && (Code == ';' || str_utf8_isspace(Code)))
+				break;
+			if(Code == '"')
+				InQuotes = !InQuotes;
+			pCursor = pNext;
+		}
+		const int TokenLen = (int)(pCursor - pTokenStart);
+
+		for(const char *pKey : s_apKeys)
+		{
+			const int KeyLen = str_length(pKey);
+			if(TokenLen > KeyLen && str_comp_nocase_num(pTokenStart, pKey, KeyLen) == 0)
+			{
+				const int TokenOffset = (int)(pTokenStart - pStr);
+				Splits.emplace_back(TokenOffset, KeyLen, HIGHLIGHTED_TEXT_COLOR);
+				Splits.emplace_back(TokenOffset + KeyLen, TokenLen - KeyLen, FILTERED_TEXT_COLOR);
+				break;
+			}
+		}
+	}
+	return Splits;
+}
 
 static ColorRGBA PlayerBackgroundColor(bool Friend, bool Clan, bool Afk, bool InSelectedServer, bool Inside)
 {
@@ -509,8 +560,7 @@ void CMenus::RenderServerbrowserStatusBox(CUIRect StatusBox, bool WasListboxItem
 
 	CUIRect SearchInfoAndAddr, ServersAndConnect, ServersPlayersOnline, SearchAndInfo, ServerAddr, ConnectButtons;
 	StatusBox.VSplitRight(135.0f, &SearchInfoAndAddr, &ServersAndConnect);
-	if(SearchInfoAndAddr.w > 350.0f)
-		SearchInfoAndAddr.VSplitLeft(350.0f, &SearchInfoAndAddr, nullptr);
+	SearchInfoAndAddr.VSplitRight(maximum(0.0f, (SearchInfoAndAddr.w - 365.0f) * 0.4f), &SearchInfoAndAddr, nullptr);
 	SearchInfoAndAddr.HSplitTop(40.0f, &SearchAndInfo, &ServerAddr);
 	ServersAndConnect.HSplitTop(35.0f, &ServersPlayersOnline, &ConnectButtons);
 	ConnectButtons.HSplitTop(5.0f, nullptr, &ConnectButtons);
@@ -545,7 +595,7 @@ void CMenus::RenderServerbrowserStatusBox(CUIRect StatusBox, bool WasListboxItem
 			Ui()->SetActiveItem(&s_FilterInput);
 			s_FilterInput.SelectAll();
 		}
-		if(Ui()->DoClearableEditBox(&s_FilterInput, &QuickSearch, 12.0f))
+		if(Ui()->DoClearableEditBox(&s_FilterInput, &QuickSearch, 12.0f, IGraphics::CORNER_ALL, BuildFilterColorSplits(g_Config.m_BrFilterString)))
 			Client()->ServerBrowserUpdate();
 	}
 
@@ -574,7 +624,7 @@ void CMenus::RenderServerbrowserStatusBox(CUIRect StatusBox, bool WasListboxItem
 			Ui()->SetActiveItem(&s_ExcludeInput);
 			s_ExcludeInput.SelectAll();
 		}
-		if(Ui()->DoClearableEditBox(&s_ExcludeInput, &QuickExclude, 12.0f))
+		if(Ui()->DoClearableEditBox(&s_ExcludeInput, &QuickExclude, 12.0f, IGraphics::CORNER_ALL, BuildFilterColorSplits(g_Config.m_BrExcludeString)))
 			Client()->ServerBrowserUpdate();
 	}
 

--- a/src/test/serverbrowser_test.cpp
+++ b/src/test/serverbrowser_test.cpp
@@ -1,7 +1,9 @@
 #include "test.h"
 
 #include <base/net.h>
+#include <base/str.h>
 
+#include <engine/client/serverbrowser_filter.h>
 #include <engine/client/serverbrowser_ping_cache.h>
 #include <engine/console.h>
 #include <engine/engine.h>
@@ -10,6 +12,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstring>
 #include <memory>
 
 TEST(ServerBrowser, PingCache)
@@ -101,4 +104,422 @@ TEST(ServerBrowser, PingCache)
 	EXPECT_EQ(pPingCache->GetPing(aLocalhostBoth, 2), 345);
 	EXPECT_EQ(pPingCache->GetPing(&OtherLocalhost4, 1), 1337);
 	EXPECT_EQ(pPingCache->GetPing(&OtherLocalhost6, 1), 345);
+}
+
+using serverbrowser_filter::EFilterField;
+using serverbrowser_filter::NextWhitespaceToken;
+using serverbrowser_filter::ParseFilterToken;
+using serverbrowser_filter::SFilterToken;
+using serverbrowser_filter::TokenMatches;
+
+namespace
+{
+
+	// ParseFilterToken mutates its input, so wrap the common pattern of copying
+	// a literal into a fresh writable buffer before parsing.
+	SFilterToken ParseCopy(char *pBuffer, size_t BufferSize, const char *pInput)
+	{
+		str_copy(pBuffer, pInput, BufferSize);
+		return ParseFilterToken(pBuffer);
+	}
+
+} // namespace
+
+TEST(ServerBrowserFilter, ParseTokenPlain)
+{
+	char aBuf[64];
+	const SFilterToken Token = ParseCopy(aBuf, sizeof(aBuf), "hello");
+	EXPECT_EQ(Token.m_Field, EFilterField::ALL);
+	EXPECT_STREQ(Token.m_pValue, "hello");
+	EXPECT_FALSE(Token.m_Exact);
+}
+
+TEST(ServerBrowserFilter, ParseTokenEmpty)
+{
+	char aBuf[64] = "";
+	const SFilterToken Token = ParseFilterToken(aBuf);
+	EXPECT_EQ(Token.m_Field, EFilterField::ALL);
+	EXPECT_STREQ(Token.m_pValue, "");
+	EXPECT_FALSE(Token.m_Exact);
+}
+
+TEST(ServerBrowserFilter, ParseTokenKeys)
+{
+	struct
+	{
+		const char *m_pInput;
+		EFilterField m_ExpectedField;
+		const char *m_pExpectedValue;
+	} const s_aCases[] = {
+		{"map:foo", EFilterField::MAP, "foo"},
+		{"type:dm", EFilterField::TYPE, "dm"},
+		{"addr:127.0.0.1", EFilterField::ADDR, "127.0.0.1"},
+		{"name:bob", EFilterField::NAME, "bob"},
+		{"player:alice", EFilterField::PLAYER, "alice"},
+	};
+	for(const auto &Case : s_aCases)
+	{
+		char aBuf[64];
+		const SFilterToken Token = ParseCopy(aBuf, sizeof(aBuf), Case.m_pInput);
+		EXPECT_EQ(Token.m_Field, Case.m_ExpectedField) << Case.m_pInput;
+		EXPECT_STREQ(Token.m_pValue, Case.m_pExpectedValue) << Case.m_pInput;
+		EXPECT_FALSE(Token.m_Exact) << Case.m_pInput;
+	}
+}
+
+TEST(ServerBrowserFilter, ParseTokenKeyCaseInsensitive)
+{
+	char aBuf[64];
+	const SFilterToken Token = ParseCopy(aBuf, sizeof(aBuf), "MAP:foo");
+	EXPECT_EQ(Token.m_Field, EFilterField::MAP);
+	EXPECT_STREQ(Token.m_pValue, "foo");
+}
+
+TEST(ServerBrowserFilter, ParseTokenKeyEmptyValue)
+{
+	char aBuf[64];
+	const SFilterToken Token = ParseCopy(aBuf, sizeof(aBuf), "map:");
+	EXPECT_EQ(Token.m_Field, EFilterField::MAP);
+	EXPECT_STREQ(Token.m_pValue, "");
+	EXPECT_FALSE(Token.m_Exact);
+}
+
+TEST(ServerBrowserFilter, ParseTokenUnknownKeyIsLiteral)
+{
+	char aBuf[64];
+	const SFilterToken Token = ParseCopy(aBuf, sizeof(aBuf), "foo:bar");
+	EXPECT_EQ(Token.m_Field, EFilterField::ALL);
+	EXPECT_STREQ(Token.m_pValue, "foo:bar");
+}
+
+TEST(ServerBrowserFilter, ParseTokenColonOnly)
+{
+	char aBuf[64];
+	const SFilterToken Token = ParseCopy(aBuf, sizeof(aBuf), ":");
+	EXPECT_EQ(Token.m_Field, EFilterField::ALL);
+	EXPECT_STREQ(Token.m_pValue, ":");
+}
+
+TEST(ServerBrowserFilter, ParseTokenQuoted)
+{
+	char aBuf[64];
+	const SFilterToken Token = ParseCopy(aBuf, sizeof(aBuf), "\"hello\"");
+	EXPECT_EQ(Token.m_Field, EFilterField::ALL);
+	EXPECT_STREQ(Token.m_pValue, "hello");
+	EXPECT_TRUE(Token.m_Exact);
+}
+
+TEST(ServerBrowserFilter, ParseTokenEmptyQuoted)
+{
+	char aBuf[64];
+	const SFilterToken Token = ParseCopy(aBuf, sizeof(aBuf), "\"\"");
+	EXPECT_EQ(Token.m_Field, EFilterField::ALL);
+	EXPECT_STREQ(Token.m_pValue, "");
+	EXPECT_TRUE(Token.m_Exact);
+}
+
+TEST(ServerBrowserFilter, ParseTokenSingleQuote)
+{
+	// A single `"` is length 1 — too short to be a quoted exact token.
+	char aBuf[64];
+	const SFilterToken Token = ParseCopy(aBuf, sizeof(aBuf), "\"");
+	EXPECT_EQ(Token.m_Field, EFilterField::ALL);
+	EXPECT_STREQ(Token.m_pValue, "\"");
+	EXPECT_FALSE(Token.m_Exact);
+}
+
+TEST(ServerBrowserFilter, ParseTokenOpenQuoteOnly)
+{
+	// Leading quote but no trailing quote must NOT be treated as exact.
+	char aBuf[64];
+	const SFilterToken Token = ParseCopy(aBuf, sizeof(aBuf), "\"hello");
+	EXPECT_EQ(Token.m_Field, EFilterField::ALL);
+	EXPECT_STREQ(Token.m_pValue, "\"hello");
+	EXPECT_FALSE(Token.m_Exact);
+}
+
+TEST(ServerBrowserFilter, ParseTokenCloseQuoteOnly)
+{
+	char aBuf[64];
+	const SFilterToken Token = ParseCopy(aBuf, sizeof(aBuf), "hello\"");
+	EXPECT_EQ(Token.m_Field, EFilterField::ALL);
+	EXPECT_STREQ(Token.m_pValue, "hello\"");
+	EXPECT_FALSE(Token.m_Exact);
+}
+
+TEST(ServerBrowserFilter, ParseTokenKeyQuoted)
+{
+	char aBuf[64];
+	const SFilterToken Token = ParseCopy(aBuf, sizeof(aBuf), "name:\"John Doe\"");
+	EXPECT_EQ(Token.m_Field, EFilterField::NAME);
+	EXPECT_STREQ(Token.m_pValue, "John Doe");
+	EXPECT_TRUE(Token.m_Exact);
+}
+
+TEST(ServerBrowserFilter, ParseTokenKeyEmptyQuoted)
+{
+	char aBuf[64];
+	const SFilterToken Token = ParseCopy(aBuf, sizeof(aBuf), "map:\"\"");
+	EXPECT_EQ(Token.m_Field, EFilterField::MAP);
+	EXPECT_STREQ(Token.m_pValue, "");
+	EXPECT_TRUE(Token.m_Exact);
+}
+
+TEST(ServerBrowserFilter, ParseTokenKeyPrefixOnly)
+{
+	// Exactly `map:` — empty value, no quotes. The quote check requires
+	// Len >= 2, so this exercises the length guard.
+	char aBuf[64];
+	const SFilterToken Token = ParseCopy(aBuf, sizeof(aBuf), "map:");
+	EXPECT_EQ(Token.m_Field, EFilterField::MAP);
+	EXPECT_STREQ(Token.m_pValue, "");
+}
+
+TEST(ServerBrowserFilter, ParseTokenUtf8Value)
+{
+	char aBuf[64];
+	const SFilterToken Token = ParseCopy(aBuf, sizeof(aBuf), "name:\xf0\x9f\x98\x80");
+	EXPECT_EQ(Token.m_Field, EFilterField::NAME);
+	EXPECT_STREQ(Token.m_pValue, "\xf0\x9f\x98\x80");
+}
+
+TEST(ServerBrowserFilter, NextTokenEmpty)
+{
+	char aBuf[64];
+	EXPECT_EQ(NextWhitespaceToken("", aBuf, sizeof(aBuf)), nullptr);
+}
+
+TEST(ServerBrowserFilter, NextTokenWhitespaceOnly)
+{
+	char aBuf[64];
+	EXPECT_EQ(NextWhitespaceToken("   \t  ", aBuf, sizeof(aBuf)), nullptr);
+}
+
+TEST(ServerBrowserFilter, NextTokenSingle)
+{
+	char aBuf[64];
+	const char *pRest = NextWhitespaceToken("foo", aBuf, sizeof(aBuf));
+	ASSERT_NE(pRest, nullptr);
+	EXPECT_STREQ(aBuf, "foo");
+	EXPECT_STREQ(pRest, "");
+	EXPECT_EQ(NextWhitespaceToken(pRest, aBuf, sizeof(aBuf)), nullptr);
+}
+
+TEST(ServerBrowserFilter, NextTokenMultiple)
+{
+	char aBuf[64];
+	const char *pRest = NextWhitespaceToken("  foo  bar\tbaz   ", aBuf, sizeof(aBuf));
+	ASSERT_NE(pRest, nullptr);
+	EXPECT_STREQ(aBuf, "foo");
+
+	pRest = NextWhitespaceToken(pRest, aBuf, sizeof(aBuf));
+	ASSERT_NE(pRest, nullptr);
+	EXPECT_STREQ(aBuf, "bar");
+
+	pRest = NextWhitespaceToken(pRest, aBuf, sizeof(aBuf));
+	ASSERT_NE(pRest, nullptr);
+	EXPECT_STREQ(aBuf, "baz");
+
+	EXPECT_EQ(NextWhitespaceToken(pRest, aBuf, sizeof(aBuf)), nullptr);
+}
+
+TEST(ServerBrowserFilter, NextTokenQuotedSpaces)
+{
+	char aBuf[64];
+	const char *pRest = NextWhitespaceToken("\"hello world\" end", aBuf, sizeof(aBuf));
+	ASSERT_NE(pRest, nullptr);
+	EXPECT_STREQ(aBuf, "\"hello world\"");
+
+	pRest = NextWhitespaceToken(pRest, aBuf, sizeof(aBuf));
+	ASSERT_NE(pRest, nullptr);
+	EXPECT_STREQ(aBuf, "end");
+
+	EXPECT_EQ(NextWhitespaceToken(pRest, aBuf, sizeof(aBuf)), nullptr);
+}
+
+TEST(ServerBrowserFilter, NextTokenUnclosedQuote)
+{
+	// Unclosed quote consumes to end-of-string without overrunning.
+	char aBuf[64];
+	const char *pRest = NextWhitespaceToken("\"unterminated", aBuf, sizeof(aBuf));
+	ASSERT_NE(pRest, nullptr);
+	EXPECT_STREQ(aBuf, "\"unterminated");
+	EXPECT_EQ(*pRest, '\0');
+	EXPECT_EQ(NextWhitespaceToken(pRest, aBuf, sizeof(aBuf)), nullptr);
+}
+
+TEST(ServerBrowserFilter, NextTokenQuoteMidToken)
+{
+	// `foo"bar baz"qux` is a single token: the embedded quote toggles the
+	// "in quotes" state, so the interior space does not end the token.
+	char aBuf[64];
+	const char *pRest = NextWhitespaceToken("foo\"bar baz\"qux after", aBuf, sizeof(aBuf));
+	ASSERT_NE(pRest, nullptr);
+	EXPECT_STREQ(aBuf, "foo\"bar baz\"qux");
+
+	pRest = NextWhitespaceToken(pRest, aBuf, sizeof(aBuf));
+	ASSERT_NE(pRest, nullptr);
+	EXPECT_STREQ(aBuf, "after");
+}
+
+TEST(ServerBrowserFilter, NextTokenAdjacentTokens)
+{
+	// `a;b c` — semicolons are not treated as token separators here (the
+	// caller splits on `;` before calling NextWhitespaceToken). The first
+	// token spans `a;b`, the second is `c`.
+	char aBuf[64];
+	const char *pRest = NextWhitespaceToken("a;b c", aBuf, sizeof(aBuf));
+	ASSERT_NE(pRest, nullptr);
+	EXPECT_STREQ(aBuf, "a;b");
+
+	pRest = NextWhitespaceToken(pRest, aBuf, sizeof(aBuf));
+	ASSERT_NE(pRest, nullptr);
+	EXPECT_STREQ(aBuf, "c");
+}
+
+TEST(ServerBrowserFilter, NextTokenBufferTruncation)
+{
+	// A 5-byte buffer holds 4 chars + NUL. The token must be truncated
+	// cleanly and the function must return a non-null cursor so subsequent
+	// calls can continue.
+	char aBuf[5];
+	const char *pRest = NextWhitespaceToken("abcdefg hi", aBuf, sizeof(aBuf));
+	ASSERT_NE(pRest, nullptr);
+	EXPECT_EQ(aBuf[sizeof(aBuf) - 1], '\0');
+	EXPECT_LE(std::strlen(aBuf), sizeof(aBuf) - 1);
+	// After truncation the parser stops writing but the cursor still points
+	// somewhere inside the remaining string. Drive it to completion to make
+	// sure no undefined state leaks out.
+	while(pRest != nullptr)
+		pRest = NextWhitespaceToken(pRest, aBuf, sizeof(aBuf));
+}
+
+TEST(ServerBrowserFilter, NextTokenTinyBuffer)
+{
+	// Two-byte buffer holds one character + NUL.
+	char aBuf[2];
+	const char *pRest = NextWhitespaceToken("abc de", aBuf, sizeof(aBuf));
+	ASSERT_NE(pRest, nullptr);
+	EXPECT_EQ(aBuf[1], '\0');
+	while(pRest != nullptr)
+		pRest = NextWhitespaceToken(pRest, aBuf, sizeof(aBuf));
+}
+
+TEST(ServerBrowserFilter, NextTokenUtf8)
+{
+	// Multi-byte UTF-8 must not be split mid-codepoint: the inner loop
+	// copies one full codepoint at a time while the output has room.
+	char aBuf[64];
+	const char *pRest = NextWhitespaceToken("\xe4\xb8\x96\xe7\x95\x8c hello", aBuf, sizeof(aBuf));
+	ASSERT_NE(pRest, nullptr);
+	EXPECT_STREQ(aBuf, "\xe4\xb8\x96\xe7\x95\x8c");
+
+	pRest = NextWhitespaceToken(pRest, aBuf, sizeof(aBuf));
+	ASSERT_NE(pRest, nullptr);
+	EXPECT_STREQ(aBuf, "hello");
+}
+
+TEST(ServerBrowserFilter, NextTokenLoneQuoteToken)
+{
+	// A bare `"` opens quote mode, then end-of-string terminates the loop.
+	// Should not infinite-loop or read past the NUL.
+	char aBuf[64];
+	const char *pRest = NextWhitespaceToken("\"", aBuf, sizeof(aBuf));
+	ASSERT_NE(pRest, nullptr);
+	EXPECT_STREQ(aBuf, "\"");
+	EXPECT_EQ(*pRest, '\0');
+}
+
+TEST(ServerBrowserFilter, TokenMatchesSubstringCaseInsensitive)
+{
+	char aBuf[] = "foo";
+	SFilterToken Token = ParseFilterToken(aBuf);
+	EXPECT_TRUE(TokenMatches("FooBar", Token));
+	EXPECT_TRUE(TokenMatches("foo", Token));
+	EXPECT_FALSE(TokenMatches("bar", Token));
+}
+
+TEST(ServerBrowserFilter, TokenMatchesExact)
+{
+	char aBuf[] = "\"foo\"";
+	SFilterToken Token = ParseFilterToken(aBuf);
+	ASSERT_TRUE(Token.m_Exact);
+	EXPECT_TRUE(TokenMatches("foo", Token));
+	EXPECT_FALSE(TokenMatches("Foo", Token));
+	EXPECT_FALSE(TokenMatches("foobar", Token));
+}
+
+TEST(ServerBrowserFilter, TokenMatchesEmptySubstring)
+{
+	// An empty substring matches any non-empty field (str_utf8_find_nocase
+	// returns nullptr when the haystack is also empty, but the important
+	// property for this test is that it doesn't crash or read out of
+	// bounds on either input being empty).
+	char aBuf[] = "";
+	SFilterToken Token = ParseFilterToken(aBuf);
+	ASSERT_FALSE(Token.m_Exact);
+	EXPECT_TRUE(TokenMatches("anything", Token));
+	(void)TokenMatches("", Token);
+}
+
+TEST(ServerBrowserFilter, TokenMatchesEmptyExact)
+{
+	char aBuf[] = "\"\"";
+	SFilterToken Token = ParseFilterToken(aBuf);
+	ASSERT_TRUE(Token.m_Exact);
+	EXPECT_TRUE(TokenMatches("", Token));
+	EXPECT_FALSE(TokenMatches("x", Token));
+}
+
+TEST(ServerBrowserFilter, FuzzNoCrash)
+{
+	// Drive every entry through the full parser pipeline: walk the string
+	// with NextWhitespaceToken, then hand each emitted token to
+	// ParseFilterToken + TokenMatches. The assertion is simply "no crash,
+	// no undefined behavior" — we do not check outputs here.
+	const char *s_apInputs[] = {
+		"",
+		" ",
+		"\t\n",
+		":",
+		"::",
+		":::::",
+		"\"",
+		"\"\"",
+		"\"\"\"",
+		"\"\"\"\"",
+		"map:",
+		"map:\"",
+		"map:\"\"",
+		"map:\"unterminated",
+		"name:\"\"\"\"",
+		"addr::",
+		"player:player:",
+		"foo:bar:baz",
+		"MaP:Foo TyPe:DM aDdR:1.2.3.4",
+		"name:\"a b c\" player:\"x\"",
+		"\"\"\"\"\"\"\"\"\"\"",
+		"         ",
+		"a  b  c  d  e",
+		"\xff\xfe\xfd",
+		"\xc3\x28",
+		"foo\"bar\"baz",
+		"\"foo\" \"bar\" \"baz\"",
+		"name:map:type:foo",
+		"name:\"\xf0\x9f\x98\x80\"",
+	};
+
+	for(const char *pInput : s_apInputs)
+	{
+		const char *pCursor = pInput;
+		char aToken[128];
+		int Iterations = 0;
+		while((pCursor = NextWhitespaceToken(pCursor, aToken, sizeof(aToken))))
+		{
+			const SFilterToken Token = ParseFilterToken(aToken);
+			(void)TokenMatches("sample field", Token);
+			(void)TokenMatches("", Token);
+			ASSERT_LT(++Iterations, 1024) << "Runaway loop for input: " << pInput;
+		}
+	}
 }


### PR DESCRIPTION
closes #11345

gamemode match:
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/ec5ba557-587c-418f-96f8-1f1ba77c11bb" />

addr match:
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/2147c56f-b25c-4d06-8416-33e5c889dee2" />

to search for strict gametype, surround gametype in quotes:
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/6128918b-5ad6-4d7e-943e-065987f5ae03" />


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions


Used claude code (Opus 4.7). Double checked diff + tested ingame.