### PR TITLE
`str_copy` template for `std::array`

### DIFF
--- a/src/base/str.h
+++ b/src/base/str.h
@@ -4,6 +4,7 @@
 #ifndef BASE_STR_H
 #define BASE_STR_H
 
+#include <array>
 #include <cinttypes>
 #include <cstdarg>
 #include <cstddef>
@@ -59,6 +60,23 @@ template<int N>
 void str_copy(char (&dst)[N], const char *src)
 {
 	str_copy(dst, src, N);
+}
+
+/**
+ * Copies a string to a fixed-size std::array of chars.
+ *
+ * @ingroup Strings
+ *
+ * @param dst Array that shall receive the string.
+ * @param src String to be copied.
+ *
+ * @remark The strings are treated as null-terminated strings.
+ * @remark Guarantees that dst string will contain null-termination.
+ */
+template<size_t N>
+void str_copy(std::array<char, N> &dst, const char *src)
+{
+	str_copy(dst.data(), src, static_cast<int>(N));
 }
 
 /**

--- a/src/test/str_test.cpp
+++ b/src/test/str_test.cpp
@@ -814,6 +814,17 @@ TEST(Str, Copy)
 	EXPECT_STREQ(aBuf, "DDNet最好了");
 }
 
+TEST(Str, CopyArray)
+{
+	std::array<char, 512> aBuf;
+	str_copy(aBuf, "hello");
+	EXPECT_STREQ(aBuf.data(), "hello");
+
+	std::array<char, 8> aSmallBuf;
+	str_copy(aSmallBuf, "long string");
+	EXPECT_STREQ(aSmallBuf.data(), "long st");
+}
+
 TEST(Str, Append)
 {
 	char aBuf[64];


### PR DESCRIPTION
Today I realized `std::array` is pretty cool! It is used a bit already in the ddnet code base. This helper makes working with it cleaner :)

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

The model **inkling-medium** generated the following code on https://arena.ai/ for me. Which I copied 1:1 into the pr.

```C++
#include <array>

template<std::size_t N>
void str_copy(std::array<char, N>& dst, const char* src)
{
    str_copy(dst.data(), src, static_cast<int>(N));
}
```