### PR TITLE
Fix rescue blocking team from finishing when used before start line

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2515,11 +2515,13 @@ void CCharacter::Rescue()
 
 		m_LastRescue = Server()->Tick();
 		int StartTime = m_StartTime;
+		ERaceState DDRaceState = m_DDRaceState;
 		m_RescueTee[GetPlayer()->m_RescueMode].Load(this);
 		// Don't load these from saved tee:
 		m_Core.m_Vel = vec2(0, 0);
 		m_Core.m_HookState = HOOK_IDLE;
 		m_StartTime = StartTime;
+		m_DDRaceState = DDRaceState;
 		m_SavedInput.m_Direction = 0;
 		m_SavedInput.m_Jump = 0;
 		// simulate releasing the fire button


### PR DESCRIPTION
I found the bug that leads to issue #9254: the problem is that when playing in a team, and one tee resets to before the start line using `/r`, the tee's racing state gets bugged which blocks the entire team from finishing the map in the end.

I noticed that when `Rescue()` loads the rescueTee snapshot it overwrites the characters's `m_DDRaceState`. This doesnt seem to be a problem when you are playing solo, because re-crossing the start line works as intended.

But [as def- suspected](https://github.com/ddnet/ddnet/issues/9254#issuecomment-2480561462) this logic leads to an invalid state when playing as a team, as `m_DDRaceState` can be reset to NONE on rescue and re-crossing the start line doesnt set it to STARTED, as this process is triggered only once for the entire team, when the first tee crosses the start line.

In this PR i provide a very simple fix, which prevents the invalid state when playing in teams. However, it does slightly change the behavior for solo: when using `/r` to reset before the start line the character remains in the STARTED state (originally would have reset to NONE), but regardless once crossing the start line it correctly resets. We _could_ add an extra condition that only applies the fix when playing in a team, but i chose to keep it simple for now. Happy for any feedback, not sure if this is the optimal way to fix it.

Here is a [Video](https://github.com/user-attachments/assets/2a4cf70a-2d55-43c5-a925-9200981d419c) with this fix applied. For reference videos before check out #9254.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
