### PR TITLE
Use `CUi::SetMouseSlow` to properly slow mouse in envelope editor

### DIFF
--- a/src/game/editor/envelope_editor.cpp
+++ b/src/game/editor/envelope_editor.cpp
@@ -554,8 +554,12 @@ void CEnvelopeEditor::Render(CUIRect View)
 
 				if(m_Operation == EEnvelopeEditorOp::DRAG_TIME_BAR)
 				{
-					float DeltaX = ScreenToEnvelopeDeltaX(View, Ui()->MouseDeltaX()) * (Input()->ModifierIsPressed() ? 0.05f : 1.0f);
-					Map()->m_EnvelopeEvaluator.m_AnimateTime += DeltaX / Map()->m_EnvelopeEvaluator.m_AnimateSpeed;
+					if(Input()->ModifierIsPressed())
+					{
+						Ui()->SetMouseSlow(true);
+					}
+
+					Map()->m_EnvelopeEvaluator.m_AnimateTime += ScreenToEnvelopeDeltaX(View, Ui()->MouseDeltaX()) / Map()->m_EnvelopeEvaluator.m_AnimateSpeed;
 					Map()->m_EnvelopeEvaluator.m_AnimateTime = std::max(Map()->m_EnvelopeEvaluator.m_AnimateTime, 0.0f);
 				}
 
@@ -886,6 +890,11 @@ void CEnvelopeEditor::Render(CUIRect View)
 
 							if(m_Operation == EEnvelopeEditorOp::DRAG_POINT || m_Operation == EEnvelopeEditorOp::DRAG_POINT_X || m_Operation == EEnvelopeEditorOp::DRAG_POINT_Y)
 							{
+								if(Input()->ModifierIsPressed())
+								{
+									Ui()->SetMouseSlow(true);
+								}
+
 								if(Input()->ShiftIsPressed())
 								{
 									if(m_Operation == EEnvelopeEditorOp::DRAG_POINT || m_Operation == EEnvelopeEditorOp::DRAG_POINT_Y)
@@ -897,7 +906,7 @@ void CEnvelopeEditor::Render(CUIRect View)
 									}
 									else
 									{
-										float DeltaX = ScreenToEnvelopeDeltaX(View, Ui()->MouseDeltaX()) * (Input()->ModifierIsPressed() ? 50.0f : 1000.0f);
+										float DeltaX = ScreenToEnvelopeDeltaX(View, Ui()->MouseDeltaX()) * 1000.0f;
 
 										for(size_t k = 0; k < Map()->m_vSelectedEnvelopePoints.size(); k++)
 										{
@@ -948,7 +957,7 @@ void CEnvelopeEditor::Render(CUIRect View)
 									}
 									else
 									{
-										float DeltaY = ScreenToEnvelopeDeltaY(View, Ui()->MouseDeltaY()) * (Input()->ModifierIsPressed() ? 51.2f : 1024.0f);
+										float DeltaY = ScreenToEnvelopeDeltaY(View, Ui()->MouseDeltaY()) * 1024.0f;
 										for(size_t k = 0; k < Map()->m_vSelectedEnvelopePoints.size(); k++)
 										{
 											auto [SelectedIndex, SelectedChannel] = Map()->m_vSelectedEnvelopePoints[k];
@@ -1090,10 +1099,13 @@ void CEnvelopeEditor::Render(CUIRect View)
 
 								if(m_Operation == EEnvelopeEditorOp::DRAG_POINT)
 								{
-									float DeltaX = ScreenToEnvelopeDeltaX(View, Ui()->MouseDeltaX()) * (Input()->ModifierIsPressed() ? 50.0f : 1000.0f);
-									float DeltaY = ScreenToEnvelopeDeltaY(View, Ui()->MouseDeltaY()) * (Input()->ModifierIsPressed() ? 51.2f : 1024.0f);
-									m_vAccurateDragValuesX[0] += DeltaX;
-									m_vAccurateDragValuesY[0] -= DeltaY;
+									if(Input()->ModifierIsPressed())
+									{
+										Ui()->SetMouseSlow(true);
+									}
+
+									m_vAccurateDragValuesX[0] += ScreenToEnvelopeDeltaX(View, Ui()->MouseDeltaX()) * 1000.0f;
+									m_vAccurateDragValuesY[0] -= ScreenToEnvelopeDeltaY(View, Ui()->MouseDeltaY()) * 1024.0f;
 
 									pEnvelope->m_vPoints[i].m_Bezier.m_aOutTangentDeltaX[c] = CFixedTime(std::round(m_vAccurateDragValuesX[0]));
 									pEnvelope->m_vPoints[i].m_Bezier.m_aOutTangentDeltaY[c] = std::round(m_vAccurateDragValuesY[0]);
@@ -1218,10 +1230,13 @@ void CEnvelopeEditor::Render(CUIRect View)
 
 								if(m_Operation == EEnvelopeEditorOp::DRAG_POINT)
 								{
-									float DeltaX = ScreenToEnvelopeDeltaX(View, Ui()->MouseDeltaX()) * (Input()->ModifierIsPressed() ? 50.0f : 1000.0f);
-									float DeltaY = ScreenToEnvelopeDeltaY(View, Ui()->MouseDeltaY()) * (Input()->ModifierIsPressed() ? 51.2f : 1024.0f);
-									m_vAccurateDragValuesX[0] += DeltaX;
-									m_vAccurateDragValuesY[0] -= DeltaY;
+									if(Input()->ModifierIsPressed())
+									{
+										Ui()->SetMouseSlow(true);
+									}
+
+									m_vAccurateDragValuesX[0] += ScreenToEnvelopeDeltaX(View, Ui()->MouseDeltaX()) * 1000.0f;
+									m_vAccurateDragValuesY[0] -= ScreenToEnvelopeDeltaY(View, Ui()->MouseDeltaY()) * 1024.0f;
 
 									pEnvelope->m_vPoints[i].m_Bezier.m_aInTangentDeltaX[c] = CFixedTime(std::round(m_vAccurateDragValuesX[0]));
 									pEnvelope->m_vPoints[i].m_Bezier.m_aInTangentDeltaY[c] = std::round(m_vAccurateDragValuesY[0]);
@@ -1340,9 +1355,14 @@ void CEnvelopeEditor::Render(CUIRect View)
 		{
 			str_copy(Editor()->m_aTooltip, "Press shift to scale the time. Press alt to scale along midpoint. Press ctrl to be more precise.");
 
+			if(Input()->ModifierIsPressed())
+			{
+				Ui()->SetMouseSlow(true);
+			}
+
 			if(Input()->ShiftIsPressed())
 			{
-				m_ScaleFactor.x += Ui()->MouseDeltaX() / Graphics()->ScreenWidth() * (Input()->ModifierIsPressed() ? 0.5f : 10.0f);
+				m_ScaleFactor.x += Ui()->MouseDeltaX() / Graphics()->ScreenWidth() * 10.0f;
 				float Midpoint = Input()->AltIsPressed() ? m_Midpoint.x : 0.0f;
 				for(size_t k = 0; k < Map()->m_vSelectedEnvelopePoints.size(); k++)
 				{
@@ -1395,7 +1415,7 @@ void CEnvelopeEditor::Render(CUIRect View)
 			}
 			else
 			{
-				m_ScaleFactor.y -= Ui()->MouseDeltaY() / Graphics()->ScreenHeight() * (Input()->ModifierIsPressed() ? 0.5f : 10.0f);
+				m_ScaleFactor.y -= Ui()->MouseDeltaY() / Graphics()->ScreenHeight() * 10.0f;
 				for(size_t k = 0; k < Map()->m_vSelectedEnvelopePoints.size(); k++)
 				{
 					auto [SelectedIndex, SelectedChannel] = Map()->m_vSelectedEnvelopePoints[k];


### PR DESCRIPTION
Previously, when holding the Ctrl (or GUI) key while dragging an envelope point, dragging a tangent point, dragging the timebar, or scaling envelopes, the applied mouse delta was scaled down to 5% to make actions more precise but the mouse still moved at the regular speed.

By using `CUi::SetMouseSlow` which is specifically designed for this purpose, the UI mouse delta is scaled down to 5% directly, which synchronizes the position of the mouse cursor with the object being dragged.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions