### PR TITLE
Use safe array access to prevent out-of-bounds panic

### DIFF
--- a/src/engine/shared/snapshot/delta.rs
+++ b/src/engine/shared/snapshot/delta.rs
@@ -260,11 +260,9 @@ impl CSnapshotDelta {
 
 fn obj_size(static_sizes: &[u16], type_: u16) -> Option<u32> {
     let type_: usize = type_.into();
-    if type_ > static_sizes.len() {
+    let size = *static_sizes.get(type_)?;
+    if size == 0 {
         return None;
     }
-    if static_sizes[type_] == 0 {
-        return None;
-    }
-    Some(static_sizes[type_].into())
+    Some(size.into())
 }


### PR DESCRIPTION
`.get` returns `None` if the index is out of bounds. The question mark operator `?` propagates that `None` to the return value, or extracts the value if it's present.

Fixes #12127.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions