### PR TITLE
Use `dbg_assert_failed` on Rust panic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -859,6 +859,7 @@ endif()
 set_glob(RUST_BASE GLOB_RECURSE "rs;toml" src/base
   Cargo.toml
   color.rs
+  dbg.rs
   lib.rs
   rust.rs
 )

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,7 @@ version = "0.0.1"
 dependencies = [
  "cxx",
  "ddnet-test",
+ "libc",
 ]
 
 [[package]]
@@ -88,6 +89,12 @@ dependencies = [
 [[package]]
 name = "ddnet-test"
 version = "0.0.1"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libtw2-buffer"

--- a/src/base/Cargo.toml
+++ b/src/base/Cargo.toml
@@ -11,6 +11,7 @@ path = "lib.rs"
 
 [dependencies]
 cxx = "=1.0.71"
+libc = "0.2"
 
 [dev-dependencies]
 ddnet-test = { path = "../rust-bridge/test", features = ["link-test-libraries"] }

--- a/src/base/color.rs
+++ b/src/base/color.rs
@@ -8,6 +8,7 @@
 /// # Examples
 ///
 /// ```
+/// # extern crate ddnet_test;
 /// use ddnet_base::ColorRGBA;
 ///
 /// let white = ColorRGBA { r: 1.0, g: 1.0, b: 1.0, a: 1.0 };
@@ -47,6 +48,7 @@ unsafe impl cxx::ExternType for ColorRGBA {
 /// # Examples
 ///
 /// ```
+/// # extern crate ddnet_test;
 /// use ddnet_base::ColorHSLA;
 ///
 /// let white = ColorHSLA { h: 0.0, s: 0.0, l: 1.0, a: 1.0 };

--- a/src/base/dbg.cpp
+++ b/src/base/dbg.cpp
@@ -18,7 +18,7 @@ bool dbg_assert_has_failed()
 	return dbg_assert_failing.load(std::memory_order_acquire);
 }
 
-void dbg_assert_imp(const char *filename, int line, const char *fmt, ...)
+extern "C" void dbg_assert_imp(const char *filename, int line, const char *fmt, ...)
 {
 	const bool already_failing = dbg_assert_has_failed();
 	dbg_assert_failing.store(true, std::memory_order_release);

--- a/src/base/dbg.h
+++ b/src/base/dbg.h
@@ -49,11 +49,14 @@
 /**
  * Use the @link dbg_assert @endlink function instead!
  *
+ * This is also used from Rust, if you modify the signature, also look into
+ * src/base/dbg.rs.
+ *
  * @ingroup Debug
  *
  * @see dbg_assert
  */
-[[gnu::format(printf, 3, 4)]] [[noreturn]] void
+extern "C" [[gnu::format(printf, 3, 4)]] [[noreturn]] void
 dbg_assert_imp(const char *filename, int line, const char *fmt, ...);
 
 /**

--- a/src/base/dbg.rs
+++ b/src/base/dbg.rs
@@ -1,0 +1,10 @@
+use libc::c_char;
+use libc::c_int;
+
+extern "C" {
+    /// Breaks into the debugger with a message.
+    ///
+    /// Don't use this function directly. From C++, use the `dbg_assert` or
+    /// `dbg_assert_failed` macro, from Rust, use `assert!` directly.
+    pub fn dbg_assert_imp(filename: *const c_char, line: c_int, fmt: *const c_char, ...) -> !;
+}

--- a/src/base/lib.rs
+++ b/src/base/lib.rs
@@ -13,7 +13,9 @@
 extern crate ddnet_test;
 
 mod color;
+mod dbg;
 mod rust;
 
 pub use color::*;
+pub use dbg::*;
 pub use rust::*;

--- a/src/base/rust.h
+++ b/src/base/rust.h
@@ -2,4 +2,6 @@
 #define BASE_RUST_H
 typedef const char *StrRef;
 typedef void *UserPtr;
+
+extern "C" void rust_panic_use_dbg_assert();
 #endif // BASE_RUST_H

--- a/src/base/rust.rs
+++ b/src/base/rust.rs
@@ -26,6 +26,7 @@ use std::str;
 /// # Examples
 ///
 /// ```
+/// # extern crate ddnet_test;
 /// use ddnet_base::UserPtr;
 ///
 /// struct CallbackData {
@@ -58,6 +59,7 @@ impl UserPtr {
     /// # Examples
     ///
     /// ```
+    /// # extern crate ddnet_test;
     /// use ddnet_base::UserPtr;
     ///
     /// // Can't do anything useful with this.
@@ -78,6 +80,7 @@ impl UserPtr {
     /// # Examples
     ///
     /// ```
+    /// # extern crate ddnet_test;
     /// use ddnet_base::UserPtr;
     ///
     /// let the_answer = 42;
@@ -102,6 +105,7 @@ impl UserPtr {
     /// # Examples
     ///
     /// ```
+    /// # extern crate ddnet_test;
     /// use ddnet_base::UserPtr;
     ///
     /// let mut seen_it = false;
@@ -144,6 +148,7 @@ impl<'a, T> From<&'a mut T> for UserPtr {
 /// # Examples
 ///
 /// ```
+/// # extern crate ddnet_test;
 /// # fn some_c_function(_: StrRef<'_>) {}
 /// use ddnet_base::StrRef;
 /// use ddnet_base::s;
@@ -184,12 +189,14 @@ impl<'a> StrRef<'a> {
     /// # Examples
     ///
     /// ```
+    /// # extern crate ddnet_test;
     /// use ddnet_base::s;
     ///
     /// let str1: &'static str = s!("static string").to_str();
     /// ```
     ///
     /// ```compile_fail
+    /// # extern crate ddnet_test;
     /// use ddnet_base::s;
     ///
     /// // Wrong lifetime.
@@ -257,6 +264,7 @@ impl ops::Deref for StrRef<'_> {
 /// # Examples
 ///
 /// ```
+/// # extern crate ddnet_test;
 /// use ddnet_base::StrRef;
 /// use ddnet_base::s;
 ///

--- a/src/base/rust.rs
+++ b/src/base/rust.rs
@@ -1,9 +1,14 @@
+use crate::dbg_assert_imp;
 use std::cmp;
 use std::ffi::CStr;
+use std::ffi::CString;
 use std::fmt;
 use std::marker::PhantomData;
 use std::ops;
 use std::os::raw::c_char;
+use std::panic;
+#[allow(deprecated)] // MSRV (1.81): Use `PanicHookInfo` instead.
+use std::panic::PanicInfo;
 use std::ptr;
 use std::str;
 
@@ -265,4 +270,53 @@ macro_rules! s {
             ::std::ffi::CStr::from_bytes_with_nul(::std::concat!($str, "\0").as_bytes()).unwrap(),
         )
     };
+}
+
+// TODO (MSRV 1.91): Replace with built-in `PanicHookInfo::payload_as_str`.
+//
+// Adapted from that function.
+#[allow(deprecated)] // MSRV (1.81): Use `PanicHookInfo` instead.
+fn payload_as_str<'a>(panic_info: &'a PanicInfo) -> Option<&'a str> {
+    if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
+        Some(s)
+    } else if let Some(s) = panic_info.payload().downcast_ref::<String>() {
+        Some(s)
+    } else {
+        None
+    }
+}
+
+// This function tries pretty hard not to panic, even for suspicious parameters.
+#[allow(deprecated)] // MSRV (1.81): Use `PanicHookInfo` instead.
+fn dbg_assert_panic_handler(panic_info: &PanicInfo) -> ! {
+    // TODO (MSRV 1.92): Use `file_as_c_str`.
+    let filename = panic_info.location().map(|l| l.file()).unwrap_or("unknown");
+    let line = panic_info.location().map(|l| l.line()).unwrap_or(0);
+    let message = payload_as_str(panic_info).unwrap_or("(non-string panic payload)");
+
+    let filename = CString::new(filename)
+        .ok()
+        .unwrap_or_else(|| CString::new("(invalid filename)").unwrap());
+    let message = CString::new(message).ok().unwrap_or_else(|| {
+        CString::new(format!(
+            "interior NULs in message: {}",
+            message.replace('\0', "<NUL>")
+        ))
+        .unwrap()
+    });
+    unsafe {
+        // Just cast the line number to `i32` and accept the overflow.
+        dbg_assert_imp(
+            filename.as_ptr(),
+            line as i32,
+            b"%s\0".as_ptr() as *const c_char,
+            message.as_ptr(),
+        );
+    }
+}
+
+/// Installs a panic handler for Rust that calls `dbg_assert_failed` on panic.
+#[no_mangle]
+pub extern "C" fn rust_panic_use_dbg_assert() {
+    panic::set_hook(Box::new(|info| dbg_assert_panic_handler(info)));
 }

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -5,6 +5,7 @@
 #include <base/logger.h>
 #include <base/net.h>
 #include <base/os.h>
+#include <base/rust.h>
 #include <base/str.h>
 #include <base/time.h>
 
@@ -66,6 +67,8 @@ public:
 			{
 				log_info("engine", "operating system version: %s", aVersionStr);
 			}
+
+			rust_panic_use_dbg_assert();
 
 			// init the network
 			net_init();


### PR DESCRIPTION
Fixes #12074.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions