### PR TITLE
Match `CUi` clipping area with `CUi::Draw` more closely

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -787,7 +787,7 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 		CUIRect TabContents, CountriesTab, TypesTab;
 		View.HSplitTop(6.0f, nullptr, &View);
 		View.HSplitTop(19.0f, &Button, &View);
-		View.HSplitTop(minimum(4.0f * 22.0f + CScrollRegion::HEIGHT_MAGIC_FIX, View.h), &TabContents, &View);
+		View.HSplitTop(minimum(4.0f * 22.0f, View.h), &TabContents, &View);
 		Button.VSplitMid(&CountriesTab, &TypesTab);
 		TabContents.Draw(ColorActive, IGraphics::CORNER_B, 4.0f);
 
@@ -1865,7 +1865,7 @@ void CMenus::RenderServerbrowser(CUIRect MainView)
 	if(g_Config.m_UiPage == PAGE_INTERNET || g_Config.m_UiPage == PAGE_FAVORITES)
 	{
 		CUIRect CommunityFilter;
-		ToolBox.HSplitTop(19.0f + 4.0f * 17.0f + CScrollRegion::HEIGHT_MAGIC_FIX, &CommunityFilter, &ToolBox);
+		ToolBox.HSplitTop(19.0f + 4.0f * 17.0f, &CommunityFilter, &ToolBox);
 		ToolBox.HSplitTop(8.0f, nullptr, &ToolBox);
 		RenderServerbrowserCommunitiesFilter(CommunityFilter);
 	}

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1330,7 +1330,7 @@ void CMenus::RenderLanguageSettings(CUIRect MainView)
 	const float CreditsMargin = 10.0f;
 
 	CUIRect List, CreditsScroll;
-	MainView.HSplitBottom(4.0f * CreditsFontSize + 2.0f * CreditsMargin + CScrollRegion::HEIGHT_MAGIC_FIX, &List, &CreditsScroll);
+	MainView.HSplitBottom(4.0f * CreditsFontSize + 2.0f * CreditsMargin, &List, &CreditsScroll);
 	List.HSplitBottom(5.0f, &List, nullptr);
 
 	RenderLanguageSelection(List);

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -501,7 +501,12 @@ void CUi::UpdateClipping()
 		const CUIRect *pRect = ClipArea();
 		const float XScale = Graphics()->ScreenWidth() / Screen()->w;
 		const float YScale = Graphics()->ScreenHeight() / Screen()->h;
-		Graphics()->ClipEnable((int)(pRect->x * XScale), (int)(pRect->y * YScale), (int)(pRect->w * XScale), (int)(pRect->h * YScale));
+
+		const float ScaledX = pRect->x * XScale;
+		const float ScaledY = pRect->y * YScale;
+		const float RoundX = std::round(ScaledX);
+		const float RoundY = std::round(ScaledY);
+		Graphics()->ClipEnable(RoundX, RoundY, std::round(pRect->w * XScale + (ScaledX - RoundX)), std::round(pRect->h * YScale + (ScaledY - RoundY)));
 	}
 	else
 	{

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -1948,7 +1948,7 @@ CUi::EPopupMenuFunctionResult CUi::PopupSelection(void *pContext, CUIRect View, 
 void CUi::ShowPopupSelection(float X, float Y, SSelectionPopupContext *pContext)
 {
 	const STextBoundingBox TextBoundingBox = TextRender()->TextBoundingBox(pContext->m_FontSize, pContext->m_aMessage, -1, pContext->m_Width);
-	const float PopupHeight = minimum((pContext->m_aMessage[0] == '\0' ? -pContext->m_EntrySpacing : TextBoundingBox.m_H) + pContext->m_vEntries.size() * (pContext->m_EntryHeight + pContext->m_EntrySpacing) + (SPopupMenu::POPUP_BORDER + SPopupMenu::POPUP_MARGIN) * 2 + CScrollRegion::HEIGHT_MAGIC_FIX, Screen()->h * 0.4f);
+	const float PopupHeight = minimum((pContext->m_aMessage[0] == '\0' ? -pContext->m_EntrySpacing : TextBoundingBox.m_H) + pContext->m_vEntries.size() * (pContext->m_EntryHeight + pContext->m_EntrySpacing) + (SPopupMenu::POPUP_BORDER + SPopupMenu::POPUP_MARGIN) * 2, Screen()->h * 0.4f);
 	pContext->m_pUI = this;
 	pContext->m_pSelection = nullptr;
 	pContext->m_SelectionIndex = -1;

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -204,8 +204,7 @@ void CScrollRegion::End()
 bool CScrollRegion::AddRect(const CUIRect &Rect, bool ShouldScrollHere)
 {
 	m_LastAddedRect = Rect;
-	// Round up and add magic to fix pixel clipping at the end of the scrolling area
-	m_ContentH = maximum(std::ceil(Rect.y + Rect.h - (m_ClipRect.y + m_ContentScrollOff.y)) + HEIGHT_MAGIC_FIX, m_ContentH);
+	m_ContentH = maximum(Rect.y + Rect.h - (m_ClipRect.y + m_ContentScrollOff.y), m_ContentH);
 	if(ShouldScrollHere)
 		ScrollHere();
 	return !RectClipped(Rect);

--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -89,10 +89,6 @@ Usage:
 class CScrollRegion : private CUIElementBase
 {
 public:
-	// TODO: Properly fix whatever is causing the 1-pixel discrepancy in scrolling rect height and remove this magic value.
-	// Currently this must be added when calculating the required height of a UI rect for a scroll region to get a perfect fit.
-	static constexpr float HEIGHT_MAGIC_FIX = 1.0f;
-
 	enum EScrollRelative
 	{
 		SCROLLRELATIVE_UP = -1,

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -2469,7 +2469,7 @@ void CEditor::PopupSelectConfigAutoMapInvoke(int Current, float x, float y)
 	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Map()->SelectedLayer(0));
 	const int ItemCount = minimum(Map()->m_vpImages[pLayer->m_Image]->m_AutoMapper.ConfigNamesNum() + 1, 10); // +1 for None-entry
 	// Width for buttons is 120, 15 is the scrollbar width, 2 is the margin between both.
-	Ui()->DoPopupMenu(&s_PopupSelectConfigAutoMapId, x, y, 120.0f + 15.0f + 2.0f, 10.0f + 12.0f * ItemCount + 2.0f * (ItemCount - 1) + CScrollRegion::HEIGHT_MAGIC_FIX, this, PopupSelectConfigAutoMap);
+	Ui()->DoPopupMenu(&s_PopupSelectConfigAutoMapId, x, y, 120.0f + 15.0f + 2.0f, 10.0f + 12.0f * ItemCount + 2.0f * (ItemCount - 1), this, PopupSelectConfigAutoMap);
 }
 
 int CEditor::PopupSelectConfigAutoMapResult()


### PR DESCRIPTION
This closes a TODO in `CScrollRegion`. Before, the areas of `CUi::ClipEnable(Rect)` and `Cui::Draw(Rect)`
sometimes differed by one pixel.

The code was adapted from [https://github.com/ddnet/ddnet-rs/blob/997113bac236ab6e3f8a5be368ffa2b7903a0777/lib/graphics-types/src/rendering.rs#L140-L149](url). However the top left coordinates need to be floored instead.

To test I added the following at the end of `CEditor::Render`:

```C++
for(int i = 0; i < 100; i++)
{
  CUIRect Rect;
  Rect.x = 20.0f + 0.1f * i;
  Rect.y = 20.0f + 6.0f * i;
  Rect.w = 20.0f;
  Rect.h = 5.0f;

  Rect.Draw({0.0f, 1.0f, 0.0f, 0.5f}, IGraphics::CORNER_NONE, 0.0f);
  Ui()->ClipEnable(&Rect);
  Rect.Draw({1.0f, 0.0f, 0.0f, 0.5f}, IGraphics::CORNER_NONE, 0.0f);
  Ui()->ClipDisable();
}

for(int i = 0; i < 100; i++)
{
  CUIRect Rect;
  Rect.x = 100.0f + 6.0f * i;
  Rect.y = 20.0f + 0.1f * i;
  Rect.w = 5.0f;
  Rect.h = 20.0f;

  Rect.Draw({0.0f, 1.0f, 0.0f, 0.5f}, IGraphics::CORNER_NONE, 0.0f);
  Ui()->ClipEnable(&Rect);
  Rect.Draw({1.0f, 0.0f, 0.0f, 0.5f}, IGraphics::CORNER_NONE, 0.0f);
  Ui()->ClipDisable();
}

for(int i = 0; i < 100; i++)
{
  CUIRect Rect;
  Rect.x = 60.0f + 0.1f * i;
  Rect.y = 20.0f + 6.0f * i;
  Rect.w = 5.0f + 0.1f * i;
  Rect.h = 5.0f;

  Rect.Draw({0.0f, 1.0f, 0.0f, 0.5f}, IGraphics::CORNER_NONE, 0.0f);
  Ui()->ClipEnable(&Rect);
  Rect.Draw({1.0f, 0.0f, 0.0f, 0.5f}, IGraphics::CORNER_NONE, 0.0f);
  Ui()->ClipDisable();
}

for(int i = 0; i < 100; i++)
{
  CUIRect Rect;
  Rect.x = 100.0f + 6.0f * i;
  Rect.y = 60.0f + 0.1f * i;
  Rect.w = 5.0f;
  Rect.h = 5.0f + 0.1f * i;

  Rect.Draw({0.0f, 1.0f, 0.0f, 0.5f}, IGraphics::CORNER_NONE, 0.0f);
  Ui()->ClipEnable(&Rect);
  Rect.Draw({1.0f, 0.0f, 0.0f, 0.5f}, IGraphics::CORNER_NONE, 0.0f);
  Ui()->ClipDisable();
}
```

Before:
<img width="1920" height="1011" alt="screenshot_2026-05-10_20-23-01" src="https://github.com/user-attachments/assets/962e1841-f1b1-43a1-ad76-efa1739de9ce" />

After:
<img width="1920" height="1011" alt="screenshot_2026-05-10_20-23-27" src="https://github.com/user-attachments/assets/aadd690a-8b05-4801-bfaa-aab05b236333" />

I did this with multiple aspect ratios. I also looked at a few scrollregions but could not find any visual bugs.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
