### PR TITLE
Fix inactive envelope editor region background clipping

### DIFF
--- a/src/game/editor/envelope_editor.cpp
+++ b/src/game/editor/envelope_editor.cpp
@@ -705,13 +705,14 @@ void CEnvelopeEditor::Render(CUIRect View)
 		CUIRect InactiveRegionLeft{
 			View.x,
 			View.y,
-			std::max(0.0f, EnvelopeToScreenX(View, 0.0f) - View.x),
+			std::clamp(EnvelopeToScreenX(View, 0.0f) - View.x, 0.0f, View.w),
 			View.h,
 		};
+		const float EndX = EnvelopeToScreenX(View, pEnvelope->EndTime());
 		CUIRect InactiveRegionRight{
-			EnvelopeToScreenX(View, pEnvelope->EndTime()),
+			std::max(View.x, EndX),
 			View.y,
-			std::max(0.0f, View.x + View.w - EnvelopeToScreenX(View, pEnvelope->EndTime())),
+			std::clamp(View.x + View.w - EndX, 0.0f, View.w),
 			View.h,
 		};
 		InactiveRegionLeft.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.5f), IGraphics::CORNER_NONE, 0.0f);


### PR DESCRIPTION
Before: 
<img src="https://github.com/user-attachments/assets/c2054297-e47d-410d-95f3-8f3c427a6b67" />


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
