### PR TITLE
Be explicit about virtual OnReset call in constructor

### DIFF
--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -15,7 +15,7 @@
 
 CEmoticon::CEmoticon()
 {
-	OnReset();
+	CEmoticon::OnReset();
 }
 
 void CEmoticon::ConKeyEmoticon(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/client/components/particles.cpp
+++ b/src/game/client/components/particles.cpp
@@ -15,7 +15,7 @@
 
 CParticles::CParticles()
 {
-	OnReset();
+	CParticles::OnReset();
 	m_RenderTrail.m_pParts = this;
 	m_RenderTrailExtra.m_pParts = this;
 	m_RenderExplosions.m_pParts = this;

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -25,7 +25,7 @@
 
 CScoreboard::CScoreboard()
 {
-	OnReset();
+	CScoreboard::OnReset();
 }
 
 void CScoreboard::SetUiMousePos(vec2 Pos)

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -142,7 +142,7 @@ void CSpectator::ConMultiView(IConsole::IResult *pResult, void *pUserData)
 CSpectator::CSpectator()
 {
 	m_SelectorMouse = vec2(0.0f, 0.0f);
-	OnReset();
+	CSpectator::OnReset();
 }
 
 void CSpectator::OnConsoleInit()

--- a/src/game/client/components/tooltips.cpp
+++ b/src/game/client/components/tooltips.cpp
@@ -6,7 +6,7 @@
 
 CTooltips::CTooltips()
 {
-	OnReset();
+	CTooltips::OnReset();
 }
 
 void CTooltips::OnReset()

--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -155,7 +155,7 @@ int CVoting::SecondsLeft() const
 CVoting::CVoting()
 {
 	ClearOptions();
-	OnReset();
+	CVoting::OnReset();
 }
 
 void CVoting::AddOption(const char *pDescription)


### PR DESCRIPTION
The warning in general seems to be useful

https://cmu-sei.github.io/secure-coding-standards/sei-cert-cpp-coding-standard/rules/object-oriented-programming-oop/oop50-cpp/

But in this specific case calling OnReset() in the constructor is fine. So while this diff looks a bit ugly it does help with the clang warnings.

Fixes this clang warning

```
/home/chiller/Desktop/git/ddnet/src/game/client/components/particles.cpp:18:2: warning: Call to virtual method 'CParticles::OnReset' during construction bypasses virtual dispatch [clang-analyzer-optin.cplu
splus.VirtualCall]
   18 |         OnReset();
      |         ^~~~~~~~~
/home/chiller/Desktop/git/ddnet/src/game/client/components/particles.cpp:18:2: note: Call to virtual method 'CParticles::OnReset' during construction bypasses virtual dispatch
   18 |         OnReset();
      |         ^~~~~~~~~
[47/690] ./src/game/client/components/ghost.cpp
```

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
