### PR TITLE
change editor zoom value based on current zoom value

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4477,9 +4477,9 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				if(DoButton_FontIcon(&s_ZoomOutButton, FontIcon::MINUS, 0, &Button, BUTTONFLAG_LEFT, "[NumPad-] Zoom out horizontally, hold shift to zoom vertically.", IGraphics::CORNER_R, 9.0f))
 				{
 					if(Input()->ShiftIsPressed())
-						m_ZoomEnvelopeY.ChangeValue(0.1f * m_ZoomEnvelopeY.GetValue());
+						m_ZoomEnvelopeY.ScaleValue(1.1f);
 					else
-						m_ZoomEnvelopeX.ChangeValue(0.1f * m_ZoomEnvelopeX.GetValue());
+						m_ZoomEnvelopeX.ScaleValue(1.1f);
 				}
 
 				ToolBar.VSplitRight(20.0f, &ToolBar, &Button);
@@ -4492,9 +4492,9 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				if(DoButton_FontIcon(&s_ZoomInButton, FontIcon::PLUS, 0, &Button, BUTTONFLAG_LEFT, "[NumPad+] Zoom in horizontally, hold shift to zoom vertically.", IGraphics::CORNER_L, 9.0f))
 				{
 					if(Input()->ShiftIsPressed())
-						m_ZoomEnvelopeY.ChangeValue(-0.1f * m_ZoomEnvelopeY.GetValue());
+						m_ZoomEnvelopeY.ScaleValue(1.0f / 1.1f);
 					else
-						m_ZoomEnvelopeX.ChangeValue(-0.1f * m_ZoomEnvelopeX.GetValue());
+						m_ZoomEnvelopeX.ScaleValue(1.0f / 1.1f);
 				}
 			}
 
@@ -4646,24 +4646,24 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			if(Input()->ShiftIsPressed())
 			{
 				if(Input()->KeyPress(KEY_KP_MINUS) && CLineInput::GetActiveInput() == nullptr)
-					m_ZoomEnvelopeY.ChangeValue(0.1f * m_ZoomEnvelopeY.GetValue());
+					m_ZoomEnvelopeY.ScaleValue(1.1f);
 				if(Input()->KeyPress(KEY_KP_PLUS) && CLineInput::GetActiveInput() == nullptr)
-					m_ZoomEnvelopeY.ChangeValue(-0.1f * m_ZoomEnvelopeY.GetValue());
+					m_ZoomEnvelopeY.ScaleValue(1.0f / 1.1f);
 				if(Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN))
-					m_ZoomEnvelopeY.ChangeValue(0.1f * m_ZoomEnvelopeY.GetValue());
+					m_ZoomEnvelopeY.ScaleValue(1.1f);
 				if(Input()->KeyPress(KEY_MOUSE_WHEEL_UP))
-					m_ZoomEnvelopeY.ChangeValue(-0.1f * m_ZoomEnvelopeY.GetValue());
+					m_ZoomEnvelopeY.ScaleValue(1.0f / 1.1f);
 			}
 			else
 			{
 				if(Input()->KeyPress(KEY_KP_MINUS) && CLineInput::GetActiveInput() == nullptr)
-					m_ZoomEnvelopeX.ChangeValue(0.1f * m_ZoomEnvelopeX.GetValue());
+					m_ZoomEnvelopeX.ScaleValue(1.1f);
 				if(Input()->KeyPress(KEY_KP_PLUS) && CLineInput::GetActiveInput() == nullptr)
-					m_ZoomEnvelopeX.ChangeValue(-0.1f * m_ZoomEnvelopeX.GetValue());
+					m_ZoomEnvelopeX.ScaleValue(1.0f / 1.1f);
 				if(Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN))
-					m_ZoomEnvelopeX.ChangeValue(0.1f * m_ZoomEnvelopeX.GetValue());
+					m_ZoomEnvelopeX.ScaleValue(1.1f);
 				if(Input()->KeyPress(KEY_MOUSE_WHEEL_UP))
-					m_ZoomEnvelopeX.ChangeValue(-0.1f * m_ZoomEnvelopeX.GetValue());
+					m_ZoomEnvelopeX.ScaleValue(1.0f / 1.1f);
 			}
 		}
 
@@ -6303,10 +6303,12 @@ void CEditor::Render()
 		// handle zoom hotkeys
 		if(CLineInput::GetActiveInput() == nullptr)
 		{
+			// one keypress should be equivalent to zooming
+			// three times using mousewheel: 1.1^3 = 1.331
 			if(Input()->KeyPress(KEY_KP_MINUS))
-				MapView()->Zoom()->ChangeValue(50.0f);
+				MapView()->Zoom()->ScaleValue(1.331f);
 			if(Input()->KeyPress(KEY_KP_PLUS))
-				MapView()->Zoom()->ChangeValue(-50.0f);
+				MapView()->Zoom()->ScaleValue(1.0f / 1.331f);
 			if(Input()->KeyPress(KEY_KP_MULTIPLY))
 				MapView()->ResetZoom();
 		}
