### PR TITLE
Add horizontal scrolling mode to `CScrollRegion`

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -873,7 +873,7 @@ void CMenus::RenderServerbrowserDDNetFilter(CUIRect View,
 	vItemIds.resize(MaxItems);
 
 	CScrollRegionParams ScrollParams;
-	ScrollParams.m_ScrollbarWidth = 10.0f;
+	ScrollParams.m_ScrollbarThickness = 10.0f;
 	ScrollParams.m_ScrollbarMargin = 3.0f;
 	ScrollParams.m_ScrollUnit = 2.0f * ItemHeight;
 	ScrollRegion.Begin(&View, &ScrollParams);
@@ -1473,7 +1473,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 	// friends list
 	static CScrollRegion s_ScrollRegion;
 	CScrollRegionParams ScrollParams;
-	ScrollParams.m_ScrollbarWidth = 16.0f;
+	ScrollParams.m_ScrollbarThickness = 16.0f;
 	ScrollParams.m_ScrollbarMargin = 5.0f;
 	ScrollParams.m_ScrollUnit = 80.0f;
 	ScrollParams.m_ForceShowScrollbar = true;

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1476,7 +1476,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 	ScrollParams.m_ScrollbarWidth = 16.0f;
 	ScrollParams.m_ScrollbarMargin = 5.0f;
 	ScrollParams.m_ScrollUnit = 80.0f;
-	ScrollParams.m_Flags = CScrollRegionParams::FLAG_CONTENT_STATIC_WIDTH;
+	ScrollParams.m_ForceShowScrollbar = true;
 	s_ScrollRegion.Begin(&List, &ScrollParams);
 
 	char aBuf[256];

--- a/src/game/client/components/menus_ingame_touch_controls.cpp
+++ b/src/game/client/components/menus_ingame_touch_controls.cpp
@@ -431,7 +431,7 @@ bool CMenusIngameTouchControls::RenderBehaviorSettingBlock(CUIRect Block)
 			{
 				EditBox.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f), IGraphics::CORNER_T, 5.0f);
 				EditBox.VSplitMid(&EditBox, &RightButton);
-				RightButton.VSplitLeft(ScrollParam.m_ScrollbarWidth / 2.0f, nullptr, &RightButton);
+				RightButton.VSplitLeft(ScrollParam.m_ScrollbarThickness / 2.0f, nullptr, &RightButton);
 				EditBox.VSplitLeft(ROWSIZE, &MiddleButton, &EditBox);
 				EditBox.VSplitLeft(SUBMARGIN, nullptr, &LeftButton);
 				Ui()->DoLabel(&LeftButton, Localize("Add command"), FONTSIZE, TEXTALIGN_ML);
@@ -472,7 +472,7 @@ bool CMenusIngameTouchControls::RenderBehaviorSettingBlock(CUIRect Block)
 			{
 				EditBox.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f), IGraphics::CORNER_NONE, 0.0f);
 				EditBox.VSplitMid(&LeftButton, &MiddleButton);
-				MiddleButton.VSplitLeft(ScrollParam.m_ScrollbarWidth / 2.0f, nullptr, &MiddleButton);
+				MiddleButton.VSplitLeft(ScrollParam.m_ScrollbarThickness / 2.0f, nullptr, &MiddleButton);
 				str_format(aBuf, sizeof(aBuf), "%s:", Localize("Command"));
 				Ui()->DoLabel(&LeftButton, aBuf, FONTSIZE, TEXTALIGN_ML);
 				if(Ui()->DoClearableEditBox(&m_vBehaviorElements[CommandIndex]->m_InputCommand, &MiddleButton, 10.0f))
@@ -492,7 +492,7 @@ bool CMenusIngameTouchControls::RenderBehaviorSettingBlock(CUIRect Block)
 			{
 				EditBox.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f), IGraphics::CORNER_NONE, 0.0f);
 				EditBox.VSplitMid(&LeftButton, &MiddleButton);
-				MiddleButton.VSplitLeft(ScrollParam.m_ScrollbarWidth / 2.0f, nullptr, &MiddleButton);
+				MiddleButton.VSplitLeft(ScrollParam.m_ScrollbarThickness / 2.0f, nullptr, &MiddleButton);
 				str_format(aBuf, sizeof(aBuf), "%s:", Localize("Label"));
 				Ui()->DoLabel(&LeftButton, aBuf, FONTSIZE, TEXTALIGN_ML);
 				if(Ui()->DoClearableEditBox(&m_vBehaviorElements[CommandIndex]->m_InputLabel, &MiddleButton, 10.0f))
@@ -512,7 +512,7 @@ bool CMenusIngameTouchControls::RenderBehaviorSettingBlock(CUIRect Block)
 			{
 				EditBox.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f), IGraphics::CORNER_B, 5.0f);
 				EditBox.VSplitMid(&LeftButton, &MiddleButton);
-				MiddleButton.VSplitLeft(ScrollParam.m_ScrollbarWidth / 2.0f, nullptr, &MiddleButton);
+				MiddleButton.VSplitLeft(ScrollParam.m_ScrollbarThickness / 2.0f, nullptr, &MiddleButton);
 				str_format(aBuf, sizeof(aBuf), "%s:", Localize("Label type"));
 				Ui()->DoLabel(&LeftButton, aBuf, FONTSIZE, TEXTALIGN_ML);
 				CTouchControls::CButtonLabel::EType NewButtonLabelType = m_vBehaviorElements[CommandIndex]->m_CachedCommands.m_LabelType;
@@ -582,7 +582,7 @@ bool CMenusIngameTouchControls::RenderVisibilitySettingBlock(CUIRect Block)
 		if(s_VisibilityScrollRegion.AddRect(EditBox))
 		{
 			EditBox.VSplitRight(EditBox.w / 2.0f + ROWGAP + ROWSIZE, &Label, &MiddleButton);
-			MiddleButton.VSplitLeft(ScrollParam.m_ScrollbarWidth / 2.0f, nullptr, &MiddleButton);
+			MiddleButton.VSplitLeft(ScrollParam.m_ScrollbarThickness / 2.0f, nullptr, &MiddleButton);
 			MiddleButton.VSplitLeft(ROWSIZE, &HelpButton, &MiddleButton);
 			MiddleButton.VSplitLeft(ROWGAP, nullptr, &MiddleButton);
 			// We'll only do help button for the first extra menu visibility.

--- a/src/game/client/components/menus_settings_controls.cpp
+++ b/src/game/client/components/menus_settings_controls.cpp
@@ -173,7 +173,7 @@ void CMenusSettingsControls::Render(CUIRect MainView)
 
 	CScrollRegionParams ScrollParams;
 	ScrollParams.m_ScrollUnit = 6.0f * BUTTON_HEIGHT;
-	ScrollParams.m_Flags = CScrollRegionParams::FLAG_CONTENT_STATIC_WIDTH;
+	ScrollParams.m_ForceShowScrollbar = true;
 	m_SettingsScrollRegion.Begin(&MainView, &ScrollParams);
 
 	CUIRect LeftColumn, RightColumn;

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -216,7 +216,7 @@ void CUi::Update()
 			{
 				if(m_pHotScrollRegion != nullptr)
 				{
-					m_pHotScrollRegion->ScrollRelativeDirect(-m_TouchState.m_ScrollAmount.y * pScreen->h);
+					m_pHotScrollRegion->ScrollRelativeDirect(-m_TouchState.m_ScrollAmount * pScreen->Size());
 				}
 				m_TouchState.m_ScrollAmount = vec2(0.0f, 0.0f);
 			}
@@ -372,6 +372,13 @@ void CUi::UpdateTouchState(CTouchState &State) const
 			{
 				// Accumulate average delta of the two fingers
 				State.m_ScrollAmount.y += (Delta0.y + Delta1.y) / 2.0f;
+			}
+			else if(absolute(Delta0.x) > DirectionThreshold * absolute(Delta0.y) && // Horizontal scrolling (x-delta must be larger than y-delta)
+				absolute(Delta1.x) > DirectionThreshold * absolute(Delta1.y) &&
+				Delta0.x * Delta1.x > 0.0f) // Same x direction required
+			{
+				// Accumulate average delta of the two fingers
+				State.m_ScrollAmount.x += (Delta0.x + Delta1.x) / 2.0f;
 			}
 		}
 	}

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -1903,9 +1903,9 @@ CUi::EPopupMenuFunctionResult CUi::PopupSelection(void *pContext, CUIRect View, 
 	CScrollRegion *pScrollRegion = pSelectionPopup->m_pScrollRegion;
 
 	CScrollRegionParams ScrollParams;
-	ScrollParams.m_ScrollbarWidth = 10.0f;
+	ScrollParams.m_ScrollbarThickness = 10.0f;
 	ScrollParams.m_ScrollbarMargin = SPopupMenu::POPUP_MARGIN;
-	ScrollParams.m_ScrollbarNoMarginRight = true;
+	ScrollParams.m_ScrollbarNoOuterMargin = true;
 	ScrollParams.m_ScrollUnit = 3 * (pSelectionPopup->m_EntryHeight + pSelectionPopup->m_EntrySpacing);
 	pScrollRegion->Begin(&View, &ScrollParams);
 

--- a/src/game/client/ui_listbox.cpp
+++ b/src/game/client/ui_listbox.cpp
@@ -106,7 +106,7 @@ void CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsP
 	ScrollParams.m_ScrollbarWidth = ScrollbarWidthMax();
 	ScrollParams.m_ScrollbarMargin = ScrollbarMargin();
 	ScrollParams.m_ScrollUnit = (m_ListBoxRowHeight + m_AutoSpacing) * RowsPerScroll;
-	ScrollParams.m_Flags = ForceShowScrollbar ? CScrollRegionParams::FLAG_CONTENT_STATIC_WIDTH : 0;
+	ScrollParams.m_ForceShowScrollbar = ForceShowScrollbar;
 	m_ScrollRegion.Begin(&m_ListBoxView, &ScrollParams);
 }
 

--- a/src/game/client/ui_listbox.cpp
+++ b/src/game/client/ui_listbox.cpp
@@ -103,7 +103,7 @@ void CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsP
 
 	// setup the scrollbar
 	CScrollRegionParams ScrollParams;
-	ScrollParams.m_ScrollbarWidth = ScrollbarWidthMax();
+	ScrollParams.m_ScrollbarThickness = ScrollbarWidthMax();
 	ScrollParams.m_ScrollbarMargin = ScrollbarMargin();
 	ScrollParams.m_ScrollUnit = (m_ListBoxRowHeight + m_AutoSpacing) * RowsPerScroll;
 	ScrollParams.m_ForceShowScrollbar = ForceShowScrollbar;

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -15,16 +15,16 @@ CScrollRegion::CScrollRegion()
 
 void CScrollRegion::Reset()
 {
-	m_ScrollY = 0.0f;
-	m_ContentH = 0.0f;
-	m_RequestScrollY = -1.0f;
+	m_ScrollPos = 0.0f;
+	m_ContentSize = 0.0f;
+	m_RequestScrollPos = -1.0f;
 	m_ScrollDirection = SCROLLRELATIVE_NONE;
 	m_ScrollSpeedMultiplier = 1.0f;
 
 	m_AnimTimeMax = 0.0f;
 	m_AnimTime = 0.0f;
-	m_AnimInitScrollY = 0.0f;
-	m_AnimTargetScrollY = 0.0f;
+	m_AnimInitScrollPos = 0.0f;
+	m_AnimTargetScrollPos = 0.0f;
 
 	m_ClipRect = m_RailRect = m_LastAddedRect = CUIRect{0.0f, 0.0f, 0.0f, 0.0f};
 	m_SliderGrabPos = 0.0f;
@@ -37,11 +37,11 @@ void CScrollRegion::Begin(CUIRect *pClipRect, const CScrollRegionParams *pParams
 	if(pParams)
 		m_Params = *pParams;
 
-	const bool ContentOverflows = m_ContentH > pClipRect->h;
+	const bool ContentOverflows = m_ContentSize > pClipRect->h;
 	const bool HasScrollBar = ContentOverflows || m_Params.m_ForceShowScrollbar;
 	CUIRect ScrollBarBg;
-	pClipRect->VSplitRight(m_Params.m_ScrollbarWidth, HasScrollBar ? pClipRect : nullptr, &ScrollBarBg);
-	if(m_Params.m_ScrollbarNoMarginRight)
+	pClipRect->VSplitRight(m_Params.m_ScrollbarThickness, HasScrollBar ? pClipRect : nullptr, &ScrollBarBg);
+	if(m_Params.m_ScrollbarNoOuterMargin)
 	{
 		ScrollBarBg.HMargin(m_Params.m_ScrollbarMargin, &m_RailRect);
 		m_RailRect.VSplitLeft(m_Params.m_ScrollbarMargin, nullptr, &m_RailRect);
@@ -66,7 +66,7 @@ void CScrollRegion::Begin(CUIRect *pClipRect, const CScrollRegionParams *pParams
 	Ui()->ClipEnable(pClipRect);
 
 	m_ClipRect = *pClipRect;
-	m_ContentH = 0.0f;
+	m_ContentSize = 0.0f;
 	pClipRect->y += m_ContentScrollOff.y;
 }
 
@@ -75,12 +75,12 @@ void CScrollRegion::End()
 	Ui()->ClipDisable();
 
 	// only show scrollbar if content overflows
-	if(m_ContentH <= m_ClipRect.h)
+	if(m_ContentSize <= m_ClipRect.h)
 		return;
 
 	// scroll wheel
 	CUIRect RegionRect = m_ClipRect;
-	RegionRect.w += m_Params.m_ScrollbarWidth;
+	RegionRect.w += m_Params.m_ScrollbarThickness;
 
 	if(m_ScrollDirection != SCROLLRELATIVE_NONE || Ui()->HotScrollRegion() == this)
 	{
@@ -102,8 +102,8 @@ void CScrollRegion::End()
 
 			m_AnimTimeMax = g_Config.m_UiSmoothScrollTime / 1000.0f;
 			m_AnimTime = m_AnimTimeMax;
-			m_AnimInitScrollY = m_ScrollY;
-			m_AnimTargetScrollY = (ProgrammaticScroll ? m_ScrollY : m_AnimTargetScrollY) + (int)m_ScrollDirection * ScrollUnit * m_ScrollSpeedMultiplier;
+			m_AnimInitScrollPos = m_ScrollPos;
+			m_AnimTargetScrollPos = (ProgrammaticScroll ? m_ScrollPos : m_AnimTargetScrollPos) + (int)m_ScrollDirection * ScrollUnit * m_ScrollSpeedMultiplier;
 			m_ScrollDirection = SCROLLRELATIVE_NONE;
 			m_ScrollSpeedMultiplier = 1.0f;
 		}
@@ -114,24 +114,24 @@ void CScrollRegion::End()
 		Ui()->SetHotScrollRegion(this);
 	}
 
-	const float SliderHeight = maximum(m_Params.m_SliderMinHeight, m_ClipRect.h / m_ContentH * m_RailRect.h);
+	const float SliderHeight = maximum(m_Params.m_SliderMinSize, m_ClipRect.h / m_ContentSize * m_RailRect.h);
 
 	CUIRect Slider = m_RailRect;
 	Slider.h = SliderHeight;
 
 	const float MaxSlider = m_RailRect.h - SliderHeight;
-	const float MaxScroll = m_ContentH - m_ClipRect.h;
+	const float MaxScroll = m_ContentSize - m_ClipRect.h;
 
-	if(m_RequestScrollY >= 0.0f)
+	if(m_RequestScrollPos >= 0.0f)
 	{
-		m_AnimTargetScrollY = m_RequestScrollY;
+		m_AnimTargetScrollPos = m_RequestScrollPos;
 		m_AnimTime = 0.0f;
-		m_RequestScrollY = -1.0f;
+		m_RequestScrollPos = -1.0f;
 	}
 
-	m_AnimTargetScrollY = std::clamp(m_AnimTargetScrollY, 0.0f, MaxScroll);
+	m_AnimTargetScrollPos = std::clamp(m_AnimTargetScrollPos, 0.0f, MaxScroll);
 
-	if(absolute(m_AnimInitScrollY - m_AnimTargetScrollY) < 0.5f)
+	if(absolute(m_AnimInitScrollPos - m_AnimTargetScrollPos) < 0.5f)
 		m_AnimTime = 0.0f;
 
 	if(m_AnimTime > 0.0f)
@@ -142,26 +142,26 @@ void CScrollRegion::End()
 			m_AnimTime = 0.0f;
 		}
 		float AnimProgress = (1.0f - std::pow(m_AnimTime / m_AnimTimeMax, 3.0f)); // cubic ease out
-		m_ScrollY = m_AnimInitScrollY + (m_AnimTargetScrollY - m_AnimInitScrollY) * AnimProgress;
+		m_ScrollPos = m_AnimInitScrollPos + (m_AnimTargetScrollPos - m_AnimInitScrollPos) * AnimProgress;
 	}
 	else
 	{
-		m_ScrollY = m_AnimTargetScrollY;
+		m_ScrollPos = m_AnimTargetScrollPos;
 	}
 
-	Slider.y += m_ScrollY / MaxScroll * MaxSlider;
+	Slider.y += m_ScrollPos / MaxScroll * MaxSlider;
 
 	bool Grabbed = false;
-	const void *pId = &m_ScrollY;
+	const void *pId = &m_ScrollPos;
 	const bool InsideSlider = Ui()->MouseHovered(&Slider);
 	const bool InsideRail = Ui()->MouseHovered(&m_RailRect);
 
 	if(Ui()->CheckActiveItem(pId) && Ui()->MouseButton(0))
 	{
 		float MouseY = Ui()->MouseY();
-		m_ScrollY += (MouseY - (Slider.y + m_SliderGrabPos)) / MaxSlider * MaxScroll;
+		m_ScrollPos += (MouseY - (Slider.y + m_SliderGrabPos)) / MaxSlider * MaxScroll;
 		m_SliderGrabPos = std::clamp(m_SliderGrabPos, 0.0f, SliderHeight);
-		m_AnimTargetScrollY = m_ScrollY;
+		m_AnimTargetScrollPos = m_ScrollPos;
 		m_AnimTime = 0.0f;
 		Grabbed = true;
 	}
@@ -174,17 +174,17 @@ void CScrollRegion::End()
 		{
 			Ui()->SetActiveItem(pId);
 			m_SliderGrabPos = Ui()->MouseY() - Slider.y;
-			m_AnimTargetScrollY = m_ScrollY;
+			m_AnimTargetScrollPos = m_ScrollPos;
 			m_AnimTime = 0.0f;
 		}
 	}
 	else if(InsideRail && Ui()->MouseButtonClicked(0))
 	{
-		m_ScrollY += (Ui()->MouseY() - (Slider.y + Slider.h / 2.0f)) / MaxSlider * MaxScroll;
+		m_ScrollPos += (Ui()->MouseY() - (Slider.y + Slider.h / 2.0f)) / MaxSlider * MaxScroll;
 		Ui()->SetHotItem(pId);
 		Ui()->SetActiveItem(pId);
 		m_SliderGrabPos = Slider.h / 2.0f;
-		m_AnimTargetScrollY = m_ScrollY;
+		m_AnimTargetScrollPos = m_ScrollPos;
 		m_AnimTime = 0.0f;
 	}
 
@@ -193,8 +193,8 @@ void CScrollRegion::End()
 		Ui()->SetActiveItem(nullptr);
 	}
 
-	m_ScrollY = std::clamp(m_ScrollY, 0.0f, MaxScroll);
-	m_ContentScrollOff.y = -m_ScrollY;
+	m_ScrollPos = std::clamp(m_ScrollPos, 0.0f, MaxScroll);
+	m_ContentScrollOff.y = -m_ScrollPos;
 
 	Slider.Draw(m_Params.SliderColor(Grabbed, Ui()->HotItem() == pId), IGraphics::CORNER_ALL, Slider.w / 2.0f);
 }
@@ -202,7 +202,7 @@ void CScrollRegion::End()
 bool CScrollRegion::AddRect(const CUIRect &Rect, bool ShouldScrollHere)
 {
 	m_LastAddedRect = Rect;
-	m_ContentH = maximum(Rect.y + Rect.h - (m_ClipRect.y + m_ContentScrollOff.y), m_ContentH);
+	m_ContentSize = maximum(Rect.y + Rect.h - (m_ClipRect.y + m_ContentScrollOff.y), m_ContentSize);
 	if(ShouldScrollHere)
 		ScrollHere();
 	return !RectClipped(Rect);
@@ -216,20 +216,20 @@ void CScrollRegion::ScrollHere(EScrollOption Option)
 	switch(Option)
 	{
 	case SCROLLHERE_TOP:
-		m_RequestScrollY = TopScroll;
+		m_RequestScrollPos = TopScroll;
 		break;
 
 	case SCROLLHERE_BOTTOM:
-		m_RequestScrollY = TopScroll - (m_ClipRect.h - MinHeight);
+		m_RequestScrollPos = TopScroll - (m_ClipRect.h - MinHeight);
 		break;
 
 	case SCROLLHERE_KEEP_IN_VIEW:
 	default:
 		const float DeltaY = m_LastAddedRect.y - m_ClipRect.y;
 		if(DeltaY < 0)
-			m_RequestScrollY = TopScroll;
+			m_RequestScrollPos = TopScroll;
 		else if(DeltaY > (m_ClipRect.h - MinHeight))
-			m_RequestScrollY = TopScroll - (m_ClipRect.h - MinHeight);
+			m_RequestScrollPos = TopScroll - (m_ClipRect.h - MinHeight);
 		break;
 	}
 }
@@ -242,7 +242,7 @@ void CScrollRegion::ScrollRelative(EScrollRelative Direction, float SpeedMultipl
 
 void CScrollRegion::ScrollRelativeDirect(float ScrollAmount)
 {
-	m_RequestScrollY = std::clamp(m_ScrollY + ScrollAmount, 0.0f, m_ContentH - m_ClipRect.h);
+	m_RequestScrollPos = std::clamp(m_ScrollPos + ScrollAmount, 0.0f, m_ContentSize - m_ClipRect.h);
 }
 
 void CScrollRegion::DoEdgeScrolling()
@@ -268,7 +268,7 @@ bool CScrollRegion::RectClipped(const CUIRect &Rect) const
 
 bool CScrollRegion::ScrollbarShown() const
 {
-	return m_ContentH > m_ClipRect.h;
+	return m_ContentSize > m_ClipRect.h;
 }
 
 bool CScrollRegion::Animating() const
@@ -278,5 +278,5 @@ bool CScrollRegion::Animating() const
 
 bool CScrollRegion::Active() const
 {
-	return Ui()->ActiveItem() == &m_ScrollY;
+	return Ui()->ActiveItem() == &m_ScrollPos;
 }

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -96,140 +96,14 @@ void CScrollRegion::End()
 {
 	Ui()->ClipDisable();
 
-	const float ContentAreaSize = m_Params.m_ScrollHorizontal ? m_ContentAreaRect.w : m_ContentAreaRect.h;
-
 	// only show scrollbar if content overflows
 	if(!ContentOverflows())
 		return;
 
-	if(m_ScrollDirection != SCROLLRELATIVE_NONE || Ui()->HotScrollRegion() == this)
-	{
-		bool ProgrammaticScroll = false;
-		if(Ui()->ConsumeHotkey(CUi::HOTKEY_SCROLL_UP))
-			m_ScrollDirection = SCROLLRELATIVE_UP;
-		else if(Ui()->ConsumeHotkey(CUi::HOTKEY_SCROLL_DOWN))
-			m_ScrollDirection = SCROLLRELATIVE_DOWN;
-		else
-			ProgrammaticScroll = true;
-
-		if(!ProgrammaticScroll)
-			m_ScrollSpeedMultiplier = 1.0f;
-
-		if(m_ScrollDirection != SCROLLRELATIVE_NONE)
-		{
-			const bool IsPageScroll = Input()->AltIsPressed();
-			const float ScrollUnit = IsPageScroll && !ProgrammaticScroll ? ContentAreaSize : m_Params.m_ScrollUnit;
-
-			m_AnimTimeMax = g_Config.m_UiSmoothScrollTime / 1000.0f;
-			m_AnimTime = m_AnimTimeMax;
-			m_AnimInitScrollPos = m_ScrollPos;
-			m_AnimTargetScrollPos = (ProgrammaticScroll ? m_ScrollPos : m_AnimTargetScrollPos) + (int)m_ScrollDirection * ScrollUnit * m_ScrollSpeedMultiplier;
-			m_ScrollDirection = SCROLLRELATIVE_NONE;
-			m_ScrollSpeedMultiplier = 1.0f;
-		}
-	}
-
-	// scroll wheel
-	CUIRect RegionRect = m_ContentAreaRect;
-	if(m_Params.m_ScrollHorizontal)
-		RegionRect.h += m_Params.m_ScrollbarThickness;
-	else
-		RegionRect.w += m_Params.m_ScrollbarThickness;
-
-	if(Ui()->Enabled() && Ui()->MouseHovered(&RegionRect))
-	{
-		Ui()->SetHotScrollRegion(this);
-	}
-
-	const float RailSize = m_Params.m_ScrollHorizontal ? m_RailRect.w : m_RailRect.h;
-	const float SliderSize = maximum(m_Params.m_SliderMinSize, ContentAreaSize / m_ContentSize * RailSize);
-
-	CUIRect Slider = m_RailRect;
-	float &SliderPos = m_Params.m_ScrollHorizontal ? Slider.x : Slider.y;
-	if(m_Params.m_ScrollHorizontal)
-		Slider.w = SliderSize;
-	else
-		Slider.h = SliderSize;
-
-	const float MaxSlider = RailSize - SliderSize;
-	const float MaxScroll = m_ContentSize - ContentAreaSize;
-
-	if(m_RequestScrollPos >= 0.0f)
-	{
-		m_AnimTargetScrollPos = m_RequestScrollPos;
-		m_AnimTime = 0.0f;
-		m_RequestScrollPos = -1.0f;
-	}
-
-	m_AnimTargetScrollPos = std::clamp(m_AnimTargetScrollPos, 0.0f, MaxScroll);
-
-	if(absolute(m_AnimInitScrollPos - m_AnimTargetScrollPos) < 0.5f)
-		m_AnimTime = 0.0f;
-
-	if(m_AnimTime > 0.0f)
-	{
-		m_AnimTime -= Client()->RenderFrameTime();
-		if(m_AnimTime < 0.0f)
-		{
-			m_AnimTime = 0.0f;
-		}
-		float AnimProgress = (1.0f - std::pow(m_AnimTime / m_AnimTimeMax, 3.0f)); // cubic ease out
-		m_ScrollPos = m_AnimInitScrollPos + (m_AnimTargetScrollPos - m_AnimInitScrollPos) * AnimProgress;
-	}
-	else
-	{
-		m_ScrollPos = m_AnimTargetScrollPos;
-	}
-
-	SliderPos += m_ScrollPos / MaxScroll * MaxSlider;
-
-	bool Grabbed = false;
-	const void *pId = &m_ScrollPos;
-	const bool InsideSlider = Ui()->MouseHovered(&Slider);
-	const bool InsideRail = Ui()->MouseHovered(&m_RailRect);
-
-	float MousePos = m_Params.m_ScrollHorizontal ? Ui()->MouseX() : Ui()->MouseY();
-	if(Ui()->CheckActiveItem(pId) && Ui()->MouseButton(0))
-	{
-		m_ScrollPos += (MousePos - (SliderPos + m_SliderGrabPos)) / MaxSlider * MaxScroll;
-		m_SliderGrabPos = std::clamp(m_SliderGrabPos, 0.0f, SliderSize);
-		m_AnimTargetScrollPos = m_ScrollPos;
-		m_AnimTime = 0.0f;
-		Grabbed = true;
-	}
-	else if(InsideSlider)
-	{
-		if(!Ui()->MouseButton(0))
-			Ui()->SetHotItem(pId);
-
-		if(!Ui()->CheckActiveItem(pId) && Ui()->MouseButtonClicked(0))
-		{
-			Ui()->SetActiveItem(pId);
-			m_SliderGrabPos = MousePos - SliderPos;
-			m_AnimTargetScrollPos = m_ScrollPos;
-			m_AnimTime = 0.0f;
-		}
-	}
-	else if(InsideRail && Ui()->MouseButtonClicked(0))
-	{
-		m_ScrollPos += (MousePos - (SliderPos + SliderSize / 2.0f)) / MaxSlider * MaxScroll;
-		Ui()->SetHotItem(pId);
-		Ui()->SetActiveItem(pId);
-		m_SliderGrabPos = SliderSize / 2.0f;
-		m_AnimTargetScrollPos = m_ScrollPos;
-		m_AnimTime = 0.0f;
-	}
-
-	if(Ui()->CheckActiveItem(pId) && !Ui()->MouseButton(0))
-	{
-		Ui()->SetActiveItem(nullptr);
-	}
-
-	m_ScrollPos = std::clamp(m_ScrollPos, 0.0f, MaxScroll);
-	m_ContentScrollOffset = -m_ScrollPos;
-
-	float Rounding = m_Params.m_ScrollHorizontal ? Slider.h / 2.0f : Slider.w / 2.0f;
-	Slider.Draw(m_Params.SliderColor(Grabbed, Ui()->HotItem() == pId), IGraphics::CORNER_ALL, Rounding);
+	DoScrollInput();
+	UpdateHotScrollRegion();
+	AdvanceAnimation();
+	DoSlider();
 }
 
 bool CScrollRegion::AddRect(const CUIRect &Rect, bool ShouldScrollHere)
@@ -328,4 +202,150 @@ bool CScrollRegion::Animating() const
 bool CScrollRegion::Active() const
 {
 	return Ui()->ActiveItem() == &m_ScrollPos;
+}
+
+void CScrollRegion::DoScrollInput()
+{
+	const float ContentAreaSize = m_Params.m_ScrollHorizontal ? m_ContentAreaRect.w : m_ContentAreaRect.h;
+
+	if(m_ScrollDirection != SCROLLRELATIVE_NONE || Ui()->HotScrollRegion() == this)
+	{
+		bool ProgrammaticScroll = false;
+		if(Ui()->ConsumeHotkey(CUi::HOTKEY_SCROLL_UP))
+			m_ScrollDirection = SCROLLRELATIVE_UP;
+		else if(Ui()->ConsumeHotkey(CUi::HOTKEY_SCROLL_DOWN))
+			m_ScrollDirection = SCROLLRELATIVE_DOWN;
+		else
+			ProgrammaticScroll = true;
+
+		if(!ProgrammaticScroll)
+			m_ScrollSpeedMultiplier = 1.0f;
+
+		if(m_ScrollDirection != SCROLLRELATIVE_NONE)
+		{
+			const bool IsPageScroll = Input()->AltIsPressed();
+			const float ScrollUnit = IsPageScroll && !ProgrammaticScroll ? ContentAreaSize : m_Params.m_ScrollUnit;
+
+			m_AnimTimeMax = g_Config.m_UiSmoothScrollTime / 1000.0f;
+			m_AnimTime = m_AnimTimeMax;
+			m_AnimInitScrollPos = m_ScrollPos;
+			m_AnimTargetScrollPos = (ProgrammaticScroll ? m_ScrollPos : m_AnimTargetScrollPos) + (int)m_ScrollDirection * ScrollUnit * m_ScrollSpeedMultiplier;
+			m_ScrollDirection = SCROLLRELATIVE_NONE;
+			m_ScrollSpeedMultiplier = 1.0f;
+		}
+	}
+}
+
+void CScrollRegion::UpdateHotScrollRegion()
+{
+	CUIRect RegionRect = m_ContentAreaRect;
+	if(m_Params.m_ScrollHorizontal)
+		RegionRect.h += m_Params.m_ScrollbarThickness;
+	else
+		RegionRect.w += m_Params.m_ScrollbarThickness;
+
+	if(Ui()->Enabled() && Ui()->MouseHovered(&RegionRect))
+	{
+		Ui()->SetHotScrollRegion(this);
+	}
+}
+
+void CScrollRegion::AdvanceAnimation()
+{
+	const float ContentAreaSize = m_Params.m_ScrollHorizontal ? m_ContentAreaRect.w : m_ContentAreaRect.h;
+	const float MaxScroll = m_ContentSize - ContentAreaSize;
+
+	if(m_RequestScrollPos >= 0.0f)
+	{
+		m_AnimTargetScrollPos = m_RequestScrollPos;
+		m_AnimTime = 0.0f;
+		m_RequestScrollPos = -1.0f;
+	}
+
+	m_AnimTargetScrollPos = std::clamp(m_AnimTargetScrollPos, 0.0f, MaxScroll);
+
+	if(absolute(m_AnimInitScrollPos - m_AnimTargetScrollPos) < 0.5f)
+		m_AnimTime = 0.0f;
+
+	if(m_AnimTime > 0.0f)
+	{
+		m_AnimTime -= Client()->RenderFrameTime();
+		if(m_AnimTime < 0.0f)
+		{
+			m_AnimTime = 0.0f;
+		}
+		float AnimProgress = (1.0f - std::pow(m_AnimTime / m_AnimTimeMax, 3.0f)); // cubic ease out
+		m_ScrollPos = m_AnimInitScrollPos + (m_AnimTargetScrollPos - m_AnimInitScrollPos) * AnimProgress;
+	}
+	else
+	{
+		m_ScrollPos = m_AnimTargetScrollPos;
+	}
+}
+
+void CScrollRegion::DoSlider()
+{
+	const float ContentAreaSize = m_Params.m_ScrollHorizontal ? m_ContentAreaRect.w : m_ContentAreaRect.h;
+	const float RailSize = m_Params.m_ScrollHorizontal ? m_RailRect.w : m_RailRect.h;
+	const float SliderSize = maximum(m_Params.m_SliderMinSize, ContentAreaSize / m_ContentSize * RailSize);
+
+	CUIRect Slider = m_RailRect;
+	float &SliderPos = m_Params.m_ScrollHorizontal ? Slider.x : Slider.y;
+	if(m_Params.m_ScrollHorizontal)
+		Slider.w = SliderSize;
+	else
+		Slider.h = SliderSize;
+
+	const float MaxSlider = RailSize - SliderSize;
+	const float MaxScroll = m_ContentSize - ContentAreaSize;
+
+	SliderPos += m_ScrollPos / MaxScroll * MaxSlider;
+
+	bool Grabbed = false;
+	const void *pId = &m_ScrollPos;
+	const bool InsideSlider = Ui()->MouseHovered(&Slider);
+	const bool InsideRail = Ui()->MouseHovered(&m_RailRect);
+
+	float MousePos = m_Params.m_ScrollHorizontal ? Ui()->MouseX() : Ui()->MouseY();
+	if(Ui()->CheckActiveItem(pId) && Ui()->MouseButton(0))
+	{
+		m_ScrollPos += (MousePos - (SliderPos + m_SliderGrabPos)) / MaxSlider * MaxScroll;
+		m_SliderGrabPos = std::clamp(m_SliderGrabPos, 0.0f, SliderSize);
+		m_AnimTargetScrollPos = m_ScrollPos;
+		m_AnimTime = 0.0f;
+		Grabbed = true;
+	}
+	else if(InsideSlider)
+	{
+		if(!Ui()->MouseButton(0))
+			Ui()->SetHotItem(pId);
+
+		if(!Ui()->CheckActiveItem(pId) && Ui()->MouseButtonClicked(0))
+		{
+			Ui()->SetActiveItem(pId);
+			m_SliderGrabPos = MousePos - SliderPos;
+			m_AnimTargetScrollPos = m_ScrollPos;
+			m_AnimTime = 0.0f;
+		}
+	}
+	else if(InsideRail && Ui()->MouseButtonClicked(0))
+	{
+		m_ScrollPos += (MousePos - (SliderPos + SliderSize / 2.0f)) / MaxSlider * MaxScroll;
+		Ui()->SetHotItem(pId);
+		Ui()->SetActiveItem(pId);
+		m_SliderGrabPos = SliderSize / 2.0f;
+		m_AnimTargetScrollPos = m_ScrollPos;
+		m_AnimTime = 0.0f;
+	}
+
+	if(Ui()->CheckActiveItem(pId) && !Ui()->MouseButton(0))
+	{
+		Ui()->SetActiveItem(nullptr);
+	}
+
+	m_ScrollPos = std::clamp(m_ScrollPos, 0.0f, MaxScroll);
+	m_ContentScrollOffset = -m_ScrollPos;
+
+	float Rounding = m_Params.m_ScrollHorizontal ? Slider.h / 2.0f : Slider.w / 2.0f;
+	Slider.Draw(m_Params.SliderColor(Grabbed, Ui()->HotItem() == pId), IGraphics::CORNER_ALL, Rounding);
 }

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -102,13 +102,6 @@ void CScrollRegion::End()
 	if(!ContentOverflows())
 		return;
 
-	// scroll wheel
-	CUIRect RegionRect = m_ContentAreaRect;
-	if(m_Params.m_ScrollHorizontal)
-		RegionRect.h += m_Params.m_ScrollbarThickness;
-	else
-		RegionRect.w += m_Params.m_ScrollbarThickness;
-
 	if(m_ScrollDirection != SCROLLRELATIVE_NONE || Ui()->HotScrollRegion() == this)
 	{
 		bool ProgrammaticScroll = false;
@@ -135,6 +128,13 @@ void CScrollRegion::End()
 			m_ScrollSpeedMultiplier = 1.0f;
 		}
 	}
+
+	// scroll wheel
+	CUIRect RegionRect = m_ContentAreaRect;
+	if(m_Params.m_ScrollHorizontal)
+		RegionRect.h += m_Params.m_ScrollbarThickness;
+	else
+		RegionRect.w += m_Params.m_ScrollbarThickness;
 
 	if(Ui()->Enabled() && Ui()->MouseHovered(&RegionRect))
 	{

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -54,15 +54,14 @@ void CScrollRegion::Begin(CUIRect *pClipRect, const CScrollRegionParams *pParams
 			m_RailRect.Draw(m_Params.m_RailBgColor, IGraphics::CORNER_ALL, Rounding);
 		}
 	}
-	if(!ContentOverflows())
-		m_ContentScrollOffset = 0.0f;
-
 	if(m_Params.m_ClipBgColor.a > 0.0f)
 	{
 		int CornersPartial = m_Params.m_ScrollHorizontal ? IGraphics::CORNER_T : IGraphics::CORNER_L;
 		m_ContentAreaRect.Draw(m_Params.m_ClipBgColor, ScrollbarShown() ? CornersPartial : IGraphics::CORNER_ALL, 4.0f);
 	}
-
+	
+	if(!ContentOverflows())
+		m_ContentScrollOffset = 0.0f;
 	m_ContentSize = 0.0f;
 
 	Ui()->ClipEnable(&m_ContentAreaRect);

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -38,9 +38,7 @@ void CScrollRegion::Begin(CUIRect *pClipRect, const CScrollRegionParams *pParams
 		m_Params = *pParams;
 
 	const bool ContentOverflows = m_ContentH > pClipRect->h;
-	const bool ForceShowScrollbar = m_Params.m_Flags & CScrollRegionParams::FLAG_CONTENT_STATIC_WIDTH;
-
-	const bool HasScrollBar = ContentOverflows || ForceShowScrollbar;
+	const bool HasScrollBar = ContentOverflows || m_Params.m_ForceShowScrollbar;
 	CUIRect ScrollBarBg;
 	pClipRect->VSplitRight(m_Params.m_ScrollbarWidth, HasScrollBar ? pClipRect : nullptr, &ScrollBarBg);
 	if(m_Params.m_ScrollbarNoMarginRight)

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -26,7 +26,7 @@ void CScrollRegion::Reset()
 	m_AnimInitScrollPos = 0.0f;
 	m_AnimTargetScrollPos = 0.0f;
 
-	m_ClipRect = m_RailRect = m_LastAddedRect = CUIRect{0.0f, 0.0f, 0.0f, 0.0f};
+	m_ContentAreaRect = m_RailRect = m_LastAddedRect = CUIRect{0.0f, 0.0f, 0.0f, 0.0f};
 	m_SliderGrabPos = 0.0f;
 	m_ContentScrollOffset = 0.0f;
 	m_Params = CScrollRegionParams();
@@ -36,13 +36,13 @@ void CScrollRegion::Begin(CUIRect *pClipRect, const CScrollRegionParams *pParams
 {
 	if(pParams)
 		m_Params = *pParams;
-	m_ClipRect = *pClipRect;
+	m_ContentAreaRect = *pClipRect;
 
 	CUIRect ScrollBarBg;
 	if(m_Params.m_ScrollHorizontal)
-		m_ClipRect.HSplitBottom(m_Params.m_ScrollbarThickness, ScrollbarShown() ? &m_ClipRect : nullptr, &ScrollBarBg);
+		m_ContentAreaRect.HSplitBottom(m_Params.m_ScrollbarThickness, ScrollbarShown() ? &m_ContentAreaRect : nullptr, &ScrollBarBg);
 	else
-		m_ClipRect.VSplitRight(m_Params.m_ScrollbarThickness, ScrollbarShown() ? &m_ClipRect : nullptr, &ScrollBarBg);
+		m_ContentAreaRect.VSplitRight(m_Params.m_ScrollbarThickness, ScrollbarShown() ? &m_ContentAreaRect : nullptr, &ScrollBarBg);
 	if(m_Params.m_ScrollbarNoOuterMargin)
 	{
 		if(m_Params.m_ScrollHorizontal)
@@ -79,13 +79,13 @@ void CScrollRegion::Begin(CUIRect *pClipRect, const CScrollRegionParams *pParams
 	if(m_Params.m_ClipBgColor.a > 0.0f)
 	{
 		int CornersPartial = m_Params.m_ScrollHorizontal ? IGraphics::CORNER_T : IGraphics::CORNER_L;
-		m_ClipRect.Draw(m_Params.m_ClipBgColor, ScrollbarShown() ? CornersPartial : IGraphics::CORNER_ALL, 4.0f);
+		m_ContentAreaRect.Draw(m_Params.m_ClipBgColor, ScrollbarShown() ? CornersPartial : IGraphics::CORNER_ALL, 4.0f);
 	}
 
 	m_ContentSize = 0.0f;
 
-	Ui()->ClipEnable(&m_ClipRect);
-	*pClipRect = m_ClipRect;
+	Ui()->ClipEnable(&m_ContentAreaRect);
+	*pClipRect = m_ContentAreaRect;
 	if(m_Params.m_ScrollHorizontal)
 		pClipRect->x += m_ContentScrollOffset;
 	else
@@ -96,14 +96,14 @@ void CScrollRegion::End()
 {
 	Ui()->ClipDisable();
 
-	const float ClipSize = m_Params.m_ScrollHorizontal ? m_ClipRect.w : m_ClipRect.h;
+	const float ContentAreaSize = m_Params.m_ScrollHorizontal ? m_ContentAreaRect.w : m_ContentAreaRect.h;
 
 	// only show scrollbar if content overflows
 	if(!ContentOverflows())
 		return;
 
 	// scroll wheel
-	CUIRect RegionRect = m_ClipRect;
+	CUIRect RegionRect = m_ContentAreaRect;
 	if(m_Params.m_ScrollHorizontal)
 		RegionRect.h += m_Params.m_ScrollbarThickness;
 	else
@@ -125,7 +125,7 @@ void CScrollRegion::End()
 		if(m_ScrollDirection != SCROLLRELATIVE_NONE)
 		{
 			const bool IsPageScroll = Input()->AltIsPressed();
-			const float ScrollUnit = IsPageScroll && !ProgrammaticScroll ? ClipSize : m_Params.m_ScrollUnit;
+			const float ScrollUnit = IsPageScroll && !ProgrammaticScroll ? ContentAreaSize : m_Params.m_ScrollUnit;
 
 			m_AnimTimeMax = g_Config.m_UiSmoothScrollTime / 1000.0f;
 			m_AnimTime = m_AnimTimeMax;
@@ -142,7 +142,7 @@ void CScrollRegion::End()
 	}
 
 	const float RailSize = m_Params.m_ScrollHorizontal ? m_RailRect.w : m_RailRect.h;
-	const float SliderSize = maximum(m_Params.m_SliderMinSize, ClipSize / m_ContentSize * RailSize);
+	const float SliderSize = maximum(m_Params.m_SliderMinSize, ContentAreaSize / m_ContentSize * RailSize);
 
 	CUIRect Slider = m_RailRect;
 	float &SliderPos = m_Params.m_ScrollHorizontal ? Slider.x : Slider.y;
@@ -152,7 +152,7 @@ void CScrollRegion::End()
 		Slider.h = SliderSize;
 
 	const float MaxSlider = RailSize - SliderSize;
-	const float MaxScroll = m_ContentSize - ClipSize;
+	const float MaxScroll = m_ContentSize - ContentAreaSize;
 
 	if(m_RequestScrollPos >= 0.0f)
 	{
@@ -236,9 +236,9 @@ bool CScrollRegion::AddRect(const CUIRect &Rect, bool ShouldScrollHere)
 {
 	m_LastAddedRect = Rect;
 	if(m_Params.m_ScrollHorizontal)
-		m_ContentSize = maximum(std::ceil(Rect.x + Rect.w - (m_ClipRect.x + m_ContentScrollOffset)), m_ContentSize);
+		m_ContentSize = maximum(std::ceil(Rect.x + Rect.w - (m_ContentAreaRect.x + m_ContentScrollOffset)), m_ContentSize);
 	else
-		m_ContentSize = maximum(Rect.y + Rect.h - (m_ClipRect.y + m_ContentScrollOffset), m_ContentSize);
+		m_ContentSize = maximum(std::ceil(Rect.y + Rect.h - (m_ContentAreaRect.y + m_ContentScrollOffset)), m_ContentSize);
 	if(ShouldScrollHere)
 		ScrollHere();
 	return !RectClipped(Rect);
@@ -246,12 +246,12 @@ bool CScrollRegion::AddRect(const CUIRect &Rect, bool ShouldScrollHere)
 
 void CScrollRegion::ScrollHere(EScrollOption Option)
 {
-	const float ClipPos = m_Params.m_ScrollHorizontal ? m_ClipRect.x : m_ClipRect.y;
-	const float ClipSize = m_Params.m_ScrollHorizontal ? m_ClipRect.w : m_ClipRect.h;
+	const float ContentAreaPos = m_Params.m_ScrollHorizontal ? m_ContentAreaRect.x : m_ContentAreaRect.y;
+	const float ContentAreaSize = m_Params.m_ScrollHorizontal ? m_ContentAreaRect.w : m_ContentAreaRect.h;
 	const float LastAddedPos = m_Params.m_ScrollHorizontal ? m_LastAddedRect.x : m_LastAddedRect.y;
 	const float LastAddedSize = m_Params.m_ScrollHorizontal ? m_LastAddedRect.w : m_LastAddedRect.h;
-	const float MinHeight = minimum(ClipSize, LastAddedSize);
-	const float TopScroll = LastAddedPos - (ClipPos + m_ContentScrollOffset);
+	const float MinHeight = minimum(ContentAreaSize, LastAddedSize);
+	const float TopScroll = LastAddedPos - (ContentAreaPos + m_ContentScrollOffset);
 
 	switch(Option)
 	{
@@ -260,16 +260,16 @@ void CScrollRegion::ScrollHere(EScrollOption Option)
 		break;
 
 	case SCROLLHERE_BOTTOM:
-		m_RequestScrollPos = TopScroll - (ClipSize - MinHeight);
+		m_RequestScrollPos = TopScroll - (ContentAreaSize - MinHeight);
 		break;
 
 	case SCROLLHERE_KEEP_IN_VIEW:
 	default:
-		const float DeltaY = LastAddedPos - ClipPos;
+		const float DeltaY = LastAddedPos - ContentAreaPos;
 		if(DeltaY < 0)
 			m_RequestScrollPos = TopScroll;
-		else if(DeltaY > (ClipSize - MinHeight))
-			m_RequestScrollPos = TopScroll - (ClipSize - MinHeight);
+		else if(DeltaY > (ContentAreaSize - MinHeight))
+			m_RequestScrollPos = TopScroll - (ContentAreaSize - MinHeight);
 		break;
 	}
 }
@@ -282,8 +282,8 @@ void CScrollRegion::ScrollRelative(EScrollRelative Direction, float SpeedMultipl
 
 void CScrollRegion::ScrollRelativeDirect(float ScrollAmount)
 {
-	const float ClipSize = m_Params.m_ScrollHorizontal ? m_ClipRect.w : m_ClipRect.h;
-	m_RequestScrollPos = std::clamp(m_ScrollPos + ScrollAmount, 0.0f, m_ContentSize - ClipSize);
+	const float ContentAreaSize = m_Params.m_ScrollHorizontal ? m_ContentAreaRect.w : m_ContentAreaRect.h;
+	m_RequestScrollPos = std::clamp(m_ScrollPos + ScrollAmount, 0.0f, m_ContentSize - ContentAreaSize);
 }
 
 void CScrollRegion::DoEdgeScrolling()
@@ -291,13 +291,13 @@ void CScrollRegion::DoEdgeScrolling()
 	if(!ContentOverflows())
 		return;
 
-	const float ClipPos = m_Params.m_ScrollHorizontal ? m_ClipRect.x : m_ClipRect.y;
-	const float ClipSize = m_Params.m_ScrollHorizontal ? m_ClipRect.w : m_ClipRect.h;
+	const float ContentAreaPos = m_Params.m_ScrollHorizontal ? m_ContentAreaRect.x : m_ContentAreaRect.y;
+	const float ContentAreaSize = m_Params.m_ScrollHorizontal ? m_ContentAreaRect.w : m_ContentAreaRect.h;
 	const float ScrollBorderSize = 20.0f;
 	const float MaxScrollMultiplier = 2.0f;
 	const float ScrollSpeedFactor = MaxScrollMultiplier / ScrollBorderSize;
-	const float TopScrollPosition = ClipPos + ScrollBorderSize;
-	const float BottomScrollPosition = ClipPos + ClipSize - ScrollBorderSize;
+	const float TopScrollPosition = ContentAreaPos + ScrollBorderSize;
+	const float BottomScrollPosition = ContentAreaPos + ContentAreaSize - ScrollBorderSize;
 	const float MousePos = m_Params.m_ScrollHorizontal ? Ui()->MouseX() : Ui()->MouseY();
 	if(MousePos < TopScrollPosition)
 		ScrollRelative(SCROLLRELATIVE_UP, minimum(MaxScrollMultiplier, (TopScrollPosition - MousePos) * ScrollSpeedFactor));
@@ -307,12 +307,12 @@ void CScrollRegion::DoEdgeScrolling()
 
 bool CScrollRegion::RectClipped(const CUIRect &Rect) const
 {
-	return (m_ClipRect.x > (Rect.x + Rect.w) || (m_ClipRect.x + m_ClipRect.w) < Rect.x || m_ClipRect.y > (Rect.y + Rect.h) || (m_ClipRect.y + m_ClipRect.h) < Rect.y);
+	return (m_ContentAreaRect.x > (Rect.x + Rect.w) || (m_ContentAreaRect.x + m_ContentAreaRect.w) < Rect.x || m_ContentAreaRect.y > (Rect.y + Rect.h) || (m_ContentAreaRect.y + m_ContentAreaRect.h) < Rect.y);
 }
 
 bool CScrollRegion::ContentOverflows() const
 {
-	return m_Params.m_ScrollHorizontal ? m_ContentSize > m_ClipRect.w : m_ContentSize > m_ClipRect.h;
+	return m_Params.m_ScrollHorizontal ? m_ContentSize > m_ContentAreaRect.w : m_ContentSize > m_ContentAreaRect.h;
 }
 
 bool CScrollRegion::ScrollbarShown() const

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -39,27 +39,8 @@ void CScrollRegion::Begin(CUIRect *pClipRect, const CScrollRegionParams *pParams
 	m_ContentAreaRect = *pClipRect;
 
 	CUIRect ScrollbarBg = SplitContentArea();
+	DrawBackground(ScrollbarBg);
 
-	// only show scrollbar if required
-	if(ScrollbarShown())
-	{
-		if(m_Params.m_ScrollbarBgColor.a > 0.0f)
-		{
-			int Corners = m_Params.m_ScrollHorizontal ? IGraphics::CORNER_B : IGraphics::CORNER_R;
-			ScrollbarBg.Draw(m_Params.m_ScrollbarBgColor, Corners, 4.0f);
-		}
-		if(m_Params.m_RailBgColor.a > 0.0f)
-		{
-			float Rounding = m_Params.m_ScrollHorizontal ? m_RailRect.h / 2.0f : m_RailRect.w / 2.0f;
-			m_RailRect.Draw(m_Params.m_RailBgColor, IGraphics::CORNER_ALL, Rounding);
-		}
-	}
-	if(m_Params.m_ClipBgColor.a > 0.0f)
-	{
-		int CornersPartial = m_Params.m_ScrollHorizontal ? IGraphics::CORNER_T : IGraphics::CORNER_L;
-		m_ContentAreaRect.Draw(m_Params.m_ClipBgColor, ScrollbarShown() ? CornersPartial : IGraphics::CORNER_ALL, 4.0f);
-	}
-	
 	if(!ContentOverflows())
 		m_ContentScrollOffset = 0.0f;
 	m_ContentSize = 0.0f;
@@ -208,6 +189,29 @@ CUIRect CScrollRegion::SplitContentArea()
 		ScrollbarBg.Margin(m_Params.m_ScrollbarMargin, &m_RailRect);
 
 	return ScrollbarBg;
+}
+
+void CScrollRegion::DrawBackground(const CUIRect &ScrollbarBg)
+{
+	// only show scrollbar if required
+	if(ScrollbarShown())
+	{
+		if(m_Params.m_ScrollbarBgColor.a > 0.0f)
+		{
+			int Corners = m_Params.m_ScrollHorizontal ? IGraphics::CORNER_B : IGraphics::CORNER_R;
+			ScrollbarBg.Draw(m_Params.m_ScrollbarBgColor, Corners, 4.0f);
+		}
+		if(m_Params.m_RailBgColor.a > 0.0f)
+		{
+			float Rounding = m_Params.m_ScrollHorizontal ? m_RailRect.h / 2.0f : m_RailRect.w / 2.0f;
+			m_RailRect.Draw(m_Params.m_RailBgColor, IGraphics::CORNER_ALL, Rounding);
+		}
+	}
+	if(m_Params.m_ClipBgColor.a > 0.0f)
+	{
+		int CornersPartial = m_Params.m_ScrollHorizontal ? IGraphics::CORNER_T : IGraphics::CORNER_L;
+		m_ContentAreaRect.Draw(m_Params.m_ClipBgColor, ScrollbarShown() ? CornersPartial : IGraphics::CORNER_ALL, 4.0f);
+	}
 }
 
 void CScrollRegion::DoScrollInput()

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -28,7 +28,7 @@ void CScrollRegion::Reset()
 
 	m_ClipRect = m_RailRect = m_LastAddedRect = CUIRect{0.0f, 0.0f, 0.0f, 0.0f};
 	m_SliderGrabPos = 0.0f;
-	m_ContentScrollOff = vec2(0.0f, 0.0f);
+	m_ContentScrollOffset = 0.0f;
 	m_Params = CScrollRegionParams();
 }
 
@@ -58,7 +58,7 @@ void CScrollRegion::Begin(CUIRect *pClipRect, const CScrollRegionParams *pParams
 			m_RailRect.Draw(m_Params.m_RailBgColor, IGraphics::CORNER_ALL, m_RailRect.w / 2.0f);
 	}
 	if(!ContentOverflows)
-		m_ContentScrollOff.y = 0.0f;
+		m_ContentScrollOffset = 0.0f;
 
 	if(m_Params.m_ClipBgColor.a > 0.0f)
 		pClipRect->Draw(m_Params.m_ClipBgColor, HasScrollBar ? IGraphics::CORNER_L : IGraphics::CORNER_ALL, 4.0f);
@@ -67,7 +67,7 @@ void CScrollRegion::Begin(CUIRect *pClipRect, const CScrollRegionParams *pParams
 
 	m_ClipRect = *pClipRect;
 	m_ContentSize = 0.0f;
-	pClipRect->y += m_ContentScrollOff.y;
+	pClipRect->y += m_ContentScrollOffset;
 }
 
 void CScrollRegion::End()
@@ -194,7 +194,7 @@ void CScrollRegion::End()
 	}
 
 	m_ScrollPos = std::clamp(m_ScrollPos, 0.0f, MaxScroll);
-	m_ContentScrollOff.y = -m_ScrollPos;
+	m_ContentScrollOffset = -m_ScrollPos;
 
 	Slider.Draw(m_Params.SliderColor(Grabbed, Ui()->HotItem() == pId), IGraphics::CORNER_ALL, Slider.w / 2.0f);
 }
@@ -202,7 +202,7 @@ void CScrollRegion::End()
 bool CScrollRegion::AddRect(const CUIRect &Rect, bool ShouldScrollHere)
 {
 	m_LastAddedRect = Rect;
-	m_ContentSize = maximum(Rect.y + Rect.h - (m_ClipRect.y + m_ContentScrollOff.y), m_ContentSize);
+	m_ContentSize = maximum(Rect.y + Rect.h - (m_ClipRect.y + m_ContentScrollOffset), m_ContentSize);
 	if(ShouldScrollHere)
 		ScrollHere();
 	return !RectClipped(Rect);
@@ -211,7 +211,7 @@ bool CScrollRegion::AddRect(const CUIRect &Rect, bool ShouldScrollHere)
 void CScrollRegion::ScrollHere(EScrollOption Option)
 {
 	const float MinHeight = minimum(m_ClipRect.h, m_LastAddedRect.h);
-	const float TopScroll = m_LastAddedRect.y - (m_ClipRect.y + m_ContentScrollOff.y);
+	const float TopScroll = m_LastAddedRect.y - (m_ClipRect.y + m_ContentScrollOffset);
 
 	switch(Option)
 	{

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -81,12 +81,10 @@ bool CScrollRegion::AddRect(const CUIRect &Rect, bool ShouldScrollHere)
 
 void CScrollRegion::ScrollHere(EScrollOption Option)
 {
-	const float ContentAreaPos = m_Params.m_ScrollHorizontal ? m_ContentAreaRect.x : m_ContentAreaRect.y;
-	const float ContentAreaSize = m_Params.m_ScrollHorizontal ? m_ContentAreaRect.w : m_ContentAreaRect.h;
 	const float LastAddedPos = m_Params.m_ScrollHorizontal ? m_LastAddedRect.x : m_LastAddedRect.y;
 	const float LastAddedSize = m_Params.m_ScrollHorizontal ? m_LastAddedRect.w : m_LastAddedRect.h;
-	const float MinHeight = minimum(ContentAreaSize, LastAddedSize);
-	const float TopScroll = LastAddedPos - (ContentAreaPos + m_ContentScrollOffset);
+	const float MinHeight = minimum(ContentAreaSize(), LastAddedSize);
+	const float TopScroll = LastAddedPos - (ContentAreaPos() + m_ContentScrollOffset);
 
 	switch(Option)
 	{
@@ -95,16 +93,16 @@ void CScrollRegion::ScrollHere(EScrollOption Option)
 		break;
 
 	case SCROLLHERE_BOTTOM:
-		m_RequestScrollPos = TopScroll - (ContentAreaSize - MinHeight);
+		m_RequestScrollPos = TopScroll - (ContentAreaSize() - MinHeight);
 		break;
 
 	case SCROLLHERE_KEEP_IN_VIEW:
 	default:
-		const float DeltaY = LastAddedPos - ContentAreaPos;
+		const float DeltaY = LastAddedPos - ContentAreaPos();
 		if(DeltaY < 0)
 			m_RequestScrollPos = TopScroll;
-		else if(DeltaY > (ContentAreaSize - MinHeight))
-			m_RequestScrollPos = TopScroll - (ContentAreaSize - MinHeight);
+		else if(DeltaY > (ContentAreaSize() - MinHeight))
+			m_RequestScrollPos = TopScroll - (ContentAreaSize() - MinHeight);
 		break;
 	}
 }
@@ -117,8 +115,7 @@ void CScrollRegion::ScrollRelative(EScrollRelative Direction, float SpeedMultipl
 
 void CScrollRegion::ScrollRelativeDirect(float ScrollAmount)
 {
-	const float ContentAreaSize = m_Params.m_ScrollHorizontal ? m_ContentAreaRect.w : m_ContentAreaRect.h;
-	m_RequestScrollPos = std::clamp(m_ScrollPos + ScrollAmount, 0.0f, m_ContentSize - ContentAreaSize);
+	m_RequestScrollPos = std::clamp(m_ScrollPos + ScrollAmount, 0.0f, m_ContentSize - ContentAreaSize());
 }
 
 void CScrollRegion::DoEdgeScrolling()
@@ -126,13 +123,11 @@ void CScrollRegion::DoEdgeScrolling()
 	if(!ContentOverflows())
 		return;
 
-	const float ContentAreaPos = m_Params.m_ScrollHorizontal ? m_ContentAreaRect.x : m_ContentAreaRect.y;
-	const float ContentAreaSize = m_Params.m_ScrollHorizontal ? m_ContentAreaRect.w : m_ContentAreaRect.h;
 	const float ScrollBorderSize = 20.0f;
 	const float MaxScrollMultiplier = 2.0f;
 	const float ScrollSpeedFactor = MaxScrollMultiplier / ScrollBorderSize;
-	const float TopScrollPosition = ContentAreaPos + ScrollBorderSize;
-	const float BottomScrollPosition = ContentAreaPos + ContentAreaSize - ScrollBorderSize;
+	const float TopScrollPosition = ContentAreaPos() + ScrollBorderSize;
+	const float BottomScrollPosition = ContentAreaPos() + ContentAreaSize() - ScrollBorderSize;
 	const float MousePos = m_Params.m_ScrollHorizontal ? Ui()->MouseX() : Ui()->MouseY();
 	if(MousePos < TopScrollPosition)
 		ScrollRelative(SCROLLRELATIVE_UP, minimum(MaxScrollMultiplier, (TopScrollPosition - MousePos) * ScrollSpeedFactor));
@@ -163,6 +158,21 @@ bool CScrollRegion::Animating() const
 bool CScrollRegion::Active() const
 {
 	return Ui()->ActiveItem() == &m_ScrollPos;
+}
+
+float CScrollRegion::ContentAreaPos() const
+{
+	return m_Params.m_ScrollHorizontal ? m_ContentAreaRect.x : m_ContentAreaRect.y;
+}
+
+float CScrollRegion::ContentAreaSize() const
+{
+	return m_Params.m_ScrollHorizontal ? m_ContentAreaRect.w : m_ContentAreaRect.h;
+}
+
+float CScrollRegion::MaxScroll() const
+{
+	return m_ContentSize - ContentAreaSize();
 }
 
 CUIRect CScrollRegion::SplitContentArea()
@@ -216,8 +226,6 @@ void CScrollRegion::DrawBackground(const CUIRect &ScrollbarBg)
 
 void CScrollRegion::DoScrollInput()
 {
-	const float ContentAreaSize = m_Params.m_ScrollHorizontal ? m_ContentAreaRect.w : m_ContentAreaRect.h;
-
 	if(m_ScrollDirection != SCROLLRELATIVE_NONE || Ui()->HotScrollRegion() == this)
 	{
 		bool ProgrammaticScroll = false;
@@ -234,7 +242,7 @@ void CScrollRegion::DoScrollInput()
 		if(m_ScrollDirection != SCROLLRELATIVE_NONE)
 		{
 			const bool IsPageScroll = Input()->AltIsPressed();
-			const float ScrollUnit = IsPageScroll && !ProgrammaticScroll ? ContentAreaSize : m_Params.m_ScrollUnit;
+			const float ScrollUnit = IsPageScroll && !ProgrammaticScroll ? ContentAreaSize() : m_Params.m_ScrollUnit;
 
 			m_AnimTimeMax = g_Config.m_UiSmoothScrollTime / 1000.0f;
 			m_AnimTime = m_AnimTimeMax;
@@ -262,9 +270,6 @@ void CScrollRegion::UpdateHotScrollRegion()
 
 void CScrollRegion::AdvanceAnimation()
 {
-	const float ContentAreaSize = m_Params.m_ScrollHorizontal ? m_ContentAreaRect.w : m_ContentAreaRect.h;
-	const float MaxScroll = m_ContentSize - ContentAreaSize;
-
 	if(m_RequestScrollPos >= 0.0f)
 	{
 		m_AnimTargetScrollPos = m_RequestScrollPos;
@@ -272,7 +277,7 @@ void CScrollRegion::AdvanceAnimation()
 		m_RequestScrollPos = -1.0f;
 	}
 
-	m_AnimTargetScrollPos = std::clamp(m_AnimTargetScrollPos, 0.0f, MaxScroll);
+	m_AnimTargetScrollPos = std::clamp(m_AnimTargetScrollPos, 0.0f, MaxScroll());
 
 	if(absolute(m_AnimInitScrollPos - m_AnimTargetScrollPos) < 0.5f)
 		m_AnimTime = 0.0f;
@@ -295,9 +300,8 @@ void CScrollRegion::AdvanceAnimation()
 
 void CScrollRegion::DoSlider()
 {
-	const float ContentAreaSize = m_Params.m_ScrollHorizontal ? m_ContentAreaRect.w : m_ContentAreaRect.h;
 	const float RailSize = m_Params.m_ScrollHorizontal ? m_RailRect.w : m_RailRect.h;
-	const float SliderSize = maximum(m_Params.m_SliderMinSize, ContentAreaSize / m_ContentSize * RailSize);
+	const float SliderSize = maximum(m_Params.m_SliderMinSize, ContentAreaSize() / m_ContentSize * RailSize);
 
 	CUIRect Slider = m_RailRect;
 	float &SliderPos = m_Params.m_ScrollHorizontal ? Slider.x : Slider.y;
@@ -307,9 +311,8 @@ void CScrollRegion::DoSlider()
 		Slider.h = SliderSize;
 
 	const float MaxSlider = RailSize - SliderSize;
-	const float MaxScroll = m_ContentSize - ContentAreaSize;
 
-	SliderPos += m_ScrollPos / MaxScroll * MaxSlider;
+	SliderPos += m_ScrollPos / MaxScroll() * MaxSlider;
 
 	bool Grabbed = false;
 	const void *pId = &m_ScrollPos;
@@ -319,7 +322,7 @@ void CScrollRegion::DoSlider()
 	float MousePos = m_Params.m_ScrollHorizontal ? Ui()->MouseX() : Ui()->MouseY();
 	if(Ui()->CheckActiveItem(pId) && Ui()->MouseButton(0))
 	{
-		m_ScrollPos += (MousePos - (SliderPos + m_SliderGrabPos)) / MaxSlider * MaxScroll;
+		m_ScrollPos += (MousePos - (SliderPos + m_SliderGrabPos)) / MaxSlider * MaxScroll();
 		m_SliderGrabPos = std::clamp(m_SliderGrabPos, 0.0f, SliderSize);
 		m_AnimTargetScrollPos = m_ScrollPos;
 		m_AnimTime = 0.0f;
@@ -340,7 +343,7 @@ void CScrollRegion::DoSlider()
 	}
 	else if(InsideRail && Ui()->MouseButtonClicked(0))
 	{
-		m_ScrollPos += (MousePos - (SliderPos + SliderSize / 2.0f)) / MaxSlider * MaxScroll;
+		m_ScrollPos += (MousePos - (SliderPos + SliderSize / 2.0f)) / MaxSlider * MaxScroll();
 		Ui()->SetHotItem(pId);
 		Ui()->SetActiveItem(pId);
 		m_SliderGrabPos = SliderSize / 2.0f;
@@ -353,7 +356,7 @@ void CScrollRegion::DoSlider()
 		Ui()->SetActiveItem(nullptr);
 	}
 
-	m_ScrollPos = std::clamp(m_ScrollPos, 0.0f, MaxScroll);
+	m_ScrollPos = std::clamp(m_ScrollPos, 0.0f, MaxScroll());
 	m_ContentScrollOffset = -m_ScrollPos;
 
 	float Rounding = m_Params.m_ScrollHorizontal ? Slider.h / 2.0f : Slider.w / 2.0f;

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -113,9 +113,12 @@ void CScrollRegion::ScrollRelative(EScrollRelative Direction, float SpeedMultipl
 	m_ScrollSpeedMultiplier = SpeedMultiplier;
 }
 
-void CScrollRegion::ScrollRelativeDirect(float ScrollAmount)
+void CScrollRegion::ScrollRelativeDirect(vec2 ScrollAmount)
 {
-	m_RequestScrollPos = std::clamp(m_ScrollPos + ScrollAmount, 0.0f, m_ContentSize - ContentAreaSize());
+	if(m_Params.m_ScrollHorizontal)
+		m_RequestScrollPos = std::clamp(m_ScrollPos + ScrollAmount.x, 0.0f, m_ContentSize - ContentAreaSize());
+	else
+		m_RequestScrollPos = std::clamp(m_ScrollPos + ScrollAmount.y, 0.0f, m_ContentSize - ContentAreaSize());
 }
 
 void CScrollRegion::DoEdgeScrolling()

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -289,7 +289,7 @@ void CScrollRegion::ScrollRelativeDirect(float ScrollAmount)
 
 void CScrollRegion::DoEdgeScrolling()
 {
-	if(!ScrollbarShown())
+	if(!ContentOverflows())
 		return;
 
 	const float ClipPos = m_Params.m_ScrollHorizontal ? m_ClipRect.x : m_ClipRect.y;
@@ -311,9 +311,14 @@ bool CScrollRegion::RectClipped(const CUIRect &Rect) const
 	return (m_ClipRect.x > (Rect.x + Rect.w) || (m_ClipRect.x + m_ClipRect.w) < Rect.x || m_ClipRect.y > (Rect.y + Rect.h) || (m_ClipRect.y + m_ClipRect.h) < Rect.y);
 }
 
-bool CScrollRegion::ScrollbarShown() const
+bool CScrollRegion::ContentOverflows() const
 {
 	return m_Params.m_ScrollHorizontal ? m_ContentSize > m_ClipRect.w : m_ContentSize > m_ClipRect.h;
+}
+
+bool CScrollRegion::ScrollbarShown() const
+{
+	return ContentOverflows() || m_Params.m_ForceShowScrollbar;
 }
 
 bool CScrollRegion::Animating() const

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -38,13 +38,11 @@ void CScrollRegion::Begin(CUIRect *pClipRect, const CScrollRegionParams *pParams
 		m_Params = *pParams;
 	m_ClipRect = *pClipRect;
 
-	const bool ContentOverflows = m_Params.m_ScrollHorizontal ? m_ContentSize > m_ClipRect.w : m_ContentSize > m_ClipRect.h;
-	const bool HasScrollBar = ContentOverflows || m_Params.m_ForceShowScrollbar;
 	CUIRect ScrollBarBg;
 	if(m_Params.m_ScrollHorizontal)
-		m_ClipRect.HSplitBottom(m_Params.m_ScrollbarThickness, HasScrollBar ? &m_ClipRect : nullptr, &ScrollBarBg);
+		m_ClipRect.HSplitBottom(m_Params.m_ScrollbarThickness, ScrollbarShown() ? &m_ClipRect : nullptr, &ScrollBarBg);
 	else
-		m_ClipRect.VSplitRight(m_Params.m_ScrollbarThickness, HasScrollBar ? &m_ClipRect : nullptr, &ScrollBarBg);
+		m_ClipRect.VSplitRight(m_Params.m_ScrollbarThickness, ScrollbarShown() ? &m_ClipRect : nullptr, &ScrollBarBg);
 	if(m_Params.m_ScrollbarNoOuterMargin)
 	{
 		if(m_Params.m_ScrollHorizontal)
@@ -62,7 +60,7 @@ void CScrollRegion::Begin(CUIRect *pClipRect, const CScrollRegionParams *pParams
 		ScrollBarBg.Margin(m_Params.m_ScrollbarMargin, &m_RailRect);
 
 	// only show scrollbar if required
-	if(HasScrollBar)
+	if(ScrollbarShown())
 	{
 		if(m_Params.m_ScrollbarBgColor.a > 0.0f)
 		{
@@ -75,13 +73,13 @@ void CScrollRegion::Begin(CUIRect *pClipRect, const CScrollRegionParams *pParams
 			m_RailRect.Draw(m_Params.m_RailBgColor, IGraphics::CORNER_ALL, Rounding);
 		}
 	}
-	if(!ContentOverflows)
+	if(!ContentOverflows())
 		m_ContentScrollOffset = 0.0f;
 
 	if(m_Params.m_ClipBgColor.a > 0.0f)
 	{
 		int CornersPartial = m_Params.m_ScrollHorizontal ? IGraphics::CORNER_T : IGraphics::CORNER_L;
-		m_ClipRect.Draw(m_Params.m_ClipBgColor, HasScrollBar ? CornersPartial : IGraphics::CORNER_ALL, 4.0f);
+		m_ClipRect.Draw(m_Params.m_ClipBgColor, ScrollbarShown() ? CornersPartial : IGraphics::CORNER_ALL, 4.0f);
 	}
 
 	m_ContentSize = 0.0f;
@@ -101,7 +99,7 @@ void CScrollRegion::End()
 	const float ClipSize = m_Params.m_ScrollHorizontal ? m_ClipRect.w : m_ClipRect.h;
 
 	// only show scrollbar if content overflows
-	if(m_ContentSize <= ClipSize)
+	if(!ContentOverflows())
 		return;
 
 	// scroll wheel

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -98,10 +98,10 @@ void CScrollRegion::ScrollHere(EScrollOption Option)
 
 	case SCROLLHERE_KEEP_IN_VIEW:
 	default:
-		const float DeltaY = LastAddedPos - ContentAreaPos();
-		if(DeltaY < 0)
+		const float DeltaPos = LastAddedPos - ContentAreaPos();
+		if(DeltaPos < 0)
 			m_RequestScrollPos = TopScroll;
-		else if(DeltaY > (ContentAreaSize() - MinHeight))
+		else if(DeltaPos > (ContentAreaSize() - MinHeight))
 			m_RequestScrollPos = TopScroll - (ContentAreaSize() - MinHeight);
 		break;
 	}

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -36,14 +36,15 @@ void CScrollRegion::Begin(CUIRect *pClipRect, const CScrollRegionParams *pParams
 {
 	if(pParams)
 		m_Params = *pParams;
+	m_ClipRect = *pClipRect;
 
-	const bool ContentOverflows = m_Params.m_ScrollHorizontal ? m_ContentSize > pClipRect->w : m_ContentSize > pClipRect->h;
+	const bool ContentOverflows = m_Params.m_ScrollHorizontal ? m_ContentSize > m_ClipRect.w : m_ContentSize > m_ClipRect.h;
 	const bool HasScrollBar = ContentOverflows || m_Params.m_ForceShowScrollbar;
 	CUIRect ScrollBarBg;
 	if(m_Params.m_ScrollHorizontal)
-		pClipRect->HSplitBottom(m_Params.m_ScrollbarThickness, HasScrollBar ? pClipRect : nullptr, &ScrollBarBg);
+		m_ClipRect.HSplitBottom(m_Params.m_ScrollbarThickness, HasScrollBar ? &m_ClipRect : nullptr, &ScrollBarBg);
 	else
-		pClipRect->VSplitRight(m_Params.m_ScrollbarThickness, HasScrollBar ? pClipRect : nullptr, &ScrollBarBg);
+		m_ClipRect.VSplitRight(m_Params.m_ScrollbarThickness, HasScrollBar ? &m_ClipRect : nullptr, &ScrollBarBg);
 	if(m_Params.m_ScrollbarNoOuterMargin)
 	{
 		if(m_Params.m_ScrollHorizontal)
@@ -80,13 +81,13 @@ void CScrollRegion::Begin(CUIRect *pClipRect, const CScrollRegionParams *pParams
 	if(m_Params.m_ClipBgColor.a > 0.0f)
 	{
 		int CornersPartial = m_Params.m_ScrollHorizontal ? IGraphics::CORNER_T : IGraphics::CORNER_L;
-		pClipRect->Draw(m_Params.m_ClipBgColor, HasScrollBar ? CornersPartial : IGraphics::CORNER_ALL, 4.0f);
+		m_ClipRect.Draw(m_Params.m_ClipBgColor, HasScrollBar ? CornersPartial : IGraphics::CORNER_ALL, 4.0f);
 	}
 
-	Ui()->ClipEnable(pClipRect);
-
-	m_ClipRect = *pClipRect;
 	m_ContentSize = 0.0f;
+
+	Ui()->ClipEnable(&m_ClipRect);
+	*pClipRect = m_ClipRect;
 	if(m_Params.m_ScrollHorizontal)
 		pClipRect->x += m_ContentScrollOffset;
 	else

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -38,26 +38,7 @@ void CScrollRegion::Begin(CUIRect *pClipRect, const CScrollRegionParams *pParams
 		m_Params = *pParams;
 	m_ContentAreaRect = *pClipRect;
 
-	CUIRect ScrollBarBg;
-	if(m_Params.m_ScrollHorizontal)
-		m_ContentAreaRect.HSplitBottom(m_Params.m_ScrollbarThickness, ScrollbarShown() ? &m_ContentAreaRect : nullptr, &ScrollBarBg);
-	else
-		m_ContentAreaRect.VSplitRight(m_Params.m_ScrollbarThickness, ScrollbarShown() ? &m_ContentAreaRect : nullptr, &ScrollBarBg);
-	if(m_Params.m_ScrollbarNoOuterMargin)
-	{
-		if(m_Params.m_ScrollHorizontal)
-		{
-			ScrollBarBg.VMargin(m_Params.m_ScrollbarMargin, &m_RailRect);
-			m_RailRect.HSplitTop(m_Params.m_ScrollbarMargin, nullptr, &m_RailRect);
-		}
-		else
-		{
-			ScrollBarBg.HMargin(m_Params.m_ScrollbarMargin, &m_RailRect);
-			m_RailRect.VSplitLeft(m_Params.m_ScrollbarMargin, nullptr, &m_RailRect);
-		}
-	}
-	else
-		ScrollBarBg.Margin(m_Params.m_ScrollbarMargin, &m_RailRect);
+	CUIRect ScrollbarBg = SplitContentArea();
 
 	// only show scrollbar if required
 	if(ScrollbarShown())
@@ -65,7 +46,7 @@ void CScrollRegion::Begin(CUIRect *pClipRect, const CScrollRegionParams *pParams
 		if(m_Params.m_ScrollbarBgColor.a > 0.0f)
 		{
 			int Corners = m_Params.m_ScrollHorizontal ? IGraphics::CORNER_B : IGraphics::CORNER_R;
-			ScrollBarBg.Draw(m_Params.m_ScrollbarBgColor, Corners, 4.0f);
+			ScrollbarBg.Draw(m_Params.m_ScrollbarBgColor, Corners, 4.0f);
 		}
 		if(m_Params.m_RailBgColor.a > 0.0f)
 		{
@@ -202,6 +183,32 @@ bool CScrollRegion::Animating() const
 bool CScrollRegion::Active() const
 {
 	return Ui()->ActiveItem() == &m_ScrollPos;
+}
+
+CUIRect CScrollRegion::SplitContentArea()
+{
+	CUIRect ScrollbarBg;
+	if(m_Params.m_ScrollHorizontal)
+		m_ContentAreaRect.HSplitBottom(m_Params.m_ScrollbarThickness, ScrollbarShown() ? &m_ContentAreaRect : nullptr, &ScrollbarBg);
+	else
+		m_ContentAreaRect.VSplitRight(m_Params.m_ScrollbarThickness, ScrollbarShown() ? &m_ContentAreaRect : nullptr, &ScrollbarBg);
+	if(m_Params.m_ScrollbarNoOuterMargin)
+	{
+		if(m_Params.m_ScrollHorizontal)
+		{
+			ScrollbarBg.VMargin(m_Params.m_ScrollbarMargin, &m_RailRect);
+			m_RailRect.HSplitTop(m_Params.m_ScrollbarMargin, nullptr, &m_RailRect);
+		}
+		else
+		{
+			ScrollbarBg.HMargin(m_Params.m_ScrollbarMargin, &m_RailRect);
+			m_RailRect.VSplitLeft(m_Params.m_ScrollbarMargin, nullptr, &m_RailRect);
+		}
+	}
+	else
+		ScrollbarBg.Margin(m_Params.m_ScrollbarMargin, &m_RailRect);
+
+	return ScrollbarBg;
 }
 
 void CScrollRegion::DoScrollInput()

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -37,14 +37,25 @@ void CScrollRegion::Begin(CUIRect *pClipRect, const CScrollRegionParams *pParams
 	if(pParams)
 		m_Params = *pParams;
 
-	const bool ContentOverflows = m_ContentSize > pClipRect->h;
+	const bool ContentOverflows = m_Params.m_ScrollHorizontal ? m_ContentSize > pClipRect->w : m_ContentSize > pClipRect->h;
 	const bool HasScrollBar = ContentOverflows || m_Params.m_ForceShowScrollbar;
 	CUIRect ScrollBarBg;
-	pClipRect->VSplitRight(m_Params.m_ScrollbarThickness, HasScrollBar ? pClipRect : nullptr, &ScrollBarBg);
+	if(m_Params.m_ScrollHorizontal)
+		pClipRect->HSplitBottom(m_Params.m_ScrollbarThickness, HasScrollBar ? pClipRect : nullptr, &ScrollBarBg);
+	else
+		pClipRect->VSplitRight(m_Params.m_ScrollbarThickness, HasScrollBar ? pClipRect : nullptr, &ScrollBarBg);
 	if(m_Params.m_ScrollbarNoOuterMargin)
 	{
-		ScrollBarBg.HMargin(m_Params.m_ScrollbarMargin, &m_RailRect);
-		m_RailRect.VSplitLeft(m_Params.m_ScrollbarMargin, nullptr, &m_RailRect);
+		if(m_Params.m_ScrollHorizontal)
+		{
+			ScrollBarBg.VMargin(m_Params.m_ScrollbarMargin, &m_RailRect);
+			m_RailRect.HSplitTop(m_Params.m_ScrollbarMargin, nullptr, &m_RailRect);
+		}
+		else
+		{
+			ScrollBarBg.HMargin(m_Params.m_ScrollbarMargin, &m_RailRect);
+			m_RailRect.VSplitLeft(m_Params.m_ScrollbarMargin, nullptr, &m_RailRect);
+		}
 	}
 	else
 		ScrollBarBg.Margin(m_Params.m_ScrollbarMargin, &m_RailRect);
@@ -53,34 +64,51 @@ void CScrollRegion::Begin(CUIRect *pClipRect, const CScrollRegionParams *pParams
 	if(HasScrollBar)
 	{
 		if(m_Params.m_ScrollbarBgColor.a > 0.0f)
-			ScrollBarBg.Draw(m_Params.m_ScrollbarBgColor, IGraphics::CORNER_R, 4.0f);
+		{
+			int Corners = m_Params.m_ScrollHorizontal ? IGraphics::CORNER_B : IGraphics::CORNER_R;
+			ScrollBarBg.Draw(m_Params.m_ScrollbarBgColor, Corners, 4.0f);
+		}
 		if(m_Params.m_RailBgColor.a > 0.0f)
-			m_RailRect.Draw(m_Params.m_RailBgColor, IGraphics::CORNER_ALL, m_RailRect.w / 2.0f);
+		{
+			float Rounding = m_Params.m_ScrollHorizontal ? m_RailRect.h / 2.0f : m_RailRect.w / 2.0f;
+			m_RailRect.Draw(m_Params.m_RailBgColor, IGraphics::CORNER_ALL, Rounding);
+		}
 	}
 	if(!ContentOverflows)
 		m_ContentScrollOffset = 0.0f;
 
 	if(m_Params.m_ClipBgColor.a > 0.0f)
-		pClipRect->Draw(m_Params.m_ClipBgColor, HasScrollBar ? IGraphics::CORNER_L : IGraphics::CORNER_ALL, 4.0f);
+	{
+		int CornersPartial = m_Params.m_ScrollHorizontal ? IGraphics::CORNER_T : IGraphics::CORNER_L;
+		pClipRect->Draw(m_Params.m_ClipBgColor, HasScrollBar ? CornersPartial : IGraphics::CORNER_ALL, 4.0f);
+	}
 
 	Ui()->ClipEnable(pClipRect);
 
 	m_ClipRect = *pClipRect;
 	m_ContentSize = 0.0f;
-	pClipRect->y += m_ContentScrollOffset;
+	if(m_Params.m_ScrollHorizontal)
+		pClipRect->x += m_ContentScrollOffset;
+	else
+		pClipRect->y += m_ContentScrollOffset;
 }
 
 void CScrollRegion::End()
 {
 	Ui()->ClipDisable();
 
+	const float ClipSize = m_Params.m_ScrollHorizontal ? m_ClipRect.w : m_ClipRect.h;
+
 	// only show scrollbar if content overflows
-	if(m_ContentSize <= m_ClipRect.h)
+	if(m_ContentSize <= ClipSize)
 		return;
 
 	// scroll wheel
 	CUIRect RegionRect = m_ClipRect;
-	RegionRect.w += m_Params.m_ScrollbarThickness;
+	if(m_Params.m_ScrollHorizontal)
+		RegionRect.h += m_Params.m_ScrollbarThickness;
+	else
+		RegionRect.w += m_Params.m_ScrollbarThickness;
 
 	if(m_ScrollDirection != SCROLLRELATIVE_NONE || Ui()->HotScrollRegion() == this)
 	{
@@ -98,7 +126,7 @@ void CScrollRegion::End()
 		if(m_ScrollDirection != SCROLLRELATIVE_NONE)
 		{
 			const bool IsPageScroll = Input()->AltIsPressed();
-			const float ScrollUnit = IsPageScroll && !ProgrammaticScroll ? m_ClipRect.h : m_Params.m_ScrollUnit;
+			const float ScrollUnit = IsPageScroll && !ProgrammaticScroll ? ClipSize : m_Params.m_ScrollUnit;
 
 			m_AnimTimeMax = g_Config.m_UiSmoothScrollTime / 1000.0f;
 			m_AnimTime = m_AnimTimeMax;
@@ -114,13 +142,18 @@ void CScrollRegion::End()
 		Ui()->SetHotScrollRegion(this);
 	}
 
-	const float SliderHeight = maximum(m_Params.m_SliderMinSize, m_ClipRect.h / m_ContentSize * m_RailRect.h);
+	const float RailSize = m_Params.m_ScrollHorizontal ? m_RailRect.w : m_RailRect.h;
+	const float SliderSize = maximum(m_Params.m_SliderMinSize, ClipSize / m_ContentSize * RailSize);
 
 	CUIRect Slider = m_RailRect;
-	Slider.h = SliderHeight;
+	float &SliderPos = m_Params.m_ScrollHorizontal ? Slider.x : Slider.y;
+	if(m_Params.m_ScrollHorizontal)
+		Slider.w = SliderSize;
+	else
+		Slider.h = SliderSize;
 
-	const float MaxSlider = m_RailRect.h - SliderHeight;
-	const float MaxScroll = m_ContentSize - m_ClipRect.h;
+	const float MaxSlider = RailSize - SliderSize;
+	const float MaxScroll = m_ContentSize - ClipSize;
 
 	if(m_RequestScrollPos >= 0.0f)
 	{
@@ -149,18 +182,18 @@ void CScrollRegion::End()
 		m_ScrollPos = m_AnimTargetScrollPos;
 	}
 
-	Slider.y += m_ScrollPos / MaxScroll * MaxSlider;
+	SliderPos += m_ScrollPos / MaxScroll * MaxSlider;
 
 	bool Grabbed = false;
 	const void *pId = &m_ScrollPos;
 	const bool InsideSlider = Ui()->MouseHovered(&Slider);
 	const bool InsideRail = Ui()->MouseHovered(&m_RailRect);
 
+	float MousePos = m_Params.m_ScrollHorizontal ? Ui()->MouseX() : Ui()->MouseY();
 	if(Ui()->CheckActiveItem(pId) && Ui()->MouseButton(0))
 	{
-		float MouseY = Ui()->MouseY();
-		m_ScrollPos += (MouseY - (Slider.y + m_SliderGrabPos)) / MaxSlider * MaxScroll;
-		m_SliderGrabPos = std::clamp(m_SliderGrabPos, 0.0f, SliderHeight);
+		m_ScrollPos += (MousePos - (SliderPos + m_SliderGrabPos)) / MaxSlider * MaxScroll;
+		m_SliderGrabPos = std::clamp(m_SliderGrabPos, 0.0f, SliderSize);
 		m_AnimTargetScrollPos = m_ScrollPos;
 		m_AnimTime = 0.0f;
 		Grabbed = true;
@@ -173,17 +206,17 @@ void CScrollRegion::End()
 		if(!Ui()->CheckActiveItem(pId) && Ui()->MouseButtonClicked(0))
 		{
 			Ui()->SetActiveItem(pId);
-			m_SliderGrabPos = Ui()->MouseY() - Slider.y;
+			m_SliderGrabPos = MousePos - SliderPos;
 			m_AnimTargetScrollPos = m_ScrollPos;
 			m_AnimTime = 0.0f;
 		}
 	}
 	else if(InsideRail && Ui()->MouseButtonClicked(0))
 	{
-		m_ScrollPos += (Ui()->MouseY() - (Slider.y + Slider.h / 2.0f)) / MaxSlider * MaxScroll;
+		m_ScrollPos += (MousePos - (SliderPos + SliderSize / 2.0f)) / MaxSlider * MaxScroll;
 		Ui()->SetHotItem(pId);
 		Ui()->SetActiveItem(pId);
-		m_SliderGrabPos = Slider.h / 2.0f;
+		m_SliderGrabPos = SliderSize / 2.0f;
 		m_AnimTargetScrollPos = m_ScrollPos;
 		m_AnimTime = 0.0f;
 	}
@@ -196,13 +229,17 @@ void CScrollRegion::End()
 	m_ScrollPos = std::clamp(m_ScrollPos, 0.0f, MaxScroll);
 	m_ContentScrollOffset = -m_ScrollPos;
 
-	Slider.Draw(m_Params.SliderColor(Grabbed, Ui()->HotItem() == pId), IGraphics::CORNER_ALL, Slider.w / 2.0f);
+	float Rounding = m_Params.m_ScrollHorizontal ? Slider.h / 2.0f : Slider.w / 2.0f;
+	Slider.Draw(m_Params.SliderColor(Grabbed, Ui()->HotItem() == pId), IGraphics::CORNER_ALL, Rounding);
 }
 
 bool CScrollRegion::AddRect(const CUIRect &Rect, bool ShouldScrollHere)
 {
 	m_LastAddedRect = Rect;
-	m_ContentSize = maximum(Rect.y + Rect.h - (m_ClipRect.y + m_ContentScrollOffset), m_ContentSize);
+	if(m_Params.m_ScrollHorizontal)
+		m_ContentSize = maximum(std::ceil(Rect.x + Rect.w - (m_ClipRect.x + m_ContentScrollOffset)), m_ContentSize);
+	else
+		m_ContentSize = maximum(Rect.y + Rect.h - (m_ClipRect.y + m_ContentScrollOffset), m_ContentSize);
 	if(ShouldScrollHere)
 		ScrollHere();
 	return !RectClipped(Rect);
@@ -210,8 +247,12 @@ bool CScrollRegion::AddRect(const CUIRect &Rect, bool ShouldScrollHere)
 
 void CScrollRegion::ScrollHere(EScrollOption Option)
 {
-	const float MinHeight = minimum(m_ClipRect.h, m_LastAddedRect.h);
-	const float TopScroll = m_LastAddedRect.y - (m_ClipRect.y + m_ContentScrollOffset);
+	const float ClipPos = m_Params.m_ScrollHorizontal ? m_ClipRect.x : m_ClipRect.y;
+	const float ClipSize = m_Params.m_ScrollHorizontal ? m_ClipRect.w : m_ClipRect.h;
+	const float LastAddedPos = m_Params.m_ScrollHorizontal ? m_LastAddedRect.x : m_LastAddedRect.y;
+	const float LastAddedSize = m_Params.m_ScrollHorizontal ? m_LastAddedRect.w : m_LastAddedRect.h;
+	const float MinHeight = minimum(ClipSize, LastAddedSize);
+	const float TopScroll = LastAddedPos - (ClipPos + m_ContentScrollOffset);
 
 	switch(Option)
 	{
@@ -220,16 +261,16 @@ void CScrollRegion::ScrollHere(EScrollOption Option)
 		break;
 
 	case SCROLLHERE_BOTTOM:
-		m_RequestScrollPos = TopScroll - (m_ClipRect.h - MinHeight);
+		m_RequestScrollPos = TopScroll - (ClipSize - MinHeight);
 		break;
 
 	case SCROLLHERE_KEEP_IN_VIEW:
 	default:
-		const float DeltaY = m_LastAddedRect.y - m_ClipRect.y;
+		const float DeltaY = LastAddedPos - ClipPos;
 		if(DeltaY < 0)
 			m_RequestScrollPos = TopScroll;
-		else if(DeltaY > (m_ClipRect.h - MinHeight))
-			m_RequestScrollPos = TopScroll - (m_ClipRect.h - MinHeight);
+		else if(DeltaY > (ClipSize - MinHeight))
+			m_RequestScrollPos = TopScroll - (ClipSize - MinHeight);
 		break;
 	}
 }
@@ -242,7 +283,8 @@ void CScrollRegion::ScrollRelative(EScrollRelative Direction, float SpeedMultipl
 
 void CScrollRegion::ScrollRelativeDirect(float ScrollAmount)
 {
-	m_RequestScrollPos = std::clamp(m_ScrollPos + ScrollAmount, 0.0f, m_ContentSize - m_ClipRect.h);
+	const float ClipSize = m_Params.m_ScrollHorizontal ? m_ClipRect.w : m_ClipRect.h;
+	m_RequestScrollPos = std::clamp(m_ScrollPos + ScrollAmount, 0.0f, m_ContentSize - ClipSize);
 }
 
 void CScrollRegion::DoEdgeScrolling()
@@ -250,15 +292,18 @@ void CScrollRegion::DoEdgeScrolling()
 	if(!ScrollbarShown())
 		return;
 
+	const float ClipPos = m_Params.m_ScrollHorizontal ? m_ClipRect.x : m_ClipRect.y;
+	const float ClipSize = m_Params.m_ScrollHorizontal ? m_ClipRect.w : m_ClipRect.h;
 	const float ScrollBorderSize = 20.0f;
 	const float MaxScrollMultiplier = 2.0f;
 	const float ScrollSpeedFactor = MaxScrollMultiplier / ScrollBorderSize;
-	const float TopScrollPosition = m_ClipRect.y + ScrollBorderSize;
-	const float BottomScrollPosition = m_ClipRect.y + m_ClipRect.h - ScrollBorderSize;
-	if(Ui()->MouseY() < TopScrollPosition)
-		ScrollRelative(SCROLLRELATIVE_UP, minimum(MaxScrollMultiplier, (TopScrollPosition - Ui()->MouseY()) * ScrollSpeedFactor));
-	else if(Ui()->MouseY() > BottomScrollPosition)
-		ScrollRelative(SCROLLRELATIVE_DOWN, minimum(MaxScrollMultiplier, (Ui()->MouseY() - BottomScrollPosition) * ScrollSpeedFactor));
+	const float TopScrollPosition = ClipPos + ScrollBorderSize;
+	const float BottomScrollPosition = ClipPos + ClipSize - ScrollBorderSize;
+	const float MousePos = m_Params.m_ScrollHorizontal ? Ui()->MouseX() : Ui()->MouseY();
+	if(MousePos < TopScrollPosition)
+		ScrollRelative(SCROLLRELATIVE_UP, minimum(MaxScrollMultiplier, (TopScrollPosition - MousePos) * ScrollSpeedFactor));
+	else if(MousePos > BottomScrollPosition)
+		ScrollRelative(SCROLLRELATIVE_DOWN, minimum(MaxScrollMultiplier, (MousePos - BottomScrollPosition) * ScrollSpeedFactor));
 }
 
 bool CScrollRegion::RectClipped(const CUIRect &Rect) const
@@ -268,7 +313,7 @@ bool CScrollRegion::RectClipped(const CUIRect &Rect) const
 
 bool CScrollRegion::ScrollbarShown() const
 {
-	return m_ContentSize > m_ClipRect.h;
+	return m_Params.m_ScrollHorizontal ? m_ContentSize > m_ClipRect.w : m_ContentSize > m_ClipRect.h;
 }
 
 bool CScrollRegion::Animating() const

--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -142,7 +142,7 @@ public:
 	bool AddRect(const CUIRect &Rect, bool ShouldScrollHere = false); // returns true if the added rect is visible (not clipped)
 	void ScrollHere(EScrollOption Option = SCROLLHERE_KEEP_IN_VIEW);
 	void ScrollRelative(EScrollRelative Direction, float SpeedMultiplier = 1.0f);
-	void ScrollRelativeDirect(float ScrollAmount);
+	void ScrollRelativeDirect(vec2 ScrollAmount);
 	void DoEdgeScrolling();
 	bool RectClipped(const CUIRect &Rect) const;
 	bool ContentOverflows() const;

--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -19,6 +19,7 @@ struct CScrollRegionParams
 	ColorRGBA m_SliderColorHover;
 	ColorRGBA m_SliderColorGrabbed;
 	bool m_ForceShowScrollbar;
+	bool m_ScrollHorizontal;
 
 	CScrollRegionParams()
 	{
@@ -34,6 +35,7 @@ struct CScrollRegionParams
 		m_SliderColorHover = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
 		m_SliderColorGrabbed = ColorRGBA(0.9f, 0.9f, 0.9f, 1.0f);
 		m_ForceShowScrollbar = false;
+		m_ScrollHorizontal = false;
 	}
 
 	ColorRGBA SliderColor(bool Active, bool Hovered) const

--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -151,6 +151,9 @@ public:
 	bool Active() const;
 
 private:
+	float ContentAreaPos() const;
+	float ContentAreaSize() const;
+	float MaxScroll() const;
 	CUIRect SplitContentArea();
 	void DrawBackground(const CUIRect &ScrollbarBg);
 	void DoScrollInput();

--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -143,14 +143,12 @@ public:
 	void ScrollHere(EScrollOption Option = SCROLLHERE_KEEP_IN_VIEW);
 	void ScrollRelative(EScrollRelative Direction, float SpeedMultiplier = 1.0f);
 	void ScrollRelativeDirect(float ScrollAmount);
-	const CUIRect *ClipRect() const { return &m_ClipRect; }
 	void DoEdgeScrolling();
 	bool RectClipped(const CUIRect &Rect) const;
 	bool ContentOverflows() const;
 	bool ScrollbarShown() const;
 	bool Animating() const;
 	bool Active() const;
-	const CScrollRegionParams &Params() const { return m_Params; }
 };
 
 #endif

--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -151,6 +151,7 @@ public:
 	bool Active() const;
 
 private:
+	CUIRect SplitContentArea();
 	void DoScrollInput();
 	void UpdateHotScrollRegion();
 	void AdvanceAnimation();

--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -146,6 +146,7 @@ public:
 	const CUIRect *ClipRect() const { return &m_ClipRect; }
 	void DoEdgeScrolling();
 	bool RectClipped(const CUIRect &Rect) const;
+	bool ContentOverflows() const;
 	bool ScrollbarShown() const;
 	bool Animating() const;
 	bool Active() const;

--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -7,10 +7,10 @@
 
 struct CScrollRegionParams
 {
-	float m_ScrollbarWidth;
+	float m_ScrollbarThickness;
 	float m_ScrollbarMargin;
-	bool m_ScrollbarNoMarginRight;
-	float m_SliderMinHeight;
+	bool m_ScrollbarNoOuterMargin;
+	float m_SliderMinSize;
 	float m_ScrollUnit;
 	ColorRGBA m_ClipBgColor;
 	ColorRGBA m_ScrollbarBgColor;
@@ -22,10 +22,10 @@ struct CScrollRegionParams
 
 	CScrollRegionParams()
 	{
-		m_ScrollbarWidth = 20.0f;
+		m_ScrollbarThickness = 20.0f;
 		m_ScrollbarMargin = 5.0f;
-		m_ScrollbarNoMarginRight = false;
-		m_SliderMinHeight = 25.0f;
+		m_ScrollbarNoOuterMargin = false;
+		m_SliderMinSize = 25.0f;
 		m_ScrollUnit = 10.0f;
 		m_ClipBgColor = ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f);
 		m_ScrollbarBgColor = ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f);
@@ -106,16 +106,16 @@ public:
 	};
 
 private:
-	float m_ScrollY;
-	float m_ContentH;
-	float m_RequestScrollY; // [0, ContentHeight]
+	float m_ScrollPos;
+	float m_ContentSize;
+	float m_RequestScrollPos; // [0, ContentSize]
 	EScrollRelative m_ScrollDirection;
 	float m_ScrollSpeedMultiplier;
 
 	float m_AnimTimeMax;
 	float m_AnimTime;
-	float m_AnimInitScrollY;
-	float m_AnimTargetScrollY;
+	float m_AnimInitScrollPos;
+	float m_AnimTargetScrollPos;
 
 	CUIRect m_ClipRect;
 	CUIRect m_RailRect;

--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -121,7 +121,7 @@ private:
 	CUIRect m_RailRect;
 	CUIRect m_LastAddedRect; // saved for ScrollHere()
 	float m_SliderGrabPos; // where did user grab the slider
-	vec2 m_ContentScrollOff;
+	float m_ContentScrollOffset;
 	CScrollRegionParams m_Params;
 
 public:

--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -152,6 +152,7 @@ public:
 
 private:
 	CUIRect SplitContentArea();
+	void DrawBackground(const CUIRect &ScrollbarBg);
 	void DoScrollInput();
 	void UpdateHotScrollRegion();
 	void AdvanceAnimation();

--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -149,6 +149,12 @@ public:
 	bool ScrollbarShown() const;
 	bool Animating() const;
 	bool Active() const;
+
+private:
+	void DoScrollInput();
+	void UpdateHotScrollRegion();
+	void AdvanceAnimation();
+	void DoSlider();
 };
 
 #endif

--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -18,12 +18,7 @@ struct CScrollRegionParams
 	ColorRGBA m_SliderColor;
 	ColorRGBA m_SliderColorHover;
 	ColorRGBA m_SliderColorGrabbed;
-	unsigned m_Flags;
-
-	enum
-	{
-		FLAG_CONTENT_STATIC_WIDTH = 1 << 0,
-	};
+	bool m_ForceShowScrollbar;
 
 	CScrollRegionParams()
 	{
@@ -38,7 +33,7 @@ struct CScrollRegionParams
 		m_SliderColor = ColorRGBA(0.8f, 0.8f, 0.8f, 1.0f);
 		m_SliderColorHover = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
 		m_SliderColorGrabbed = ColorRGBA(0.9f, 0.9f, 0.9f, 1.0f);
-		m_Flags = 0;
+		m_ForceShowScrollbar = false;
 	}
 
 	ColorRGBA SliderColor(bool Active, bool Hovered) const

--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -119,7 +119,7 @@ private:
 	float m_AnimInitScrollPos;
 	float m_AnimTargetScrollPos;
 
-	CUIRect m_ClipRect;
+	CUIRect m_ContentAreaRect;
 	CUIRect m_RailRect;
 	CUIRect m_LastAddedRect; // saved for ScrollHere()
 	float m_SliderGrabPos; // where did user grab the slider

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2236,7 +2236,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 	CUIRect UnscrolledLayersBox = LayersBox;
 
 	CScrollRegionParams ScrollParams;
-	ScrollParams.m_ScrollbarWidth = 10.0f;
+	ScrollParams.m_ScrollbarThickness = 10.0f;
 	ScrollParams.m_ScrollbarMargin = 3.0f;
 	ScrollParams.m_ScrollUnit = RowHeight * 5.0f;
 	State.m_ScrollRegion.Begin(&LayersBox, &ScrollParams);
@@ -3123,7 +3123,7 @@ void CEditor::RenderImagesList(CUIRect ToolBox)
 
 	static CScrollRegion s_ScrollRegion;
 	CScrollRegionParams ScrollParams;
-	ScrollParams.m_ScrollbarWidth = 10.0f;
+	ScrollParams.m_ScrollbarThickness = 10.0f;
 	ScrollParams.m_ScrollbarMargin = 3.0f;
 	ScrollParams.m_ScrollUnit = RowHeight * 5;
 	s_ScrollRegion.Begin(&ToolBox, &ScrollParams);
@@ -3256,7 +3256,7 @@ void CEditor::RenderSounds(CUIRect ToolBox)
 
 	static CScrollRegion s_ScrollRegion;
 	CScrollRegionParams ScrollParams;
-	ScrollParams.m_ScrollbarWidth = 10.0f;
+	ScrollParams.m_ScrollbarThickness = 10.0f;
 	ScrollParams.m_ScrollbarMargin = 3.0f;
 	ScrollParams.m_ScrollUnit = RowHeight * 5;
 	s_ScrollRegion.Begin(&ToolBox, &ScrollParams);


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

Add support for vertical scrolling needed for #11776.

The screenshot uses a slightly modified version, using a horizontal scrollbar but still vertical scroll:
<img width="1920" height="1011" alt="screenshot_2026-05-17_09-22-22" src="https://github.com/user-attachments/assets/582646c8-7348-4830-bce8-c2ba037efb2c" />

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
