### PR TITLE
Fix integer config variable help text when using constants, reduce memory usage for color and string config variable help text

### DIFF
--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -308,20 +308,24 @@ void CConfigManager::Init()
 
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Flags, Desc) \
 	{ \
-		const size_t HelpSize = (size_t)str_length(Desc) + 32; \
-		char *pHelp = static_cast<char *>(m_ConfigHeap.Allocate(HelpSize)); \
+		const char *pScriptName = #ScriptName; \
 		const bool Alpha = ((Flags) & CFGFLAG_COLALPHA) != 0; \
-		str_format(pHelp, HelpSize, "%s (default: $%0*X)", Desc, Alpha ? 8 : 6, color_cast<ColorRGBA>(ColorHSLA(Def, Alpha)).Pack(Alpha)); \
-		AddVariable(m_ConfigHeap.Allocate<SColorConfigVariable>(m_pConsole, #ScriptName, SConfigVariable::VAR_COLOR, Flags, pHelp, &g_Config.m_##Name, Def)); \
+		char aHelp[512]; \
+		const size_t HelpSize = str_format(aHelp, sizeof(aHelp), "%s (default: $%0*X)", Desc, Alpha ? 8 : 6, color_cast<ColorRGBA>(ColorHSLA(Def, Alpha)).Pack(Alpha)); \
+		dbg_assert(HelpSize < sizeof(aHelp) - UTF8_BYTE_LENGTH - 1, "MACRO_CONFIG_COL(%s): help text possibly truncated. Increase size of aHelp.", pScriptName); \
+		AddVariable(m_ConfigHeap.Allocate<SColorConfigVariable>( \
+			m_pConsole, pScriptName, SConfigVariable::VAR_COLOR, Flags, m_ConfigHeap.StoreString(aHelp), &g_Config.m_##Name, Def)); \
 	}
 
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Flags, Desc) \
 	{ \
-		const size_t HelpSize = (size_t)str_length(Desc) + str_length(Def) + 64; \
-		char *pHelp = static_cast<char *>(m_ConfigHeap.Allocate(HelpSize)); \
-		str_format(pHelp, HelpSize, "%s (default: \"%s\", max length: %d)", Desc, Def, Len - 1); \
+		const char *pScriptName = #ScriptName; \
+		char aHelp[512]; \
+		const size_t HelpSize = str_format(aHelp, sizeof(aHelp), "%s (default: \"%s\", max length: %d)", Desc, Def, Len - 1); \
+		dbg_assert(HelpSize < sizeof(aHelp) - UTF8_BYTE_LENGTH - 1, "MACRO_CONFIG_STR(%s): help text possibly truncated. Increase size of aHelp.", pScriptName); \
 		char *pOldValue = static_cast<char *>(m_ConfigHeap.Allocate(Len)); \
-		AddVariable(m_ConfigHeap.Allocate<SStringConfigVariable>(m_pConsole, #ScriptName, SConfigVariable::VAR_STRING, Flags, pHelp, g_Config.m_##Name, Def, Len, pOldValue)); \
+		AddVariable(m_ConfigHeap.Allocate<SStringConfigVariable>( \
+			m_pConsole, pScriptName, SConfigVariable::VAR_STRING, Flags, m_ConfigHeap.StoreString(aHelp), g_Config.m_##Name, Def, Len, pOldValue)); \
 	}
 
 #include "config_variables.h"

--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -290,8 +290,20 @@ void CConfigManager::Init()
 
 #define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Flags, Desc) \
 	{ \
-		const char *pHelp = Min == Max ? Desc " (default: " #Def ")" : (Max == 0 ? Desc " (default: " #Def ", min: " #Min ")" : Desc " (default: " #Def ", min: " #Min ", max: " #Max ")"); \
-		AddVariable(m_ConfigHeap.Allocate<SIntConfigVariable>(m_pConsole, #ScriptName, SConfigVariable::VAR_INT, Flags, pHelp, &g_Config.m_##Name, Def, Min, Max)); \
+		const char *pScriptName = #ScriptName; \
+		dbg_assert(Min == 0 || Max == 0 || Min < Max, "MACRO_CONFIG_INT(%s): minimum (%d) must be less than maximum (%d)", pScriptName, Min, Max); \
+		dbg_assert((Min == 0 || Def >= Min) && (Max == 0 || Def <= Max), "MACRO_CONFIG_INT(%s): default (%d) must be in range of minimum (%d) and maximum (%d)", pScriptName, Def, Min, Max); \
+		char aHelp[512]; \
+		size_t HelpSize; \
+		if(Min == 0 && Max == 0) \
+			HelpSize = str_format(aHelp, sizeof(aHelp), "%s (default: %d)", Desc, Def); \
+		else if(Max == 0) \
+			HelpSize = str_format(aHelp, sizeof(aHelp), "%s (default: %d, min: %d)", Desc, Def, Min); \
+		else \
+			HelpSize = str_format(aHelp, sizeof(aHelp), "%s (default: %d, min: %d, max: %d)", Desc, Def, Min, Max); \
+		dbg_assert(HelpSize < sizeof(aHelp) - UTF8_BYTE_LENGTH - 1, "MACRO_CONFIG_INT(%s): help text possibly truncated. Increase size of aHelp.", pScriptName); \
+		AddVariable(m_ConfigHeap.Allocate<SIntConfigVariable>( \
+			m_pConsole, pScriptName, SConfigVariable::VAR_INT, Flags, m_ConfigHeap.StoreString(aHelp), &g_Config.m_##Name, Def, Min, Max)); \
 	}
 
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Flags, Desc) \


### PR DESCRIPTION
See commit messages.

Fixes regression from #12315 reported by Hoco4ek on Discord:

- Before: <img src="https://github.com/user-attachments/assets/240895c4-6f7c-4ad7-b27a-c1975e0a1b2f" />
- After: <img src="https://github.com/user-attachments/assets/8b57633d-0052-4531-bc0c-0143a1aaf3f3" />



## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
