### PR TITLE
Update cxxbridge from 1.0.194 to 1.0.195

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,7 @@ jobs:
               ./
     - name: Run cxxbridge
       run: |
-        cargo install cxxbridge-cmd@1.0.194
+        cargo install cxxbridge-cmd@1.0.195
         python scripts/generate_rust_bridge.py
         git diff --exit-code
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747d8437319e3a2f43d93b341c137927ca70c0f5dabeea7a005a73665e247c7e"
+checksum = "201f2332bd98022973bbf50c87f2d2f8151200f43e640da370901b20f1bea9d3"
 dependencies = [
  "cc",
  "cxx-build",
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f4697d190a142477b16aef7da8a99bfdc41e7e8b1687583c0d23a79c7afc1e"
+checksum = "02da7762e3807681f61c4561f34e1ff791417334294b225dbe22236459c9deef"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0956799fa8678d4c50eed028f2de1c0552ae183c76e976cf7ca8c4e36a7c328"
+checksum = "21c216b8cd7c26c2798bbecdb13de2f8dc65239b9ed892756deacff10fc0fa64"
 dependencies = [
  "clap",
  "codespan-reporting",
@@ -100,15 +100,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23384a836ab4f0ad98ace7e3955ad2de39de42378ab487dc28d3990392cb283a"
+checksum = "61c618f09812e388d1d065fd43fdc4340fade506ab2e0903397bf238650fce45"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6acc6b5822b9526adfb4fc377b67128fdd60aac757cc4a741a6278603f763cf"
+checksum = "415b113deba00cc605302b9b0b4974ab3d57c41135d81737cd47b89dbaa17c38"
 dependencies = [
  "indexmap",
  "proc-macro2",

--- a/scripts/generate_rust_bridge.py
+++ b/scripts/generate_rust_bridge.py
@@ -30,7 +30,7 @@ def main():
 	p = argparse.ArgumentParser(description="Generate src/rust-bridge")
 	_args = p.parse_args()
 
-	cxxbridge = find_cxxbridge(version="1.0.194")
+	cxxbridge = find_cxxbridge(version="1.0.195")
 	for input_, output_prefix in FILES.items():
 		subprocess.check_call([
 			cxxbridge,

--- a/src/base/Cargo.toml
+++ b/src/base/Cargo.toml
@@ -10,7 +10,7 @@ license = "Zlib"
 path = "lib.rs"
 
 [dependencies]
-cxx = "=1.0.194"
+cxx = "=1.0.195"
 libc = "0.2"
 
 [dev-dependencies]

--- a/src/engine/Cargo.toml
+++ b/src/engine/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib.rs"
 [dependencies]
 ddnet-base = { path = "../base" }
 
-cxx = "=1.0.194"
+cxx = "=1.0.195"
 
 [dev-dependencies]
 ddnet-engine-shared = { path = "shared" }

--- a/src/engine/shared/Cargo.toml
+++ b/src/engine/shared/Cargo.toml
@@ -14,7 +14,7 @@ path = "lib.rs"
 ddnet-base = { path = "../../base" }
 ddnet-engine = { path = ".." }
 
-cxx = "=1.0.194"
+cxx = "=1.0.195"
 
 [dev-dependencies]
 ddnet-test = { path = "../../rust-bridge/test", features = ["link-test-libraries"] }

--- a/src/rust-bridge/cpp/console.cpp
+++ b/src/rust-bridge/cpp/console.cpp
@@ -99,52 +99,52 @@ static_assert(
     "type IConsole_FCommandCallback should be trivially move constructible and trivially destructible in C++ to be used as an argument of `Register` in Rust");
 
 extern "C" {
-::std::int32_t cxxbridge1$194$IConsole_IResult$GetInteger(::IConsole_IResult const &self, ::std::uint32_t Index) noexcept {
+::std::int32_t cxxbridge1$195$IConsole_IResult$GetInteger(::IConsole_IResult const &self, ::std::uint32_t Index) noexcept {
   ::std::int32_t (::IConsole_IResult::*GetInteger$)(::std::uint32_t) const = &::IConsole_IResult::GetInteger;
   return (self.*GetInteger$)(Index);
 }
 
-float cxxbridge1$194$IConsole_IResult$GetFloat(::IConsole_IResult const &self, ::std::uint32_t Index) noexcept {
+float cxxbridge1$195$IConsole_IResult$GetFloat(::IConsole_IResult const &self, ::std::uint32_t Index) noexcept {
   float (::IConsole_IResult::*GetFloat$)(::std::uint32_t) const = &::IConsole_IResult::GetFloat;
   return (self.*GetFloat$)(Index);
 }
 
-void cxxbridge1$194$IConsole_IResult$GetString(::IConsole_IResult const &self, ::std::uint32_t Index, ::StrRef *return$) noexcept {
+void cxxbridge1$195$IConsole_IResult$GetString(::IConsole_IResult const &self, ::std::uint32_t Index, ::StrRef *return$) noexcept {
   ::StrRef (::IConsole_IResult::*GetString$)(::std::uint32_t) const = &::IConsole_IResult::GetString;
   new (return$) ::StrRef((self.*GetString$)(Index));
 }
 
-void cxxbridge1$194$IConsole_IResult$GetColor(::IConsole_IResult const &self, ::std::uint32_t Index, float DarkestLighting, ::ColorHSLA *return$) noexcept {
+void cxxbridge1$195$IConsole_IResult$GetColor(::IConsole_IResult const &self, ::std::uint32_t Index, float DarkestLighting, ::ColorHSLA *return$) noexcept {
   ::ColorHSLA (::IConsole_IResult::*GetColor$)(::std::uint32_t, float) const = &::IConsole_IResult::GetColor;
   new (return$) ::ColorHSLA((self.*GetColor$)(Index, DarkestLighting));
 }
 
-::std::int32_t cxxbridge1$194$IConsole_IResult$NumArguments(::IConsole_IResult const &self) noexcept {
+::std::int32_t cxxbridge1$195$IConsole_IResult$NumArguments(::IConsole_IResult const &self) noexcept {
   ::std::int32_t (::IConsole_IResult::*NumArguments$)() const = &::IConsole_IResult::NumArguments;
   return (self.*NumArguments$)();
 }
 
-::std::int32_t cxxbridge1$194$IConsole_IResult$GetVictim(::IConsole_IResult const &self) noexcept {
+::std::int32_t cxxbridge1$195$IConsole_IResult$GetVictim(::IConsole_IResult const &self) noexcept {
   ::std::int32_t (::IConsole_IResult::*GetVictim$)() const = &::IConsole_IResult::GetVictim;
   return (self.*GetVictim$)();
 }
 
-void cxxbridge1$194$IConsole$ExecuteLine(::IConsole &self, ::StrRef *pStr, ::std::int32_t ClientId, bool InterpretSemicolons) noexcept {
+void cxxbridge1$195$IConsole$ExecuteLine(::IConsole &self, ::StrRef *pStr, ::std::int32_t ClientId, bool InterpretSemicolons) noexcept {
   void (::IConsole::*ExecuteLine$)(::StrRef, ::std::int32_t, bool) = &::IConsole::ExecuteLine;
   (self.*ExecuteLine$)(::std::move(*pStr), ClientId, InterpretSemicolons);
 }
 
-void cxxbridge1$194$IConsole$Print(::IConsole const &self, ::std::int32_t Level, ::StrRef *pFrom, ::StrRef *pStr, ::ColorRGBA *PrintColor) noexcept {
+void cxxbridge1$195$IConsole$Print(::IConsole const &self, ::std::int32_t Level, ::StrRef *pFrom, ::StrRef *pStr, ::ColorRGBA *PrintColor) noexcept {
   void (::IConsole::*Print$)(::std::int32_t, ::StrRef, ::StrRef, ::ColorRGBA) const = &::IConsole::Print;
   (self.*Print$)(Level, ::std::move(*pFrom), ::std::move(*pStr), ::std::move(*PrintColor));
 }
 
-void cxxbridge1$194$IConsole$Register(::IConsole &self, ::StrRef *pName, ::StrRef *pParams, ::std::int32_t Flags, ::IConsole_FCommandCallback *pfnFunc, ::UserPtr *pUser, ::StrRef *pHelp) noexcept {
+void cxxbridge1$195$IConsole$Register(::IConsole &self, ::StrRef *pName, ::StrRef *pParams, ::std::int32_t Flags, ::IConsole_FCommandCallback *pfnFunc, ::UserPtr *pUser, ::StrRef *pHelp) noexcept {
   void (::IConsole::*Register$)(::StrRef, ::StrRef, ::std::int32_t, ::IConsole_FCommandCallback, ::UserPtr, ::StrRef) = &::IConsole::Register;
   (self.*Register$)(::std::move(*pName), ::std::move(*pParams), Flags, ::std::move(*pfnFunc), ::std::move(*pUser), ::std::move(*pHelp));
 }
 
-::IConsole *cxxbridge1$194$CreateConsole(::std::int32_t FlagMask) noexcept {
+::IConsole *cxxbridge1$195$CreateConsole(::std::int32_t FlagMask) noexcept {
   ::std::unique_ptr<::IConsole> (*CreateConsole$)(::std::int32_t) = ::CreateConsole;
   return CreateConsole$(FlagMask).release();
 }

--- a/src/rust-bridge/engine/shared/rust_version.cpp
+++ b/src/rust-bridge/engine/shared/rust_version.cpp
@@ -6,15 +6,15 @@
 #endif // __clang__
 
 extern "C" {
-void cxxbridge1$194$RustVersionPrint(::IConsole const &console) noexcept;
+void cxxbridge1$195$RustVersionPrint(::IConsole const &console) noexcept;
 
-void cxxbridge1$194$RustVersionRegister(::IConsole &console) noexcept;
+void cxxbridge1$195$RustVersionRegister(::IConsole &console) noexcept;
 } // extern "C"
 
 void RustVersionPrint(::IConsole const &console) noexcept {
-  cxxbridge1$194$RustVersionPrint(console);
+  cxxbridge1$195$RustVersionPrint(console);
 }
 
 void RustVersionRegister(::IConsole &console) noexcept {
-  cxxbridge1$194$RustVersionRegister(console);
+  cxxbridge1$195$RustVersionRegister(console);
 }


### PR DESCRIPTION
CC https://github.com/dtolnay/cxx/issues/1729

```
cargo install cxxbridge-cmd@1.0.195
./scripts/generate_rust_bridge.py
```

This fixes the cargo deny CI

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions