### PR TITLE
Fix some steam variable naming violations

### DIFF
--- a/src/engine/client/steam.cpp
+++ b/src/engine/client/steam.cpp
@@ -62,7 +62,7 @@ public:
 		ParseConnectString(aConnect);
 	}
 
-	void OnGameRichPresenceJoinRequested(GameRichPresenceJoinRequested_t *pEvent)
+	void OnGameRichPresenceJoinRequested(SGameRichPresenceJoinRequested_t *pEvent)
 	{
 		ParseConnectString(pEvent->m_aRGCHConnect);
 	}
@@ -91,21 +91,21 @@ public:
 	void Update() override
 	{
 		SteamAPI_ManualDispatch_RunFrame(m_SteamPipe);
-		CallbackMsg_t Callback;
+		SCallbackMsg_t Callback;
 		while(SteamAPI_ManualDispatch_GetNextCallback(m_SteamPipe, &Callback))
 		{
-			switch(Callback.m_iCallback)
+			switch(Callback.m_ICallback)
 			{
-			case NewUrlLaunchParameters_t::k_iCallback:
+			case SNewUrlLaunchParameters_t::k_iCallback:
 				ReadLaunchCommandLine();
 				break;
-			case GameRichPresenceJoinRequested_t::k_iCallback:
-				OnGameRichPresenceJoinRequested((GameRichPresenceJoinRequested_t *)Callback.m_pubParam);
+			case SGameRichPresenceJoinRequested_t::k_iCallback:
+				OnGameRichPresenceJoinRequested((SGameRichPresenceJoinRequested_t *)Callback.m_pPubParam);
 				break;
 			default:
 				if(g_Config.m_Debug)
 				{
-					dbg_msg("steam/dbg", "unhandled callback id=%d", Callback.m_iCallback);
+					dbg_msg("steam/dbg", "unhandled callback id=%d", Callback.m_ICallback);
 				}
 			}
 			SteamAPI_ManualDispatch_FreeLastCallback(m_SteamPipe);

--- a/src/steam/steam_api_flat.h
+++ b/src/steam/steam_api_flat.h
@@ -15,25 +15,25 @@ typedef uint64_t CSteamId;
 typedef int32_t HSteamPipe;
 typedef int32_t HSteamUser;
 
-struct CallbackMsg_t
+struct SCallbackMsg_t
 {
-	HSteamUser m_hSteamUser;
-	int m_iCallback;
-	unsigned char *m_pubParam;
-	int m_cubParam;
+	HSteamUser m_HSteamUser;
+	int m_ICallback;
+	unsigned char *m_pPubParam;
+	int m_CubParam;
 };
 
-struct GameRichPresenceJoinRequested_t
+struct SGameRichPresenceJoinRequested_t
 {
 	enum
 	{
 		k_iCallback = 337
 	};
-	CSteamId m_steamIdFriend;
+	CSteamId m_SteamIdFriend;
 	char m_aRGCHConnect[256];
 };
 
-struct NewUrlLaunchParameters_t
+struct SNewUrlLaunchParameters_t
 {
 	enum
 	{
@@ -51,7 +51,7 @@ STEAMAPI void SteamAPI_Shutdown();
 
 STEAMAPI void SteamAPI_ManualDispatch_Init();
 STEAMAPI void SteamAPI_ManualDispatch_FreeLastCallback(HSteamPipe SteamPipe);
-STEAMAPI bool SteamAPI_ManualDispatch_GetNextCallback(HSteamPipe SteamPipe, CallbackMsg_t *pCallbackMsg);
+STEAMAPI bool SteamAPI_ManualDispatch_GetNextCallback(HSteamPipe SteamPipe, SCallbackMsg_t *pCallbackMsg);
 STEAMAPI void SteamAPI_ManualDispatch_RunFrame(HSteamPipe SteamPipe);
 
 STEAMAPI ISteamApps *SteamAPI_SteamApps_v008();

--- a/src/steam/steam_api_stub.cpp
+++ b/src/steam/steam_api_stub.cpp
@@ -11,7 +11,7 @@ HSteamPipe SteamAPI_GetHSteamPipe() { abort(); }
 void SteamAPI_Shutdown() { abort(); }
 void SteamAPI_ManualDispatch_Init() { abort(); }
 void SteamAPI_ManualDispatch_FreeLastCallback(HSteamPipe SteamPipe) { abort(); }
-bool SteamAPI_ManualDispatch_GetNextCallback(HSteamPipe SteamPipe, CallbackMsg_t *pCallbackMsg) { abort(); }
+bool SteamAPI_ManualDispatch_GetNextCallback(HSteamPipe SteamPipe, SCallbackMsg_t *pCallbackMsg) { abort(); }
 void SteamAPI_ManualDispatch_RunFrame(HSteamPipe SteamPipe) { abort(); }
 ISteamApps *SteamAPI_SteamApps_v008() { abort(); }
 int SteamAPI_ISteamApps_GetLaunchCommandLine(ISteamApps *pSelf, char *pBuffer, int BufferSize) { abort(); }


### PR DESCRIPTION
## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions