### PR TITLE
Refactor `EscapeUrl` function and usage

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1740,7 +1740,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 				{
 					char aUrl[256];
 					char aEscaped[256];
-					EscapeUrl(aEscaped, m_aMapdownloadFilename + 15); // cut off downloadedmaps/
+					EscapeUrl(aEscaped, str_startswith(m_aMapdownloadFilename, "downloadedmaps/"));
 					bool UseConfigUrl = str_comp(g_Config.m_ClMapDownloadUrl, "https://maps.ddnet.org") != 0 || m_aMapDownloadUrl[0] == '\0';
 					str_format(aUrl, sizeof(aUrl), "%s/%s", UseConfigUrl ? g_Config.m_ClMapDownloadUrl : m_aMapDownloadUrl, aEscaped);
 
@@ -5261,7 +5261,7 @@ void CClient::RequestDDNetInfo()
 	if(g_Config.m_BrIndicateFinished)
 	{
 		char aEscaped[128];
-		EscapeUrl(aEscaped, sizeof(aEscaped), PlayerName());
+		EscapeUrl(aEscaped, PlayerName());
 		str_append(aUrl, "?name=");
 		str_append(aUrl, aEscaped);
 	}

--- a/src/engine/shared/http.cpp
+++ b/src/engine/shared/http.cpp
@@ -51,7 +51,7 @@ static int CurlDebug(CURL *pHandle, curl_infotype Type, char *pData, size_t Data
 	return 0;
 }
 
-void EscapeUrl(char *pBuf, int Size, const char *pStr)
+void EscapeUrl(char *pBuf, size_t Size, const char *pStr)
 {
 	char *pEsc = curl_easy_escape(nullptr, pStr, 0);
 	str_copy(pBuf, pEsc, Size);

--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -297,12 +297,12 @@ inline std::unique_ptr<CHttpRequest> HttpPostJson(const char *pUrl, const char *
 	return pResult;
 }
 
-void EscapeUrl(char *pBuf, int Size, const char *pStr);
+void EscapeUrl(char *pBuf, size_t Size, const char *pStr);
 
-template<int N>
-void EscapeUrl(char (&aBuf)[N], const char *pStr)
+template<size_t Size>
+void EscapeUrl(char (&aBuf)[Size], const char *pStr)
 {
-	EscapeUrl(aBuf, N, pStr);
+	EscapeUrl(aBuf, Size, pStr);
 }
 
 bool HttpHasIpresolveBug();


### PR DESCRIPTION
- Use `size_t` for size argument.
- Use templated function when possible.
- Use `str_startswith` instead of hard-coding offset.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions