### PR TITLE
Use SDL_GetWindowSize for current window size when reverting config variables after failed window resize

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1770,6 +1770,11 @@ bool CGraphicsBackend_SDL_GL::ResizeWindow(int w, int h, int RefreshRate)
 	return false;
 }
 
+void CGraphicsBackend_SDL_GL::GetWindowSize(int &w, int &h)
+{
+	SDL_GetWindowSize(m_pWindow, &w, &h);
+}
+
 void CGraphicsBackend_SDL_GL::GetViewportSize(int &w, int &h)
 {
 	if(m_BackendType != EBackendType::BACKEND_TYPE_VULKAN)

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -257,6 +257,7 @@ public:
 	int WindowOpen() override;
 	void SetWindowGrab(bool Grab) override;
 	bool ResizeWindow(int w, int h, int RefreshRate) override;
+	void GetWindowSize(int &w, int &h) override;
 	void GetViewportSize(int &w, int &h) override;
 	void NotifyWindow() override;
 	bool IsScreenKeyboardShown() override;

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -2615,7 +2615,9 @@ bool CGraphics_Threaded::Resize(int w, int h, int RefreshRate)
 		return false;
 #endif
 
-	if(WindowWidth() == w && WindowHeight() == h && RefreshRate == m_ScreenRefreshRate)
+	int CurW, CurH;
+	m_pBackend->GetWindowSize(CurW, CurH);
+	if(CurW == w && CurH == h && RefreshRate == m_ScreenRefreshRate)
 		return false;
 
 	// if the size is changed manually, only set the window resize, a window size changed event is triggered anyway
@@ -2635,8 +2637,10 @@ void CGraphics_Threaded::ResizeToScreen()
 		return;
 
 	// Revert config variables if the change was not accepted
-	g_Config.m_GfxScreenWidth = ScreenWidth();
-	g_Config.m_GfxScreenHeight = ScreenHeight();
+	int CurW, CurH;
+	m_pBackend->GetWindowSize(CurW, CurH);
+	g_Config.m_GfxScreenWidth = CurW;
+	g_Config.m_GfxScreenHeight = CurH;
 	g_Config.m_GfxScreenRefreshRate = m_ScreenRefreshRate;
 }
 

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -699,6 +699,7 @@ public:
 	virtual void SetWindowGrab(bool Grab) = 0;
 	// returns true, if the video mode changed
 	virtual bool ResizeWindow(int w, int h, int RefreshRate) = 0;
+	virtual void GetWindowSize(int &w, int &h) = 0;
 	virtual void GetViewportSize(int &w, int &h) = 0;
 	virtual void NotifyWindow() = 0;
 	virtual bool IsScreenKeyboardShown() = 0;


### PR DESCRIPTION
Fixes #12115. 

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

AI generated, I tested on macOS with OpenGL backend

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
