### PR TITLE
feat(server): collapse redundant freeze condition in SnapCharacter

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1086,11 +1086,8 @@ void CCharacter::SnapCharacter(int SnappingClient, int Id)
 	}
 
 	// use ninja graphic for old clients if player is frozen
-	if(m_Core.m_DeepFrozen || m_FreezeTime > 0 || m_Core.m_LiveFrozen)
-	{
-		if((m_Core.m_DeepFrozen || m_FreezeTime > 0) && SnappingClientVersion < VERSION_DDNET_NEW_HUD)
-			Weapon = WEAPON_NINJA;
-	}
+	if((m_Core.m_DeepFrozen || m_FreezeTime > 0) && SnappingClientVersion < VERSION_DDNET_NEW_HUD)
+		Weapon = WEAPON_NINJA;
 
 	// solo, collision, jetpack and ninjajetpack prediction
 	if(m_pPlayer->GetCid() == SnappingClient)


### PR DESCRIPTION
Closes #12168. The outer `if` in `SnapCharacter` is redundant since the nested condition strictly implies it, so this collapses both into a single check with no behavior change.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

This is a pure boolean simplification with no physics or array-indexing changes. An AI assistant helped identify the redundant condition; I reviewed and verified the resulting logic is equivalent.
