### PR TITLE
Use `IMap` for `map_test` tool

### DIFF
--- a/src/engine/map.h
+++ b/src/engine/map.h
@@ -9,6 +9,7 @@
 #include <memory>
 
 class IStorage;
+struct CUuid;
 
 enum
 {
@@ -28,7 +29,7 @@ public:
 	virtual int NumData() const = 0;
 
 	virtual int GetItemSize(int Index) = 0;
-	virtual void *GetItem(int Index, int *pType = nullptr, int *pId = nullptr) = 0;
+	virtual void *GetItem(int Index, int *pType = nullptr, int *pId = nullptr, CUuid *pUuid = nullptr) = 0;
 	virtual void GetType(int Type, int *pStart, int *pNum) = 0;
 	virtual int FindItemIndex(int Type, int Id) = 0;
 	virtual void *FindItem(int Type, int Id) = 0;

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -51,9 +51,9 @@ int CMap::GetItemSize(int Index)
 	return m_DataFile.GetItemSize(Index);
 }
 
-void *CMap::GetItem(int Index, int *pType, int *pId)
+void *CMap::GetItem(int Index, int *pType, int *pId, CUuid *pUuid)
 {
-	return m_DataFile.GetItem(Index, pType, pId);
+	return m_DataFile.GetItem(Index, pType, pId, pUuid);
 }
 
 void CMap::GetType(int Type, int *pStart, int *pNum)

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -25,7 +25,7 @@ public:
 	int NumData() const override;
 
 	int GetItemSize(int Index) override;
-	void *GetItem(int Index, int *pType = nullptr, int *pId = nullptr) override;
+	void *GetItem(int Index, int *pType = nullptr, int *pId = nullptr, CUuid *pUuid = nullptr) override;
 	void GetType(int Type, int *pStart, int *pNum) override;
 	int FindItemIndex(int Type, int Id) override;
 	void *FindItem(int Type, int Id) override;

--- a/src/tools/map_test.cpp
+++ b/src/tools/map_test.cpp
@@ -3,37 +3,38 @@
 #include <base/os.h>
 #include <base/str.h>
 
-#include <engine/shared/datafile.h>
+#include <engine/map.h>
+#include <engine/shared/uuid_manager.h>
 #include <engine/storage.h>
 
 static const char *TOOL_NAME = "map_test";
 
-static int TestMap(const char *pMap, bool CalcHashes, IStorage *pStorage)
+static int TestMap(const char *pMapPath, bool CalcHashes, IStorage *pStorage)
 {
-	log_info(TOOL_NAME, "Testing map '%s'...", pMap);
+	log_info(TOOL_NAME, "Testing map '%s'...", pMapPath);
 
-	CDataFileReader Reader;
-	if(!Reader.Open(pStorage, pMap, IStorage::TYPE_ABSOLUTE))
+	std::unique_ptr<IMap> pMap = CreateMap();
+	if(!pMap->Load(pStorage, pMapPath, IStorage::TYPE_ABSOLUTE))
 	{
-		log_error(TOOL_NAME, "Failed to open map '%s' for reading", pMap);
+		log_error(TOOL_NAME, "Failed to open map '%s' for reading", pMapPath);
 		return -1;
 	}
 
 	char aSha256Str[SHA256_MAXSTRSIZE];
-	sha256_str(Reader.Sha256(), aSha256Str, sizeof(aSha256Str));
-	log_info(TOOL_NAME, "File size: %d", Reader.Size());
+	sha256_str(pMap->Sha256(), aSha256Str, sizeof(aSha256Str));
+	log_info(TOOL_NAME, "File size: %d", pMap->Size());
 	log_info(TOOL_NAME, "File SHA256: %s", aSha256Str);
-	log_info(TOOL_NAME, "File CRC32: %08x", Reader.Crc());
-	log_info(TOOL_NAME, "Num items: %d", Reader.NumItems());
-	log_info(TOOL_NAME, "Num data: %d", Reader.NumData());
+	log_info(TOOL_NAME, "File CRC32: %08x", pMap->Crc());
+	log_info(TOOL_NAME, "Num items: %d", pMap->NumItems());
+	log_info(TOOL_NAME, "Num data: %d", pMap->NumData());
 
-	for(int Index = 0; Index < Reader.NumItems(); Index++)
+	for(int Index = 0; Index < pMap->NumItems(); Index++)
 	{
 		log_info(TOOL_NAME, "Item %d:", Index);
 
 		int Type, Id;
 		CUuid Uuid;
-		const void *pItem = Reader.GetItem(Index, &Type, &Id, &Uuid);
+		const void *pItem = pMap->GetItem(Index, &Type, &Id, &Uuid);
 
 		log_info(TOOL_NAME, "  Type: %d", Type);
 		log_info(TOOL_NAME, "  ID: %d", Id);
@@ -41,7 +42,7 @@ static int TestMap(const char *pMap, bool CalcHashes, IStorage *pStorage)
 		FormatUuid(Uuid, aUuidStr, sizeof(aUuidStr));
 		log_info(TOOL_NAME, "  UUID: %s", aUuidStr);
 
-		const int Size = Reader.GetItemSize(Index);
+		const int Size = pMap->GetItemSize(Index);
 		log_info(TOOL_NAME, "  Size: %d bytes", Size);
 
 		if(CalcHashes)
@@ -52,14 +53,14 @@ static int TestMap(const char *pMap, bool CalcHashes, IStorage *pStorage)
 		}
 	}
 
-	for(int Index = 0; Index < Reader.NumData(); Index++)
+	for(int Index = 0; Index < pMap->NumData(); Index++)
 	{
 		log_info(TOOL_NAME, "Data %d:", Index);
 
-		const int Size = Reader.GetDataSize(Index);
+		const int Size = pMap->GetDataSize(Index);
 		log_info(TOOL_NAME, "  Size: %d bytes", Size);
 
-		const void *pData = Reader.GetData(Index);
+		const void *pData = pMap->GetData(Index);
 		if(pData == nullptr)
 		{
 			log_info(TOOL_NAME, "  Data erroneous");
@@ -71,11 +72,11 @@ static int TestMap(const char *pMap, bool CalcHashes, IStorage *pStorage)
 			log_info(TOOL_NAME, "  Data (SHA256): %s", aSha256Str);
 		}
 
-		Reader.UnloadData(Index);
+		pMap->UnloadData(Index);
 	}
 
-	Reader.Close();
-	log_info(TOOL_NAME, "Tested map '%s' successfully", pMap);
+	pMap->Unload();
+	log_info(TOOL_NAME, "Tested map '%s' successfully", pMapPath);
 	return 0;
 }
 
@@ -84,16 +85,16 @@ int main(int argc, const char **argv)
 	const CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 
-	const char *pMap;
+	const char *pMapPath;
 	bool CalcHashes;
 	if(argc == 2)
 	{
-		pMap = argv[1];
+		pMapPath = argv[1];
 		CalcHashes = false;
 	}
 	else if(argc == 3 && str_comp(argv[1], "--calc-hashes") == 0)
 	{
-		pMap = argv[2];
+		pMapPath = argv[2];
 		CalcHashes = true;
 	}
 	else
@@ -109,5 +110,5 @@ int main(int argc, const char **argv)
 		return -1;
 	}
 
-	return TestMap(pMap, CalcHashes, pStorage.get());
+	return TestMap(pMapPath, CalcHashes, pStorage.get());
 }


### PR DESCRIPTION
Properly test the map error handling by using `IMap` in the `map_test` tool instead of using a raw `CDataFileReader`.

## Checklist

- [X] Tested the change: by running the `map_test` tool on all ddnet-maps
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions

