### PR TITLE
Various Emscripten error and exit handling improvements, fix Emscripten CI being stuck on errors

### DIFF
--- a/cmake/toolchains/Emscripten.toolchain
+++ b/cmake/toolchains/Emscripten.toolchain
@@ -32,7 +32,7 @@ set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s FULL_ES3=1")
 
 # Make sure C callback functions are available to JS.
 set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=[\\$autoResumeAudioContext,\\$dynCall]")
-set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s EXPORTED_FUNCTIONS=_main,_EmscriptenCallbackDropFile,_EmscriptenCallbackQuit")
+set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s EXPORTED_FUNCTIONS=_main,_EmscriptenCallbackDropFile,_EmscriptenCallbackQuit,_EmscriptenCallbackQuitForce")
 set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s EXPORTED_RUNTIME_METHODS=ccall")
 
 # Very important: use same stack size that other platforms have, as the default of 64 KiB that Emscripten uses is too small for our code and causes stack overflows.

--- a/other/emscripten/index.html
+++ b/other/emscripten/index.html
@@ -97,6 +97,28 @@
 						appendOutput(line, false, "red");
 					}
 				}
+				// Force stop audio processing because the client does not do so when force quit on
+				// assertion errors and segmentation faults. This would otherwise cause many error
+				// messages to be emitted when audio processing continues after the runtime exited.
+				var SDL2 = Module['SDL2'];
+				if (SDL2.audio !== undefined) {
+					if (SDL2.audio.scriptProcessorNode !== undefined) {
+						SDL2.audio.scriptProcessorNode.disconnect();
+					}
+					if (SDL2.audio.silenceTimer !== undefined) {
+						clearInterval(SDL2.audio.silenceTimer);
+					}
+					SDL2.audio = undefined;
+				}
+				if (SDL2.audioContext !== undefined) {
+					SDL2.audioContext.close();
+					SDL2.audioContext = undefined;
+				}
+				// Force quit the client on errors, because the runtime does not exit otherwise, which
+				// would cause tests using `emrun` to time out and prevent `onExit` from being invoked.
+				if (!ABORT) {
+					Module.ccall('EmscriptenCallbackQuitForce', null, [], []);
+				}
 			};
 			Module['canvas'].addEventListener('contextmenu', e => e.preventDefault());
 			Module['canvas'].addEventListener('webglcontextcreationerror', e => {

--- a/other/emscripten/index.html
+++ b/other/emscripten/index.html
@@ -90,8 +90,13 @@
 				},
 				canvas: document.getElementById('canvas')
 			};
-			window.onerror = function(text) {
-				appendOutput(text, true, "red");
+			window.onerror = function(message, url, line, column, error) {
+				appendOutput(message, true, "red");
+				if (error) {
+					for (const line of error.stack.split("\n")) {
+						appendOutput(line, false, "red");
+					}
+				}
 			};
 			Module['canvas'].addEventListener('contextmenu', e => e.preventDefault());
 			Module['canvas'].addEventListener('webglcontextcreationerror', e => {

--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -35,7 +35,13 @@ void log_set_global_logger(ILogger *logger)
 	{
 		dbg_assert_failed("global logger has already been set and can only be set once");
 	}
+#if !defined(CONF_PLATFORM_EMSCRIPTEN)
+	// With Emscripten, when atexit calls log_global_logger_finish, which calls GlobalFinish, the
+	// Emscripten runtime has already exited, so we cannot wait for the AIO thread to finish and
+	// calling io_sync in the assertion logger is not possible. We instead finish the global logger
+	// manually in src/engine/client/client.cpp before exit.
 	atexit(log_global_logger_finish);
+#endif
 }
 
 void log_global_logger_finish()

--- a/src/base/thread.cpp
+++ b/src/base/thread.cpp
@@ -100,7 +100,21 @@ void *thread_init(void (*threadfunc)(void *), void *u, const char *name)
 
 void thread_wait(void *thread)
 {
-#if defined(CONF_FAMILY_UNIX)
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+	// TODO: Remove this workaround when https://github.com/emscripten-core/emscripten/issues/9910 is fixed.
+	while(true)
+	{
+		const int join_result = pthread_tryjoin_np((pthread_t)thread, nullptr);
+		if(join_result == 0)
+		{
+			break;
+		}
+		dbg_assert(join_result == EBUSY, "pthread_tryjoin_np failure");
+		// Busy waiting so we can periodically yield control to browser's
+		// main thread because blocking on the main thread is very bad.
+		emscripten_sleep(10);
+	}
+#elif defined(CONF_FAMILY_UNIX)
 	dbg_assert(pthread_join((pthread_t)thread, nullptr) == 0, "pthread_join failure");
 #elif defined(CONF_FAMILY_WINDOWS)
 	dbg_assert(WaitForSingleObject((HANDLE)thread, INFINITE) == WAIT_OBJECT_0, "WaitForSingleObject failure");

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4787,6 +4787,10 @@ int main(int argc, const char **argv)
 		//       ignores the activity lifecycle entirely, which may cause issues if
 		//       we ever used any global resources like the camera.
 		std::exit(0);
+#elif defined(CONF_PLATFORM_EMSCRIPTEN)
+		// We cannot use atexit with Emscripten so we finish the global logger here.
+		// See comment in the log_set_global_logger function for details.
+		log_global_logger_finish();
 #endif
 	};
 	std::function<void()> PerformAllCleanup = [PerformCleanup, PerformFinalCleanup]() mutable {

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -73,6 +73,10 @@
 #include <android/android_main.h>
 #endif
 
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+#include <emscripten/emscripten.h>
+#endif
+
 #include "SDL.h"
 #ifdef main
 #undef main
@@ -4669,6 +4673,17 @@ static bool SaveUnknownCommandCallback(const char *pCommand, void *pUser)
 	pClient->ConfigManager()->StoreUnknownCommand(pCommand);
 	return true;
 }
+
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+extern "C" {
+
+// This will be called from Emscripten JS code
+void EmscriptenCallbackQuitForce()
+{
+	emscripten_force_exit(-1);
+}
+}
+#endif
 
 /*
 	Server Time


### PR DESCRIPTION
See commit messages.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options: debug, release, headless
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
