### PR TITLE
 Build: Autoformat generated files if detecting clang-format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -585,6 +585,12 @@ else()
   set(VULKAN_INCLUDE_DIRS)
 endif()
 
+find_program(CLANG_FORMAT_BIN clang-format OPTIONAL)
+if(CLANG_FORMAT_BIN)
+  execute_process(COMMAND ${CLANG_FORMAT_BIN} --version OUTPUT_VARIABLE CLANG_FORMAT_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(CLANG_FORMAT_FOUND true)
+endif()
+
 message(STATUS "******** ${CMAKE_PROJECT_NAME} ********")
 set(TARGET "Target OS: ${TARGET_OS} ${CMAKE_SYSTEM_PROCESSOR}")
 if(TARGET_OS STREQUAL "mac")
@@ -780,6 +786,12 @@ else()
   else()
     set(PLATFORM_LIBS)
   endif()
+endif()
+
+message(STATUS "Optional:")
+show_dependency_status("clang-format" CLANG_FORMAT)
+if(CLANG_FORMAT_FOUND)
+  message(STATUS "clang-format version '${CLANG_FORMAT_VERSION}'")
 endif()
 
 ########################################################################
@@ -1962,9 +1974,16 @@ file(COPY ${COPY_DIRS} DESTINATION .)
 ########################################################################
 
 function(generate_source output_file script_parameter)
+  if(CLANG_FORMAT_BIN)
+    set(FORMAT_COMMAND
+      COMMAND ${CLANG_FORMAT_BIN} -i --verbose "${PROJECT_BINARY_DIR}/${output_file}"
+    )
+  endif()
+
   add_custom_command(OUTPUT ${output_file}
     COMMAND ${Python3_EXECUTABLE} datasrc/compile.py ${script_parameter}
       > "${PROJECT_BINARY_DIR}/${output_file}"
+    ${FORMAT_COMMAND}
     DEPENDS
       # tidy-alphabetical-start
       datasrc/compile.py


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

closes #12228

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->

I did brainstorm with AI what would be the best way to integrate this feature into our CMake file, but ended up with my own solution. Tested locally and automatically in the github pipeline. The idea, to put the FORMAT_COMMAND into a variable which is empty if CLANG_FORMAT_BIN is not there came from the AI