### PR TITLE
Refactor console victim handling

### DIFF
--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -10,6 +10,8 @@
 #include <engine/storage.h>
 
 #include <memory>
+#include <optional>
+#include <vector>
 
 static constexpr ColorRGBA CONSOLE_DEFAULT_COLOR = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
 
@@ -97,6 +99,7 @@ public:
 		virtual EAccessLevel GetAccessLevel() const = 0;
 	};
 
+	typedef std::optional<std::vector<int>> (*FGetVictimsCommandCallback)(int ClientId, const char *pVictim, void *pUser);
 	typedef void (*FTeeHistorianCommandCallback)(int ClientId, int FlagMask, const char *pCmd, IResult *pResult, void *pUser);
 	typedef void (*FPossibleCallback)(int Index, const char *pCmd, void *pUser);
 	typedef void (*FCommandCallback)(IResult *pResult, void *pUserData);
@@ -134,6 +137,7 @@ public:
 	 * - They do not require a pointer to `IConsole` to be used.
 	 */
 	virtual void Print(int Level, const char *pFrom, const char *pStr, ColorRGBA PrintColor = CONSOLE_DEFAULT_COLOR) const = 0;
+	virtual void SetGetVictimsCommandCallback(FGetVictimsCommandCallback pfnCallback, void *pUser) = 0;
 	virtual void SetTeeHistorianCommandCallback(FTeeHistorianCommandCallback pfnCallback, void *pUser) = 0;
 	virtual void SetUnknownCommandCallback(FUnknownCommandCallback pfnCallback, void *pUser) = 0;
 	virtual void SetCanUseCommandCallback(FCanUseCommandCallback pfnCallback, void *pUser) = 0;

--- a/src/engine/console.rs
+++ b/src/engine/console.rs
@@ -266,59 +266,15 @@ mod ffi {
         /// # let mut console = CreateConsole(CFGFLAG_SERVER);
         /// # let mut executed: u32 = 0;
         /// # console.pin_mut().Register(s!("command"), s!("v"), CFGFLAG_SERVER, IConsole_FCommandCallback(callback), UserPtr::from(&mut executed), s!(""));
-        /// # console.pin_mut().ExecuteLine(s!(r#"command me"#), 33, true);
-        /// # console.pin_mut().ExecuteLine(s!(r#"command string"#), 33, true);
         /// # console.pin_mut().ExecuteLine(s!(r#"command 42"#), 33, true);
-        /// # console.pin_mut().ExecuteLine(s!(r#"command all"#), 33, true);
         /// # extern "C" fn callback(result_param: &IConsole_IResult, mut user: UserPtr) {
         /// # let executed;
         /// # unsafe { executed = *user.cast_mut::<u32>(); *user.cast_mut::<u32>() += 1; }
-        /// # match executed {
-        /// # 0 => {
-        /// let result: &IConsole_IResult /* = `command me` */;
-        /// # result = result_param;
-        /// // Assume the executing client ID is 33.
-        /// assert_eq!(result.GetVictim(), 33);
-        ///
-        /// # }
-        /// # 1 => {
-        /// let result: &IConsole_IResult /* = `command string` */;
-        /// # result = result_param;
-        /// assert_eq!(result.GetVictim(), 0);
-        ///
-        /// # }
-        /// # 2 => {
         /// let result: &IConsole_IResult /* = `command 42` */;
         /// # result = result_param;
         /// assert_eq!(result.GetVictim(), 42);
-        ///
         /// # }
-        /// # 3 => {
-        /// let result: &IConsole_IResult /* = `command all` first invocation */;
-        /// # result = result_param;
-        /// assert_eq!(result.GetVictim(), 0);
-        /// # }
-        /// # 4 => {
-        /// let result: &IConsole_IResult /* = `command all` second invocation */;
-        /// # result = result_param;
-        /// assert_eq!(result.GetVictim(), 1);
-        /// # }
-        /// // …
-        /// # 66 => {
-        /// let result: &IConsole_IResult /* = `command all` last invocation */;
-        /// # result = result_param;
-        /// assert_eq!(result.GetVictim(), 63);
-        /// # }
-        /// // …
-        /// # 130 => {
-        /// let result: &IConsole_IResult /* = `command all` last invocation */;
-        /// # result = result_param;
-        /// assert_eq!(result.GetVictim(), 127);
-        /// # }
-        /// # _ => {}
-        /// # }
-        /// # }
-        /// # assert!(executed == 131);
+        /// # assert!(executed == 1);
         /// ```
         pub fn GetVictim(self: &IConsole_IResult) -> i32;
 

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -211,7 +211,7 @@ int CConsole::ParseArgs(CResult *pResult, const char *pFormat)
 			{
 				if(Command == 'v')
 				{
-					pResult->SetVictim(CResult::VICTIM_ME);
+					pResult->SetVictim("me");
 					break;
 				}
 				Command = NextParam(pFormat);
@@ -374,6 +374,12 @@ void CConsole::Print(int Level, const char *pFrom, const char *pStr, ColorRGBA P
 	{
 		log_log(LogLevel, pFrom, "%s", pStr);
 	}
+}
+
+void CConsole::SetGetVictimsCommandCallback(FGetVictimsCommandCallback pfnCallback, void *pUser)
+{
+	m_pfnGetVictimsCommandCallback = pfnCallback;
+	m_pGetVictimsCommandUserData = pUser;
 }
 
 void CConsole::SetTeeHistorianCommandCallback(FTeeHistorianCommandCallback pfnCallback, void *pUser)
@@ -595,14 +601,26 @@ void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientId, bo
 							m_pfnTeeHistorianCommandCallback(ClientId, m_FlagMask, pCommand->m_pName, &Result, m_pTeeHistorianCommandUserdata);
 						}
 
-						if(Result.GetVictim() == CResult::VICTIM_ME)
-							Result.SetVictim(ClientId);
-
-						if(Result.HasVictim() && Result.GetVictim() == CResult::VICTIM_ALL)
+						if(Result.m_aSpecialVictim[0])
 						{
-							for(int i = 0; i < MAX_CLIENTS; i++)
+							std::optional<std::vector<int>> Victims;
+							if(m_pfnGetVictimsCommandCallback)
 							{
-								Result.SetVictim(i);
+								Victims = m_pfnGetVictimsCommandCallback(ClientId, Result.m_aSpecialVictim, m_pGetVictimsCommandUserData);
+							}
+							else
+							{
+								Victims = std::nullopt;
+							}
+
+							if(!Victims.has_value())
+							{
+								log_error("console", "Invalid victim '%s'", Result.m_aSpecialVictim);
+								return;
+							}
+							for(const int VictimId : Victims.value())
+							{
+								Result.SetVictim(VictimId);
 								pCommand->m_pfnCallback(&Result, pCommand->m_pUserData);
 							}
 						}
@@ -863,6 +881,8 @@ CConsole::CConsole(int FlagMask)
 	m_pFirstExec = nullptr;
 	m_pfnTeeHistorianCommandCallback = nullptr;
 	m_pTeeHistorianCommandUserdata = nullptr;
+	m_pfnGetVictimsCommandCallback = nullptr;
+	m_pGetVictimsCommandUserData = nullptr;
 
 	m_pStorage = nullptr;
 
@@ -1134,32 +1154,32 @@ std::unique_ptr<IConsole> CreateConsole(int FlagMask) { return std::make_unique<
 
 int CConsole::CResult::GetVictim() const
 {
-	return m_Victim;
+	dbg_assert(m_VictimId.has_value(), "m_VictimId has no value");
+	return m_VictimId.value();
 }
 
 void CConsole::CResult::ResetVictim()
 {
-	m_Victim = VICTIM_NONE;
-}
-
-bool CConsole::CResult::HasVictim() const
-{
-	return m_Victim != VICTIM_NONE;
+	m_VictimId = std::nullopt;
+	m_aSpecialVictim[0] = '\0';
 }
 
 void CConsole::CResult::SetVictim(int Victim)
 {
-	m_Victim = std::clamp<int>(Victim, VICTIM_NONE, MAX_CLIENTS - 1);
+	dbg_assert(in_range(Victim, 0, MAX_CLIENTS - 1), "Victim ID %d out of range [0, %d]", Victim, MAX_CLIENTS - 1);
+	m_VictimId = Victim;
 }
 
 void CConsole::CResult::SetVictim(const char *pVictim)
 {
-	if(!str_comp(pVictim, "me"))
-		m_Victim = VICTIM_ME;
-	else if(!str_comp(pVictim, "all"))
-		m_Victim = VICTIM_ALL;
-	else
-		m_Victim = std::clamp<int>(str_toint(pVictim), 0, MAX_CLIENTS - 1);
+	int Value;
+	if(!str_toint(pVictim, &Value) || !in_range(Value, 0, MAX_CLIENTS - 1))
+	{
+		str_copy(m_aSpecialVictim, pVictim);
+		return;
+	}
+
+	SetVictim(Value);
 }
 
 std::optional<ColorHSLA> CConsole::ColorParse(const char *pStr, float DarkestLighting)

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -77,6 +77,9 @@ class CConsole : public IConsole
 
 	void ExecuteLineStroked(int Stroke, const char *pStr, int ClientId = IConsole::CLIENT_ID_UNSPECIFIED, bool InterpretSemicolons = true) override;
 
+	FGetVictimsCommandCallback m_pfnGetVictimsCommandCallback = nullptr;
+	void *m_pGetVictimsCommandUserData = nullptr;
+
 	FTeeHistorianCommandCallback m_pfnTeeHistorianCommandCallback;
 	void *m_pTeeHistorianCommandUserdata;
 
@@ -116,16 +119,9 @@ class CConsole : public IConsole
 
 		// DDRace
 
-		enum
-		{
-			VICTIM_NONE = -3,
-			VICTIM_ME = -2,
-			VICTIM_ALL = -1,
-		};
-
-		int m_Victim;
+		char m_aSpecialVictim[16];
+		std::optional<int> m_VictimId;
 		void ResetVictim();
-		bool HasVictim() const;
 		void SetVictim(int Victim);
 		void SetVictim(const char *pVictim);
 		int GetVictim() const override;
@@ -192,6 +188,7 @@ public:
 	bool ExecuteFile(const char *pFilename, int ClientId = IConsole::CLIENT_ID_UNSPECIFIED, bool LogFailure = false, int StorageType = IStorage::TYPE_ALL) override;
 
 	void Print(int Level, const char *pFrom, const char *pStr, ColorRGBA PrintColor = CONSOLE_DEFAULT_COLOR) const override;
+	void SetGetVictimsCommandCallback(FGetVictimsCommandCallback pfnCallback, void *pUser) override;
 	void SetTeeHistorianCommandCallback(FTeeHistorianCommandCallback pfnCallback, void *pUser) override;
 	void SetUnknownCommandCallback(FUnknownCommandCallback pfnCallback, void *pUser) override;
 	void SetCanUseCommandCallback(FCanUseCommandCallback pfnCallback, void *pUser) override;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -195,6 +195,34 @@ void CGameContext::TeeHistorianWrite(const void *pData, int DataSize, void *pUse
 	aio_write(pSelf->m_pTeeHistorianFile, pData, DataSize);
 }
 
+std::optional<std::vector<int>> CGameContext::ClientsForVictim(int ClientId, const char *pVictim, void *pUser)
+{
+	CGameContext *pSelf = (CGameContext *)pUser;
+	std::vector<int> vClientIds;
+
+	if(!str_comp(pVictim, "me"))
+	{
+		vClientIds.emplace_back(ClientId);
+	}
+	else if(!str_comp(pVictim, "all"))
+	{
+		const int MaxClients = pSelf->Server()->MaxClients();
+		for(int i = 0; i < MaxClients; i++)
+		{
+			if(!pSelf->Server()->ClientIngame(i))
+				continue;
+
+			vClientIds.emplace_back(i);
+		}
+	}
+	else
+	{
+		return std::nullopt;
+	}
+
+	return std::make_optional(std::move(vClientIds));
+}
+
 void CGameContext::CommandCallback(int ClientId, int FlagMask, const char *pCmd, IConsole::IResult *pResult, void *pUser)
 {
 	CGameContext *pSelf = (CGameContext *)pUser;
@@ -4162,6 +4190,7 @@ void CGameContext::OnInit(const void *pPersistentData)
 	m_Events.SetGameServer(this);
 
 	m_GameUuid = RandomUuid();
+	Console()->SetGetVictimsCommandCallback(ClientsForVictim, this);
 	Console()->SetTeeHistorianCommandCallback(CommandCallback, this);
 
 	uint64_t aSeed[2];

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -135,6 +135,7 @@ class CGameContext : public IGameServer
 
 	bool m_Resetting;
 
+	static std::optional<std::vector<int>> ClientsForVictim(int ClientId, const char *pVictim, void *pUser);
 	static void CommandCallback(int ClientId, int FlagMask, const char *pCmd, IConsole::IResult *pResult, void *pUser);
 	static void TeeHistorianWrite(const void *pData, int DataSize, void *pUser);
 


### PR DESCRIPTION
Closes #10747.
Closes #10371.

Refactor console victim handling to avoid enum usage and support special victim callbacks.

```
> muteid 129 1 test
2026-06-04 19:10:53 E console: Invalid victim '129'
> muteid 101 1 test
2026-06-04 19:10:54 I mutes: Client ID not found: 101
> muteid me 1 test
2026-06-04 19:13:05 I chat: *** 'ByFox' has been muted for 1 seconds (test)
> muteid all 1 test
2026-06-04 19:13:08 I chat: *** 'ByFox' has been muted for 1 seconds (test)
2026-06-04 19:13:08 I chat: *** '[D] ByFox' has been muted for 1 seconds (test)
2026-06-04 19:13:08 I chat: *** '(1)ByFox' has been muted for 1 seconds (test)
```

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
