### PR TITLE
Feature: Add NetIntCustom which takes all kind of NetIntCustomOptions

### DIFF
--- a/datasrc/compile.py
+++ b/datasrc/compile.py
@@ -107,6 +107,7 @@ class CNetObjHandler
 	char m_aUnpackedData[1024 * 2];
 	int m_NumObjCorrections;
 	int ClampInt(const char *pErrorMsg, int Value, int Min, int Max);
+	void ReportNetCorrection(const char *pErrorMsg);
 
 	static const char *ms_apObjNames[];
 	static const char *ms_apExObjNames[];
@@ -178,6 +179,12 @@ int CNetObjHandler::ClampInt(const char *pErrorMsg, int Value, int Min, int Max)
 	if(Value < Min) { m_pObjCorrectedOn = pErrorMsg; m_NumObjCorrections++; return Min; }
 	if(Value > Max) { m_pObjCorrectedOn = pErrorMsg; m_NumObjCorrections++; return Max; }
 	return Value;
+}
+
+void CNetObjHandler::ReportNetCorrection(const char *pErrorMsg)
+{
+	m_pObjCorrectedOn = pErrorMsg;
+	m_NumObjCorrections++;
 }
 	""")
 

--- a/datasrc/datatypes.py
+++ b/datasrc/datatypes.py
@@ -1,3 +1,6 @@
+from abc import ABC, abstractmethod
+
+
 def only(x):
 	if len(x) != 1:
 		raise ValueError
@@ -606,3 +609,128 @@ class NetTwIntString(NetArray):
 			result += NetVariable(self.var).emit_dump(offset + i)
 			result += [f'dbg_msg("snapshot", "%s\\t{self.base_name}[{int(i)}]=%d\\tIntToStr: %s", aRawData, pObj->{self.base_name}[{int(i)}], aStr);']
 		return result
+
+
+class NetIntCustomOption(ABC):
+	@abstractmethod
+	def is_valid(self) -> bool:
+		return False
+
+	@abstractmethod
+	def is_contained_check(self, name) -> str:
+		return ""
+
+	@abstractmethod
+	def static_assert(self) -> list:
+		return []
+
+	@abstractmethod
+	def get_dump(self) -> tuple[str, str]:
+		"""
+		fmt, args
+		"""
+		return "", ""
+
+
+class Constant(NetIntCustomOption):
+	def __init__(self, value, key):
+		if not isinstance(value, int):
+			raise ValueError(f"Value {value} needs to be an integer")
+		if not isinstance(key, str):
+			raise ValueError(f"Key {key} needs to be a string")
+		self.value = value
+		self.key = key
+
+	def is_valid(self):
+		return True
+
+	def is_contained_check(self, name) -> str:
+		return f"pData->{name} == {self.key}"
+
+	def static_assert(self):
+		return [f'static_assert({self.key} == {self.value}, "Value and key aren\'t equal");']
+
+	def get_dump(self):
+		return f"Constant={self.key}({self.value})", ""
+
+
+class Range(NetIntCustomOption):
+	def __init__(self, val_min, val_max):
+		self.min = val_min
+		self.max = val_max
+
+	def is_valid(self):
+		if isinstance(self.min, int) and isinstance(self.max, int):
+			return self.max >= self.min
+		return True  # we don't know
+
+	def is_contained_check(self, name) -> str:
+		return f"(pData->{name} >= {self.min} && pData->{name} <= {self.max})"
+
+	def static_assert(self):
+		static_asserts = []
+		if not isinstance(self.min, int):
+			static_asserts += [f'static_assert((int){self.min} == {self.min}, "Value is not an integer");']
+		if not isinstance(self.max, int):
+			static_asserts += [f'static_assert((int){self.max} == {self.max}, "Value is not an integer");']
+		return static_asserts
+
+	def get_dump(self):
+		min_fmt = f"min={self.min}"
+		min_arg = ""
+		try:
+			int(self.min)
+		except ValueError:
+			min_fmt = f"min={self.min}(%d)"
+			min_arg = f", (int){self.min}"
+		max_fmt = f"max={self.max}"
+		max_arg = ""
+		try:
+			int(self.max)
+		except ValueError:
+			max_fmt = f"max={self.max}(%d)"
+			max_arg = f", (int){self.max}"
+
+		return f"Range=[{min_fmt} {max_fmt}]", f"{min_arg}{max_arg}"
+
+
+class NetIntCustom(NetIntAny):
+	def __init__(self, name, values, default=None):
+		if not isinstance(values, list):
+			raise ValueError("'values' is not a list")
+		for index, option in enumerate(values):
+			if not isinstance(option, NetIntCustomOption):
+				raise ValueError(f"Value #{index} needs to be of type 'NetIntCustomOptions'")
+			if not option.is_valid():
+				raise ValueError(f"Value #{index} of type {type(option)} is not valid")
+		NetIntAny.__init__(self, name, default=default)
+		self.values = values
+
+	def emit_validate_obj(self):
+		# add some compile time validation
+		validation = []
+		for option in self.values:
+			validation += option.static_assert()
+
+		# validate content
+		bool_name = f"IsValid{self.name[2:]}"
+		bool_expression = [option.is_contained_check(self.name) for option in self.values]
+		validation += [f"bool {bool_name} = " + " || ".join(bool_expression) + ";"]
+		validation += [f"if(!{bool_name})", "{", f"\tpData->{self.name} = {self.default};", "}"]
+
+		return validation
+
+	def emit_unpack_msg_check(self):
+		bool_expression = [option.is_contained_check(self.name) for option in self.values]
+		return [f'if({" || ".join(bool_expression)}) {{ m_pMsgFailedOn = "{self.name}"; break; }}']
+
+	def emit_dump(self, offset):
+		contents = []
+		content_args = []
+		for option in self.values:
+			fmt, fmt_arg = option.get_dump()
+			contents.append(fmt)
+			content_args.append(fmt_arg)
+		contents = ", ".join(contents)
+		content_args = "".join(content_args)
+		return NetVariable(self.name).emit_dump(offset) + [f'dbg_msg("snapshot", "%s\\t{self.name}=%d (Contents=[{contents}])", aRawData, pObj->{self.name}{content_args});']

--- a/datasrc/datatypes.py
+++ b/datasrc/datatypes.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
 def only(x):
 	if len(x) != 1:
 		raise ValueError
@@ -497,7 +502,7 @@ class NetIntRange(NetIntAny):
 		return [f'pData->{self.name} = ClampInt("{self.name}", pData->{self.name}, {self.min}, {self.max});']
 
 	def emit_unpack_msg_check(self):
-		return [f'if(pData->{self.name} < {self.min} || pData->{self.name} > {self.max}) {{ m_pMsgFailedOn = "{self.name}"; break; }}']
+		return [f"if(pData->{self.name} < {self.min} || pData->{self.name} > {self.max})", "{", f'\tm_pMsgFailedOn = "{self.name}";', "\tbreak;", "}"]
 
 	def emit_dump(self, offset):
 		min_fmt = f"min={self.min}"
@@ -608,3 +613,195 @@ class NetTwIntString(NetArray):
 			result += NetVariable(self.var).emit_dump(offset + i)
 			result += [f'dbg_msg("snapshot", "%s\\t{self.base_name}[{int(i)}]=%d\\tIntToStr: %s", aRawData, pObj->{self.base_name}[{int(i)}], aStr);']
 		return result
+
+
+class NetIntCustomOption(ABC):
+	@abstractmethod
+	def is_valid(self) -> bool:
+		raise NotImplementedError
+
+	@abstractmethod
+	def is_contained_check(self, name) -> str:
+		raise NotImplementedError
+
+	@abstractmethod
+	def static_assert(self) -> list:
+		raise NotImplementedError
+
+	@abstractmethod
+	def get_dump(self) -> tuple[str, str]:
+		raise NotImplementedError
+
+	@abstractmethod
+	def get_clamped_value(self, name) -> str:
+		raise NotImplementedError
+
+
+class Constant(NetIntCustomOption):
+	def __init__(self, value: int, key: str | None = None, description: str | None = None):
+		if key is None:
+			key = str(value)
+		self.value = value
+		self.key = key
+		self.description = description
+
+	def is_valid(self):
+		return True
+
+	def is_contained_check(self, name) -> str:
+		return f"pData->{name} == {self.key}"
+
+	def static_assert(self):
+		if str(self.value) == self.key:
+			return []
+		return [f'static_assert({self.key} == {self.value}, "Value and key aren\'t equal");']
+
+	def get_dump(self):
+		if str(self.value) == self.key:
+			if self.description:
+				return f"{self.key}({self.description})", ""
+			return f"Const({self.key})", ""
+
+		return f"{self.key}({self.value})", ""
+
+	def get_clamped_value(self, name):
+		return f"pData->{name} = {self.key};"
+
+
+class Range(NetIntCustomOption):
+	def __init__(self, val_min: int | str, val_max: int | str):
+		self.min = val_min
+		self.max = val_max
+		if not self.is_valid():
+			raise ValueError(f"Range [{self.min}, {self.max}] is not valid")
+
+	def is_valid(self):
+		if isinstance(self.min, int) and isinstance(self.max, int):
+			return self.max >= self.min
+		return True  # we don't know
+
+	def is_contained_check(self, name) -> str:
+		return f"(pData->{name} >= {self.min} && pData->{name} <= {self.max})"
+
+	def static_assert(self):
+		static_asserts = []
+		if not isinstance(self.min, int):
+			static_asserts += [f'static_assert((int){self.min} == {self.min}, "Value is not an integer");']
+		if not isinstance(self.max, int):
+			static_asserts += [f'static_assert((int){self.max} == {self.max}, "Value is not an integer");']
+		return static_asserts
+
+	def get_dump(self):
+		min_fmt = f"min={self.min}"
+		min_arg = ""
+		try:
+			int(self.min)
+		except ValueError:
+			min_fmt = f"min={self.min}(%d)"
+			min_arg = f", (int){self.min}"
+		max_fmt = f"max={self.max}"
+		max_arg = ""
+		try:
+			int(self.max)
+		except ValueError:
+			max_fmt = f"max={self.max}(%d)"
+			max_arg = f", (int){self.max}"
+
+		return f"[{min_fmt} {max_fmt}]", f"{min_arg}{max_arg}"
+
+	def get_clamped_value(self, name):
+		return f'pData->{name} = ClampInt("{name}", pData->{name}, {self.min}, {self.max});'
+
+
+class NetIntCustom(NetIntAny):
+	def __init__(self, name, values, default=None):
+		if not isinstance(values, list):
+			raise TypeError("'values' is not a list")
+		if len(values) == 0:
+			raise ValueError("'values' is not allowed to be empty")
+		for index, option in enumerate(values):
+			if not isinstance(option, NetIntCustomOption):
+				raise TypeError(f"Value #{index} needs to be of type 'NetIntCustomOptions'")
+			if not option.is_valid():
+				raise ValueError(f"Value #{index} of type {type(option)} is not valid, its constructor should have failed?!")
+		super().__init__(name, default=default)
+		self.values = values
+
+	def emit_validate_obj(self):
+		# add some compile time validation
+		validation = []
+		for option in self.values:
+			validation += option.static_assert()
+
+		# validate content
+		bool_name = f"IsValid{self.name[2:]}"
+		bool_expression_list = [option.is_contained_check(self.name) for option in self.values]
+
+		# handle linebreaks
+		if len(bool_expression_list) > 2:
+			collapsed_expression = bool_expression_list[0]
+			for i in range(1, len(bool_expression_list)):
+				if i % 2 == 0:
+					collapsed_expression += f" ||\n\t{bool_expression_list[i]}"
+				else:
+					collapsed_expression += f" || {bool_expression_list[i]}"
+		else:
+			collapsed_expression = " || ".join(bool_expression_list)
+
+		validation += f"bool {bool_name} = {collapsed_expression};".split("\n")
+		validation += [f"if(!{bool_name})", "{"]
+		if self.default is not None:
+			validation += [f"\tpData->{self.name} = {self.default};", f'\tReportNetCorrection("{self.name}");']
+		else:
+			validation += [f"\t{self.values[0].get_clamped_value(self.name)}"]
+			if isinstance(self.values[0], Constant):
+				validation += [f'\tReportNetCorrection("{self.name}");']
+		validation += ["}"]
+		return validation
+
+	def emit_unpack_msg_check(self):
+		bool_expression_list = [option.is_contained_check(self.name) for option in self.values]
+		collapsed_expression = ""
+
+		# handle linebreaks
+		if len(bool_expression_list) > 3:
+			collapsed_expression = bool_expression_list[0]
+			for i in range(1, len(bool_expression_list)):
+				if i % 3 == 0:
+					collapsed_expression += f" ||\n\t{bool_expression_list[i]}"
+				else:
+					collapsed_expression += f" || {bool_expression_list[i]}"
+		else:
+			collapsed_expression = " || ".join(bool_expression_list)
+
+		bool_expression = f"if(!({collapsed_expression}))".split("\n")
+		return bool_expression + ["{", f'\tm_pMsgFailedOn = "{self.name}";', "\tbreak;", "}"]
+
+	def emit_dump(self, offset):
+		contents = []
+		content_args = []
+		for option in self.values:
+			fmt, fmt_arg = option.get_dump()
+			contents.append(fmt)
+			content_args.append(fmt_arg)
+
+		content_args = "".join(content_args)
+		debug_message_part1 = f'dbg_msg("snapshot", "%s\\t{self.name}=%d (Contents=[{", ".join(contents)}])",'
+		debug_message_part2 = f"aRawData, pObj->{self.name}{content_args});"
+
+		# add line break(s) for extreme cases
+		max_line_length = 130
+		debug_message = []
+		if len(debug_message_part1) > max_line_length:
+			# rebuild message with linebreaks inside the message
+			debug_message += [f'dbg_msg("snapshot", "%s\\t{self.name}=%d (Contents=[ \\']
+			debug_message += [f"\t\t{info}, \\" for info in contents]
+			debug_message += ['\t])",', f"\t{debug_message_part2}"]
+		elif len(debug_message_part1) + len(debug_message_part2) > max_line_length:
+			# add a linebreak between arguments
+			debug_message = [debug_message_part1, f"\t{debug_message_part2}"]
+		else:
+			# all in one line
+			debug_message = [f"{debug_message_part1} {debug_message_part2}"]
+
+		return NetVariable(self.name).emit_dump(offset) + debug_message

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -1,4 +1,4 @@
-from datatypes import Enum, Flags, NetArray, NetBool, NetEvent, NetEventEx, NetIntAny, NetTwIntString, NetIntRange
+from datatypes import Enum, Flags, NetArray, NetBool, NetEvent, NetEventEx, NetIntAny, NetTwIntString, NetIntRange, NetIntCustom, Range, Constant
 from datatypes import NetMessage, NetMessageEx, NetObject, NetObjectEx, NetString, NetStringHalfStrict, NetStringStrict, NetTick
 
 Emotes = ["NORMAL", "PAIN", "HAPPY", "SURPRISE", "ANGRY", "BLINK"]
@@ -264,7 +264,13 @@ Objects = [
 	NetObjectEx("DDNetPlayer", "player@netobj.ddnet.tw", [
 		NetIntAny("m_Flags"),
 		NetIntRange("m_AuthLevel", "AUTHED_NO", "AUTHED_ADMIN"),
-		NetIntRange("m_FinishTimeSeconds", 'FinishTime::UNSET', 'max_int', default='FinishTime::UNSET'),
+		NetIntCustom("m_FinishTimeSeconds",
+			values=[
+				Constant(-2, 'FinishTime::UNSET'),
+				Constant(-1, 'FinishTime::NOT_FINISHED_MILLIS'),
+				Range(0, 'max_int')
+			],
+			default='FinishTime::UNSET'),
 		NetIntRange("m_FinishTimeMillis", 0, 999, default=0),
 	]),
 

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -1,4 +1,4 @@
-from datatypes import Enum, Flags, NetArray, NetBool, NetEvent, NetEventEx, NetIntAny, NetTwIntString, NetIntRange
+from datatypes import Constant, Enum, Flags, NetArray, NetBool, NetEvent, NetEventEx, NetIntAny, NetIntCustom, NetTwIntString, NetIntRange, Range
 from datatypes import NetMessage, NetMessageEx, NetObject, NetObjectEx, NetString, NetStringHalfStrict, NetStringStrict, NetTick, NetTickStrict
 
 Emotes = ["NORMAL", "PAIN", "HAPPY", "SURPRISE", "ANGRY", "BLINK"]
@@ -6,9 +6,9 @@ PlayerFlags = ["PLAYING", "IN_MENU", "CHATTING", "SCOREBOARD", "AIM", "SPEC_CAM"
 GameFlags = ["TEAMS", "FLAGS"]
 GameStateFlags = ["GAMEOVER", "SUDDENDEATH", "PAUSED", "RACETIME"]
 CharacterFlags = ["SOLO", "JETPACK", "COLLISION_DISABLED", "ENDLESS_HOOK", "ENDLESS_JUMP", "SUPER",
-                  "HAMMER_HIT_DISABLED", "SHOTGUN_HIT_DISABLED", "GRENADE_HIT_DISABLED", "LASER_HIT_DISABLED", "HOOK_HIT_DISABLED",
-                  "TELEGUN_GUN", "TELEGUN_GRENADE", "TELEGUN_LASER",
-                  "WEAPON_HAMMER", "WEAPON_GUN", "WEAPON_SHOTGUN", "WEAPON_GRENADE", "WEAPON_LASER", "WEAPON_NINJA",
+				  "HAMMER_HIT_DISABLED", "SHOTGUN_HIT_DISABLED", "GRENADE_HIT_DISABLED", "LASER_HIT_DISABLED", "HOOK_HIT_DISABLED",
+				  "TELEGUN_GUN", "TELEGUN_GRENADE", "TELEGUN_LASER",
+				  "WEAPON_HAMMER", "WEAPON_GUN", "WEAPON_SHOTGUN", "WEAPON_GRENADE", "WEAPON_LASER", "WEAPON_NINJA",
 				  "MOVEMENTS_DISABLED", "IN_FREEZE", "PRACTICE_MODE", "LOCK_MODE", "TEAM0_MODE", "INVINCIBLE"]
 GameInfoFlags = [
 	"TIMESCORE", "GAMETYPE_RACE", "GAMETYPE_FASTCAP", "GAMETYPE_FNG",
@@ -157,7 +157,12 @@ Objects = [
 		NetIntAny("m_X"),
 		NetIntAny("m_Y"),
 
-		NetIntRange("m_Team", 'TEAM_RED', 'TEAM_BLUE')
+		NetIntCustom("m_Team",
+			values=[
+				Constant(0, "TEAM_RED"),
+				Constant(1, "TEAM_BLUE"),
+			]
+		),
 	]),
 
 	NetObject("GameInfo", [
@@ -176,9 +181,22 @@ Objects = [
 	NetObject("GameData", [
 		NetIntAny("m_TeamscoreRed"),
 		NetIntAny("m_TeamscoreBlue"),
-
-		NetIntRange("m_FlagCarrierRed", 'FLAG_MISSING', 'MAX_CLIENTS-1'),
-		NetIntRange("m_FlagCarrierBlue", 'FLAG_MISSING', 'MAX_CLIENTS-1'),
+		NetIntCustom("m_FlagCarrierRed",
+			values=[
+				Constant(-3, "FLAG_MISSING"),
+				Constant(-2, "FLAG_ATSTAND"),
+				Constant(-1, "FLAG_TAKEN"),
+				Range(0, "MAX_CLIENTS-1"),
+			]
+		),
+  		NetIntCustom("m_FlagCarrierBlue",
+			values=[
+				Constant(-3, "FLAG_MISSING"),
+				Constant(-2, "FLAG_ATSTAND"),
+				Constant(-1, "FLAG_TAKEN"),
+				Range(0, "MAX_CLIENTS-1"),
+			]
+		)
 	]),
 
 	NetObject("CharacterCore", [
@@ -189,11 +207,39 @@ Objects = [
 		NetIntAny("m_VelY"),
 
 		NetIntAny("m_Angle"),
-		NetIntRange("m_Direction", -1, 1),
+		NetIntCustom("m_Direction",
+			values=[
+				Constant(-1, description="Left"),
+				Constant(0, description="None"),
+				Constant(1, description="Right"),
+			]
+		),
 
-		NetIntRange("m_Jumped", 0, 3),
-		NetIntRange("m_HookedPlayer", -1, 'MAX_CLIENTS-1'),
-		NetIntRange("m_HookState", -1, 5),
+		NetIntCustom("m_Jumped",
+			values=[
+				Constant(0, description="Not jumping and can air jump"),  # Tee has not jumped on current input and can do air jumps
+				Constant(1, description="Jumping and can air jump"),  # Tee made a jump on current input and can do air jumps
+				Constant(2, description="Not jumping but can't air jump"),  # Tee has not jumped on current input but can't do air jumps
+				Constant(3, description="Jumping but can't air jump"),  # Tee made a jump on current input and can't do air jumps anymore
+			]
+		),
+		NetIntCustom("m_HookedPlayer",
+			values=[
+				Constant(-1, description="Nobody"),
+				Range(0, "MAX_CLIENTS-1"),
+			]
+		),
+		NetIntCustom("m_HookState",
+			values=[
+				Constant(-1, "HOOK_RETRACTED"),
+				Constant(0, "HOOK_IDLE"),
+				Constant(1, "HOOK_RETRACT_START"),
+				Constant(2, description="Hook retract middle"),
+				Constant(3, "HOOK_RETRACT_END"),
+				Constant(4, "HOOK_FLYING"),
+				Constant(5, "HOOK_GRABBED"),
+			]
+		),
 		NetIntAny("m_HookTick"),
 
 		NetIntAny("m_HookX"),
@@ -206,10 +252,18 @@ Objects = [
 		NetIntRange("m_PlayerFlags", 0, 256),
 		NetIntRange("m_Health", 0, 10),
 		NetIntRange("m_Armor", 0, 10),
-		# -1 is infinite ammo
-		NetIntRange("m_AmmoCount", -1, 10),
-		# -1 means "no weapon"
-		NetIntRange("m_Weapon", -1, 'NUM_WEAPONS-1'),
+		NetIntCustom("m_AmmoCount",
+			values=[
+				Constant(-1, description="Infinite"),
+				Range(0, 10),
+			]
+   		),
+		NetIntCustom("m_Weapon",
+			values=[
+				Constant(-1, description="No weapon"),
+				Range(0, "NUM_WEAPONS-1"),
+			]
+   		),
 		NetIntRange("m_Emote", 0, len(Emotes)),
 		NetIntRange("m_AttackTick", 0, 'max_int'),
 	]),
@@ -217,7 +271,13 @@ Objects = [
 	NetObject("PlayerInfo", [
 		NetIntRange("m_Local", 0, 1),
 		NetIntRange("m_ClientId", 0, 'MAX_CLIENTS-1'),
-		NetIntRange("m_Team", 'TEAM_SPECTATORS', 'TEAM_BLUE'),
+		NetIntCustom("m_Team",
+			values=[
+				Constant(-1, "TEAM_SPECTATORS"),
+				Constant(0, "TEAM_RED"),
+				Constant(1, "TEAM_BLUE"),
+			]
+		),
 
 		NetIntAny("m_Score"),
 		NetIntAny("m_Latency"),
@@ -234,7 +294,12 @@ Objects = [
 	]),
 
 	NetObject("SpectatorInfo", [
-		NetIntRange("m_SpectatorId", 'SPEC_FREEVIEW', 'MAX_CLIENTS-1'),
+		NetIntCustom("m_SpectatorId",
+			values=[
+				Constant(-1, "SPEC_FREEVIEW"),
+				Range(0, "MAX_CLIENTS-1"),
+			]
+   		),
 		NetIntAny("m_X"),
 		NetIntAny("m_Y"),
 	]),
@@ -246,25 +311,49 @@ Objects = [
 	NetObjectEx("DDNetCharacter", "character@netobj.ddnet.tw", [
 		NetIntAny("m_Flags", default=0),
 		NetTick("m_FreezeEnd", default=0),
-		NetIntRange("m_Jumps", -1, 255, default=2),
+		NetIntCustom("m_Jumps",
+			values=[
+				Constant(-1, description="Only ground jump"),  # Only a single ground jump
+				Range(0, 255),
+			],
+			default=2
+		),
 		NetIntAny("m_TeleCheckpoint", default=-1),
 		NetIntRange("m_StrongWeakId", 0, 'MAX_CLIENTS-1', default=0),
 
 		# New data fields for jump display, freeze bar and ninja bar
 		# Default values indicate that these values should not be used
-		NetIntRange("m_JumpedTotal", -1, 255, default=-1),
+		NetIntCustom("m_JumpedTotal",
+			values=[
+				Constant(-1, description="No display info"),
+				Range(0, 255),
+			],
+			default=-1,
+		),
 		NetTick("m_NinjaActivationTick", default=-1),
 		NetTick("m_FreezeStart", default=-1),
 		# New data fields for improved target accuracy
 		NetIntAny("m_TargetX", default=0),
 		NetIntAny("m_TargetY", default=0),
-		NetIntRange("m_TuneZoneOverride", 'TuneZone::OVERRIDE_NONE', 'TuneZone::NUM-1', default='TuneZone::OVERRIDE_NONE'),
+		NetIntCustom("m_TuneZoneOverride",
+			values=[
+				Constant(-1, "TuneZone::OVERRIDE_NONE"),
+				Range(0, 'TuneZone::NUM-1'),
+			],
+			default='TuneZone::OVERRIDE_NONE'
+		)
 	], validate_size=False),
 
 	NetObjectEx("DDNetPlayer", "player@netobj.ddnet.tw", [
 		NetIntAny("m_Flags"),
 		NetIntRange("m_AuthLevel", "AUTHED_NO", "AUTHED_ADMIN"),
-		NetIntRange("m_FinishTimeSeconds", 'FinishTime::UNSET', 'max_int', default='FinishTime::UNSET'),
+		NetIntCustom("m_FinishTimeSeconds",
+			values=[
+				Constant(-2, 'FinishTime::UNSET'),
+				Constant(-1, 'FinishTime::NOT_FINISHED_MILLIS'),
+				Range(0, 'max_int'),
+			],
+			default='FinishTime::UNSET'),
 		NetIntRange("m_FinishTimeMillis", 0, 999, default=0),
 	]),
 
@@ -291,7 +380,12 @@ Objects = [
 		NetIntAny("m_FromX"),
 		NetIntAny("m_FromY"),
 		NetTick("m_StartTick"),
-		NetIntRange("m_Owner", -1, 'MAX_CLIENTS-1'),
+		NetIntCustom("m_Owner",
+			values=[
+				Constant(-1, description="No owner"),  # (i.e. player left)
+				Range(0, 'MAX_CLIENTS-1'),
+			]
+		),
 		NetIntAny("m_Type"),
 		NetIntAny("m_SwitchNumber", default=-1),
 		NetIntAny("m_Subtype", default=-1),
@@ -305,7 +399,12 @@ Objects = [
 		NetIntAny("m_VelY"),
 		NetIntRange("m_Type", 0, 'NUM_WEAPONS-1'),
 		NetTick("m_StartTick"),
-		NetIntRange("m_Owner", -1, 'MAX_CLIENTS-1'),
+		NetIntCustom("m_Owner",
+			values=[
+				Constant(-1, description="No owner"),  # (i.e. player left)
+				Range(0, 'MAX_CLIENTS-1'),
+			]
+		),
 		NetIntAny("m_SwitchNumber"),
 		NetIntRange("m_TuneZone", 0, 'TuneZone::NUM-1'),
 		NetIntAny("m_Flags"),
@@ -393,7 +492,13 @@ Objects = [
 
  	# the current best time in the server
 	NetObjectEx("MapBestTime", "map-best-time@netobj.ddnet.org", [
-			NetIntRange("m_MapBestTimeSeconds", 'FinishTime::NOT_FINISHED_MILLIS', 'max_int'),
+			NetIntCustom("m_MapBestTimeSeconds",
+				values=[
+					Constant(-1, "FinishTime::NOT_FINISHED_MILLIS"),
+					Range(0, "max_int"),
+				],
+				default="FinishTime::NOT_FINISHED_MILLIS"
+			),
 			NetIntRange("m_MapBestTimeMillis", 0, 999),
 	]),
 
@@ -414,15 +519,36 @@ Messages = [
 	]),
 
 	NetMessage("Sv_Chat", [
-		NetIntRange("m_Team", -2, 3),
-		NetIntRange("m_ClientId", -1, 'MAX_CLIENTS-1'),
+		NetIntCustom("m_Team",
+			values=[
+				Constant(-2, "TEAM_ALL"),
+				Constant(-1, "TEAM_SPECTATORS"),
+				Constant(0, "TEAM_RED"),
+				Constant(1, "TEAM_BLUE"),
+				Constant(2, "TEAM_WHISPER_SEND"),
+				Constant(3, "TEAM_WHISPER_RECV"),
+			]
+		),
+		NetIntCustom("m_ClientId",
+			values=[
+				Constant(-1, description="All clients"),
+				Range(0, "MAX_CLIENTS-1"),
+			],
+		),
 		NetStringHalfStrict("m_pMessage"),
 	]),
 
 	NetMessage("Sv_KillMsg", [
 		NetIntRange("m_Killer", 0, 'MAX_CLIENTS-1'),
 		NetIntRange("m_Victim", 0, 'MAX_CLIENTS-1'),
-		NetIntRange("m_Weapon", 'WEAPON_GAME', 'NUM_WEAPONS-1'),
+		NetIntCustom("m_Weapon",
+			values=[
+				Constant(-3, "WEAPON_GAME"),
+				Constant(-2, "WEAPON_SELF"),
+				Constant(-1, "WEAPON_WORLD"),
+				Range(0, "NUM_WEAPONS-1"),
+			]
+   		),
 		NetIntAny("m_ModeSpecial"),
 	]),
 
@@ -483,11 +609,22 @@ Messages = [
 	], teehistorian=False),
 
 	NetMessage("Cl_SetTeam", [
-		NetIntRange("m_Team", 'TEAM_SPECTATORS', 'TEAM_BLUE'),
+		NetIntCustom("m_Team",
+			values=[
+				Constant(-1, "TEAM_SPECTATORS"),
+				Constant(0, "TEAM_RED"),
+				Constant(1, "TEAM_BLUE"),
+			]
+		),
 	]),
 
 	NetMessage("Cl_SetSpectatorMode", [
-		NetIntRange("m_SpectatorId", 'SPEC_FREEVIEW', 'MAX_CLIENTS-1'),
+		NetIntCustom("m_SpectatorId",
+			values=[
+				Constant(-1, "SPEC_FREEVIEW"),
+				Range(0, "MAX_CLIENTS-1"),
+			]
+   		)
 	]),
 
 	NetMessage("Cl_StartInfo", [
@@ -517,7 +654,12 @@ Messages = [
 	]),
 
 	NetMessage("Cl_Vote", [
-		NetIntRange("m_Vote", -1, 1),
+		NetIntCustom("m_Vote",
+			values=[
+				Constant(-1, description="Vote no"),
+				Constant(1, description="Vote yes"),
+			]
+		)
 	], teehistorian=False),
 
 	NetMessage("Cl_CallVote", [
@@ -583,11 +725,21 @@ Messages = [
 
 	NetMessageEx("Sv_KillMsgTeam", "killmsgteam@netmsg.ddnet.tw", [
 		NetIntRange("m_Team", 0, 'MAX_CLIENTS-1'),
-		NetIntRange("m_First", -1, 'MAX_CLIENTS-1'),
+		NetIntCustom("m_First",
+			values=[
+				Constant(-1, description="Nobody"),
+				Range(0, "MAX_CLIENTS-1"),
+			]
+		)
 	]),
 
 	NetMessageEx("Sv_YourVote", "yourvote@netmsg.ddnet.org", [
-		NetIntRange("m_Voted", -1, 1),
+		NetIntCustom("m_Voted",
+			values=[
+				Constant(-1, description="Vote no"),
+				Constant(1, description="Vote yes"),
+			]
+		)
 	]),
 
 	NetMessageEx("Sv_RaceFinish", "racefinish@netmsg.ddnet.org", [
@@ -630,7 +782,7 @@ Messages = [
 		NetIntAny("m_Jump"),
 		NetIntAny("m_Fire"),
 		NetIntAny("m_Hook"),
-		
+
 		NetIntAny("m_WantedWeapon"),
 		NetIntAny("m_NextWeapon"),
 		NetIntAny("m_PrevWeapon"),
@@ -640,14 +792,22 @@ Messages = [
 	]),
 
 	NetMessageEx("Sv_SaveCode", "save-code@netmsg.ddnet.org", [
-		NetIntRange("m_State", 'SAVESTATE_PENDING', 'SAVESTATE_ERROR'),
+		NetIntCustom("m_State",
+			values=[
+				Constant(0, "SAVESTATE_PENDING"),
+				Constant(1, "SAVESTATE_DONE"),
+				Constant(2, "SAVESTATE_FALLBACKFILE"),
+				Constant(3, "SAVESTATE_WARNING"),
+				Constant(4, "SAVESTATE_ERROR"),
+			]
+		),
 		NetStringStrict("m_pError"),
 		NetStringStrict("m_pSaveRequester"),
 		NetStringStrict("m_pServerName"),
 		NetStringStrict("m_pGeneratedCode"),
 		NetStringStrict("m_pCode"),
 		NetStringStrict("m_pTeamMembers"),
-    ]),
+	]),
 
 	NetMessageEx("Sv_ServerAlert", "server-alert@netmsg.ddnet.org", [
 		NetString("m_pMessage"),
@@ -660,7 +820,7 @@ Messages = [
 	NetMessageEx("Cl_EnableSpectatorCount", "enable-spectator-count@netmsg.ddnet.org", [
 		NetBool("m_Enable"),
 	]),
-	
+
 	NetMessageEx("Sv_MapInfo", "map-info@netmsg.ddnet.org", [
 		NetString("m_pDescription"),
 	]),


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This PR creates a NetIntCustom element, which takes `Range` and/or `Constant` parameters in order to explicitly define special values, which are currently used in `NetIntRange`.

Only changed "m_FinishTimeSeconds" as long as the implementation is not clear.

supersedes #12101
closes #12091

```python
	NetObjectEx("DDNetPlayer", "player@netobj.ddnet.tw", [
		NetIntAny("m_Flags"),
		NetIntRange("m_AuthLevel", "AUTHED_NO", "AUTHED_ADMIN"),
		NetIntCustom("m_FinishTimeSeconds",
			values=[
				Constant(-2, 'FinishTime::UNSET'),
				Constant(-1, 'FinishTime::NOT_FINISHED_MILLIS'),
				Range(0, 'max_int')
			],
			default='FinishTime::UNSET'),
		NetIntRange("m_FinishTimeMillis", 0, 999, default=0),
	]),
```

creates

protocol.cpp:
`void *CNetObjHandler::SecureUnpackObj`
```C++
case NETOBJTYPE_DDNETPLAYER:
	{
		CNetObj_DDNetPlayer *pData = (CNetObj_DDNetPlayer *)m_aUnpackedData;
		pData->m_Flags = pUnpacker->GetUncompressedInt();
		pData->m_AuthLevel = pUnpacker->GetUncompressedInt();
		pData->m_FinishTimeSeconds = pUnpacker->GetUncompressedIntOrDefault(FinishTime::UNSET);
		pData->m_FinishTimeMillis = pUnpacker->GetUncompressedIntOrDefault(0);
		pData->m_AuthLevel = ClampInt("m_AuthLevel", pData->m_AuthLevel, AUTHED_NO, AUTHED_ADMIN);
		static_assert(FinishTime::UNSET == -2, "Value and key aren't equal");
		static_assert(FinishTime::NOT_FINISHED_MILLIS == -1, "Value and key aren't equal");
		static_assert((int)max_int == max_int, "Value is not an integer");
		bool IsValidFinishTimeSeconds = pData->m_FinishTimeSeconds == FinishTime::UNSET || pData->m_FinishTimeSeconds == FinishTime::NOT_FINISHED_MILLIS ||
			(pData->m_FinishTimeSeconds >= 0 && pData->m_FinishTimeSeconds <= max_int);
		if(!IsValidFinishTimeSeconds)
		{
			pData->m_FinishTimeSeconds = FinishTime::UNSET;
		}
		pData->m_FinishTimeMillis = ClampInt("m_FinishTimeMillis", pData->m_FinishTimeMillis, 0, 999);
	} break;
```

`int CNetObjHandler::DumpObj`
```C++
		str_format(aRawData, sizeof(aRawData), "\t\t%3d %12d\t%08x", 2, ((const int *)pData)[2], ((const int *)pData)[2]);
		dbg_msg("snapshot", "%s\tm_FinishTimeSeconds=%d (Contents=[ \
				FinishTime::UNSET(-2), \
				FinishTime::NOT_FINISHED_MILLIS(-1), \
				[min=0 max=max_int(%d)], \
			])",
			aRawData, pObj->m_FinishTimeSeconds, (int)max_int);
```

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
