### PR TITLE
Split cmake args into multiple lines in the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,7 +166,12 @@ jobs:
       run: |
         mkdir release
         cd release
-        ${{ matrix.cmake-path }}cmake -E env ${{ matrix.cmake-init-env }} ${{ matrix.cmake-path }}cmake ${{ matrix.cmake-args }} -DCMAKE_BUILD_TYPE=Release -Werror=dev -DDOWNLOAD_GTEST=ON -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=. ..
+        ${{ matrix.cmake-path }}cmake -E env ${{ matrix.cmake-init-env }} ${{ matrix.cmake-path }}cmake \
+         ${{ matrix.cmake-args }} \
+         -DCMAKE_BUILD_TYPE=Release \
+         -Werror=dev \
+         -DDOWNLOAD_GTEST=ON \
+         -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=. ..
         ${{ matrix.workaround-issue10203-run-after-configure }}
         ${{ matrix.cmake-path }}cmake --build . --config Release --target everything
 


### PR DESCRIPTION
Reading and editing lines this long is always annoying. Also reading diffs or merge conflicts is a mess like this.
This is just one of many cmake calls that should be split up. I just cba to maintain a big pr with the current merge situation.
If this gets merged I will send a follow up pr.