### PR TITLE
Add envelope copy/paste buttons to editor

### DIFF
--- a/src/engine/font_icons.h
+++ b/src/engine/font_icons.h
@@ -30,6 +30,7 @@ namespace FontIcon
 	inline const char *const CLAPPERBOARD = "\uE131";
 	inline const char *const COMMENT = "\uF075";
 	inline const char *const COMMENT_SLASH = "\uF4B3";
+	inline const char *const COPY = "\uF0C5";
 	inline const char *const DICE_FIVE = "\uF523";
 	inline const char *const DICE_FOUR = "\uF524";
 	inline const char *const DICE_ONE = "\uF525";
@@ -68,6 +69,7 @@ namespace FontIcon
 	inline const char *const NETWORK_WIRED = "\uF6FF";
 	inline const char *const NEWSPAPER = "\uF1EA";
 	inline const char *const PAUSE = "\uF04C";
+	inline const char *const PASTE = "\uF0EA";
 	inline const char *const PEN_TO_SQUARE = "\uF044";
 	inline const char *const PENCIL = "\uF303";
 	inline const char *const PLAY = "\uF04B";

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -136,6 +136,7 @@ class CEditor : public IEditor, public IEnvelopeEval
 	IGraphics::CTextureHandle m_SpeedupTexture;
 	IGraphics::CTextureHandle m_SwitchTexture;
 	IGraphics::CTextureHandle m_TuneTexture;
