### PR TITLE
Add `CMapEnvelopeEvaluator` to separate editor animations per map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2676,6 +2676,8 @@ if(CLIENT)
     mapitems.h
     mapitems/envelope.cpp
     mapitems/envelope.h
+    mapitems/envelope_evaluator.cpp
+    mapitems/envelope_evaluator.h
     mapitems/image.cpp
     mapitems/image.h
     mapitems/layer.cpp

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -82,18 +82,6 @@ bool CEditor::IsVanillaImage(const char *pImage)
 	return std::any_of(std::begin(VANILLA_IMAGES), std::end(VANILLA_IMAGES), [pImage](const char *pVanillaImage) { return str_comp(pImage, pVanillaImage) == 0; });
 }
 
-void CEditor::EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels)
-{
-	if(EnvelopeIndex < 0 || EnvelopeIndex >= (int)Map()->m_vpEnvelopes.size())
-		return;
-
-	std::shared_ptr<CEnvelope> pEnvelope = Map()->m_vpEnvelopes[EnvelopeIndex];
-	float Time = m_AnimateTime;
-	Time *= m_AnimateSpeed;
-	Time += (TimeOffsetMillis / 1000.0f);
-	pEnvelope->Eval(Time, Result, Channels);
-}
-
 bool CEditor::CallbackOpenMap(const char *pFilename, int StorageType, void *pUser)
 {
 	CEditor *pEditor = (CEditor *)pUser;
@@ -404,17 +392,17 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 		static char s_JumpStartButton = 0;
 		if(DoButton_FontIcon(&s_JumpStartButton, FontIcon::BACKWARD_STEP, false, &Button, BUTTONFLAG_LEFT, "Jump to beginning of animation.", IGraphics::CORNER_L))
 		{
-			m_AnimateTime = 0;
-			m_Animate = false;
+			Map()->m_EnvelopeEvaluator.m_AnimateTime = 0;
+			Map()->m_EnvelopeEvaluator.m_Animate = false;
 		}
 
 		ToolbarTop.VSplitLeft(25.0f, &Button, &ToolbarTop);
 		static char s_AnimateButton = 0;
-		if(DoButton_FontIcon(&s_AnimateButton, m_Animate ? FontIcon::PAUSE : FontIcon::PLAY, m_Animate, &Button, BUTTONFLAG_LEFT, "[Ctrl+M] Toggle animation.", IGraphics::CORNER_NONE) ||
+		if(DoButton_FontIcon(&s_AnimateButton, Map()->m_EnvelopeEvaluator.m_Animate ? FontIcon::PAUSE : FontIcon::PLAY, Map()->m_EnvelopeEvaluator.m_Animate, &Button, BUTTONFLAG_LEFT, "[Ctrl+M] Toggle animation.", IGraphics::CORNER_NONE) ||
 			(m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && Input()->KeyPress(KEY_M) && ModPressed))
 		{
-			m_AnimateStart = Client()->GlobalTime() - m_AnimateTime;
-			m_Animate = !m_Animate;
+			Map()->m_EnvelopeEvaluator.m_AnimateStart = Client()->GlobalTime() - Map()->m_EnvelopeEvaluator.m_AnimateTime;
+			Map()->m_EnvelopeEvaluator.m_Animate = !Map()->m_EnvelopeEvaluator.m_Animate;
 		}
 
 		// animation settings button
@@ -422,7 +410,7 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 		static char s_AnimateSettingsButton;
 		if(DoButton_FontIcon(&s_AnimateSettingsButton, FontIcon::CIRCLE_CHEVRON_DOWN, 0, &Button, BUTTONFLAG_LEFT, "Change the animation settings.", IGraphics::CORNER_R, 8.0f))
 		{
-			m_AnimateUpdatePopup = true;
+			Map()->m_EnvelopeEvaluator.m_AnimateUpdatePopup = true;
 			static SPopupMenuId s_PopupAnimateSettingsId;
 			Ui()->DoPopupMenu(&s_PopupAnimateSettingsId, Button.x, Button.y + Button.h, 150.0f, 37.0f, this, PopupAnimateSettings);
 		}
@@ -3608,7 +3596,7 @@ void CEditor::RenderMenubar(CUIRect MenuBar)
 	char aTimeStr[6];
 	str_timestamp_format(aTimeStr, sizeof(aTimeStr), "%H:%M");
 
-	str_format(aBuf, sizeof(aBuf), "X: %.1f, Y: %.1f, Z: %.1f, T: %.1f, A: %.1f, G: %i  %s", MapView()->MouseWorldPos().x / 32.0f, MapView()->MouseWorldPos().y / 32.0f, MapView()->Zoom()->GetValue(), m_AnimateTime * m_AnimateSpeed, m_AnimateSpeed, MapView()->MapGrid()->Factor(), aTimeStr);
+	str_format(aBuf, sizeof(aBuf), "X: %.1f, Y: %.1f, Z: %.1f, T: %.1f, A: %.1f, G: %i  %s", MapView()->MouseWorldPos().x / 32.0f, MapView()->MouseWorldPos().y / 32.0f, MapView()->Zoom()->GetValue(), Map()->m_EnvelopeEvaluator.m_AnimateTime * Map()->m_EnvelopeEvaluator.m_AnimateSpeed, Map()->m_EnvelopeEvaluator.m_AnimateSpeed, MapView()->MapGrid()->Factor(), aTimeStr);
 	Ui()->DoLabel(&Info, aBuf, 10.0f, TEXTALIGN_MR);
 
 	static int s_HelpButton = 0;
@@ -4410,9 +4398,6 @@ void CEditor::Reset(bool CreateDefault)
 	m_ActiveEnvelopePreview = EEnvelopePreview::NONE;
 	m_QuadEnvelopePointOperation = EQuadEnvelopePointOperation::NONE;
 
-	m_AnimateTime = 0;
-	m_Animate = false;
-
 	m_ResetZoomEnvelope = true;
 	m_SettingsCommandInput.Clear();
 	m_MapSettingsCommandContext.Reset();
@@ -4688,8 +4673,8 @@ void CEditor::OnRender()
 	if(Input()->KeyPress(KEY_F10))
 		m_ShowMousePointer = false;
 
-	if(m_Animate)
-		m_AnimateTime = Client()->GlobalTime() - m_AnimateStart;
+	if(Map()->m_EnvelopeEvaluator.m_Animate)
+		Map()->m_EnvelopeEvaluator.m_AnimateTime = Client()->GlobalTime() - Map()->m_EnvelopeEvaluator.m_AnimateStart;
 
 	m_pUiGotContext = nullptr;
 	Ui()->StartCheck();

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -38,7 +38,6 @@
 #include <game/editor/mapitems/map.h>
 #include <game/editor/prompt.h>
 #include <game/editor/quick_action.h>
-#include <game/map/render_interfaces.h>
 #include <game/mapitems.h>
 
 #include <deque>
@@ -105,7 +104,7 @@ enum
 	PROPTYPE_AUTOMAPPER_REFERENCE,
 };
 
-class CEditor : public IEditor, public IEnvelopeEval
+class CEditor : public IEditor
 {
 	class IInput *m_pInput = nullptr;
 	class IClient *m_pClient = nullptr;
@@ -230,11 +229,6 @@ public:
 
 		m_ShowTileInfo = SHOW_TILE_OFF;
 		m_ShowDetail = true;
-		m_Animate = false;
-		m_AnimateStart = 0.0f;
-		m_AnimateTime = 0.0f;
-		m_AnimateSpeed = 1.0f;
-		m_AnimateUpdatePopup = false;
 
 		for(size_t i = 0; i < std::size(m_aSavedColors); ++i)
 		{
@@ -418,12 +412,6 @@ public:
 	EShowTile m_ShowTileInfo;
 	bool m_ShowDetail;
 
-	bool m_Animate;
-	float m_AnimateStart;
-	float m_AnimateTime;
-	float m_AnimateSpeed;
-	bool m_AnimateUpdatePopup;
-
 	enum EExtraEditor
 	{
 		EXTRAEDITOR_NONE = -1,
@@ -481,8 +469,6 @@ public:
 	const void *m_pUiGotContext = nullptr;
 
 	std::deque<std::shared_ptr<CDataFileWriterFinishJob>> m_WriterFinishJobs;
-
-	void EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels) override;
 
 	CLineInputBuffered<256> m_SettingsCommandInput;
 	CMapSettingsBackend m_MapSettingsBackend;

--- a/src/game/editor/envelope_editor.cpp
+++ b/src/game/editor/envelope_editor.cpp
@@ -545,7 +545,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			}
 
 			ColorRGBA BarColor;
-			if(Ui()->CheckActiveItem(&m_AnimateTime))
+			if(Ui()->CheckActiveItem(&Map()->m_EnvelopeEvaluator.m_AnimateTime))
 			{
 				if(s_Operation == EEnvelopeEditorOp::SELECT)
 				{
@@ -559,8 +559,8 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				if(s_Operation == EEnvelopeEditorOp::DRAG_TIME_BAR)
 				{
 					float DeltaX = ScreenToEnvelopeDX(View, Ui()->MouseDeltaX()) * (Input()->ModifierIsPressed() ? 0.05f : 1.0f);
-					m_AnimateTime += DeltaX / m_AnimateSpeed;
-					m_AnimateTime = std::max(m_AnimateTime, 0.0f);
+					Map()->m_EnvelopeEvaluator.m_AnimateTime += DeltaX / Map()->m_EnvelopeEvaluator.m_AnimateSpeed;
+					Map()->m_EnvelopeEvaluator.m_AnimateTime = std::max(Map()->m_EnvelopeEvaluator.m_AnimateTime, 0.0f);
 				}
 
 				if(!Ui()->MouseButton(0))
@@ -573,11 +573,11 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				BarColor = ColorRGBA(1.0f, 1.0f, 0.0f, 0.8f);
 				str_copy(m_aTooltip, "Timebar. Press left-click to drag. Hold ctrl to be more precise.");
 			}
-			else if(Ui()->HotItem() == &m_AnimateTime)
+			else if(Ui()->HotItem() == &Map()->m_EnvelopeEvaluator.m_AnimateTime)
 			{
 				if(Ui()->MouseButton(0))
 				{
-					Ui()->SetActiveItem(&m_AnimateTime);
+					Ui()->SetActiveItem(&Map()->m_EnvelopeEvaluator.m_AnimateTime);
 					s_Operation = EEnvelopeEditorOp::SELECT;
 
 					s_MouseXStart = Ui()->MouseX();
@@ -591,7 +591,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			else
 				BarColor = ColorRGBA(1.0f, 1.0f, 0.0f, 0.5f);
 
-			float Time = m_AnimateTime * m_AnimateSpeed;
+			float Time = Map()->m_EnvelopeEvaluator.m_AnimateTime * Map()->m_EnvelopeEvaluator.m_AnimateSpeed;
 			const float BarWidth = 1.5f;
 			CUIRect TimeBar{
 				EnvelopeToScreenX(View, Time) - BarWidth / 2.0f,
@@ -1655,13 +1655,13 @@ void CEditor::UpdateHotEnvelopeObject(const CUIRect &View, const CEnvelope *pEnv
 	{
 		Ui()->SetHotItem(pMinPointId);
 	}
-	else if(!m_Animate)
+	else if(!Map()->m_EnvelopeEvaluator.m_Animate)
 	{
-		float Time = m_AnimateTime * m_AnimateSpeed;
+		float Time = Map()->m_EnvelopeEvaluator.m_AnimateTime * Map()->m_EnvelopeEvaluator.m_AnimateSpeed;
 		float LoopedTime = std::fmod(Time, pEnvelope->EndTime());
 		if(absolute(EnvelopeToScreenX(View, Time) - MousePos.x) < 20.0f || absolute(EnvelopeToScreenX(View, LoopedTime) - MousePos.x) < 20.0f)
 		{
-			Ui()->SetHotItem(&m_AnimateTime);
+			Ui()->SetHotItem(&Map()->m_EnvelopeEvaluator.m_AnimateTime);
 		}
 	}
 }

--- a/src/game/editor/mapitems/envelope_evaluator.cpp
+++ b/src/game/editor/mapitems/envelope_evaluator.cpp
@@ -1,0 +1,21 @@
+#include "envelope_evaluator.h"
+
+#include <game/editor/mapitems/envelope.h>
+#include <game/editor/mapitems/map.h>
+
+CMapEnvelopeEvaluator::CMapEnvelopeEvaluator(CEditorMap *pMap) :
+	CMapObject(pMap)
+{
+}
+
+void CMapEnvelopeEvaluator::EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels)
+{
+	if(EnvelopeIndex < 0 || EnvelopeIndex >= (int)Map()->m_vpEnvelopes.size())
+		return;
+
+	std::shared_ptr<CEnvelope> pEnvelope = Map()->m_vpEnvelopes[EnvelopeIndex];
+	float Time = m_AnimateTime;
+	Time *= m_AnimateSpeed;
+	Time += (TimeOffsetMillis / 1000.0f);
+	pEnvelope->Eval(Time, Result, Channels);
+}

--- a/src/game/editor/mapitems/envelope_evaluator.h
+++ b/src/game/editor/mapitems/envelope_evaluator.h
@@ -1,0 +1,23 @@
+#ifndef GAME_EDITOR_MAPITEMS_ENVELOPE_EVALUATOR_H
+#define GAME_EDITOR_MAPITEMS_ENVELOPE_EVALUATOR_H
+
+#include <base/color.h>
+
+#include <game/editor/map_object.h>
+#include <game/map/render_interfaces.h>
+
+class CMapEnvelopeEvaluator : public CMapObject, public IEnvelopeEval
+{
+public:
+	explicit CMapEnvelopeEvaluator(CEditorMap *pMap);
+
+	void EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels) override;
+
+	bool m_Animate = false;
+	float m_AnimateStart = 0.0f;
+	float m_AnimateTime = 0.0f;
+	float m_AnimateSpeed = 1.0f;
+	bool m_AnimateUpdatePopup = false;
+};
+
+#endif

--- a/src/game/editor/mapitems/layer_quads.cpp
+++ b/src/game/editor/mapitems/layer_quads.cpp
@@ -30,9 +30,9 @@ void CLayerQuads::Render(bool QuadPicker)
 		Graphics()->TextureSet(Map()->m_vpImages[m_Image]->m_Texture);
 
 	Graphics()->BlendNone();
-	Editor()->RenderMap()->ForceRenderQuads(m_vQuads.data(), m_vQuads.size(), LAYERRENDERFLAG_OPAQUE, Editor());
+	Editor()->RenderMap()->ForceRenderQuads(m_vQuads.data(), m_vQuads.size(), LAYERRENDERFLAG_OPAQUE, &Map()->m_EnvelopeEvaluator);
 	Graphics()->BlendNormal();
-	Editor()->RenderMap()->ForceRenderQuads(m_vQuads.data(), m_vQuads.size(), LAYERRENDERFLAG_TRANSPARENT, Editor());
+	Editor()->RenderMap()->ForceRenderQuads(m_vQuads.data(), m_vQuads.size(), LAYERRENDERFLAG_TRANSPARENT, &Map()->m_EnvelopeEvaluator);
 }
 
 CQuad *CLayerQuads::NewQuad(int x, int y, int Width, int Height)

--- a/src/game/editor/mapitems/layer_sounds.cpp
+++ b/src/game/editor/mapitems/layer_sounds.cpp
@@ -34,7 +34,7 @@ void CLayerSounds::Render(bool Tileset)
 	for(const auto &Source : m_vSources)
 	{
 		ColorRGBA Offset = ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f);
-		Editor()->EnvelopeEval(Source.m_PosEnvOffset, Source.m_PosEnv, Offset, 2);
+		Map()->m_EnvelopeEvaluator.EnvelopeEval(Source.m_PosEnvOffset, Source.m_PosEnv, Offset, 2);
 		const vec2 Position = vec2(fx2f(Source.m_Position.x) + Offset.r, fx2f(Source.m_Position.y) + Offset.g);
 		const float Falloff = Source.m_Falloff / 255.0f;
 
@@ -74,7 +74,7 @@ void CLayerSounds::Render(bool Tileset)
 	for(const auto &Source : m_vSources)
 	{
 		ColorRGBA Offset = ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f);
-		Editor()->EnvelopeEval(Source.m_PosEnvOffset, Source.m_PosEnv, Offset, 2);
+		Map()->m_EnvelopeEvaluator.EnvelopeEval(Source.m_PosEnvOffset, Source.m_PosEnv, Offset, 2);
 		const vec2 Position = vec2(fx2f(Source.m_Position.x) + Offset.r, fx2f(Source.m_Position.y) + Offset.g);
 		Graphics()->DrawSprite(Position.x, Position.y, Editor()->MapView()->ScaleLength(s_SourceVisualSize));
 	}

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -178,7 +178,7 @@ void CLayerTiles::Render(bool Tileset)
 	Graphics()->TextureSet(Texture);
 
 	ColorRGBA ColorEnv = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
-	Editor()->EnvelopeEval(m_ColorEnvOffset, m_ColorEnv, ColorEnv, 4);
+	Map()->m_EnvelopeEvaluator.EnvelopeEval(m_ColorEnvOffset, m_ColorEnv, ColorEnv, 4);
 	const ColorRGBA Color = ColorRGBA(m_Color.r / 255.0f, m_Color.g / 255.0f, m_Color.b / 255.0f, m_Color.a / 255.0f).Multiply(ColorEnv);
 
 	Graphics()->BlendNone();

--- a/src/game/editor/mapitems/map.h
+++ b/src/game/editor/mapitems/map.h
@@ -14,6 +14,7 @@
 #include <game/editor/map_grid.h>
 #include <game/editor/map_view.h>
 #include <game/editor/mapitems/envelope.h>
+#include <game/editor/mapitems/envelope_evaluator.h>
 #include <game/editor/mapitems/layer.h>
 #include <game/editor/proof_mode.h>
 #include <game/editor/quad_art.h>
@@ -75,6 +76,7 @@ public:
 		m_SoundSourcePropTracker(this),
 		m_SoundSourceRectShapePropTracker(this),
 		m_SoundSourceCircleShapePropTracker(this),
+		m_EnvelopeEvaluator(this),
 		m_pEditor(pEditor)
 	{
 	}
@@ -165,6 +167,7 @@ public:
 	CMapGrid::CState m_MapGridState;
 	CProofMode::CState m_ProofModeState;
 	CQuadKnife::CState m_QuadKnifeState;
+	CMapEnvelopeEvaluator m_EnvelopeEvaluator;
 
 	// Housekeeping
 	void Clean();

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -2736,6 +2736,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupProofMode(void *pContext, CUIRect Vi
 CUi::EPopupMenuFunctionResult CEditor::PopupAnimateSettings(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
+	CMapEnvelopeEvaluator &EnvelopeEvaluator = pEditor->Map()->m_EnvelopeEvaluator;
 
 	static constexpr float MIN_ANIM_SPEED = 0.001f;
 	static constexpr float MAX_ANIM_SPEED = 1000000.0f;
@@ -2749,53 +2750,53 @@ CUi::EPopupMenuFunctionResult CEditor::PopupAnimateSettings(void *pContext, CUIR
 	View.HSplitBottom(12.0f, &View, &ButtonReset);
 	pEditor->Ui()->DoLabel(&Label, "Speed", 10.0f, TEXTALIGN_ML);
 
-	const float OldAnimateSpeed = pEditor->m_AnimateSpeed;
+	const float OldAnimateSpeed = EnvelopeEvaluator.m_AnimateSpeed;
 
 	static char s_DecreaseButton;
 	if(pEditor->DoButton_FontIcon(&s_DecreaseButton, FontIcon::MINUS, 0, &ButtonDecrease, BUTTONFLAG_LEFT, "Decrease animation speed.", IGraphics::CORNER_L, 7.0f))
 	{
-		pEditor->m_AnimateSpeed -= pEditor->m_AnimateSpeed <= 1.0f ? 0.1f : 0.5f;
-		pEditor->m_AnimateSpeed = std::max(pEditor->m_AnimateSpeed, MIN_ANIM_SPEED);
-		pEditor->m_AnimateUpdatePopup = true;
+		EnvelopeEvaluator.m_AnimateSpeed -= EnvelopeEvaluator.m_AnimateSpeed <= 1.0f ? 0.1f : 0.5f;
+		EnvelopeEvaluator.m_AnimateSpeed = std::max(EnvelopeEvaluator.m_AnimateSpeed, MIN_ANIM_SPEED);
+		EnvelopeEvaluator.m_AnimateUpdatePopup = true;
 	}
 
 	static char s_IncreaseButton;
 	if(pEditor->DoButton_FontIcon(&s_IncreaseButton, FontIcon::PLUS, 0, &ButtonIncrease, BUTTONFLAG_LEFT, "Increase animation speed.", IGraphics::CORNER_R, 7.0f))
 	{
-		if(pEditor->m_AnimateSpeed < 0.1f)
-			pEditor->m_AnimateSpeed = 0.1f;
+		if(EnvelopeEvaluator.m_AnimateSpeed < 0.1f)
+			EnvelopeEvaluator.m_AnimateSpeed = 0.1f;
 		else
-			pEditor->m_AnimateSpeed += pEditor->m_AnimateSpeed < 1.0f ? 0.1f : 0.5f;
-		pEditor->m_AnimateSpeed = std::min(pEditor->m_AnimateSpeed, MAX_ANIM_SPEED);
-		pEditor->m_AnimateUpdatePopup = true;
+			EnvelopeEvaluator.m_AnimateSpeed += EnvelopeEvaluator.m_AnimateSpeed < 1.0f ? 0.1f : 0.5f;
+		EnvelopeEvaluator.m_AnimateSpeed = std::min(EnvelopeEvaluator.m_AnimateSpeed, MAX_ANIM_SPEED);
+		EnvelopeEvaluator.m_AnimateUpdatePopup = true;
 	}
 
 	static char s_DefaultButton;
 	if(pEditor->DoButton_Ex(&s_DefaultButton, "Default", 0, &ButtonReset, BUTTONFLAG_LEFT, "Reset to normal animation speed.", IGraphics::CORNER_ALL))
 	{
-		pEditor->m_AnimateSpeed = 1.0f;
-		pEditor->m_AnimateUpdatePopup = true;
+		EnvelopeEvaluator.m_AnimateSpeed = 1.0f;
+		EnvelopeEvaluator.m_AnimateUpdatePopup = true;
 	}
 
 	static CLineInputNumber s_SpeedInput;
-	if(pEditor->m_AnimateUpdatePopup)
+	if(EnvelopeEvaluator.m_AnimateUpdatePopup)
 	{
-		s_SpeedInput.SetFloat(pEditor->m_AnimateSpeed);
-		pEditor->m_AnimateUpdatePopup = false;
+		s_SpeedInput.SetFloat(EnvelopeEvaluator.m_AnimateSpeed);
+		EnvelopeEvaluator.m_AnimateUpdatePopup = false;
 	}
 
 	if(pEditor->DoEditBox(&s_SpeedInput, &EditBox, 10.0f, IGraphics::CORNER_NONE, "The animation speed."))
 	{
-		pEditor->m_AnimateSpeed = std::clamp(s_SpeedInput.GetFloat(), MIN_ANIM_SPEED, MAX_ANIM_SPEED);
+		EnvelopeEvaluator.m_AnimateSpeed = std::clamp(s_SpeedInput.GetFloat(), MIN_ANIM_SPEED, MAX_ANIM_SPEED);
 	}
 
 	// adjust start time to avoid jumps in animation
-	float AnimateSpeedRatio = OldAnimateSpeed / pEditor->m_AnimateSpeed;
+	float AnimateSpeedRatio = OldAnimateSpeed / EnvelopeEvaluator.m_AnimateSpeed;
 	float Time = pEditor->Client()->GlobalTime();
-	pEditor->m_AnimateStart = Time + (pEditor->m_AnimateStart - Time) * AnimateSpeedRatio;
-	if(!pEditor->m_Animate)
+	EnvelopeEvaluator.m_AnimateStart = Time + (EnvelopeEvaluator.m_AnimateStart - Time) * AnimateSpeedRatio;
+	if(!EnvelopeEvaluator.m_Animate)
 	{
-		pEditor->m_AnimateTime *= AnimateSpeedRatio;
+		EnvelopeEvaluator.m_AnimateTime *= AnimateSpeedRatio;
 	}
 
 	return CUi::POPUP_KEEP_OPEN;


### PR DESCRIPTION
For #11800 and #11776.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
