### PR TITLE
Fix stack overflow on `dbg_assert` in test runner with captured log

### DIFF
--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -176,6 +176,14 @@ public:
 
 	void GlobalFinish() override
 	{
+		if(dbg_assert_has_failed() && m_pMemoryLogger != nullptr)
+		{
+			for(const CLogMessage &Line : m_pMemoryLogger->Lines())
+			{
+				m_pGlobalLogger->Log(&Line);
+			}
+			m_pMemoryLogger = nullptr;
+		}
 		dbg_assert(m_pMemoryLogger == nullptr, "Memory logger should be unset when test logger finishes");
 		m_pGlobalLogger->GlobalFinish();
 	}


### PR DESCRIPTION
When a `dbg_assert` fails in a test case, then the `CTestLogListener::OnTestEnd` callback will not be called to print the captured log and remove the memory logger that is set when not using `--no-capture`. When the `CTestLogger::Finish` function is then called after the initial `dbg_assert` failed, this causes the `m_pMemoryLogger == nullptr` assertion to fail as the memory logger is still set, which causes the same assertion to fail repeatedly.

Regression from #12036.

## Checklist

- [X] Tested the change
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions