### PR TITLE
Fix stack overflow parsing unexpected OpenGL driver version string, various refactoring

### DIFF
--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -183,10 +183,16 @@ static void ParseVersionString(EBackendType BackendType, const char *pStr, int &
 	size_t TotalNumbersPassed = 0;
 	int aNumbers[3] = {0};
 	bool LastWasNumber = false;
+	bool Error = false;
 	while(*pStr && TotalNumbersPassed < 3)
 	{
 		if(str_isnum(*pStr))
 		{
+			if(CurNumberStrLen >= std::size(aCurNumberStr) - 1)
+			{
+				Error = true;
+				break;
+			}
 			aCurNumberStr[CurNumberStrLen++] = (char)*pStr;
 			LastWasNumber = true;
 		}
@@ -212,9 +218,21 @@ static void ParseVersionString(EBackendType BackendType, const char *pStr, int &
 		++pStr;
 	}
 
-	VersionMajor = aNumbers[0];
-	VersionMinor = aNumbers[1];
-	VersionPatch = aNumbers[2];
+	if(Error || TotalNumbersPassed == 0)
+	{
+		// Use the newest supported OpenGL version if the version string could not be parsed.
+		// We assume that the format was changed in a future driver that supports all OpenGL
+		// capabilities that we use.
+		VersionMajor = 3;
+		VersionMinor = BackendType == BACKEND_TYPE_OPENGL_ES ? 0 : 3;
+		VersionPatch = 0;
+	}
+	else
+	{
+		VersionMajor = aNumbers[0];
+		VersionMinor = aNumbers[1];
+		VersionPatch = aNumbers[2];
+	}
 }
 
 #ifndef BACKEND_AS_OPENGL_ES

--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -167,57 +167,54 @@ void CCommandProcessorFragment_OpenGL::SetState(const CCommandBuffer::SState &St
 
 static void ParseVersionString(EBackendType BackendType, const char *pStr, int &VersionMajor, int &VersionMinor, int &VersionPatch)
 {
-	if(pStr)
+	// if backend is GLES, it starts with "OpenGL ES " or OpenGL ES-CM for older contexts, rest is the same
+	if(BackendType == BACKEND_TYPE_OPENGL_ES)
 	{
-		// if backend is GLES, it starts with "OpenGL ES " or OpenGL ES-CM for older contexts, rest is the same
-		if(BackendType == BACKEND_TYPE_OPENGL_ES)
-		{
-			int StrLenGLES = str_length("OpenGL ES ");
-			int StrLenGLESCM = str_length("OpenGL ES-CM ");
-			if(str_comp_num(pStr, "OpenGL ES ", StrLenGLES) == 0)
-				pStr += StrLenGLES;
-			else if(str_comp_num(pStr, "OpenGL ES-CM ", StrLenGLESCM) == 0)
-				pStr += StrLenGLESCM;
-		}
-
-		char aCurNumberStr[32];
-		size_t CurNumberStrLen = 0;
-		size_t TotalNumbersPassed = 0;
-		int aNumbers[3] = {0};
-		bool LastWasNumber = false;
-		while(*pStr && TotalNumbersPassed < 3)
-		{
-			if(str_isnum(*pStr))
-			{
-				aCurNumberStr[CurNumberStrLen++] = (char)*pStr;
-				LastWasNumber = true;
-			}
-			else if(LastWasNumber && (*pStr == '.' || *pStr == ' '))
-			{
-				if(CurNumberStrLen > 0)
-				{
-					aCurNumberStr[CurNumberStrLen] = 0;
-					aNumbers[TotalNumbersPassed++] = str_toint(aCurNumberStr);
-					CurNumberStrLen = 0;
-				}
-
-				LastWasNumber = false;
-
-				if(*pStr != '.')
-					break;
-			}
-			else
-			{
-				break;
-			}
-
-			++pStr;
-		}
-
-		VersionMajor = aNumbers[0];
-		VersionMinor = aNumbers[1];
-		VersionPatch = aNumbers[2];
+		int StrLenGLES = str_length("OpenGL ES ");
+		int StrLenGLESCM = str_length("OpenGL ES-CM ");
+		if(str_comp_num(pStr, "OpenGL ES ", StrLenGLES) == 0)
+			pStr += StrLenGLES;
+		else if(str_comp_num(pStr, "OpenGL ES-CM ", StrLenGLESCM) == 0)
+			pStr += StrLenGLESCM;
 	}
+
+	char aCurNumberStr[32];
+	size_t CurNumberStrLen = 0;
+	size_t TotalNumbersPassed = 0;
+	int aNumbers[3] = {0};
+	bool LastWasNumber = false;
+	while(*pStr && TotalNumbersPassed < 3)
+	{
+		if(str_isnum(*pStr))
+		{
+			aCurNumberStr[CurNumberStrLen++] = (char)*pStr;
+			LastWasNumber = true;
+		}
+		else if(LastWasNumber && (*pStr == '.' || *pStr == ' '))
+		{
+			if(CurNumberStrLen > 0)
+			{
+				aCurNumberStr[CurNumberStrLen] = 0;
+				aNumbers[TotalNumbersPassed++] = str_toint(aCurNumberStr);
+				CurNumberStrLen = 0;
+			}
+
+			LastWasNumber = false;
+
+			if(*pStr != '.')
+				break;
+		}
+		else
+		{
+			break;
+		}
+
+		++pStr;
+	}
+
+	VersionMajor = aNumbers[0];
+	VersionMinor = aNumbers[1];
+	VersionPatch = aNumbers[2];
 }
 
 #ifndef BACKEND_AS_OPENGL_ES

--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -167,15 +167,15 @@ void CCommandProcessorFragment_OpenGL::SetState(const CCommandBuffer::SState &St
 
 static void ParseVersionString(EBackendType BackendType, const char *pStr, int &VersionMajor, int &VersionMinor, int &VersionPatch)
 {
-	// if backend is GLES, it starts with "OpenGL ES " or OpenGL ES-CM for older contexts, rest is the same
+	// If the backend is GLES, the version string starts with `OpenGL ES ` or `OpenGL ES-CM ` for older contexts, rest is the same.
 	if(BackendType == BACKEND_TYPE_OPENGL_ES)
 	{
-		int StrLenGLES = str_length("OpenGL ES ");
-		int StrLenGLESCM = str_length("OpenGL ES-CM ");
-		if(str_comp_num(pStr, "OpenGL ES ", StrLenGLES) == 0)
-			pStr += StrLenGLES;
-		else if(str_comp_num(pStr, "OpenGL ES-CM ", StrLenGLESCM) == 0)
-			pStr += StrLenGLESCM;
+		const char *pSkippedPrefix;
+		if((pSkippedPrefix = str_startswith(pStr, "OpenGL ES ")) != nullptr ||
+			(pSkippedPrefix = str_startswith(pStr, "OpenGL ES-CM ")) != nullptr)
+		{
+			pStr = pSkippedPrefix;
+		}
 	}
 
 	char aCurNumberStr[32];

--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -178,13 +178,13 @@ static void ParseVersionString(EBackendType BackendType, const char *pStr, int &
 		}
 	}
 
-	char aCurNumberStr[32];
+	char aCurNumberStr[10];
 	size_t CurNumberStrLen = 0;
 	size_t TotalNumbersPassed = 0;
 	int aNumbers[3] = {0};
 	bool LastWasNumber = false;
 	bool Error = false;
-	while(*pStr && TotalNumbersPassed < 3)
+	while(true)
 	{
 		if(str_isnum(*pStr))
 		{
@@ -193,28 +193,25 @@ static void ParseVersionString(EBackendType BackendType, const char *pStr, int &
 				Error = true;
 				break;
 			}
-			aCurNumberStr[CurNumberStrLen++] = (char)*pStr;
+			aCurNumberStr[CurNumberStrLen++] = *pStr;
 			LastWasNumber = true;
 		}
-		else if(LastWasNumber && (*pStr == '.' || *pStr == ' '))
+		else if(LastWasNumber && (*pStr == '.' || *pStr == ' ' || *pStr == '\0'))
 		{
-			if(CurNumberStrLen > 0)
-			{
-				aCurNumberStr[CurNumberStrLen] = 0;
-				aNumbers[TotalNumbersPassed++] = str_toint(aCurNumberStr);
-				CurNumberStrLen = 0;
-			}
-
+			aCurNumberStr[CurNumberStrLen] = '\0';
+			aNumbers[TotalNumbersPassed] = str_toint(aCurNumberStr);
+			CurNumberStrLen = 0;
+			TotalNumbersPassed++;
 			LastWasNumber = false;
-
-			if(*pStr != '.')
+			if(TotalNumbersPassed == std::size(aNumbers) || *pStr != '.')
+			{
 				break;
+			}
 		}
 		else
 		{
 			break;
 		}
-
 		++pStr;
 	}
 

--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -319,13 +319,16 @@ bool CCommandProcessorFragment_OpenGL::InitOpenGL(const SCommand_Init *pCommand)
 	};
 
 	const char *pVendorString = (const char *)glGetString(GL_VENDOR);
+	dbg_assert(pVendorString != nullptr, "glGetString(GL_VENDOR) failure");
 	log_info("gfx/opengl", "Vendor string: %s", pVendorString);
 
 	// check what this context can do
 	const char *pVersionString = (const char *)glGetString(GL_VERSION);
+	dbg_assert(pVersionString != nullptr, "glGetString(GL_VERSION) failure");
 	log_info("gfx/opengl", "Version string: %s", pVersionString);
 
 	const char *pRendererString = (const char *)glGetString(GL_RENDERER);
+	dbg_assert(pRendererString != nullptr, "glGetString(GL_RENDERER) failure");
 
 	str_copy(pCommand->m_pVendorString, pVendorString, GPU_INFO_STRING_SIZE);
 	str_copy(pCommand->m_pVersionString, pVersionString, GPU_INFO_STRING_SIZE);


### PR DESCRIPTION
See commit messages. [View the second commit without whitespace difference](https://github.com/ddnet/ddnet/commit/238674ad6d8b4a5c2fc509a4ea5eabfb9d2ce10a?w=1).

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options: OpenGL, OpenGL ES
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions: AI found the stack overflow.
