### PR TITLE
Keep state of `CProofMode` separate for each map

### DIFF
--- a/src/game/editor/map_view.cpp
+++ b/src/game/editor/map_view.cpp
@@ -31,11 +31,6 @@ void CMapView::OnInit(CEditor *pEditor)
 	InitSubComponents();
 }
 
-void CMapView::OnReset()
-{
-	m_ProofMode.OnReset();
-}
-
 void CMapView::OnMapLoad()
 {
 	m_ProofMode.OnMapLoad();

--- a/src/game/editor/map_view.h
+++ b/src/game/editor/map_view.h
@@ -42,7 +42,6 @@ public:
 	};
 
 	void OnInit(CEditor *pEditor) override;
-	void OnReset() override;
 	void OnMapLoad() override;
 
 	void ZoomMouseTarget(float ZoomFactor);

--- a/src/game/editor/mapitems/map.cpp
+++ b/src/game/editor/mapitems/map.cpp
@@ -92,6 +92,7 @@ void CEditorMap::Clean()
 
 	m_MapViewState.Reset(Editor());
 	m_MapGridState.Reset();
+	m_ProofModeState.Reset();
 	m_QuadKnifeState.Reset();
 }
 

--- a/src/game/editor/mapitems/map.h
+++ b/src/game/editor/mapitems/map.h
@@ -15,6 +15,7 @@
 #include <game/editor/map_view.h>
 #include <game/editor/mapitems/envelope.h>
 #include <game/editor/mapitems/layer.h>
+#include <game/editor/proof_mode.h>
 #include <game/editor/quad_art.h>
 #include <game/editor/quad_knife.h>
 
@@ -162,6 +163,7 @@ public:
 	// Component states
 	CMapView::CState m_MapViewState;
 	CMapGrid::CState m_MapGridState;
+	CProofMode::CState m_ProofModeState;
 	CQuadKnife::CState m_QuadKnifeState;
 
 	// Housekeeping

--- a/src/game/editor/proof_mode.cpp
+++ b/src/game/editor/proof_mode.cpp
@@ -4,18 +4,18 @@
 
 #include <game/client/components/menu_background.h>
 
+void CProofMode::CState::Reset()
+{
+	m_ProofBorders = EProofBorder::OFF;
+	m_CurrentMenuProofIndex = 0;
+	m_vMenuBackgroundPositions.clear();
+	m_vvMenuBackgroundCollisions.clear();
+}
+
 void CProofMode::OnInit(CEditor *pEditor)
 {
 	CEditorComponent::OnInit(pEditor);
 	InitMenuBackgroundPositionNames();
-	OnReset();
-	OnMapLoad();
-}
-
-void CProofMode::OnReset()
-{
-	m_ProofBorders = EProofBorder::OFF;
-	m_CurrentMenuProofIndex = 0;
 }
 
 void CProofMode::OnMapLoad()
@@ -56,8 +56,9 @@ void CProofMode::InitMenuBackgroundPositionNames()
 
 void CProofMode::InitMenuBackgroundPositions()
 {
+	CState &State = Map()->m_ProofModeState;
 	std::array<vec2, CMenuBackground::NUM_POS> aBackgroundPositions = GenerateMenuBackgroundPositions();
-	m_vMenuBackgroundPositions.assign(aBackgroundPositions.begin(), aBackgroundPositions.end());
+	State.m_vMenuBackgroundPositions.assign(aBackgroundPositions.begin(), aBackgroundPositions.end());
 
 	if(Map()->m_pGameLayer)
 	{
@@ -69,7 +70,7 @@ void CProofMode::InitMenuBackgroundPositions()
 				if(Tile.m_Index >= TILE_TIME_CHECKPOINT_FIRST && Tile.m_Index <= TILE_TIME_CHECKPOINT_LAST)
 				{
 					int ArrayIndex = std::clamp<int>((Tile.m_Index - TILE_TIME_CHECKPOINT_FIRST), 0, CMenuBackground::NUM_POS);
-					m_vMenuBackgroundPositions[ArrayIndex] = vec2(x * 32.0f + 16.0f, y * 32.0f + 16.0f);
+					State.m_vMenuBackgroundPositions[ArrayIndex] = vec2(x * 32.0f + 16.0f, y * 32.0f + 16.0f);
 				}
 
 				x += Tile.m_Skip;
@@ -77,14 +78,14 @@ void CProofMode::InitMenuBackgroundPositions()
 		}
 	}
 
-	m_vvMenuBackgroundCollisions.clear();
-	m_vvMenuBackgroundCollisions.resize(m_vMenuBackgroundPositions.size());
-	for(size_t i = 0; i < m_vMenuBackgroundPositions.size(); i++)
+	State.m_vvMenuBackgroundCollisions.clear();
+	State.m_vvMenuBackgroundCollisions.resize(State.m_vMenuBackgroundPositions.size());
+	for(size_t i = 0; i < State.m_vMenuBackgroundPositions.size(); i++)
 	{
-		for(size_t j = i + 1; j < m_vMenuBackgroundPositions.size(); j++)
+		for(size_t j = i + 1; j < State.m_vMenuBackgroundPositions.size(); j++)
 		{
-			if(i != j && distance(m_vMenuBackgroundPositions[i], m_vMenuBackgroundPositions[j]) < 0.001f)
-				m_vvMenuBackgroundCollisions.at(i).push_back(j);
+			if(i != j && distance(State.m_vMenuBackgroundPositions[i], State.m_vMenuBackgroundPositions[j]) < 0.001f)
+				State.m_vvMenuBackgroundCollisions.at(i).push_back(j);
 		}
 	}
 }
@@ -209,52 +210,52 @@ void CProofMode::RenderScreenSizes()
 
 bool CProofMode::IsEnabled() const
 {
-	return m_ProofBorders != EProofBorder::OFF;
+	return Map()->m_ProofModeState.m_ProofBorders != EProofBorder::OFF;
 }
 
 bool CProofMode::IsModeMenu() const
 {
-	return m_ProofBorders == EProofBorder::MENU;
+	return Map()->m_ProofModeState.m_ProofBorders == EProofBorder::MENU;
 }
 
 bool CProofMode::IsModeIngame() const
 {
-	return m_ProofBorders == EProofBorder::INGAME;
+	return Map()->m_ProofModeState.m_ProofBorders == EProofBorder::INGAME;
 }
 
 void CProofMode::Toggle()
 {
-	m_ProofBorders = m_ProofBorders == EProofBorder::OFF ? EProofBorder::INGAME : EProofBorder::OFF;
+	Map()->m_ProofModeState.m_ProofBorders = Map()->m_ProofModeState.m_ProofBorders == EProofBorder::OFF ? EProofBorder::INGAME : EProofBorder::OFF;
 }
 
 void CProofMode::SetModeIngame()
 {
-	m_ProofBorders = EProofBorder::INGAME;
+	Map()->m_ProofModeState.m_ProofBorders = EProofBorder::INGAME;
 }
 
 void CProofMode::SetModeMenu()
 {
-	m_ProofBorders = EProofBorder::MENU;
+	Map()->m_ProofModeState.m_ProofBorders = EProofBorder::MENU;
 }
 
 int CProofMode::CurrentMenuProofIndex() const
 {
-	return m_CurrentMenuProofIndex;
+	return Map()->m_ProofModeState.m_CurrentMenuProofIndex;
 }
 
 void CProofMode::SetCurrentMenuProofIndex(int MenuProofIndex)
 {
-	m_CurrentMenuProofIndex = MenuProofIndex;
+	Map()->m_ProofModeState.m_CurrentMenuProofIndex = MenuProofIndex;
 }
 
 const std::vector<vec2> &CProofMode::MenuBackgroundPositions() const
 {
-	return m_vMenuBackgroundPositions;
+	return Map()->m_ProofModeState.m_vMenuBackgroundPositions;
 }
 
 vec2 CProofMode::CurrentMenuBackgroundPosition() const
 {
-	return m_vMenuBackgroundPositions[CurrentMenuProofIndex()];
+	return Map()->m_ProofModeState.m_vMenuBackgroundPositions[CurrentMenuProofIndex()];
 }
 
 const char *CProofMode::MenuBackgroundPositionName(int MenuProofIndex) const
@@ -264,5 +265,5 @@ const char *CProofMode::MenuBackgroundPositionName(int MenuProofIndex) const
 
 const std::vector<int> &CProofMode::MenuBackgroundCollisions(int MenuProofIndex) const
 {
-	return m_vvMenuBackgroundCollisions[MenuProofIndex];
+	return Map()->m_ProofModeState.m_vvMenuBackgroundCollisions[MenuProofIndex];
 }

--- a/src/game/editor/proof_mode.h
+++ b/src/game/editor/proof_mode.h
@@ -10,8 +10,25 @@
 class CProofMode : public CEditorComponent
 {
 public:
+	enum class EProofBorder
+	{
+		OFF,
+		INGAME,
+		MENU,
+	};
+	class CState
+	{
+	public:
+		EProofBorder m_ProofBorders;
+		int m_CurrentMenuProofIndex;
+
+		std::vector<vec2> m_vMenuBackgroundPositions;
+		std::vector<std::vector<int>> m_vvMenuBackgroundCollisions;
+
+		void Reset();
+	};
+
 	void OnInit(CEditor *pEditor) override;
-	void OnReset() override;
 	void OnMapLoad() override;
 	void RenderScreenSizes();
 
@@ -30,18 +47,7 @@ public:
 	void InitMenuBackgroundPositions();
 
 private:
-	enum class EProofBorder
-	{
-		OFF,
-		INGAME,
-		MENU,
-	};
-	EProofBorder m_ProofBorders;
-
-	int m_CurrentMenuProofIndex;
-	std::vector<vec2> m_vMenuBackgroundPositions;
 	std::vector<const char *> m_vpMenuBackgroundPositionNames;
-	std::vector<std::vector<int>> m_vvMenuBackgroundCollisions;
 
 	void InitMenuBackgroundPositionNames();
 };


### PR DESCRIPTION
Required for #11776.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions