### PR TITLE
Reduce memory usage for door collision from 8 to 3 bytes per tile

### DIFF
--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -749,7 +749,7 @@ void CCharacter::HandleSkippableTiles(int Index)
 	}
 }
 
-bool CCharacter::IsSwitchActiveCb(int Number, void *pUser)
+bool CCharacter::IsSwitchActiveCb(unsigned char Number, void *pUser)
 {
 	CCharacter *pThis = (CCharacter *)pUser;
 	auto &aSwitchers = pThis->Switchers();

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -170,7 +170,7 @@ private:
 
 	// DDRace
 
-	static bool IsSwitchActiveCb(int Number, void *pUser);
+	static bool IsSwitchActiveCb(unsigned char Number, void *pUser);
 	void HandleTiles(int Index);
 	void HandleSkippableTiles(int Index);
 	void DDRaceTick();

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -302,7 +302,7 @@ int CCollision::GetMoveRestrictions(CALLBACK_SWITCHACTIVE pfnSwitchActive, void 
 		{
 			CDoorTile DoorTile;
 			GetDoorTile(ModMapIndex, &DoorTile);
-			if(in_range(DoorTile.m_Number, 0, m_HighestSwitchNumber) &&
+			if((int)DoorTile.m_Number <= m_HighestSwitchNumber &&
 				pfnSwitchActive(DoorTile.m_Number, pUser))
 			{
 				Restrictions |= ::GetMoveRestrictions(d, DoorTile.m_Index, DoorTile.m_Flags);
@@ -1087,7 +1087,7 @@ void CCollision::SetCollisionAt(float x, float y, int Index)
 	m_pTiles[Ny * m_Width + Nx].m_Index = Index;
 }
 
-void CCollision::SetDoorCollisionAt(float x, float y, int Type, int Flags, int Number)
+void CCollision::SetDoorCollisionAt(float x, float y, unsigned char Type, unsigned char Flags, unsigned char Number)
 {
 	if(!m_pDoor)
 		return;

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -56,7 +56,7 @@ public:
 
 	// DDRace
 	void SetCollisionAt(float x, float y, int Index);
-	void SetDoorCollisionAt(float x, float y, int Type, int Flags, int Number);
+	void SetDoorCollisionAt(float x, float y, unsigned char Type, unsigned char Flags, unsigned char Number);
 	void GetDoorTile(int Index, CDoorTile *pDoorTile) const;
 	int GetFrontCollisionAt(float x, float y) const { return GetFrontTile(round_to_int(x), round_to_int(y)); }
 	int IntersectNoLaser(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision) const;

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -28,7 +28,7 @@ enum
 
 vec2 ClampVel(int MoveRestriction, vec2 Vel);
 
-typedef bool (*CALLBACK_SWITCHACTIVE)(int Number, void *pUser);
+typedef bool (*CALLBACK_SWITCHACTIVE)(unsigned char Number, void *pUser);
 struct CAntibotMapData;
 
 class CCollision

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -729,7 +729,7 @@ void CCharacterCore::SetTeamsCore(CTeamsCore *pTeams)
 	m_pTeams = pTeams;
 }
 
-bool CCharacterCore::IsSwitchActiveCb(int Number, void *pUser)
+bool CCharacterCore::IsSwitchActiveCb(unsigned char Number, void *pUser)
 {
 	CCharacterCore *pThis = (CCharacterCore *)pUser;
 	if(pThis->m_pWorld && !pThis->m_pWorld->m_vSwitchers.empty())

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -277,7 +277,7 @@ private:
 	CTeamsCore *m_pTeams;
 	int m_MoveRestrictions;
 	int m_HookedPlayer;
-	static bool IsSwitchActiveCb(int Number, void *pUser);
+	static bool IsSwitchActiveCb(unsigned char Number, void *pUser);
 };
 
 // input count

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -661,7 +661,7 @@ class CDoorTile
 public:
 	unsigned char m_Index;
 	unsigned char m_Flags;
-	int m_Number;
+	unsigned char m_Number;
 };
 
 class CTuneTile

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1558,7 +1558,7 @@ void CCharacter::HandleSkippableTiles(int Index)
 	}
 }
 
-bool CCharacter::IsSwitchActiveCb(int Number, void *pUser)
+bool CCharacter::IsSwitchActiveCb(unsigned char Number, void *pUser)
 {
 	CCharacter *pThis = (CCharacter *)pUser;
 	auto &aSwitchers = pThis->Switchers();

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -169,7 +169,7 @@ private:
 	// DDRace
 
 	void SnapCharacter(int SnappingClient, int Id);
-	static bool IsSwitchActiveCb(int Number, void *pUser);
+	static bool IsSwitchActiveCb(unsigned char Number, void *pUser);
 	void SetTimeCheckpoint(int TimeCheckpoint);
 	void HandleTiles(int Index);
 	float m_Time;


### PR DESCRIPTION
The `CDoorTile::m_Number` member does not need to be an `int` because the `CSwitchTile::m_Number` member is an `unsigned char`. The `m_HighestSwitchNumber` is also only allowed to be in the range from 0 to 255.

Previously, the `CDoorTile` class also had two unused bytes for alignment of the `int m_Number` and therefore a total size of 8 bytes. Using `unsigned char m_Number` reduces the memory usage per tile to only 3 bytes.

The `CDoorTile` class is not used in the map format but only at runtime in `CCollision`, so the size and layout of the class can be changed without concerns for compatiblity.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions