### PR TITLE
Reset quad knife state without depending on currently selected map

### DIFF
--- a/src/game/editor/mapitems/map.cpp
+++ b/src/game/editor/mapitems/map.cpp
@@ -91,7 +91,7 @@ void CEditorMap::Clean()
 	m_ShiftBy = 1;
 
 	m_MapViewState.Reset(Editor());
-	Editor()->QuadKnife()->Deactivate();
+	m_QuadKnifeState.Reset();
 }
 
 void CEditorMap::CreateDefault()
@@ -333,7 +333,7 @@ void CEditorMap::SelectLayer(int LayerIndex, int GroupIndex)
 void CEditorMap::AddSelectedLayer(int LayerIndex)
 {
 	m_vSelectedLayers.push_back(LayerIndex);
-	Editor()->QuadKnife()->Deactivate();
+	m_QuadKnifeState.Reset();
 }
 
 void CEditorMap::SelectNextLayer()

--- a/src/game/editor/quad_knife.cpp
+++ b/src/game/editor/quad_knife.cpp
@@ -3,6 +3,14 @@
 #include "editor.h"
 #include "editor_actions.h"
 
+void CQuadKnife::CState::Reset()
+{
+	m_Active = false;
+	m_Count = 0;
+	m_SelectedQuadIndex = -1;
+	std::fill(std::begin(m_aPoints), std::end(m_aPoints), vec2(0.0f, 0.0f));
+}
+
 bool CQuadKnife::IsActive() const
 {
 	return Map()->m_QuadKnifeState.m_Active;
@@ -17,12 +25,7 @@ void CQuadKnife::Activate(int SelectedQuad)
 
 void CQuadKnife::Deactivate()
 {
-	Map()->m_QuadKnifeState.m_Active = false;
-	Map()->m_QuadKnifeState.m_Count = 0;
-	Map()->m_QuadKnifeState.m_SelectedQuadIndex = -1;
-
-	auto &aPoints = Map()->m_QuadKnifeState.m_aPoints;
-	std::fill(std::begin(aPoints), std::end(aPoints), vec2(0.0f, 0.0f));
+	Map()->m_QuadKnifeState.Reset();
 }
 
 static float TriangleArea(vec2 A, vec2 B, vec2 C)

--- a/src/game/editor/quad_knife.h
+++ b/src/game/editor/quad_knife.h
@@ -13,6 +13,8 @@ public:
 		int m_SelectedQuadIndex;
 		int m_Count;
 		vec2 m_aPoints[4];
+
+		void Reset();
 	};
 
 	bool IsActive() const;


### PR DESCRIPTION
Calling `Editor()->QuadKnife()->Deactivate()` in the `CEditorMap::Clean` and `CEditorMap::AddSelectedLayer` functions is not correct when there are multiple maps, as it refers to the map selected in the editor and not the current map object on which the `Clean`/`AddSelectedLayer` function was called.

Required for #11776.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions