### PR TITLE
Use our index page when testing Emscripten client in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -406,7 +406,7 @@ jobs:
       run: |
         export MOZ_HEADLESS=1
         source emsdk/emsdk_env.sh
-        emrun --browser firefox build-emscripten-headless/DDNet.html -- "quit"
+        emrun --browser firefox build-emscripten-headless/index.html -- "quit"
 
     - name: Build Emscripten client in release mode
       run: |


### PR DESCRIPTION
The default Emscripten index page does not correctly handle the client crashing due to assertion errors or segmentation faults, which causes the CI to timeout after waiting for 6 hours for `emrun` to quit. This makes 86fd4a02832f9d97ec37b8a9fee0c998bb9307cf actually work in the CI.

## Checklist

- [X] Tested the change
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions