### PR TITLE
Add assertion instead of leaking memory in unreachable case

### DIFF
--- a/src/game/client/components/menus_ingame_touch_controls.cpp
+++ b/src/game/client/components/menus_ingame_touch_controls.cpp
@@ -1471,10 +1471,11 @@ std::string CMenusIngameTouchControls::CBehaviorElements::ParseLabel(const char 
 	char aJsonString[1048];
 	str_format(aJsonString, sizeof(aJsonString), "\"%s\"", pLabel);
 	json_value *pJsonLabel = json_parse_ex(&JsonSettings, aJsonString, str_length(aJsonString), aError);
-	if(pJsonLabel == nullptr || pJsonLabel->type != json_string)
+	if(pJsonLabel == nullptr)
 	{
 		return pLabel;
 	}
+	dbg_assert(pJsonLabel->type == json_string, "Parsed label must be string");
 	std::string ParsedString = pJsonLabel->u.string.ptr;
 	json_value_free(pJsonLabel);
 	return ParsedString;


### PR DESCRIPTION
With the given input string, either JSON parsing of the touch button label should fail or the result should be a string literal.

Thanks to @ByFox213 in https://github.com/ddnet/ddnet/pull/12159#discussion_r3215256685.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
