### PR TITLE
Split apt install in build CI in multiple lines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,27 @@ jobs:
         sudo apt-get update -y
         # mount: /var/lib/grub/esp: special device /dev/disk/by-id/scsi-... does not exist.
         # sudo apt-get upgrade -y
-        sudo apt-get install pkg-config ninja-build libfreetype6-dev libnotify-dev libsdl2-dev libsqlite3-dev libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev libx264-dev libpng-dev valgrind gcovr libglew-dev -y
+        packages=(
+          # tidy-alphabetical-start
+          gcovr
+          libavcodec-dev
+          libavformat-dev
+          libavutil-dev
+          libfreetype6-dev
+          libglew-dev
+          libnotify-dev
+          libpng-dev
+          libsdl2-dev
+          libsqlite3-dev
+          libswresample-dev
+          libswscale-dev
+          libx264-dev
+          ninja-build
+          pkg-config
+          valgrind
+          # tidy-alphabetical-end
+        )
+        sudo apt-get install -y "${packages[@]}"
 
     - name: Prepare Linux (non-fancy)
       if: contains(matrix.os, 'ubuntu') && !contains(matrix.name, 'fancy')

--- a/scripts/tidy_alphabetical.py
+++ b/scripts/tidy_alphabetical.py
@@ -183,6 +183,7 @@ TEXT_EXTS = set(
 )
 
 TOPLEVEL_DIRS = """tidy-alphabetical-start
+.github
 cmake
 data
 datsrc


### PR DESCRIPTION
Makes git conflicts simpler and removes the need for side scrolling when reading diffs.

CC #12302

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions