### PR TITLE
Add suggestion for `rustup` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ You can install the required libraries on your system, `touch CMakeLists.txt` an
 ```sh
 sudo apt install build-essential cargo cmake git glslang-tools google-mock libavcodec-extra libavdevice-dev libavfilter-dev libavformat-dev libavutil-dev libcurl4-openssl-dev libfreetype6-dev libglew-dev libnotify-dev libogg-dev libopus-dev libopusfile-dev libpng-dev libsdl2-dev libsqlite3-dev libssl-dev libvulkan-dev libwavpack-dev libx264-dev ninja-build python3 rustc spirv-tools
 ```
+If you distribution doesn't ship with a `rustc` that is new enough, you can use `rustup` which automatically provides `rustc` 1.85.0 and above (this command removes `rustc` and reinstalls it as part of `rustup`.):
+```sh
+sudo apt install rustup
+```
+
+In case the `rustc` dependency doesn't have the required version for any reason:
+```sh
+sudo apt install rustup-1.85
+```
 
 On older distributions like Ubuntu 18.04 don't install `google-mock`, but instead set `-DDOWNLOAD_GTEST=ON` when building to get a more recent gtest/gmock version.
 


### PR DESCRIPTION
- NOTE: Installed required dependencies via the README instructions.

In `cmake/FindRust.cmake`, during compilation it prints and error related to `rustc` dependency's version (1.75.0) being outdated to the required (1.85.0+) version. This means that the given command to install dependencies will produce the same error for everyone, as in the cmake file expects `rustup` to be installed on the latest distributions.

- Replaced dependency `rustc` with `rustup` for proper Rust Version usage.
- Added extra information about this issue, so developers using older distributions can have a clue on why this issue happens.
- Added extra information in the fatal error message to nudge developers in the right direction. (in case dependencies were ignored or other reason...)

To replicate this issue, uninstall `rustup` and install `rustc` which was the original dependency in the commands given in the README file.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
