### PR TITLE
Fix error handling when `execlp` fails after forking process

### DIFF
--- a/src/base/os.cpp
+++ b/src/base/os.cpp
@@ -13,7 +13,7 @@
 #include "io.h"
 
 #include <sys/utsname.h> // uname, utsname
-#include <unistd.h> // execlp, fork
+#include <unistd.h> // _exit, execlp, fork
 
 #if defined(CONF_PLATFORM_MACOS)
 #include <CoreFoundation/CoreFoundation.h>
@@ -108,12 +108,18 @@ int os_open_link(const char *link)
 #elif defined(CONF_PLATFORM_LINUX)
 	const int pid = fork();
 	if(pid == 0)
+	{
 		execlp("xdg-open", "xdg-open", link, nullptr);
+		_exit(1);
+	}
 	return pid > 0;
 #elif defined(CONF_FAMILY_UNIX)
 	const int pid = fork();
 	if(pid == 0)
+	{
 		execlp("open", "open", link, nullptr);
+		_exit(1);
+	}
 	return pid > 0;
 #endif
 }


### PR DESCRIPTION
Previously, when the `execlp` function fails to execute a file in the `os_open_link` function, the forked child process incorrectly continued executing with the file descriptors and memory inherited from the parent process. After calling `fork`, the child process may only call async-signal-safe functions, so the proper handling is to exit the child process on `execlp` failure by calling `_exit`, which skips calling `atexit` handlers of the parent process.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions: AI found the issue.
