### PR TITLE
Improve country flag error handling, various refactoring

### DIFF
--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -2,6 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "countryflags.h"
 
+#include <base/dbg.h>
 #include <base/io.h>
 #include <base/log.h>
 #include <base/math.h>
@@ -12,96 +13,144 @@
 #include <engine/shared/linereader.h>
 #include <engine/storage.h>
 
-void CCountryFlags::LoadCountryflagsIndexfile()
+bool CCountryFlags::CCountryFlag::operator<(const CCountryFlag &Other) const
 {
-	const char *pFilename = "countryflags/index.txt";
-	CLineReader LineReader;
-	if(!LineReader.OpenFile(Storage()->OpenFile(pFilename, IOFLAG_READ, IStorage::TYPE_ALL)))
+	return str_comp(m_aCountryCodeString, Other.m_aCountryCodeString) < 0;
+}
+
+bool CCountryFlags::ValidateCountryCodeString(const char *pString)
+{
+	const size_t Length = str_length(pString);
+	if(Length >= sizeof(CCountryFlag{}.m_aCountryCodeString))
 	{
-		log_error("countryflags", "couldn't open index file '%s'", pFilename);
-		return;
+		log_error("countryflags", "Country name '%s' is too long (max. %" PRIzu " characters)", pString, sizeof(CCountryFlag{}.m_aCountryCodeString) - 1);
+		return false;
 	}
 
-	char aOrigin[128];
-	while(const char *pLine = LineReader.Get())
+	for(size_t Index = 0; Index < Length; ++Index)
 	{
-		if(!str_length(pLine) || pLine[0] == '#') // skip empty lines and comments
-			continue;
-
-		str_copy(aOrigin, pLine);
-		const char *pReplacement = LineReader.Get();
-		if(!pReplacement)
+		if(pString[Index] != '-' &&
+			!(pString[Index] >= 'a' && pString[Index] <= 'z') &&
+			!(pString[Index] >= 'A' && pString[Index] <= 'Z'))
 		{
-			log_error("countryflags", "unexpected end of index file");
-			break;
+			log_error("countryflags", "Country name '%s' must only contain letters and dash characters", pString);
+			return false;
 		}
+	}
 
-		if(pReplacement[0] != '=' || pReplacement[1] != '=' || pReplacement[2] != ' ')
+	return true;
+}
+
+void CCountryFlags::LoadCountryflagsIndexfile()
+{
+	m_vCountryFlags.clear();
+
+	const char *pFilename = "countryflags/index.txt";
+	CLineReader LineReader;
+	if(LineReader.OpenFile(Storage()->OpenFile(pFilename, IOFLAG_READ, IStorage::TYPE_ALL)))
+	{
+		while(const char *pLine = LineReader.Get())
 		{
-			log_error("countryflags", "malformed replacement for index '%s'", aOrigin);
-			continue;
-		}
+			if(pLine[0] == '\0' || pLine[0] == '#') // Skip empty lines and comments
+			{
+				continue;
+			}
 
-		int CountryCode = str_toint(pReplacement + 3);
-		if(CountryCode < CODE_LB || CountryCode > CODE_UB)
-		{
-			log_error("countryflags", "country code '%i' not within valid code range [%i..%i]", CountryCode, CODE_LB, CODE_UB);
-			continue;
-		}
+			if(!ValidateCountryCodeString(pLine))
+			{
+				continue;
+			}
+			CCountryFlag CountryFlag;
+			str_copy(CountryFlag.m_aCountryCodeString, pLine);
 
-		// load the graphic file
-		char aBuf[128];
-		CImageInfo Info;
-		str_format(aBuf, sizeof(aBuf), "countryflags/%s.png", aOrigin);
-		if(!Graphics()->LoadPng(Info, aBuf, IStorage::TYPE_ALL))
-		{
-			log_error("countryflags", "failed to load '%s'", aBuf);
-			continue;
-		}
+			const char *pCountryCodeLine = LineReader.Get();
+			if(!pCountryCodeLine)
+			{
+				log_error("countryflags", "Unexpected end of index file after country '%s'", CountryFlag.m_aCountryCodeString);
+				break;
+			}
 
-		// add entry
-		CCountryFlag CountryFlag;
-		CountryFlag.m_CountryCode = CountryCode;
-		str_copy(CountryFlag.m_aCountryCodeString, aOrigin);
-		CountryFlag.m_Texture = Graphics()->LoadTextureRawMove(Info, 0, aBuf);
+			if(!str_startswith(pCountryCodeLine, "== "))
+			{
+				log_error("countryflags", "Malformed country code for country '%s'", CountryFlag.m_aCountryCodeString);
+				continue;
+			}
+			pCountryCodeLine += str_length("== ");
 
-		if(g_Config.m_Debug)
-		{
-			log_debug("countryflags", "loaded country flag '%s'", aOrigin);
+			if(!str_toint(pCountryCodeLine, &CountryFlag.m_CountryCode))
+			{
+				log_error("countryflags", "Country code '%s' for country '%s' is not a number", pCountryCodeLine, CountryFlag.m_aCountryCodeString);
+				continue;
+			}
+			if(!in_range(CountryFlag.m_CountryCode, CODE_LB, CODE_UB))
+			{
+				log_error("countryflags", "Country code '%d' for country '%s' is not within valid code range [%d..%d]", CountryFlag.m_CountryCode, CountryFlag.m_aCountryCodeString, CODE_LB, CODE_UB);
+				continue;
+			}
+			if(CountryFlag.m_CountryCode == -1 && str_comp(CountryFlag.m_aCountryCodeString, "default") != 0)
+			{
+				log_error("countryflags", "Country code '%d' for country '%s' is only allowed for the default country", CountryFlag.m_CountryCode, CountryFlag.m_aCountryCodeString);
+				continue;
+			}
+
+			char aFlagPath[IO_MAX_PATH_LENGTH];
+			CImageInfo ImageInfo;
+			str_format(aFlagPath, sizeof(aFlagPath), "countryflags/%s.png", CountryFlag.m_aCountryCodeString);
+			if(!Graphics()->LoadPng(ImageInfo, aFlagPath, IStorage::TYPE_ALL))
+			{
+				log_error("countryflags", "Failed to load country flag from '%s'", aFlagPath);
+				continue;
+			}
+
+			CountryFlag.m_Texture = Graphics()->LoadTextureRawMove(ImageInfo, 0, aFlagPath);
+			if(g_Config.m_Debug)
+			{
+				log_trace("countryflags", "Loaded country flag '%s'", CountryFlag.m_aCountryCodeString);
+			}
+			m_vCountryFlags.push_back(CountryFlag);
 		}
-		m_vCountryFlags.push_back(CountryFlag);
+	}
+	else
+	{
+		log_error("countryflags", "Failed to open country flags index file '%s'", pFilename);
+	}
+
+	// Ensure a default flag exists
+	auto ExistingDefaultFlag = std::find_if(m_vCountryFlags.begin(), m_vCountryFlags.end(), [](const CCountryFlag &Flag) {
+		return Flag.m_CountryCode == -1;
+	});
+	if(ExistingDefaultFlag == m_vCountryFlags.end())
+	{
+		CCountryFlag DefaultFlag;
+		DefaultFlag.m_CountryCode = -1;
+		str_copy(DefaultFlag.m_aCountryCodeString, "default");
+		m_vCountryFlags.push_back(DefaultFlag);
 	}
 
 	std::sort(m_vCountryFlags.begin(), m_vCountryFlags.end());
 
-	// find index of default item
 	size_t DefaultIndex = 0;
 	for(size_t Index = 0; Index < m_vCountryFlags.size(); ++Index)
+	{
 		if(m_vCountryFlags[Index].m_CountryCode == -1)
 		{
 			DefaultIndex = Index;
 			break;
 		}
+	}
 
-	// init LUT
-	std::fill(std::begin(m_aCodeIndexLUT), std::end(m_aCodeIndexLUT), DefaultIndex);
+	std::fill(std::begin(m_aCountryCodeToIndexTable), std::end(m_aCountryCodeToIndexTable), DefaultIndex);
 	for(size_t i = 0; i < m_vCountryFlags.size(); ++i)
-		m_aCodeIndexLUT[maximum(0, (m_vCountryFlags[i].m_CountryCode - CODE_LB) % CODE_RANGE)] = i;
+	{
+		m_aCountryCodeToIndexTable[m_vCountryFlags[i].m_CountryCode - CODE_LB] = i;
+	}
+
+	log_debug("countryflags", "Loaded %" PRIzu " country flags", m_vCountryFlags.size());
 }
 
 void CCountryFlags::OnInit()
 {
-	// load country flags
-	m_vCountryFlags.clear();
 	LoadCountryflagsIndexfile();
-	if(m_vCountryFlags.empty())
-	{
-		log_error("countryflags", "failed to load country flags. folder='countryflags/'");
-		CCountryFlag DummyEntry;
-		DummyEntry.m_CountryCode = -1;
-		DummyEntry.m_aCountryCodeString[0] = '\0';
-		m_vCountryFlags.push_back(DummyEntry);
-	}
 
 	m_FlagsQuadContainerIndex = Graphics()->CreateQuadContainer(false);
 	Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
@@ -117,12 +166,14 @@ size_t CCountryFlags::Num() const
 
 const CCountryFlags::CCountryFlag &CCountryFlags::GetByCountryCode(int CountryCode) const
 {
-	return GetByIndex(m_aCodeIndexLUT[maximum(0, (CountryCode - CODE_LB) % CODE_RANGE)]);
+	dbg_assert(CountryCode >= CODE_LB && CountryCode <= CODE_UB, "Invalid CountryCode: %d", CountryCode);
+	return GetByIndex(m_aCountryCodeToIndexTable[CountryCode - CODE_LB]);
 }
 
 const CCountryFlags::CCountryFlag &CCountryFlags::GetByIndex(size_t Index) const
 {
-	return m_vCountryFlags[Index % m_vCountryFlags.size()];
+	dbg_assert(Index < m_vCountryFlags.size(), "Invalid Index: %" PRIzu, Index);
+	return m_vCountryFlags[Index];
 }
 
 void CCountryFlags::Render(const CCountryFlag &Flag, ColorRGBA Color, float x, float y, float w, float h)

--- a/src/game/client/components/countryflags.h
+++ b/src/game/client/components/countryflags.h
@@ -3,24 +3,24 @@
 #ifndef GAME_CLIENT_COMPONENTS_COUNTRYFLAGS_H
 #define GAME_CLIENT_COMPONENTS_COUNTRYFLAGS_H
 
-#include <base/str.h>
-
 #include <engine/graphics.h>
 
 #include <game/client/component.h>
 
+#include <cstddef>
 #include <vector>
 
 class CCountryFlags : public CComponent
 {
 public:
-	struct CCountryFlag
+	class CCountryFlag
 	{
+	public:
 		int m_CountryCode;
 		char m_aCountryCodeString[8];
 		IGraphics::CTextureHandle m_Texture;
 
-		bool operator<(const CCountryFlag &Other) const { return str_comp(m_aCountryCodeString, Other.m_aCountryCodeString) < 0; }
+		bool operator<(const CCountryFlag &Other) const;
 	};
 
 	int Sizeof() const override { return sizeof(*this); }
@@ -33,17 +33,15 @@ public:
 	void Render(int CountryCode, ColorRGBA Color, float x, float y, float w, float h);
 
 private:
-	enum
-	{
-		CODE_LB = -1,
-		CODE_UB = 999,
-		CODE_RANGE = CODE_UB - CODE_LB + 1,
-	};
+	static constexpr int CODE_LB = -1;
+	static constexpr int CODE_UB = 999;
+
 	std::vector<CCountryFlag> m_vCountryFlags;
-	size_t m_aCodeIndexLUT[CODE_RANGE];
+	size_t m_aCountryCodeToIndexTable[CODE_UB - CODE_LB + 1];
 
 	int m_FlagsQuadContainerIndex;
 
+	static bool ValidateCountryCodeString(const char *pString);
 	void LoadCountryflagsIndexfile();
 };
 #endif

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -348,7 +348,7 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 		FlagRect.x += (OldWidth - FlagRect.w) / 2.0f;
 		GameClient()->m_CountryFlags.Render(pEntry->m_CountryCode, ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f), FlagRect.x, FlagRect.y, FlagRect.w, FlagRect.h);
 
-		if(pEntry->m_Texture.IsValid())
+		if(pEntry->m_Texture.IsValid() || pEntry->m_CountryCode == -1)
 		{
 			Ui()->DoLabel(&Label, pEntry->m_aCountryCodeString, 10.0f, TEXTALIGN_MC);
 		}


### PR DESCRIPTION
Add various error handling for country flag index file parsing:

- Ensure country code string does not exceed the maximum length and does not contain unexpected characters.
- Ensure country code integer is a valid number.
- Ensure default country flag exists and has expected country code string and integer. Previously, a default flag was added only when there are no flags at all but not when there is no default flag.
- Ensure country code lookup table is initialized also when the index file could not be opened.

Add assertions to `CCountryFlags::GetByCountryCode` and `CCountryFlags::GetByIndex` functions instead of silently translating invalid indices to other flag indices.

Always render the label of the default flag even if it could not be loaded.

Various refactoring:

- Avoid `base/str.h` include in header file.
- Use `class` instead of `struct`.
- Use `static constexpr` instead of unnamed `enum`.
- Rename `m_aCodeIndexLUT` to `m_aCountryCodeToIndexTable`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions