### PR TITLE
DTRT when toggling `cl_show_chat_system`

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -655,13 +655,14 @@ void CChat::StoreSave(const char *pText)
 
 void CChat::AddLine(int ClientId, int Team, const char *pLine)
 {
-	if(*pLine == 0 ||
-		(ClientId == SERVER_MSG && !g_Config.m_ClShowChatSystem) ||
-		(ClientId >= 0 && (GameClient()->m_aClients[ClientId].m_aName[0] == '\0' || // unknown client
-					  GameClient()->m_aClients[ClientId].m_ChatIgnore ||
-					  (GameClient()->m_Snap.m_LocalClientId != ClientId && g_Config.m_ClShowChatFriends && !GameClient()->m_aClients[ClientId].m_Friend) ||
-					  (GameClient()->m_Snap.m_LocalClientId != ClientId && g_Config.m_ClShowChatTeamMembersOnly && GameClient()->IsOtherTeam(ClientId) && GameClient()->m_Teams.Team(GameClient()->m_Snap.m_LocalClientId) != TEAM_FLOCK) ||
-					  (GameClient()->m_Snap.m_LocalClientId != ClientId && GameClient()->m_aClients[ClientId].m_Foe))))
+	if(*pLine == '\0') // Empty message
+		return;
+	if(ClientId >= 0 && GameClient()->m_aClients[ClientId].m_aName[0] == '\0') // Unknown client
+		return;
+	if(ClientId >= 0 && (GameClient()->m_aClients[ClientId].m_ChatIgnore ||
+				    (GameClient()->m_Snap.m_LocalClientId != ClientId && g_Config.m_ClShowChatFriends && !GameClient()->m_aClients[ClientId].m_Friend) ||
+				    (GameClient()->m_Snap.m_LocalClientId != ClientId && g_Config.m_ClShowChatTeamMembersOnly && GameClient()->IsOtherTeam(ClientId) && GameClient()->m_Teams.Team(GameClient()->m_Snap.m_LocalClientId) != TEAM_FLOCK) ||
+				    (GameClient()->m_Snap.m_LocalClientId != ClientId && GameClient()->m_aClients[ClientId].m_Foe)))
 		return;
 
 	// trim right and set maximum length to 256 utf8-characters
@@ -1275,6 +1276,9 @@ void CChat::OnRender()
 			break;
 		if(Now > Line.m_Time + 16 * time_freq() && !m_PrevShowChat)
 			break;
+
+		if(Line.m_ClientId == SERVER_MSG && !g_Config.m_ClShowChatSystem)
+			continue;
 
 		y -= Line.m_aYOffset[OffsetType];
 


### PR DESCRIPTION
When system messages are disabled they get filtered before getting logged which means that if you miss something it's gone forever.

To fix this, filter system messages when chat is rendered so that they get logged and they can be reshown by toggling `cl_show_chat_system`.

This is what I consider to be DTRT, however is inconsistent behaviour with all other filters that currently exist. Regardless I think this should be merged

It is possible to move all the other filters but unfortunately they rely on IDs which are not consistent. A solution would be to
1. store the original name to determine friend/foe and
2. store the original team of the message and team to determine other team
I'm not sure if this is a good solution though which is why I've left it out

[toggleable_system_messages-2026-06-19_09.15.36.webm](https://github.com/user-attachments/assets/d84bf1e2-f866-4fbc-a8f4-97babfb49d7b)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
