### PR TITLE
Readd `DoChatMsg` argument, default to `false` for DDNet gametype

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2747,7 +2747,7 @@ void CGameContext::OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int Clien
 	{
 		if(pPlayer->GetTeam() == TEAM_SPECTATORS || pMsg->m_Team == TEAM_SPECTATORS)
 			m_VoteUpdate = true;
-		m_pController->DoTeamChange(pPlayer, pMsg->m_Team);
+		m_pController->DoTeamChange(pPlayer, pMsg->m_Team, true);
 		pPlayer->m_TeamChangeTick = Server()->Tick();
 	}
 	else
@@ -3453,7 +3453,7 @@ void CGameContext::ConSetTeam(IConsole::IResult *pResult, void *pUserData)
 
 	pSelf->m_apPlayers[ClientId]->Pause(CPlayer::PAUSE_NONE, false); // reset /spec and /pause to allow rejoin
 	pSelf->m_apPlayers[ClientId]->m_TeamChangeTick = pSelf->Server()->Tick() + pSelf->Server()->TickSpeed() * Delay * 60;
-	pSelf->m_pController->DoTeamChange(pSelf->m_apPlayers[ClientId], Team);
+	pSelf->m_pController->DoTeamChange(pSelf->m_apPlayers[ClientId], Team, true);
 	if(Team == TEAM_SPECTATORS)
 		pSelf->m_apPlayers[ClientId]->Pause(CPlayer::PAUSE_NONE, true);
 }
@@ -3474,7 +3474,7 @@ void CGameContext::ConSetTeamAll(IConsole::IResult *pResult, void *pUserData)
 
 	for(auto &pPlayer : pSelf->m_apPlayers)
 		if(pPlayer)
-			pSelf->m_pController->DoTeamChange(pPlayer, Team);
+			pSelf->m_pController->DoTeamChange(pPlayer, Team, false);
 }
 
 void CGameContext::ConHotReload(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -59,7 +59,7 @@ void IGameController::DoActivityCheck()
 				case 0:
 				{
 					// move player to spectator
-					DoTeamChange(GameServer()->m_apPlayers[i], TEAM_SPECTATORS);
+					DoTeamChange(GameServer()->m_apPlayers[i], TEAM_SPECTATORS, true);
 				}
 				break;
 				case 1:
@@ -72,7 +72,7 @@ void IGameController::DoActivityCheck()
 					if(Spectators >= g_Config.m_SvSpectatorSlots)
 						Server()->Kick(i, "Kicked for inactivity");
 					else
-						DoTeamChange(GameServer()->m_apPlayers[i], TEAM_SPECTATORS);
+						DoTeamChange(GameServer()->m_apPlayers[i], TEAM_SPECTATORS, true);
 				}
 				break;
 				case 2:
@@ -746,7 +746,7 @@ CClientMask IGameController::GetMaskForPlayerWorldEvent(int Asker, int ExceptId)
 	return Teams().TeamMask(GameServer()->GetDDRaceTeam(Asker), ExceptId, Asker);
 }
 
-void IGameController::DoTeamChange(CPlayer *pPlayer, int Team)
+void IGameController::DoTeamChange(CPlayer *pPlayer, int Team, bool DoChatMsg)
 {
 	if(!IsValidTeam(Team))
 		return;
@@ -758,6 +758,12 @@ void IGameController::DoTeamChange(CPlayer *pPlayer, int Team)
 	int ClientId = pPlayer->GetCid();
 
 	char aBuf[128];
+	if(DoChatMsg)
+	{
+		str_format(aBuf, sizeof(aBuf), "'%s' joined the %s", Server()->ClientName(ClientId), GameServer()->m_pController->GetTeamName(Team));
+		GameServer()->SendChat(-1, TEAM_ALL, aBuf);
+	}
+
 	str_format(aBuf, sizeof(aBuf), "team_join player='%d:%s' m_Team=%d", ClientId, Server()->ClientName(ClientId), Team);
 	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -202,7 +202,7 @@ public:
 	// spawn
 	virtual bool CanSpawn(int Team, vec2 *pOutPos, int ClientId);
 
-	virtual void DoTeamChange(class CPlayer *pPlayer, int Team);
+	virtual void DoTeamChange(class CPlayer *pPlayer, int Team, bool DoChatMsg);
 
 	int TileFlagsToPickupFlags(int TileFlags) const;
 

--- a/src/game/server/gamemodes/ddnet.cpp
+++ b/src/game/server/gamemodes/ddnet.cpp
@@ -234,7 +234,7 @@ void CGameControllerDDNet::Tick()
 	Teams().Tick();
 }
 
-void CGameControllerDDNet::DoTeamChange(class CPlayer *pPlayer, int Team)
+void CGameControllerDDNet::DoTeamChange(class CPlayer *pPlayer, int Team, bool DoChatMsg)
 {
 	if(!IsValidTeam(Team))
 		return;
@@ -257,5 +257,5 @@ void CGameControllerDDNet::DoTeamChange(class CPlayer *pPlayer, int Team)
 		}
 	}
 
-	IGameController::DoTeamChange(pPlayer, Team);
+	IGameController::DoTeamChange(pPlayer, Team, /* Suppress chat message */ false);
 }

--- a/src/game/server/gamemodes/ddnet.h
+++ b/src/game/server/gamemodes/ddnet.h
@@ -27,6 +27,6 @@ public:
 
 	void Tick() override;
 
-	void DoTeamChange(class CPlayer *pPlayer, int Team) override;
+	void DoTeamChange(class CPlayer *pPlayer, int Team, bool DoChatMsg) override;
 };
 #endif // GAME_SERVER_GAMEMODES_DDNET_H


### PR DESCRIPTION
Revert #12241 and instead pass `DoChatMsg = false` in `CGameControllerDDNet`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options: with `sv_gametype mod` the server now prints chat messages on team change.
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions