### PR TITLE
Keep state of `CMapView` separate for each map

### DIFF
--- a/src/game/editor/map_view.cpp
+++ b/src/game/editor/map_view.cpp
@@ -7,6 +7,15 @@
 
 #include <game/client/ui.h>
 
+void CMapView::CState::Reset(CEditor *pEditor)
+{
+	m_Zoom = CSmoothValue(200.0f, 10.0f, 2000.0f);
+	m_Zoom.OnInit(pEditor);
+	m_WorldZoom = 1.0f;
+	m_WorldOffset = vec2(0.0f, 0.0f);
+	m_EditorOffset = vec2(0.0f, 0.0f);
+}
+
 void CMapView::OnInit(CEditor *pEditor)
 {
 	CEditorComponent::OnInit(pEditor);
@@ -17,13 +26,6 @@ void CMapView::OnInit(CEditor *pEditor)
 
 void CMapView::OnReset()
 {
-	m_Zoom = CSmoothValue(200.0f, 10.0f, 2000.0f);
-	m_Zoom.OnInit(Editor());
-	m_WorldZoom = 1.0f;
-
-	SetWorldOffset({0, 0});
-	SetEditorOffset({0, 0});
-
 	m_ProofMode.OnReset();
 	m_MapGrid.OnReset();
 }
@@ -107,7 +109,7 @@ void CMapView::RenderEditorMap()
 	}
 
 	std::shared_ptr<CLayerTiles> pSelectedTilesLayer = std::static_pointer_cast<CLayerTiles>(Map()->SelectedLayerType(0, LAYERTYPE_TILES));
-	if(Editor()->m_ShowTileInfo != CEditor::SHOW_TILE_OFF && pSelectedTilesLayer && pSelectedTilesLayer->m_Visible && m_Zoom.GetValue() <= 300.0f)
+	if(Editor()->m_ShowTileInfo != CEditor::SHOW_TILE_OFF && pSelectedTilesLayer && pSelectedTilesLayer->m_Visible && Zoom()->GetValue() <= 300.0f)
 	{
 		Map()->SelectedGroup()->MapScreen();
 		pSelectedTilesLayer->ShowInfo();
@@ -117,12 +119,12 @@ void CMapView::RenderEditorMap()
 void CMapView::ResetZoom()
 {
 	SetEditorOffset({0, 0});
-	m_Zoom.SetValue(100.0f);
+	Zoom()->SetValue(100.0f);
 }
 
 float CMapView::ScaleLength(float Value) const
 {
-	return m_WorldZoom * Value;
+	return GetWorldZoom() * Value;
 }
 
 void CMapView::ZoomMouseTarget(float ZoomFactor)
@@ -132,7 +134,7 @@ void CMapView::ZoomMouseTarget(float ZoomFactor)
 	float aPoints[4];
 	Graphics()->MapScreenToWorld(
 		GetWorldOffset().x, GetWorldOffset().y,
-		100.0f, 100.0f, 100.0f, 0.0f, 0.0f, Graphics()->ScreenAspect(), m_WorldZoom, aPoints);
+		100.0f, 100.0f, 100.0f, 0.0f, 0.0f, Graphics()->ScreenAspect(), GetWorldZoom(), aPoints);
 
 	float WorldWidth = aPoints[2] - aPoints[0];
 	float WorldHeight = aPoints[3] - aPoints[1];
@@ -146,23 +148,23 @@ void CMapView::ZoomMouseTarget(float ZoomFactor)
 
 void CMapView::UpdateZoom()
 {
-	float OldLevel = m_Zoom.GetValue();
-	bool UpdatedZoom = m_Zoom.UpdateValue();
-	m_Zoom.SetValueRange(10.0f, g_Config.m_EdLimitMaxZoomLevel ? 2000.0f : std::numeric_limits<float>::max());
-	float NewLevel = m_Zoom.GetValue();
+	float OldLevel = Zoom()->GetValue();
+	bool UpdatedZoom = Zoom()->UpdateValue();
+	Zoom()->SetValueRange(10.0f, g_Config.m_EdLimitMaxZoomLevel ? 2000.0f : std::numeric_limits<float>::max());
+	float NewLevel = Zoom()->GetValue();
 	if(UpdatedZoom && g_Config.m_EdZoomTarget)
 		ZoomMouseTarget(NewLevel / OldLevel);
-	m_WorldZoom = NewLevel / 100.0f;
+	Map()->m_MapViewState.m_WorldZoom = NewLevel / 100.0f;
 }
 
 CSmoothValue *CMapView::Zoom()
 {
-	return &m_Zoom;
+	return &Map()->m_MapViewState.m_Zoom;
 }
 
 const CSmoothValue *CMapView::Zoom() const
 {
-	return &m_Zoom;
+	return &Map()->m_MapViewState.m_Zoom;
 }
 
 CProofMode *CMapView::ProofMode()
@@ -187,35 +189,35 @@ const CMapGrid *CMapView::MapGrid() const
 
 void CMapView::OffsetWorld(vec2 Offset)
 {
-	m_WorldOffset += Offset;
+	Map()->m_MapViewState.m_WorldOffset += Offset;
 }
 
 void CMapView::OffsetEditor(vec2 Offset)
 {
-	m_EditorOffset += Offset;
+	Map()->m_MapViewState.m_EditorOffset += Offset;
 }
 
 void CMapView::SetWorldOffset(vec2 WorldOffset)
 {
-	m_WorldOffset = WorldOffset;
+	Map()->m_MapViewState.m_WorldOffset = WorldOffset;
 }
 
 void CMapView::SetEditorOffset(vec2 EditorOffset)
 {
-	m_EditorOffset = EditorOffset;
+	Map()->m_MapViewState.m_EditorOffset = EditorOffset;
 }
 
 vec2 CMapView::GetWorldOffset() const
 {
-	return m_WorldOffset;
+	return Map()->m_MapViewState.m_WorldOffset;
 }
 
 vec2 CMapView::GetEditorOffset() const
 {
-	return m_EditorOffset;
+	return Map()->m_MapViewState.m_EditorOffset;
 }
 
 float CMapView::GetWorldZoom() const
 {
-	return m_WorldZoom;
+	return Map()->m_MapViewState.m_WorldZoom;
 }

--- a/src/game/editor/map_view.h
+++ b/src/game/editor/map_view.h
@@ -13,6 +13,17 @@ class CLayerGroup;
 class CMapView : public CEditorComponent
 {
 public:
+	class CState
+	{
+	public:
+		CSmoothValue m_Zoom;
+		float m_WorldZoom;
+		vec2 m_WorldOffset;
+		vec2 m_EditorOffset;
+
+		void Reset(CEditor *pEditor);
+	};
+
 	void OnInit(CEditor *pEditor) override;
 	void OnReset() override;
 	void OnMapLoad() override;
@@ -53,14 +64,8 @@ public:
 	const CMapGrid *MapGrid() const;
 
 private:
-	CSmoothValue m_Zoom = CSmoothValue(200.0f, 10.0f, 2000.0f);
-	float m_WorldZoom;
-
 	CProofMode m_ProofMode;
 	CMapGrid m_MapGrid;
-
-	vec2 m_WorldOffset;
-	vec2 m_EditorOffset;
 };
 
 #endif

--- a/src/game/editor/mapitems/map.cpp
+++ b/src/game/editor/mapitems/map.cpp
@@ -90,6 +90,7 @@ void CEditorMap::Clean()
 
 	m_ShiftBy = 1;
 
+	m_MapViewState.Reset(Editor());
 	Editor()->QuadKnife()->Deactivate();
 }
 

--- a/src/game/editor/mapitems/map.h
+++ b/src/game/editor/mapitems/map.h
@@ -11,6 +11,7 @@
 #include <game/editor/editor_history.h>
 #include <game/editor/editor_server_settings.h>
 #include <game/editor/editor_trackers.h>
+#include <game/editor/map_view.h>
 #include <game/editor/mapitems/envelope.h>
 #include <game/editor/mapitems/layer.h>
 #include <game/editor/quad_art.h>
@@ -158,6 +159,7 @@ public:
 	int m_ShiftBy;
 
 	// Component states
+	CMapView::CState m_MapViewState;
 	CQuadKnife::CState m_QuadKnifeState;
 
 	// Housekeeping

--- a/src/game/editor/smooth_value.h
+++ b/src/game/editor/smooth_value.h
@@ -1,16 +1,17 @@
 #ifndef GAME_EDITOR_SMOOTH_VALUE_H
 #define GAME_EDITOR_SMOOTH_VALUE_H
 
-#include "component.h"
+#include "editor_object.h"
 
 #include <base/bezier.h>
 
 /**
  * A value that is changed smoothly over time.
  */
-class CSmoothValue : public CEditorComponent
+class CSmoothValue : public CEditorObject
 {
 public:
+	CSmoothValue() = default;
 	CSmoothValue(float InitialValue, float MinValue, float MaxValue);
 
 	/**


### PR DESCRIPTION
Required for #12119 and #11776.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions