### PR TITLE
Show flying laser projectiles to dead players

### DIFF
--- a/src/game/server/interactions.cpp
+++ b/src/game/server/interactions.cpp
@@ -65,8 +65,6 @@ bool CInteractions::CanSee(const CGameContext *pGameServer, int ClientId) const
 	{ // Not spectator
 		if(ClientId != m_OwnerId)
 		{ // Actions of other players
-			if(!Character(pGameServer, ClientId))
-				return false; // Player is currently dead
 			if(pPlayer->m_ShowOthers == SHOW_OTHERS_ONLY_TEAM)
 			{
 				if(GetDDRaceTeam(pGameServer, ClientId) != m_DDRaceTeam && GetDDRaceTeam(pGameServer, ClientId) != TEAM_SUPER)


### PR DESCRIPTION
Closes https://github.com/ddnet-insta/ddnet-insta/issues/678

This should have no effect for ddnet, I need this downstream to fix a display bug without creating a code diff to the ddnet repo.
In good old teeworlds there used to be a death screen. Once someone dies they see the scoreboard for a second and then they respawn. This was removed server side in ddnet. So being dead is not really a thing anymore. This fix is just for the dead state. This is also why it does not affect ddnet. In my fork I am recreating teeworlds standard gametypes and modes based on standard gametypes while using recent ddnet as the foundation of the codebase. There the dead state was reintroduced. And the line removed in this pr makes it impossible for dead players to see flying lasers. Which is nasty because you will not see the laser that killed you in modes like ctf/dm/ictf and so on. Here a clip show casing the issue in ddnet-insta NOT in ddnet!

https://github.com/user-attachments/assets/9af54125-428f-4903-882e-6b3de1d0d704

I am not sure why this check was there in the first place. If someone is concerned about some segfaults happening in the half tick that ddnet still has a dead state, it should be fine I have this [patch](https://github.com/ddnet-insta/ddnet-insta/pull/62) without issues in my fork since 3 years.

In case someone is still confused why ddnet is not affected by the bug here is a clip on a ddnet server showing no death screen so the laser is never hidden. This clip was taken on a server compiled with this pr. And looks the exact same on the master branch.

https://github.com/user-attachments/assets/5d3f2c14-8ef7-4987-86bc-5087cbc816c0

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
