### PR TITLE
Fix dummy input bugs related to cl_dummy_hammer and copy moves

### DIFF
--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -278,7 +278,11 @@ int CControls::SnapInput(int *pData)
 				pDummyInput->m_WantedWeapon = m_aInputData[g_Config.m_ClDummy].m_WantedWeapon;
 
 				if(!g_Config.m_ClDummyControl)
+				{
 					pDummyInput->m_Fire += m_aInputData[g_Config.m_ClDummy].m_Fire - m_aLastData[g_Config.m_ClDummy].m_Fire;
+					if((pDummyInput->m_Fire & 1) != (m_aInputData[g_Config.m_ClDummy].m_Fire & 1))
+						pDummyInput->m_Fire++;
+				}
 
 				pDummyInput->m_NextWeapon += m_aInputData[g_Config.m_ClDummy].m_NextWeapon - m_aLastData[g_Config.m_ClDummy].m_NextWeapon;
 				pDummyInput->m_PrevWeapon += m_aInputData[g_Config.m_ClDummy].m_PrevWeapon - m_aLastData[g_Config.m_ClDummy].m_PrevWeapon;

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -296,9 +296,7 @@ int CControls::SnapInput(int *pData)
 			CNetObj_PlayerInput *pDummyInput = &GameClient()->m_DummyInput;
 			pDummyInput->m_Jump = g_Config.m_ClDummyJump;
 
-			if(g_Config.m_ClDummyFire)
-				pDummyInput->m_Fire = g_Config.m_ClDummyFire;
-			else if((pDummyInput->m_Fire & 1) != 0)
+			if(g_Config.m_ClDummyFire != (pDummyInput->m_Fire & 1))
 				pDummyInput->m_Fire++;
 
 			pDummyInput->m_Hook = g_Config.m_ClDummyHook;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -544,7 +544,8 @@ int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
 	{
 		if(m_DummyFire != 0)
 		{
-			m_DummyInput.m_Fire = (m_HammerInput.m_Fire + 1) & ~1;
+			int Parity = m_DummyInput.m_Fire & 1;
+			m_DummyInput.m_Fire = ((m_HammerInput.m_Fire + 1) & ~1) | Parity;
 			m_DummyFire = 0;
 		}
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -548,8 +548,11 @@ void CGameClient::OnDummySwap()
 		}
 	}
 
-	m_Controls.m_aInputData[g_Config.m_ClDummy].m_NextWeapon = OldDummyInput.m_NextWeapon;
-	m_Controls.m_aInputData[g_Config.m_ClDummy].m_PrevWeapon = OldDummyInput.m_PrevWeapon;
+	if(!g_Config.m_ClDummyHammer)
+	{
+		m_Controls.m_aInputData[g_Config.m_ClDummy].m_NextWeapon = OldDummyInput.m_NextWeapon;
+		m_Controls.m_aInputData[g_Config.m_ClDummy].m_PrevWeapon = OldDummyInput.m_PrevWeapon;
+	}
 
 	m_Controls.m_aLastData[g_Config.m_ClDummy] = m_Controls.m_aInputData[g_Config.m_ClDummy];
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -523,9 +523,36 @@ void CGameClient::OnDummySwap()
 		m_Controls.ResetInput(PlayerOrDummy);
 		m_Controls.m_aInputData[PlayerOrDummy].m_Hook = 0;
 	}
-	const int PrevDummyFire = m_DummyInput.m_Fire;
+	CNetObj_PlayerInput OldDummyInput = g_Config.m_ClDummyHammer ? m_HammerInput : m_DummyInput;
+
 	m_DummyInput = m_Controls.m_aInputData[!g_Config.m_ClDummy];
-	m_Controls.m_aInputData[g_Config.m_ClDummy].m_Fire = PrevDummyFire;
+
+	m_Controls.m_aInputData[g_Config.m_ClDummy].m_Fire = OldDummyInput.m_Fire;
+
+	if((m_DummyInput.m_Fire & 1) == 0 && (OldDummyInput.m_Fire & 1) != 0)
+	{
+		m_Controls.m_aInputData[g_Config.m_ClDummy].m_Fire = OldDummyInput.m_Fire + 1;
+		OldDummyInput.m_Fire += 1;
+		if(g_Config.m_ClDummyHammer)
+		{
+			m_HammerInput.m_Fire = OldDummyInput.m_Fire;
+		}
+	}
+
+	if(g_Config.m_ClDummyCopyMoves && !g_Config.m_ClDummyHammer)
+	{
+		if((m_DummyInput.m_Fire & 1) != (m_Controls.m_aInputData[g_Config.m_ClDummy].m_Fire & 1))
+		{
+			m_Controls.m_aInputData[g_Config.m_ClDummy].m_Fire++;
+			OldDummyInput.m_Fire++;
+		}
+	}
+
+	m_Controls.m_aInputData[g_Config.m_ClDummy].m_NextWeapon = OldDummyInput.m_NextWeapon;
+	m_Controls.m_aInputData[g_Config.m_ClDummy].m_PrevWeapon = OldDummyInput.m_PrevWeapon;
+
+	m_Controls.m_aLastData[g_Config.m_ClDummy] = m_Controls.m_aInputData[g_Config.m_ClDummy];
+
 	m_IsDummySwapping = 1;
 }
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -576,11 +576,14 @@ int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
 			m_DummyFire = 0;
 		}
 
-		if(!Force && (!m_DummyInput.m_Direction && !m_DummyInput.m_Jump && !m_DummyInput.m_Hook))
+		bool FireChanged = (m_DummyInput.m_Fire != m_LastDummyFire);
+
+		if(!Force && (!m_DummyInput.m_Direction && !m_DummyInput.m_Jump && !m_DummyInput.m_Hook && !FireChanged))
 		{
 			return 0;
 		}
 
+		m_LastDummyFire = m_DummyInput.m_Fire;
 		mem_copy(pData, &m_DummyInput, sizeof(m_DummyInput));
 		return sizeof(m_DummyInput);
 	}
@@ -709,6 +712,7 @@ void CGameClient::OnReset()
 	m_DummyInput = {};
 	m_HammerInput = {};
 	m_DummyFire = 0;
+	m_LastDummyFire = 0;
 	m_ReceivedDDNetPlayer = false;
 	m_ReceivedDDNetPlayerFinishTimes = false;
 	m_ReceivedDDNetPlayerFinishTimesMillis = false;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -682,6 +682,7 @@ public:
 	CNetObj_PlayerInput m_DummyInput;
 	CNetObj_PlayerInput m_HammerInput;
 	unsigned int m_DummyFire;
+	int m_LastDummyFire;
 	bool m_ReceivedDDNetPlayer;
 	bool m_ReceivedDDNetPlayerFinishTimes;
 	bool m_ReceivedDDNetPlayerFinishTimesMillis;


### PR DESCRIPTION
> These bugs were constantly bothering me while playing, so I wanted to fix them to help not only myself but also other players who struggle with the same issues. This PR fixes two annoying bugs related to dummy inputs and copy moves.

## 1. Fix dummy fire parity desync when toggling cl_dummy_hammer
**Problem:** 
When using `copy moves`, if you hold the `cl_dummy_hammer` bind and press `+fire` on your main tee, the inputs get desynced. The dummy starts firing when you *release* the button, and stops when you *press* it (reversed parity).

**Cause:** 
When releasing the dummy hammer, `OnSnapInput` was hard-resetting `m_DummyInput.m_Fire` to `(m_HammerInput.m_Fire + 1) & ~1`. This incorrectly wiped the lowest bit (the parity bit) of the dummy's fire state.

**Fix:** 
Extract and preserve the parity bit of `m_DummyInput.m_Fire` before resetting the counter, and apply it back to prevent the desync.

[Without fix](https://github.com/user-attachments/assets/90a7b69f-8f7f-4c0f-a79a-883e29cb4b73)
[With fix](https://github.com/user-attachments/assets/6b901715-239d-428f-a91a-60273d9148b5)

## 2. Fix phantom fire and swap delays in dummy copy moves
**Problem:** 
When `copy moves` is enabled, if you press `+fire` and do a dummy swap, the tee you swapped from makes a phantom hit, which loops infinitely on subsequent swaps.

**Cause:** 
During `OnDummySwap()`, `m_aInputData` is updated, but `m_aLastData` was completely left behind for the new active tee. On the very next tick, `CControls::OnUpdate()` calculates `m_aInputData` - `m_aLastData` and applies a massive "ghost" delta to the dummy's fire and weapon inputs, causing the phantom hits.

**Fix:** 
We now fully synchronize `m_aLastData` for the new active tee to `OldDummyInput`. This zeroes out any ghost deltas on the first tick. Furthermore, because `m_aLastData` now perfectly reflects what the tee was just doing as a dummy, the `Send` flag is evaluated correctly, ensuring that if the new active tee's movement changes, it updates the server instantly with zero delay.

[Without fix](https://github.com/user-attachments/assets/cec4565b-3d4a-425f-9163-f4a31f7d64ec)
[With fix](https://github.com/user-attachments/assets/029585fb-632d-45c2-94f9-74160738cde8)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

> AI helped me find the root cause of the synchronization bugs in the game client code and suggested the C++ fixes, which I tested and verified ingame.
