### PR TITLE
client: Only create demo snapshot when necessary

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -84,6 +84,7 @@
 #undef main
 #endif
 
+#include <algorithm>
 #include <chrono>
 #include <limits>
 #include <stack>
@@ -2222,26 +2223,31 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 					{
 						GameClient()->ProcessDemoSnapshot(TmpBuffer3.AsSnapshot());
 
-						CSnapshotBuffer SnapSeven;
-						int DemoSnapSize = SnapSize;
-						if(IsSixup())
+						auto &DemoRecordersRef = DemoRecorders();
+						const bool AnyRecording = std::any_of(std::begin(DemoRecordersRef), std::end(DemoRecordersRef), [](const CDemoRecorder &DemoRecorder) { return DemoRecorder.IsRecording(); });
+						if(AnyRecording)
 						{
-							DemoSnapSize = GameClient()->OnDemoRecSnap7(TmpBuffer3.AsSnapshot(), &SnapSeven, Conn);
-							if(DemoSnapSize < 0)
+							CSnapshotBuffer SnapSeven;
+							int DemoSnapSize = SnapSize;
+							if(IsSixup())
 							{
-								dbg_msg("sixup", "demo snapshot failed. error=%d", DemoSnapSize);
-							}
-						}
-
-						if(DemoSnapSize >= 0)
-						{
-							// add snapshot to demo
-							for(auto &DemoRecorder : DemoRecorders())
-							{
-								if(DemoRecorder.IsRecording())
+								DemoSnapSize = GameClient()->OnDemoRecSnap7(TmpBuffer3.AsSnapshot(), &SnapSeven, Conn);
+								if(DemoSnapSize < 0)
 								{
-									// write snapshot
-									DemoRecorder.RecordSnapshot(GameTick, IsSixup() ? SnapSeven.AsSnapshot() : TmpBuffer3.AsSnapshot(), DemoSnapSize);
+									dbg_msg("sixup", "demo snapshot failed. error=%d", DemoSnapSize);
+								}
+							}
+
+							if(DemoSnapSize >= 0)
+							{
+								// add snapshot to demo
+								for(auto &DemoRecorder : DemoRecorders())
+								{
+									if(DemoRecorder.IsRecording())
+									{
+										// write snapshot
+										DemoRecorder.RecordSnapshot(GameTick, IsSixup() ? SnapSeven.AsSnapshot() : TmpBuffer3.AsSnapshot(), DemoSnapSize);
+									}
 								}
 							}
 						}


### PR DESCRIPTION
Check diff with `-w`.
Claude (Opus 4.8) wrote the code.
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions