### PR TITLE
Fix uninitialized bouncing variable causing projectile glitches

### DIFF
--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -37,6 +37,7 @@ CProjectile::CProjectile(
 
 	m_Layer = Layer;
 	m_Number = Number;
+	m_Bouncing = 0;
 	m_Freeze = Freeze;
 
 	m_TuneZone = GameWorld()->m_WorldConfig.m_UseTuneZones ? Collision()->IsTune(Collision()->GetMapIndex(m_Pos)) : 0;

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -38,6 +38,7 @@ CProjectile::CProjectile(
 
 	m_Layer = Layer;
 	m_Number = Number;
+	m_Bouncing = 0;
 	m_Freeze = Freeze;
 
 	m_InitDir = InitDir;


### PR DESCRIPTION
Closed #12184

The variable m_Bouncing was not initialized. So in release build I would get super high values for it on one specific device. This would cause projectiles to get stuck when hitting collision until the end of their lifetime. I noticed this with the gun bullet in a fork so I had a bit of a tunnel vision on that. But after finding the fix I wondered if this is a physics affecting change for ddnet and yes in theory it is. This grenade glitch is no longer possible. But I doubt any mapper was using it (would have been trending on tiktok lel).
So I don't think the fix changes physics label or teehistorian bump fit here because production servers were probably never affected by this.

https://github.com/user-attachments/assets/48f5bfd8-0ce8-4df6-a871-3d02aa8da0b3

I checked the other variables and it seems like m_Bouncing was the only one that is not set in the constructor. [The current style guide](https://github.com/ddnet/ddnet/blob/f2b60b402f02367631d6f2d4271a2422ebb2ee92/docs/CONTRIBUTING.md#class-member-variables-should-be-initialized-where-they-are-declared) would dictate to set it in the header instead of the constructor. But that would cause either inconsistent code or a bigger diff. Not something I want to do in a bug fix pr.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
