### PR TITLE
Include shortened git revision hash in server version, change `0.6.4` game version prefix to `0.6`

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -120,6 +120,13 @@ CGameContext::CGameContext(bool Resetting) :
 	m_LatestLog = 0;
 	mem_zero(&m_aLogs, sizeof(m_aLogs));
 
+	str_copy(m_aVersionString, GAME_VERSION);
+	if(GIT_SHORTREV_HASH != nullptr)
+	{
+		str_append(m_aVersionString, " ");
+		str_append(m_aVersionString, GIT_SHORTREV_HASH);
+	}
+
 	if(!Resetting)
 	{
 		m_pMap = CreateMap();
@@ -4791,7 +4798,7 @@ const char *CGameContext::GameType() const
 	dbg_assert(m_pController->m_pGameType, "no gametype");
 	return m_pController->m_pGameType;
 }
-const char *CGameContext::Version() const { return GAME_VERSION; }
+const char *CGameContext::Version() const { return m_aVersionString; }
 const char *CGameContext::NetVersion() const { return GAME_NETVERSION; }
 
 IGameServer *CreateGameServer() { return new CGameContext; }

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -392,6 +392,7 @@ public:
 
 	CUuid GameUuid() const override;
 	const char *GameType() const override;
+	char m_aVersionString[32];
 	const char *Version() const override;
 	const char *NetVersion() const override;
 

--- a/src/game/version.h
+++ b/src/game/version.h
@@ -14,7 +14,9 @@ extern const char *GIT_SHORTREV_HASH;
 
 // teeworlds
 #define CLIENT_VERSION7 0x0705
-#define GAME_VERSION "0.6.4, " GAME_RELEASE_VERSION
+// For compatibility with DDNet client 15.8 and older we need to include the prefix `0.6` in the version string
+// because this was used for a "Compatible version" filter in the server browser.
+#define GAME_VERSION "0.6, " GAME_RELEASE_VERSION
 #define GAME_NETVERSION "0.6 626fce9a778df4d4"
 #define GAME_NETVERSION7 "0.7 802f1be60a05665f"
 


### PR DESCRIPTION
This allows hosters to easily determine which exact versions of servers they are hosting based on the server info.

The exact Teeworlds version is irrelevant to players looking at DDNet servers in the server browser. The prefix `0.6` is kept for backwards compatiblity with DDNet client version 15.8 and older which compare this prefix for the "Compatible version" server browser filter.

<img width="375" height="223" alt="image" src="https://github.com/user-attachments/assets/0a4ecbca-2522-4c9f-889e-52e27d27847f" />


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
