### PR TITLE
server: batch preinput broadcasts into per-recipient packets

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2853,6 +2853,11 @@ void CServer::PumpNetwork(bool PacketWaiting)
 
 	m_NetServer.Update();
 
+	// Coalesce the flushes triggered while handling this burst of incoming
+	// packets (preinput broadcasts, timing/ping replies, ...) into one packet
+	// per recipient, flushed once all packets have been handled below.
+	m_NetServer.BeginFlushBatch();
+
 	if(PacketWaiting)
 	{
 		// process packets
@@ -2944,6 +2949,8 @@ void CServer::PumpNetwork(bool PacketWaiting)
 			ProcessClientPacket(&Packet);
 		}
 	}
+
+	m_NetServer.EndFlushBatch();
 
 	m_ServerBan.Update();
 	m_Econ.Update();

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -433,6 +433,9 @@ class CNetServer
 	int m_MaxClients = NET_MAX_CLIENTS;
 	int m_MaxClientsPerIp;
 
+	bool m_FlushBatch = false;
+	bool m_aFlushPending[NET_MAX_CLIENTS] = {};
+
 	NETFUNC_NEWCLIENT m_pfnNewClient;
 	NETFUNC_NEWCLIENT_NOAUTH m_pfnNewClientNoAuth;
 	NETFUNC_DELCLIENT m_pfnDelClient;
@@ -475,6 +478,13 @@ public:
 	int Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken);
 	int Send(CNetChunk *pChunk);
 	void Update();
+
+	// While a flush batch is open, sends requesting MSGFLAG_FLUSH only queue
+	// their chunk and mark the connection; EndFlushBatch() then flushes each
+	// marked connection once. Used to coalesce the flushes triggered while
+	// draining a burst of incoming packets into one packet per recipient.
+	void BeginFlushBatch() { m_FlushBatch = true; }
+	void EndFlushBatch();
 
 	//
 	void Drop(int ClientId, const char *pReason);

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -121,6 +121,19 @@ void CNetServer::Update()
 	}
 }
 
+void CNetServer::EndFlushBatch()
+{
+	m_FlushBatch = false;
+	for(int ClientId = 0; ClientId < MaxClients(); ClientId++)
+	{
+		if(!m_aFlushPending[ClientId])
+			continue;
+		m_aFlushPending[ClientId] = false;
+		if(m_aSlots[ClientId].m_Connection.State() == CNetConnection::EState::ONLINE)
+			m_aSlots[ClientId].m_Connection.Flush();
+	}
+}
+
 SECURITY_TOKEN CNetServer::GetGlobalToken()
 {
 	static const NETADDR NULL_ADDR = {0};
@@ -719,7 +732,12 @@ int CNetServer::Send(CNetChunk *pChunk)
 		if(m_aSlots[pChunk->m_ClientId].m_Connection.QueueChunk(Flags, pChunk->m_DataSize, pChunk->m_pData) == 0)
 		{
 			if(pChunk->m_Flags & NETSENDFLAG_FLUSH)
-				m_aSlots[pChunk->m_ClientId].m_Connection.Flush();
+			{
+				if(m_FlushBatch)
+					m_aFlushPending[pChunk->m_ClientId] = true;
+				else
+					m_aSlots[pChunk->m_ClientId].m_Connection.Flush();
+			}
 		}
 	}
 	return 0;


### PR DESCRIPTION
Less network traffic, less CPU usage in server and client.

Written entirely by Fable 5 with me prompting. I have manually reviewed the code, and another Claude Code session did so as well.
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions
