### PR TITLE
server: Purge acked snapshots from server snapshot storage

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1062,8 +1062,12 @@ void CServer::DoSnapshot()
 			int Crc = Data.AsSnapshot()->Crc();
 
 			// remove old snapshots
-			// keep 3 seconds worth of snapshots
-			m_aClients[i].m_Snapshots.PurgeUntil(m_CurrentGameTick - TickSpeed() * 3);
+			// only the last acked snapshot is still needed as delta base,
+			// keep at most 3 seconds worth for clients that aren't acking.
+			// m_LastAckedSnapshot is -1 before the first ack: the max then falls
+			// back to the 3 second cap, so we keep the old age-based behavior until
+			// the client acks.
+			m_aClients[i].m_Snapshots.PurgeUntil(std::max(m_CurrentGameTick - TickSpeed() * 3, m_aClients[i].m_LastAckedSnapshot));
 
 			// save the snapshot
 			m_aClients[i].m_Snapshots.Add(m_CurrentGameTick, time_get(), SnapshotSize, Data.AsSnapshot(), 0, nullptr);


### PR DESCRIPTION
Fable wrote this PR, I reviewed it.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5 and Opus 4.8)