### PR TITLE
Fix console argument handling for strings ending in `\\`

### DIFF
--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -422,18 +422,25 @@ bool CConsole::LineIsValid(const char *pStr)
 		CResult Result(IConsole::CLIENT_ID_UNSPECIFIED);
 		const char *pEnd = pStr;
 		const char *pNextPart = nullptr;
-		int InString = 0;
+		bool InString = false;
+		bool IsEscaping = false;
 
 		while(*pEnd)
 		{
-			if(*pEnd == '"')
-				InString ^= 1;
-			else if(*pEnd == '\\') // escape sequences
+			if(IsEscaping)
 			{
-				if(pEnd[1] == '"')
-					pEnd++;
+				IsEscaping = false;
 			}
-			else if(!InString)
+			else if(*pEnd == '"')
+			{
+				InString = !InString;
+			}
+			else if(InString && *pEnd == '\\') // escape sequences
+			{
+				IsEscaping = true;
+			}
+
+			if(!InString)
 			{
 				if(*pEnd == ';') // command separator
 				{
@@ -473,18 +480,25 @@ void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientId, bo
 		CResult Result(ClientId);
 		const char *pEnd = pStr;
 		const char *pNextPart = nullptr;
-		int InString = 0;
+		bool InString = false;
+		bool IsEscaping = false;
 
 		while(*pEnd)
 		{
-			if(*pEnd == '"')
-				InString ^= 1;
-			else if(*pEnd == '\\') // escape sequences
+			if(IsEscaping)
 			{
-				if(pEnd[1] == '"')
-					pEnd++;
+				IsEscaping = false;
 			}
-			else if(!InString && InterpretSemicolons)
+			else if(*pEnd == '"')
+			{
+				InString = !InString;
+			}
+			else if(InString && *pEnd == '\\') // escape sequences
+			{
+				IsEscaping = true;
+			}
+
+			if(!InString && InterpretSemicolons)
 			{
 				if(*pEnd == ';') // command separator
 				{

--- a/src/game/editor/editor_server_settings.cpp
+++ b/src/game/editor/editor_server_settings.cpp
@@ -1229,18 +1229,25 @@ void CMapSettingsBackend::CContext::UpdateFromString(const char *pStr)
 
 	// Check for comment
 	const char *pEnd = pStr;
-	int InString = 0;
+	bool InString = false;
+	bool IsEscaping = false;
 
 	while(*pEnd)
 	{
-		if(*pEnd == '"')
-			InString ^= 1;
-		else if(*pEnd == '\\') // Escape sequences
+		if(IsEscaping)
 		{
-			if(pEnd[1] == '"')
-				pEnd++;
+			IsEscaping = false;
 		}
-		else if(!InString)
+		else if(*pEnd == '"')
+		{
+			InString = !InString;
+		}
+		else if(InString && *pEnd == '\\') // escape sequences
+		{
+			IsEscaping = true;
+		}
+
+		if(!InString)
 		{
 			if(*pEnd == '#') // Found comment
 			{


### PR DESCRIPTION
Previously, when the argument parser encountered a `\` character, it read ahead to check if the next character is `"` and then skipped both. However, when reading a string like `"\\"`, the first `\` character did not properly escape the second `\` character, so the latter was incorrectly escaping the closing `"` character.  This caused following commands not to be executed when chaining multiple commands with `;`. For example `echo "1\\";echo "2"` only logged the first message.

Closes #12123.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions