### PR TITLE
Optimization: render all tile layer rows in one draw call if the left and right side of a layer are visible

### DIFF
--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -307,38 +307,61 @@ void CRenderLayerTile::RenderTileLayer(const ColorRGBA &Color, const CRenderLaye
 
 	if(IsVisibleInClipRegion(m_LayerClip))
 	{
-		// create the indice buffers we want to draw -- reuse them
-		std::vector<char *> vpIndexOffsets;
-		std::vector<unsigned int> vDrawCounts;
+		size_t X0 = std::max(ScreenRectX0, 0);
+		size_t X1 = std::clamp(ScreenRectX1, 0, (int)Visuals.m_Width);
 
-		int X0 = std::max(ScreenRectX0, 0);
-		int X1 = std::min(ScreenRectX1, (int)Visuals.m_Width);
-		int XR = X1 == std::numeric_limits<int>::min() ? X1 : X1 - 1;
-		if(X0 <= XR)
+		size_t Y0 = std::max(ScreenRectY0, 0);
+		size_t Y1 = std::clamp(ScreenRectY1, 0, (int)Visuals.m_Height);
+
+		// make sure we have any width and height
+		if(X0 < X1 && Y0 < Y1)
 		{
-			int Y0 = std::max(ScreenRectY0, 0);
-			int Y1 = std::min(ScreenRectY1, (int)Visuals.m_Height);
-
-			unsigned long long Reserve = absolute(Y1 - Y0) + 1;
-			vpIndexOffsets.reserve(Reserve);
-			vDrawCounts.reserve(Reserve);
-
-			for(int y = Y0; y < Y1; ++y)
+			// render all visible rows directly, because their start and end are are not offscreen
+			if(X0 == 0 && X1 == (size_t)Visuals.m_Width)
 			{
-				dbg_assert(Visuals.m_vTilesOfLayer[y * Visuals.m_Width + XR].IndexBufferByteOffset() >= Visuals.m_vTilesOfLayer[y * Visuals.m_Width + X0].IndexBufferByteOffset(), "Tile offsets are not monotone.");
-				unsigned int NumVertices = ((Visuals.m_vTilesOfLayer[y * Visuals.m_Width + XR].IndexBufferByteOffset() - Visuals.m_vTilesOfLayer[y * Visuals.m_Width + X0].IndexBufferByteOffset()) / sizeof(unsigned int)) + (Visuals.m_vTilesOfLayer[y * Visuals.m_Width + XR].DoDraw() ? 6lu : 0lu);
+				size_t StartIndex = Y0 * Visuals.m_Width;
+				size_t EndIndex = Y1 * Visuals.m_Width - 1;
+				const auto &Start = Visuals.m_vTilesOfLayer[StartIndex];
+				const auto &End = Visuals.m_vTilesOfLayer[EndIndex];
+				unsigned int NumVertices = ((End.IndexBufferByteOffset() - Start.IndexBufferByteOffset()) / sizeof(unsigned int)) + (End.DoDraw() ? 6lu : 0lu);
 
 				if(NumVertices)
 				{
-					vpIndexOffsets.push_back((offset_ptr_size)Visuals.m_vTilesOfLayer[y * Visuals.m_Width + X0].IndexBufferByteOffset());
-					vDrawCounts.push_back(NumVertices);
+					offset_ptr_size ByteOffset = (offset_ptr_size)Start.IndexBufferByteOffset();
+					Graphics()->RenderTileLayer(Visuals.m_BufferContainerIndex, Color, &ByteOffset, &NumVertices, 1);
 				}
 			}
-
-			int DrawCount = vpIndexOffsets.size();
-			if(DrawCount != 0)
+			// render slices of rows
+			else
 			{
-				Graphics()->RenderTileLayer(Visuals.m_BufferContainerIndex, Color, vpIndexOffsets.data(), vDrawCounts.data(), DrawCount);
+				// create the indice buffers we want to draw
+				std::vector<char *> vpIndexOffsets;
+				std::vector<unsigned int> vDrawCounts;
+
+				unsigned long long Reserve = Y1 - Y0 + 1;
+
+				vpIndexOffsets.reserve(Reserve);
+				vDrawCounts.reserve(Reserve);
+				for(size_t RowIndex = Y0; RowIndex < Y1; ++RowIndex)
+				{
+					size_t StartIndex = RowIndex * Visuals.m_Width + X0;
+					size_t EndIndex = RowIndex * Visuals.m_Width + (X1 - 1);
+					const auto &Start = Visuals.m_vTilesOfLayer[StartIndex];
+					const auto &End = Visuals.m_vTilesOfLayer[EndIndex];
+					dbg_assert(End.IndexBufferByteOffset() >= Start.IndexBufferByteOffset(), "Tile offsets are not monotone.");
+					unsigned int NumVertices = ((End.IndexBufferByteOffset() - Start.IndexBufferByteOffset()) / sizeof(unsigned int)) + (End.DoDraw() ? 6lu : 0lu);
+
+					if(NumVertices)
+					{
+						vpIndexOffsets.push_back((offset_ptr_size)Start.IndexBufferByteOffset());
+						vDrawCounts.push_back(NumVertices);
+					}
+				}
+
+				if(!vpIndexOffsets.empty())
+				{
+					Graphics()->RenderTileLayer(Visuals.m_BufferContainerIndex, Color, vpIndexOffsets.data(), vDrawCounts.data(), vpIndexOffsets.size());
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

If both, the left and right side of a tile layer are visible on the screen, we can switch to directly rendering all rows in one draw call. This is pretty much irrelevant in normal gameplay, but greatly improves the performance if you zoom out a lot.

This is mostly relevant for big maps with lots of designs. I have very good hardware and can easily get >60 fps when zooming out, but this is certainly not the case for everyone.

FPS
| Map          | Before | After | Zoom lvl|
| -------------- | --------- | -------- | ------------ |
| Springlobe 4 | 286    | 603   | -25 |
| bit3         | 579    | 653   | idk but the same |
| Until Dawn   | 1604   | ~2165  | -35 |

This only affects buffered backends, i.e. Vulkan and OpenGl 3.3

**Before:**

<img width="2560" height="1440" alt="screenshot_2026-06-10_11-16-14" src="https://github.com/user-attachments/assets/4e224159-4cf6-4c01-a76d-0ff5f9929413" />

<img width="2560" height="1440" alt="screenshot_2026-06-10_11-19-16" src="https://github.com/user-attachments/assets/9a0e6934-6a27-4c75-9419-a31f7ad97e08" />

<img width="2560" height="1440" alt="screenshot_2026-06-10_11-26-27" src="https://github.com/user-attachments/assets/9293e8a7-9b47-4b43-a185-52170e7ea831" />

---

**After:**

<img width="2560" height="1440" alt="screenshot_2026-06-10_11-41-13" src="https://github.com/user-attachments/assets/301611f6-1a72-4a07-81b0-d9af9de30126" />

<img width="2560" height="1440" alt="screenshot_2026-06-10_11-18-02" src="https://github.com/user-attachments/assets/806eb827-fb6a-4b1c-8d1c-f660c6f2828d" />

<img width="2560" height="1440" alt="screenshot_2026-06-10_11-27-24" src="https://github.com/user-attachments/assets/a95d22c3-f020-4f1e-aa45-d7d8dd35c403" />

Yes, screenshot benchmarks are not that reliable, but a 2x increase on Springlobe 4 is **undeniable**.

### Benchmark of normal meaning default zoom gameplay:
<img width="306" height="473" alt="Benchmark-12272" src="https://github.com/user-attachments/assets/c605f700-d43c-44e5-bbbd-530e2522687e" />

As you can see this feature has almost no effect on normal gameplay, ctf1 _might_ even benefit from it due to being relatively small

| map                |   FT avg. µs (%) |   AVG FPS (%) |   worst 0.01 FPS (%) |   worst 0.001 FPS (%) |
|:-------------------|-----------------:|--------------:|---------------------:|----------------------:|
| Abyss              |            -0.32 |          0.32 |                 8.49 |                 86.31 |
| KingsLeap          |             2    |         -1.96 |                -0.66 |                 -2.31 |
| Linear             |            -1.02 |          1.03 |                 1.34 |                  0.76 |
| Mud                |            -0.75 |          0.76 |                 1.22 |                 -0.75 |
| Victory 2          |             0.11 |         -0.11 |                -1.14 |                  7.04 |
| run_world_war_zero |             0.14 |         -0.14 |                 0.29 |                 -3.04 |
| ctf1               |            -2.18 |          2.22 |                -3.27 |                -17.72 |
| Springlobe4        |            -0.69 |          0.7  |                 2.73 |                  4.66 |

Supersedes: #11303
closes #11079

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

The idea to investigate row flattening came from a brainstorming with ChatGPT. However the implementation is fully handmade and selfmade, the concept is fully understood (and was understood before I even asked the AI) and it wasn't even my goal to improve zoom rendering when brainstorming.

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
