### PR TITLE
Match projectile init order to network protocol

### DIFF
--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -360,9 +360,9 @@ CNetObj_DDNetProjectile CProjectile::NetInfo() const
 	Result.m_Type = m_Type;
 	Result.m_StartTick = m_StartTick;
 	Result.m_Owner = m_Owner;
-	Result.m_Flags = Flags;
 	Result.m_SwitchNumber = m_Number;
 	Result.m_TuneZone = m_TuneZone;
+	Result.m_Flags = Flags;
 	return Result;
 }
 


### PR DESCRIPTION
The order in the code I touched does not really matter from a logic or readability standpoint. All of the fields were already exactly matching the order that is used when being sent over the network. Except this one swap.
See the definition in datasrc/network.py

```py
	NetObjectEx("DDNetProjectile", "ddnet-projectile@netobj.ddnet.tw", [
		NetIntAny("m_X"),
		NetIntAny("m_Y"),
		NetIntAny("m_VelX"),
		NetIntAny("m_VelY"),
		NetIntRange("m_Type", 0, 'NUM_WEAPONS-1'),
		NetTick("m_StartTick"),
		NetIntRange("m_Owner", -1, 'MAX_CLIENTS-1'),
		NetIntAny("m_SwitchNumber"),
		NetIntAny("m_TuneZone"),
		NetIntAny("m_Flags"),
	]),
```

Makes it easier to reason about completness when moving, copying or extending the code.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions