### PR TITLE
Centralize `cxx` version specification

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
               ./
     - name: Run cxxbridge
       run: |
-        cargo install cxxbridge-cmd@1.0.194
+        cargo install cxxbridge-cmd@"$(python scripts/generate_rust_bridge.py --cxx-version)"
         python scripts/generate_rust_bridge.py
         git diff --exit-code
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,11 @@ members = [
 
 resolver = "2"
 
+[workspace.dependencies]
+# After updating the cxx version, you need to run
+# `python scripts/generate_rust_bridge.py`.
+cxx = "=1.0.194"
+
 [profile.dev]
 panic = "abort"
 

--- a/scripts/generate_rust_bridge.py
+++ b/scripts/generate_rust_bridge.py
@@ -1,11 +1,22 @@
 #!/usr/bin/env python3
 
+import argparse
 import os
 import subprocess
 import sys
-import argparse
+import tomllib
 
 os.chdir(os.path.dirname(__file__) + "/..")
+
+
+def find_cxxbridge_version():
+	with open("Cargo.toml") as f:
+		cargo_toml = f.read()
+	cargo_toml = tomllib.loads(cargo_toml)
+	cxx_version = cargo_toml["workspace"]["dependencies"]["cxx"]
+	if not cxx_version.startswith("="):
+		raise RuntimeError("expected cxx package to pin a specific version")
+	return cxx_version[1:]
 
 
 def find_cxxbridge(version):
@@ -28,9 +39,14 @@ FILES = {
 
 def main():
 	p = argparse.ArgumentParser(description="Generate src/rust-bridge")
-	_args = p.parse_args()
+	p.add_argument("--cxx-version", action="store_true", help="Print cxx version and exit")
+	args = p.parse_args()
 
-	cxxbridge = find_cxxbridge(version="1.0.194")
+	cxxbridge_version = find_cxxbridge_version()
+	if args.cxx_version:
+		print(cxxbridge_version)
+		return
+	cxxbridge = find_cxxbridge(version=cxxbridge_version)
 	for input_, output_prefix in FILES.items():
 		subprocess.check_call([
 			cxxbridge,

--- a/src/base/Cargo.toml
+++ b/src/base/Cargo.toml
@@ -10,7 +10,7 @@ license = "Zlib"
 path = "lib.rs"
 
 [dependencies]
-cxx = "=1.0.194"
+cxx = { workspace = true }
 libc = "0.2"
 
 [dev-dependencies]

--- a/src/engine/Cargo.toml
+++ b/src/engine/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib.rs"
 [dependencies]
 ddnet-base = { path = "../base" }
 
-cxx = "=1.0.194"
+cxx = { workspace = true }
 
 [dev-dependencies]
 ddnet-engine-shared = { path = "shared" }

--- a/src/engine/shared/Cargo.toml
+++ b/src/engine/shared/Cargo.toml
@@ -14,7 +14,7 @@ path = "lib.rs"
 ddnet-base = { path = "../../base" }
 ddnet-engine = { path = ".." }
 
-cxx = "=1.0.194"
+cxx = { workspace = true }
 
 [dev-dependencies]
 ddnet-test = { path = "../../rust-bridge/test", features = ["link-test-libraries"] }


### PR DESCRIPTION
This can allow distributions to adapt to their shipped cxx version more easily.

Fixes #12385.

## Checklist

- [x] Tested the change ~ingame~
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions