### PR TITLE
allow instantly swiching team after server reload

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1105,7 +1105,7 @@ void CGameContext::AttemptJoinTeam(int ClientId, int Team)
 	}
 
 	char aError[512];
-	if(pPlayer->m_LastDDRaceTeamChange + (int64_t)Server()->TickSpeed() * g_Config.m_SvTeamChangeDelay > Server()->Tick())
+	if(pPlayer->m_LastDDRaceTeamChange.has_value() && pPlayer->m_LastDDRaceTeamChange.value() + (int64_t)Server()->TickSpeed() * g_Config.m_SvTeamChangeDelay > Server()->Tick())
 	{
 		log_info("chatresp", "You can't change teams that fast!");
 	}

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -113,7 +113,7 @@ void CPlayer::Reset()
 	GameServer()->Score()->PlayerData(m_ClientId)->Reset();
 
 	m_LastKickVote = 0;
-	m_LastDDRaceTeamChange = 0;
+	m_LastDDRaceTeamChange.reset();
 	m_ShowOthers = g_Config.m_SvShowOthersDefault;
 	m_ShowAll = g_Config.m_SvShowAllDefault;
 	m_EnableSpectatorCount = true;

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -180,7 +180,7 @@ public:
 
 	bool IsPlaying() const;
 	int64_t m_LastKickVote;
-	int64_t m_LastDDRaceTeamChange;
+	std::optional<int64_t> m_LastDDRaceTeamChange;
 	int m_ShowOthers;
 	bool m_ShowAll;
 	bool m_EnableSpectatorCount;


### PR DESCRIPTION
Reload server -> attempt to join team directly after reconnecting -> "You can't change teams that fast!"
This pr fixes this by checking if we have ever switched teams beforehand

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
