### PR TITLE
Significantly reduce server memory usage especially for large maps

### DIFF
--- a/src/game/client/components/background.cpp
+++ b/src/game/client/components/background.cpp
@@ -67,7 +67,7 @@ void CBackground::LoadBackground()
 		}
 		else if(m_pMap->Load(g_Config.m_ClBackgroundEntities, Storage(), aBuf, IStorage::TYPE_ALL))
 		{
-			m_pLayers->Init(m_pMap, true);
+			m_pLayers->Init(m_pMap, true, true);
 			NeedImageLoading = true;
 			m_Loaded = true;
 		}

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -259,7 +259,7 @@ void CMenuBackground::LoadMenuBackground(bool HasDayHint, bool HasNightHint)
 
 		if(m_Loaded)
 		{
-			m_pLayers->Init(m_pMap, true);
+			m_pLayers->Init(m_pMap, true, true);
 
 			m_pImages->LoadBackground(m_pLayers, m_pMap);
 			CMapLayers::OnMapLoad();

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -585,7 +585,7 @@ void CGameClient::OnConnected()
 	const char *pLoadMapContent = Localize("Initializing map logic");
 	// render loading before skip is calculated
 	m_Menus.RenderLoading(pConnectCaption, pLoadMapContent, 0);
-	m_Layers.Init(Map(), false);
+	m_Layers.Init(Map(), false, true);
 	m_Collision.Init(Layers());
 	m_GameWorld.m_Core.InitSwitchers(m_Collision.m_HighestSwitchNumber);
 	m_GameWorld.m_PredictedEvents.clear();

--- a/src/game/layers.cpp
+++ b/src/game/layers.cpp
@@ -11,7 +11,7 @@ CLayers::CLayers()
 	Unload();
 }
 
-void CLayers::Init(IMap *pMap, bool GameOnly)
+void CLayers::Init(IMap *pMap, bool GameOnly, bool InitializeTilemapSkip)
 {
 	Unload();
 
@@ -115,7 +115,10 @@ void CLayers::Init(IMap *pMap, bool GameOnly)
 		}
 	}
 
-	InitTilemapSkip();
+	if(InitializeTilemapSkip)
+	{
+		InitTilemapSkip(GameOnly);
+	}
 }
 
 void CLayers::Unload()
@@ -136,7 +139,7 @@ void CLayers::Unload()
 	m_pTuneLayer = nullptr;
 }
 
-void CLayers::InitTilemapSkip()
+void CLayers::InitTilemapSkip(bool GameOnly)
 {
 	for(int GroupIndex = 0; GroupIndex < NumGroups(); GroupIndex++)
 	{
@@ -148,6 +151,9 @@ void CLayers::InitTilemapSkip()
 				continue;
 
 			const CMapItemLayerTilemap *pTilemap = reinterpret_cast<const CMapItemLayerTilemap *>(pLayer);
+			if(GameOnly && (pTilemap->m_Flags & (TILESLAYERFLAG_TELE | TILESLAYERFLAG_SPEEDUP | TILESLAYERFLAG_FRONT | TILESLAYERFLAG_SWITCH | TILESLAYERFLAG_TUNE)) != 0)
+				continue;
+
 			CTile *pTiles = static_cast<CTile *>(m_pMap->GetData(pTilemap->m_Data));
 			for(int y = 0; y < pTilemap->m_Height; y++)
 			{

--- a/src/game/layers.h
+++ b/src/game/layers.h
@@ -13,7 +13,7 @@ class CLayers
 {
 public:
 	CLayers();
-	void Init(IMap *pMap, bool GameOnly);
+	void Init(IMap *pMap, bool GameOnly, bool InitializeTilemapSkip);
 	void Unload();
 
 	int NumGroups() const { return m_GroupsNum; }
@@ -48,7 +48,7 @@ private:
 	CMapItemLayerTilemap *m_pSwitchLayer;
 	CMapItemLayerTilemap *m_pTuneLayer;
 
-	void InitTilemapSkip();
+	void InitTilemapSkip(bool GameOnly);
 };
 
 #endif

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4184,7 +4184,7 @@ void CGameContext::OnInit(const void *pPersistentData)
 		Server()->SnapSetStaticsize7(i, m_NetObjHandler7.GetObjSize(i));
 	}
 
-	m_Layers.Init(Map(), false);
+	m_Layers.Init(Map(), false, false);
 	m_Collision.Init(&m_Layers);
 	m_World.Init(&m_Collision, m_aTuningList);
 	m_MapBugs = CMapBugs::Create(Map()->BaseName(), Map()->Size(), Map()->Sha256());


### PR DESCRIPTION
Avoid loading the data of all design and physics tiles layers into memory to initialize the `CTile::m_Skip` values, which are not used on the server side.

Also avoid initializing the `CTile::m_Skip` values on the client side for non-game physics layers when the `GameOnly` parameter is `true` for ingame and menu background maps.

Memory usage comparison of an empty server with different maps:

| Map          | Before (MiB) | After (MiB) |
|--------------|--------------|-------------|
| Aardvark     | 24           | 19          |
| Nordic       | 43           | 22          |
| Until Dawn   | 869          | 130         |
| Springlobe 4 | 1133         | 168         |

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
