### PR TITLE
client serverbrowser: Store server info clients in a vector instead of a fixed 128-slot array

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1454,10 +1454,10 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 	}
 
 	bool IgnoreError = false;
-	for(int i = 0; i < MAX_CLIENTS && Info.m_NumReceivedClients < MAX_CLIENTS && !Up.Error(); i++)
+	for(int i = 0; i < MAX_CLIENTS && (int)Info.m_vClients.size() < MAX_CLIENTS && !Up.Error(); i++)
 	{
-		CServerInfo::CClient *pClient = &Info.m_aClients[Info.m_NumReceivedClients];
-		GET_STRING(pClient->m_aName);
+		CServerInfo::CClient Client = {};
+		GET_STRING(Client.m_aName);
 		if(Up.Error())
 		{
 			// Packet end, no problem unless it happens during one
@@ -1465,14 +1465,14 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 			IgnoreError = true;
 			break;
 		}
-		GET_STRING(pClient->m_aClan);
-		GET_INT(pClient->m_Country);
-		if(!in_range(pClient->m_Country, CountryCode::MINIMUM, CountryCode::MAXIMUM))
+		GET_STRING(Client.m_aClan);
+		GET_INT(Client.m_Country);
+		if(!in_range(Client.m_Country, CountryCode::MINIMUM, CountryCode::MAXIMUM))
 		{
-			pClient->m_Country = CountryCode::DEFAULT;
+			Client.m_Country = CountryCode::DEFAULT;
 		}
-		GET_INT(pClient->m_Score);
-		GET_INT(pClient->m_Player);
+		GET_INT(Client.m_Score);
+		GET_INT(Client.m_Player);
 		if(SavedType == SERVERINFO_EXTENDED)
 		{
 			Up.GetString(); // extra info, reserved
@@ -1485,12 +1485,12 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 				if(!(Info.m_ReceivedPackets & Flag))
 				{
 					Info.m_ReceivedPackets |= Flag;
-					Info.m_NumReceivedClients++;
+					Info.m_vClients.push_back(Client);
 				}
 			}
 			else
 			{
-				Info.m_NumReceivedClients++;
+				Info.m_vClients.push_back(Client);
 			}
 		}
 	}

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -486,9 +486,9 @@ void CServerBrowser::Filter()
 			{
 				Filtered = true;
 				// match against player country
-				for(int p = 0; p < std::min(Info.m_NumClients, (int)MAX_CLIENTS); p++)
+				for(const auto &Client : Info.m_vClients)
 				{
-					if(Info.m_aClients[p].m_Country == g_Config.m_BrFilterCountryIndex)
+					if(Client.m_Country == g_Config.m_BrFilterCountryIndex)
 					{
 						Filtered = false;
 						break;
@@ -527,14 +527,14 @@ void CServerBrowser::Filter()
 					}
 
 					// match against players
-					for(int p = 0; p < std::min(Info.m_NumClients, (int)MAX_CLIENTS); p++)
+					for(const auto &Client : Info.m_vClients)
 					{
-						if(MatchesFn(Info.m_aClients[p].m_aName, aFilterStrTrimmed) ||
-							MatchesFn(Info.m_aClients[p].m_aClan, aFilterStrTrimmed))
+						if(MatchesFn(Client.m_aName, aFilterStrTrimmed) ||
+							MatchesFn(Client.m_aClan, aFilterStrTrimmed))
 						{
 							if(g_Config.m_BrFilterConnectingPlayers &&
-								str_comp(Info.m_aClients[p].m_aName, "(connecting)") == 0 &&
-								Info.m_aClients[p].m_aClan[0] == '\0')
+								str_comp(Client.m_aName, "(connecting)") == 0 &&
+								Client.m_aClan[0] == '\0')
 							{
 								continue;
 							}
@@ -810,7 +810,7 @@ void CServerBrowser::SetInfo(CServerEntry *pEntry, const CServerInfo &Info) cons
 		}
 	};
 
-	std::sort(pEntry->m_Info.m_aClients, pEntry->m_Info.m_aClients + Info.m_NumReceivedClients, CPlayerScoreNameLess(pEntry->m_Info.m_ClientScoreKind));
+	std::sort(pEntry->m_Info.m_vClients.begin(), pEntry->m_Info.m_vClients.end(), CPlayerScoreNameLess(pEntry->m_Info.m_ClientScoreKind));
 
 	pEntry->m_GotInfo = 1;
 }
@@ -854,8 +854,7 @@ void CServerBrowser::SetLatency(NETADDR Addr, int Latency)
 CServerBrowser::CServerEntry *CServerBrowser::Add(const NETADDR *pAddrs, int NumAddrs)
 {
 	// create new pEntry
-	CServerEntry *pEntry = m_ServerlistHeap.Allocate<CServerEntry>();
-	*pEntry = {};
+	CServerEntry *pEntry = &m_ServerlistStorage.emplace_back();
 
 	// set the info
 	mem_copy(pEntry->m_Info.m_aAddresses, pAddrs, NumAddrs * sizeof(pAddrs[0]));
@@ -1258,7 +1257,7 @@ void CServerBrowser::CleanUp()
 	// clear out everything
 	m_vSortedServerlist.clear();
 	m_vpServerlist.clear();
-	m_ServerlistHeap.Reset();
+	m_ServerlistStorage.clear();
 	m_NumSortedPlayers = 0;
 	m_ByAddr.clear();
 	m_pFirstReqServer = nullptr;
@@ -1648,7 +1647,7 @@ void CServerBrowser::UpdateServerFilteredPlayers(CServerInfo *pInfo) const
 	pInfo->m_NumFilteredPlayers = g_Config.m_BrFilterSpectators ? pInfo->m_NumPlayers : pInfo->m_NumClients;
 	if(g_Config.m_BrFilterConnectingPlayers)
 	{
-		for(const auto &Client : pInfo->m_aClients)
+		for(const auto &Client : pInfo->m_vClients)
 		{
 			if((!g_Config.m_BrFilterSpectators || Client.m_Player) && str_comp(Client.m_aName, "(connecting)") == 0 && Client.m_aClan[0] == '\0')
 				pInfo->m_NumFilteredPlayers--;
@@ -1660,11 +1659,11 @@ void CServerBrowser::UpdateServerFriends(CServerInfo *pInfo) const
 {
 	pInfo->m_FriendState = IFriends::FRIEND_NO;
 	pInfo->m_FriendNum = 0;
-	for(int ClientIndex = 0; ClientIndex < std::min(pInfo->m_NumReceivedClients, (int)MAX_CLIENTS); ClientIndex++)
+	for(auto &Client : pInfo->m_vClients)
 	{
-		pInfo->m_aClients[ClientIndex].m_FriendState = m_pFriends->GetFriendState(pInfo->m_aClients[ClientIndex].m_aName, pInfo->m_aClients[ClientIndex].m_aClan);
-		pInfo->m_FriendState = std::max(pInfo->m_FriendState, pInfo->m_aClients[ClientIndex].m_FriendState);
-		if(pInfo->m_aClients[ClientIndex].m_FriendState != IFriends::FRIEND_NO)
+		Client.m_FriendState = m_pFriends->GetFriendState(Client.m_aName, Client.m_aClan);
+		pInfo->m_FriendState = std::max(pInfo->m_FriendState, Client.m_FriendState);
+		if(Client.m_FriendState != IFriends::FRIEND_NO)
 			pInfo->m_FriendNum++;
 	}
 }

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -8,8 +8,8 @@
 
 #include <engine/console.h>
 #include <engine/serverbrowser.h>
-#include <engine/shared/memheap.h>
 
+#include <deque>
 #include <functional>
 #include <map>
 #include <optional>
@@ -336,7 +336,10 @@ private:
 	IServerBrowserPingCache *m_pPingCache = nullptr;
 	const char *m_pHttpPrevBestUrl = nullptr;
 
-	CHeap m_ServerlistHeap;
+	// Entries are owned by m_ServerlistStorage; m_vpServerlist holds non-owning
+	// pointers into it. std::deque keeps element pointers stable across growth,
+	// which the request list (m_pPrevReq/m_pNextReq) and m_vpServerlist rely on.
+	std::deque<CServerEntry> m_ServerlistStorage;
 	std::vector<CServerEntry *> m_vpServerlist;
 	std::vector<int> m_vSortedServerlist;
 	std::unordered_map<NETADDR, int> m_ByAddr;

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -93,7 +93,6 @@ public:
 
 	int m_Type;
 	uint64_t m_ReceivedPackets;
-	int m_NumReceivedClients;
 
 	int m_NumAddresses;
 	NETADDR m_aAddresses[MAX_SERVER_ADDRESSES];
@@ -125,7 +124,7 @@ public:
 	int m_MapSize;
 	char m_aVersion[32];
 	char m_aAddress[MAX_SERVER_ADDRESSES * NETADDR_MAXSTRSIZE];
-	CClient m_aClients[SERVERINFO_MAX_CLIENTS];
+	std::vector<CClient> m_vClients;
 	int m_NumFilteredPlayers;
 	bool m_RequiresLogin;
 

--- a/src/engine/shared/serverinfo.cpp
+++ b/src/engine/shared/serverinfo.cpp
@@ -287,30 +287,30 @@ CServerInfo2::operator CServerInfo() const
 	str_copy(Result.m_aMap, m_aMapName);
 	str_copy(Result.m_aVersion, m_aVersion);
 
-	for(int i = 0; i < std::min(m_NumClients, (int)SERVERINFO_MAX_CLIENTS); i++)
+	Result.m_vClients.resize(std::min(m_NumClients, (int)SERVERINFO_MAX_CLIENTS));
+	for(size_t i = 0; i < Result.m_vClients.size(); i++)
 	{
-		str_copy(Result.m_aClients[i].m_aName, m_aClients[i].m_aName);
-		str_copy(Result.m_aClients[i].m_aClan, m_aClients[i].m_aClan);
-		Result.m_aClients[i].m_Country = m_aClients[i].m_Country;
-		Result.m_aClients[i].m_Score = m_aClients[i].m_Score;
-		Result.m_aClients[i].m_Player = m_aClients[i].m_IsPlayer;
-		Result.m_aClients[i].m_Afk = m_aClients[i].m_IsAfk;
+		str_copy(Result.m_vClients[i].m_aName, m_aClients[i].m_aName);
+		str_copy(Result.m_vClients[i].m_aClan, m_aClients[i].m_aClan);
+		Result.m_vClients[i].m_Country = m_aClients[i].m_Country;
+		Result.m_vClients[i].m_Score = m_aClients[i].m_Score;
+		Result.m_vClients[i].m_Player = m_aClients[i].m_IsPlayer;
+		Result.m_vClients[i].m_Afk = m_aClients[i].m_IsAfk;
 
 		// 0.6 skin
-		str_copy(Result.m_aClients[i].m_aSkin, m_aClients[i].m_aSkin);
-		Result.m_aClients[i].m_CustomSkinColors = m_aClients[i].m_CustomSkinColors;
-		Result.m_aClients[i].m_CustomSkinColorBody = m_aClients[i].m_CustomSkinColorBody;
-		Result.m_aClients[i].m_CustomSkinColorFeet = m_aClients[i].m_CustomSkinColorFeet;
+		str_copy(Result.m_vClients[i].m_aSkin, m_aClients[i].m_aSkin);
+		Result.m_vClients[i].m_CustomSkinColors = m_aClients[i].m_CustomSkinColors;
+		Result.m_vClients[i].m_CustomSkinColorBody = m_aClients[i].m_CustomSkinColorBody;
+		Result.m_vClients[i].m_CustomSkinColorFeet = m_aClients[i].m_CustomSkinColorFeet;
 		// 0.7 skin
 		for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
 		{
-			str_copy(Result.m_aClients[i].m_aaSkin7[Part], m_aClients[i].m_aaSkin7[Part]);
-			Result.m_aClients[i].m_aUseCustomSkinColor7[Part] = m_aClients[i].m_aUseCustomSkinColor7[Part];
-			Result.m_aClients[i].m_aCustomSkinColor7[Part] = m_aClients[i].m_aCustomSkinColor7[Part];
+			str_copy(Result.m_vClients[i].m_aaSkin7[Part], m_aClients[i].m_aaSkin7[Part]);
+			Result.m_vClients[i].m_aUseCustomSkinColor7[Part] = m_aClients[i].m_aUseCustomSkinColor7[Part];
+			Result.m_vClients[i].m_aCustomSkinColor7[Part] = m_aClients[i].m_aCustomSkinColor7[Part];
 		}
 	}
 
-	Result.m_NumReceivedClients = std::min(m_NumClients, (int)SERVERINFO_MAX_CLIENTS);
 	Result.m_Latency = -1;
 
 	return Result;

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1278,11 +1278,11 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 	s_ListBox.DoAutoSpacing(2.0f);
 	s_ListBox.SetScrollbarWidth(16.0f);
 	s_ListBox.SetScrollbarMargin(5.0f);
-	s_ListBox.DoStart(25.0f, pSelectedServer->m_NumReceivedClients, 1, 3, -1, &View, false, IGraphics::CORNER_NONE, true);
+	s_ListBox.DoStart(25.0f, (int)pSelectedServer->m_vClients.size(), 1, 3, -1, &View, false, IGraphics::CORNER_NONE, true);
 
-	for(int i = 0; i < pSelectedServer->m_NumReceivedClients; i++)
+	for(size_t i = 0; i < pSelectedServer->m_vClients.size(); i++)
 	{
-		const CServerInfo::CClient &CurrentClient = pSelectedServer->m_aClients[i];
+		const CServerInfo::CClient &CurrentClient = pSelectedServer->m_vClients[i];
 		const CListboxItem Item = s_ListBox.DoNextItem(&CurrentClient);
 		if(!Item.m_Visible)
 			continue;
@@ -1411,7 +1411,7 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 	const int NewSelected = s_ListBox.DoEnd();
 	if(s_ListBox.WasItemSelected())
 	{
-		const CServerInfo::CClient &SelectedClient = pSelectedServer->m_aClients[NewSelected];
+		const CServerInfo::CClient &SelectedClient = pSelectedServer->m_vClients[NewSelected];
 		if(SelectedClient.m_FriendState == IFriends::FRIEND_PLAYER)
 			GameClient()->Friends()->RemoveFriend(SelectedClient.m_aName, SelectedClient.m_aClan);
 		else
@@ -1455,9 +1455,8 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 		if(pEntry->m_FriendState == IFriends::FRIEND_NO)
 			continue;
 
-		for(int ClientIndex = 0; ClientIndex < pEntry->m_NumClients; ++ClientIndex)
+		for(const CServerInfo::CClient &CurrentClient : pEntry->m_vClients)
 		{
-			const CServerInfo::CClient &CurrentClient = pEntry->m_aClients[ClientIndex];
 			if(CurrentClient.m_FriendState == IFriends::FRIEND_NO)
 				continue;
 

--- a/src/game/client/sixup_translate_connless.cpp
+++ b/src/game/client/sixup_translate_connless.cpp
@@ -31,17 +31,18 @@ void CClient::PreprocessConnlessPacket7(CNetChunk *pPacket)
 		Info.m_NumClients = Up.GetInt();
 		Info.m_MaxClients = Up.GetInt();
 
-		for(int i = 0; i < Info.m_NumClients; i++)
+		Info.m_vClients.resize(std::clamp(Info.m_NumClients, 0, (int)SERVERINFO_MAX_CLIENTS));
+		for(auto &Client : Info.m_vClients)
 		{
-			GetString(Info.m_aClients[i].m_aName);
-			GetString(Info.m_aClients[i].m_aClan);
-			Info.m_aClients[i].m_Country = Up.GetInt();
-			if(!in_range(Info.m_aClients[i].m_Country, CountryCode::MINIMUM, CountryCode::MAXIMUM))
+			GetString(Client.m_aName);
+			GetString(Client.m_aClan);
+			Client.m_Country = Up.GetInt();
+			if(!in_range(Client.m_Country, CountryCode::MINIMUM, CountryCode::MAXIMUM))
 			{
-				Info.m_aClients[i].m_Country = CountryCode::DEFAULT;
+				Client.m_Country = CountryCode::DEFAULT;
 			}
-			Info.m_aClients[i].m_Score = Up.GetInt();
-			Info.m_aClients[i].m_Player = !(Up.GetInt() & 1);
+			Client.m_Score = Up.GetInt();
+			Client.m_Player = !(Up.GetInt() & 1);
 		}
 
 		const bool IsNotVanilla = Info.m_MaxPlayers > VANILLA_MAX_CLIENTS || Info.m_MaxClients > VANILLA_MAX_CLIENTS;
@@ -82,14 +83,14 @@ void CClient::PreprocessConnlessPacket7(CNetChunk *pPacket)
 			Packer.AddString(""); // extra info, reserved
 		}
 
-		for(int i = 0; i < Info.m_NumClients; i++)
+		for(const auto &Client : Info.m_vClients)
 		{
-			Packer.AddString(Info.m_aClients[i].m_aName);
-			Packer.AddString(Info.m_aClients[i].m_aClan);
+			Packer.AddString(Client.m_aName);
+			Packer.AddString(Client.m_aClan);
 
-			PutInt(Info.m_aClients[i].m_Country);
-			PutInt(Info.m_aClients[i].m_Score);
-			PutInt(Info.m_aClients[i].m_Player);
+			PutInt(Client.m_Country);
+			PutInt(Client.m_Score);
+			PutInt(Client.m_Player);
 
 			if(IsNotVanilla)
 			{


### PR DESCRIPTION
CServerInfo held CClient m_aClients[SERVERINFO_MAX_CLIENTS], a fixed array of 128 entries of ~256 bytes each, making sizeof(CServerInfo) ~34 KB with ~95% of it unused on typical servers.
The full master list (~1200 servers) is stored twice on the client, once as std::vector<CServerInfo> in CServerBrowserHttp and once as CServerEntry allocations on the browser's CHeap, and it is loaded on startup even when the server browser is never opened.

Replace the fixed array with std::vector<CClient> m_vClients holding only the actually received clients (m_NumReceivedClients == m_vClients.size() everywhere).

Written entirely by Fable 5 with me prompting to make changes based on looking at actual memory usage of client in serverbrowser. I have manually reviewed the code, and another Claude Code session did so as well.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions