### PR TITLE
Don't send chat messages before `NETMSG_ENTERGAME`

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -980,7 +980,9 @@ int CServer::SendMsg(CMsgPacker *pMsg, int Flags, int ClientId)
 				m_aDemoRecorder[RECORDER_AUTO].RecordMessage(Pack.Data(), Pack.Size());
 		}
 
-		if(!(Flags & MSGFLAG_NOSEND))
+		// Clients that purposefully do not send `NETMSG_ENTERGAME` should not receive chat messages.
+		bool Send = m_aClients[ClientId].m_State == CClient::STATE_INGAME || pMsg->m_System || pMsg->m_MsgId != NETMSGTYPE_SV_CHAT;
+		if(!(Flags & MSGFLAG_NOSEND) && Send)
 			m_NetServer.Send(&Packet);
 	}
 


### PR DESCRIPTION


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
