### PR TITLE
Add `data/languages/README.txt` to refer to Weblate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1512,6 +1512,7 @@ set(EXPECTED_DATA
   gui_icons.png
   gui_logo.png
   hud.png
+  languages/README.txt
   languages/arabic.txt
   languages/azerbaijani.txt
   languages/belarusian.txt

--- a/data/languages/README.txt
+++ b/data/languages/README.txt
@@ -1,0 +1,11 @@
+Files in this directory contain the translations of all strings used by the client.
+These files use an internal format and should NOT be changed to contribute translations.
+
+If you want to help translate: register on Weblate to contribute to the translation project.
+Link to DDNet translation project on Weblate: https://hosted.weblate.org/engage/ddnet/
+
+Refer to the Weblate documentation for an introduction into translating with Weblate.
+Link to Weblate documentation: https://docs.weblate.org/en/latest/index.html
+
+To suggest adding translation for another language: open an Issue on GitHub.
+Link to DDNet issue tracker on GitHub: https://github.com/ddnet/ddnet/issues


### PR DESCRIPTION
Closes #12202.

Text based on https://ddnet.org/news/client-translations/.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
