### PR TITLE
Fix clang-tidy checks not being enabled for `src/base`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2147,7 +2147,7 @@ set_src(BASE GLOB_RECURSE src/base
   types.h
   unicode/confusables.cpp
   unicode/confusables.h
-  unicode/confusables_data.h
+  unicode/confusables_data.cpp
   unicode/tolower.cpp
   unicode/tolower_data.cpp
   unicode/tolower_data.h

--- a/scripts/generate_unicode_confusables_data.py
+++ b/scripts/generate_unicode_confusables_data.py
@@ -6,7 +6,7 @@
 #
 # If executed as a script, it will generate the contents of the files
 # python3 scripts/generate_unicode_confusables_data.py header > `src/base/unicode/confusables.h`,
-# python3 scripts/generate_unicode_confusables_data.py data > `src/base/unicode/confusables_data.h`.
+# python3 scripts/generate_unicode_confusables_data.py data > `src/base/unicode/confusables_data.cpp`.
 
 import sys
 import unicode
@@ -78,9 +78,7 @@ struct DECOMP_SLICE
 
 def gen_data(decompositions, decomposition_set, decomposition_offsets, len_set):
 	print("""\
-#ifndef CONFUSABLES_DATA
-#error "This file should only be included in `confusables.cpp`"
-#endif
+#include "confusables.h"
 """)
 
 	print("const uint8_t decomp_lengths[NUM_DECOMP_LENGTHS] = {")

--- a/src/base/.clang-tidy
+++ b/src/base/.clang-tidy
@@ -1,3 +1,4 @@
+InheritParentConfig: true
 Checks: >
   -readability-duplicate-include,
   -readability-identifier-naming,

--- a/src/base/.clang-tidy
+++ b/src/base/.clang-tidy
@@ -1,1 +1,4 @@
-Checks: '-readability-identifier-naming'
+Checks: >
+  -readability-duplicate-include,
+  -readability-identifier-naming,
+  -modernize-deprecated-headers,

--- a/src/base/dbg.cpp
+++ b/src/base/dbg.cpp
@@ -10,8 +10,8 @@
 #include <cstdarg>
 #include <cstdlib>
 
-std::atomic_bool dbg_assert_failing = false;
-DBG_ASSERT_HANDLER dbg_assert_handler;
+static std::atomic_bool dbg_assert_failing = false;
+static DBG_ASSERT_HANDLER dbg_assert_handler;
 
 bool dbg_assert_has_failed()
 {

--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -24,9 +24,9 @@
 #include <android/log.h>
 #endif
 
-std::atomic<ILogger *> global_logger = nullptr;
-thread_local ILogger *scope_logger = nullptr;
-thread_local bool in_logger = false;
+static std::atomic<ILogger *> global_logger = nullptr;
+thread_local ILogger *scope_logger = nullptr; // NOLINT(misc-use-internal-linkage) // TODO: remove NOLINT when updating clang-tidy version
+thread_local bool in_logger = false; // NOLINT(misc-use-internal-linkage) // TODO: remove NOLINT when updating clang-tidy version
 
 void log_set_global_logger(ILogger *logger)
 {

--- a/src/base/net.cpp
+++ b/src/base/net.cpp
@@ -59,7 +59,7 @@ typedef struct
 #endif
 } NETSOCKET_BUFFER;
 
-void net_buffer_init(NETSOCKET_BUFFER *buffer)
+static void net_buffer_init(NETSOCKET_BUFFER *buffer)
 {
 #if defined(CONF_PLATFORM_LINUX)
 	buffer->pos = 0;
@@ -79,17 +79,18 @@ void net_buffer_init(NETSOCKET_BUFFER *buffer)
 #endif
 }
 
-void net_buffer_reinit(NETSOCKET_BUFFER *buffer)
-{
 #if defined(CONF_PLATFORM_LINUX)
+static void net_buffer_reinit(NETSOCKET_BUFFER *buffer)
+{
 	for(int i = 0; i < VLEN; i++)
 	{
 		buffer->msgs[i].msg_hdr.msg_namelen = sizeof(buffer->sockaddrs[i]);
 	}
-#endif
 }
+#endif
 
-void net_buffer_simple(NETSOCKET_BUFFER *buffer, char **buf, int *size)
+#if defined(CONF_WEBSOCKETS)
+static void net_buffer_simple(NETSOCKET_BUFFER *buffer, char **buf, int *size)
 {
 #if defined(CONF_PLATFORM_LINUX)
 	*buf = buffer->bufs[0];
@@ -99,6 +100,7 @@ void net_buffer_simple(NETSOCKET_BUFFER *buffer, char **buf, int *size)
 	*size = sizeof(buffer->buf);
 #endif
 }
+#endif
 
 struct NETSOCKET_INTERNAL
 {
@@ -205,7 +207,7 @@ int net_addr_comp_noport(const NETADDR *a, const NETADDR *b)
 	return mem_comp(a->ip, b->ip, sizeof(a->ip));
 }
 
-void net_addr_str_v6(const unsigned short ip[8], int port, char *buffer, int buffer_size)
+static void net_addr_str_v6(const unsigned short ip[8], int port, char *buffer, int buffer_size)
 {
 	int longest_seq_len = 0;
 	int longest_seq_start = -1;

--- a/src/base/net.cpp
+++ b/src/base/net.cpp
@@ -682,12 +682,12 @@ static int net_set_blocking_impl(NETSOCKET sock, bool blocking)
 		if(sockets[i] >= 0)
 		{
 #if defined(CONF_FAMILY_WINDOWS)
-			if(ioctlsocket(sockets[i], FIONBIO, (unsigned long *)&mode) != NO_ERROR)
+			if(ioctlsocket(sockets[i], FIONBIO, &mode) != NO_ERROR)
 			{
 				log_error("net", "Setting %s mode for %s socket failed (%s)", socket_str[i], mode_str, net_error_message().c_str());
 			}
 #else
-			if(ioctl(sockets[i], FIONBIO, (unsigned long *)&mode) == -1)
+			if(ioctl(sockets[i], FIONBIO, &mode) == -1)
 			{
 				log_error("net", "Setting %s mode for %s socket failed (%s)", socket_str[i], mode_str, net_error_message().c_str());
 			}

--- a/src/base/os.cpp
+++ b/src/base/os.cpp
@@ -19,8 +19,6 @@
 #include <CoreFoundation/CoreFoundation.h>
 #endif
 #elif defined(CONF_FAMILY_WINDOWS)
-#include "mem.h"
-
 #include <objbase.h> // required for shellapi.h
 #include <shellapi.h> // ShellExecuteExW
 #include <windows.h>

--- a/src/base/str.cpp
+++ b/src/base/str.cpp
@@ -248,16 +248,11 @@ bool str_valid_filename(const char *str)
 		"CON", "PRN", "AUX", "NUL",
 		"COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "COM¹", "COM²", "COM³",
 		"LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9", "LPT¹", "LPT²", "LPT³"};
-	for(const char *reserved_name : RESERVED_NAMES)
-	{
+	return std::none_of(std::begin(RESERVED_NAMES), std::end(RESERVED_NAMES), [str](const char *reserved_name) {
 		const char *prefix = str_startswith_nocase(str, reserved_name);
-		if(prefix != nullptr && (prefix[0] == '\0' || prefix[0] == '.'))
-		{
-			return false; // reserved name not allowed when it makes up the entire filename or when followed by period
-		}
-	}
-
-	return true;
+		// reserved name not allowed when it makes up the entire filename or when followed by period
+		return prefix != nullptr && (prefix[0] == '\0' || prefix[0] == '.');
+	});
 }
 
 int str_comp_filenames(const char *a, const char *b)

--- a/src/base/time.cpp
+++ b/src/base/time.cpp
@@ -63,7 +63,7 @@ static tm time_localtime_threadlocal(time_t *time_data)
 	tm *time = localtime(time_data);
 #else
 	// Thread-local buffer for the result of localtime_r
-	thread_local tm time_info_buf;
+	thread_local tm time_info_buf; // NOLINT(misc-use-internal-linkage) // TODO: remove NOLINT when updating clang-tidy version
 	tm *time = localtime_r(time_data, &time_info_buf);
 #endif
 	dbg_assert(time != nullptr, "Failed to get local time for time data %" PRId64, (int64_t)time_data);

--- a/src/base/unicode/confusables.cpp
+++ b/src/base/unicode/confusables.cpp
@@ -100,7 +100,3 @@ int str_utf8_comp_confusable(const char *str1, const char *str2)
 			return 1;
 	}
 }
-
-#define CONFUSABLES_DATA
-#include "confusables_data.h"
-#undef CONFUSABLES_DATA

--- a/src/base/unicode/confusables_data.cpp
+++ b/src/base/unicode/confusables_data.cpp
@@ -1,6 +1,4 @@
-#ifndef CONFUSABLES_DATA
-#error "This file should only be included in `confusables.cpp`"
-#endif
+#include "confusables.h"
 
 const uint8_t decomp_lengths[NUM_DECOMP_LENGTHS] = {
 	0,

--- a/src/base/unicode/tolower.cpp
+++ b/src/base/unicode/tolower.cpp
@@ -1,5 +1,7 @@
 #include "tolower_data.h"
 
+#include <base/str.h>
+
 int str_utf8_tolower_codepoint(int code)
 {
 	auto it = UPPER_TO_LOWER_CODEPOINT_MAP.find(code);


### PR DESCRIPTION
See commit messages.

Closes #12247.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
