### PR TITLE
Validate 0.7 skin names, fix stack overflow

### DIFF
--- a/src/game/client/components/skins7.cpp
+++ b/src/game/client/components/skins7.cpp
@@ -181,11 +181,28 @@ public:
 
 int CSkins7::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 {
-	if(IsDir || !str_endswith(pName, ".json"))
+	if(IsDir)
+	{
 		return 0;
+	}
+
+	const char *pSuffix = str_endswith(pName, ".json");
+	if(pSuffix == nullptr)
+	{
+		return 0;
+	}
+
+	char aSkinName[IO_MAX_PATH_LENGTH];
+	str_truncate(aSkinName, sizeof(aSkinName), pName, pSuffix - pName);
+	if(str_length(aSkinName) >= (int)sizeof(CSkin().m_aName) || !str_valid_filename(aSkinName))
+	{
+		log_error("skins7", "Skin name is not valid: %s", aSkinName);
+		log_error("skins7", "Skin names must be valid filenames shorter than %d characters.", (int)sizeof(CSkin().m_aName));
+		return 0;
+	}
 
 	CSkinScanData *pScanData = static_cast<CSkinScanData *>(pUser);
-	pScanData->m_pThis->LoadSkin(pName, DirType);
+	pScanData->m_pThis->LoadSkin(aSkinName, DirType);
 	pScanData->m_SkinLoadedCallback();
 	return 0;
 }
@@ -193,7 +210,7 @@ int CSkins7::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 bool CSkins7::LoadSkin(const char *pName, int DirType)
 {
 	char aFilename[IO_MAX_PATH_LENGTH];
-	str_format(aFilename, sizeof(aFilename), SKINS_DIR "/%s", pName);
+	str_format(aFilename, sizeof(aFilename), SKINS_DIR "/%s.json", pName);
 	void *pFileData;
 	unsigned JsonFileSize;
 	if(!Storage()->ReadFile(aFilename, DirType, &pFileData, &JsonFileSize))
@@ -203,7 +220,7 @@ bool CSkins7::LoadSkin(const char *pName, int DirType)
 	}
 
 	CSkin Skin;
-	str_copy(Skin.m_aName, pName, 1 + str_length(pName) - str_length(".json"));
+	str_copy(Skin.m_aName, pName);
 	const bool SpecialSkin = IsSpecialSkin(Skin.m_aName);
 	Skin.m_Flags = 0;
 	if(SpecialSkin)


### PR DESCRIPTION
The `str_copy` into `Skin.m_aName` was not considering the size of the buffer.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions