### PR TITLE
Skip lines containing control characters except `\t` in line reader

### DIFF
--- a/src/engine/shared/linereader.cpp
+++ b/src/engine/shared/linereader.cpp
@@ -8,6 +8,26 @@
 
 #include <cstdlib>
 
+static bool IsValidLine(const char *pLine)
+{
+	if(!str_utf8_check(pLine))
+	{
+		// Skip lines containing invalid UTF-8
+		return false;
+	}
+
+	// Skip lines containing any control character except `\t`
+	for(size_t Index = 0; pLine[Index] != '\0'; ++Index)
+	{
+		if((unsigned char)pLine[Index] < ' ' && pLine[Index] != '\t')
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
 CLineReader::CLineReader()
 {
 	m_pBuffer = nullptr;
@@ -77,9 +97,8 @@ const char *CLineReader::Get()
 				++m_BufferPos;
 			}
 
-			if(!str_utf8_check(&m_pBuffer[LineStart]))
+			if(!IsValidLine(&m_pBuffer[LineStart]))
 			{
-				// Skip lines containing invalid UTF-8
 				if(m_ReadLastLine)
 				{
 					return nullptr;

--- a/src/test/linereader_test.cpp
+++ b/src/test/linereader_test.cpp
@@ -8,7 +8,7 @@
 
 #include <gtest/gtest.h>
 
-void TestFileLineReaderRaw(const char *pWritten, unsigned WrittenLength, std::initializer_list<const char *> pReads, bool ExpectSuccess, bool WriteBom)
+void TestFileLineReaderRaw(const char *pWritten, unsigned WrittenLength, std::initializer_list<const char *> pExpectedLines, bool ExpectSuccess, bool WriteBom)
 {
 	CTestInfo Info;
 	IOHANDLE File = io_open(Info.m_aFilename, IOFLAG_WRITE);
@@ -26,13 +26,14 @@ void TestFileLineReaderRaw(const char *pWritten, unsigned WrittenLength, std::in
 	ASSERT_EQ(ActualSuccess, ExpectSuccess);
 	if(ActualSuccess)
 	{
-		for(const char *pRead : pReads)
+		for(const char *pExpectedLine : pExpectedLines)
 		{
-			const char *pReadLine = LineReader.Get();
-			ASSERT_TRUE(pReadLine) << "Line reader returned less lines than expected";
-			EXPECT_STREQ(pReadLine, pRead) << "Line reader returned unexpected line";
+			const char *pActualLine = LineReader.Get();
+			ASSERT_TRUE(pActualLine) << "Line reader returned less lines than expected. Expected next line: '" << pExpectedLine << "'";
+			EXPECT_STREQ(pActualLine, pExpectedLine) << "Line reader returned unexpected line";
 		}
-		EXPECT_FALSE(LineReader.Get()) << "Line reader returned more lines than expected";
+		const char *pActualLastLine = LineReader.Get();
+		EXPECT_FALSE(pActualLastLine) << "Line reader returned more lines than expected. Unexpected last line: '" << pActualLastLine << "'";
 	}
 
 	EXPECT_FALSE(fs_remove(Info.m_aFilename));
@@ -49,24 +50,31 @@ void TestFileLineReader(const char *pWritten, std::initializer_list<const char *
 	TestFileLineReaderRaw(pWritten, str_length(pWritten), pReads, true);
 }
 
-TEST(LineReader, NormalNewline)
+TEST(LineReader, LineFeedLineEndings)
 {
 	TestFileLineReader("foo\nbar\nbaz", {"foo", "bar", "baz"});
 	TestFileLineReader("foo\nbar\nbaz\n", {"foo", "bar", "baz"});
 }
 
-TEST(LineReader, CRLFNewline)
+TEST(LineReader, CarriageReturnLineFeedLineEndings)
 {
 	TestFileLineReader("foo\r\nbar\r\nbaz", {"foo", "bar", "baz"});
 	TestFileLineReader("foo\r\nbar\r\nbaz\r\n", {"foo", "bar", "baz"});
 }
 
-TEST(LineReader, MixedNewline)
+TEST(LineReader, CarriageReturnLineEndings)
+{
+	// Line ending `\r` not supported
+	TestFileLineReader("foo\rbar\rbaz", {});
+	TestFileLineReader("foo\rbar\rbaz\r", {});
+}
+
+TEST(LineReader, MixedLineEndings)
 {
 	TestFileLineReader("1\n2\r\n3\n4\n5\r\n6", {"1", "2", "3", "4", "5", "6"});
 	TestFileLineReader("1\n2\r\n3\n4\n5\r\n6\n", {"1", "2", "3", "4", "5", "6"});
 	TestFileLineReader("1\n2\r\n3\n4\n5\r\n6\r\n", {"1", "2", "3", "4", "5", "6"});
-	TestFileLineReader("1\n2\r\n3\n4\n5\r\n6\r", {"1", "2", "3", "4", "5", "6\r"});
+	TestFileLineReader("1\n2\r\n3\n4\n5\r\n6\r", {"1", "2", "3", "4", "5"}); // Line with trailing `\r` is skipped
 }
 
 TEST(LineReader, EmptyLines)
@@ -74,10 +82,10 @@ TEST(LineReader, EmptyLines)
 	TestFileLineReader("\n\r\n\n\n\r\n", {"", "", "", "", ""});
 	TestFileLineReader("\n\r\n\n\n\r\n\n", {"", "", "", "", "", ""});
 	TestFileLineReader("\n\r\n\n\n\r\n\r\n", {"", "", "", "", "", ""});
-	TestFileLineReader("\n\r\n\n\n\r\n\r", {"", "", "", "", "", "\r"});
+	TestFileLineReader("\n\r\n\n\n\r\n\r", {"", "", "", "", ""}); // Line with trailing `\r` is skipped
 }
 
-TEST(LineReader, Invalid)
+TEST(LineReader, InvalidUtf8)
 {
 	// Lines containing invalid UTF-8 are skipped
 	TestFileLineReader("foo\xff\nbar\xff\nbaz\xff", {});
@@ -85,6 +93,15 @@ TEST(LineReader, Invalid)
 	TestFileLineReader("foo\nbar\xff\nbaz", {"foo", "baz"});
 	TestFileLineReader("foo\nbar\nbaz\xff", {"foo", "bar"});
 	TestFileLineReader("foo\nbar1\xff\nbar2\xff\nfoobar\nbar3\xff\nbaz", {"foo", "foobar", "baz"});
+}
+
+TEST(LineReader, ControlCharacters)
+{
+	// Lines containing control characters except `\t` are skipped
+	TestFileLineReader(
+		"\x01\n\x02\n\x03\n\x04\n\x05\n\x06\n\x07\n\x08\n\x09\n\x0B\n\x0C\n\x0E\n\x0F\n\x10\n" // `\0x0A` and `\0x0D` are `\n` and `\r`
+		"\x11\n\x12\n\x13\n\x14\n\x15\n\x16\n\x17\n\x18\n\x19\n\x1A\n\x1B\n\x1C\n\x1D\n\x1E\n\x1F",
+		{"\t"});
 }
 
 TEST(LineReader, NullBytes)


### PR DESCRIPTION
CC #12104.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
