### PR TITLE
Adjust iteration bounds in non-buffered rendering

### DIFF
--- a/src/game/map/render_map.cpp
+++ b/src/game/map/render_map.cpp
@@ -610,10 +610,19 @@ void CRenderMap::RenderTilemap(CTile *pTiles, int w, int h, float Scale, ColorRG
 	Graphics()->SetColor(Color);
 	const bool ColorOpaque = Color.a > 254.0f / 255.0f;
 
+	const bool ExtendTiles = (RenderFlags & TILERENDERFLAG_EXTEND) != 0;
+
 	int StartY = (int)(ScreenY0 / Scale) - 1;
 	int StartX = (int)(ScreenX0 / Scale) - 1;
 	int EndY = (int)(ScreenY1 / Scale) + 1;
 	int EndX = (int)(ScreenX1 / Scale) + 1;
+	if(!ExtendTiles)
+	{
+		StartY = std::max(0, StartY);
+		StartX = std::max(0, StartX);
+		EndY = std::min(h, EndY);
+		EndX = std::min(w, EndX);
+	}
 
 	// adjust the texture shift according to mipmap level
 	float TexSize = 1024.0f;
@@ -627,7 +636,7 @@ void CRenderMap::RenderTilemap(CTile *pTiles, int w, int h, float Scale, ColorRG
 			int mx = x;
 			int my = y;
 
-			if(RenderFlags & TILERENDERFLAG_EXTEND)
+			if(ExtendTiles)
 			{
 				if(mx < 0)
 					mx = 0;
@@ -637,17 +646,6 @@ void CRenderMap::RenderTilemap(CTile *pTiles, int w, int h, float Scale, ColorRG
 					my = 0;
 				if(my >= h)
 					my = h - 1;
-			}
-			else
-			{
-				if(mx < 0)
-					continue; // mx = 0;
-				if(mx >= w)
-					continue; // mx = w-1;
-				if(my < 0)
-					continue; // my = 0;
-				if(my >= h)
-					continue; // my = h-1;
 			}
 
 			int c = mx + my * w;
@@ -766,9 +764,13 @@ void CRenderMap::RenderTeleOverlay(CTeleTile *pTele, int w, int h, float Scale, 
 	int StartX = (int)(ScreenX0 / Scale) - 1;
 	int EndY = (int)(ScreenY1 / Scale) + 1;
 	int EndX = (int)(ScreenX1 / Scale) + 1;
-
 	if(EndX - StartX > Graphics()->ScreenWidth() / g_Config.m_GfxTextOverlay || EndY - StartY > Graphics()->ScreenHeight() / g_Config.m_GfxTextOverlay)
 		return; // its useless to render text at this distance
+
+	StartY = std::max(0, StartY);
+	StartX = std::max(0, StartX);
+	EndY = std::min(h, EndY);
+	EndX = std::min(w, EndX);
 
 	float Size = g_Config.m_ClTextEntitiesSize / 100.f;
 	char aBuf[16];
@@ -778,19 +780,7 @@ void CRenderMap::RenderTeleOverlay(CTeleTile *pTele, int w, int h, float Scale, 
 	{
 		for(int x = StartX; x < EndX; x++)
 		{
-			int mx = x;
-			int my = y;
-
-			if(mx < 0)
-				continue; // mx = 0;
-			if(mx >= w)
-				continue; // mx = w-1;
-			if(my < 0)
-				continue; // my = 0;
-			if(my >= h)
-				continue; // my = h-1;
-
-			int c = mx + my * w;
+			int c = x + y * w;
 
 			unsigned char Index = pTele[c].m_Number;
 			if(Index && IsTeleTileNumberUsedAny(pTele[c].m_Type))
@@ -801,7 +791,7 @@ void CRenderMap::RenderTeleOverlay(CTeleTile *pTele, int w, int h, float Scale, 
 				float Factor = std::clamp(Scale / ScaledWidth, 0.0f, 1.0f);
 				float LocalSize = Size * Factor;
 				float ToCenterOffset = (1 - LocalSize) / 2.f;
-				TextRender()->Text((mx + 0.5f) * Scale - (ScaledWidth * Factor) / 2.0f, (my + ToCenterOffset) * Scale, LocalSize * Scale, aBuf);
+				TextRender()->Text((x + 0.5f) * Scale - (ScaledWidth * Factor) / 2.0f, (y + ToCenterOffset) * Scale, LocalSize * Scale, aBuf);
 			}
 		}
 	}
@@ -818,9 +808,13 @@ void CRenderMap::RenderSpeedupOverlay(CSpeedupTile *pSpeedup, int w, int h, floa
 	int StartX = (int)(ScreenX0 / Scale) - 1;
 	int EndY = (int)(ScreenY1 / Scale) + 1;
 	int EndX = (int)(ScreenX1 / Scale) + 1;
-
 	if(EndX - StartX > Graphics()->ScreenWidth() / g_Config.m_GfxTextOverlay || EndY - StartY > Graphics()->ScreenHeight() / g_Config.m_GfxTextOverlay)
 		return; // its useless to render text at this distance
+
+	StartY = std::max(0, StartY);
+	StartX = std::max(0, StartX);
+	EndY = std::min(h, EndY);
+	EndX = std::min(w, EndX);
 
 	float Size = g_Config.m_ClTextEntitiesSize / 100.f;
 	float ToCenterOffset = (1 - Size) / 2.f;
@@ -831,19 +825,7 @@ void CRenderMap::RenderSpeedupOverlay(CSpeedupTile *pSpeedup, int w, int h, floa
 	{
 		for(int x = StartX; x < EndX; x++)
 		{
-			int mx = x;
-			int my = y;
-
-			if(mx < 0)
-				continue; // mx = 0;
-			if(mx >= w)
-				continue; // mx = w-1;
-			if(my < 0)
-				continue; // my = 0;
-			if(my >= h)
-				continue; // my = h-1;
-
-			int c = mx + my * w;
+			int c = x + y * w;
 
 			int Force = (int)pSpeedup[c].m_Force;
 			int MaxSpeed = (int)pSpeedup[c].m_MaxSpeed;
@@ -859,18 +841,18 @@ void CRenderMap::RenderSpeedupOverlay(CSpeedupTile *pSpeedup, int w, int h, floa
 					Graphics()->SetColor(1.0f, 1.0f, 1.0f, Alpha);
 					Graphics()->SelectSprite(SPRITE_SPEEDUP_ARROW);
 					Graphics()->QuadsSetRotation(pSpeedup[c].m_Angle * (pi / 180.0f));
-					Graphics()->DrawSprite(mx * Scale + 16, my * Scale + 16, 35.0f);
+					Graphics()->DrawSprite(x * Scale + 16, y * Scale + 16, 35.0f);
 					Graphics()->QuadsEnd();
 
 					// draw force and max speed
 					if(OverlayRenderFlag & OVERLAYRENDERFLAG_TEXT)
 					{
 						str_format(aBuf, sizeof(aBuf), "%d", Force);
-						TextRender()->Text(mx * Scale, (my + 0.5f + ToCenterOffset / 2) * Scale, Size * Scale / 2.f, aBuf);
+						TextRender()->Text(x * Scale, (y + 0.5f + ToCenterOffset / 2) * Scale, Size * Scale / 2.f, aBuf);
 						if(MaxSpeed)
 						{
 							str_format(aBuf, sizeof(aBuf), "%d", MaxSpeed);
-							TextRender()->Text(mx * Scale, (my + ToCenterOffset / 2) * Scale, Size * Scale / 2.f, aBuf);
+							TextRender()->Text(x * Scale, (y + ToCenterOffset / 2) * Scale, Size * Scale / 2.f, aBuf);
 						}
 					}
 				}
@@ -880,13 +862,13 @@ void CRenderMap::RenderSpeedupOverlay(CSpeedupTile *pSpeedup, int w, int h, floa
 					if(OverlayRenderFlag & OVERLAYRENDERFLAG_TEXT)
 					{
 						float LineSpacing = Size * Scale / 3.f;
-						float BaseY = (my + ToCenterOffset) * Scale;
+						float BaseY = (y + ToCenterOffset) * Scale;
 						str_format(aBuf, sizeof(aBuf), "%d", Force);
-						TextRender()->Text(mx * Scale, BaseY, LineSpacing, aBuf);
+						TextRender()->Text(x * Scale, BaseY, LineSpacing, aBuf);
 						str_format(aBuf, sizeof(aBuf), "%d", MaxSpeed);
-						TextRender()->Text(mx * Scale, BaseY + LineSpacing, LineSpacing, aBuf);
+						TextRender()->Text(x * Scale, BaseY + LineSpacing, LineSpacing, aBuf);
 						str_format(aBuf, sizeof(aBuf), "%d", Angle);
-						TextRender()->Text(mx * Scale, BaseY + 2 * LineSpacing, LineSpacing, aBuf);
+						TextRender()->Text(x * Scale, BaseY + 2 * LineSpacing, LineSpacing, aBuf);
 					}
 				}
 			}
@@ -908,9 +890,13 @@ void CRenderMap::RenderSwitchOverlay(CSwitchTile *pSwitch, int w, int h, float S
 	int StartX = (int)(ScreenX0 / Scale) - 1;
 	int EndY = (int)(ScreenY1 / Scale) + 1;
 	int EndX = (int)(ScreenX1 / Scale) + 1;
-
 	if(EndX - StartX > Graphics()->ScreenWidth() / g_Config.m_GfxTextOverlay || EndY - StartY > Graphics()->ScreenHeight() / g_Config.m_GfxTextOverlay)
 		return; // its useless to render text at this distance
+
+	StartY = std::max(0, StartY);
+	StartX = std::max(0, StartX);
+	EndY = std::min(h, EndY);
+	EndX = std::min(w, EndX);
 
 	float Size = g_Config.m_ClTextEntitiesSize / 100.f;
 	float ToCenterOffset = (1 - Size) / 2.f;
@@ -921,32 +907,20 @@ void CRenderMap::RenderSwitchOverlay(CSwitchTile *pSwitch, int w, int h, float S
 	{
 		for(int x = StartX; x < EndX; x++)
 		{
-			int mx = x;
-			int my = y;
-
-			if(mx < 0)
-				continue; // mx = 0;
-			if(mx >= w)
-				continue; // mx = w-1;
-			if(my < 0)
-				continue; // my = 0;
-			if(my >= h)
-				continue; // my = h-1;
-
-			int c = mx + my * w;
+			int c = x + y * w;
 
 			unsigned char Index = pSwitch[c].m_Number;
 			if(Index && IsSwitchTileNumberUsed(pSwitch[c].m_Type))
 			{
 				str_format(aBuf, sizeof(aBuf), "%d", Index);
-				TextRender()->Text(mx * Scale, (my + ToCenterOffset / 2) * Scale, Size * Scale / 2.f, aBuf);
+				TextRender()->Text(x * Scale, (y + ToCenterOffset / 2) * Scale, Size * Scale / 2.f, aBuf);
 			}
 
 			unsigned char Delay = pSwitch[c].m_Delay;
 			if(Delay && IsSwitchTileDelayUsed(pSwitch[c].m_Type))
 			{
 				str_format(aBuf, sizeof(aBuf), "%d", Delay);
-				TextRender()->Text(mx * Scale, (my + 0.5f + ToCenterOffset / 2) * Scale, Size * Scale / 2.f, aBuf);
+				TextRender()->Text(x * Scale, (y + 0.5f + ToCenterOffset / 2) * Scale, Size * Scale / 2.f, aBuf);
 			}
 		}
 	}
@@ -966,9 +940,13 @@ void CRenderMap::RenderTuneOverlay(CTuneTile *pTune, int w, int h, float Scale, 
 	int StartX = (int)(ScreenX0 / Scale) - 1;
 	int EndY = (int)(ScreenY1 / Scale) + 1;
 	int EndX = (int)(ScreenX1 / Scale) + 1;
-
 	if(EndX - StartX > Graphics()->ScreenWidth() / g_Config.m_GfxTextOverlay || EndY - StartY > Graphics()->ScreenHeight() / g_Config.m_GfxTextOverlay)
 		return; // its useless to render text at this distance
+
+	StartY = std::max(0, StartY);
+	StartX = std::max(0, StartX);
+	EndY = std::min(h, EndY);
+	EndX = std::min(w, EndX);
 
 	float Size = g_Config.m_ClTextEntitiesSize / 200.f;
 	char aBuf[16];
@@ -978,19 +956,7 @@ void CRenderMap::RenderTuneOverlay(CTuneTile *pTune, int w, int h, float Scale, 
 	{
 		for(int x = StartX; x < EndX; x++)
 		{
-			int mx = x;
-			int my = y;
-
-			if(mx < 0)
-				continue; // mx = 0;
-			if(mx >= w)
-				continue; // mx = w-1;
-			if(my < 0)
-				continue; // my = 0;
-			if(my >= h)
-				continue; // my = h-1;
-
-			int c = mx + my * w;
+			int c = x + y * w;
 
 			unsigned char Index = pTune[c].m_Number;
 			if(Index)
@@ -1001,7 +967,7 @@ void CRenderMap::RenderTuneOverlay(CTuneTile *pTune, int w, int h, float Scale, 
 				float Factor = std::clamp(Scale / ScaledWidth, 0.0f, 1.0f);
 				float LocalSize = Size * Factor;
 				float ToCenterOffset = (1 - LocalSize) / 2.f;
-				TextRender()->Text((mx + 0.5f) * Scale - (ScaledWidth * Factor) / 2.0f, (my + ToCenterOffset) * Scale, LocalSize * Scale, aBuf);
+				TextRender()->Text((x + 0.5f) * Scale - (ScaledWidth * Factor) / 2.0f, (y + ToCenterOffset) * Scale, LocalSize * Scale, aBuf);
 			}
 		}
 	}
@@ -1025,10 +991,19 @@ void CRenderMap::RenderTelemap(CTeleTile *pTele, int w, int h, float Scale, Colo
 		Graphics()->QuadsBegin();
 	Graphics()->SetColor(Color);
 
+	bool ExtendTiles = (RenderFlags & TILERENDERFLAG_EXTEND) != 0;
+
 	int StartY = (int)(ScreenY0 / Scale) - 1;
 	int StartX = (int)(ScreenX0 / Scale) - 1;
 	int EndY = (int)(ScreenY1 / Scale) + 1;
 	int EndX = (int)(ScreenX1 / Scale) + 1;
+	if(!ExtendTiles)
+	{
+		StartY = std::max(0, StartY);
+		StartX = std::max(0, StartX);
+		EndY = std::min(h, EndY);
+		EndX = std::min(w, EndX);
+	}
 
 	// adjust the texture shift according to mipmap level
 	float TexSize = 1024.0f;
@@ -1041,7 +1016,7 @@ void CRenderMap::RenderTelemap(CTeleTile *pTele, int w, int h, float Scale, Colo
 			int mx = x;
 			int my = y;
 
-			if(RenderFlags & TILERENDERFLAG_EXTEND)
+			if(ExtendTiles)
 			{
 				if(mx < 0)
 					mx = 0;
@@ -1051,17 +1026,6 @@ void CRenderMap::RenderTelemap(CTeleTile *pTele, int w, int h, float Scale, Colo
 					my = 0;
 				if(my >= h)
 					my = h - 1;
-			}
-			else
-			{
-				if(mx < 0)
-					continue; // mx = 0;
-				if(mx >= w)
-					continue; // mx = w-1;
-				if(my < 0)
-					continue; // my = 0;
-				if(my >= h)
-					continue; // my = h-1;
 			}
 
 			int c = mx + my * w;
@@ -1142,10 +1106,19 @@ void CRenderMap::RenderSwitchmap(CSwitchTile *pSwitchTile, int w, int h, float S
 		Graphics()->QuadsBegin();
 	Graphics()->SetColor(Color);
 
+	bool ExtendTiles = (RenderFlags & TILERENDERFLAG_EXTEND) != 0;
+
 	int StartY = (int)(ScreenY0 / Scale) - 1;
 	int StartX = (int)(ScreenX0 / Scale) - 1;
 	int EndY = (int)(ScreenY1 / Scale) + 1;
 	int EndX = (int)(ScreenX1 / Scale) + 1;
+	if(!ExtendTiles)
+	{
+		StartY = std::max(0, StartY);
+		StartX = std::max(0, StartX);
+		EndY = std::min(h, EndY);
+		EndX = std::min(w, EndX);
+	}
 
 	// adjust the texture shift according to mipmap level
 	float TexSize = 1024.0f;
@@ -1158,7 +1131,7 @@ void CRenderMap::RenderSwitchmap(CSwitchTile *pSwitchTile, int w, int h, float S
 			int mx = x;
 			int my = y;
 
-			if(RenderFlags & TILERENDERFLAG_EXTEND)
+			if(ExtendTiles)
 			{
 				if(mx < 0)
 					mx = 0;
@@ -1168,17 +1141,6 @@ void CRenderMap::RenderSwitchmap(CSwitchTile *pSwitchTile, int w, int h, float S
 					my = 0;
 				if(my >= h)
 					my = h - 1;
-			}
-			else
-			{
-				if(mx < 0)
-					continue; // mx = 0;
-				if(mx >= w)
-					continue; // mx = w-1;
-				if(my < 0)
-					continue; // my = 0;
-				if(my >= h)
-					continue; // my = h-1;
 			}
 
 			int c = mx + my * w;
@@ -1302,10 +1264,19 @@ void CRenderMap::RenderTunemap(CTuneTile *pTune, int w, int h, float Scale, Colo
 		Graphics()->QuadsBegin();
 	Graphics()->SetColor(Color);
 
+	bool ExtendTiles = (RenderFlags & TILERENDERFLAG_EXTEND) != 0;
+
 	int StartY = (int)(ScreenY0 / Scale) - 1;
 	int StartX = (int)(ScreenX0 / Scale) - 1;
 	int EndY = (int)(ScreenY1 / Scale) + 1;
 	int EndX = (int)(ScreenX1 / Scale) + 1;
+	if(!ExtendTiles)
+	{
+		StartY = std::max(0, StartY);
+		StartX = std::max(0, StartX);
+		EndY = std::min(h, EndY);
+		EndX = std::min(w, EndX);
+	}
 
 	// adjust the texture shift according to mipmap level
 	float TexSize = 1024.0f;
@@ -1318,7 +1289,7 @@ void CRenderMap::RenderTunemap(CTuneTile *pTune, int w, int h, float Scale, Colo
 			int mx = x;
 			int my = y;
 
-			if(RenderFlags & TILERENDERFLAG_EXTEND)
+			if(ExtendTiles)
 			{
 				if(mx < 0)
 					mx = 0;
@@ -1328,17 +1299,6 @@ void CRenderMap::RenderTunemap(CTuneTile *pTune, int w, int h, float Scale, Colo
 					my = 0;
 				if(my >= h)
 					my = h - 1;
-			}
-			else
-			{
-				if(mx < 0)
-					continue; // mx = 0;
-				if(mx >= w)
-					continue; // mx = w-1;
-				if(my < 0)
-					continue; // my = 0;
-				if(my >= h)
-					continue; // my = h-1;
 			}
 
 			int c = mx + my * w;


### PR DESCRIPTION
Before the loop iterated over all tiles that could be on screen. This is only necessary if TILERENDERFLAG_EXTEND is set.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
