### PR TITLE
Fix editor tele/switch/tune/XY tile finder not centered on tile

### DIFF
--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -2290,7 +2290,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupTele(void *pContext, CUIRect View, b
 		pEd->Map()->m_pTeleLayer->GetPos(pEd->m_ViewTeleNumber, -1, TeleX, TeleY);
 		if(TeleX != -1 && TeleY != -1)
 		{
-			pEd->MapView()->SetWorldOffset({32.0f * TeleX + 0.5f, 32.0f * TeleY + 0.5f});
+			pEd->MapView()->SetWorldOffset({32.0f * (TeleX + 0.5f), 32.0f * (TeleY + 0.5f)});
 			return true;
 		}
 		return false;
@@ -2453,7 +2453,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSwitch(void *pContext, CUIRect View,
 		pEditor->Map()->m_pSwitchLayer->GetPos(pEditor->m_ViewSwitch, -1, SwitchPos);
 		if(SwitchPos != ivec2(-1, -1))
 		{
-			pEditor->MapView()->SetWorldOffset({32.0f * SwitchPos.x + 0.5f, 32.0f * SwitchPos.y + 0.5f});
+			pEditor->MapView()->SetWorldOffset({32.0f * (SwitchPos.x + 0.5f), 32.0f * (SwitchPos.y + 0.5f)});
 			return true;
 		}
 		return false;
@@ -2555,7 +2555,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupTune(void *pContext, CUIRect View, b
 
 		if(TunePos != ivec2(-1, -1))
 		{
-			pEditor->MapView()->SetWorldOffset({32.0f * TunePos.x + 0.5f, 32.0f * TunePos.y + 0.5f});
+			pEditor->MapView()->SetWorldOffset({32.0f * (TunePos.x + 0.5f), 32.0f * (TunePos.y + 0.5f)});
 			return true;
 		}
 		return false;
@@ -2665,7 +2665,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupGoto(void *pContext, CUIRect View, b
 	static int s_Button;
 	if(pEditor->DoButton_Editor(&s_Button, "Go", 0, &Button, BUTTONFLAG_LEFT, nullptr))
 	{
-		pEditor->MapView()->SetWorldOffset({32.0f * s_GotoPos.x + 0.5f, 32.0f * s_GotoPos.y + 0.5f});
+		pEditor->MapView()->SetWorldOffset({32.0f * (s_GotoPos.x + 0.5f), 32.0f * (s_GotoPos.y + 0.5f)});
 	}
 
 	return CUi::POPUP_KEEP_OPEN;


### PR DESCRIPTION
The world offset was previously set to the top-left corner of the tile plus 1/64 of the tile size, instead of fully centering the view on the tile.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions