### PR TITLE
Fix Emscripten error handling in Firefox

### DIFF
--- a/other/emscripten/index.html
+++ b/other/emscripten/index.html
@@ -95,9 +95,11 @@
 			};
 			window.onerror = function(message, url, line, column, error) {
 				appendOutput(message, true, "red");
-				if (error) {
+				if (error && error.stack) {
 					for (const line of error.stack.split("\n")) {
-						appendOutput(line, false, "red");
+						if (line.length > 0) {
+							appendOutput(line, false, "red");
+						}
 					}
 				}
 				// Force stop audio processing because the client does not do so when force quit on


### PR DESCRIPTION
In Firefox, the `error.stack` value is not available for some errors, which was causing an error during the error handling.

Skip empty lines which are included in the stack trace in Firefox (when it is available).

## Checklist

- [X] Tested the change
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions