### PR TITLE
Fix some unnecessary large copies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2167,6 +2167,7 @@ set_src(ENGINE_INTERFACE GLOB src/engine
   notifications.h
   rust.h
   server.h
+  serverbrowser.cpp
   serverbrowser.h
   sound.h
   sqlite.h

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -112,9 +112,9 @@ CClient::CClient() :
 {
 	m_StateStartTime = time_get();
 	for(auto &DemoRecorder : m_aDemoRecorders)
-		DemoRecorder = CDemoRecorder(&m_SnapshotDelta);
+		DemoRecorder.Init(&m_SnapshotDelta);
 	for(auto &DemoRecorder : m_aDemoRecordersSixup)
-		DemoRecorder = CDemoRecorder(&m_SnapshotDeltaSixup);
+		DemoRecorder.Init(&m_SnapshotDeltaSixup);
 	m_LastRenderTime = time_get();
 	mem_zero(m_aInputs, sizeof(m_aInputs));
 	mem_zero(m_aapSnapshots, sizeof(m_aapSnapshots));

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -121,7 +121,6 @@ CClient::CClient() :
 	for(auto &SnapshotStorage : m_aSnapshotStorage)
 		SnapshotStorage.Init();
 	mem_zero(m_aDemorecSnapshotHolders, sizeof(m_aDemorecSnapshotHolders));
-	m_CurrentServerInfo = {};
 	mem_zero(&m_Checksum, sizeof(m_Checksum));
 	for(auto &GameTime : m_aGameTime)
 		GameTime.Init(0);
@@ -772,7 +771,7 @@ void CClient::DisconnectWithReason(const char *pReason)
 	ResetMapDownload(true);
 
 	// clear the current server info
-	m_CurrentServerInfo = {};
+	m_CurrentServerInfo.Reset();
 
 	// clear snapshots
 	m_aapSnapshots[0][SNAP_CURRENT] = nullptr;
@@ -885,7 +884,7 @@ const CServerInfo &CClient::ServerInfo() const
 
 void CClient::ServerInfoRequest()
 {
-	m_CurrentServerInfo = {};
+	m_CurrentServerInfo.Reset();
 	m_CurrentServerInfoRequestTime = 0;
 }
 
@@ -1352,7 +1351,7 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 {
 	CServerBrowser::CServerEntry *pEntry = m_ServerBrowser.Find(*pFrom);
 
-	CServerInfo Info = {0};
+	CServerInfo Info = {};
 	int SavedType = SavedServerInfoType(RawType);
 	if(SavedType == SERVERINFO_EXTENDED && pEntry && pEntry->m_GotInfo && SavedType == pEntry->m_Info.m_Type)
 	{
@@ -4058,7 +4057,7 @@ const char *CClient::DemoPlayer_Play(const char *pFilename, int StorageType)
 	}
 
 	// setup current server info
-	m_CurrentServerInfo = {};
+	m_CurrentServerInfo.Reset();
 	str_copy(m_CurrentServerInfo.m_aMap, pMapInfo->m_aName);
 	m_CurrentServerInfo.m_MapCrc = pMapInfo->m_Crc;
 	m_CurrentServerInfo.m_MapSize = pMapInfo->m_Size;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -239,9 +239,9 @@ CServer::CServer()
 {
 	m_pConfig = &g_Config;
 	for(int i = 0; i < MAX_CLIENTS; i++)
-		m_aDemoRecorder[i] = CDemoRecorder(&m_SnapshotDelta, true);
-	m_aDemoRecorder[RECORDER_MANUAL] = CDemoRecorder(&m_SnapshotDelta, false);
-	m_aDemoRecorder[RECORDER_AUTO] = CDemoRecorder(&m_SnapshotDelta, false);
+		m_aDemoRecorder[i].Init(&m_SnapshotDelta, true);
+	m_aDemoRecorder[RECORDER_MANUAL].Init(&m_SnapshotDelta, false);
+	m_aDemoRecorder[RECORDER_AUTO].Init(&m_SnapshotDelta, false);
 
 	m_pGameServer = nullptr;
 

--- a/src/engine/serverbrowser.cpp
+++ b/src/engine/serverbrowser.cpp
@@ -1,0 +1,48 @@
+#include "serverbrowser.h"
+
+#include <base/color.h>
+#include <base/types.h>
+
+#include <engine/friends.h>
+#include <engine/shared/masterserver.h>
+
+void CServerInfo::Reset()
+{
+	m_ServerIndex = 0;
+
+	m_Type = SERVERINFO_VANILLA;
+	m_ReceivedPackets = 0;
+
+	m_NumAddresses = 0;
+
+	m_QuickSearchHit = 0;
+	m_FriendState = IFriends::FRIEND_NO;
+	m_FriendNum = 0;
+
+	m_MaxClients = 0;
+	m_NumClients = 0;
+	m_MaxPlayers = 0;
+	m_NumPlayers = 0;
+	m_Flags = 0;
+	m_ClientScoreKind = CLIENT_SCORE_KIND_UNSPECIFIED;
+	m_Favorite = TRISTATE::NONE;
+	m_FavoriteAllowPing = TRISTATE::NONE;
+	m_aCommunityId[0] = '\0';
+	m_aCommunityCountry[0] = '\0';
+	m_aCommunityType[0] = '\0';
+	m_Location = LOC_UNKNOWN;
+	m_LatencyIsEstimated = false;
+	m_Latency = 0;
+	m_HasRank = RANK_UNAVAILABLE;
+	m_aGameType[0] = '\0';
+	m_GametypeColor = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+	m_aName[0] = '\0';
+	m_aMap[0] = '\0';
+	m_MapCrc = 0;
+	m_MapSize = 0;
+	m_aVersion[0] = '\0';
+	m_aAddress[0] = '\0';
+	m_vClients.clear();
+	m_NumFilteredPlayers = 0;
+	m_RequiresLogin = false;
+}

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -128,6 +128,12 @@ public:
 	int m_NumFilteredPlayers;
 	bool m_RequiresLogin;
 
+	CServerInfo()
+	{
+		Reset();
+	}
+
+	void Reset();
 	static int EstimateLatency(int Loc1, int Loc2);
 	static bool ParseLocation(int *pResult, const char *pString);
 	static ColorRGBA GametypeColor(const char *pGametype);

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -48,6 +48,16 @@ bool CDemoHeader::Valid() const
 
 CDemoRecorder::CDemoRecorder(CSnapshotDelta *pSnapshotDelta, bool NoMapData)
 {
+	Init(pSnapshotDelta, NoMapData);
+}
+
+CDemoRecorder::~CDemoRecorder()
+{
+	dbg_assert(m_File == nullptr, "Demo recorder was not stopped");
+}
+
+void CDemoRecorder::Init(CSnapshotDelta *pSnapshotDelta, bool NoMapData)
+{
 	m_File = nullptr;
 	m_aCurrentFilename[0] = '\0';
 	m_pfnFilter = nullptr;
@@ -55,11 +65,6 @@ CDemoRecorder::CDemoRecorder(CSnapshotDelta *pSnapshotDelta, bool NoMapData)
 	m_LastTickMarker = -1;
 	m_pSnapshotDelta = pSnapshotDelta;
 	m_NoMapData = NoMapData;
-}
-
-CDemoRecorder::~CDemoRecorder()
-{
-	dbg_assert(m_File == nullptr, "Demo recorder was not stopped");
 }
 
 // Record

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -49,6 +49,8 @@ public:
 	CDemoRecorder() = default;
 	~CDemoRecorder() override;
 
+	void Init(CSnapshotDelta *pSnapshotDelta, bool NoMapData = false);
+
 	int Start(IStorage *pStorage, IConsole *pConsole, const char *pFilename, const char *pNetversion, const char *pMap, const SHA256_DIGEST &Sha256, unsigned MapCrc, const char *pType, unsigned MapSize, unsigned char *pMapData, IOHANDLE MapFile, DEMOFUNC_FILTER pfnFilter, void *pUser);
 	int Stop(IDemoRecorder::EStopMode Mode, const char *pTargetFilename = "") override;
 

--- a/src/engine/shared/serverinfo.cpp
+++ b/src/engine/shared/serverinfo.cpp
@@ -274,7 +274,7 @@ bool CServerInfo2::operator==(const CServerInfo2 &Other) const
 
 CServerInfo2::operator CServerInfo() const
 {
-	CServerInfo Result = {0};
+	CServerInfo Result = {};
 	Result.m_MaxClients = m_MaxClients;
 	Result.m_NumClients = m_NumClients;
 	Result.m_MaxPlayers = m_MaxPlayers;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

This pull request fixes some unnecessary large class copies by constructing them in-place instead of copy-assigning.
It is a little ugly unfortunately so I don't know if it's worth it. I considered implementing init/reset methods for these classes to avoid using placement new but I don't want to make the code inconsistent since other related classes don't have those methods either

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
