### PR TITLE
Validate country codes in client, server info, and community info

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -226,7 +226,7 @@ Objects = [
 	NetObject("ClientInfo", [
 		NetTwIntString("m_aName", 16),
 		NetTwIntString("m_aClan", 12),
-		NetIntAny("m_Country"),
+		NetIntAny("m_Country"), # ISO 3166-1 numeric
 		NetTwIntString("m_aSkin", 24),
 		NetIntRange("m_UseCustomColor", 0, 1),
 		NetIntAny("m_ColorBody"),
@@ -493,7 +493,7 @@ Messages = [
 	NetMessage("Cl_StartInfo", [
 		NetStringStrict("m_pName"),
 		NetStringStrict("m_pClan"),
-		NetIntAny("m_Country"),
+		NetIntAny("m_Country"), # ISO 3166-1 numeric
 		NetStringStrict("m_pSkin"),
 		NetBool("m_UseCustomColor"),
 		NetIntAny("m_ColorBody"),
@@ -503,7 +503,7 @@ Messages = [
 	NetMessage("Cl_ChangeInfo", [
 		NetStringStrict("m_pName"),
 		NetStringStrict("m_pClan"),
-		NetIntAny("m_Country"),
+		NetIntAny("m_Country"), # ISO 3166-1 numeric
 		NetStringStrict("m_pSkin"),
 		NetBool("m_UseCustomColor"),
 		NetIntAny("m_ColorBody"),

--- a/datasrc/seven/network.py
+++ b/datasrc/seven/network.py
@@ -203,7 +203,7 @@ Objects = [
 		NetArray(NetIntAny("m_aName"), 4),
 		NetArray(NetIntAny("m_aClan"), 3),
 
-		NetIntAny("m_Country"),
+		NetIntAny("m_Country"), # ISO 3166-1 numeric
 
 		NetArray(NetArray(NetIntAny("m_aaSkinPartNames"), 6), 6),
 		NetArray(NetBool("m_aUseCustomColors"), 6),
@@ -353,7 +353,7 @@ Messages = [
 		NetIntRange("m_Team", 'TEAM_SPECTATORS', 'TEAM_BLUE'),
 		NetStringStrict("m_pName"),
 		NetStringStrict("m_pClan"),
-		NetIntAny("m_Country"),
+		NetIntAny("m_Country"), # ISO 3166-1 numeric
 		NetArray(NetStringStrict("m_apSkinPartNames"), 6),
 		NetArray(NetBool("m_aUseCustomColors"), 6),
 		NetArray(NetIntAny("m_aSkinPartColors"), 6),
@@ -410,7 +410,7 @@ Messages = [
 	NetMessage("Cl_StartInfo", [
 		NetStringStrict("m_pName"),
 		NetStringStrict("m_pClan"),
-		NetIntAny("m_Country"),
+		NetIntAny("m_Country"), # ISO 3166-1 numeric
 		NetArray(NetStringStrict("m_apSkinPartNames"), 6),
 		NetArray(NetBool("m_aUseCustomColors"), 6),
 		NetArray(NetIntAny("m_aSkinPartColors"), 6),

--- a/scripts/export_settings_commands_table.py
+++ b/scripts/export_settings_commands_table.py
@@ -67,6 +67,9 @@ def parse_settings(lines):
 		value = value.replace("SERVERINFO_LEVEL_MAX", "2")
 		value = value.replace("SERVER_MAX_CLIENTS", "64")
 		value = value.replace("MAX_CLIENTS", "128")
+		value = value.replace("CountryCode::DEFAULT", "-1")
+		value = value.replace("CountryCode::MINIMUM", "-1")
+		value = value.replace("CountryCode::MAXIMUM", "999")
 		try:
 			return int(value, base=16) if value.startswith(("0x", "0X")) else int(value)
 		except Exception as e:

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1469,6 +1469,10 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 		}
 		GET_STRING(pClient->m_aClan);
 		GET_INT(pClient->m_Country);
+		if(!in_range(pClient->m_Country, CountryCode::MINIMUM, CountryCode::MAXIMUM))
+		{
+			pClient->m_Country = CountryCode::DEFAULT;
+		}
 		GET_INT(pClient->m_Score);
 		GET_INT(pClient->m_Player);
 		if(SavedType == SERVERINFO_EXTENDED)

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -1469,6 +1469,11 @@ bool CServerBrowser::ParseCommunityServers(CCommunity *pCommunity, const json_va
 			log_error("serverbrowser", "invalid community country name (ServerIndex=%u)", ServerIndex);
 			return false;
 		}
+		if(!in_range(FlagId.u.integer, (int64_t)CountryCode::MINIMUM, (int64_t)CountryCode::MAXIMUM))
+		{
+			log_error("serverbrowser", "invalid community country code (ServerIndex=%u)", ServerIndex);
+			return false;
+		}
 		pCommunity->m_vCountries.emplace_back(Name.u.string.ptr, FlagId.u.integer);
 		CCommunityCountry *pCountry = &pCommunity->m_vCountries.back();
 
@@ -1644,7 +1649,7 @@ void CServerBrowser::LoadDDNetServers()
 	// Add default none community
 	{
 		CCommunity NoneCommunity(COMMUNITY_NONE, "None", std::nullopt, "");
-		NoneCommunity.m_vCountries.emplace_back(COMMUNITY_COUNTRY_NONE, -1);
+		NoneCommunity.m_vCountries.emplace_back(COMMUNITY_COUNTRY_NONE, CountryCode::DEFAULT);
 		NoneCommunity.m_vTypes.emplace_back(COMMUNITY_TYPE_NONE);
 		m_vCommunities.push_back(std::move(NoneCommunity));
 	}

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -596,7 +596,7 @@ int CServer::Init()
 		Client.m_State = CClient::STATE_EMPTY;
 		Client.m_aName[0] = 0;
 		Client.m_aClan[0] = 0;
-		Client.m_Country = -1;
+		Client.m_Country = CountryCode::DEFAULT;
 		Client.m_Snapshots.Init();
 		Client.m_Traffic = 0;
 		Client.m_TrafficSince = 0;
@@ -1186,7 +1186,7 @@ int CServer::NewClientNoAuthCallback(int ClientId, void *pUser)
 	pThis->m_aClients[ClientId].m_State = CClient::STATE_CONNECTING;
 	pThis->m_aClients[ClientId].m_aName[0] = 0;
 	pThis->m_aClients[ClientId].m_aClan[0] = 0;
-	pThis->m_aClients[ClientId].m_Country = -1;
+	pThis->m_aClients[ClientId].m_Country = CountryCode::DEFAULT;
 	pThis->m_aClients[ClientId].m_AuthKey = -1;
 	pThis->m_aClients[ClientId].m_AuthTries = 0;
 	pThis->m_aClients[ClientId].m_AuthHidden = false;
@@ -1218,7 +1218,7 @@ int CServer::NewClientCallback(int ClientId, void *pUser, bool Sixup)
 	pThis->m_aClients[ClientId].m_DnsblState = EDnsblState::NONE;
 	pThis->m_aClients[ClientId].m_aName[0] = 0;
 	pThis->m_aClients[ClientId].m_aClan[0] = 0;
-	pThis->m_aClients[ClientId].m_Country = -1;
+	pThis->m_aClients[ClientId].m_Country = CountryCode::DEFAULT;
 	pThis->m_aClients[ClientId].m_AuthKey = -1;
 	pThis->m_aClients[ClientId].m_AuthTries = 0;
 	pThis->m_aClients[ClientId].m_AuthHidden = false;
@@ -1307,7 +1307,7 @@ int CServer::DelClientCallback(int ClientId, const char *pReason, void *pUser)
 	pThis->m_aClients[ClientId].m_State = CClient::STATE_EMPTY;
 	pThis->m_aClients[ClientId].m_aName[0] = 0;
 	pThis->m_aClients[ClientId].m_aClan[0] = 0;
-	pThis->m_aClients[ClientId].m_Country = -1;
+	pThis->m_aClients[ClientId].m_Country = CountryCode::DEFAULT;
 	pThis->m_aClients[ClientId].m_AuthKey = -1;
 	pThis->m_aClients[ClientId].m_AuthTries = 0;
 	pThis->m_aClients[ClientId].m_AuthHidden = false;

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -159,6 +159,9 @@ public:
 
 		char m_aName[MAX_NAME_LENGTH];
 		char m_aClan[MAX_CLAN_LENGTH];
+		/**
+		 * Country code in ISO 3166-1 numeric.
+		 */
 		int m_Country;
 		std::optional<int> m_Score;
 		int m_AuthKey;

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -70,6 +70,9 @@ public:
 	public:
 		char m_aName[MAX_NAME_LENGTH];
 		char m_aClan[MAX_CLAN_LENGTH];
+		/**
+		 * Country code in ISO 3166-1 numeric.
+		 */
 		int m_Country;
 		int m_Score;
 		bool m_Player;
@@ -152,6 +155,9 @@ class CCommunityCountry
 	friend class CServerBrowser;
 
 	char m_aName[CServerInfo::MAX_COMMUNITY_COUNTRY_LENGTH];
+	/**
+	 * Country code in ISO 3166-1 numeric.
+	 */
 	int m_FlagId;
 	std::vector<CCommunityCountryServer> m_vServers;
 

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -242,7 +242,7 @@ MACRO_CONFIG_INT(GfxNoclip, gfx_noclip, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, 
 // dummy
 MACRO_CONFIG_STR(ClDummyName, dummy_name, 16, "", CFGFLAG_SAVE | CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Name of the dummy")
 MACRO_CONFIG_STR(ClDummyClan, dummy_clan, 12, "", CFGFLAG_SAVE | CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Clan of the dummy")
-MACRO_CONFIG_INT(ClDummyCountry, dummy_country, -1, -1, 1000, CFGFLAG_SAVE | CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Country of the dummy (ISO 3166-1 numeric)")
+MACRO_CONFIG_INT(ClDummyCountry, dummy_country, CountryCode::DEFAULT, CountryCode::MINIMUM, CountryCode::MAXIMUM, CFGFLAG_SAVE | CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Country of the dummy (ISO 3166-1 numeric)")
 MACRO_CONFIG_INT(ClDummyUseCustomColor, dummy_use_custom_color, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Toggles usage of custom colors")
 MACRO_CONFIG_COL(ClDummyColorBody, dummy_color_body, 65408, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_COLLIGHT | CFGFLAG_INSENSITIVE, "Dummy body color")
 MACRO_CONFIG_COL(ClDummyColorFeet, dummy_color_feet, 65408, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_COLLIGHT | CFGFLAG_INSENSITIVE, "Dummy feet color")
@@ -319,7 +319,7 @@ MACRO_CONFIG_INT(DbgTuning, dbg_tuning, 0, 0, 2, CFGFLAG_CLIENT, "Display inform
 
 MACRO_CONFIG_STR(PlayerName, player_name, 16, "", CFGFLAG_SAVE | CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Name of the player")
 MACRO_CONFIG_STR(PlayerClan, player_clan, 12, "", CFGFLAG_SAVE | CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Clan of the player")
-MACRO_CONFIG_INT(PlayerCountry, player_country, -1, -1, 1000, CFGFLAG_SAVE | CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Country of the player (ISO 3166-1 numeric)")
+MACRO_CONFIG_INT(PlayerCountry, player_country, CountryCode::DEFAULT, CountryCode::MINIMUM, CountryCode::MAXIMUM, CFGFLAG_SAVE | CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Country of the player (ISO 3166-1 numeric)")
 
 MACRO_CONFIG_STR(Password, password, 256, "", CFGFLAG_CLIENT | CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, "Password to the server")
 MACRO_CONFIG_INT(Events, events, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT | CFGFLAG_SERVER, "Enable triggering of events, (eye emotes on some holidays in server, christmas skins in client).")
@@ -364,8 +364,8 @@ MACRO_CONFIG_INT(BrFilterFull, br_filter_full, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_C
 MACRO_CONFIG_INT(BrFilterEmpty, br_filter_empty, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Filter out empty server in browser")
 MACRO_CONFIG_INT(BrFilterSpectators, br_filter_spectators, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Filter out spectators from player numbers")
 MACRO_CONFIG_INT(BrFilterFriends, br_filter_friends, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Filter out servers with no friends")
-MACRO_CONFIG_INT(BrFilterCountry, br_filter_country, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Filter out servers with non-matching player country (ISO 3166-1 numeric)")
-MACRO_CONFIG_INT(BrFilterCountryIndex, br_filter_country_index, -1, -1, 999, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Player country to filter by in the server browser (ISO 3166-1 numeric)")
+MACRO_CONFIG_INT(BrFilterCountry, br_filter_country, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Filter out servers with non-matching player country (see br_filter_country_index)")
+MACRO_CONFIG_INT(BrFilterCountryIndex, br_filter_country_index, CountryCode::DEFAULT, CountryCode::MINIMUM, CountryCode::MAXIMUM, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Player country to filter by in the server browser (ISO 3166-1 numeric)")
 MACRO_CONFIG_INT(BrFilterPw, br_filter_pw, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Filter out password protected servers in browser")
 MACRO_CONFIG_STR(BrFilterGametype, br_filter_gametype, 128, "", CFGFLAG_SAVE | CFGFLAG_CLIENT, "Game types to filter")
 MACRO_CONFIG_INT(BrFilterGametypeStrict, br_filter_gametype_strict, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Strict gametype filter")
@@ -468,7 +468,7 @@ MACRO_CONFIG_STR(SvRegisterExtra, sv_register_extra, 256, "", CFGFLAG_SERVER, "E
 MACRO_CONFIG_STR(SvRegisterUrl, sv_register_url, 128, "https://master1.ddnet.org/ddnet/15/register", CFGFLAG_SERVER, "Masterserver URL to register to")
 MACRO_CONFIG_INT(SvRegisterPort, sv_register_port, 0, 0, 65535, CFGFLAG_SERVER, "Port for the master server to register the server with, useful if you are behind NAT, otherwise you only need sv_port")
 MACRO_CONFIG_STR(SvRegisterCommunityToken, sv_register_community_token, 128, "", CFGFLAG_SERVER, "Token to register this server to a particular community")
-MACRO_CONFIG_INT(SvFlag, sv_flag, -1, -1, 999, CFGFLAG_SERVER, "Country flag to group this community under (ISO 3166-1 numeric)")
+MACRO_CONFIG_INT(SvFlag, sv_flag, CountryCode::DEFAULT, CountryCode::MINIMUM, CountryCode::MAXIMUM, CFGFLAG_SERVER, "Country flag to group this community under (ISO 3166-1 numeric)")
 MACRO_CONFIG_STR(SvOfficialTutorial, sv_official_tutorial, 128, "", CFGFLAG_SERVER, "Don't set this, used to mark official tutorial servers")
 MACRO_CONFIG_STR(SvMapsBaseUrl, sv_maps_base_url, 128, "", CFGFLAG_SERVER, "Base path used to provide HTTPS map download URL to the clients")
 MACRO_CONFIG_STR(SvRconPassword, sv_rcon_password, 128, "", CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, "Remote console password (full access)")

--- a/src/engine/shared/protocol.h
+++ b/src/engine/shared/protocol.h
@@ -159,6 +159,16 @@ enum
 	VERSION_DDNET_MAP_BESTTIME = 19070,
 };
 
+/**
+ * Country codes in ISO 3166-1 numeric.
+ */
+namespace CountryCode
+{
+	inline constexpr int DEFAULT = -1;
+	inline constexpr int MINIMUM = -1;
+	inline constexpr int MAXIMUM = 999;
+};
+
 namespace TuneZone
 {
 	inline constexpr int OVERRIDE_NONE = -1;

--- a/src/engine/shared/serverinfo.cpp
+++ b/src/engine/shared/serverinfo.cpp
@@ -140,6 +140,10 @@ bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 			str_copy(pClient->m_aName, ClientName);
 			str_copy(pClient->m_aClan, Clan);
 			pClient->m_Country = json_int_get(&Country);
+			if(!in_range(pClient->m_Country, CountryCode::MINIMUM, CountryCode::MAXIMUM))
+			{
+				pClient->m_Country = CountryCode::DEFAULT;
+			}
 			pClient->m_Score = json_int_get(&Score);
 			pClient->m_IsPlayer = IsPlayer;
 

--- a/src/engine/shared/translation_context.h
+++ b/src/engine/shared/translation_context.h
@@ -63,7 +63,7 @@ public:
 
 			m_aName[0] = '\0';
 			m_aClan[0] = '\0';
-			m_Country = 0;
+			m_Country = CountryCode::DEFAULT;
 			m_Team = 0;
 			m_PlayerFlags7 = 0;
 		}
@@ -72,6 +72,9 @@ public:
 
 		char m_aName[MAX_NAME_LENGTH];
 		char m_aClan[MAX_CLAN_LENGTH];
+		/**
+		 * Country code in ISO 3166-1 numeric.
+		 */
 		int m_Country;
 		int m_Team;
 		int m_PlayerFlags7;

--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -82,12 +82,12 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 				log_error("countryflags", "Country code '%s' for country '%s' is not a number", pCountryCodeLine, CountryFlag.m_aCountryCodeString);
 				continue;
 			}
-			if(!in_range(CountryFlag.m_CountryCode, CODE_LB, CODE_UB))
+			if(!in_range(CountryFlag.m_CountryCode, CountryCode::MINIMUM, CountryCode::MAXIMUM))
 			{
-				log_error("countryflags", "Country code '%d' for country '%s' is not within valid code range [%d..%d]", CountryFlag.m_CountryCode, CountryFlag.m_aCountryCodeString, CODE_LB, CODE_UB);
+				log_error("countryflags", "Country code '%d' for country '%s' is not within valid code range [%d..%d]", CountryFlag.m_CountryCode, CountryFlag.m_aCountryCodeString, CountryCode::MINIMUM, CountryCode::MAXIMUM);
 				continue;
 			}
-			if(CountryFlag.m_CountryCode == -1 && str_comp(CountryFlag.m_aCountryCodeString, "default") != 0)
+			if(CountryFlag.m_CountryCode == CountryCode::DEFAULT && str_comp(CountryFlag.m_aCountryCodeString, "default") != 0)
 			{
 				log_error("countryflags", "Country code '%d' for country '%s' is only allowed for the default country", CountryFlag.m_CountryCode, CountryFlag.m_aCountryCodeString);
 				continue;
@@ -117,12 +117,12 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 
 	// Ensure a default flag exists
 	auto ExistingDefaultFlag = std::find_if(m_vCountryFlags.begin(), m_vCountryFlags.end(), [](const CCountryFlag &Flag) {
-		return Flag.m_CountryCode == -1;
+		return Flag.m_CountryCode == CountryCode::DEFAULT;
 	});
 	if(ExistingDefaultFlag == m_vCountryFlags.end())
 	{
 		CCountryFlag DefaultFlag;
-		DefaultFlag.m_CountryCode = -1;
+		DefaultFlag.m_CountryCode = CountryCode::DEFAULT;
 		str_copy(DefaultFlag.m_aCountryCodeString, "default");
 		m_vCountryFlags.push_back(DefaultFlag);
 	}
@@ -132,7 +132,7 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 	size_t DefaultIndex = 0;
 	for(size_t Index = 0; Index < m_vCountryFlags.size(); ++Index)
 	{
-		if(m_vCountryFlags[Index].m_CountryCode == -1)
+		if(m_vCountryFlags[Index].m_CountryCode == CountryCode::DEFAULT)
 		{
 			DefaultIndex = Index;
 			break;
@@ -142,7 +142,7 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 	std::fill(std::begin(m_aCountryCodeToIndexTable), std::end(m_aCountryCodeToIndexTable), DefaultIndex);
 	for(size_t i = 0; i < m_vCountryFlags.size(); ++i)
 	{
-		m_aCountryCodeToIndexTable[m_vCountryFlags[i].m_CountryCode - CODE_LB] = i;
+		m_aCountryCodeToIndexTable[m_vCountryFlags[i].m_CountryCode - CountryCode::MINIMUM] = i;
 	}
 
 	log_debug("countryflags", "Loaded %" PRIzu " country flags", m_vCountryFlags.size());
@@ -166,8 +166,8 @@ size_t CCountryFlags::Num() const
 
 const CCountryFlags::CCountryFlag &CCountryFlags::GetByCountryCode(int CountryCode) const
 {
-	dbg_assert(CountryCode >= CODE_LB && CountryCode <= CODE_UB, "Invalid CountryCode: %d", CountryCode);
-	return GetByIndex(m_aCountryCodeToIndexTable[CountryCode - CODE_LB]);
+	dbg_assert(CountryCode >= CountryCode::MINIMUM && CountryCode <= CountryCode::MAXIMUM, "Invalid CountryCode: %d", CountryCode);
+	return GetByIndex(m_aCountryCodeToIndexTable[CountryCode - CountryCode::MINIMUM]);
 }
 
 const CCountryFlags::CCountryFlag &CCountryFlags::GetByIndex(size_t Index) const

--- a/src/game/client/components/countryflags.h
+++ b/src/game/client/components/countryflags.h
@@ -4,6 +4,7 @@
 #define GAME_CLIENT_COMPONENTS_COUNTRYFLAGS_H
 
 #include <engine/graphics.h>
+#include <engine/shared/protocol.h>
 
 #include <game/client/component.h>
 
@@ -16,6 +17,9 @@ public:
 	class CCountryFlag
 	{
 	public:
+		/**
+		 * Country code in ISO 3166-1 numeric.
+		 */
 		int m_CountryCode;
 		char m_aCountryCodeString[8];
 		IGraphics::CTextureHandle m_Texture;
@@ -33,11 +37,8 @@ public:
 	void Render(int CountryCode, ColorRGBA Color, float x, float y, float w, float h);
 
 private:
-	static constexpr int CODE_LB = -1;
-	static constexpr int CODE_UB = 999;
-
 	std::vector<CCountryFlag> m_vCountryFlags;
-	size_t m_aCountryCodeToIndexTable[CODE_UB - CODE_LB + 1];
+	size_t m_aCountryCodeToIndexTable[CountryCode::MAXIMUM - CountryCode::MINIMUM + 1];
 
 	int m_FlagsQuadContainerIndex;
 

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -838,7 +838,7 @@ void CMenus::ResetServerbrowserFilters()
 	g_Config.m_BrFilterSpectators = 0;
 	g_Config.m_BrFilterFriends = 0;
 	g_Config.m_BrFilterCountry = 0;
-	g_Config.m_BrFilterCountryIndex = -1;
+	g_Config.m_BrFilterCountryIndex = DefaultConfig::BrFilterCountryIndex;
 	g_Config.m_BrFilterPw = 0;
 	g_Config.m_BrFilterGametype[0] = '\0';
 	g_Config.m_BrFilterGametypeStrict = 0;
@@ -1148,7 +1148,7 @@ CUi::EPopupMenuFunctionResult CMenus::PopupCountrySelection(void *pContext, CUIR
 	}
 
 	const int NewSelected = s_ListBox.DoEnd();
-	pPopupContext->m_Selection = NewSelected >= 0 ? pMenus->GameClient()->m_CountryFlags.GetByIndex(NewSelected).m_CountryCode : -1;
+	pPopupContext->m_Selection = NewSelected >= 0 ? pMenus->GameClient()->m_CountryFlags.GetByIndex(NewSelected).m_CountryCode : CountryCode::DEFAULT;
 	if(s_ListBox.WasItemSelected() || s_ListBox.WasItemActivated())
 	{
 		g_Config.m_BrFilterCountry = 1;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -348,7 +348,7 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 		FlagRect.x += (OldWidth - FlagRect.w) / 2.0f;
 		GameClient()->m_CountryFlags.Render(pEntry->m_CountryCode, ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f), FlagRect.x, FlagRect.y, FlagRect.w, FlagRect.h);
 
-		if(pEntry->m_Texture.IsValid() || pEntry->m_CountryCode == -1)
+		if(pEntry->m_Texture.IsValid() || pEntry->m_CountryCode == CountryCode::DEFAULT)
 		{
 			Ui()->DoLabel(&Label, pEntry->m_aCountryCodeString, 10.0f, TEXTALIGN_MC);
 		}

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1808,6 +1808,10 @@ void CGameClient::OnNewSnapshot(bool DummySwapped)
 					}
 					IntsToStr(pInfo->m_aClan, std::size(pInfo->m_aClan), pClient->m_aClan, std::size(pClient->m_aClan));
 					pClient->m_Country = pInfo->m_Country;
+					if(!in_range(pClient->m_Country, CountryCode::MINIMUM, CountryCode::MAXIMUM))
+					{
+						pClient->m_Country = CountryCode::DEFAULT;
+					}
 
 					IntsToStr(pInfo->m_aSkin, std::size(pInfo->m_aSkin), pClient->m_aSkinName, std::size(pClient->m_aSkinName));
 					if(!CSkin::IsValidName(pClient->m_aSkinName) ||
@@ -3022,7 +3026,7 @@ void CGameClient::CClientData::Reset()
 
 	m_aName[0] = '\0';
 	m_aClan[0] = '\0';
-	m_Country = -1;
+	m_Country = CountryCode::DEFAULT;
 	str_copy(m_aSkinName, "default");
 
 	m_Team = 0;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -450,6 +450,9 @@ public:
 
 		char m_aName[MAX_NAME_LENGTH];
 		char m_aClan[MAX_CLAN_LENGTH];
+		/**
+		 * Country code in ISO 3166-1 numeric.
+		 */
 		int m_Country;
 		char m_aSkinName[MAX_SKIN_LENGTH];
 		int m_Team;

--- a/src/game/client/sixup_translate_connless.cpp
+++ b/src/game/client/sixup_translate_connless.cpp
@@ -36,6 +36,10 @@ void CClient::PreprocessConnlessPacket7(CNetChunk *pPacket)
 			GetString(Info.m_aClients[i].m_aName);
 			GetString(Info.m_aClients[i].m_aClan);
 			Info.m_aClients[i].m_Country = Up.GetInt();
+			if(!in_range(Info.m_aClients[i].m_Country, CountryCode::MINIMUM, CountryCode::MAXIMUM))
+			{
+				Info.m_aClients[i].m_Country = CountryCode::DEFAULT;
+			}
 			Info.m_aClients[i].m_Score = Up.GetInt();
 			Info.m_aClients[i].m_Player = !(Up.GetInt() & 1);
 		}

--- a/src/game/client/sixup_translate_game.cpp
+++ b/src/game/client/sixup_translate_game.cpp
@@ -541,6 +541,10 @@ void *CGameClient::TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn)
 		str_copy(Client.m_aName, pMsg7->m_pName);
 		str_copy(Client.m_aClan, pMsg7->m_pClan);
 		Client.m_Country = pMsg7->m_Country;
+		if(!in_range(Client.m_Country, CountryCode::MINIMUM, CountryCode::MAXIMUM))
+		{
+			Client.m_Country = CountryCode::DEFAULT;
+		}
 		ApplySkin7InfoFromGameMsg(pMsg7, pMsg7->m_ClientId, Conn);
 		if(m_pClient->m_TranslationContext.m_aLocalClientId[Conn] == -1)
 			return nullptr;

--- a/src/game/client/sixup_translate_snapshot.cpp
+++ b/src/game/client/sixup_translate_snapshot.cpp
@@ -403,6 +403,10 @@ int CGameClient::TranslateSnap(CSnapshotBuffer *pSnapDstSix, CSnapshot *pSnapSrc
 			IntsToStr(pInfo->m_aName, std::size(pInfo->m_aName), Client.m_aName, std::size(Client.m_aName));
 			IntsToStr(pInfo->m_aClan, std::size(pInfo->m_aClan), Client.m_aClan, std::size(Client.m_aClan));
 			Client.m_Country = pInfo->m_Country;
+			if(!in_range(Client.m_Country, CountryCode::MINIMUM, CountryCode::MAXIMUM))
+			{
+				Client.m_Country = CountryCode::DEFAULT;
+			}
 
 			ApplySkin7InfoFromSnapObj(pInfo, ClientId);
 		}

--- a/src/game/localization.h
+++ b/src/game/localization.h
@@ -17,6 +17,9 @@ public:
 
 	std::string m_Name;
 	std::string m_Filename;
+	/**
+	 * Country code in ISO 3166-1 numeric.
+	 */
 	int m_CountryCode;
 	std::vector<std::string> m_vLanguageCodes;
 


### PR DESCRIPTION
The client was crashing with the assertions added in https://github.com/ddnet/ddnet/pull/12309 because the ISO 3166-1 numeric country codes were not actually validated in the client, server info, and community info. Apparently, some modified clients have been sending negative country codes.

Add `namespace CountryCode` with `DEFAULT`, `MINIMUM` and `MAXIMUM` constants to the protocol and use the constants consistently. Ensure country codes in the client, server info, and community info are in the expected range.

The `player_country` and `dummy_country` config variables previously had an incorrect maximum value of `1000` instead of `999`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
