### PR TITLE
Cleanup `CCollision::Init` switch/door/tele handling

### DIFF
--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -95,27 +95,30 @@ void CCollision::Init(class CLayers *pLayers)
 			m_pFront = static_cast<CTile *>(m_pLayers->Map()->GetData(m_pLayers->FrontLayer()->m_Front));
 	}
 
-	for(int i = 0; i < m_Width * m_Height; i++)
+	if(m_pSwitch)
 	{
-		int Index;
-		if(m_pSwitch)
+		for(int i = 0; i < m_Width * m_Height; i++)
 		{
 			if(m_pSwitch[i].m_Number > m_HighestSwitchNumber)
+			{
 				m_HighestSwitchNumber = m_pSwitch[i].m_Number;
+			}
 
-			if(m_pSwitch[i].m_Number)
-				m_pDoor[i].m_Number = m_pSwitch[i].m_Number;
-			else
-				m_pDoor[i].m_Number = 0;
+			m_pDoor[i].m_Number = m_pSwitch[i].m_Number;
 
-			Index = m_pSwitch[i].m_Type;
-
+			const unsigned char Index = m_pSwitch[i].m_Type;
 			if(Index <= TILE_NPH_ENABLE)
 			{
-				if((Index >= TILE_JUMP && Index <= TILE_SUBTRACT_TIME) || Index == TILE_ALLOW_TELE_GUN || Index == TILE_ALLOW_BLUE_TELE_GUN)
+				if((Index >= TILE_JUMP && Index <= TILE_SUBTRACT_TIME) ||
+					Index == TILE_ALLOW_TELE_GUN ||
+					Index == TILE_ALLOW_BLUE_TELE_GUN)
+				{
 					m_pSwitch[i].m_Type = Index;
+				}
 				else
+				{
 					m_pSwitch[i].m_Type = 0;
+				}
 			}
 		}
 	}
@@ -124,25 +127,26 @@ void CCollision::Init(class CLayers *pLayers)
 	{
 		for(int i = 0; i < m_Width * m_Height; i++)
 		{
-			int Number = m_pTele[i].m_Number;
-			int Type = m_pTele[i].m_Type;
-			if(Number > 0)
+			const unsigned char Number = m_pTele[i].m_Number;
+			const unsigned char Type = m_pTele[i].m_Type;
+			if(Number && Type)
 			{
+				const vec2 TelePos = vec2(i % m_Width * 32.0f + 16.0f, i / m_Width * 32.0f + 16.0f);
 				if(Type == TILE_TELEIN)
 				{
-					m_TeleIns[Number - 1].emplace_back(i % m_Width * 32.0f + 16.0f, i / m_Width * 32.0f + 16.0f);
+					m_TeleIns[Number - 1].push_back(TelePos);
 				}
 				else if(Type == TILE_TELEOUT)
 				{
-					m_TeleOuts[Number - 1].emplace_back(i % m_Width * 32.0f + 16.0f, i / m_Width * 32.0f + 16.0f);
+					m_TeleOuts[Number - 1].push_back(TelePos);
 				}
 				else if(Type == TILE_TELECHECKOUT)
 				{
-					m_TeleCheckOuts[Number - 1].emplace_back(i % m_Width * 32.0f + 16.0f, i / m_Width * 32.0f + 16.0f);
+					m_TeleCheckOuts[Number - 1].push_back(TelePos);
 				}
-				else if(Type)
+				else
 				{
-					m_TeleOthers[Number - 1].emplace_back(i % m_Width * 32.0f + 16.0f, i / m_Width * 32.0f + 16.0f);
+					m_TeleOthers[Number - 1].push_back(TelePos);
 				}
 			}
 		}


### PR DESCRIPTION
- Move `m_pSwitch` condition outside of loop to avoid unnecessary iterations.
- Remove unnecessary conditional assignment of `m_pDoor[i].m_Number = m_pSwitch[i].m_Number` or `0`.
- Split `Index` condition over multiple lines for readability.
- Move variable declarations closer to usages.
- Use `unsigned char` for switch type and tele number and type like for the underlying values.
- Add `TelePos` variable to avoid duplicate code.
- Use `const` variables.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions