### PR TITLE
Various fixes and refactoring of huffman compression/decompression

### DIFF
--- a/src/engine/shared/huffman.cpp
+++ b/src/engine/shared/huffman.cpp
@@ -2,6 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "huffman.h"
 
+#include <base/dbg.h>
 #include <base/mem.h>
 
 #include <algorithm>
@@ -132,6 +133,9 @@ void CHuffman::Init(const unsigned *pFrequencies)
 //***************************************************************
 int CHuffman::Compress(const void *pInput, int InputSize, void *pOutput, int OutputSize) const
 {
+	dbg_assert(InputSize >= 0, "Invalid InputSize: %d", InputSize);
+	dbg_assert(OutputSize > 0, "Invalid OutputSize: %d", OutputSize);
+
 	// this macro loads a symbol for a byte into bits and bitcount
 #define HUFFMAN_MACRO_LOADSYMBOL(Sym) \
 	do \
@@ -205,6 +209,9 @@ int CHuffman::Compress(const void *pInput, int InputSize, void *pOutput, int Out
 //***************************************************************
 int CHuffman::Decompress(const void *pInput, int InputSize, void *pOutput, int OutputSize) const
 {
+	dbg_assert(InputSize >= 0, "Invalid InputSize: %d", InputSize);
+	dbg_assert(OutputSize > 0, "Invalid OutputSize: %d", OutputSize);
+
 	// setup buffer pointers
 	unsigned char *pDst = (unsigned char *)pOutput;
 	unsigned char *pSrc = (unsigned char *)pInput;

--- a/src/engine/shared/huffman.cpp
+++ b/src/engine/shared/huffman.cpp
@@ -93,7 +93,7 @@ void CHuffman::ConstructTree(const unsigned *pFrequencies)
 	Setbits_r(m_pStartNode, 0, 0);
 }
 
-void CHuffman::Init(const unsigned *pFrequencies)
+void CHuffman::Init()
 {
 	// make sure to cleanout every thing
 	mem_zero(m_aNodes, sizeof(m_aNodes));
@@ -102,7 +102,7 @@ void CHuffman::Init(const unsigned *pFrequencies)
 	m_NumNodes = 0;
 
 	// construct the tree
-	ConstructTree(pFrequencies);
+	ConstructTree(ms_aFreqTable);
 
 	// build decode LUT
 	for(int i = 0; i < HUFFMAN_LUTSIZE; i++)

--- a/src/engine/shared/huffman.cpp
+++ b/src/engine/shared/huffman.cpp
@@ -246,12 +246,20 @@ int CHuffman::Decompress(const void *pInput, int InputSize, void *pOutput, int O
 		if(pNode->m_NumBits)
 		{
 			// remove the bits for that symbol
+			if(Bitcount < pNode->m_NumBits)
+			{
+				return -1;
+			}
 			Bits >>= pNode->m_NumBits;
 			Bitcount -= pNode->m_NumBits;
 		}
 		else
 		{
 			// remove the bits that the lut checked up for us
+			if(Bitcount < HUFFMAN_LUTBITS)
+			{
+				return -1;
+			}
 			Bits >>= HUFFMAN_LUTBITS;
 			Bitcount -= HUFFMAN_LUTBITS;
 

--- a/src/engine/shared/huffman.cpp
+++ b/src/engine/shared/huffman.cpp
@@ -213,10 +213,10 @@ int CHuffman::Decompress(const void *pInput, int InputSize, void *pOutput, int O
 	dbg_assert(OutputSize > 0, "Invalid OutputSize: %d", OutputSize);
 
 	// setup buffer pointers
+	const unsigned char *pSrc = (const unsigned char *)pInput;
+	const unsigned char *pSrcEnd = pSrc + InputSize;
 	unsigned char *pDst = (unsigned char *)pOutput;
-	unsigned char *pSrc = (unsigned char *)pInput;
 	unsigned char *pDstEnd = pDst + OutputSize;
-	unsigned char *pSrcEnd = pSrc + InputSize;
 
 	unsigned Bits = 0;
 	unsigned Bitcount = 0;

--- a/src/engine/shared/huffman.cpp
+++ b/src/engine/shared/huffman.cpp
@@ -34,12 +34,12 @@ static bool CompareNodesByFrequencyDesc(const CHuffmanConstructNode *pNode1, con
 	return pNode2->m_Frequency < pNode1->m_Frequency;
 }
 
-void CHuffman::Setbits_r(CNode *pNode, int Bits, unsigned Depth)
+void CHuffman::SetBitsRecursive(CNode *pNode, int Bits, unsigned Depth)
 {
 	if(pNode->m_aLeaves[1] != 0xffff)
-		Setbits_r(&m_aNodes[pNode->m_aLeaves[1]], Bits | (1 << Depth), Depth + 1);
+		SetBitsRecursive(&m_aNodes[pNode->m_aLeaves[1]], Bits | (1 << Depth), Depth + 1);
 	if(pNode->m_aLeaves[0] != 0xffff)
-		Setbits_r(&m_aNodes[pNode->m_aLeaves[0]], Bits, Depth + 1);
+		SetBitsRecursive(&m_aNodes[pNode->m_aLeaves[0]], Bits, Depth + 1);
 
 	if(pNode->m_NumBits)
 	{
@@ -91,7 +91,7 @@ void CHuffman::ConstructTree(const unsigned *pFrequencies)
 	m_pStartNode = &m_aNodes[m_NumNodes - 1];
 
 	// build symbol bits
-	Setbits_r(m_pStartNode, 0, 0);
+	SetBitsRecursive(m_pStartNode, 0, 0);
 }
 
 void CHuffman::Init()

--- a/src/engine/shared/huffman.cpp
+++ b/src/engine/shared/huffman.cpp
@@ -20,7 +20,7 @@ const unsigned CHuffman::ms_aFreqTable[HUFFMAN_MAX_SYMBOLS] = {
 	136, 53, 180, 57, 142, 57, 158, 61, 166, 112, 152, 92, 26, 22, 21, 28, 20, 26, 30, 21,
 	32, 27, 20, 17, 23, 21, 30, 22, 22, 21, 27, 25, 17, 27, 23, 18, 39, 26, 15, 21,
 	12, 18, 18, 27, 20, 18, 15, 19, 11, 17, 33, 12, 18, 15, 19, 18, 16, 26, 17, 18,
-	9, 10, 25, 22, 22, 17, 20, 16, 6, 16, 15, 20, 14, 18, 24, 335, 1517};
+	9, 10, 25, 22, 22, 17, 20, 16, 6, 16, 15, 20, 14, 18, 24, 335, 1};
 
 class CHuffmanConstructNode
 {
@@ -62,10 +62,7 @@ void CHuffman::ConstructTree(const unsigned *pFrequencies)
 		m_aNodes[i].m_aLeaves[0] = 0xffff;
 		m_aNodes[i].m_aLeaves[1] = 0xffff;
 
-		if(i == HUFFMAN_EOF_SYMBOL)
-			aNodesLeftStorage[i].m_Frequency = 1;
-		else
-			aNodesLeftStorage[i].m_Frequency = pFrequencies[i];
+		aNodesLeftStorage[i].m_Frequency = pFrequencies[i];
 		aNodesLeftStorage[i].m_NodeId = i;
 		apNodesLeft[i] = &aNodesLeftStorage[i];
 	}

--- a/src/engine/shared/huffman.cpp
+++ b/src/engine/shared/huffman.cpp
@@ -22,8 +22,9 @@ const unsigned CHuffman::ms_aFreqTable[HUFFMAN_MAX_SYMBOLS] = {
 	12, 18, 18, 27, 20, 18, 15, 19, 11, 17, 33, 12, 18, 15, 19, 18, 16, 26, 17, 18,
 	9, 10, 25, 22, 22, 17, 20, 16, 6, 16, 15, 20, 14, 18, 24, 335, 1517};
 
-struct CHuffmanConstructNode
+class CHuffmanConstructNode
 {
+public:
 	unsigned short m_NodeId;
 	int m_Frequency;
 };

--- a/src/engine/shared/huffman.cpp
+++ b/src/engine/shared/huffman.cpp
@@ -116,9 +116,6 @@ void CHuffman::Init()
 			pNode = &m_aNodes[pNode->m_aLeaves[Bits & 1]];
 			Bits >>= 1;
 
-			if(!pNode)
-				break;
-
 			if(pNode->m_NumBits)
 			{
 				m_apDecodeLut[i] = pNode;

--- a/src/engine/shared/huffman.cpp
+++ b/src/engine/shared/huffman.cpp
@@ -148,9 +148,9 @@ int CHuffman::Compress(const void *pInput, int InputSize, void *pOutput, int Out
 	{ \
 		while(Bitcount >= 8) \
 		{ \
-			*pDst++ = (unsigned char)(Bits & 0xff); \
 			if(pDst == pDstEnd) \
 				return -1; \
+			*pDst++ = (unsigned char)(Bits & 0xff); \
 			Bits >>= 8; \
 			Bitcount -= 8; \
 		} \
@@ -193,8 +193,13 @@ int CHuffman::Compress(const void *pInput, int InputSize, void *pOutput, int Out
 	HUFFMAN_MACRO_LOADSYMBOL(HUFFMAN_EOF_SYMBOL);
 	HUFFMAN_MACRO_WRITE();
 
-	// write out the last bits
-	*pDst++ = Bits;
+	// write out the last bits if we have any
+	if(Bitcount != 0)
+	{
+		if(pDst == pDstEnd)
+			return -1;
+		*pDst++ = Bits;
+	}
 
 	// return the size of the output
 	return (int)(pDst - (const unsigned char *)pOutput);

--- a/src/engine/shared/huffman.h
+++ b/src/engine/shared/huffman.h
@@ -17,8 +17,9 @@ class CHuffman
 		HUFFMAN_LUTMASK = (HUFFMAN_LUTSIZE - 1)
 	};
 
-	struct CNode
+	class CNode
 	{
+	public:
 		// symbol
 		unsigned m_Bits;
 		unsigned m_NumBits;

--- a/src/engine/shared/huffman.h
+++ b/src/engine/shared/huffman.h
@@ -45,14 +45,11 @@ public:
 		Function: Init
 			Inits the compressor/decompressor.
 
-		Parameters:
-			pFrequencies - A pointer to an array of 256 entries of the frequencies of the bytes
-
 		Remarks:
 			- Does no allocation whatsoever.
 			- You don't have to call any cleanup functions when you are done with it.
 	*/
-	void Init(const unsigned *pFrequencies = ms_aFreqTable);
+	void Init();
 
 	/*
 		Function: Compress

--- a/src/engine/shared/huffman.h
+++ b/src/engine/shared/huffman.h
@@ -38,7 +38,7 @@ class CHuffman
 	CNode *m_pStartNode;
 	int m_NumNodes;
 
-	void Setbits_r(CNode *pNode, int Bits, unsigned Depth);
+	void SetBitsRecursive(CNode *pNode, int Bits, unsigned Depth);
 	void ConstructTree(const unsigned *pFrequencies);
 
 public:

--- a/src/test/huffman_test.cpp
+++ b/src/test/huffman_test.cpp
@@ -11,17 +11,25 @@ TEST(Huffman, CompressionShouldNotChangeData)
 
 	unsigned char aInput[64];
 	unsigned char aCompressed[2048];
-
-	mem_zero(aInput, sizeof(aInput));
-	mem_zero(aCompressed, sizeof(aCompressed));
-
-	int Size = Huffman.Compress(aInput, sizeof(aInput), aCompressed, sizeof(aCompressed));
-
 	unsigned char aDecompressed[2048];
-	Huffman.Decompress(aCompressed, sizeof(aCompressed), aDecompressed, sizeof(aDecompressed));
 
-	int match = mem_comp(aInput, aDecompressed, Size);
-	EXPECT_EQ(match, 0);
+	for(int InputMod = 0x00; InputMod <= 0xFFFF; ++InputMod)
+	{
+		mem_zero(aInput, sizeof(aInput));
+		mem_zero(aCompressed, sizeof(aCompressed));
+		mem_zero(aDecompressed, sizeof(aDecompressed));
+		aInput[0] = InputMod & 0xFF;
+		aInput[1] = (InputMod >> 8) & 0xFF;
+
+		const int CompressedSize = Huffman.Compress(aInput, sizeof(aInput), aCompressed, sizeof(aCompressed));
+		const int MaxSize = InputMod <= 0xFF ? 12 : 14;
+		ASSERT_GE(CompressedSize, 10);
+		ASSERT_LE(CompressedSize, MaxSize);
+
+		const int UncompressedSize = Huffman.Decompress(aCompressed, CompressedSize, aDecompressed, sizeof(aDecompressed));
+		ASSERT_EQ(UncompressedSize, (int)sizeof(aInput));
+		EXPECT_EQ(mem_comp(aInput, aDecompressed, UncompressedSize), 0);
+	}
 }
 
 TEST(Huffman, CompressionCompatible)

--- a/src/test/huffman_test.cpp
+++ b/src/test/huffman_test.cpp
@@ -79,3 +79,19 @@ TEST(Huffman, CompressionTruncated)
 		EXPECT_EQ(Huffman.Compress(aInput, sizeof(aInput), aCompressed, CompressedSize), 15) << "Compression expected to succeed with size " << CompressedSize;
 	}
 }
+
+TEST(Huffman, DecompressionTableLookupIntegerOverflow)
+{
+	CHuffman Huffman;
+	Huffman.Init();
+
+	// Test data found by fuzzing
+	const unsigned char aInput1[] = {0x1A};
+	const unsigned char aInput2[] = {0x62, 0x91, 0x62, 0xA9};
+	const unsigned char aInput3[] = {0x4C, 0x04, 0xFE, 0x00, 0x68};
+	unsigned char aUncompressed[2048];
+
+	EXPECT_EQ(Huffman.Decompress(aInput1, sizeof(aInput1), aUncompressed, sizeof(aUncompressed)), -1);
+	EXPECT_EQ(Huffman.Decompress(aInput2, sizeof(aInput2), aUncompressed, sizeof(aUncompressed)), -1);
+	EXPECT_EQ(Huffman.Decompress(aInput3, sizeof(aInput3), aUncompressed, sizeof(aUncompressed)), -1);
+}

--- a/src/test/huffman_test.cpp
+++ b/src/test/huffman_test.cpp
@@ -55,7 +55,7 @@ TEST(Huffman, CompressionCompatible)
 	EXPECT_EQ(mem_comp(aCompressed, aExpected, Size), 0) << "The compression is not compatible with older/other implementations anymore";
 }
 
-TEST(Huffman, CompressionTrailingNull)
+TEST(Huffman, CompressionNoTrailingNull)
 {
 	CHuffman Huffman;
 	Huffman.Init();
@@ -71,7 +71,7 @@ TEST(Huffman, CompressionTrailingNull)
 
 	const int CompressedSize = Huffman.Compress(aInput, sizeof(aInput), aCompressed, sizeof(aCompressed));
 
-	const unsigned char aExpected[] = {0xBE, 0xFD, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x15, 0x37, 0x00};
+	const unsigned char aExpected[] = {0xBE, 0xFD, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x15, 0x37};
 
 	ASSERT_EQ(CompressedSize, (int)sizeof(aExpected));
 	EXPECT_EQ(mem_comp(aCompressed, aExpected, CompressedSize), 0);

--- a/src/test/huffman_test.cpp
+++ b/src/test/huffman_test.cpp
@@ -4,6 +4,25 @@
 
 #include <gtest/gtest.h>
 
+TEST(Huffman, CompressionInputSizeZero)
+{
+	CHuffman Huffman;
+	Huffman.Init();
+
+	unsigned char aInput[64];
+	unsigned char aCompressed[2048];
+	unsigned char aDecompressed[2048];
+
+	const int CompressedSize = Huffman.Compress(aInput, 0, aCompressed, sizeof(aCompressed));
+	const unsigned char aExpected[] = {0x8A, 0x1B};
+
+	ASSERT_EQ(CompressedSize, (int)sizeof(aExpected));
+	EXPECT_EQ(mem_comp(aCompressed, aExpected, CompressedSize), 0);
+
+	const int UncompressedSize = Huffman.Decompress(aCompressed, CompressedSize, aDecompressed, sizeof(aDecompressed));
+	ASSERT_EQ(UncompressedSize, 0);
+}
+
 TEST(Huffman, CompressionShouldNotChangeData)
 {
 	CHuffman Huffman;

--- a/src/test/huffman_test.cpp
+++ b/src/test/huffman_test.cpp
@@ -54,3 +54,28 @@ TEST(Huffman, CompressionCompatible)
 	ASSERT_EQ(Size, (int)sizeof(aExpected)) << "The compression is not compatible with older/other implementations anymore";
 	EXPECT_EQ(mem_comp(aCompressed, aExpected, Size), 0) << "The compression is not compatible with older/other implementations anymore";
 }
+
+TEST(Huffman, CompressionTruncated)
+{
+	CHuffman Huffman;
+	Huffman.Init();
+
+	unsigned char aInput[64];
+	unsigned char aCompressed[2048];
+
+	mem_zero(aInput, sizeof(aInput));
+	mem_zero(aCompressed, sizeof(aCompressed));
+
+	// compress 1-7 followed by a bunch of nullbytes
+	for(int i = 0; i < 8; i++)
+		aInput[i] = i;
+
+	for(size_t CompressedSize = 1; CompressedSize <= 14; ++CompressedSize)
+	{
+		EXPECT_EQ(Huffman.Compress(aInput, sizeof(aInput), aCompressed, CompressedSize), -1) << "Compression expected to fail with size " << CompressedSize;
+	}
+	for(size_t CompressedSize = 15; CompressedSize <= 20; ++CompressedSize)
+	{
+		EXPECT_EQ(Huffman.Compress(aInput, sizeof(aInput), aCompressed, CompressedSize), 15) << "Compression expected to succeed with size " << CompressedSize;
+	}
+}

--- a/src/test/huffman_test.cpp
+++ b/src/test/huffman_test.cpp
@@ -47,11 +47,10 @@ TEST(Huffman, CompressionCompatible)
 	for(int i = 0; i < 8; i++)
 		aInput[i] = i;
 
-	int Size = Huffman.Compress(aInput, sizeof(aInput), aCompressed, sizeof(aCompressed));
+	const int Size = Huffman.Compress(aInput, sizeof(aInput), aCompressed, sizeof(aCompressed));
 
-	unsigned char aExpected[] = {0x51, 0x58, 0x78, 0x76, 0x1B, 0xB7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F, 0xc5, 0x0D};
+	const unsigned char aExpected[] = {0x51, 0x58, 0x78, 0x76, 0x1B, 0xB7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F, 0xc5, 0x0D};
 
-	int match = mem_comp(aCompressed, aExpected, Size);
-	EXPECT_EQ(match, 0) << "The compression is not compatible with older/other implementations anymore";
-	EXPECT_EQ(Size, 15);
+	ASSERT_EQ(Size, (int)sizeof(aExpected)) << "The compression is not compatible with older/other implementations anymore";
+	EXPECT_EQ(mem_comp(aCompressed, aExpected, Size), 0) << "The compression is not compatible with older/other implementations anymore";
 }

--- a/src/test/huffman_test.cpp
+++ b/src/test/huffman_test.cpp
@@ -55,6 +55,32 @@ TEST(Huffman, CompressionCompatible)
 	EXPECT_EQ(mem_comp(aCompressed, aExpected, Size), 0) << "The compression is not compatible with older/other implementations anymore";
 }
 
+TEST(Huffman, CompressionTrailingNull)
+{
+	CHuffman Huffman;
+	Huffman.Init();
+
+	unsigned char aInput[64];
+	unsigned char aCompressed[2048];
+	unsigned char aDecompressed[2048];
+
+	mem_zero(aInput, sizeof(aInput));
+	mem_zero(aCompressed, sizeof(aCompressed));
+	mem_zero(aDecompressed, sizeof(aDecompressed));
+	aInput[0] = 0x15;
+
+	const int CompressedSize = Huffman.Compress(aInput, sizeof(aInput), aCompressed, sizeof(aCompressed));
+
+	const unsigned char aExpected[] = {0xBE, 0xFD, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x15, 0x37, 0x00};
+
+	ASSERT_EQ(CompressedSize, (int)sizeof(aExpected));
+	EXPECT_EQ(mem_comp(aCompressed, aExpected, CompressedSize), 0);
+
+	const int UncompressedSize = Huffman.Decompress(aCompressed, CompressedSize, aDecompressed, sizeof(aDecompressed));
+	ASSERT_EQ(UncompressedSize, (int)sizeof(aInput));
+	EXPECT_EQ(mem_comp(aInput, aDecompressed, UncompressedSize), 0);
+}
+
 TEST(Huffman, CompressionTruncated)
 {
 	CHuffman Huffman;


### PR DESCRIPTION
See commit messages.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions:
   - AI found the unsigned integer underflow on decompression, but assumed it could cause very many loop iterations (DoS). However, in practice, tree node lookup prevents the loop from being iterated often. I fuzzed the decompression for a combined ~20 hours with AFL++ and could not find any crashes or hangs with ASAN, UBSAN, CFISAN and CmpLog.
   - AI found a potential OOB write in the compression function that can only happen when the output size is zero, which is now checked with assertions.
   - AI noted the missing handling of negative sizes.
