### PR TITLE
Fix various client crashes during connecting and on map changes

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1191,6 +1191,27 @@ const char *CClient::LoadMap(const char *pName, const char *pFilename, const std
 	if((bool)m_LoadingCallback)
 		m_LoadingCallback(IClient::LOADING_CALLBACK_DETAIL_MAP);
 
+	// Stop demo recording before loading a new map.
+	for(int Recorder = 0; Recorder < RECORDER_MAX; Recorder++)
+	{
+		DemoRecorder(Recorder)->Stop(Recorder == RECORDER_REPLAYS ? IDemoRecorder::EStopMode::REMOVE_FILE : IDemoRecorder::EStopMode::KEEP_FILE);
+	}
+
+	// Unload the current map and reset all snapshots before loading a new map,
+	// because the snapshots are only valid for the old map.
+	GameClient()->Map()->Unload();
+	for(int Dummy = 0; Dummy < NUM_DUMMIES; Dummy++)
+	{
+		m_aapSnapshots[Dummy][SNAP_CURRENT] = nullptr;
+		m_aapSnapshots[Dummy][SNAP_PREV] = nullptr;
+		m_aSnapshotStorage[Dummy].PurgeAll();
+		m_aReceivedSnapshots[Dummy] = 0;
+		m_aSnapshotParts[Dummy] = 0;
+		m_aSnapshotIncomingDataSize[Dummy] = 0;
+	}
+	m_SnapCrcErrors = 0;
+	GameClient()->InvalidateSnapshot();
+
 	if(!GameClient()->Map()->Load(pName, Storage(), pFilename, IStorage::TYPE_ALL))
 	{
 		str_format(s_aErrorMsg, sizeof(s_aErrorMsg), "map '%s' not found", pFilename);
@@ -1216,12 +1237,6 @@ const char *CClient::LoadMap(const char *pName, const char *pFilename, const std
 		m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "client", s_aErrorMsg);
 		GameClient()->Map()->Unload();
 		return s_aErrorMsg;
-	}
-
-	// stop demo recording if we loaded a new map
-	for(int Recorder = 0; Recorder < RECORDER_MAX; Recorder++)
-	{
-		DemoRecorder(Recorder)->Stop(Recorder == RECORDER_REPLAYS ? IDemoRecorder::EStopMode::REMOVE_FILE : IDemoRecorder::EStopMode::KEEP_FILE);
 	}
 
 	char aBuf[256];
@@ -1499,7 +1514,8 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 			// Only accept server info that has a type that is
 			// newer or equal to something the server already sent
 			// us.
-			if(SavedType >= m_CurrentServerInfo.m_Type)
+			if(SavedType >= m_CurrentServerInfo.m_Type &&
+				GameClient()->Map()->IsLoaded())
 			{
 				SetCurrentServerInfo(Info);
 				Discord()->UpdateServerInfo(m_CurrentServerInfo);
@@ -1823,6 +1839,10 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 		}
 		else if(Conn == CONN_MAIN && (pPacket->m_Flags & NET_CHUNKFLAG_VITAL) != 0 && Msg == NETMSG_CON_READY)
 		{
+			if(!GameClient()->Map()->IsLoaded())
+			{
+				return;
+			}
 			GameClient()->OnConnected();
 			if(m_DummyReconnectOnReload)
 			{
@@ -2026,8 +2046,9 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 		}
 		else if(Msg == NETMSG_SNAP || Msg == NETMSG_SNAPSINGLE || Msg == NETMSG_SNAPEMPTY)
 		{
-			// we are not allowed to process snapshot yet
-			if(State() < IClient::STATE_LOADING)
+			// We are not allowed to process snapshots yet.
+			if(State() < IClient::STATE_LOADING ||
+				!GameClient()->Map()->IsLoaded())
 			{
 				return;
 			}


### PR DESCRIPTION
Fix various crashes with the `File not open` assertion error due to the map being accessed when it is unloaded. This assertion error was triggered in multiple ways. When receiving the current server's info via a connection-less packet during the connection process, the map name was accessed in the `CClient::SetCurrentServerInfo` function without checking whether the map is already loaded. The server sends the current server info after the client should have already loaded the map, but it was very rarely possible for the client to receive the server info, potentially from a different connection attempt, with the map being unloaded when connecting and disconnecting quickly. Also, when handling messages like `NETMSG_CON_READY`, the client did not check whether the map is loaded, which could trigger this assertion error in game client layer initialization and potentially other client functions. The newer assertion error may have also overshadowed some of the other, older crashes described below. Closes #9882. Closes #11909.

Fix crashes when receiving snapshots while the map is not loaded. This can trivially happen with modified servers incorrectly sending snapshots when they are not expected. With DDNet servers this may happen very rarely when the client receives multiple map changes in quick succession during a connection attempt, for example when connecting to a server (which sends the first map change) at almost the same time as the map is changed on the server (e.g., by vote). Closes #4274.

Fix crashes when receiving `NETMSG_CON_READY` while the map is not loaded. By protocol definition, the server sends `NETMSG_CON_READY` in response to the client sending `NETMSG_READY`, but the client only sends `NETMSG_READY` specifically after the map is loaded. This may also very rarely happen due to multiple map changes being received in quick succession while connecting to a server. Closes #8101.

Fix crashes in prediction and rendering after quick connection attempts and map changes. When a map change is received, the engine client loads the new map while unloading the old map. On map loading failure the map would be left unloaded, which is now handled as described above. However, regardless of whether map loading succeeded, the game client still kept its current snapshots that are based on the old map. To fix this, before loading a new map, the client now always unloads the current map first and clears the snapshot pointers and storage so the client has to wait for two snapshots (based on the new map) before being considered ingame again. Closes #6908. Closes #8720.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
