### PR TITLE
Fix compilation in touch_controls.cpp

### DIFF
--- a/src/game/client/components/touch_controls.cpp
+++ b/src/game/client/components/touch_controls.cpp
@@ -2363,7 +2363,7 @@ CTouchControls::CUnitRect CTouchControls::FindSizeWH(std::vector<CUnitRect> vVis
 	}
 	vVisibleButtonRects.resize(Write);
 
-	int64_t Delta = LLONG_MAX;
+	int64_t Delta = std::numeric_limits<int64_t>::max();
 	CUnitRect Result = MyRect;
 	auto CalculateDelta = [&](int64_t NewHeight, int64_t NewWidth) -> int64_t {
 		return (MyRect.m_H - NewHeight) * (MyRect.m_H - NewHeight) + (MyRect.m_W - NewWidth) * (MyRect.m_W - NewWidth);


### PR DESCRIPTION
```
src/game/client/components/touch_controls.cpp:2366:18: error: ‘LLONG_MAX’ was not declared in this scope
 2366 |  int64_t Delta = LLONG_MAX;
      |                  ^~~~~~~~~
```
Follow-up to https://github.com/ddnet/ddnet/pull/12035