### PR TITLE
Fix simple case of quad flipping

### DIFF
--- a/src/game/editor/mapitems/layer_quads.cpp
+++ b/src/game/editor/mapitems/layer_quads.cpp
@@ -138,8 +138,12 @@ void CLayerQuads::BrushFlipX()
 {
 	for(auto &Quad : m_vQuads)
 	{
-		std::swap(Quad.m_aPoints[0], Quad.m_aPoints[1]);
-		std::swap(Quad.m_aPoints[2], Quad.m_aPoints[3]);
+		const CPoint &PivotPoint = Quad.m_aPoints[4];
+
+		for(size_t Index = 0; Index < 4; ++Index)
+		{
+			Quad.m_aPoints[Index].x = f2fx(2 * fx2f(PivotPoint.x) - fx2f(Quad.m_aPoints[Index].x));
+		}
 	}
 	Map()->OnModify();
 }
@@ -148,8 +152,12 @@ void CLayerQuads::BrushFlipY()
 {
 	for(auto &Quad : m_vQuads)
 	{
-		std::swap(Quad.m_aPoints[0], Quad.m_aPoints[2]);
-		std::swap(Quad.m_aPoints[1], Quad.m_aPoints[3]);
+		const CPoint &PivotPoint = Quad.m_aPoints[4];
+
+		for(size_t Index = 0; Index < 4; ++Index)
+		{
+			Quad.m_aPoints[Index].y = f2fx(2 * fx2f(PivotPoint.y) - fx2f(Quad.m_aPoints[Index].y));
+		}
 	}
 	Map()->OnModify();
 }


### PR DESCRIPTION
Fixes one of the bugs mentioned in #12348.

Now quad flipping works exactly as shown in "What I expect" sections(except in the first image second example, the [M] one, it's different, because I think Souly pasted an incorrect result).

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions