### PR TITLE
When changing animation speed adjust start time to avoid jumps

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -405,7 +405,7 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 		if(DoButton_FontIcon(&s_AnimateButton, FontIcon::CIRCLE_PLAY, m_Animate, &Button, BUTTONFLAG_LEFT, "[Ctrl+M] Toggle animation.", IGraphics::CORNER_L) ||
 			(m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && Input()->KeyPress(KEY_M) && ModPressed))
 		{
-			m_AnimateStart = time_get();
+			m_AnimateStart = Client()->GlobalTime();
 			m_Animate = !m_Animate;
 		}
 
@@ -4869,7 +4869,7 @@ void CEditor::OnRender()
 		m_ShowMousePointer = false;
 
 	if(m_Animate)
-		m_AnimateTime = (time_get() - m_AnimateStart) / (float)time_freq();
+		m_AnimateTime = Client()->GlobalTime() - m_AnimateStart;
 	else
 		m_AnimateTime = 0;
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -231,9 +231,9 @@ public:
 		m_ShowTileInfo = SHOW_TILE_OFF;
 		m_ShowDetail = true;
 		m_Animate = false;
-		m_AnimateStart = 0;
-		m_AnimateTime = 0;
-		m_AnimateSpeed = 1;
+		m_AnimateStart = 0.0f;
+		m_AnimateTime = 0.0f;
+		m_AnimateSpeed = 1.0f;
 		m_AnimateUpdatePopup = false;
 
 		for(size_t i = 0; i < std::size(m_aSavedColors); ++i)
@@ -440,7 +440,7 @@ public:
 	bool m_ShowDetail;
 
 	bool m_Animate;
-	int64_t m_AnimateStart;
+	float m_AnimateStart;
 	float m_AnimateTime;
 	float m_AnimateSpeed;
 	bool m_AnimateUpdatePopup;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -2749,6 +2749,8 @@ CUi::EPopupMenuFunctionResult CEditor::PopupAnimateSettings(void *pContext, CUIR
 	View.HSplitBottom(12.0f, &View, &ButtonReset);
 	pEditor->Ui()->DoLabel(&Label, "Speed", 10.0f, TEXTALIGN_ML);
 
+	const float OldAnimateSpeed = pEditor->m_AnimateSpeed;
+
 	static char s_DecreaseButton;
 	if(pEditor->DoButton_FontIcon(&s_DecreaseButton, FontIcon::MINUS, 0, &ButtonDecrease, BUTTONFLAG_LEFT, "Decrease animation speed.", IGraphics::CORNER_L, 7.0f))
 	{
@@ -2786,6 +2788,11 @@ CUi::EPopupMenuFunctionResult CEditor::PopupAnimateSettings(void *pContext, CUIR
 	{
 		pEditor->m_AnimateSpeed = std::clamp(s_SpeedInput.GetFloat(), MIN_ANIM_SPEED, MAX_ANIM_SPEED);
 	}
+
+	// adjust start time to avoid jumps in animation
+	float AnimateSpeedRatio = OldAnimateSpeed / pEditor->m_AnimateSpeed;
+	float Time = pEditor->Client()->GlobalTime();
+	pEditor->m_AnimateStart = Time + (pEditor->m_AnimateStart - Time) * AnimateSpeedRatio;
 
 	return CUi::POPUP_KEEP_OPEN;
 }


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

After:

https://github.com/user-attachments/assets/57d168ef-de9a-46d8-99da-eccac4058b81

Before:

https://github.com/user-attachments/assets/43d529ff-a949-462c-8079-ba5ea2e182d5

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
