### PR TITLE
Call the constructor for persistent data

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1835,6 +1835,7 @@ bool CGameContext::OnClientDataPersist(int ClientId, void *pData)
 	{
 		return false;
 	}
+	new(pPersistent) CPersistentClientData();
 	pPersistent->m_IsSpectator = m_apPlayers[ClientId]->GetTeam() == TEAM_SPECTATORS;
 	pPersistent->m_IsAfk = m_apPlayers[ClientId]->IsAfk();
 	pPersistent->m_LastWhisperTo = m_apPlayers[ClientId]->m_LastWhisperTo;
@@ -4594,6 +4595,7 @@ void CGameContext::OnShutdown(void *pPersistentData)
 
 	if(pPersistent)
 	{
+		new(pPersistent) CPersistentData();
 		pPersistent->m_PrevGameUuid = m_GameUuid;
 	}
 

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -180,13 +180,15 @@ class CGameContext : public IGameServer
 	void AddVote(const char *pDescription, const char *pCommand);
 	static int MapScan(const char *pName, int IsDir, int DirType, void *pUserData);
 
-	struct CPersistentData
+	class CPersistentData
 	{
+	public:
 		CUuid m_PrevGameUuid;
 	};
 
-	struct CPersistentClientData
+	class CPersistentClientData
 	{
+	public:
 		bool m_IsSpectator;
 		bool m_IsAfk;
 		int m_LastWhisperTo;


### PR DESCRIPTION
Huge disclaimer this falls under #7777 and helps me in a fork. For ddnet this will only change the debugging experience. In case some variable is forgotten to be initialized in the init method it will be 0 instead of uninitialized.

The problem I am facing is that in a ddnet fork I am using different gametype controllers to load and persist data. So on gametype change I do not know who stored the data (CC https://github.com/ddnet-insta/ddnet-insta/issues/669). If I could rely on fields not being set in the persist method to be 0 I can work with that. If it is uninitialized that will be tricky. For ddnet this should never be the case.

Another thing that I noticed is that the member initialization does not work which is a bit trappy.
Here an example of it not working:

```diff
diff --git a/src/game/server/gamecontext.cpp b/src/game/server/gamecontext.cpp
index 9a4bf3af56..28f70c8ee8 100644
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1837,7 +1837,7 @@ bool CGameContext::OnClientDataPersist(int ClientId, void *pData)
 	}
 	pPersistent->m_IsSpectator = m_apPlayers[ClientId]->GetTeam() == TEAM_SPECTATORS;
 	pPersistent->m_IsAfk = m_apPlayers[ClientId]->IsAfk();
-	pPersistent->m_LastWhisperTo = m_apPlayers[ClientId]->m_LastWhisperTo;
+	// pPersistent->m_LastWhisperTo = m_apPlayers[ClientId]->m_LastWhisperTo;
 	return true;
 }
 
@@ -1852,6 +1852,7 @@ void CGameContext::OnClientConnected(int ClientId, void *pData)
 		Spec = pPersistentData->m_IsSpectator;
 		Afk = pPersistentData->m_IsAfk;
 		LastWhisperTo = pPersistentData->m_LastWhisperTo;
+		log_info("game", "loaded last whisper %d", LastWhisperTo);
 	}
 	else
 	{
diff --git a/src/game/server/gamecontext.h b/src/game/server/gamecontext.h
index 21c133f2dc..b78ffe6c9c 100644
--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -189,7 +189,7 @@ class CGameContext : public IGameServer
 	{
 		bool m_IsSpectator;
 		bool m_IsAfk;
-		int m_LastWhisperTo;
+		int m_LastWhisperTo = 69;
 	};
 
 public:
```

```
2026-06-04 09:15:59 I game: loaded last whisper 32630
```

That is why I thought these classes could benefit from a warning comment that member initialization would not work

https://github.com/ddnet/ddnet/blob/5d39cf8d5f4f6c113ace283e803612784c98794c/src/game/server/gamecontext.h#L183-L193

But then I had too many things to say for a short juicy comment. Things I wanted to say are:
- initializing members here will not work because the memory comes from a raw malloc
- it will be mem zeroed
- you have to set ALL variables in the persist method anyways

So I decided against adding a comment because I could not come up with a short and useful sentence for that.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
