### PR TITLE
client: Flash taskbar when hooked by another player while alt tabbed

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -92,6 +92,7 @@ MACRO_CONFIG_INT(ClShowpred, cl_showpred, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE
 MACRO_CONFIG_INT(ClEyeWheel, cl_eye_wheel, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show eye wheel along together with emotes")
 MACRO_CONFIG_INT(ClEyeDuration, cl_eye_duration, 999999, 1, 999999, CFGFLAG_CLIENT | CFGFLAG_SAVE, "How long the eyes emotes last")
 MACRO_CONFIG_INT(ClFreezeStars, cl_freeze_stars, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show old star particles for frozen tees")
+MACRO_CONFIG_INT(ClFlashOnHook, cl_flash_on_hook, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Flash taskbar when hooked by another player while alt-tabbed")
 
 MACRO_CONFIG_INT(ClSpecCursor, cl_spec_cursor, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable the cursor of spectating player if available")
 MACRO_CONFIG_INT(ClSpecAutoSync, cl_spec_auto_sync, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Automatically synchronize with spectating players's camera setting if available (0 = disable, 1 = enable on reset zoom)")
@@ -789,4 +790,3 @@ MACRO_CONFIG_INT(ClVideoRecorderFPS, cl_video_recorder_fps, 60, 1, 1000, CFGFLAG
 /*
  * Add config variables for mods below this comment to avoid merge conflicts.
  */
-MACRO_CONFIG_INT(ClFlashOnHook, cl_flash_on_hook, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Flash taskbar when hooked by another player while alt-tabbed")

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -789,3 +789,4 @@ MACRO_CONFIG_INT(ClVideoRecorderFPS, cl_video_recorder_fps, 60, 1, 1000, CFGFLAG
 /*
  * Add config variables for mods below this comment to avoid merge conflicts.
  */
+MACRO_CONFIG_INT(ClFlashOnHook, cl_flash_on_hook, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Flash taskbar when hooked by another player while alt-tabbed")

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2412,6 +2412,51 @@ void CGameClient::OnNewSnapshot()
 	m_LastFollowFactor = FollowFactor;
 	m_LastDummyConnected = Client()->DummyConnected();
 
+	if(g_Config.m_ClFlashOnHook)
+	{
+		IEngineGraphics *pEngineGraphics = Kernel()->RequestInterface<IEngineGraphics>();
+		if(pEngineGraphics)
+		{
+			if(pEngineGraphics->WindowActive())
+			{
+				m_WasHooked = false;
+			}
+			else if(!m_WasHooked)
+			{
+				bool Hooked = false;
+				if(m_Snap.m_LocalClientId >= 0)
+				{
+					int MainId = m_aLocalIds[0];
+					int DummyId = Client()->DummyConnected() ? m_aLocalIds[1] : -1;
+					for(int i = 0; i < MAX_CLIENTS; i++)
+					{
+						if(i == MainId || (DummyId != -1 && i == DummyId))
+							continue;
+
+						if(!m_Snap.m_aCharacters[i].m_Active)
+							continue;
+
+						const CNetObj_Character *pChar = &m_Snap.m_aCharacters[i].m_Cur;
+						if(pChar->m_HookState > 0 && (pChar->m_HookedPlayer == MainId || (DummyId != -1 && pChar->m_HookedPlayer == DummyId)))
+						{
+							Hooked = true;
+							break;
+						}
+					}
+				}
+				if(Hooked)
+				{
+					Graphics()->NotifyWindow();
+					m_WasHooked = true;
+				}
+			}
+		}
+	}
+	else
+	{
+		m_WasHooked = false;
+	}
+
 	for(auto &pComponent : m_vpAll)
 		pComponent->OnNewSnapshot();
 

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -940,6 +940,7 @@ private:
 	float m_LastDeadzone;
 	float m_LastFollowFactor;
 	bool m_LastDummyConnected;
+	bool m_WasHooked;
 
 	void HandleMultiView();
 	bool IsMultiViewIdSet();


### PR DESCRIPTION
This feature introduces taskbar flashing when a player (or dummy) is hooked by another player while the window is inactive. The notification is triggered once per inactive period and resets upon regaining window focus.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

AI was used to assist with the active window checking and flash notification logic.