### PR TITLE
Limit number of arguments in `process_execute` to avoid potential future overflow

### DIFF
--- a/src/base/process.cpp
+++ b/src/base/process.cpp
@@ -37,6 +37,7 @@ int process_id()
 PROCESS process_execute(const char *file, EShellExecuteWindowState window_state, const char **arguments, const size_t num_arguments)
 {
 	dbg_assert((arguments == nullptr) == (num_arguments == 0), "Invalid number of arguments");
+	dbg_assert(num_arguments < 1024, "Too many arguments: %d", (int)num_arguments);
 #if defined(CONF_FAMILY_WINDOWS)
 	dbg_assert(str_endswith_nocase(file, ".bat") == nullptr && str_endswith_nocase(file, ".cmd") == nullptr, "Running batch files not allowed");
 	dbg_assert(str_endswith(file, ".exe") != nullptr || num_arguments == 0, "Arguments only allowed with .exe files");


### PR DESCRIPTION
Irrelevant today, no callers supply more than a couple of arguments.

Supersedes #12136.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions