### PR TITLE
Fix config injection vulnerability in bans_save

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1868,7 +1868,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 		}
 		else if(Msg == NETMSG_RCON_CMD)
 		{
-			const char *pCmd = Unpacker.GetString();
+			const char *pCmd = Unpacker.GetString(CUnpacker::SANITIZE_CC);
 			if(Unpacker.Error())
 				return;
 

--- a/src/engine/shared/netban.cpp
+++ b/src/engine/shared/netban.cpp
@@ -1,7 +1,9 @@
 #include "netban.h"
 
+#include <base/dbg.h>
 #include <base/io.h>
 #include <base/math.h>
+#include <base/str.h>
 
 #include <engine/console.h>
 #include <engine/shared/config.h>
@@ -224,6 +226,7 @@ int CNetBan::Ban(T *pBanPool, const typename T::CDataType *pData, int Seconds, c
 	CBanInfo Info = {0};
 	Info.m_Expires = Stamp;
 	Info.m_VerbatimReason = VerbatimReason;
+	dbg_assert(!str_has_cc(pReason), "Ban reason cannot contain control characters");
 	str_copy(Info.m_aReason, pReason);
 
 	// check if it already exists
@@ -594,11 +597,21 @@ void CNetBan::ConBansSave(IConsole::IResult *pResult, void *pUser)
 {
 	CNetBan *pThis = static_cast<CNetBan *>(pUser);
 
+	const char *pFilename = pResult->GetString(0);
+	if(!str_valid_filename(pFilename))
+	{
+		pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "net_ban", "bans_save error (invalid filename)");
+		return;
+	}
+
+	char aPath[IO_MAX_PATH_LENGTH];
+	str_format(aPath, sizeof(aPath), "dumps/%s", pFilename);
+
 	char aBuf[256];
-	IOHANDLE File = pThis->Storage()->OpenFile(pResult->GetString(0), IOFLAG_WRITE, IStorage::TYPE_SAVE);
+	IOHANDLE File = pThis->Storage()->OpenFile(aPath, IOFLAG_WRITE, IStorage::TYPE_SAVE);
 	if(!File)
 	{
-		str_format(aBuf, sizeof(aBuf), "failed to save banlist to '%s'", pResult->GetString(0));
+		str_format(aBuf, sizeof(aBuf), "failed to save banlist to '%s'", aPath);
 		pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "net_ban", aBuf);
 		return;
 	}
@@ -609,7 +622,12 @@ void CNetBan::ConBansSave(IConsole::IResult *pResult, void *pUser)
 	{
 		int Min = pBan->m_Info.m_Expires > -1 ? (pBan->m_Info.m_Expires - Now + 59) / 60 : -1;
 		net_addr_str(&pBan->m_Data, aAddrStr1, sizeof(aAddrStr1), false);
-		str_format(aBuf, sizeof(aBuf), "ban %s %i %s", aAddrStr1, Min, pBan->m_Info.m_aReason);
+
+		char aEscapedReason[256];
+		char *pDst = aEscapedReason;
+		str_escape(&pDst, pBan->m_Info.m_aReason, aEscapedReason + sizeof(aEscapedReason));
+
+		str_format(aBuf, sizeof(aBuf), "ban %s %i \"%s\"", aAddrStr1, Min, aEscapedReason);
 		io_write(File, aBuf, str_length(aBuf));
 		io_write_newline(File);
 	}
@@ -618,12 +636,17 @@ void CNetBan::ConBansSave(IConsole::IResult *pResult, void *pUser)
 		int Min = pBan->m_Info.m_Expires > -1 ? (pBan->m_Info.m_Expires - Now + 59) / 60 : -1;
 		net_addr_str(&pBan->m_Data.m_LB, aAddrStr1, sizeof(aAddrStr1), false);
 		net_addr_str(&pBan->m_Data.m_UB, aAddrStr2, sizeof(aAddrStr2), false);
-		str_format(aBuf, sizeof(aBuf), "ban_range %s %s %i %s", aAddrStr1, aAddrStr2, Min, pBan->m_Info.m_aReason);
+
+		char aEscapedReason[256];
+		char *pDst = aEscapedReason;
+		str_escape(&pDst, pBan->m_Info.m_aReason, aEscapedReason + sizeof(aEscapedReason));
+
+		str_format(aBuf, sizeof(aBuf), "ban_range %s %s %i \"%s\"", aAddrStr1, aAddrStr2, Min, aEscapedReason);
 		io_write(File, aBuf, str_length(aBuf));
 		io_write_newline(File);
 	}
 
 	io_close(File);
-	str_format(aBuf, sizeof(aBuf), "saved banlist to '%s'", pResult->GetString(0));
+	str_format(aBuf, sizeof(aBuf), "saved banlist to '%s'", aPath);
 	pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "net_ban", aBuf);
 }


### PR DESCRIPTION
This PR fixes a critical Privilege Escalation vulnerability in the `CNetBan::ConBansSave` function caused by the lack of sanitization of ban reasons.

### The Principle of the Vulnerability:
When a ban is saved to a file, the `m_aReason` string is written directly. An attacker with basic moderator privileges (access to `ban` and `bans_save` commands) can include newline characters (`\n` or `\r`) in the ban reason. This breaks the single `ban` configuration line into multiple lines, allowing the injection of arbitrary server commands.

### Critical Attack Vector:
The attacker is not forced to overwrite a standard `bans.cfg`. They can target a configuration file that the server automatically executes upon startup. For example, many server setups include `exec myServerconfig.cfg` at the bottom of their `autoexec_server.cfg` to load user overrides.

_End of the `autoexec_server.cfg` file:_
```
# CUSTOM CONFIG
# -------------

# if you do not want updates to overwrite your settings create a
# file called myServerconfig.cfg and put your config there
exec myServerconfig.cfg
``` 

1) The attacker creates a ban: `ban 1.1.1.1 60 reason \nsv_rcon_password hacked`
2) They save it to the auto-executed file: `bans_save myServerconfig.cfg` (which writes to `~/.local/share/ddnet/myServerconfig.cfg`).
3) Upon the next server restart, the engine automatically parses `myServerconfig.cfg` and executes the injected `sv_rcon_password hacked` command with full server privileges.

### The Fix:
- Replaced `\n`, `\r`, and `"` inside the reason string with spaces before writing to the file.
- Enclosed the reason output in double quotes (`"%s"`) to ensure spaces within the reason do not break the configuration parser.

### Exploit demonstration:
https://github.com/user-attachments/assets/4dceb2af-6e09-4717-809e-60632db1f40e

Ussage: 
```
git clone https://github.com/hylooz/ddnet-server-config-injection.git
cd ddnet-server-config-injection
python3 main.py
```

### Result:
_before_
<img width="549" height="150" alt="image" src="https://github.com/user-attachments/assets/1f5bb640-1cf1-4c58-ad7e-970bc0ef2d81" />

_after_
<img width="1285" height="160" alt="image" src="https://github.com/user-attachments/assets/5a89d9cc-2db7-4924-ba47-eb6b63eb5316" />

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

I used an AI assistant as a code review tool to help identify potential vulnerabilities (like OOB reads) and memory leaks. I manually reviewed, understood, and tested all the suggested fixes before applying them.