### PR TITLE
Cleanup/Refactor: Add CScreenRect in order to simplify screen border handling

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -963,7 +963,7 @@ void CClient::RenderDebug()
 	const float FontSize = 16.0f;
 
 	Graphics()->TextureSet(m_DebugFont);
-	Graphics()->MapScreen(0, 0, Graphics()->ScreenWidth(), Graphics()->ScreenHeight());
+	Graphics()->MapScreenToSize(Graphics()->ScreenWidth(), Graphics()->ScreenHeight());
 	Graphics()->QuadsBegin();
 
 	str_format(aBuffer, sizeof(aBuffer), "Game/predicted tick: %d/%d", m_aCurGameTick[g_Config.m_ClDummy], m_aPredTick[g_Config.m_ClDummy]);
@@ -1077,7 +1077,7 @@ void CClient::RenderGraphs()
 		return;
 
 	// Make sure graph positions and sizes are aligned with pixels to avoid lines overlapping graph edges
-	Graphics()->MapScreen(0, 0, Graphics()->ScreenWidth(), Graphics()->ScreenHeight());
+	Graphics()->MapScreenToSize(Graphics()->ScreenWidth(), Graphics()->ScreenHeight());
 	const float GraphW = std::round(Graphics()->ScreenWidth() / 4.0f);
 	const float GraphH = std::round(Graphics()->ScreenHeight() / 6.0f);
 	const float GraphSpacing = std::round(Graphics()->ScreenWidth() / 100.0f);

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -199,20 +199,15 @@ const TTwGraphicsGpuList &CGraphics_Threaded::GetGpus() const
 	return m_pBackend->GetGpus();
 }
 
-void CGraphics_Threaded::MapScreen(float TopLeftX, float TopLeftY, float BottomRightX, float BottomRightY)
+void CGraphics_Threaded::MapScreen(const CScreenRect &ScreenRect)
 {
-	m_State.m_ScreenTL.x = TopLeftX;
-	m_State.m_ScreenTL.y = TopLeftY;
-	m_State.m_ScreenBR.x = BottomRightX;
-	m_State.m_ScreenBR.y = BottomRightY;
+	m_State.m_ScreenTL = ScreenRect.m_TopLeft;
+	m_State.m_ScreenBR = ScreenRect.m_BottomRight;
 }
 
-void CGraphics_Threaded::GetScreen(float *pTopLeftX, float *pTopLeftY, float *pBottomRightX, float *pBottomRightY) const
+CScreenRect CGraphics_Threaded::GetScreen() const
 {
-	*pTopLeftX = m_State.m_ScreenTL.x;
-	*pTopLeftY = m_State.m_ScreenTL.y;
-	*pBottomRightX = m_State.m_ScreenBR.x;
-	*pBottomRightY = m_State.m_ScreenBR.y;
+	return CScreenRect(m_State.m_ScreenTL, m_State.m_ScreenBR);
 }
 
 void CGraphics_Threaded::LinesBegin()
@@ -1739,11 +1734,13 @@ void CGraphics_Threaded::RenderQuadContainerEx(int ContainerIndex, int QuadOffse
 
 		WrapClamp();
 
-		float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-		GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
-		MapScreen((ScreenX0 - X) / ScaleX, (ScreenY0 - Y) / ScaleY, (ScreenX1 - X) / ScaleX, (ScreenY1 - Y) / ScaleY);
+		CScreenRect ScreenRect = GetScreen();
+		CScreenRect CommandScreenRect = ScreenRect.Move({-X, -Y});
+		CommandScreenRect.m_TopLeft /= vec2(ScaleX, ScaleY);
+		CommandScreenRect.m_BottomRight /= vec2(ScaleX, ScaleY);
 		Cmd.m_State = m_State;
-		MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
+		Cmd.m_State.m_ScreenTL = CommandScreenRect.m_TopLeft;
+		Cmd.m_State.m_ScreenBR = CommandScreenRect.m_BottomRight;
 
 		Cmd.m_DrawNum = QuadDrawNum * 6;
 		Cmd.m_pOffset = (void *)(QuadOffset * 6 * sizeof(unsigned int));

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -916,8 +916,8 @@ public:
 
 	const TTwGraphicsGpuList &GetGpus() const override;
 
-	void MapScreen(float TopLeftX, float TopLeftY, float BottomRightX, float BottomRightY) override;
-	void GetScreen(float *pTopLeftX, float *pTopLeftY, float *pBottomRightX, float *pBottomRightY) const override;
+	void MapScreen(const CScreenRect &ScreenRect) override;
+	CScreenRect GetScreen() const override;
 
 	void LinesBegin() override;
 	void LinesEnd() override;

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -1467,12 +1467,11 @@ public:
 		TextContainerIndex.Reset();
 		TextContainerIndex.m_Index = GetFreeTextContainerIndex();
 
-		float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-		Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+		CScreenRect ScreenRect = Graphics()->GetScreen();
 
 		STextContainer &TextContainer = GetTextContainer(TextContainerIndex);
 		TextContainer.m_SingleTimeUse = (m_RenderFlags & TEXT_RENDER_FLAG_ONE_TIME_USE) != 0;
-		const vec2 FakeToScreen = vec2(Graphics()->ScreenWidth() / (ScreenX1 - ScreenX0), Graphics()->ScreenHeight() / (ScreenY1 - ScreenY0));
+		const vec2 FakeToScreen = Graphics()->ScreenSize() / ScreenRect.Size();
 		TextContainer.m_AlignedStartX = round_to_int(pCursor->m_X * FakeToScreen.x) / FakeToScreen.x;
 		TextContainer.m_AlignedStartY = round_to_int(pCursor->m_Y * FakeToScreen.y) / FakeToScreen.y;
 		TextContainer.m_X = pCursor->m_X;
@@ -1517,10 +1516,9 @@ public:
 		STextContainer &TextContainer = GetTextContainer(TextContainerIndex);
 		str_append(TextContainer.m_aDebugText, pText);
 
-		float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-		Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+		CScreenRect ScreenRect = Graphics()->GetScreen();
 
-		const vec2 FakeToScreen = vec2(Graphics()->ScreenWidth() / (ScreenX1 - ScreenX0), Graphics()->ScreenHeight() / (ScreenY1 - ScreenY0));
+		const vec2 FakeToScreen = Graphics()->ScreenSize() / ScreenRect.Size();
 		const float CursorX = round_to_int(pCursor->m_X * FakeToScreen.x) / FakeToScreen.x;
 		const float CursorY = round_to_int(pCursor->m_Y * FakeToScreen.y) / FakeToScreen.y;
 		const int ActualSize = round_truncate(pCursor->m_FontSize * FakeToScreen.y);
@@ -1570,7 +1568,7 @@ public:
 
 		const bool IsRendered = (pCursor->m_Flags & TEXTFLAG_RENDER) != 0;
 
-		const float CursorInnerWidth = ((ScreenX1 - ScreenX0) / Graphics()->ScreenWidth()) * 2;
+		const float CursorInnerWidth = (ScreenRect.Width() / Graphics()->ScreenWidth()) * 2;
 		const float CursorOuterWidth = CursorInnerWidth * 2;
 		const float CursorOuterInnerDiff = (CursorOuterWidth - CursorInnerWidth) / 2;
 
@@ -2213,12 +2211,11 @@ public:
 		STextContainer &TextContainer = GetTextContainer(TextContainerIndex);
 
 		// remap the current screen, after render revert the change again
-		float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-		Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+		CScreenRect ScreenRect = Graphics()->GetScreen();
 
 		if((TextContainer.m_RenderFlags & TEXT_RENDER_FLAG_NO_PIXEL_ALIGNMENT) == 0)
 		{
-			const vec2 FakeToScreen = vec2(Graphics()->ScreenWidth() / (ScreenX1 - ScreenX0), Graphics()->ScreenHeight() / (ScreenY1 - ScreenY0));
+			const vec2 FakeToScreen = Graphics()->ScreenSize() / ScreenRect.Size();
 			const float AlignedX = round_to_int((TextContainer.m_X + X) * FakeToScreen.x) / FakeToScreen.x;
 			const float AlignedY = round_to_int((TextContainer.m_Y + Y) * FakeToScreen.y) / FakeToScreen.y;
 			X = AlignedX - TextContainer.m_AlignedStartX;
@@ -2228,9 +2225,9 @@ public:
 		TextContainer.m_BoundingBox.m_X = X;
 		TextContainer.m_BoundingBox.m_Y = Y;
 
-		Graphics()->MapScreen(ScreenX0 - X, ScreenY0 - Y, ScreenX1 - X, ScreenY1 - Y);
+		Graphics()->MapScreen(ScreenRect.Move(vec2(-X, -Y)));
 		RenderTextContainer(TextContainerIndex, TextColor, TextOutlineColor);
-		Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
+		Graphics()->MapScreen(ScreenRect);
 	}
 
 	STextBoundingBox GetBoundingBoxTextContainer(STextContainerIndex TextContainerIndex) override

--- a/src/engine/graphics.cpp
+++ b/src/engine/graphics.cpp
@@ -28,8 +28,8 @@ void IGraphics::CalcScreenParams(float Aspect, float Zoom, float *pWidth, float 
 	*pHeight *= Zoom;
 }
 
-void IGraphics::MapScreenToWorld(float CenterX, float CenterY, float ParallaxX, float ParallaxY,
-	float ParallaxZoom, float OffsetX, float OffsetY, float Aspect, float Zoom, float *pPoints) const
+CScreenRect IGraphics::MapScreenToWorld(float CenterX, float CenterY, float ParallaxX, float ParallaxY,
+	float ParallaxZoom, float OffsetX, float OffsetY, float Aspect, float Zoom) const
 {
 	float Width, Height;
 	CalcScreenParams(Aspect, Zoom, &Width, &Height);
@@ -40,16 +40,22 @@ void IGraphics::MapScreenToWorld(float CenterX, float CenterY, float ParallaxX, 
 
 	CenterX *= ParallaxX / 100.0f;
 	CenterY *= ParallaxY / 100.0f;
-	pPoints[0] = OffsetX + CenterX - Width / 2;
-	pPoints[1] = OffsetY + CenterY - Height / 2;
-	pPoints[2] = pPoints[0] + Width;
-	pPoints[3] = pPoints[1] + Height;
+
+	return CScreenRect(
+		OffsetX + CenterX - Width / 2,
+		OffsetY + CenterY - Height / 2,
+		Width,
+		Height);
 }
 
 void IGraphics::MapScreenToInterface(float CenterX, float CenterY, float Zoom)
 {
-	float aPoints[4];
-	MapScreenToWorld(CenterX, CenterY, 100.0f, 100.0f, 100.0f,
-		0, 0, ScreenAspect(), Zoom, aPoints);
-	MapScreen(aPoints[0], aPoints[1], aPoints[2], aPoints[3]);
+	CScreenRect ScreenRect = MapScreenToWorld(CenterX, CenterY, 100.0f, 100.0f, 100.0f,
+		0, 0, ScreenAspect(), Zoom);
+	MapScreen(ScreenRect);
+}
+
+void IGraphics::MapScreenToSize(float Width, float Height)
+{
+	MapScreen(CScreenRect(0, 0, Width, Height));
 }

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -182,6 +182,55 @@ typedef std::function<bool(uint32_t &Width, uint32_t &Height, CImageInfo::EImage
 
 struct CDataSprite;
 
+class CScreenRect
+{
+public:
+	CScreenRect(float Left, float Top, float Width, float Height) :
+		m_TopLeft(Left, Top), m_BottomRight(Left + Width, Top + Height) {}
+
+	CScreenRect(const vec2 &TopLeft, const vec2 &BottomRight) :
+		m_TopLeft(TopLeft), m_BottomRight(BottomRight) {}
+
+	CScreenRect Move(const vec2 &Position) const
+	{
+		CScreenRect Rect(*this);
+		Rect.m_TopLeft += Position;
+		Rect.m_BottomRight += Position;
+		return Rect;
+	}
+
+	constexpr vec2 Size() const
+	{
+		return m_BottomRight - m_TopLeft;
+	}
+
+	constexpr float Width() const
+	{
+		return m_BottomRight.x - m_TopLeft.x;
+	}
+
+	constexpr float Height() const
+	{
+		return m_BottomRight.y - m_TopLeft.y;
+	}
+
+	constexpr bool Inside(const vec2 &Position) const
+	{
+		return !(!in_range(Position.x, m_TopLeft.x, m_BottomRight.x) || !in_range(Position.y, m_TopLeft.y, m_BottomRight.y));
+	}
+
+	void Expand(float Size)
+	{
+		m_TopLeft.x -= Size;
+		m_BottomRight.x += Size;
+		m_TopLeft.y -= Size;
+		m_BottomRight.y += Size;
+	}
+
+	vec2 m_TopLeft;
+	vec2 m_BottomRight;
+};
+
 class IGraphics : public IInterface
 {
 	MACRO_INTERFACE("graphics")
@@ -219,6 +268,7 @@ public:
 
 	int ScreenWidth() const { return m_ScreenWidth; }
 	int ScreenHeight() const { return m_ScreenHeight; }
+	vec2 ScreenSize() const { return vec2(m_ScreenWidth, m_ScreenHeight); }
 	float ScreenAspect() const { return (float)ScreenWidth() / (float)ScreenHeight(); }
 	float ScreenHiDPIScale() const { return m_ScreenHiDPIScale; }
 	int WindowWidth() const { return m_ScreenWidth / m_ScreenHiDPIScale; }
@@ -257,15 +307,16 @@ public:
 	virtual void ClipEnable(int x, int y, int w, int h) = 0;
 	virtual void ClipDisable() = 0;
 
-	virtual void MapScreen(float TopLeftX, float TopLeftY, float BottomRightX, float BottomRightY) = 0;
+	virtual void MapScreen(const CScreenRect &ScreenRect) = 0;
 
 	// helper functions
 	void CalcScreenParams(float Aspect, float Zoom, float *pWidth, float *pHeight) const;
-	void MapScreenToWorld(float CenterX, float CenterY, float ParallaxX, float ParallaxY,
-		float ParallaxZoom, float OffsetX, float OffsetY, float Aspect, float Zoom, float *pPoints) const;
+	CScreenRect MapScreenToWorld(float CenterX, float CenterY, float ParallaxX, float ParallaxY,
+		float ParallaxZoom, float OffsetX, float OffsetY, float Aspect, float Zoom) const;
 	void MapScreenToInterface(float CenterX, float CenterY, float Zoom = 1.0f);
+	void MapScreenToSize(float Width, float Height);
 
-	virtual void GetScreen(float *pTopLeftX, float *pTopLeftY, float *pBottomRightX, float *pBottomRightY) const = 0;
+	virtual CScreenRect GetScreen() const = 0;
 
 	// TODO: These should perhaps not be virtuals
 	virtual void BlendNone() = 0;

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -53,7 +53,7 @@ void CBroadcast::RenderServerBroadcast()
 
 	const float Height = 300.0f;
 	const float Width = Height * Graphics()->ScreenAspect();
-	Graphics()->MapScreen(0.0f, 0.0f, Width, Height);
+	Graphics()->MapScreenToSize(Width, Height);
 
 	if(m_BroadcastRenderOffset < 0.0f)
 		m_BroadcastRenderOffset = Width / 2.0f - TextRender()->TextWidth(12.0f, m_aBroadcastText, -1, Width) / 2.0f;

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1172,7 +1172,7 @@ void CChat::OnRender()
 
 	const float Height = 300.0f;
 	const float Width = Height * Graphics()->ScreenAspect();
-	Graphics()->MapScreen(0.0f, 0.0f, Width, Height);
+	Graphics()->MapScreenToSize(Width, Height);
 
 	float x = 5.0f;
 	float y = 300.0f - 20.0f * FontSize() / 6.0f;

--- a/src/game/client/components/debughud.cpp
+++ b/src/game/client/components/debughud.cpp
@@ -27,7 +27,7 @@ void CDebugHud::RenderNetCorrections()
 
 	const float Height = 300.0f;
 	const float Width = Height * Graphics()->ScreenAspect();
-	Graphics()->MapScreen(0.0f, 0.0f, Width, Height);
+	Graphics()->MapScreenToSize(Width, Height);
 
 	const float Velspeed = length(vec2(GameClient()->m_Snap.m_pLocalCharacter->m_VelX / 256.0f, GameClient()->m_Snap.m_pLocalCharacter->m_VelY / 256.0f)) * Client()->GameTickSpeed();
 	const float VelspeedX = GameClient()->m_Snap.m_pLocalCharacter->m_VelX / 256.0f * Client()->GameTickSpeed();
@@ -100,7 +100,7 @@ void CDebugHud::RenderTuning()
 
 	const float Height = 300.0f;
 	const float Width = Height * Graphics()->ScreenAspect();
-	Graphics()->MapScreen(0.0f, 0.0f, Width, Height);
+	Graphics()->MapScreenToSize(Width, Height);
 
 	const float FontSize = 5.0f;
 
@@ -168,7 +168,7 @@ void CDebugHud::RenderTuning()
 		return;
 
 	// Render Velspeed.X * Ramp Graphs
-	Graphics()->MapScreen(0.0f, 0.0f, Graphics()->ScreenWidth(), Graphics()->ScreenHeight());
+	Graphics()->MapScreenToSize(Graphics()->ScreenWidth(), Graphics()->ScreenHeight());
 	// Make sure graph positions and sizes are aligned with pixels to avoid lines overlapping graph edges
 	const float GraphSpacing = std::round(Graphics()->ScreenWidth() / 100.0f);
 	const float GraphW = std::round(Graphics()->ScreenWidth() / 4.0f);
@@ -250,7 +250,7 @@ void CDebugHud::RenderHint()
 
 	const float Height = 300.0f;
 	const float Width = Height * Graphics()->ScreenAspect();
-	Graphics()->MapScreen(0.0f, 0.0f, Width, Height);
+	Graphics()->MapScreenToSize(Width, Height);
 
 	const float FontSize = 5.0f;
 	const float Spacing = 5.0f;

--- a/src/game/client/components/freezebars.cpp
+++ b/src/game/client/components/freezebars.cpp
@@ -204,17 +204,13 @@ void CFreezeBars::OnRender()
 		return;
 	}
 	// get screen edges to avoid rendering offscreen
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 	// expand the edges to prevent popping in/out onscreen
 	//
 	// it is assumed that the tee with the freeze bar fit into a 240x240 box centered on the tee
 	// this may need to be changed or calculated differently in the future
-	float BorderBuffer = 120;
-	ScreenX0 -= BorderBuffer;
-	ScreenX1 += BorderBuffer;
-	ScreenY0 -= BorderBuffer;
-	ScreenY1 += BorderBuffer;
+	constexpr float BorderBuffer = 120.0f;
+	ScreenRect.Expand(BorderBuffer);
 
 	int LocalClientId = GameClient()->m_Snap.m_LocalClientId;
 
@@ -227,8 +223,7 @@ void CFreezeBars::OnRender()
 		}
 
 		//don't render if the tee is offscreen
-		vec2 *pRenderPos = &GameClient()->m_aClients[ClientId].m_RenderPos;
-		if(pRenderPos->x < ScreenX0 || pRenderPos->x > ScreenX1 || pRenderPos->y < ScreenY0 || pRenderPos->y > ScreenY1)
+		if(!ScreenRect.Inside(GameClient()->m_aClients[ClientId].m_RenderPos))
 		{
 			continue;
 		}

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -627,9 +627,8 @@ void CHud::RenderCursor()
 	float Alpha = 1.0f;
 
 	const vec2 Center = GameClient()->m_Camera.m_Center;
-	float aPoints[4];
-	Graphics()->MapScreenToWorld(Center.x, Center.y, 100.0f, 100.0f, 100.0f, 0, 0, Graphics()->ScreenAspect(), 1.0f, aPoints);
-	Graphics()->MapScreen(aPoints[0], aPoints[1], aPoints[2], aPoints[3]);
+	CScreenRect ScreenRect = Graphics()->MapScreenToWorld(Center.x, Center.y, 100.0f, 100.0f, 100.0f, 0, 0, Graphics()->ScreenAspect(), 1.0f);
+	Graphics()->MapScreen(ScreenRect);
 
 	if(Client()->State() != IClient::STATE_DEMOPLAYBACK && GameClient()->m_Snap.m_pLocalCharacter)
 	{
@@ -649,7 +648,7 @@ void CHud::RenderCursor()
 			return;
 
 		// Calculate factor to keep cursor on screen
-		const vec2 HalfSize = vec2(Center.x - aPoints[0], Center.y - aPoints[1]);
+		const vec2 HalfSize = Center - ScreenRect.m_TopLeft;
 		const vec2 ScreenPos = (GameClient()->m_CursorInfo.WorldTarget() - Center) / GameClient()->m_Camera.m_Zoom;
 		const float ClampFactor = std::max({
 			1.0f,
@@ -1689,7 +1688,7 @@ void CHud::OnRender()
 
 	m_Width = 300.0f * Graphics()->ScreenAspect();
 	m_Height = 300.0f;
-	Graphics()->MapScreen(0.0f, 0.0f, m_Width, m_Height);
+	Graphics()->MapScreenToSize(m_Width, m_Height);
 
 #if defined(CONF_VIDEORECORDER)
 	if((IVideo::Current() && g_Config.m_ClVideoShowhud) || (!IVideo::Current() && g_Config.m_ClShowhud))

--- a/src/game/client/components/important_alert.cpp
+++ b/src/game/client/components/important_alert.cpp
@@ -67,7 +67,7 @@ void CImportantAlert::RenderImportantAlert()
 
 	const float Height = 300.0f;
 	const float Width = Height * Graphics()->ScreenAspect();
-	Graphics()->MapScreen(0.0f, 0.0f, Width, Height);
+	Graphics()->MapScreenToSize(Width, Height);
 
 	const float TitleFontSize = 20.0f;
 	const float MessageFontSize = 16.0f;

--- a/src/game/client/components/infomessages.cpp
+++ b/src/game/client/components/infomessages.cpp
@@ -130,16 +130,15 @@ void CInfoMessages::AddInfoMsg(const CInfoMsg &InfoMsg)
 	const float Height = 1.5f * 400.0f * 3.0f;
 	const float Width = Height * Graphics()->ScreenAspect();
 
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
-	Graphics()->MapScreen(0, 0, Width, Height);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
+	Graphics()->MapScreenToSize(Width, Height);
 
 	m_InfoMsgCurrent = (m_InfoMsgCurrent + 1) % MAX_INFOMSGS;
 	DeleteTextContainers(m_aInfoMsgs[m_InfoMsgCurrent]);
 	m_aInfoMsgs[m_InfoMsgCurrent] = InfoMsg;
 	CreateTextContainersIfNotCreated(m_aInfoMsgs[m_InfoMsgCurrent]);
 
-	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
+	Graphics()->MapScreen(ScreenRect);
 }
 
 void CInfoMessages::CreateTextContainersIfNotCreated(CInfoMsg &InfoMsg)
@@ -450,7 +449,7 @@ void CInfoMessages::OnRender()
 	const float Height = 1.5f * 400.0f * 3.0f;
 	const float Width = Height * Graphics()->ScreenAspect();
 
-	Graphics()->MapScreen(0, 0, Width, Height);
+	Graphics()->MapScreenToSize(Width, Height);
 	Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 
 	int Showfps = g_Config.m_ClShowfps;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2573,7 +2573,7 @@ void CMenus::RenderBackground()
 {
 	const float ScreenHeight = 300.0f;
 	const float ScreenWidth = ScreenHeight * Graphics()->ScreenAspect();
-	Graphics()->MapScreen(0.0f, 0.0f, ScreenWidth, ScreenHeight);
+	Graphics()->MapScreenToSize(ScreenWidth, ScreenHeight);
 
 	// render background color
 	Graphics()->TextureClear();

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -1628,7 +1628,7 @@ void CMenus::RenderIngameHint()
 		return;
 
 	float Width = 300 * Graphics()->ScreenAspect();
-	Graphics()->MapScreen(0, 0, Width, 300);
+	Graphics()->MapScreenToSize(Width, 300);
 	TextRender()->TextColor(1, 1, 1, 1);
 	TextRender()->Text(5, 280, 5, Localize("Menu opened. Press Esc key again to close menu."), -1.0f);
 	Ui()->MapScreen();

--- a/src/game/client/components/motd.cpp
+++ b/src/game/client/components/motd.cpp
@@ -63,7 +63,7 @@ void CMotd::OnRender()
 	const float FontSize = 32.0f; // also the size of the margin and rect rounding
 	const float ScreenHeight = 40.0f * FontSize; // multiple of the font size to get perfect alignment
 	const float ScreenWidth = ScreenHeight * Graphics()->ScreenAspect();
-	Graphics()->MapScreen(0.0f, 0.0f, ScreenWidth, ScreenHeight);
+	Graphics()->MapScreenToSize(ScreenWidth, ScreenHeight);
 
 	const float RectHeight = (MaxLines + 2) * FontSize;
 	const float RectWidth = 630.0f + 2.0f * FontSize;

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -107,12 +107,11 @@ public:
 		if(Data.m_InGame)
 		{
 			// Create text at standard zoom
-			float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-			This.Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+			CScreenRect ScreenRect = This.Graphics()->GetScreen();
 			This.Graphics()->MapScreenToInterface(This.m_Camera.m_Center.x, This.m_Camera.m_Center.y);
 			This.TextRender()->DeleteTextContainer(m_TextContainerIndex);
 			UpdateText(This, Data);
-			This.Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
+			This.Graphics()->MapScreen(ScreenRect);
 		}
 		else
 		{
@@ -626,14 +625,13 @@ public:
 void CNamePlates::RenderNamePlateGame(vec2 Position, const CNetObj_PlayerInfo *pPlayerInfo, float Alpha)
 {
 	// Get screen edges to avoid rendering offscreen
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 
 	// Assume that the name plate fits into a 800x800 box placed directly above the tee
-	ScreenX0 -= 400;
-	ScreenX1 += 400;
-	ScreenY1 += 800;
-	if(!(in_range(Position.x, ScreenX0, ScreenX1) && in_range(Position.y, ScreenY0, ScreenY1)))
+	ScreenRect.m_TopLeft.x -= 400;
+	ScreenRect.m_BottomRight.x += 400;
+	ScreenRect.m_BottomRight.y += 800;
+	if(!ScreenRect.Inside(Position))
 		return;
 
 	CNamePlateData Data;

--- a/src/game/client/components/particles.cpp
+++ b/src/game/client/components/particles.cpp
@@ -174,10 +174,9 @@ void CParticles::OnInit()
 	Graphics()->QuadContainerUpload(m_ExtraParticleQuadContainerIndex);
 }
 
-bool CParticles::ParticleIsVisibleOnScreen(const vec2 &CurPos, float CurSize)
+bool CParticles::ParticleIsVisibleOnScreen(const vec2 &CurPos, float CurSize) const
 {
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 
 	// for simplicity assume the worst case rotation, that increases the bounding box around the particle by its diagonal
 	const float SqrtOf2 = std::sqrt(2);
@@ -185,8 +184,9 @@ bool CParticles::ParticleIsVisibleOnScreen(const vec2 &CurPos, float CurSize)
 
 	// always uses the mid of the particle
 	float SizeHalf = CurSize / 2;
+	ScreenRect.Expand(SizeHalf);
 
-	return CurPos.x + SizeHalf >= ScreenX0 && CurPos.x - SizeHalf <= ScreenX1 && CurPos.y + SizeHalf >= ScreenY0 && CurPos.y - SizeHalf <= ScreenY1;
+	return ScreenRect.Inside(CurPos);
 }
 
 void CParticles::RenderGroup(int Group)

--- a/src/game/client/components/particles.h
+++ b/src/game/client/components/particles.h
@@ -121,6 +121,6 @@ private:
 	CRenderGroup<GROUP_EXTRA> m_RenderExtra;
 	CRenderGroup<GROUP_GENERAL> m_RenderGeneral;
 
-	bool ParticleIsVisibleOnScreen(const vec2 &CurPos, float CurSize);
+	bool ParticleIsVisibleOnScreen(const vec2 &CurPos, float CurSize) const;
 };
 #endif

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -972,17 +972,13 @@ void CPlayers::OnRender()
 	}
 
 	// get screen edges to avoid rendering offscreen
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 	// expand the edges to prevent popping in/out onscreen
 	//
 	// it is assumed that the tee, all its weapons, and emotes fit into a 200x200 box centered on the tee
 	// this may need to be changed or calculated differently in the future
-	float BorderBuffer = 100;
-	ScreenX0 -= BorderBuffer;
-	ScreenX1 += BorderBuffer;
-	ScreenY0 -= BorderBuffer;
-	ScreenY1 += BorderBuffer;
+	constexpr float PlayerBorderBuffer = 100.0f;
+	ScreenRect.Expand(PlayerBorderBuffer);
 
 	// render everyone else's hook, then our own
 	const int LocalClientId = GameClient()->m_Snap.m_LocalClientId;
@@ -1029,7 +1025,7 @@ void CPlayers::OnRender()
 
 		RenderHookCollLine(&GameClient()->m_aClients[ClientId].m_RenderPrev, &GameClient()->m_aClients[ClientId].m_RenderCur, ClientId);
 
-		if(!in_range(GameClient()->m_aClients[ClientId].m_RenderPos.x, ScreenX0, ScreenX1) || !in_range(GameClient()->m_aClients[ClientId].m_RenderPos.y, ScreenY0, ScreenY1))
+		if(!ScreenRect.Inside(GameClient()->m_aClients[ClientId].m_RenderPos))
 		{
 			continue;
 		}

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -332,7 +332,7 @@ void CSpectator::OnRender()
 		}
 	}
 
-	Graphics()->MapScreen(0, 0, Width, Height);
+	Graphics()->MapScreenToSize(Width, Height);
 
 	SpectatorRect.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.3f), IGraphics::CORNER_ALL, 20.0f);
 

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -212,7 +212,7 @@ void CStatboard::RenderGlobalStats()
 	float x = StatboardWidth / 2 - StatboardContentWidth / 2;
 	float y = 200.0f;
 
