### PR TITLE
Remove unused `CHostLookup` default constructor

### DIFF
--- a/src/engine/shared/host_lookup.cpp
+++ b/src/engine/shared/host_lookup.cpp
@@ -6,8 +6,6 @@
 #include <base/net.h>
 #include <base/str.h>
 
-CHostLookup::CHostLookup() = default;
-
 CHostLookup::CHostLookup(const char *pHostname, int Nettype)
 {
 	str_copy(m_aHostname, pHostname);

--- a/src/engine/shared/host_lookup.h
+++ b/src/engine/shared/host_lookup.h
@@ -18,7 +18,6 @@ private:
 	void Run() override;
 
 public:
-	CHostLookup();
 	CHostLookup(const char *pHostname, int Nettype);
 
 	int Result() const { return m_Result; }


### PR DESCRIPTION


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions: AI found that it's unused and would leave the class uninitialized
