### PR TITLE
Optimize server browser memory usage

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1437,7 +1437,8 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 	bool IgnoreError = false;
 	for(int i = 0; i < MAX_CLIENTS && Info.m_NumReceivedClients < MAX_CLIENTS && !Up.Error(); i++)
 	{
-		CServerInfo::CClient *pClient = &Info.m_aClients[Info.m_NumReceivedClients];
+		Info.m_vClients.emplace_back();
+		CServerInfo::CClient *pClient = &Info.m_vClients.back();
 		GET_STRING(pClient->m_aName);
 		if(Up.Error())
 		{

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -488,7 +488,7 @@ void CServerBrowser::Filter()
 				// match against player country
 				for(int p = 0; p < minimum(Info.m_NumClients, (int)MAX_CLIENTS); p++)
 				{
-					if(Info.m_aClients[p].m_Country == g_Config.m_BrFilterCountryIndex)
+					if(Info.m_vClients[p].m_Country == g_Config.m_BrFilterCountryIndex)
 					{
 						Filtered = false;
 						break;
@@ -529,12 +529,12 @@ void CServerBrowser::Filter()
 					// match against players
 					for(int p = 0; p < minimum(Info.m_NumClients, (int)MAX_CLIENTS); p++)
 					{
-						if(MatchesFn(Info.m_aClients[p].m_aName, aFilterStrTrimmed) ||
-							MatchesFn(Info.m_aClients[p].m_aClan, aFilterStrTrimmed))
+						if(MatchesFn(Info.m_vClients[p].m_aName, aFilterStrTrimmed) ||
+							MatchesFn(Info.m_vClients[p].m_aClan, aFilterStrTrimmed))
 						{
 							if(g_Config.m_BrFilterConnectingPlayers &&
-								str_comp(Info.m_aClients[p].m_aName, "(connecting)") == 0 &&
-								Info.m_aClients[p].m_aClan[0] == '\0')
+								str_comp(Info.m_vClients[p].m_aName, "(connecting)") == 0 &&
+								Info.m_vClients[p].m_aClan[0] == '\0')
 							{
 								continue;
 							}
@@ -810,7 +810,7 @@ void CServerBrowser::SetInfo(CServerEntry *pEntry, const CServerInfo &Info) cons
 		}
 	};
 
-	std::sort(pEntry->m_Info.m_aClients, pEntry->m_Info.m_aClients + Info.m_NumReceivedClients, CPlayerScoreNameLess(pEntry->m_Info.m_ClientScoreKind));
+	std::sort(pEntry->m_Info.m_vClients.begin(), pEntry->m_Info.m_vClients.end(), CPlayerScoreNameLess(pEntry->m_Info.m_ClientScoreKind));
 
 	pEntry->m_GotInfo = 1;
 }
@@ -1653,7 +1653,7 @@ void CServerBrowser::UpdateServerFilteredPlayers(CServerInfo *pInfo) const
 	pInfo->m_NumFilteredPlayers = g_Config.m_BrFilterSpectators ? pInfo->m_NumPlayers : pInfo->m_NumClients;
 	if(g_Config.m_BrFilterConnectingPlayers)
 	{
-		for(const auto &Client : pInfo->m_aClients)
+		for(const auto &Client : pInfo->m_vClients)
 		{
 			if((!g_Config.m_BrFilterSpectators || Client.m_Player) && str_comp(Client.m_aName, "(connecting)") == 0 && Client.m_aClan[0] == '\0')
 				pInfo->m_NumFilteredPlayers--;
@@ -1667,9 +1667,9 @@ void CServerBrowser::UpdateServerFriends(CServerInfo *pInfo) const
 	pInfo->m_FriendNum = 0;
 	for(int ClientIndex = 0; ClientIndex < minimum(pInfo->m_NumReceivedClients, (int)MAX_CLIENTS); ClientIndex++)
 	{
-		pInfo->m_aClients[ClientIndex].m_FriendState = m_pFriends->GetFriendState(pInfo->m_aClients[ClientIndex].m_aName, pInfo->m_aClients[ClientIndex].m_aClan);
-		pInfo->m_FriendState = maximum(pInfo->m_FriendState, pInfo->m_aClients[ClientIndex].m_FriendState);
-		if(pInfo->m_aClients[ClientIndex].m_FriendState != IFriends::FRIEND_NO)
+		pInfo->m_vClients[ClientIndex].m_FriendState = m_pFriends->GetFriendState(pInfo->m_vClients[ClientIndex].m_aName, pInfo->m_vClients[ClientIndex].m_aClan);
+		pInfo->m_FriendState = maximum(pInfo->m_FriendState, pInfo->m_vClients[ClientIndex].m_FriendState);
+		if(pInfo->m_vClients[ClientIndex].m_FriendState != IFriends::FRIEND_NO)
 			pInfo->m_FriendNum++;
 	}
 }

--- a/src/engine/client/serverbrowser_http.cpp
+++ b/src/engine/client/serverbrowser_http.cpp
@@ -441,14 +441,15 @@ bool CServerBrowserHttp::Validate(json_value *pJson)
 }
 bool CServerBrowserHttp::Parse(json_value *pJson, std::vector<CServerInfo> *pvServers)
 {
-	std::vector<CServerInfo> vServers;
-
 	const json_value &Json = *pJson;
 	const json_value &Servers = Json["servers"];
 	if(Servers.type != json_array)
 	{
 		return true;
 	}
+
+	std::vector<CServerInfo> vServers;
+	vServers.reserve(Servers.u.array.length);
 	for(unsigned int i = 0; i < Servers.u.array.length; i++)
 	{
 		const json_value &Server = Servers[i];
@@ -518,10 +519,10 @@ bool CServerBrowserHttp::Parse(json_value *pJson, std::vector<CServerInfo> *pvSe
 		}
 		if(SetInfo.m_NumAddresses > 0)
 		{
-			vServers.push_back(SetInfo);
+			vServers.push_back(std::move(SetInfo));
 		}
 	}
-	*pvServers = vServers;
+	*pvServers = std::move(vServers);
 	return false;
 }
 

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -122,7 +122,7 @@ public:
 	int m_MapSize;
 	char m_aVersion[32];
 	char m_aAddress[MAX_SERVER_ADDRESSES * NETADDR_MAXSTRSIZE];
-	CClient m_aClients[SERVERINFO_MAX_CLIENTS];
+	std::vector<CClient> m_vClients;
 	int m_NumFilteredPlayers;
 	bool m_RequiresLogin;
 

--- a/src/engine/shared/serverinfo.cpp
+++ b/src/engine/shared/serverinfo.cpp
@@ -270,7 +270,7 @@ bool CServerInfo2::operator==(const CServerInfo2 &Other) const
 
 CServerInfo2::operator CServerInfo() const
 {
-	CServerInfo Result = {0};
+	CServerInfo Result{};
 	Result.m_MaxClients = m_MaxClients;
 	Result.m_NumClients = m_NumClients;
 	Result.m_MaxPlayers = m_MaxPlayers;
@@ -283,30 +283,36 @@ CServerInfo2::operator CServerInfo() const
 	str_copy(Result.m_aMap, m_aMapName);
 	str_copy(Result.m_aVersion, m_aVersion);
 
-	for(int i = 0; i < minimum(m_NumClients, (int)SERVERINFO_MAX_CLIENTS); i++)
+	int NumToCopy = minimum(m_NumClients, (int)SERVERINFO_MAX_CLIENTS);
+	Result.m_vClients.reserve(NumToCopy);
+	for(int i = 0; i < NumToCopy; i++)
 	{
-		str_copy(Result.m_aClients[i].m_aName, m_aClients[i].m_aName);
-		str_copy(Result.m_aClients[i].m_aClan, m_aClients[i].m_aClan);
-		Result.m_aClients[i].m_Country = m_aClients[i].m_Country;
-		Result.m_aClients[i].m_Score = m_aClients[i].m_Score;
-		Result.m_aClients[i].m_Player = m_aClients[i].m_IsPlayer;
-		Result.m_aClients[i].m_Afk = m_aClients[i].m_IsAfk;
+		CServerInfo::CClient Client{};
+
+		str_copy(Client.m_aName, m_aClients[i].m_aName);
+		str_copy(Client.m_aClan, m_aClients[i].m_aClan);
+		Client.m_Country = m_aClients[i].m_Country;
+		Client.m_Score = m_aClients[i].m_Score;
+		Client.m_Player = m_aClients[i].m_IsPlayer;
+		Client.m_Afk = m_aClients[i].m_IsAfk;
 
 		// 0.6 skin
-		str_copy(Result.m_aClients[i].m_aSkin, m_aClients[i].m_aSkin);
-		Result.m_aClients[i].m_CustomSkinColors = m_aClients[i].m_CustomSkinColors;
-		Result.m_aClients[i].m_CustomSkinColorBody = m_aClients[i].m_CustomSkinColorBody;
-		Result.m_aClients[i].m_CustomSkinColorFeet = m_aClients[i].m_CustomSkinColorFeet;
+		str_copy(Client.m_aSkin, m_aClients[i].m_aSkin);
+		Client.m_CustomSkinColors = m_aClients[i].m_CustomSkinColors;
+		Client.m_CustomSkinColorBody = m_aClients[i].m_CustomSkinColorBody;
+		Client.m_CustomSkinColorFeet = m_aClients[i].m_CustomSkinColorFeet;
+
 		// 0.7 skin
 		for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
 		{
-			str_copy(Result.m_aClients[i].m_aaSkin7[Part], m_aClients[i].m_aaSkin7[Part]);
-			Result.m_aClients[i].m_aUseCustomSkinColor7[Part] = m_aClients[i].m_aUseCustomSkinColor7[Part];
-			Result.m_aClients[i].m_aCustomSkinColor7[Part] = m_aClients[i].m_aCustomSkinColor7[Part];
+			str_copy(Client.m_aaSkin7[Part], m_aClients[i].m_aaSkin7[Part]);
+			Client.m_aUseCustomSkinColor7[Part] = m_aClients[i].m_aUseCustomSkinColor7[Part];
+			Client.m_aCustomSkinColor7[Part] = m_aClients[i].m_aCustomSkinColor7[Part];
 		}
+		Result.m_vClients.push_back(Client);
 	}
 
-	Result.m_NumReceivedClients = minimum(m_NumClients, (int)SERVERINFO_MAX_CLIENTS);
+	Result.m_NumReceivedClients = NumToCopy;
 	Result.m_Latency = -1;
 
 	return Result;

--- a/src/engine/shared/serverinfo.cpp
+++ b/src/engine/shared/serverinfo.cpp
@@ -270,7 +270,7 @@ bool CServerInfo2::operator==(const CServerInfo2 &Other) const
 
 CServerInfo2::operator CServerInfo() const
 {
-	CServerInfo Result = {0};
+	CServerInfo Result{};
 	Result.m_MaxClients = m_MaxClients;
 	Result.m_NumClients = m_NumClients;
 	Result.m_MaxPlayers = m_MaxPlayers;
@@ -283,30 +283,36 @@ CServerInfo2::operator CServerInfo() const
 	str_copy(Result.m_aMap, m_aMapName);
 	str_copy(Result.m_aVersion, m_aVersion);
 
-	for(int i = 0; i < minimum(m_NumClients, (int)SERVERINFO_MAX_CLIENTS); i++)
+	int NumToCopy = minimum(m_NumClients, (int)SERVERINFO_MAX_CLIENTS);
+	Result.m_vClients.reserve(NumToCopy);
+	for(int i = 0; i < NumToCopy; i++)
 	{
-		str_copy(Result.m_aClients[i].m_aName, m_aClients[i].m_aName);
-		str_copy(Result.m_aClients[i].m_aClan, m_aClients[i].m_aClan);
-		Result.m_aClients[i].m_Country = m_aClients[i].m_Country;
-		Result.m_aClients[i].m_Score = m_aClients[i].m_Score;
-		Result.m_aClients[i].m_Player = m_aClients[i].m_IsPlayer;
-		Result.m_aClients[i].m_Afk = m_aClients[i].m_IsAfk;
+		Result.m_vClients.emplace_back();
+		CServerInfo::CClient &Client = Result.m_vClients.back();
+
+		str_copy(Client.m_aName, m_aClients[i].m_aName);
+		str_copy(Client.m_aClan, m_aClients[i].m_aClan);
+		Client.m_Country = m_aClients[i].m_Country;
+		Client.m_Score = m_aClients[i].m_Score;
+		Client.m_Player = m_aClients[i].m_IsPlayer;
+		Client.m_Afk = m_aClients[i].m_IsAfk;
 
 		// 0.6 skin
-		str_copy(Result.m_aClients[i].m_aSkin, m_aClients[i].m_aSkin);
-		Result.m_aClients[i].m_CustomSkinColors = m_aClients[i].m_CustomSkinColors;
-		Result.m_aClients[i].m_CustomSkinColorBody = m_aClients[i].m_CustomSkinColorBody;
-		Result.m_aClients[i].m_CustomSkinColorFeet = m_aClients[i].m_CustomSkinColorFeet;
+		str_copy(Client.m_aSkin, m_aClients[i].m_aSkin);
+		Client.m_CustomSkinColors = m_aClients[i].m_CustomSkinColors;
+		Client.m_CustomSkinColorBody = m_aClients[i].m_CustomSkinColorBody;
+		Client.m_CustomSkinColorFeet = m_aClients[i].m_CustomSkinColorFeet;
+
 		// 0.7 skin
 		for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
 		{
-			str_copy(Result.m_aClients[i].m_aaSkin7[Part], m_aClients[i].m_aaSkin7[Part]);
-			Result.m_aClients[i].m_aUseCustomSkinColor7[Part] = m_aClients[i].m_aUseCustomSkinColor7[Part];
-			Result.m_aClients[i].m_aCustomSkinColor7[Part] = m_aClients[i].m_aCustomSkinColor7[Part];
+			str_copy(Client.m_aaSkin7[Part], m_aClients[i].m_aaSkin7[Part]);
+			Client.m_aUseCustomSkinColor7[Part] = m_aClients[i].m_aUseCustomSkinColor7[Part];
+			Client.m_aCustomSkinColor7[Part] = m_aClients[i].m_aCustomSkinColor7[Part];
 		}
 	}
 
-	Result.m_NumReceivedClients = minimum(m_NumClients, (int)SERVERINFO_MAX_CLIENTS);
+	Result.m_NumReceivedClients = NumToCopy;
 	Result.m_Latency = -1;
 
 	return Result;

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1279,7 +1279,7 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 
 	for(int i = 0; i < pSelectedServer->m_NumReceivedClients; i++)
 	{
-		const CServerInfo::CClient &CurrentClient = pSelectedServer->m_aClients[i];
+		const CServerInfo::CClient &CurrentClient = pSelectedServer->m_vClients[i];
 		const CListboxItem Item = s_ListBox.DoNextItem(&CurrentClient);
 		if(!Item.m_Visible)
 			continue;
@@ -1408,7 +1408,7 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 	const int NewSelected = s_ListBox.DoEnd();
 	if(s_ListBox.WasItemSelected())
 	{
-		const CServerInfo::CClient &SelectedClient = pSelectedServer->m_aClients[NewSelected];
+		const CServerInfo::CClient &SelectedClient = pSelectedServer->m_vClients[NewSelected];
 		if(SelectedClient.m_FriendState == IFriends::FRIEND_PLAYER)
 			GameClient()->Friends()->RemoveFriend(SelectedClient.m_aName, SelectedClient.m_aClan);
 		else
@@ -1454,7 +1454,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 
 		for(int ClientIndex = 0; ClientIndex < pEntry->m_NumClients; ++ClientIndex)
 		{
-			const CServerInfo::CClient &CurrentClient = pEntry->m_aClients[ClientIndex];
+			const CServerInfo::CClient &CurrentClient = pEntry->m_vClients[ClientIndex];
 			if(CurrentClient.m_FriendState == IFriends::FRIEND_NO)
 				continue;
 

--- a/src/game/client/sixup_translate_connless.cpp
+++ b/src/game/client/sixup_translate_connless.cpp
@@ -29,13 +29,21 @@ void CClient::PreprocessConnlessPacket7(CNetChunk *pPacket)
 		Info.m_NumClients = Up.GetInt();
 		Info.m_MaxClients = Up.GetInt();
 
+		// Prevent memory allocation crashes from spoofed servers.
+		if(Info.m_NumClients < 0 || Info.m_NumClients > MAX_CLIENTS)
+		{
+			Info.m_NumClients = 0;
+		}
+
+		Info.m_vClients.resize(Info.m_NumClients);
+
 		for(int i = 0; i < Info.m_NumClients; i++)
 		{
-			GetString(Info.m_aClients[i].m_aName);
-			GetString(Info.m_aClients[i].m_aClan);
-			Info.m_aClients[i].m_Country = Up.GetInt();
-			Info.m_aClients[i].m_Score = Up.GetInt();
-			Info.m_aClients[i].m_Player = !(Up.GetInt() & 1);
+			GetString(Info.m_vClients[i].m_aName);
+			GetString(Info.m_vClients[i].m_aClan);
+			Info.m_vClients[i].m_Country = Up.GetInt();
+			Info.m_vClients[i].m_Score = Up.GetInt();
+			Info.m_vClients[i].m_Player = !(Up.GetInt() & 1);
 		}
 
 		const bool IsNotVanilla = Info.m_MaxPlayers > VANILLA_MAX_CLIENTS || Info.m_MaxClients > VANILLA_MAX_CLIENTS;
@@ -78,12 +86,12 @@ void CClient::PreprocessConnlessPacket7(CNetChunk *pPacket)
 
 		for(int i = 0; i < Info.m_NumClients; i++)
 		{
-			Packer.AddString(Info.m_aClients[i].m_aName);
-			Packer.AddString(Info.m_aClients[i].m_aClan);
+			Packer.AddString(Info.m_vClients[i].m_aName);
+			Packer.AddString(Info.m_vClients[i].m_aClan);
 
-			PutInt(Info.m_aClients[i].m_Country);
-			PutInt(Info.m_aClients[i].m_Score);
-			PutInt(Info.m_aClients[i].m_Player);
+			PutInt(Info.m_vClients[i].m_Country);
+			PutInt(Info.m_vClients[i].m_Score);
+			PutInt(Info.m_vClients[i].m_Player);
 
 			if(IsNotVanilla)
 			{


### PR DESCRIPTION
This PR significantly reduces the peak memory consumption of the server browser.

### Changes:
* Replaced the static `CClient m_aClients[SERVERINFO_MAX_CLIENTS]` array inside `CServerInfo` with `std::vector<CClient> m_vClients`.
* Pre-allocated memory using `.reserve()` during JSON parsing and internal copying to prevent reallocation overhead.

### Reasoning:
Previously, every server in the master list reserved ~16.6 KB of memory to accommodate 64 potential clients, regardless of the actual player count. With a large number of servers, this led to sharp spikes in memory allocation (up to 80MB+) during the `CServerBrowserHttp::Parse` step. By switching to `std::vector`, memory is only allocated for actual players, flattening the memory consumption curve completely.

## Screenshots
The screenshots below show the memory allocation profiles during client load, server list refresh, and a short (< 15s) gameplay session. This testing methodology mimics standard user behavior to prove the concrete, real-world benefits of this optimization.

### Flame Graph
*before*
<img width="1918" height="1015" alt="image" src="https://github.com/user-attachments/assets/a09b1cbb-935a-44ea-9511-8d60df1cef8f" />

*after*
<img width="1918" height="1015" alt="image" src="https://github.com/user-attachments/assets/8f0031ef-1be8-4afb-b7e0-84988526d3ad" />

### Consumed Memory chart
*before*
<img width="1918" height="1015" alt="image" src="https://github.com/user-attachments/assets/649a8936-8431-438b-98ec-90c5f8c91c80" />

*after*
<img width="1918" height="1015" alt="image" src="https://github.com/user-attachments/assets/a054b137-90b1-4985-8cc9-c5ea9f959d5e" />

Heaptrack reports (Usage: heaptrack --analyze "path/to/file.zst"): [download (heaptrack_reports.zip)](https://github.com/user-attachments/files/27055091/heaptrack_reports.zip)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change (Not a game visual, but memory profiling screenshots attached)
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

I used an AI assistant to help analyze memory profiles (Heaptrack) and to assist with the C++ refactoring of the static arrays into `std::vector`. All changes were manually reviewed, compiled, and tested in-game.