@@ -6314,9 +6316,9 @@ void CEditor::Render()
 		if(m_pBrush->IsEmpty() || !Input()->ShiftIsPressed())
 		{
 			if(Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN))
-				MapView()->Zoom()->ChangeValue(20.0f);
+				MapView()->Zoom()->ScaleValue(1.1f);
 			if(Input()->KeyPress(KEY_MOUSE_WHEEL_UP))
-				MapView()->Zoom()->ChangeValue(-20.0f);
+				MapView()->Zoom()->ScaleValue(1.0f / 1.1f);
 		}
 		if(!m_pBrush->IsEmpty())
 		{

--- a/src/game/editor/quick_actions.h
+++ b/src/game/editor/quick_actions.h
@@ -160,7 +160,7 @@ REGISTER_QUICK_ACTION(
 REGISTER_QUICK_ACTION(
 	ZoomOut,
 	"Zoom out",
-	[&]() { MapView()->Zoom()->ChangeValue(50.0f); },
+	[&]() { MapView()->Zoom()->ScaleValue(1.331f); },
 	ALWAYS_FALSE,
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
@@ -168,7 +168,7 @@ REGISTER_QUICK_ACTION(
 REGISTER_QUICK_ACTION(
 	ZoomIn,
 	"Zoom in",
-	[&]() { MapView()->Zoom()->ChangeValue(-50.0f); },
+	[&]() { MapView()->Zoom()->ScaleValue(1.0f / 1.331f); },
 	ALWAYS_FALSE,
 	ALWAYS_FALSE,
 	DEFAULT_BTN,

--- a/src/game/editor/smooth_value.cpp
+++ b/src/game/editor/smooth_value.cpp
@@ -32,10 +32,10 @@ void CSmoothValue::SetValue(float Target)
 	m_Smoothing = true;
 }
 
-void CSmoothValue::ChangeValue(float Amount)
+void CSmoothValue::ScaleValue(float Factor)
 {
 	const float CurrentTarget = m_Smoothing ? m_ValueSmoothingTarget : m_Value;
-	SetValue(CurrentTarget + Amount);
+	SetValue(CurrentTarget * Factor);
 }
 
 bool CSmoothValue::UpdateValue()

--- a/src/game/editor/smooth_value.cpp
+++ b/src/game/editor/smooth_value.cpp
@@ -19,9 +19,8 @@ void CSmoothValue::SetValue(float Target)
 	float Derivative = 0.0f;
 	if(m_Smoothing)
 	{
-		const float Progress = ZoomProgress(Now);
-		Current = m_ValueSmoothing.Evaluate(Progress);
-		Derivative = m_ValueSmoothing.Derivative(Progress);
+		Current = m_ValueSmoothing.Evaluate(Progress(Now));
+		Derivative = m_ValueSmoothing.Derivative(Progress(Now));
 	}
 
 	m_ValueSmoothingTarget = Target;
@@ -51,7 +50,7 @@ bool CSmoothValue::UpdateValue()
 		}
 		else
 		{
-			m_Value = m_ValueSmoothing.Evaluate(ZoomProgress(Time));
+			m_Value = m_ValueSmoothing.Evaluate(Progress(Time));
 			if((OldLevel < m_ValueSmoothingTarget && m_Value > m_ValueSmoothingTarget) || (OldLevel > m_ValueSmoothingTarget && m_Value < m_ValueSmoothingTarget))
 			{
 				m_Value = m_ValueSmoothingTarget;
@@ -66,7 +65,7 @@ bool CSmoothValue::UpdateValue()
 	return false;
 }
 
-float CSmoothValue::ZoomProgress(float CurrentTime) const
+float CSmoothValue::Progress(float CurrentTime) const
 {
 	return (CurrentTime - m_ValueSmoothingStart) / (m_ValueSmoothingEnd - m_ValueSmoothingStart);
 }

--- a/src/game/editor/smooth_value.h
+++ b/src/game/editor/smooth_value.h
@@ -37,7 +37,7 @@ public:
 	float GetMaxValue() const;
 
 private:
-	float ZoomProgress(float CurrentTime) const;
+	float Progress(float CurrentTime) const;
 
 	bool m_Smoothing;
 	float m_Value;

--- a/src/game/editor/smooth_value.h
+++ b/src/game/editor/smooth_value.h
@@ -19,9 +19,9 @@ public:
 	void SetValue(float Target);
 
 	/**
-	 * Change the value by the given amount.
+	 * Scale the value by the given amount.
 	 */
-	void ChangeValue(float Amount);
+	void ScaleValue(float Factor);
 
 	/**
 	 * Set the value to the target instantly. If the value was changing the


### PR DESCRIPTION
This makes zooming more precise when zooming far in and faster when zooming far out.
The constants are based on what I felt was similar to the old values.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
