### PR TITLE
Fix points of unused channels selected by envelope box selection

### DIFF
--- a/src/game/editor/envelope_editor.cpp
+++ b/src/game/editor/envelope_editor.cpp
@@ -1463,7 +1463,7 @@ void CEnvelopeEditor::Render(CUIRect View)
 
 				for(int i = 0; i < (int)pEnvelope->m_vPoints.size(); i++)
 				{
-					for(int c = 0; c < CEnvPoint::MAX_CHANNELS; c++)
+					for(int c = 0; c < pEnvelope->GetChannels(); c++)
 					{
 						if(!(State.m_ActiveChannels & (1 << c)))
 							continue;


### PR DESCRIPTION
When using the box selection operation in the envelope editor to select multiple envelope points/channels, all four channels were considered for selection without checking how many channels the envelope type has. When for example selecting an envelope point of a position envelope, the unused fourth channel was also added to the list of selected points and channels when the selection box covers the position of the invisible point.

## Checklist

- [X] Tested the change ingame (noticed it while working on #8584, which made the incorrect selection visible)
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions