### PR TITLE
Optimization: Stop rendering off screen entities

### DIFF
--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -219,12 +219,17 @@ public:
 		return !(!in_range(Position.x, m_TopLeft.x, m_BottomRight.x) || !in_range(Position.y, m_TopLeft.y, m_BottomRight.y));
 	}
 
+	void Expand(float Width, float Height)
+	{
+		m_TopLeft.x -= Width;
+		m_BottomRight.x += Width;
+		m_TopLeft.y -= Height;
+		m_BottomRight.y += Height;
+	}
+
 	void Expand(float Size)
 	{
-		m_TopLeft.x -= Size;
-		m_BottomRight.x += Size;
-		m_TopLeft.y -= Size;
-		m_BottomRight.y += Size;
+		Expand(Size, Size);
 	}
 
 	vec2 m_TopLeft;

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -460,6 +460,23 @@ void CItems::OnRender()
 
 	bool UsePredicted = GameClient()->Predict() && GameClient()->AntiPingGunfire();
 	auto &aSwitchers = GameClient()->Switchers();
+
+	CScreenRect ScreenRectLaser = Graphics()->GetScreen();
+	CScreenRect ScreenRectProjectile = ScreenRectLaser;
+	CScreenRect ScreenRectPickup = ScreenRectLaser;
+
+	constexpr float TileSize = 64.0f;
+	ScreenRectProjectile.Expand(TileSize);
+	ScreenRectLaser.Expand(TileSize / 2.0f);
+	ScreenRectPickup.Expand(1.75f * TileSize, 0.75f * TileSize);
+
+	auto IsLaserInside = [&](const CLaserData &LaserData) -> bool {
+		const vec2 &From = LaserData.m_From;
+		const vec2 &To = LaserData.m_To;
+		return !((From.x < ScreenRectLaser.m_TopLeft.x && To.x < ScreenRectLaser.m_TopLeft.x) || (From.x > ScreenRectLaser.m_BottomRight.x && To.x > ScreenRectLaser.m_BottomRight.x) ||
+			 (From.y < ScreenRectLaser.m_TopLeft.y && To.y < ScreenRectLaser.m_TopLeft.y) || (From.y > ScreenRectLaser.m_BottomRight.y && To.y > ScreenRectLaser.m_BottomRight.y));
+	};
+
 	if(UsePredicted)
 	{
 		for(auto *pProj = (CProjectile *)GameClient()->m_PrevPredictedWorld.FindFirst(CGameWorld::ENTTYPE_PROJECTILE); pProj; pProj = (CProjectile *)pProj->NextEntity())
@@ -468,6 +485,8 @@ void CItems::OnRender()
 				continue;
 
 			CProjectileData Data = pProj->GetData();
+			if(!ScreenRectProjectile.Inside(Data.m_StartPos))
+				continue;
 			RenderProjectile(&Data, pProj->GetId());
 		}
 		for(CEntity *pEnt = GameClient()->m_PrevPredictedWorld.FindFirst(CGameWorld::ENTTYPE_LASER); pEnt; pEnt = pEnt->NextEntity())
@@ -476,6 +495,8 @@ void CItems::OnRender()
 			if(!pLaser || pLaser->GetOwner() < 0 || !GameClient()->m_aClients[pLaser->GetOwner()].m_IsPredictedLocal)
 				continue;
 			CLaserData Data = pLaser->GetData();
+			if(!IsLaserInside(Data))
+				continue;
 			RenderLaser(&Data, true);
 		}
 		for(auto *pPickup = (CPickup *)GameClient()->m_PrevPredictedWorld.FindFirst(CGameWorld::ENTTYPE_PICKUP); pPickup; pPickup = (CPickup *)pPickup->NextEntity())
