### PR TITLE
Slug minus in header guard script

### DIFF
--- a/scripts/check_header_guards.py
+++ b/scripts/check_header_guards.py
@@ -23,6 +23,7 @@ def check_file(filename):
 	if filename in EXCEPTIONS:
 		return False
 	guard_name = ("_".join(filename.split(PATH)[1].split("/"))[:-2]).upper() + "_H"
+	guard_name = guard_name.replace("-", "_")
 	header_guard_line1 = f"#ifndef {guard_name}"
 	header_guard_line2 = f"#define {guard_name}"
 	footer1 = f"#endif // {guard_name}"


### PR DESCRIPTION
If a folder is called foo-bar the guard script will suggest a syntax error like this

```C
#ifndef FOO-BAR_BAZ_H
```

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
