### PR TITLE
Get server info by const reference instead of copying

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -272,7 +272,6 @@ public:
 
 	// server info
 	virtual const class CServerInfo &ServerInfo() const = 0;
-	virtual void GetServerInfo(class CServerInfo *pServerInfo) const = 0;
 	virtual bool ServerCapAnyPlayerFlag() const = 0;
 
 	virtual int GetPredictionTime() = 0;

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -271,6 +271,7 @@ public:
 	virtual const std::vector<std::string> &MaplistEntries() const = 0;
 
 	// server info
+	virtual const class CServerInfo &ServerInfo() const = 0;
 	virtual void GetServerInfo(class CServerInfo *pServerInfo) const = 0;
 	virtual bool ServerCapAnyPlayerFlag() const = 0;
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -883,11 +883,6 @@ const CServerInfo &CClient::ServerInfo() const
 	return m_CurrentServerInfo;
 }
 
-void CClient::GetServerInfo(CServerInfo *pServerInfo) const
-{
-	*pServerInfo = m_CurrentServerInfo;
-}
-
 void CClient::ServerInfoRequest()
 {
 	m_CurrentServerInfo = {};

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -878,6 +878,11 @@ bool CClient::DummyAllowed() const
 	return m_ServerCapabilities.m_AllowDummy;
 }
 
+const CServerInfo &CClient::ServerInfo() const
+{
+	return m_CurrentServerInfo;
+}
+
 void CClient::GetServerInfo(CServerInfo *pServerInfo) const
 {
 	*pServerInfo = m_CurrentServerInfo;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -347,7 +347,6 @@ public:
 	bool DummyAllowed() const override;
 
 	const CServerInfo &ServerInfo() const override;
-	void GetServerInfo(CServerInfo *pServerInfo) const override;
 	void ServerInfoRequest();
 	void SetCurrentServerInfo(const CServerInfo &ServerInfo);
 

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -346,6 +346,7 @@ public:
 	bool DummyConnectingDelayed() const override;
 	bool DummyAllowed() const override;
 
+	const CServerInfo &ServerInfo() const override;
 	void GetServerInfo(CServerInfo *pServerInfo) const override;
 	void ServerInfoRequest();
 	void SetCurrentServerInfo(const CServerInfo &ServerInfo);

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -627,8 +627,7 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 	const float FontSizeTitle = 32.0f;
 	const float FontSizeBody = 20.0f;
 
-	CServerInfo CurrentServerInfo;
-	Client()->GetServerInfo(&CurrentServerInfo);
+	const CServerInfo &CurrentServerInfo = Client()->ServerInfo();
 
 	CUIRect ServerInfo, GameInfo, Motd;
 	MainView.Draw(ms_ColorTabbarActive, IGraphics::CORNER_B, 10.0f);

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -433,7 +433,7 @@ void CStatboard::AutoStatCSV()
 	}
 }
 
-std::string CStatboard::ReplaceCommata(char *pStr)
+std::string CStatboard::ReplaceCommata(const char *pStr)
 {
 	if(!str_find(pStr, ","))
 		return pStr;
@@ -456,8 +456,8 @@ std::string CStatboard::ReplaceCommata(char *pStr)
 void CStatboard::FormatStats(char *pDest, size_t DestSize)
 {
 	// server stats
-	CServerInfo CurrentServerInfo;
-	Client()->GetServerInfo(&CurrentServerInfo);
+	const CServerInfo &CurrentServerInfo = Client()->ServerInfo();
+
 	char aServerStats[1024];
 	str_format(aServerStats, sizeof(aServerStats), "Servername,Game-type,Map\n%s,%s,%s", ReplaceCommata(CurrentServerInfo.m_aName).c_str(), ReplaceCommata(CurrentServerInfo.m_aGameType).c_str(), ReplaceCommata(CurrentServerInfo.m_aMap).c_str());
 

--- a/src/game/client/components/statboard.h
+++ b/src/game/client/components/statboard.h
@@ -18,7 +18,7 @@ private:
 	void AutoStatScreenshot();
 	void AutoStatCSV();
 
-	std::string ReplaceCommata(char *pStr);
+	std::string ReplaceCommata(const char *pStr);
 	void FormatStats(char *pDest, size_t DestSize);
 
 public:

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1771,8 +1771,7 @@ void CGameClient::OnNewSnapshot(bool DummySwapped)
 		}
 	}
 
-	CServerInfo ServerInfo;
-	Client()->GetServerInfo(&ServerInfo);
+	const CServerInfo &ServerInfo = Client()->ServerInfo();
 
 	bool FoundGameInfoEx = false;
 	bool GotSwitchStateTeam = false;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4592,9 +4592,7 @@ void CEditor::HandleWriterFinishJobs()
 	// send rcon.. if we can
 	if(Client()->RconAuthed() && g_Config.m_EdAutoMapReload)
 	{
-		CServerInfo CurrentServerInfo;
-		Client()->GetServerInfo(&CurrentServerInfo);
-
+		const CServerInfo &CurrentServerInfo = Client()->ServerInfo();
 		if(net_addr_is_local(&Client()->ServerAddress()))
 		{
 			char aMapName[MAX_MAP_LENGTH];


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

This pull request implements a new method `IClient::ServerInfo` which just returns a const reference to the server info instead of copying it like `IClient::GetServerInfo` does. Currently all calls to that method can be replaced with the new method (which this pull request also does), which avoids many unnecessary copies of the entire 34 KB `CServerInfo` to the stack.
I kept the old `IClient::GetServerInfo` method just in case but it is no longer used anywhere in the code

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