@@ -505,6 +526,8 @@ void CItems::OnRender()
 		if(Item.m_Type == NETOBJTYPE_PROJECTILE || Item.m_Type == NETOBJTYPE_DDRACEPROJECTILE || Item.m_Type == NETOBJTYPE_DDNETPROJECTILE)
 		{
 			CProjectileData Data = ExtractProjectileInfo(Item.m_Type, pData, &GameClient()->m_GameWorld, pEntEx);
+			if(!ScreenRectProjectile.Inside(Data.m_StartPos))
+				continue;
 			bool Inactive = !IsSuper && Data.m_SwitchNumber > 0 && Data.m_SwitchNumber < (int)aSwitchers.size() && !aSwitchers[Data.m_SwitchNumber].m_aStatus[SwitcherTeam];
 			if(Inactive && (Data.m_Explosive ? BlinkingProjEx : BlinkingProj))
 				continue;
@@ -531,6 +554,8 @@ void CItems::OnRender()
 		else if(Item.m_Type == NETOBJTYPE_PICKUP || Item.m_Type == NETOBJTYPE_DDNETPICKUP)
 		{
 			CPickupData Data = ExtractPickupInfo(Item.m_Type, pData, pEntEx);
+			if(!ScreenRectPickup.Inside(Data.m_Pos))
+				continue;
 			bool Inactive = !IsSuper && Data.m_SwitchNumber > 0 && Data.m_SwitchNumber < (int)aSwitchers.size() && !aSwitchers[Data.m_SwitchNumber].m_aStatus[SwitcherTeam];
 
 			if(Inactive && BlinkingPickup)
@@ -555,6 +580,8 @@ void CItems::OnRender()
 			}
 
 			CLaserData Data = ExtractLaserInfo(Item.m_Type, pData, &GameClient()->m_GameWorld, pEntEx);
+			if(!IsLaserInside(Data))
+				continue;
 			bool Inactive = !IsSuper && Data.m_SwitchNumber > 0 && Data.m_SwitchNumber < (int)aSwitchers.size() && !aSwitchers[Data.m_SwitchNumber].m_aStatus[SwitcherTeam];
 
 			bool IsEntBlink = false;

--- a/src/game/client/laser_data.cpp
+++ b/src/game/client/laser_data.cpp
@@ -12,7 +12,7 @@
 
 CLaserData ExtractLaserInfo(int NetObjType, const void *pData, CGameWorld *pGameWorld, const CNetObj_EntityEx *pEntEx)
 {
-	CLaserData Result = {vec2(0, 0)};
+	CLaserData Result;
 
 	if(NetObjType == NETOBJTYPE_DDNETLASER)
 	{
@@ -62,7 +62,7 @@ CLaserData ExtractLaserInfo(int NetObjType, const void *pData, CGameWorld *pGame
 
 CLaserData ExtractLaserInfoDDNet(const CNetObj_DDNetLaser *pLaser, CGameWorld *pGameWorld)
 {
-	CLaserData Result = {vec2(0, 0)};
+	CLaserData Result;
 	Result.m_From.x = pLaser->m_FromX;
 	Result.m_From.y = pLaser->m_FromY;
 	Result.m_To.x = pLaser->m_ToX;

--- a/src/game/client/laser_data.h
+++ b/src/game/client/laser_data.h
@@ -21,7 +21,7 @@ public:
 	int m_Type;
 	int m_SwitchNumber;
 	int m_Subtype;
-	bool m_Predict;
+	bool m_Predict = false;
 	// TuneZone is introduced locally
 	int m_TuneZone;
 };

--- a/src/game/client/pickup_data.cpp
+++ b/src/game/client/pickup_data.cpp
@@ -18,7 +18,7 @@ CPickupData ExtractPickupInfo(int NetObjType, const void *pData, const CNetObj_E
 
 	CNetObj_Pickup *pPickup = (CNetObj_Pickup *)pData;
 
-	CPickupData Result = {vec2(0, 0)};
+	CPickupData Result;
 
 	Result.m_Pos.x = pPickup->m_X;
 	Result.m_Pos.y = pPickup->m_Y;
@@ -31,7 +31,7 @@ CPickupData ExtractPickupInfo(int NetObjType, const void *pData, const CNetObj_E
 
 CPickupData ExtractPickupInfoDDNet(const CNetObj_DDNetPickup *pPickup)
 {
-	CPickupData Result = {vec2(0, 0)};
+	CPickupData Result;
 
 	Result.m_Pos.x = pPickup->m_X;
 	Result.m_Pos.y = pPickup->m_Y;

--- a/src/game/client/pickup_data.h
+++ b/src/game/client/pickup_data.h
@@ -16,7 +16,7 @@ public:
 	int m_Type;
 	int m_Subtype;
 	int m_SwitchNumber;
-	int m_Flags;
+	int m_Flags = 0;
 };
 
 CPickupData ExtractPickupInfo(int NetObjType, const void *pData, const CNetObj_EntityEx *pEntEx);

--- a/src/game/client/prediction/entities/laser.cpp
+++ b/src/game/client/prediction/entities/laser.cpp
@@ -227,5 +227,6 @@ CLaserData CLaser::GetData() const
 	Result.m_Subtype = -1;
 	Result.m_TuneZone = m_TuneZone;
 	Result.m_SwitchNumber = m_Number;
+	Result.m_Predict = true;
 	return Result;
 }

--- a/src/game/client/projectile_data.cpp
+++ b/src/game/client/projectile_data.cpp
@@ -3,6 +3,9 @@
 
 #include "projectile_data.h"
 
+#include <base/dbg.h>
+#include <base/log.h>
+
 #include <engine/shared/snapshot.h>
 
 #include <generated/protocol.h>
@@ -28,7 +31,7 @@ CProjectileData ExtractProjectileInfo(int NetObjType, const void *pData, CGameWo
 		return ExtractProjectileInfoDDRace((CNetObj_DDRaceProjectile *)pData, pGameWorld, pEntEx);
 	}
 
-	CProjectileData Result = {vec2(0, 0)};
+	CProjectileData Result;
 	Result.m_StartPos.x = pProj->m_X;
 	Result.m_StartPos.y = pProj->m_Y;
 	Result.m_StartVel.x = pProj->m_VelX / 100.0f;
@@ -44,7 +47,7 @@ CProjectileData ExtractProjectileInfo(int NetObjType, const void *pData, CGameWo
 
 CProjectileData ExtractProjectileInfoDDRace(const CNetObj_DDRaceProjectile *pProj, CGameWorld *pGameWorld, const CNetObj_EntityEx *pEntEx)
 {
-	CProjectileData Result = {vec2(0, 0)};
+	CProjectileData Result;
 
 	Result.m_StartPos.x = pProj->m_X / 100.0f;
 	Result.m_StartPos.y = pProj->m_Y / 100.0f;
@@ -71,7 +74,7 @@ CProjectileData ExtractProjectileInfoDDRace(const CNetObj_DDRaceProjectile *pPro
 
 CProjectileData ExtractProjectileInfoDDNet(const CNetObj_DDNetProjectile *pProj)
 {
-	CProjectileData Result = {vec2(0, 0)};
+	CProjectileData Result;
 
 	Result.m_StartPos = vec2(pProj->m_X / 100.0f, pProj->m_Y / 100.0f);
 	Result.m_StartVel = pProj->m_Owner < 0 ? vec2(pProj->m_VelX, pProj->m_VelY) / 1e6f : vec2(pProj->m_VelX, pProj->m_VelY);

--- a/src/game/client/projectile_data.h
+++ b/src/game/client/projectile_data.h
@@ -20,9 +20,9 @@ public:
 	bool m_ExtraInfo;
 	// The rest is only set if m_ExtraInfo is true.
 	int m_Owner;
-	bool m_Explosive;
-	int m_Bouncing;
-	bool m_Freeze;
+	bool m_Explosive = false;
+	int m_Bouncing = 0;
+	bool m_Freeze = false;
 	int m_SwitchNumber;
 	// TuneZone is introduced locally
 	int m_TuneZone;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Currently entities are rendered even if they're off screen. The client trusts, that the network clipping works and renders all entities from the snapshot. However a malicious servers or players who enable `/showall` can render all the entities all the time, even if it's offscreen. This PR basically adds a check before rendering an entity.

The pros are, that off screen entities may be known to the client but are skipped in rendering. The cons are, that this check runs even on on screen entities, which may result in worse performance. This is the case when zoomed far out, because every entity is visible but all checks are run.

I created a vote to show, if this PR regarding `/showall` is worth the effort:
https://discord.com/channels/252358080522747904/295908390956433410/1514580504316219452

## Visual changes:

Smoke trails of off screen grenades might not be visible to the player, since they're not generated in the first place. This issue is so minor, that I placed 1000 grenades on top of each other with (grenade_speed 0, etc...) only to barely notice a difference

## Benchmarks:
<img width="306" height="473" alt="Benchmark-12275" src="https://github.com/user-attachments/assets/246a8c07-362c-4873-b191-bcc83b9ff6f6" />

| map                |   FT avg. µs (%) |   AVG FPS (%) |   worst 0.01 FPS (%) |   worst 0.001 FPS (%) |
|:-------------------|-----------------:|--------------:|---------------------:|----------------------:|
| Abyss              |            -0.5  |          0.5  |                 8.97 |                 90.39 |
| KingsLeap          |            -6.46 |          6.91 |                 1.57 |                  5.99 |
| Linear             |            -0.51 |          0.51 |               -10.46 |                -50.75 |
| Mud                |            -1.56 |          1.58 |                -0.61 |                 -8.97 |
| Victory 2          |            -1.96 |          2    |                 2.49 |                 11.3  |
| run_world_war_zero |             0.9  |         -0.89 |               -11.4  |                -51.74 |
| ctf1               |            -4.58 |          4.8  |                -3.06 |                -18.84 |
| Springlobe4        |            -6.93 |          7.44 |                 4.08 |                -27.34 |

**These benchmarks were done with /showall disabled**

My benchmarks show an improvement on all maps which have a few (or a lot of) entities, which are
- ctf1 (a fair amount of entities
- Springlobe 4 (lots of entities)

Maps without entities are
- Abyss
- Linear

I don't know the entity count for the other maps except KingsLeap, which sees an improvement besides not having entities.

The benchmark clearly shows an improvement on maps with entities even with `/showall` disabled. Enabling it would **definitely** create an even stronger result.

Benchmarks were created with a branch of https://github.com/AssassinTee/ddnet-benchmarks , that I am soon going to merge into main

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options (antiping)
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
