### PR TITLE
Use `log_*` functions for `CNameBans`

### DIFF
--- a/src/engine/server/name_ban.cpp
+++ b/src/engine/server/name_ban.cpp
@@ -15,11 +15,9 @@ CNameBan::CNameBan(const char *pName, const char *pReason, int Distance, bool Is
 
 void CNameBans::InitConsole(IConsole *pConsole)
 {
-	m_pConsole = pConsole;
-
-	m_pConsole->Register("name_ban", "s[name] ?i[distance] ?i[is_substring] ?r[reason]", CFGFLAG_SERVER, ConNameBan, this, "Ban a certain nickname");
-	m_pConsole->Register("name_unban", "s[name]", CFGFLAG_SERVER, ConNameUnban, this, "Unban a certain nickname");
-	m_pConsole->Register("name_bans", "", CFGFLAG_SERVER, ConNameBans, this, "List all name bans");
+	pConsole->Register("name_ban", "s[name] ?i[distance] ?i[is_substring] ?r[reason]", CFGFLAG_SERVER, ConNameBan, this, "Ban a certain nickname");
+	pConsole->Register("name_unban", "s[name]", CFGFLAG_SERVER, ConNameUnban, this, "Unban a certain nickname");
+	pConsole->Register("name_bans", "", CFGFLAG_SERVER, ConNameBans, this, "List all name bans");
 }
 
 void CNameBans::Ban(const char *pName, const char *pReason, const int Distance, const bool IsSubstring)
@@ -28,12 +26,8 @@ void CNameBans::Ban(const char *pName, const char *pReason, const int Distance, 
 	{
 		if(str_comp(Ban.m_aName, pName) == 0)
 		{
-			if(m_pConsole)
-			{
-				char aBuf[256];
-				str_format(aBuf, sizeof(aBuf), "changed name='%s' distance=%d old_distance=%d is_substring=%d old_is_substring=%d reason='%s' old_reason='%s'", pName, Distance, Ban.m_Distance, IsSubstring, Ban.m_IsSubstring, pReason, Ban.m_aReason);
-				m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "name_ban", aBuf);
-			}
+			log_info("name_ban", "changed name='%s' distance=%d old_distance=%d is_substring=%d old_is_substring=%d reason='%s' old_reason='%s'",
+				pName, Distance, Ban.m_Distance, IsSubstring, Ban.m_IsSubstring, pReason, Ban.m_aReason);
 			str_copy(Ban.m_aReason, pReason);
 			Ban.m_Distance = Distance;
 			Ban.m_IsSubstring = IsSubstring;
@@ -42,12 +36,8 @@ void CNameBans::Ban(const char *pName, const char *pReason, const int Distance, 
 	}
 
 	m_vNameBans.emplace_back(pName, pReason, Distance, IsSubstring);
-	if(m_pConsole)
-	{
-		char aBuf[256];
-		str_format(aBuf, sizeof(aBuf), "added name='%s' distance=%d is_substring=%d reason='%s'", pName, Distance, IsSubstring, pReason);
-		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "name_ban", aBuf);
-	}
+	log_info("name_ban", "added name='%s' distance=%d is_substring=%d reason='%s'",
+		pName, Distance, IsSubstring, pReason);
 }
 
 void CNameBans::Unban(const char *pName)
@@ -55,35 +45,22 @@ void CNameBans::Unban(const char *pName)
 	auto ToRemove = std::remove_if(m_vNameBans.begin(), m_vNameBans.end(), [pName](const CNameBan &Ban) { return str_comp(Ban.m_aName, pName) == 0; });
 	if(ToRemove == m_vNameBans.end())
 	{
-		if(m_pConsole)
-		{
-			char aBuf[256];
-			str_format(aBuf, sizeof(aBuf), "name ban '%s' not found", pName);
-			m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "name_ban", aBuf);
-		}
+		log_error("name_ban", "name ban '%s' not found", pName);
 	}
 	else
 	{
-		if(m_pConsole)
-		{
-			char aBuf[256];
-			str_format(aBuf, sizeof(aBuf), "removed name='%s' distance=%d is_substring=%d reason='%s'", (*ToRemove).m_aName, (*ToRemove).m_Distance, (*ToRemove).m_IsSubstring, (*ToRemove).m_aReason);
-			m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "name_ban", aBuf);
-		}
+		log_info("name_ban", "removed name='%s' distance=%d is_substring=%d reason='%s'",
+			(*ToRemove).m_aName, (*ToRemove).m_Distance, (*ToRemove).m_IsSubstring, (*ToRemove).m_aReason);
 		m_vNameBans.erase(ToRemove, m_vNameBans.end());
 	}
 }
 
 void CNameBans::Dump() const
 {
-	if(!m_pConsole)
-		return;
-
-	char aBuf[256];
 	for(const auto &Ban : m_vNameBans)
 	{
-		str_format(aBuf, sizeof(aBuf), "name='%s' distance=%d is_substring=%d reason='%s'", Ban.m_aName, Ban.m_Distance, Ban.m_IsSubstring, Ban.m_aReason);
-		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "name_ban", aBuf);
+		log_info("name_ban", "name='%s' distance=%d is_substring=%d reason='%s'",
+			Ban.m_aName, Ban.m_Distance, Ban.m_IsSubstring, Ban.m_aReason);
 	}
 }
 

--- a/src/engine/server/name_ban.h
+++ b/src/engine/server/name_ban.h
@@ -27,7 +27,6 @@ public:
 
 class CNameBans
 {
-	IConsole *m_pConsole = nullptr;
 	std::vector<CNameBan> m_vNameBans;
 
 	static void ConNameBan(IConsole::IResult *pResult, void *pUser);


### PR DESCRIPTION
This means the name ban tests will also log messages now (on test failure or with `--no-capture`), as the console pointer was previously `nullptr` in the tests.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions