### PR TITLE
Add missing includes only transitively included from `http.h`

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -9,6 +9,7 @@
 
 #include <base/bytes.h>
 #include <base/crashdump.h>
+#include <base/dbg.h>
 #include <base/fs.h>
 #include <base/hash.h>
 #include <base/hash_ctxt.h>
@@ -16,6 +17,7 @@
 #include <base/log.h>
 #include <base/logger.h>
 #include <base/math.h>
+#include <base/mem.h>
 #include <base/os.h>
 #include <base/process.h>
 #include <base/secure.h>

--- a/src/engine/client/sixup_translate_system.cpp
+++ b/src/engine/client/sixup_translate_system.cpp
@@ -1,3 +1,5 @@
+#include <base/dbg.h>
+
 #include <engine/client/client.h>
 
 int CClient::TranslateSysMsg(int *pMsgId, bool System, CUnpacker *pUnpacker, CPacker *pPacker, CNetChunk *pPacket, bool *pIsExMsg)

--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -1,13 +1,17 @@
 #include "register.h"
 
+#include <base/dbg.h>
 #include <base/lock.h>
 #include <base/log.h>
+#include <base/mem.h>
+#include <base/str.h>
 #include <base/time.h>
 
 #include <engine/console.h>
 #include <engine/engine.h>
 #include <engine/shared/config.h>
 #include <engine/shared/http.h>
+#include <engine/shared/jobs.h>
 #include <engine/shared/json.h>
 #include <engine/shared/masterserver.h>
 #include <engine/shared/network.h>

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -8,6 +8,7 @@
 #include <base/lock.h>
 #include <base/logger.h>
 #include <base/math.h>
+#include <base/mem.h>
 #include <base/str.h>
 #include <base/time.h>
 

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -2,7 +2,9 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "controls.h"
 
+#include <base/dbg.h>
 #include <base/math.h>
+#include <base/mem.h>
 #include <base/time.h>
 #include <base/vmath.h>
 

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -3,6 +3,7 @@
 #include "ghost.h"
 
 #include <base/log.h>
+#include <base/mem.h>
 #include <base/process.h>
 #include <base/time.h>
 

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -2,7 +2,9 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "mapimages.h"
 
+#include <base/dbg.h>
 #include <base/log.h>
+#include <base/mem.h>
 
 #include <engine/graphics.h>
 #include <engine/map.h>

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -2,6 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "menus.h"
 
+#include <base/dbg.h>
 #include <base/log.h>
 #include <base/time.h>
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -4,6 +4,7 @@
 #include "menus.h"
 #include "skins.h"
 
+#include <base/dbg.h>
 #include <base/fs.h>
 #include <base/log.h>
 #include <base/math.h>

--- a/src/game/client/components/menus_settings7.cpp
+++ b/src/game/client/components/menus_settings7.cpp
@@ -3,6 +3,7 @@
 #include "menus.h"
 #include "skins7.h"
 
+#include <base/dbg.h>
 #include <base/math.h>
 #include <base/str.h>
 

--- a/src/game/client/components/particles.cpp
+++ b/src/game/client/components/particles.cpp
@@ -2,6 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "particles.h"
 
+#include <base/dbg.h>
 #include <base/math.h>
 #include <base/time.h>
 

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -4,6 +4,7 @@
 #include "players.h"
 
 #include <base/color.h>
+#include <base/dbg.h>
 #include <base/math.h>
 
 #include <engine/client/enums.h>

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -2,6 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "scoreboard.h"
 
+#include <base/dbg.h>
 #include <base/time.h>
 
 #include <engine/console.h>

--- a/src/game/client/components/sounds.cpp
+++ b/src/game/client/components/sounds.cpp
@@ -3,6 +3,7 @@
 
 #include "sounds.h"
 
+#include <base/mem.h>
 #include <base/time.h>
 
 #include <engine/engine.h>

--- a/src/game/client/sixup_translate_connless.cpp
+++ b/src/game/client/sixup_translate_connless.cpp
@@ -1,3 +1,5 @@
+#include <base/mem.h>
+
 #include <engine/shared/masterserver.h>
 
 #include <game/client/gameclient.h>

--- a/src/game/client/sixup_translate_snapshot.cpp
+++ b/src/game/client/sixup_translate_snapshot.cpp
@@ -1,3 +1,6 @@
+#include <base/dbg.h>
+#include <base/mem.h>
+
 #include <engine/shared/protocolglue.h>
 #include <engine/shared/snapshot.h>
 #include <engine/shared/translation_context.h>


### PR DESCRIPTION
Preparation for removing includes of the header `http.h` from other files and includes within this header.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions