### PR TITLE
Disable clang readability-inconsistent-ifelse-braces

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,6 +96,7 @@ Checks: >
   -readability-function-size,
   -readability-identifier-length,
   -readability-implicit-bool-conversion,
+  -readability-inconsistent-ifelse-braces,
   -readability-isolate-declaration,
   -readability-magic-numbers,
   -readability-math-missing-parentheses,


### PR DESCRIPTION
https://clang.llvm.org/extra//clang-tidy/checks/readability/inconsistent-ifelse-braces.html

Alternative would be fixing it. I let clang do it and filter out most of the other things it could not resist to fix and it still is a over 500 line diff https://github.com/ChillerDragon/ddnet/commit/af7097cafac41e6ec550c3195540fbe649eb6eca

And many cases make readability worse not better if you ask me. But I am personally also a enemy of braces for single body if statements. The mix of brace and no brace is not ideal indeed that I have to admit.

We have a bunch of cases like this where there are some clean one liners and then one bigger branch. There for sure might be a way to dance around these and massage the code to work. But not sure if that is a good idea.

https://github.com/ddnet/ddnet/blob/36336392ea7635cb35530b7388525347cbc8ccf4/src/engine/client/serverbrowser.cpp#L453-L473

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

I used claudex opus fable 7 to make sure the new line is not interrupting the alphabetical sorting.