### PR TITLE
Use right-click to change curve type in envelope editor

### DIFF
--- a/src/game/editor/envelope_editor.cpp
+++ b/src/game/editor/envelope_editor.cpp
@@ -21,18 +21,7 @@
 #include <game/editor/mapitems/map.h>
 
 static const char *const CURVE_TYPE_NAMES[] = {"Step", "Linear", "Slow", "Fast", "Smooth", "Bezier"};
-static const char *const CURVE_TYPE_NAMES_SHORT[] = {"N", "L", "S", "F", "M", "B"};
 static_assert(std::size(CURVE_TYPE_NAMES) == NUM_CURVETYPES);
-static_assert(std::size(CURVE_TYPE_NAMES_SHORT) == NUM_CURVETYPES);
-
-static const char *CurveTypeNameShort(int CurveType)
-{
-	if(in_range<int>(CurveType, 0, std::size(CURVE_TYPE_NAMES_SHORT) - 1))
-	{
-		return CURVE_TYPE_NAMES_SHORT[CurveType];
-	}
-	return "!?";
-}
 
 static float ClampDelta(float Val, float Delta, float Min, float Max)
 {
@@ -131,16 +120,15 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 	static CLineInput s_NameInput;
 
-	CUIRect ToolBar, CurveBar, ColorBar, DragBar;
+	CUIRect ToolBar, ColorBar, DragBar;
 	View.HSplitTop(30.0f, &DragBar, nullptr);
 	DragBar.y -= 2.0f;
 	DragBar.w += 2.0f;
 	DragBar.h += 4.0f;
 	DoEditorDragBar(View, &DragBar, EDragSide::TOP, &m_aExtraEditorSplits[EXTRAEDITOR_ENVELOPES]);
 	View.HSplitTop(15.0f, &ToolBar, &View);
-	View.HSplitTop(15.0f, &CurveBar, &View);
+	View.HSplitTop(2.0f, nullptr, &View);
 	ToolBar.Margin(2.0f, &ToolBar);
-	CurveBar.Margin(2.0f, &CurveBar);
 
 	bool CurrentEnvelopeSwitched = false;
 
@@ -487,7 +475,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			}
 
 			m_ActiveEnvelopePreview = EEnvelopePreview::SELECTED;
-			str_copy(m_aTooltip, "Double click to create a new point. Use shift to change the zoom axis. Press S to scale selected envelope points.");
+			str_copy(m_aTooltip, "Double click to create a new point. Right-click to change curve type. Use shift to change the zoom axis. Press S to scale selected envelope points.");
 		}
 
 		UpdateZoomEnvelopeX(View);
@@ -535,6 +523,39 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			}
 			Ui()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 			Ui()->ClipDisable();
+		}
+
+		// highlight active region and handle curve type
+		if(s_Operation == EEnvelopeEditorOp::NONE && Ui()->HotItem() == &s_EnvelopeEditorId)
+		{
+			float MouseTime = ScreenToEnvelopeX(View, Ui()->MouseX());
+			if(0.0f <= MouseTime)
+			{
+				for(size_t i = 0; i < pEnvelope->m_vPoints.size() - 1; i++)
+				{
+					float TimeRegionEnd = pEnvelope->m_vPoints[i + 1].m_Time.AsSeconds();
+					if(MouseTime <= TimeRegionEnd)
+					{
+						float RegionStartX = EnvelopeToScreenX(View, pEnvelope->m_vPoints[i].m_Time.AsSeconds());
+						float RegionEndX = EnvelopeToScreenX(View, TimeRegionEnd);
+						CUIRect ActiveRegion{
+							RegionStartX,
+							View.y,
+							RegionEndX - RegionStartX,
+							View.h,
+						};
+						ActiveRegion.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.1f), IGraphics::CORNER_NONE, 0.0f);
+
+						if(Ui()->MouseButton(1))
+						{
+							m_PopupEnvelopeSelectedPoint = i;
+							static SPopupMenuId s_PopupCurvetypeId;
+							Ui()->DoPopupMenu(&s_PopupCurvetypeId, Ui()->MouseX(), Ui()->MouseY(), 80, (float)NUM_CURVETYPES * 14.0f + 10.0f, this, PopupEnvelopeCurvetype);
+						}
+						break;
+					}
+				}
+			}
 		}
 
 		// handle time bar
@@ -769,43 +790,6 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			}
 			Graphics()->LinesEnd();
 			Ui()->ClipDisable();
-		}
-
-		// render curve options
-		{
-			for(int i = 0; i < (int)pEnvelope->m_vPoints.size() - 1; i++)
-			{
-				float t0 = pEnvelope->m_vPoints[i].m_Time.AsSeconds();
-				float t1 = pEnvelope->m_vPoints[i + 1].m_Time.AsSeconds();
-
-				CUIRect CurveButton;
-				CurveButton.x = EnvelopeToScreenX(View, t0 + (t1 - t0) * 0.5f);
-				CurveButton.y = CurveBar.y;
-				CurveButton.h = CurveBar.h;
-				CurveButton.w = CurveBar.h;
-				CurveButton.x -= CurveButton.w / 2.0f;
-				const void *pId = &pEnvelope->m_vPoints[i].m_Curvetype;
-				if(CurveButton.x >= View.x)
-				{
-					const int ButtonResult = DoButton_Editor(pId, CurveTypeNameShort(pEnvelope->m_vPoints[i].m_Curvetype), 0, &CurveButton, BUTTONFLAG_LEFT | BUTTONFLAG_RIGHT, "Switch curve type (N = step, L = linear, S = slow, F = fast, M = smooth, B = bezier).");
-					if(ButtonResult == 1)
-					{
-						const int PrevCurve = pEnvelope->m_vPoints[i].m_Curvetype;
-						const int Direction = Input()->ShiftIsPressed() ? -1 : 1;
-						pEnvelope->m_vPoints[i].m_Curvetype = (pEnvelope->m_vPoints[i].m_Curvetype + Direction + NUM_CURVETYPES) % NUM_CURVETYPES;
-
-						Map()->m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeEditPoint>(Map(),
-							Map()->m_SelectedEnvelope, i, 0, CEditorActionEnvelopeEditPoint::EEditType::CURVE_TYPE, PrevCurve, pEnvelope->m_vPoints[i].m_Curvetype));
-						Map()->OnModify();
-					}
-					else if(ButtonResult == 2)
-					{
-						m_PopupEnvelopeSelectedPoint = i;
-						static SPopupMenuId s_PopupCurvetypeId;
-						Ui()->DoPopupMenu(&s_PopupCurvetypeId, Ui()->MouseX(), Ui()->MouseY(), 80, (float)NUM_CURVETYPES * 14.0f + 10.0f, this, PopupEnvelopeCurvetype);
-					}
-				}
-			}
 		}
 
 		// render colorbar


### PR DESCRIPTION
The curve type buttons are not very intuitive. Instead the already existing right-click menu could be used directly in the envelope editor. This also gives more space to the editor. The downside is that there is no info what the current curve type is. However I think that's fine as it is either clear from the curve or it does not matter anyway.

<img width="1920" height="1080" alt="screenshot_2026-06-22_09-40-55" src="https://github.com/user-attachments/assets/feea7da6-f11b-463a-ac4a-9625b5ea6ff1" />
<img width="1920" height="1080" alt="screenshot_2026-06-22_09-41-01" src="https://github.com/user-attachments/assets/0b9dc043-f52a-4b72-bcc8-7e01a9a94a40" />

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
