### PR TITLE
Only delete destination file before renaming files on Windows

### DIFF
--- a/src/base/fs.cpp
+++ b/src/base/fs.cpp
@@ -586,6 +586,10 @@ int fs_remove(const char *filename)
 int fs_rename(const char *oldname, const char *newname)
 {
 #if defined(CONF_FAMILY_WINDOWS)
+	// Target file must be deleted first, else rename fails on Windows when the target file has open handles.
+	// Ignore the result and try to perform the rename anyway.
+	(void)fs_remove(newname);
+
 	const std::wstring wide_oldname = windows_utf8_to_wide(oldname);
 	const std::wstring wide_newname = windows_utf8_to_wide(newname);
 	if(MoveFileExW(wide_oldname.c_str(), wide_newname.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED | MOVEFILE_WRITE_THROUGH) != 0)

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2464,10 +2464,7 @@ void CClient::FinishMapDownload()
 {
 	m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "client/network", "download complete, loading map");
 
-	bool FileSuccess = true;
-	FileSuccess &= Storage()->RemoveFile(m_aMapdownloadFilename, IStorage::TYPE_SAVE);
-	FileSuccess &= Storage()->RenameFile(m_aMapdownloadFilenameTemp, m_aMapdownloadFilename, IStorage::TYPE_SAVE);
-	if(!FileSuccess)
+	if(!Storage()->RenameFile(m_aMapdownloadFilenameTemp, m_aMapdownloadFilename, IStorage::TYPE_SAVE))
 	{
 		char aError[128 + IO_MAX_PATH_LENGTH];
 		str_format(aError, sizeof(aError), Localize("Could not save downloaded map. Try manually deleting this file: %s"), m_aMapdownloadFilename);

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -42,13 +42,6 @@ void CDataFileWriterFinishJob::Run()
 {
 	m_Writer.Finish();
 
-	if(!m_pStorage->RemoveFile(m_aRealFilename, IStorage::TYPE_SAVE))
-	{
-		str_format(m_aErrorMessage, sizeof(m_aErrorMessage), "Saving failed: Could not remove old map file '%s'.", m_aRealFilename);
-		log_error("editor/save", "%s", m_aErrorMessage);
-		return;
-	}
-
 	if(!m_pStorage->RenameFile(m_aTempFilename, m_aRealFilename, IStorage::TYPE_SAVE))
 	{
 		str_format(m_aErrorMessage, sizeof(m_aErrorMessage), "Saving failed: Could not move temporary map file '%s' to '%s'.", m_aTempFilename, m_aRealFilename);

--- a/src/test/fs_test.cpp
+++ b/src/test/fs_test.cpp
@@ -347,8 +347,7 @@ TEST(Filesystem, RenameOpenFileDeleteTarget)
 
 	EXPECT_TRUE(fs_is_file(Info.m_aFilename));
 	EXPECT_TRUE(fs_is_file(aNewFilename));
-	EXPECT_FALSE(fs_remove(aNewFilename)); // Target file must be deleted else rename fails on Windows when target file has open handle.
-	EXPECT_FALSE(fs_rename(Info.m_aFilename, aNewFilename));
+	EXPECT_FALSE(fs_rename(Info.m_aFilename, aNewFilename)); // Renaming can overwrite the existing target file even if it has open handles.
 	EXPECT_FALSE(fs_is_file(Info.m_aFilename));
 	EXPECT_TRUE(fs_is_file(aNewFilename));
 


### PR DESCRIPTION
Deleting the destination file before renaming a file is only necessary on Windows to allow renaming files that are already open (e.g., editor maps and downloaded maps).

Supersedes #10969. CC @timakro.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