-	Graphics()->MapScreen(0, 0, StatboardWidth, StatboardHeight);
+	Graphics()->MapScreenToSize(StatboardWidth, StatboardHeight);
 
 	Graphics()->DrawRect(x - 10.f, y - 10.f, StatboardContentWidth, StatboardContentHeight, ColorRGBA(0.0f, 0.0f, 0.0f, 0.5f), IGraphics::CORNER_ALL, 17.0f);
 

--- a/src/game/client/components/touch_controls.cpp
+++ b/src/game/client/components/touch_controls.cpp
@@ -817,7 +817,7 @@ void CTouchControls::OnRender()
 	}
 
 	const vec2 ScreenSize = CalculateScreenSize();
-	Graphics()->MapScreen(0.0f, 0.0f, ScreenSize.x, ScreenSize.y);
+	Graphics()->MapScreenToSize(ScreenSize.x, ScreenSize.y);
 
 	if(m_EditingActive)
 	{

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -8,6 +8,7 @@
 #include <base/mem.h>
 #include <base/str.h>
 
+#include <engine/graphics.h>
 #include <engine/keys.h>
 #include <engine/shared/config.h>
 
@@ -570,10 +571,9 @@ void CLineInput::RenderCandidates()
 	const float Margin = 4.0f;
 	const float Height = 300.0f;
 	const float Width = Height * Graphics()->ScreenAspect();
-	const int ScreenWidth = Graphics()->ScreenWidth();
-	const int ScreenHeight = Graphics()->ScreenHeight();
+	const vec2 ScreenSize = Graphics()->ScreenSize();
 
-	Graphics()->MapScreen(0.0f, 0.0f, Width, Height);
+	Graphics()->MapScreenToSize(Width, Height);
 
 	// Determine longest candidate width
 	float LongestCandidateWidth = 0.0f;
@@ -584,7 +584,7 @@ void CLineInput::RenderCandidates()
 	const float RectWidth = LongestCandidateWidth + Margin + NumOffset + 2.0f * Padding;
 	const float RectHeight = Input()->GetCandidateCount() * (FontSize + 2.0f * Padding) + Margin;
 
-	vec2 Position = ms_CompositionWindowPosition / vec2(ScreenWidth, ScreenHeight) * vec2(Width, Height);
+	vec2 Position = ms_CompositionWindowPosition / ScreenSize * vec2(Width, Height);
 	Position.y += Margin;
 
 	// Move candidate window left if needed
@@ -593,7 +593,7 @@ void CLineInput::RenderCandidates()
 
 	// Move candidate window up if needed
 	if(Position.y + RectHeight + Margin > Height)
-		Position.y -= RectHeight + ms_CompositionLineHeight / ScreenHeight * Height + 2.0f * Margin;
+		Position.y -= RectHeight + ms_CompositionLineHeight / ScreenSize.y * Height + 2.0f * Margin;
 
 	Graphics()->TextureClear();
 	Graphics()->QuadsBegin();
@@ -631,12 +631,7 @@ void CLineInput::RenderCandidates()
 
 void CLineInput::SetCompositionWindowPosition(vec2 Anchor, float LineHeight)
 {
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	const int ScreenWidth = Graphics()->ScreenWidth();
-	const int ScreenHeight = Graphics()->ScreenHeight();
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
-
-	const vec2 ScreenScale = vec2(ScreenWidth / (ScreenX1 - ScreenX0), ScreenHeight / (ScreenY1 - ScreenY0));
+	const vec2 ScreenScale = Graphics()->ScreenSize() / Graphics()->GetScreen().Size();
 	ms_CompositionWindowPosition = Anchor * ScreenScale;
 	ms_CompositionLineHeight = LineHeight * ScreenScale.y;
 	Input()->SetCompositionWindowPosition(ms_CompositionWindowPosition.x, ms_CompositionWindowPosition.y, ms_CompositionLineHeight);

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -460,7 +460,9 @@ const CUIRect *CUi::Screen()
 void CUi::MapScreen()
 {
 	const CUIRect *pScreen = Screen();
-	Graphics()->MapScreen(pScreen->x, pScreen->y, pScreen->w, pScreen->h);
+
+	// x and y are supposed to be 0
+	Graphics()->MapScreenToSize(pScreen->w, pScreen->h);
 }
 
 float CUi::PixelSize()

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4216,13 +4216,12 @@ void CEditor::RenderIngameEntities(const CLayerGroup &Group, const CLayerTiles &
 	const ColorRGBA DoorOuterColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClLaserDoorOutlineColor));
 	const ColorRGBA DoorInnerColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClLaserDoorInnerColor));
 
-	float aPoints[4];
-	Group.Mapping(aPoints);
+	CScreenRect ScreenRect = Group.Mapping();
 	const int ExtraBorder = 9; // doors extend beyond the tile on which they are placed
-	const int StartX = std::max(0, (int)std::floor(aPoints[0] / TileSize) - ExtraBorder);
-	const int EndX = std::min(TilesLayer.m_Width, (int)std::ceil(aPoints[2] / TileSize) + ExtraBorder);
-	const int StartY = std::max(0, (int)std::floor(aPoints[1] / TileSize) - ExtraBorder);
-	const int EndY = std::min(TilesLayer.m_Height, (int)std::ceil(aPoints[3] / TileSize) + ExtraBorder);
+	const int StartX = std::max(0, (int)std::floor(ScreenRect.m_TopLeft.x / TileSize) - ExtraBorder);
+	const int EndX = std::min(TilesLayer.m_Width, (int)std::ceil(ScreenRect.m_BottomRight.x / TileSize) + ExtraBorder);
+	const int StartY = std::max(0, (int)std::floor(ScreenRect.m_TopLeft.y / TileSize) - ExtraBorder);
+	const int EndY = std::min(TilesLayer.m_Height, (int)std::ceil(ScreenRect.m_BottomRight.y / TileSize) + ExtraBorder);
 	for(int y = StartY; y < EndY; y++)
 	{
 		for(int x = StartX; x < EndX; x++)

--- a/src/game/editor/layer_selector.cpp
+++ b/src/game/editor/layer_selector.cpp
@@ -77,13 +77,11 @@ void CLayerSelector::UpdateHoveredTiles()
 
 			std::shared_ptr<CLayerTiles> pTiles = std::static_pointer_cast<CLayerTiles>(pLayer);
 			pGroup->MapScreen();
-			float aPoints[4];
-			pGroup->Mapping(aPoints);
-			float WorldWidth = aPoints[2] - aPoints[0];
-			float WorldHeight = aPoints[3] - aPoints[1];
+			CScreenRect GroupRect = pGroup->Mapping();
+
 			CUIRect Rect;
-			Rect.x = aPoints[0] + WorldWidth * (UpdatedMousePos.x / Graphics()->WindowWidth());
-			Rect.y = aPoints[1] + WorldHeight * (UpdatedMousePos.y / Graphics()->WindowHeight());
+			Rect.x = GroupRect.m_TopLeft.x + GroupRect.Width() * (UpdatedMousePos.x / Graphics()->WindowWidth());
+			Rect.y = GroupRect.m_TopLeft.y + GroupRect.Height() * (UpdatedMousePos.y / Graphics()->WindowHeight());
 			Rect.w = 0;
 			Rect.h = 0;
 			CIntRect r;

--- a/src/game/editor/map_grid.cpp
+++ b/src/game/editor/map_grid.cpp
@@ -2,6 +2,7 @@
 
 #include "editor.h"
 
+#include <engine/graphics.h>
 #include <engine/keys.h>
 
 static constexpr int MIN_GRID_FACTOR = 1;
@@ -28,21 +29,19 @@ void CMapGrid::Render()
 
 	pGroup->MapScreen();
 
-	float aGroupPoints[4];
-	pGroup->Mapping(aGroupPoints);
+	CScreenRect GroupRect = pGroup->Mapping();
 
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 
 	const int LineDistance = GridLineDistance();
 
-	const int XOffset = aGroupPoints[0] / LineDistance;
-	const int YOffset = aGroupPoints[1] / LineDistance;
+	const int XOffset = GroupRect.m_TopLeft.x / LineDistance;
+	const int YOffset = GroupRect.m_TopLeft.y / LineDistance;
 	const int XGridOffset = XOffset % Factor();
 	const int YGridOffset = YOffset % Factor();
 
-	const int NumColumns = (int)std::ceil((ScreenX1 - ScreenX0) / LineDistance) + 1;
-	const int NumRows = (int)std::ceil((ScreenY1 - ScreenY0) / LineDistance) + 1;
+	const int NumColumns = (int)std::ceil(ScreenRect.Width() / LineDistance) + 1;
+	const int NumRows = (int)std::ceil(ScreenRect.Height() / LineDistance) + 1;
 
 	Graphics()->TextureClear();
 
@@ -58,7 +57,7 @@ void CMapGrid::Render()
 				continue;
 			}
 			const float PosY = LineDistance * (y + YOffset);
-			const IGraphics::CLineItem Line = IGraphics::CLineItem(ScreenX0, PosY, ScreenX1, PosY);
+			const IGraphics::CLineItem Line = IGraphics::CLineItem(ScreenRect.m_TopLeft.x, PosY, ScreenRect.m_BottomRight.x, PosY);
 			Graphics()->LinesBatchDraw(&LineItemBatch, &Line, 1);
 		}
 		for(int x = 0; x < NumColumns; x++)
@@ -68,7 +67,7 @@ void CMapGrid::Render()
 				continue;
 			}
 			const float PosX = LineDistance * (x + XOffset);
-			const IGraphics::CLineItem Line = IGraphics::CLineItem(PosX, ScreenY0, PosX, ScreenY1);
+			const IGraphics::CLineItem Line = IGraphics::CLineItem(PosX, ScreenRect.m_TopLeft.y, PosX, ScreenRect.m_BottomRight.y);
 			Graphics()->LinesBatchDraw(&LineItemBatch, &Line, 1);
 		}
 		Graphics()->LinesBatchEnd(&LineItemBatch);
@@ -83,7 +82,7 @@ void CMapGrid::Render()
 			continue;
 		}
 		const float PosY = LineDistance * (y + YOffset);
-		const IGraphics::CLineItem Line = IGraphics::CLineItem(ScreenX0, PosY, ScreenX1, PosY);
+		const IGraphics::CLineItem Line = IGraphics::CLineItem(ScreenRect.m_TopLeft.x, PosY, ScreenRect.m_BottomRight.x, PosY);
 		Graphics()->LinesBatchDraw(&LineItemBatch, &Line, 1);
 	}
 	for(int x = 0; x < NumColumns; x++)
@@ -93,7 +92,7 @@ void CMapGrid::Render()
 			continue;
 		}
 		const float PosX = LineDistance * (x + XOffset);
-		const IGraphics::CLineItem Line = IGraphics::CLineItem(PosX, ScreenY0, PosX, ScreenY1);
+		const IGraphics::CLineItem Line = IGraphics::CLineItem(PosX, ScreenRect.m_TopLeft.y, PosX, ScreenRect.m_BottomRight.y);
 		Graphics()->LinesBatchDraw(&LineItemBatch, &Line, 1);
 	}
 	Graphics()->LinesBatchEnd(&LineItemBatch);

--- a/src/game/editor/map_view.cpp
+++ b/src/game/editor/map_view.cpp
@@ -2,6 +2,7 @@
 
 #include "editor.h"
 
+#include <engine/graphics.h>
 #include <engine/keys.h>
 #include <engine/shared/config.h>
 
@@ -156,7 +157,8 @@ void CMapView::Render(CUIRect View)
 		std::shared_ptr<CLayerTiles> pTileLayer = std::static_pointer_cast<CLayerTiles>(Map()->SelectedLayerType(0, LAYERTYPE_TILES));
 		if(pTileLayer)
 		{
-			Graphics()->MapScreen(x, y, x + w, y + h);
+			CScreenRect ScreenRect(x, y, w, h);
+			Graphics()->MapScreen(ScreenRect);
 			Editor()->m_pTilesetPicker->m_Image = pTileLayer->m_Image;
 			if(Editor()->m_BrushColorEnabled)
 			{
@@ -715,16 +717,15 @@ void CMapView::UpdateMouseWorld()
 	const std::shared_ptr<CLayerGroup> pGroup = Map()->SelectedGroup();
 	if(pGroup)
 	{
-		float aPoints[4];
-		pGroup->Mapping(aPoints);
+		CScreenRect GroupRect = pGroup->Mapping();
 
-		float WorldWidth = aPoints[2] - aPoints[0];
-		float WorldHeight = aPoints[3] - aPoints[1];
+		float WorldWidth = GroupRect.Width();
+		float WorldHeight = GroupRect.Height();
 
 		Map()->m_MapViewState.m_MouseWorldScale = WorldWidth / Graphics()->WindowWidth();
 
-		Map()->m_MapViewState.m_MouseWorldPos.x = aPoints[0] + WorldWidth * (UpdatedMousePos.x / Graphics()->WindowWidth());
-		Map()->m_MapViewState.m_MouseWorldPos.y = aPoints[1] + WorldHeight * (UpdatedMousePos.y / Graphics()->WindowHeight());
+		Map()->m_MapViewState.m_MouseWorldPos.x = GroupRect.m_TopLeft.x + WorldWidth * (UpdatedMousePos.x / Graphics()->WindowWidth());
+		Map()->m_MapViewState.m_MouseWorldPos.y = GroupRect.m_TopLeft.y + WorldHeight * (UpdatedMousePos.y / Graphics()->WindowHeight());
 		Map()->m_MapViewState.m_MouseDeltaWorld.x = UpdatedMouseDelta.x * (WorldWidth / Graphics()->WindowWidth());
 		Map()->m_MapViewState.m_MouseDeltaWorld.y = UpdatedMouseDelta.y * (WorldHeight / Graphics()->WindowHeight());
 	}
@@ -740,14 +741,13 @@ void CMapView::UpdateMouseWorld()
 		if(!pGameGroup->m_GameGroup)
 			continue;
 
-		float aPoints[4];
-		pGameGroup->Mapping(aPoints);
+		CScreenRect GroupRect = pGameGroup->Mapping();
 
-		float WorldWidth = aPoints[2] - aPoints[0];
-		float WorldHeight = aPoints[3] - aPoints[1];
+		float WorldWidth = GroupRect.Width();
+		float WorldHeight = GroupRect.Height();
 
-		Map()->m_MapViewState.m_MouseWorldNoParaPos.x = aPoints[0] + WorldWidth * (UpdatedMousePos.x / Graphics()->WindowWidth());
-		Map()->m_MapViewState.m_MouseWorldNoParaPos.y = aPoints[1] + WorldHeight * (UpdatedMousePos.y / Graphics()->WindowHeight());
+		Map()->m_MapViewState.m_MouseWorldNoParaPos.x = GroupRect.m_TopLeft.x + WorldWidth * (UpdatedMousePos.x / Graphics()->WindowWidth());
+		Map()->m_MapViewState.m_MouseWorldNoParaPos.y = GroupRect.m_TopLeft.y + WorldHeight * (UpdatedMousePos.y / Graphics()->WindowHeight());
 	}
 }
 
@@ -791,16 +791,16 @@ void CMapView::ZoomMouseTarget(float ZoomFactor)
 {
 	// zoom to the current mouse position
 	// get absolute mouse position
-	float aPoints[4];
-	Graphics()->MapScreenToWorld(
+
+	CScreenRect ScreenRect = Graphics()->MapScreenToWorld(
 		GetWorldOffset().x, GetWorldOffset().y,
-		100.0f, 100.0f, 100.0f, 0.0f, 0.0f, Graphics()->ScreenAspect(), GetWorldZoom(), aPoints);
+		100.0f, 100.0f, 100.0f, 0.0f, 0.0f, Graphics()->ScreenAspect(), GetWorldZoom());
 
-	float WorldWidth = aPoints[2] - aPoints[0];
-	float WorldHeight = aPoints[3] - aPoints[1];
+	float WorldWidth = ScreenRect.Width();
+	float WorldHeight = ScreenRect.Height();
 
-	float MouseWorldX = aPoints[0] + WorldWidth * (Ui()->MouseX() / Ui()->Screen()->w);
-	float MouseWorldY = aPoints[1] + WorldHeight * (Ui()->MouseY() / Ui()->Screen()->h);
+	float MouseWorldX = ScreenRect.m_TopLeft.x + WorldWidth * (Ui()->MouseX() / Ui()->Screen()->w);
+	float MouseWorldY = ScreenRect.m_TopLeft.y + WorldHeight * (Ui()->MouseY() / Ui()->Screen()->h);
 
 	// adjust camera
 	OffsetWorld((vec2(MouseWorldX, MouseWorldY) - GetWorldOffset()) * (1.0f - ZoomFactor));

--- a/src/game/editor/mapitems/layer_group.cpp
+++ b/src/game/editor/mapitems/layer_group.cpp
@@ -1,5 +1,6 @@
 #include "layer_group.h"
 
+#include <engine/graphics.h>
 #include <engine/shared/config.h>
 
 #include <game/editor/editor.h>
@@ -41,27 +42,24 @@ void CLayerGroup::Convert(CUIRect *pRect) const
 	pRect->y += m_OffsetY;
 }
 
-void CLayerGroup::Mapping(float *pPoints) const
+CScreenRect CLayerGroup::Mapping() const
 {
 	float NormalParallaxZoom = std::clamp((float)std::max(m_ParallaxX, m_ParallaxY), 0.0f, 100.0f);
 	float ParallaxZoom = Editor()->m_PreviewZoom ? NormalParallaxZoom : 100.0f;
 
-	Graphics()->MapScreenToWorld(
+	CScreenRect ScreenRect = Graphics()->MapScreenToWorld(
 		Editor()->MapView()->GetWorldOffset().x, Editor()->MapView()->GetWorldOffset().y,
 		m_ParallaxX, m_ParallaxY, ParallaxZoom, m_OffsetX, m_OffsetY,
-		Graphics()->ScreenAspect(), Editor()->MapView()->GetWorldZoom(), pPoints);
+		Graphics()->ScreenAspect(), Editor()->MapView()->GetWorldZoom());
 
-	pPoints[0] += Editor()->MapView()->GetEditorOffset().x;
-	pPoints[1] += Editor()->MapView()->GetEditorOffset().y;
-	pPoints[2] += Editor()->MapView()->GetEditorOffset().x;
-	pPoints[3] += Editor()->MapView()->GetEditorOffset().y;
+	ScreenRect = ScreenRect.Move(Editor()->MapView()->GetEditorOffset());
+	return ScreenRect;
 }
 
 void CLayerGroup::MapScreen()
 {
-	float aPoints[4];
-	Mapping(aPoints);
-	Graphics()->MapScreen(aPoints[0], aPoints[1], aPoints[2], aPoints[3]);
+	CScreenRect ScreenRect = Mapping();
+	Graphics()->MapScreen(ScreenRect);
 }
 
 void CLayerGroup::Render()
@@ -70,14 +68,13 @@ void CLayerGroup::Render()
 
 	if(m_UseClipping)
 	{
-		float aPoints[4];
-		Map()->m_pGameGroup->Mapping(aPoints);
-		float ScreenWidth = aPoints[2] - aPoints[0];
-		float ScreenHeight = aPoints[3] - aPoints[1];
-		float Left = m_ClipX - aPoints[0];
-		float Top = m_ClipY - aPoints[1];
-		float Right = (m_ClipX + m_ClipW) - aPoints[0];
-		float Bottom = (m_ClipY + m_ClipH) - aPoints[1];
+		CScreenRect ScreenRect = Map()->m_pGameGroup->Mapping();
+		float ScreenWidth = ScreenRect.Width();
+		float ScreenHeight = ScreenRect.Height();
+		float Left = m_ClipX - ScreenRect.m_TopLeft.x;
+		float Top = m_ClipY - ScreenRect.m_TopLeft.y;
+		float Right = (m_ClipX + m_ClipW) - ScreenRect.m_TopLeft.x;
+		float Bottom = (m_ClipY + m_ClipH) - ScreenRect.m_TopLeft.y;
 
 		int ClipX = (int)std::round(Left * Graphics()->ScreenWidth() / ScreenWidth);
 		int ClipY = (int)std::round(Top * Graphics()->ScreenHeight() / ScreenHeight);

--- a/src/game/editor/mapitems/layer_group.h
+++ b/src/game/editor/mapitems/layer_group.h
@@ -38,7 +38,7 @@ public:
 	void Convert(CUIRect *pRect) const;
 	void Render();
 	void MapScreen();
-	void Mapping(float *pPoints) const;
+	CScreenRect Mapping() const;
 
 	void GetSize(float *pWidth, float *pHeight) const;
 

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -4,6 +4,7 @@
 
 #include "image.h"
 
+#include <engine/graphics.h>
 #include <engine/keys.h>
 #include <engine/shared/config.h>
 #include <engine/shared/map.h>
@@ -716,15 +717,14 @@ void CLayerTiles::Shift(EShiftDirection Direction)
 
 void CLayerTiles::ShowInfo()
 {
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 	Graphics()->TextureSet(Editor()->Client()->GetDebugFont());
 	Graphics()->QuadsBegin();
 
-	int StartY = std::max(0, (int)(ScreenY0 / 32.0f) - 1);
-	int StartX = std::max(0, (int)(ScreenX0 / 32.0f) - 1);
-	int EndY = std::min((int)(ScreenY1 / 32.0f) + 1, m_Height);
-	int EndX = std::min((int)(ScreenX1 / 32.0f) + 1, m_Width);
+	int StartY = std::max(0, (int)(ScreenRect.m_TopLeft.y / 32.0f) - 1);
+	int StartX = std::max(0, (int)(ScreenRect.m_TopLeft.x / 32.0f) - 1);
+	int EndY = std::min((int)(ScreenRect.m_BottomRight.y / 32.0f) + 1, m_Height);
+	int EndX = std::min((int)(ScreenRect.m_BottomRight.x / 32.0f) + 1, m_Width);
 
 	for(int y = StartY; y < EndY; y++)
 		for(int x = StartX; x < EndX; x++)
@@ -754,7 +754,7 @@ void CLayerTiles::ShowInfo()
 		}
 
 	Graphics()->QuadsEnd();
-	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
+	Graphics()->MapScreen(ScreenRect);
 }
 
 void CLayerTiles::FillGameTiles(EGameTileOp Fill)

--- a/src/game/editor/proof_mode.cpp
+++ b/src/game/editor/proof_mode.cpp
@@ -2,6 +2,8 @@
 
 #include "editor.h"
 
+#include <engine/graphics.h>
+
 #include <game/client/components/menu_background.h>
 
 void CProofMode::CState::Reset()
@@ -104,47 +106,46 @@ void CProofMode::RenderScreenSizes()
 		Graphics()->LinesBegin();
 
 		// possible screen sizes (white border)
-		float aLastPoints[4];
+		CScreenRect LastRect(0, 0, 0, 0);
 		float Start = 1.0f; // 9.0f/16.0f;
 		float End = 16.0f / 9.0f;
 		const int NumSteps = 20;
 		for(int i = 0; i <= NumSteps; i++)
 		{
-			float aPoints[4];
 			float Aspect = Start + (End - Start) * (i / (float)NumSteps);
 
 			float Zoom = IsModeMenu() ? 0.7f : 1.0f;
-			Graphics()->MapScreenToWorld(
+			CScreenRect ScreenRect = Graphics()->MapScreenToWorld(
 				WorldOffset.x, WorldOffset.y,
-				100.0f, 100.0f, 100.0f, 0.0f, 0.0f, Aspect, Zoom, aPoints);
+				100.0f, 100.0f, 100.0f, 0.0f, 0.0f, Aspect, Zoom);
 
 			if(i == 0)
 			{
 				IGraphics::CLineItem aArray[] = {
-					IGraphics::CLineItem(aPoints[0], aPoints[1], aPoints[2], aPoints[1]),
-					IGraphics::CLineItem(aPoints[0], aPoints[3], aPoints[2], aPoints[3])};
+					IGraphics::CLineItem(ScreenRect.m_TopLeft.x, ScreenRect.m_TopLeft.y, ScreenRect.m_BottomRight.x, ScreenRect.m_TopLeft.y),
+					IGraphics::CLineItem(ScreenRect.m_TopLeft.x, ScreenRect.m_BottomRight.y, ScreenRect.m_BottomRight.x, ScreenRect.m_BottomRight.y)};
 				Graphics()->LinesDraw(aArray, std::size(aArray));
 			}
 
 			if(i != 0)
 			{
 				IGraphics::CLineItem aArray[] = {
-					IGraphics::CLineItem(aPoints[0], aPoints[1], aLastPoints[0], aLastPoints[1]),
-					IGraphics::CLineItem(aPoints[2], aPoints[1], aLastPoints[2], aLastPoints[1]),
-					IGraphics::CLineItem(aPoints[0], aPoints[3], aLastPoints[0], aLastPoints[3]),
-					IGraphics::CLineItem(aPoints[2], aPoints[3], aLastPoints[2], aLastPoints[3])};
+					IGraphics::CLineItem(ScreenRect.m_TopLeft.x, ScreenRect.m_TopLeft.y, LastRect.m_TopLeft.x, LastRect.m_TopLeft.y),
+					IGraphics::CLineItem(ScreenRect.m_BottomRight.x, ScreenRect.m_TopLeft.y, LastRect.m_BottomRight.x, LastRect.m_TopLeft.y),
+					IGraphics::CLineItem(ScreenRect.m_TopLeft.x, ScreenRect.m_BottomRight.y, LastRect.m_TopLeft.x, LastRect.m_BottomRight.y),
+					IGraphics::CLineItem(ScreenRect.m_BottomRight.x, ScreenRect.m_BottomRight.y, LastRect.m_BottomRight.x, LastRect.m_BottomRight.y)};
 				Graphics()->LinesDraw(aArray, std::size(aArray));
 			}
 
 			if(i == NumSteps)
 			{
 				IGraphics::CLineItem aArray[] = {
-					IGraphics::CLineItem(aPoints[0], aPoints[1], aPoints[0], aPoints[3]),
-					IGraphics::CLineItem(aPoints[2], aPoints[1], aPoints[2], aPoints[3])};
+					IGraphics::CLineItem(ScreenRect.m_TopLeft.x, ScreenRect.m_TopLeft.y, ScreenRect.m_TopLeft.x, ScreenRect.m_BottomRight.y),
+					IGraphics::CLineItem(ScreenRect.m_BottomRight.x, ScreenRect.m_TopLeft.y, ScreenRect.m_BottomRight.x, ScreenRect.m_BottomRight.y)};
 				Graphics()->LinesDraw(aArray, std::size(aArray));
 			}
 
-			mem_copy(aLastPoints, aPoints, sizeof(aPoints));
+			LastRect = ScreenRect;
 		}
 		Graphics()->LinesEnd();
 
@@ -153,19 +154,18 @@ void CProofMode::RenderScreenSizes()
 			Graphics()->SetColor(1, 0, 0, 1);
 			for(int Pass = 0; Pass < 2; Pass++)
 			{
-				float aPoints[4];
 				const float aAspects[] = {4.0f / 3.0f, 16.0f / 10.0f, 5.0f / 4.0f, 16.0f / 9.0f};
 				const ColorRGBA aColors[] = {ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f), ColorRGBA(0.0f, 1.0f, 0.0f, 1.0f)};
 				float Zoom = IsModeMenu() ? 0.7f : 1.0f;
-				Graphics()->MapScreenToWorld(
+				CScreenRect ScreenRect = Graphics()->MapScreenToWorld(
 					WorldOffset.x, WorldOffset.y,
-					100.0f, 100.0f, 100.0f, 0.0f, 0.0f, aAspects[Pass], Zoom, aPoints);
+					100.0f, 100.0f, 100.0f, 0.0f, 0.0f, aAspects[Pass], Zoom);
 
 				CUIRect Rect;
-				Rect.x = aPoints[0];
-				Rect.y = aPoints[1];
-				Rect.w = aPoints[2] - aPoints[0];
-				Rect.h = aPoints[3] - aPoints[1];
+				Rect.x = ScreenRect.m_TopLeft.x;
+				Rect.y = ScreenRect.m_TopLeft.y;
+				Rect.w = ScreenRect.Width();
+				Rect.h = ScreenRect.Height();
 				Rect.DrawOutline(aColors[Pass]);
 			}
 		}

--- a/src/game/editor/quick_actions.cpp
+++ b/src/game/editor/quick_actions.cpp
@@ -31,10 +31,9 @@ void CEditor::AddQuadOrSound()
 
 	std::shared_ptr<CLayerGroup> pGroup = Map()->SelectedGroup();
 
-	float aMapping[4];
-	pGroup->Mapping(aMapping);
-	int x = aMapping[0] + (aMapping[2] - aMapping[0]) / 2;
-	int y = aMapping[1] + (aMapping[3] - aMapping[1]) / 2;
+	CScreenRect GroupRect = pGroup->Mapping();
+	int x = GroupRect.m_TopLeft.x + GroupRect.Width() / 2;
+	int y = GroupRect.m_TopLeft.y + GroupRect.Height() / 2;
 	if(m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && Input()->KeyPress(KEY_Q) && Input()->ModifierIsPressed())
 	{
 		x += MapView()->MouseWorldPos().x - (MapView()->GetWorldOffset().x * pGroup->m_ParallaxX / 100) - pGroup->m_OffsetX;

--- a/src/game/map/map_renderer.cpp
+++ b/src/game/map/map_renderer.cpp
@@ -3,6 +3,8 @@
 #include <base/dbg.h>
 #include <base/log.h>
 
+#include <engine/graphics.h>
+
 #include <game/map/envelope_manager.h>
 
 const int LAYER_DEFAULT_TILESET = -1;
@@ -142,8 +144,7 @@ void CMapRenderer::Load(ERenderType Type, CLayers *pLayers, IMapImages *pMapImag
 
 void CMapRenderer::Render(const CRenderLayerParams &Params)
 {
-	float ScreenXLeft, ScreenYTop, ScreenXRight, ScreenYBottom;
-	Graphics()->GetScreen(&ScreenXLeft, &ScreenYTop, &ScreenXRight, &ScreenYBottom);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 
 	bool DoRenderGroup = true;
 	for(auto &pRenderLayer : m_vpRenderLayers)
@@ -165,7 +166,7 @@ void CMapRenderer::Render(const CRenderLayerParams &Params)
 	if(Params.m_RenderType != ERenderType::RENDERTYPE_BACKGROUND && Params.m_RenderType != ERenderType::RENDERTYPE_BACKGROUND_FORCE)
 	{
 		// reset the screen like it was before
-		Graphics()->MapScreen(ScreenXLeft, ScreenYTop, ScreenXRight, ScreenYBottom);
+		Graphics()->MapScreen(ScreenRect);
 	}
 	else
 	{

--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -210,14 +210,13 @@ bool CRenderLayer::IsVisibleInClipRegion(const std::optional<CClipRegion> &ClipR
 	if(!ClipRegion.has_value())
 		return true;
 
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 	float Left = ClipRegion->m_X;
 	float Top = ClipRegion->m_Y;
 	float Right = ClipRegion->m_X + ClipRegion->m_Width;
 	float Bottom = ClipRegion->m_Y + ClipRegion->m_Height;
 
-	return Right >= ScreenX0 && Left <= ScreenX1 && Bottom >= ScreenY0 && Top <= ScreenY1;
+	return Right >= ScreenRect.m_TopLeft.x && Left <= ScreenRect.m_BottomRight.x && Bottom >= ScreenRect.m_TopLeft.y && Top <= ScreenRect.m_BottomRight.y;
 }
 
 /**************
@@ -237,14 +236,13 @@ bool CRenderLayerGroup::DoRender(const CRenderLayerParams &Params)
 			// set clipping
 			Graphics()->MapScreenToInterface(Params.m_Center.x, Params.m_Center.y, Params.m_Zoom);
 
-			float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-			Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
-			float ScreenWidth = ScreenX1 - ScreenX0;
-			float ScreenHeight = ScreenY1 - ScreenY0;
-			float Left = m_pGroup->m_ClipX - ScreenX0;
-			float Top = m_pGroup->m_ClipY - ScreenY0;
-			float Right = m_pGroup->m_ClipX + m_pGroup->m_ClipW - ScreenX0;
-			float Bottom = m_pGroup->m_ClipY + m_pGroup->m_ClipH - ScreenY0;
+			CScreenRect ScreenRect = Graphics()->GetScreen();
+			float ScreenWidth = ScreenRect.Width();
+			float ScreenHeight = ScreenRect.Height();
+			float Left = m_pGroup->m_ClipX - ScreenRect.m_TopLeft.x;
+			float Top = m_pGroup->m_ClipY - ScreenRect.m_TopLeft.y;
+			float Right = m_pGroup->m_ClipX + m_pGroup->m_ClipW - ScreenRect.m_TopLeft.x;
+			float Bottom = m_pGroup->m_ClipY + m_pGroup->m_ClipH - ScreenRect.m_TopLeft.y;
 
 			if(Right < 0.0f || Left > ScreenWidth || Bottom < 0.0f || Top > ScreenHeight)
 				return false;
@@ -273,10 +271,9 @@ bool CRenderLayerGroup::DoRender(const CRenderLayerParams &Params)
 void CRenderLayerGroup::Render(const CRenderLayerParams &Params)
 {
 	int ParallaxZoom = std::clamp(std::max(m_pGroup->m_ParallaxX, m_pGroup->m_ParallaxY), 0, 100);
-	float aPoints[4];
-	Graphics()->MapScreenToWorld(Params.m_Center.x, Params.m_Center.y, m_pGroup->m_ParallaxX, m_pGroup->m_ParallaxY, (float)ParallaxZoom,
-		m_pGroup->m_OffsetX, m_pGroup->m_OffsetY, Graphics()->ScreenAspect(), Params.m_Zoom, aPoints);
-	Graphics()->MapScreen(aPoints[0], aPoints[1], aPoints[2], aPoints[3]);
+	CScreenRect ScreenRect = Graphics()->MapScreenToWorld(Params.m_Center.x, Params.m_Center.y, m_pGroup->m_ParallaxX, m_pGroup->m_ParallaxY, (float)ParallaxZoom,
+		m_pGroup->m_OffsetX, m_pGroup->m_OffsetY, Graphics()->ScreenAspect(), Params.m_Zoom);
+	Graphics()->MapScreen(ScreenRect);
 }
 
 /**************
@@ -297,13 +294,12 @@ void CRenderLayerTile::RenderTileLayer(const ColorRGBA &Color, const CRenderLaye
 	if(Visuals.m_BufferContainerIndex == -1)
 		return; // no visuals were created
 
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 
-	int ScreenRectY0 = std::floor(ScreenY0 / 32);
-	int ScreenRectX0 = std::floor(ScreenX0 / 32);
-	int ScreenRectY1 = std::ceil(ScreenY1 / 32);
-	int ScreenRectX1 = std::ceil(ScreenX1 / 32);
+	int ScreenRectY0 = std::floor(ScreenRect.m_TopLeft.y / 32);
+	int ScreenRectX0 = std::floor(ScreenRect.m_TopLeft.x / 32);
+	int ScreenRectY1 = std::ceil(ScreenRect.m_BottomRight.y / 32);
+	int ScreenRectX1 = std::ceil(ScreenRect.m_BottomRight.x / 32);
 
 	if(IsVisibleInClipRegion(m_LayerClip))
 	{
@@ -479,13 +475,12 @@ void CRenderLayerTile::RenderKillTileBorder(const ColorRGBA &Color)
 	if(Visuals.m_BufferContainerIndex == -1)
 		return; // no visuals were created
 
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 
-	int BorderY0 = std::floor(ScreenY0 / 32);
-	int BorderX0 = std::floor(ScreenX0 / 32);
-	int BorderY1 = std::ceil(ScreenY1 / 32);
-	int BorderX1 = std::ceil(ScreenX1 / 32);
+	int BorderY0 = std::floor(ScreenRect.m_TopLeft.y / 32);
+	int BorderX0 = std::floor(ScreenRect.m_TopLeft.x / 32);
+	int BorderY1 = std::ceil(ScreenRect.m_BottomRight.y / 32);
+	int BorderX1 = std::ceil(ScreenRect.m_BottomRight.x / 32);
 
 	if(BorderX0 >= -BorderRenderDistance && BorderY0 >= -BorderRenderDistance && BorderX1 <= (int)Visuals.m_Width + BorderRenderDistance && BorderY1 <= (int)Visuals.m_Height + BorderRenderDistance)
 		return;

--- a/src/game/map/render_map.cpp
+++ b/src/game/map/render_map.cpp
@@ -438,12 +438,11 @@ void CRenderMap::RenderTileRectangle(int RectX, int RectY, int RectW, int RectH,
 	unsigned char IndexIn, unsigned char IndexOut,
 	float Scale, ColorRGBA Color, int RenderFlags)
 {
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 
 	// calculate the final pixelsize for the tiles
 	float TilePixelSize = 1024 / 32.0f;
-	float FinalTileSize = Scale / (ScreenX1 - ScreenX0) * Graphics()->ScreenWidth();
+	float FinalTileSize = Scale / ScreenRect.Width() * Graphics()->ScreenWidth();
 	float FinalTilesetScale = FinalTileSize / TilePixelSize;
 
 	if(Graphics()->HasTextureArraysSupport())
@@ -452,10 +451,10 @@ void CRenderMap::RenderTileRectangle(int RectX, int RectY, int RectW, int RectH,
 		Graphics()->QuadsBegin();
 	Graphics()->SetColor(Color);
 
-	int StartY = (int)(ScreenY0 / Scale) - 1;
-	int StartX = (int)(ScreenX0 / Scale) - 1;
-	int EndY = (int)(ScreenY1 / Scale) + 1;
-	int EndX = (int)(ScreenX1 / Scale) + 1;
+	int StartY = (int)(ScreenRect.m_TopLeft.y / Scale) - 1;
+	int StartX = (int)(ScreenRect.m_TopLeft.x / Scale) - 1;
+	int EndY = (int)(ScreenRect.m_BottomRight.y / Scale) + 1;
+	int EndX = (int)(ScreenRect.m_BottomRight.x / Scale) + 1;
 
 	// adjust the texture shift according to mipmap level
 	float TexSize = 1024.0f;
@@ -524,7 +523,7 @@ void CRenderMap::RenderTileRectangle(int RectX, int RectY, int RectW, int RectH,
 		Graphics()->QuadsTex3DEnd();
 	else
 		Graphics()->QuadsEnd();
-	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
+	Graphics()->MapScreen(ScreenRect);
 }
 
 void CRenderMap::RenderTile(int x, int y, unsigned char Index, float Scale, ColorRGBA Color)
@@ -534,12 +533,11 @@ void CRenderMap::RenderTile(int x, int y, unsigned char Index, float Scale, Colo
 	else
 		Graphics()->QuadsBegin();
 
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 
 	// calculate the final pixelsize for the tiles
 	float TilePixelSize = 1024 / Scale;
-	float FinalTileSize = Scale / (ScreenX1 - ScreenX0) * Graphics()->ScreenWidth();
+	float FinalTileSize = Scale / ScreenRect.Width() * Graphics()->ScreenWidth();
 	float FinalTilesetScale = FinalTileSize / TilePixelSize;
 
 	float TexSize = 1024.0f;
@@ -591,17 +589,16 @@ void CRenderMap::RenderTile(int x, int y, unsigned char Index, float Scale, Colo
 		Graphics()->QuadsTex3DEnd();
 	else
 		Graphics()->QuadsEnd();
-	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
+	Graphics()->MapScreen(ScreenRect);
 }
 
 void CRenderMap::RenderTilemap(CTile *pTiles, int w, int h, float Scale, ColorRGBA Color, int RenderFlags)
 {
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 
 	// calculate the final pixelsize for the tiles
 	float TilePixelSize = 1024 / 32.0f;
-	float FinalTileSize = Scale / (ScreenX1 - ScreenX0) * Graphics()->ScreenWidth();
+	float FinalTileSize = Scale / ScreenRect.Width() * Graphics()->ScreenWidth();
 	float FinalTilesetScale = FinalTileSize / TilePixelSize;
 
 	if(Graphics()->HasTextureArraysSupport())
@@ -613,10 +610,10 @@ void CRenderMap::RenderTilemap(CTile *pTiles, int w, int h, float Scale, ColorRG
 
 	const bool ExtendTiles = (RenderFlags & TILERENDERFLAG_EXTEND) != 0;
 
-	int StartY = (int)(ScreenY0 / Scale) - 1;
-	int StartX = (int)(ScreenX0 / Scale) - 1;
-	int EndY = (int)(ScreenY1 / Scale) + 1;
-	int EndX = (int)(ScreenX1 / Scale) + 1;
+	int StartY = (int)(ScreenRect.m_TopLeft.y / Scale) - 1;
+	int StartX = (int)(ScreenRect.m_TopLeft.x / Scale) - 1;
+	int EndY = (int)(ScreenRect.m_BottomRight.y / Scale) + 1;
+	int EndX = (int)(ScreenRect.m_BottomRight.x / Scale) + 1;
 	if(!ExtendTiles)
 	{
 		StartY = std::max(0, StartY);
@@ -750,7 +747,7 @@ void CRenderMap::RenderTilemap(CTile *pTiles, int w, int h, float Scale, ColorRG
 		Graphics()->QuadsTex3DEnd();
 	else
 		Graphics()->QuadsEnd();
-	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
+	Graphics()->MapScreen(ScreenRect);
 }
 
 void CRenderMap::RenderTeleOverlay(CTeleTile *pTele, int w, int h, float Scale, int OverlayRenderFlag, float Alpha)
@@ -758,13 +755,12 @@ void CRenderMap::RenderTeleOverlay(CTeleTile *pTele, int w, int h, float Scale, 
 	if(!(OverlayRenderFlag & OVERLAYRENDERFLAG_TEXT))
 		return;
 
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 
-	int StartY = (int)(ScreenY0 / Scale) - 1;
-	int StartX = (int)(ScreenX0 / Scale) - 1;
-	int EndY = (int)(ScreenY1 / Scale) + 1;
-	int EndX = (int)(ScreenX1 / Scale) + 1;
+	int StartY = (int)(ScreenRect.m_TopLeft.y / Scale) - 1;
+	int StartX = (int)(ScreenRect.m_TopLeft.x / Scale) - 1;
+	int EndY = (int)(ScreenRect.m_BottomRight.y / Scale) + 1;
+	int EndX = (int)(ScreenRect.m_BottomRight.x / Scale) + 1;
 	if(EndX - StartX > Graphics()->ScreenWidth() / g_Config.m_GfxTextOverlay || EndY - StartY > Graphics()->ScreenHeight() / g_Config.m_GfxTextOverlay)
 		return; // its useless to render text at this distance
 
@@ -797,18 +793,17 @@ void CRenderMap::RenderTeleOverlay(CTeleTile *pTele, int w, int h, float Scale, 
 		}
 	}
 	TextRender()->TextColor(TextRender()->DefaultTextColor());
-	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
+	Graphics()->MapScreen(ScreenRect);
 }
 
 void CRenderMap::RenderSpeedupOverlay(CSpeedupTile *pSpeedup, int w, int h, float Scale, int OverlayRenderFlag, float Alpha)
 {
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 
-	int StartY = (int)(ScreenY0 / Scale) - 1;
-	int StartX = (int)(ScreenX0 / Scale) - 1;
-	int EndY = (int)(ScreenY1 / Scale) + 1;
-	int EndX = (int)(ScreenX1 / Scale) + 1;
+	int StartY = (int)(ScreenRect.m_TopLeft.y / Scale) - 1;
+	int StartX = (int)(ScreenRect.m_TopLeft.x / Scale) - 1;
+	int EndY = (int)(ScreenRect.m_BottomRight.y / Scale) + 1;
+	int EndX = (int)(ScreenRect.m_BottomRight.x / Scale) + 1;
 	if(EndX - StartX > Graphics()->ScreenWidth() / g_Config.m_GfxTextOverlay || EndY - StartY > Graphics()->ScreenHeight() / g_Config.m_GfxTextOverlay)
 		return; // its useless to render text at this distance
 
@@ -876,7 +871,7 @@ void CRenderMap::RenderSpeedupOverlay(CSpeedupTile *pSpeedup, int w, int h, floa
 		}
 	}
 	TextRender()->TextColor(TextRender()->DefaultTextColor());
-	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
+	Graphics()->MapScreen(ScreenRect);
 }
 
 void CRenderMap::RenderSwitchOverlay(CSwitchTile *pSwitch, int w, int h, float Scale, int OverlayRenderFlag, float Alpha)
@@ -884,13 +879,12 @@ void CRenderMap::RenderSwitchOverlay(CSwitchTile *pSwitch, int w, int h, float S
 	if(!(OverlayRenderFlag & OVERLAYRENDERFLAG_TEXT))
 		return;
 
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 
-	int StartY = (int)(ScreenY0 / Scale) - 1;
-	int StartX = (int)(ScreenX0 / Scale) - 1;
-	int EndY = (int)(ScreenY1 / Scale) + 1;
-	int EndX = (int)(ScreenX1 / Scale) + 1;
+	int StartY = (int)(ScreenRect.m_TopLeft.y / Scale) - 1;
+	int StartX = (int)(ScreenRect.m_TopLeft.x / Scale) - 1;
+	int EndY = (int)(ScreenRect.m_BottomRight.y / Scale) + 1;
+	int EndX = (int)(ScreenRect.m_BottomRight.x / Scale) + 1;
 	if(EndX - StartX > Graphics()->ScreenWidth() / g_Config.m_GfxTextOverlay || EndY - StartY > Graphics()->ScreenHeight() / g_Config.m_GfxTextOverlay)
 		return; // its useless to render text at this distance
 
@@ -926,7 +920,7 @@ void CRenderMap::RenderSwitchOverlay(CSwitchTile *pSwitch, int w, int h, float S
 		}
 	}
 	TextRender()->TextColor(TextRender()->DefaultTextColor());
-	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
+	Graphics()->MapScreen(ScreenRect);
 }
 
 void CRenderMap::RenderTuneOverlay(CTuneTile *pTune, int w, int h, float Scale, int OverlayRenderFlag, float Alpha)
@@ -934,13 +928,12 @@ void CRenderMap::RenderTuneOverlay(CTuneTile *pTune, int w, int h, float Scale, 
 	if(!(OverlayRenderFlag & OVERLAYRENDERFLAG_TEXT))
 		return;
 
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 
-	int StartY = (int)(ScreenY0 / Scale) - 1;
-	int StartX = (int)(ScreenX0 / Scale) - 1;
-	int EndY = (int)(ScreenY1 / Scale) + 1;
-	int EndX = (int)(ScreenX1 / Scale) + 1;
+	int StartY = (int)(ScreenRect.m_TopLeft.y / Scale) - 1;
+	int StartX = (int)(ScreenRect.m_TopLeft.x / Scale) - 1;
+	int EndY = (int)(ScreenRect.m_BottomRight.y / Scale) + 1;
+	int EndX = (int)(ScreenRect.m_BottomRight.x / Scale) + 1;
 	if(EndX - StartX > Graphics()->ScreenWidth() / g_Config.m_GfxTextOverlay || EndY - StartY > Graphics()->ScreenHeight() / g_Config.m_GfxTextOverlay)
 		return; // its useless to render text at this distance
 
@@ -973,17 +966,16 @@ void CRenderMap::RenderTuneOverlay(CTuneTile *pTune, int w, int h, float Scale, 
 		}
 	}
 	TextRender()->TextColor(TextRender()->DefaultTextColor());
-	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
+	Graphics()->MapScreen(ScreenRect);
 }
 
 void CRenderMap::RenderTelemap(CTeleTile *pTele, int w, int h, float Scale, ColorRGBA Color, int RenderFlags)
 {
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 
 	// calculate the final pixelsize for the tiles
 	float TilePixelSize = 1024 / 32.0f;
-	float FinalTileSize = Scale / (ScreenX1 - ScreenX0) * Graphics()->ScreenWidth();
+	float FinalTileSize = Scale / ScreenRect.Width() * Graphics()->ScreenWidth();
 	float FinalTilesetScale = FinalTileSize / TilePixelSize;
 
 	if(Graphics()->HasTextureArraysSupport())
@@ -994,10 +986,10 @@ void CRenderMap::RenderTelemap(CTeleTile *pTele, int w, int h, float Scale, Colo
 
 	bool ExtendTiles = (RenderFlags & TILERENDERFLAG_EXTEND) != 0;
 
-	int StartY = (int)(ScreenY0 / Scale) - 1;
-	int StartX = (int)(ScreenX0 / Scale) - 1;
-	int EndY = (int)(ScreenY1 / Scale) + 1;
-	int EndX = (int)(ScreenX1 / Scale) + 1;
+	int StartY = (int)(ScreenRect.m_TopLeft.y / Scale) - 1;
+	int StartX = (int)(ScreenRect.m_TopLeft.x / Scale) - 1;
+	int EndY = (int)(ScreenRect.m_BottomRight.y / Scale) + 1;
+	int EndX = (int)(ScreenRect.m_BottomRight.x / Scale) + 1;
 	if(!ExtendTiles)
 	{
 		StartY = std::max(0, StartY);
@@ -1088,17 +1080,16 @@ void CRenderMap::RenderTelemap(CTeleTile *pTele, int w, int h, float Scale, Colo
 		Graphics()->QuadsTex3DEnd();
 	else
 		Graphics()->QuadsEnd();
-	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
+	Graphics()->MapScreen(ScreenRect);
 }
 
 void CRenderMap::RenderSwitchmap(CSwitchTile *pSwitchTile, int w, int h, float Scale, ColorRGBA Color, int RenderFlags)
 {
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 
 	// calculate the final pixelsize for the tiles
 	float TilePixelSize = 1024 / 32.0f;
-	float FinalTileSize = Scale / (ScreenX1 - ScreenX0) * Graphics()->ScreenWidth();
+	float FinalTileSize = Scale / ScreenRect.Width() * Graphics()->ScreenWidth();
 	float FinalTilesetScale = FinalTileSize / TilePixelSize;
 
 	if(Graphics()->HasTextureArraysSupport())
@@ -1109,10 +1100,10 @@ void CRenderMap::RenderSwitchmap(CSwitchTile *pSwitchTile, int w, int h, float S
 
 	bool ExtendTiles = (RenderFlags & TILERENDERFLAG_EXTEND) != 0;
 
-	int StartY = (int)(ScreenY0 / Scale) - 1;
-	int StartX = (int)(ScreenX0 / Scale) - 1;
-	int EndY = (int)(ScreenY1 / Scale) + 1;
-	int EndX = (int)(ScreenX1 / Scale) + 1;
+	int StartY = (int)(ScreenRect.m_TopLeft.y / Scale) - 1;
+	int StartX = (int)(ScreenRect.m_TopLeft.x / Scale) - 1;
+	int EndY = (int)(ScreenRect.m_BottomRight.y / Scale) + 1;
+	int EndX = (int)(ScreenRect.m_BottomRight.x / Scale) + 1;
 	if(!ExtendTiles)
 	{
 		StartY = std::max(0, StartY);
@@ -1246,17 +1237,16 @@ void CRenderMap::RenderSwitchmap(CSwitchTile *pSwitchTile, int w, int h, float S
 		Graphics()->QuadsTex3DEnd();
 	else
 		Graphics()->QuadsEnd();
-	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
+	Graphics()->MapScreen(ScreenRect);
 }
 
 void CRenderMap::RenderTunemap(CTuneTile *pTune, int w, int h, float Scale, ColorRGBA Color, int RenderFlags, CTuneColorMapper *pTuneColorMapper)
 {
-	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	CScreenRect ScreenRect = Graphics()->GetScreen();
 
 	// calculate the final pixelsize for the tiles
 	float TilePixelSize = 1024 / 32.0f;
-	float FinalTileSize = Scale / (ScreenX1 - ScreenX0) * Graphics()->ScreenWidth();
+	float FinalTileSize = Scale / ScreenRect.Width() * Graphics()->ScreenWidth();
 	float FinalTilesetScale = FinalTileSize / TilePixelSize;
 
 	if(Graphics()->HasTextureArraysSupport())
@@ -1267,10 +1257,10 @@ void CRenderMap::RenderTunemap(CTuneTile *pTune, int w, int h, float Scale, Colo
 
 	bool ExtendTiles = (RenderFlags & TILERENDERFLAG_EXTEND) != 0;
 
-	int StartY = (int)(ScreenY0 / Scale) - 1;
-	int StartX = (int)(ScreenX0 / Scale) - 1;
-	int EndY = (int)(ScreenY1 / Scale) + 1;
-	int EndX = (int)(ScreenX1 / Scale) + 1;
+	int StartY = (int)(ScreenRect.m_TopLeft.y / Scale) - 1;
+	int StartX = (int)(ScreenRect.m_TopLeft.x / Scale) - 1;
+	int EndY = (int)(ScreenRect.m_BottomRight.y / Scale) + 1;
+	int EndX = (int)(ScreenRect.m_BottomRight.x / Scale) + 1;
 	if(!ExtendTiles)
 	{
 		StartY = std::max(0, StartY);
@@ -1372,7 +1362,7 @@ void CRenderMap::RenderTunemap(CTuneTile *pTune, int w, int h, float Scale, Colo
 		Graphics()->QuadsTex3DEnd();
 	else
 		Graphics()->QuadsEnd();
-	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
+	Graphics()->MapScreen(ScreenRect);
 }
 
 void CRenderMap::RenderDebugClip(float ClipX, float ClipY, float ClipW, float ClipH, ColorRGBA Color, float Zoom, const char *pLabel)


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This code aims to simplify and generalize the handling of the ScreenRects by introducing the `CScreenRect` class instead of moving a float[4] array around. Often we keep doing the same operations on the screen values, which are duplicated over multiple lines of code.

CC #12275

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
