### PR TITLE
server: Search snapshot storage starting from the newest snapshot

### DIFF
--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -702,7 +702,9 @@ void CSnapshotStorage::Add(int Tick, int64_t Tagtime, size_t DataSize, const voi
 
 int CSnapshotStorage::Get(int Tick, int64_t *pTagtime, const CSnapshot **ppData, const CSnapshot **ppAltData) const
 {
-	CHolder *pHolder = m_pFirst;
+	// the list is sorted by tick and the queried tick is usually one of the
+	// most recently added ones, so search backwards starting at the newest
+	CHolder *pHolder = m_pLast;
 
 	while(pHolder)
 	{
@@ -716,8 +718,10 @@ int CSnapshotStorage::Get(int Tick, int64_t *pTagtime, const CSnapshot **ppData,
 				*ppAltData = pHolder->m_pAltSnap;
 			return pHolder->m_SnapSize;
 		}
+		if(pHolder->m_Tick < Tick)
+			return -1; // all remaining snapshots are even older
 
-		pHolder = pHolder->m_pNext;
+		pHolder = pHolder->m_pPrev;
 	}
 
 	return -1;

--- a/src/test/snapshot_test.cpp
+++ b/src/test/snapshot_test.cpp
@@ -69,3 +69,37 @@ TEST(Snapshot, CrcOverflow)
 	Builder.Finish(&Buffer);
 	ASSERT_EQ(Buffer.AsSnapshot()->Crc(), 1);
 }
+
+TEST(Snapshot, StorageGet)
+{
+	// CSnapshotStorage::Get searches backwards from the newest holder and
+	// stops as soon as it passes a tick older than the requested one. That
+	// early return is only correct because all callers Add ticks in strictly
+	// increasing order, keeping the list sorted by tick. This test inserts
+	// monotonically and checks that lookups respect that invariant.
+	CSnapshotStorage Storage;
+
+	// distinct sizes and tag times so we can tell the holders apart
+	const char aData[8] = {0};
+	Storage.Add(10, 1000, 1, aData, 0, nullptr);
+	Storage.Add(20, 2000, 2, aData, 0, nullptr);
+	Storage.Add(30, 3000, 3, aData, 0, nullptr);
+	Storage.Add(40, 4000, 4, aData, 0, nullptr);
+
+	int64_t Tagtime = -1;
+
+	// newest, oldest and a middle tick all resolve to their own holder
+	EXPECT_EQ(Storage.Get(40, &Tagtime, nullptr, nullptr), 4);
+	EXPECT_EQ(Tagtime, 4000);
+	EXPECT_EQ(Storage.Get(10, &Tagtime, nullptr, nullptr), 1);
+	EXPECT_EQ(Tagtime, 1000);
+	EXPECT_EQ(Storage.Get(30, &Tagtime, nullptr, nullptr), 3);
+	EXPECT_EQ(Tagtime, 3000);
+
+	// newer than the newest: early return on the very first holder
+	EXPECT_EQ(Storage.Get(50, nullptr, nullptr, nullptr), -1);
+	// older than the oldest: search walks off the front of the list
+	EXPECT_EQ(Storage.Get(5, nullptr, nullptr, nullptr), -1);
+	// gap between two stored ticks: early return before reaching the oldest
+	EXPECT_EQ(Storage.Get(25, nullptr, nullptr, nullptr), -1);
+}


### PR DESCRIPTION
We usually need newest snapshots, so it's more efficient.

Fable wrote this PR, I reviewed it.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5 and Opus 4.8)