### PR TITLE
Fix incorrect RFC 3066 language code used for Estonian

### DIFF
--- a/data/languages/index.txt
+++ b/data/languages/index.txt
@@ -63,7 +63,7 @@ esperanto
 estonian
 == Eesti
 == 233
-== ee
+== et
 
 finnish
 == Suomi


### PR DESCRIPTION
The language was shown as "Ewe" in Weblate due to the wrong language code being used.

This would have also meant that the initial language was not correctly detected as Estonian for users with Estonian locale.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions