### PR TITLE
Support building Emscripten libraries on Windows

### DIFF
--- a/scripts/compile_libs/_build_common.sh
+++ b/scripts/compile_libs/_build_common.sh
@@ -130,6 +130,18 @@ export EMSCRIPTEN_WASM_CFLAGS="-pthread -O3 -g -s USE_PTHREADS=1"
 export EMSCRIPTEN_WASM_LDFLAGS="-pthread -O3 -g -s USE_PTHREADS=1 -s ASYNCIFY=1 -s WASM=1"
 export EMSCRIPTEN_EXTRA_RELEASE_CFLAGS="-g0"
 
+EMSCRIPTEN_CMAKE_WRAPPER="emcmake"
+EMSCRIPTEN_CC="emcc"
+EMSCRIPTEN_AR="emar"
+if [[ "${HOST_OS}" == "windows" ]]; then
+	EMSCRIPTEN_CMAKE_WRAPPER="${EMSCRIPTEN_CMAKE_WRAPPER}.bat"
+	EMSCRIPTEN_CC="${EMSCRIPTEN_CC}.bat"
+	EMSCRIPTEN_AR="${EMSCRIPTEN_AR}.bat"
+fi
+export EMSCRIPTEN_CMAKE_WRAPPER
+export EMSCRIPTEN_CC
+export EMSCRIPTEN_AR
+
 function cpu_count() {
 	if command -v nproc > /dev/null 2>&1; then
 		nproc

--- a/scripts/compile_libs/cmake_lib_compile.sh
+++ b/scripts/compile_libs/cmake_lib_compile.sh
@@ -44,7 +44,7 @@ function make_cmake() {
 		cmake_arguments+=("-DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY")
 		build_extra_cflags="${IOS_COMMON_CFLAGS}"
 	elif [[ "${TARGET_PLATFORM}" == "webasm" ]]; then
-		cmake_wrapper="emcmake"
+		cmake_wrapper="${EMSCRIPTEN_CMAKE_WRAPPER}"
 		build_extra_cflags="${EMSCRIPTEN_WASM_CFLAGS} ${EMSCRIPTEN_EXTRA_RELEASE_CFLAGS}"
 		build_extra_ldflags="${EMSCRIPTEN_WASM_LDFLAGS}"
 	fi

--- a/scripts/compile_libs/make_lib_opusfile.sh
+++ b/scripts/compile_libs/make_lib_opusfile.sh
@@ -65,8 +65,8 @@ function make_opusfile() {
 			ar="$(xcrun --sdk "${ios_sdk_path}" --find ar)"
 			build_extra_cflags="${build_extra_cflags} -arch ${build_ios_arch} -isysroot ${ios_sdk_path} ${ios_min_flag}"
 		elif [[ "${TARGET_PLATFORM}" == "webasm" ]]; then
-			cc="emcc"
-			ar="emar"
+			cc="${EMSCRIPTEN_CC}"
+			ar="${EMSCRIPTEN_AR}"
 		fi
 
 		if [[ ! -f Makefile ]]; then

--- a/scripts/compile_libs/make_lib_sqlite3.sh
+++ b/scripts/compile_libs/make_lib_sqlite3.sh
@@ -46,8 +46,8 @@ function make_sqlite3() {
 			ar="$(xcrun --sdk "${ios_sdk_path}" --find ar)"
 			build_extra_cflags="${build_extra_cflags} -arch ${build_ios_arch} -isysroot ${ios_sdk_path} ${ios_min_flag}"
 		elif [[ "${TARGET_PLATFORM}" == "webasm" ]]; then
-			cc="emcc"
-			ar="emar"
+			cc="${EMSCRIPTEN_CC}"
+			ar="${EMSCRIPTEN_AR}"
 		fi
 
 		# Remove absolute build paths and compiler identification from binary


### PR DESCRIPTION
Work around the Emscripten tools not being found when running the `gen_libs.sh` script in an MSYS2-based shell on Windows, by explicitly specifying the `.bat` file extension of the tools.

## Checklist

- [X] Tested the change
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions