### PR TITLE
Ensure cursor becomes visible after Emscripten client quits, use default browser actions for Ctrl+F5, F11 and F12 keys 

### DIFF
--- a/other/emscripten/index.html
+++ b/other/emscripten/index.html
@@ -123,6 +123,12 @@
 					Module.ccall('EmscriptenCallbackQuitForce', null, [], []);
 				}
 			};
+			document.addEventListener('keydown', e => {
+				// Always use default browser actions for Ctrl+F5 (refresh), F11 (fullscreen), F12 (developer console).
+				if ((e.ctrlKey && e.key === 'F5') || e.key === 'F11' || e.key == 'F12') {
+					e.stopPropagation();
+				}
+			}, true);
 			Module['canvas'].addEventListener('contextmenu', e => e.preventDefault());
 			Module['canvas'].addEventListener('webglcontextcreationerror', e => {
 				appendOutput(`Failed to create WebGL context: ${e.statusMessage || "Unknown error"}`, true, "red");

--- a/other/emscripten/index.html
+++ b/other/emscripten/index.html
@@ -79,6 +79,9 @@
 					Module['canvas'].style.display = "none";
 					// Make sure to reset cursor because it sometimes does not become visible.
 					Module['canvas'].style.cursor = "default";
+					// Also reset cursor of body because the cursor sometimes does not become
+					// visible until being moved.
+					document.body.style.cursor = "default";
 					appendOutput("Client closed. Reload the page to restart.", true);
 					const restartButton = document.createElement("button");
 					restartButton.textContent = "Reload page";


### PR DESCRIPTION
See commit messages.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions