### PR TITLE
Remove cargo deny (advisories) CI job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,7 +74,6 @@ jobs:
     strategy:
       matrix:
         checks:
-          - advisories
           - bans licenses sources
     continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:


### PR DESCRIPTION
It's currently blocking PRs from entering the merge queue, but it shouldn't be. Disable it until we figure out why that's happening.

Works around #12356.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions