### PR TITLE
Remove unused `DoChatMsg` argument of `DoTeamChange` function

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3474,7 +3474,7 @@ void CGameContext::ConSetTeamAll(IConsole::IResult *pResult, void *pUserData)
 
 	for(auto &pPlayer : pSelf->m_apPlayers)
 		if(pPlayer)
-			pSelf->m_pController->DoTeamChange(pPlayer, Team, false);
+			pSelf->m_pController->DoTeamChange(pPlayer, Team);
 }
 
 void CGameContext::ConHotReload(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -746,7 +746,7 @@ CClientMask IGameController::GetMaskForPlayerWorldEvent(int Asker, int ExceptId)
 	return Teams().TeamMask(GameServer()->GetDDRaceTeam(Asker), ExceptId, Asker);
 }
 
-void IGameController::DoTeamChange(CPlayer *pPlayer, int Team, bool DoChatMsg)
+void IGameController::DoTeamChange(CPlayer *pPlayer, int Team)
 {
 	if(!IsValidTeam(Team))
 		return;
@@ -758,13 +758,6 @@ void IGameController::DoTeamChange(CPlayer *pPlayer, int Team, bool DoChatMsg)
 	int ClientId = pPlayer->GetCid();
 
 	char aBuf[128];
-	DoChatMsg = false;
-	if(DoChatMsg)
-	{
-		str_format(aBuf, sizeof(aBuf), "'%s' joined the %s", Server()->ClientName(ClientId), GameServer()->m_pController->GetTeamName(Team));
-		GameServer()->SendChat(-1, TEAM_ALL, aBuf);
-	}
-
 	str_format(aBuf, sizeof(aBuf), "team_join player='%d:%s' m_Team=%d", ClientId, Server()->ClientName(ClientId), Team);
 	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -202,7 +202,7 @@ public:
 	// spawn
 	virtual bool CanSpawn(int Team, vec2 *pOutPos, int ClientId);
 
-	virtual void DoTeamChange(class CPlayer *pPlayer, int Team, bool DoChatMsg = true);
+	virtual void DoTeamChange(class CPlayer *pPlayer, int Team);
 
 	int TileFlagsToPickupFlags(int TileFlags) const;
 

--- a/src/game/server/gamemodes/ddnet.cpp
+++ b/src/game/server/gamemodes/ddnet.cpp
@@ -234,7 +234,7 @@ void CGameControllerDDNet::Tick()
 	Teams().Tick();
 }
 
-void CGameControllerDDNet::DoTeamChange(class CPlayer *pPlayer, int Team, bool DoChatMsg)
+void CGameControllerDDNet::DoTeamChange(class CPlayer *pPlayer, int Team)
 {
 	if(!IsValidTeam(Team))
 		return;
@@ -257,5 +257,5 @@ void CGameControllerDDNet::DoTeamChange(class CPlayer *pPlayer, int Team, bool D
 		}
 	}
 
-	IGameController::DoTeamChange(pPlayer, Team, DoChatMsg);
+	IGameController::DoTeamChange(pPlayer, Team);
 }

--- a/src/game/server/gamemodes/ddnet.h
+++ b/src/game/server/gamemodes/ddnet.h
@@ -27,6 +27,6 @@ public:
 
 	void Tick() override;
 
-	void DoTeamChange(class CPlayer *pPlayer, int Team, bool DoChatMsg = true) override;
+	void DoTeamChange(class CPlayer *pPlayer, int Team) override;
 };
 #endif // GAME_SERVER_GAMEMODES_DDNET_H


### PR DESCRIPTION
Closes #11969.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions