### PR TITLE
Add `[[nodiscard]]` attribute to `fs_*` functions

### DIFF
--- a/src/base/fs.cpp
+++ b/src/base/fs.cpp
@@ -232,7 +232,10 @@ void fs_listdir_fileinfo(const char *dir, FS_LISTDIR_CALLBACK_FILEINFO cb, int t
 		}
 		str_copy(buffer + length, entry->d_name, sizeof(buffer) - length);
 		time_t created = -1, modified = -1;
-		fs_file_time(buffer, &created, &modified);
+		if(fs_file_time(buffer, &created, &modified) != 0)
+		{
+			log_warn("filesystem", "Failed to determine file time of '%s'", buffer);
+		}
 
 		CFsFileInfo info;
 		info.m_pName = entry->d_name;

--- a/src/base/fs.h
+++ b/src/base/fs.h
@@ -29,7 +29,7 @@
  *
  * @remark The strings are treated as null-terminated strings.
  */
-int fs_makedir(const char *path);
+[[nodiscard]] int fs_makedir(const char *path);
 
 /**
  * Recursively creates parent directories for a file or directory.
@@ -42,7 +42,7 @@ int fs_makedir(const char *path);
  *
  * @remark The strings are treated as null-terminated strings.
  */
-int fs_makedir_rec_for(const char *path);
+[[nodiscard]] int fs_makedir_rec_for(const char *path);
 
 /**
  * Removes a directory.
@@ -57,7 +57,7 @@ int fs_makedir_rec_for(const char *path);
  *
  * @remark The strings are treated as null-terminated strings.
  */
-int fs_removedir(const char *path);
+[[nodiscard]] int fs_removedir(const char *path);
 
 /**
  * Lists the files and folders in a directory.
@@ -98,7 +98,7 @@ void fs_listdir_fileinfo(const char *dir, FS_LISTDIR_CALLBACK_FILEINFO cb, int t
  *
  * @remark The strings are treated as null-terminated strings.
  */
-int fs_chdir(const char *path);
+[[nodiscard]] int fs_chdir(const char *path);
 
 /**
  * Gets the current working directory.
@@ -112,7 +112,7 @@ int fs_chdir(const char *path);
  *
  * @remark The strings are treated as null-terminated strings.
  */
-char *fs_getcwd(char *buffer, int buffer_size);
+[[nodiscard]] char *fs_getcwd(char *buffer, int buffer_size);
 
 /**
  * Fetches per user configuration directory.
@@ -131,7 +131,7 @@ char *fs_getcwd(char *buffer, int buffer_size);
  *
  * @remark The strings are treated as null-terminated strings.
  */
-int fs_storage_path(const char *appname, char *path, int max);
+[[nodiscard]] int fs_storage_path(const char *appname, char *path, int max);
 
 /**
  * Gets the absolute path to the executable.
@@ -147,7 +147,7 @@ int fs_storage_path(const char *appname, char *path, int max);
  *
  * @remark The strings are treated as null-terminated strings.
  */
-int fs_executable_path(char *buffer, int buffer_size);
+[[nodiscard]] int fs_executable_path(char *buffer, int buffer_size);
 
 /**
  * Checks if a file exists.
@@ -161,7 +161,7 @@ int fs_executable_path(char *buffer, int buffer_size);
  *
  * @remark The strings are treated as null-terminated strings.
  */
-int fs_is_file(const char *path);
+[[nodiscard]] int fs_is_file(const char *path);
 
 /**
  * Checks if a folder exists.
@@ -175,7 +175,7 @@ int fs_is_file(const char *path);
  *
  * @remark The strings are treated as null-terminated strings.
  */
-int fs_is_dir(const char *path);
+[[nodiscard]] int fs_is_dir(const char *path);
 
 /**
  * Checks whether a given path is relative or absolute.
@@ -188,7 +188,7 @@ int fs_is_dir(const char *path);
  *
  * @remark The strings are treated as null-terminated strings.
  */
-int fs_is_relative_path(const char *path);
+[[nodiscard]] int fs_is_relative_path(const char *path);
 
 /**
  * Gets the name of a file or folder specified by a path,
@@ -204,7 +204,7 @@ int fs_is_relative_path(const char *path);
  * @remark No distinction between files and folders is being made.
  * @remark The strings are treated as null-terminated strings.
  */
-const char *fs_filename(const char *path);
+[[nodiscard]] const char *fs_filename(const char *path);
 
 /**
  * Splits a filename into name (without extension) and file extension.
@@ -234,7 +234,7 @@ void fs_split_file_extension(const char *filename, char *name, size_t name_size,
  *
  * @remark The strings are treated as null-terminated strings.
  */
-int fs_parent_dir(char *path);
+[[nodiscard]] int fs_parent_dir(char *path);
 
 /**
  * Normalizes the given path: replaces backslashes with regular slashes
@@ -260,7 +260,7 @@ void fs_normalize_path(char *path);
  * @remark The strings are treated as null-terminated strings.
  * @remark Returns an error if the path specifies a directory name.
  */
-int fs_remove(const char *filename);
+[[nodiscard]] int fs_remove(const char *filename);
 
 /**
  * Renames the file or directory. If the paths differ the file will be moved.
@@ -274,7 +274,7 @@ int fs_remove(const char *filename);
  *
  * @remark The strings are treated as null-terminated strings.
  */
-int fs_rename(const char *oldname, const char *newname);
+[[nodiscard]] int fs_rename(const char *oldname, const char *newname);
 
 /**
  * Gets the creation and the last modification date of a file or directory.
@@ -290,6 +290,6 @@ int fs_rename(const char *oldname, const char *newname);
  * @remark The strings are treated as null-terminated strings.
  * @remark Returned time is in seconds since UNIX Epoch.
  */
-int fs_file_time(const char *name, time_t *created, time_t *modified);
+[[nodiscard]] int fs_file_time(const char *name, time_t *created, time_t *modified);
 
 #endif

--- a/src/engine/shared/fifo.cpp
+++ b/src/engine/shared/fifo.cpp
@@ -86,7 +86,7 @@ void CFifo::Shutdown()
 		return;
 
 	close(m_File);
-	fs_remove(m_aFilename);
+	(void)fs_remove(m_aFilename);
 }
 
 void CFifo::Update()

--- a/src/engine/shared/http.cpp
+++ b/src/engine/shared/http.cpp
@@ -428,11 +428,11 @@ void CHttpRequest::OnCompletionInternal(void *pHandle, unsigned int Result)
 
 		if(State == EHttpState::ERROR || State == EHttpState::ABORTED)
 		{
-			fs_remove(m_aDestAbsoluteTmp);
+			(void)fs_remove(m_aDestAbsoluteTmp);
 		}
 		else if(m_IfModifiedSince >= 0 && m_StatusCode == 304) // 304 Not Modified
 		{
-			fs_remove(m_aDestAbsoluteTmp);
+			(void)fs_remove(m_aDestAbsoluteTmp);
 			if(m_WriteToMemory)
 			{
 				free(m_pBuffer);
@@ -464,7 +464,7 @@ void CHttpRequest::OnCompletionInternal(void *pHandle, unsigned int Result)
 			{
 				log_error("http", "i/o error, cannot move file: %s", m_aDest);
 				State = EHttpState::ERROR;
-				fs_remove(m_aDestAbsoluteTmp);
+				(void)fs_remove(m_aDestAbsoluteTmp);
 			}
 		}
 	}
@@ -488,20 +488,20 @@ void CHttpRequest::OnValidation(bool Success)
 	{
 		if(m_IfModifiedSince >= 0 && m_StatusCode == 304) // 304 Not Modified
 		{
-			fs_remove(m_aDestAbsoluteTmp);
+			(void)fs_remove(m_aDestAbsoluteTmp);
 			return;
 		}
 		if(fs_rename(m_aDestAbsoluteTmp, m_aDestAbsolute))
 		{
 			log_error("http", "i/o error, cannot move file: %s", m_aDest);
 			m_State = EHttpState::ERROR;
-			fs_remove(m_aDestAbsoluteTmp);
+			(void)fs_remove(m_aDestAbsoluteTmp);
 		}
 	}
 	else
 	{
 		m_State = EHttpState::ERROR;
-		fs_remove(m_aDestAbsoluteTmp);
+		(void)fs_remove(m_aDestAbsoluteTmp);
 	}
 }
 

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -368,7 +368,7 @@ public:
 
 		if(fs_executable_path(m_aBinarydir, sizeof(m_aBinarydir)) == 0)
 		{
-			fs_parent_dir(m_aBinarydir);
+			dbg_assert(fs_parent_dir(m_aBinarydir) == 0, "Could not determine parent of executable: '%s'", m_aBinarydir);
 			return;
 		}
 

--- a/src/game/client/components/local_server.cpp
+++ b/src/game/client/components/local_server.cpp
@@ -39,9 +39,8 @@ bool CLocalServer::RunServer(const std::vector<const char *> &vpArguments)
 	char aBuf[IO_MAX_PATH_LENGTH];
 	Storage()->GetBinaryPath(PLAT_SERVER_EXEC, aBuf, sizeof(aBuf));
 #if defined(CONF_PLATFORM_MACOS)
-	if(!fs_is_file(aBuf))
+	if(!fs_is_file(aBuf) && fs_parent_dir(aBuf) == 0)
 	{
-		fs_parent_dir(aBuf);
 		str_append(aBuf, "/../../../DDNet-Server.app/Contents/MacOS/");
 		str_append(aBuf, PLAT_SERVER_EXEC);
 	}

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3042,7 +3042,7 @@ CUi::EPopupMenuFunctionResult CMenus::PopupMapPicker(void *pContext, CUIRect Vie
 		{
 			if(!str_comp(SelectedItem.m_aFilename, ".."))
 			{
-				fs_parent_dir(pPopupContext->m_aCurrentMapFolder);
+				dbg_assert(fs_parent_dir(pPopupContext->m_aCurrentMapFolder) == 0, "Parent folder item selected but there is no parent folder");
 			}
 			else
 			{

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3808,7 +3808,7 @@ void CGameContext::ConAddMapVotes(IConsole::IResult *pResult, void *pUserData)
 
 		if(!str_comp(Item.m_aName, ".."))
 		{
-			fs_parent_dir(aDirectory);
+			dbg_assert(fs_parent_dir(aDirectory) == 0, "Parent folder vote selected but there is no parent folder");
 			str_format(aCommand, sizeof(aCommand), "clear_votes; add_map_votes \"%s\"", aDirectory);
 		}
 		else if(Item.m_IsDirectory)

--- a/src/test/aio_test.cpp
+++ b/src/test/aio_test.cpp
@@ -25,11 +25,11 @@ protected:
 		Delete = false;
 	}
 
-	~Async()
+	void TearDown() override
 	{
 		if(Delete)
 		{
-			fs_remove(m_Info.m_aFilename);
+			EXPECT_FALSE(fs_remove(m_Info.m_aFilename));
 		}
 	}
 

--- a/src/test/csv_test.cpp
+++ b/src/test/csv_test.cpp
@@ -21,7 +21,7 @@ static void Expect(int NumColumns, const char *const *ppColumns, const char *pEx
 	ASSERT_TRUE(File);
 	int Read = io_read(File, aBuf, sizeof(aBuf));
 	io_close(File);
-	fs_remove(Info.m_aFilename);
+	EXPECT_FALSE(fs_remove(Info.m_aFilename));
 
 	ASSERT_TRUE(Read >= 1);
 	Read -= 1;

--- a/src/test/fs_test.cpp
+++ b/src/test/fs_test.cpp
@@ -107,7 +107,7 @@ TEST(Filesystem, ExecutablePath)
 	char aExecutablePath[IO_MAX_PATH_LENGTH];
 	ASSERT_FALSE(fs_executable_path(aExecutablePath, sizeof(aExecutablePath)));
 	EXPECT_TRUE(fs_is_file(aExecutablePath));
-	fs_parent_dir(aExecutablePath);
+	EXPECT_FALSE(fs_parent_dir(aExecutablePath));
 	EXPECT_FALSE(fs_is_relative_path(aExecutablePath));
 }
 

--- a/src/test/jsonwriter_test.cpp
+++ b/src/test/jsonwriter_test.cpp
@@ -54,7 +54,7 @@ public:
 		}
 		else
 		{
-			fs_remove(m_aOutputFilename);
+			EXPECT_FALSE(fs_remove(m_aOutputFilename));
 		}
 	}
 };

--- a/src/test/linereader_test.cpp
+++ b/src/test/linereader_test.cpp
@@ -35,7 +35,7 @@ void TestFileLineReaderRaw(const char *pWritten, unsigned WrittenLength, std::in
 		EXPECT_FALSE(LineReader.Get()) << "Line reader returned more lines than expected";
 	}
 
-	fs_remove(Info.m_aFilename);
+	EXPECT_FALSE(fs_remove(Info.m_aFilename));
 }
 
 void TestFileLineReaderRaw(const char *pWritten, unsigned WrittenLength, std::initializer_list<const char *> pReads, bool ExpectSuccess)

--- a/src/tools/config_retrieve.cpp
+++ b/src/tools/config_retrieve.cpp
@@ -58,7 +58,7 @@ static void Process(IStorage *pStorage, const char *pMapName, const char *pConfi
 	Reader.Close();
 	if(!ConfigFound)
 	{
-		fs_remove(pConfigName);
+		(void)fs_remove(pConfigName);
 	}
 }
 #include "config_common.h"

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -102,11 +102,19 @@ int main(int argc, const char **argv)
 	{
 		str_format(aFilename, sizeof(aFilename), "out/%s", argv[2]);
 
-		fs_makedir_rec_for(aFilename);
+		if(fs_makedir_rec_for(aFilename) != 0)
+		{
+			// Error already logged by fs_makedir_rec_for
+			return -1;
+		}
 	}
 	else
 	{
-		fs_makedir("out");
+		if(fs_makedir("out") != 0)
+		{
+			// Error already logged by fs_makedir
+			return -1;
+		}
 		char aBuff[IO_MAX_PATH_LENGTH];
 		fs_split_file_extension(fs_filename(argv[1]), aBuff, sizeof(aBuff));
 		str_format(aFilename, sizeof(aFilename), "out/%s.map", aBuff);


### PR DESCRIPTION
Force the caller of `fs_*` functions to consider error handling.

The result of some uses of the `fs_remove`, `fs_makedir` and `fs_makedir_rec_for` functions are unused, as these functions already log error messages.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
