### PR TITLE
Fix client crash on draggers with invalid switch number

### DIFF
--- a/src/game/client/prediction/entities/dragger.cpp
+++ b/src/game/client/prediction/entities/dragger.cpp
@@ -50,7 +50,9 @@ void CDragger::LookForPlayersToDrag()
 			continue;
 		}
 		// If the dragger is disabled for the target's team, no dragger beam will be generated
-		if(m_Layer == LAYER_SWITCH && m_Number > 0 &&
+		if(m_Layer == LAYER_SWITCH &&
+			m_Number > 0 &&
+			m_Number < (int)Switchers().size() &&
 			!Switchers()[m_Number].m_aStatus[TargetTeam])
 		{
 			continue;
@@ -100,7 +102,9 @@ void CDragger::DraggerBeamTick()
 
 	if(GameWorld()->GameTick() % (int)(GameWorld()->GameTickSpeed() * 0.15f) == 0)
 	{
-		if(m_Layer == LAYER_SWITCH && m_Number > 0 &&
+		if(m_Layer == LAYER_SWITCH &&
+			m_Number > 0 &&
+			m_Number < (int)Switchers().size() &&
 			!Switchers()[m_Number].m_aStatus[pTarget->Team()])
 		{
 			DraggerBeamReset();


### PR DESCRIPTION
For projectiles and pickups the switch number is already checked.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions