### PR TITLE
base: str_next_token: Ignore invalid buffer sizes

### DIFF
--- a/src/base/str.cpp
+++ b/src/base/str.cpp
@@ -479,7 +479,7 @@ const char *str_find(const char *haystack, const char *needle)
 	return nullptr;
 }
 
-static const char *str_token_get(const char *str, const char *delim, int *length)
+static const char *str_token_get(const char *str, const char *delim, size_t *length)
 {
 	size_t len = strspn(str, delim);
 	if(len > 1)
@@ -493,11 +493,13 @@ static const char *str_token_get(const char *str, const char *delim, int *length
 	return str;
 }
 
-const char *str_next_token(const char *str, const char *delim, char *buffer, int buffer_size)
+const char *str_next_token(const char *str, const char *delim, char *buffer, size_t buffer_size)
 {
-	int len = 0;
+	dbg_assert(buffer_size > 0, "buffer size 0");
+
+	size_t len = 0;
 	const char *tok = str_token_get(str, delim, &len);
-	if(len < 0 || tok == nullptr)
+	if(tok == nullptr)
 	{
 		buffer[0] = '\0';
 		return nullptr;
@@ -513,7 +515,7 @@ const char *str_next_token(const char *str, const char *delim, char *buffer, int
 int str_in_list(const char *list, const char *delim, const char *needle)
 {
 	const char *tok = list;
-	int len = 0, notfound = 1, needlelen = str_length(needle);
+	size_t len = 0, notfound = 1, needlelen = str_length(needle);
 
 	while(notfound && (tok = str_token_get(tok, delim, &len)))
 	{

--- a/src/base/str.h
+++ b/src/base/str.h
@@ -516,7 +516,7 @@ const char *str_find(const char *haystack, const char *needle);
  *
  * @remark The token is always null-terminated.
  */
-const char *str_next_token(const char *str, const char *delim, char *buffer, int buffer_size);
+const char *str_next_token(const char *str, const char *delim, char *buffer, size_t buffer_size);
 
 /**
  * Checks if needle is in list delimited by delim.


### PR DESCRIPTION
We don't want negative lengths in `mem_copy`.
Claude (Opus 4.8) told me about the issue, I implemented the fix.
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions