### PR TITLE
Fix: Reimplement editor action to delete selected quads

### DIFF
--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -289,37 +289,53 @@ void CEditorActionSoundPlace::Redo()
 
 // ---------------------------------------------------------------------------------------
 
-CEditorActionDeleteQuad::CEditorActionDeleteQuad(CEditorMap *pMap, int GroupIndex, int LayerIndex, std::vector<int> const &vQuadsIndices, std::vector<CQuad> const &vDeletedQuads) :
-	CEditorActionLayerBase(pMap, GroupIndex, LayerIndex), m_vQuadsIndices(vQuadsIndices), m_vDeletedQuads(vDeletedQuads)
+CEditorActionDeleteQuad::CEditorActionDeleteQuad(CEditorMap *pMap, int GroupIndex, int LayerIndex) :
+	CEditorActionLayerBase(pMap, GroupIndex, LayerIndex)
 {
+	std::shared_ptr<CLayerQuads> pLayerQuads = std::static_pointer_cast<CLayerQuads>(m_pLayer);
+	m_vQuadsIndices = Map()->m_vSelectedQuads;
+
+	// make sure the indices are descending
+	std::sort(m_vQuadsIndices.begin(), m_vQuadsIndices.end(), std::greater<>());
+
+	dbg_assert(m_vQuadsIndices[0] < (int)pLayerQuads->m_vQuads.size(), "Tried to delete quad with Id %d, while the layer only contains %d quads", m_vQuadsIndices[0], (int)pLayerQuads->m_vQuads.size());
+	dbg_assert(m_vQuadsIndices.back() >= 0, "Tried to delete quad with negative Id %d", m_vQuadsIndices.back());
+
+	m_vDeletedQuads.reserve(Map()->m_vSelectedQuads.size());
+	for(int QuadId : m_vQuadsIndices)
+	{
+		m_vDeletedQuads.emplace_back(pLayerQuads->m_vQuads[QuadId]);
+	}
+
 	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Delete quad (x%d)", (int)m_vDeletedQuads.size());
 }
 
 void CEditorActionDeleteQuad::Undo()
 {
 	std::shared_ptr<CLayerQuads> pLayerQuads = std::static_pointer_cast<CLayerQuads>(m_pLayer);
-	for(size_t k = 0; k < m_vQuadsIndices.size(); k++)
+
+	// Quad indices are in descending order, so we add them back in ascending order
+	for(int IndexId = (int)m_vQuadsIndices.size() - 1; IndexId >= 0; --IndexId)
 	{
-		pLayerQuads->m_vQuads.insert(pLayerQuads->m_vQuads.begin() + m_vQuadsIndices[k], m_vDeletedQuads[k]);
+		pLayerQuads->m_vQuads.insert(pLayerQuads->m_vQuads.begin() + m_vQuadsIndices[IndexId], m_vDeletedQuads[IndexId]);
 	}
+	Map()->m_vSelectedQuads = m_vQuadsIndices;
+
+	Map()->OnModify();
 }
 
 void CEditorActionDeleteQuad::Redo()
 {
 	std::shared_ptr<CLayerQuads> pLayerQuads = std::static_pointer_cast<CLayerQuads>(m_pLayer);
-	std::vector<int> vQuads(m_vQuadsIndices);
 
-	for(int i = 0; i < (int)vQuads.size(); ++i)
+	// Quad indices are in descending order
+	for(const int &QuadId : m_vQuadsIndices)
 	{
-		pLayerQuads->m_vQuads.erase(pLayerQuads->m_vQuads.begin() + vQuads[i]);
-		for(int j = i + 1; j < (int)vQuads.size(); ++j)
-			if(vQuads[j] > vQuads[i])
-				vQuads[j]--;
-
-		vQuads.erase(vQuads.begin() + i);
-
-		i--;
+		pLayerQuads->m_vQuads.erase(pLayerQuads->m_vQuads.begin() + QuadId);
 	}
+	Map()->m_vSelectedQuads.clear();
+
+	Map()->OnModify();
 }
 
 // ---------------------------------------------------------------------------------------

--- a/src/game/editor/editor_actions.h
+++ b/src/game/editor/editor_actions.h
@@ -89,7 +89,7 @@ private:
 class CEditorActionDeleteQuad : public CEditorActionLayerBase
 {
 public:
-	CEditorActionDeleteQuad(CEditorMap *pMap, int GroupIndex, int LayerIndex, std::vector<int> const &vQuadsIndices, std::vector<CQuad> const &vDeletedQuads);
+	CEditorActionDeleteQuad(CEditorMap *pMap, int GroupIndex, int LayerIndex);
 
 	void Undo() override;
 	void Redo() override;

--- a/src/game/editor/mapitems/map.cpp
+++ b/src/game/editor/mapitems/map.cpp
@@ -525,27 +525,10 @@ void CEditorMap::DeselectQuadPoints()
 void CEditorMap::DeleteSelectedQuads()
 {
 	std::shared_ptr<CLayerQuads> pLayer = std::static_pointer_cast<CLayerQuads>(SelectedLayerType(0, LAYERTYPE_QUADS));
-	if(!pLayer)
+	if(!pLayer || m_vSelectedQuads.empty() || m_vSelectedLayers.size() != 1)
 		return;
 
-	std::vector<int> vSelectedQuads(m_vSelectedQuads);
-	std::vector<CQuad> vDeletedQuads;
-	vDeletedQuads.reserve(m_vSelectedQuads.size());
-	for(int i = 0; i < (int)m_vSelectedQuads.size(); ++i)
-	{
-		auto const &Quad = pLayer->m_vQuads[m_vSelectedQuads[i]];
-		vDeletedQuads.push_back(Quad);
-
-		pLayer->m_vQuads.erase(pLayer->m_vQuads.begin() + m_vSelectedQuads[i]);
-		for(int j = i + 1; j < (int)m_vSelectedQuads.size(); ++j)
-			if(m_vSelectedQuads[j] > m_vSelectedQuads[i])
-				m_vSelectedQuads[j]--;
-
-		m_vSelectedQuads.erase(m_vSelectedQuads.begin() + i);
-		i--;
-	}
-
-	m_EditorHistory.RecordAction(std::make_shared<CEditorActionDeleteQuad>(this, m_SelectedGroup, m_vSelectedLayers[0], vSelectedQuads, vDeletedQuads));
+	m_EditorHistory.Execute(std::make_shared<CEditorActionDeleteQuad>(this, m_SelectedGroup, m_vSelectedLayers[0]));
 }
 
 std::shared_ptr<CEnvelope> CEditorMap::NewEnvelope(CEnvelope::EType Type)


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This PR simplifies the deletion logic when deleting one or multiple quads. It also adds some more validation. I didn't fully understand the previous code, the reason it's written like this, or where the bug that leads to crashes originates. I once had the crash in the debugger and it looked to me like the sequence of selecting quads for deletion was affecting if it worked/failed/crashed, which is now impossible due to sorting the indices.

This also adds an "OnModify" call which the previous version is missing.

I tested this extensively, with deleting from the middle, from the end, multiple deletions, history redo/undo and deletion of a single quad.

I could make a video showing that the previous implementation is still buggy, steps to reproduce on current master:
- create quad layer
- create 4 quads
- repeat until it breaks:
  - delete 2 random quads
  - undo
  - redo
  - (undo if not broken)

closes #11384

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