+	std::shared_ptr<CEnvelope> m_pEnvelopeClipboard;
 
 	enum EPreviewState
 	{

--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -12,6 +12,8 @@
 #include <game/editor/mapitems/layer_sounds.h>
 #include <game/editor/mapitems/map.h>
 
+#include <utility>
+
 CEditorBrushDrawAction::CEditorBrushDrawAction(CEditorMap *pMap, int Group) :
 	IEditorAction(pMap), m_Group(Group)
 {
@@ -1459,6 +1461,15 @@ CEditorActionEnvelopeAdd::CEditorActionEnvelopeAdd(CEditorMap *pMap, CEnvelope::
 	m_PreviousSelectedEnvelope = Map()->m_SelectedEnvelope;
 }
 
+CEditorActionEnvelopeAdd::CEditorActionEnvelopeAdd(CEditorMap *pMap, std::shared_ptr<CEnvelope> pEnvelope) :
+	IEditorAction(pMap),
+	m_EnvelopeType(pEnvelope->Type()),
+	m_pEnvelope(std::move(pEnvelope))
+{
+	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Paste envelope");
+	m_PreviousSelectedEnvelope = Map()->m_SelectedEnvelope;
+}
+
 void CEditorActionEnvelopeAdd::Undo()
 {
 	// Undo is removing the envelope, which was added at the back of the list
@@ -1470,7 +1481,15 @@ void CEditorActionEnvelopeAdd::Undo()
 void CEditorActionEnvelopeAdd::Redo()
 {
 	// Redo is adding a new envelope at the back of the list
-	Map()->NewEnvelope(m_EnvelopeType);
+	if(m_pEnvelope)
+	{
+		Map()->OnModify();
+		Map()->m_vpEnvelopes.push_back(m_pEnvelope);
+	}
+	else
+	{
+		Map()->NewEnvelope(m_EnvelopeType);
+	}
 	Map()->m_SelectedEnvelope = Map()->m_vpEnvelopes.size() - 1;
 }
 

--- a/src/game/editor/editor_actions.h
+++ b/src/game/editor/editor_actions.h
@@ -410,12 +410,14 @@ class CEditorActionEnvelopeAdd : public IEditorAction
 {
 public:
 	CEditorActionEnvelopeAdd(CEditorMap *pMap, CEnvelope::EType EnvelopeType);
+	CEditorActionEnvelopeAdd(CEditorMap *pMap, std::shared_ptr<CEnvelope> pEnvelope);
 
 	void Undo() override;
 	void Redo() override;
 
 private:
 	CEnvelope::EType m_EnvelopeType;
+	std::shared_ptr<CEnvelope> m_pEnvelope;
 	int m_PreviousSelectedEnvelope;
 };
 

--- a/src/game/editor/envelope_editor.cpp
+++ b/src/game/editor/envelope_editor.cpp
@@ -196,6 +196,30 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 		if(Map()->m_SelectedEnvelope >= 0)
 		{
+			ToolBar.VSplitRight(5.0f, &ToolBar, nullptr);
+			ToolBar.VSplitRight(25.0f, &ToolBar, &Button);
+
+			static int s_CopyEnvelopeButton = 0;
+			if(DoButton_FontIcon(&s_CopyEnvelopeButton, FontIcon::COPY, 0, &Button, BUTTONFLAG_LEFT, "Copy the selected envelope.", IGraphics::CORNER_ALL, 9.0f))
+			{
+				const auto &pSource = Map()->m_vpEnvelopes[Map()->m_SelectedEnvelope];
+				m_pEnvelopeClipboard = std::make_shared<CEnvelope>(*pSource);
+			}
+		}
+
+		ToolBar.VSplitRight(5.0f, &ToolBar, nullptr);
+		ToolBar.VSplitRight(25.0f, &ToolBar, &Button);
+
+		static int s_PasteEnvelopeButton = 0;
+		if(DoButton_FontIcon(&s_PasteEnvelopeButton, FontIcon::PASTE, m_pEnvelopeClipboard ? 0 : -1, &Button, BUTTONFLAG_LEFT, "Paste copied envelope.", IGraphics::CORNER_ALL, 9.0f))
+		{
+			Map()->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionEnvelopeAdd>(Map(), std::make_shared<CEnvelope>(*m_pEnvelopeClipboard)));
+			pEnvelope = Map()->m_vpEnvelopes[Map()->m_SelectedEnvelope];
+			CurrentEnvelopeSwitched = true;
+		}
+
+		if(Map()->m_SelectedEnvelope >= 0)
+		{
 			// Delete button
 			ToolBar.VSplitRight(10.0f, &ToolBar, nullptr);
 			ToolBar.VSplitRight(25.0f, &ToolBar, &Button);

--- a/src/game/editor/mapitems/envelope.cpp
+++ b/src/game/editor/mapitems/envelope.cpp
@@ -1,6 +1,7 @@
 #include "envelope.h"
 
 #include <base/dbg.h>
+#include <base/str.h>
 
 #include <algorithm>
 #include <chrono>
@@ -52,6 +53,15 @@ CEnvelope::CEnvelope(int NumChannels) :
 	default:
 		dbg_assert_failed("invalid number of channels for envelope");
 	}
+}
+
+CEnvelope::CEnvelope(const CEnvelope &Other) :
+	m_vPoints(Other.m_vPoints),
+	m_Synchronized(Other.m_Synchronized),
+	m_Type(Other.m_Type),
+	m_PointsAccess(&m_vPoints)
+{
+	str_copy(m_aName, Other.m_aName);
 }
 
 void CEnvelope::Resort()

--- a/src/game/editor/mapitems/envelope.h
+++ b/src/game/editor/mapitems/envelope.h
@@ -22,6 +22,7 @@ public:
 	};
 	explicit CEnvelope(EType Type);
 	explicit CEnvelope(int NumChannels);
+	CEnvelope(const CEnvelope &Other);
 
 	std::pair<float, float> GetValueRange(int ChannelMask);
 	void Eval(float Time, ColorRGBA &Result, size_t Channels);


### PR DESCRIPTION
Allows you to copy and paste envelopes between maps.

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<img width="2320" height="634" alt="Screenshot_7" src="https://github.com/user-attachments/assets/eb80df7e-d024-4e4a-8255-da55e799a78c" />
the copy button only appears when there is an envelope
<img width="2323" height="636" alt="Screenshot_8" src="https://github.com/user-attachments/assets/779b4e36-b382-4142-88bc-830fdd407e22" />
the paste button only appears when something has been copied
<img width="2320" height="637" alt="Screenshot_9" src="https://github.com/user-attachments/assets/86b35b65-0656-48b2-ae6b-31b1b2e42881" />
the same here
<img width="2323" height="639" alt="Screenshot_10" src="https://github.com/user-attachments/assets/1d4a72af-fc4e-4186-84f5-ff51511b0912" />
