### PR TITLE
Add Aim-relative Joystick and relative direct input

### DIFF
--- a/src/game/client/components/menus_ingame_touch_controls.cpp
+++ b/src/game/client/components/menus_ingame_touch_controls.cpp
@@ -41,6 +41,7 @@ const CMenusIngameTouchControls::CBehaviorFactoryEditor CMenusIngameTouchControl
 	{CTouchControls::CUseActionTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CUseActionTouchButtonBehavior>(); }},
 	{CTouchControls::CJoystickActionTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CJoystickActionTouchButtonBehavior>(); }},
 	{CTouchControls::CJoystickAimTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CJoystickAimTouchButtonBehavior>(); }},
+	{CTouchControls::CJoystickAimRelativeTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CJoystickAimRelativeTouchButtonBehavior>(); }},
 	{CTouchControls::CJoystickFireTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CJoystickFireTouchButtonBehavior>(); }},
 	{CTouchControls::CJoystickHookTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CJoystickHookTouchButtonBehavior>(); }}};
 
@@ -944,7 +945,14 @@ void CMenusIngameTouchControls::RenderConfigSettings(CUIRect MainView)
 	Row.VSplitMid(&Label, &Button);
 	Ui()->DoLabel(&Label, Localize("Direct touch input while ingame"), FONTSIZE, TEXTALIGN_ML);
 
-	const char *apIngameTouchModes[(int)CTouchControls::EDirectTouchIngameMode::NUM_STATES] = {Localize("Disabled", "Direct touch input"), Localize("Active action", "Direct touch input"), Localize("Aim", "Direct touch input"), Localize("Fire", "Direct touch input"), Localize("Hook", "Direct touch input")};
+	const char *apIngameTouchModes[(int)CTouchControls::EDirectTouchIngameMode::NUM_STATES] = {
+		Localize("Disabled", "Direct touch input"),
+		Localize("Active action", "Direct touch input"),
+		Localize("Aim", "Direct touch input"),
+		Localize("Relative aim", "Direct touch input"),
+		Localize("Fire", "Direct touch input"),
+		Localize("Hook", "Direct touch input"),
+	};
 	const CTouchControls::EDirectTouchIngameMode OldDirectTouchIngame = GameClient()->m_TouchControls.DirectTouchIngame();
 	static CUi::SDropDownState s_DirectTouchIngameDropDownState;
 	static CScrollRegion s_DirectTouchIngameDropDownScrollRegion;
@@ -1539,7 +1547,7 @@ const char **CMenusIngameTouchControls::VisibilityNames() const
 
 const char **CMenusIngameTouchControls::PredefinedNames() const
 {
-	static const char *s_apPredefined[10];
+	static const char *s_apPredefined[11];
 	s_apPredefined[0] = Localize("Ingame Menu", "Predefined touch button behaviors");
 	s_apPredefined[1] = Localize("Extra Menu", "Predefined touch button behaviors");
 	s_apPredefined[2] = Localize("Emoticon", "Predefined touch button behaviors");
@@ -1548,8 +1556,9 @@ const char **CMenusIngameTouchControls::PredefinedNames() const
 	s_apPredefined[5] = Localize("Use Action", "Predefined touch button behaviors");
 	s_apPredefined[6] = Localize("Joystick Action", "Predefined touch button behaviors");
 	s_apPredefined[7] = Localize("Joystick Aim", "Predefined touch button behaviors");
-	s_apPredefined[8] = Localize("Joystick Fire", "Predefined touch button behaviors");
-	s_apPredefined[9] = Localize("Joystick Hook", "Predefined touch button behaviors");
+	s_apPredefined[8] = Localize("Joystick Relative Aim", "Predefined touch button behaviors");
+	s_apPredefined[9] = Localize("Joystick Fire", "Predefined touch button behaviors");
+	s_apPredefined[10] = Localize("Joystick Hook", "Predefined touch button behaviors");
 	static_assert(std::size(s_apPredefined) == std::size(BEHAVIOR_FACTORIES_EDITOR), "Insufficient predefined names");
 	return s_apPredefined;
 }
@@ -1578,11 +1587,12 @@ const char *CMenusIngameTouchControls::HelpMessageForPredefinedType(EPredefinedT
 	case EPredefinedType::USE_ACTION: return Localize("Uses the active action with the current aiming position."); break;
 	case EPredefinedType::JOYSTICK_ACTION: return Localize("Virtual joystick which uses the active action."); break;
 	case EPredefinedType::JOYSTICK_AIM: return Localize("Virtual joystick which only aims without using an action."); break;
+	case EPredefinedType::JOYSTICK_AIM_RELATIVE: return Localize("Virtual joystick which only aims and moves the mouse pointer relatively."); break;
 	case EPredefinedType::JOYSTICK_FIRE: return Localize("Virtual joystick which always uses fire."); break;
 	case EPredefinedType::JOYSTICK_HOOK: return Localize("Virtual joystick which always uses hook."); break;
 	default: dbg_assert_failed("Unknown behavior %d", (int)m_PredefinedBehaviorType);
 	}
-	static_assert((int)EPredefinedType::NUM_PREDEFINEDTYPES == 10, "Insufficient help messages");
+	static_assert((int)EPredefinedType::NUM_PREDEFINEDTYPES == 11, "Insufficient help messages");
 }
 
 const char *CMenusIngameTouchControls::HelpMessageForVisibilityType(CTouchControls::EButtonVisibility Type) const

--- a/src/game/client/components/menus_ingame_touch_controls.h
+++ b/src/game/client/components/menus_ingame_touch_controls.h
@@ -28,6 +28,7 @@ public:
 		USE_ACTION,
 		JOYSTICK_ACTION,
 		JOYSTICK_AIM,
+		JOYSTICK_AIM_RELATIVE,
 		JOYSTICK_FIRE,
 		JOYSTICK_HOOK,
 		NUM_PREDEFINEDTYPES
@@ -182,7 +183,7 @@ public:
 		std::function<std::unique_ptr<CTouchControls::CPredefinedTouchButtonBehavior>()> m_Factory;
 	};
 
-	static const CBehaviorFactoryEditor BEHAVIOR_FACTORIES_EDITOR[10];
+	static const CBehaviorFactoryEditor BEHAVIOR_FACTORIES_EDITOR[11];
 };
 
 #endif

--- a/src/game/client/components/touch_controls.cpp
+++ b/src/game/client/components/touch_controls.cpp
@@ -35,7 +35,6 @@
 using namespace std::chrono_literals;
 
 // TODO: Add combined weapon picker button that shows all currently available weapons
-// TODO: Add "joystick-aim-relative", a virtual joystick that moves the mouse pointer relatively. And add "aim-relative" ingame direct touch input.
 // TODO: Add "choice" predefined behavior which shows a selection popup for 2 or more other behaviors?
 // TODO: Support changing labels of menu buttons (or support overriding label for all predefined button behaviors)?
 
@@ -615,14 +614,24 @@ void CTouchControls::CJoystickTouchButtonBehavior::OnDeactivate(bool ByFinger)
 void CTouchControls::CJoystickTouchButtonBehavior::OnUpdate()
 {
 	CControls &Controls = m_pTouchControls->GameClient()->m_Controls;
+	const float Zoom = m_pTouchControls->GameClient()->m_Snap.m_SpecInfo.m_Active ? m_pTouchControls->GameClient()->m_Camera.m_Zoom : 1.0f;
 	if(m_pTouchControls->GameClient()->m_Snap.m_SpecInfo.m_Active)
 	{
 		vec2 WorldScreenSize;
-		m_pTouchControls->Graphics()->CalcScreenParams(m_pTouchControls->Graphics()->ScreenAspect(), m_pTouchControls->GameClient()->m_Camera.m_Zoom, &WorldScreenSize.x, &WorldScreenSize.y);
+		m_pTouchControls->Graphics()->CalcScreenParams(m_pTouchControls->Graphics()->ScreenAspect(), Zoom, &WorldScreenSize.x, &WorldScreenSize.y);
 		Controls.m_aMousePos[g_Config.m_ClDummy] += -m_AccumulatedDelta * WorldScreenSize;
 		Controls.m_aMouseInputType[g_Config.m_ClDummy] = CControls::EMouseInputType::RELATIVE;
 		Controls.m_aMousePos[g_Config.m_ClDummy].x = std::clamp(Controls.m_aMousePos[g_Config.m_ClDummy].x, -201.0f * 32, (m_pTouchControls->Collision()->GetWidth() + 201.0f) * 32.0f);
 		Controls.m_aMousePos[g_Config.m_ClDummy].y = std::clamp(Controls.m_aMousePos[g_Config.m_ClDummy].y, -201.0f * 32, (m_pTouchControls->Collision()->GetHeight() + 201.0f) * 32.0f);
+		m_AccumulatedDelta = vec2(0.0f, 0.0f);
+	}
+	else if(IsRelative())
+	{
+		vec2 WorldScreenSize;
+		m_pTouchControls->Graphics()->CalcScreenParams(m_pTouchControls->Graphics()->ScreenAspect(), Zoom, &WorldScreenSize.x, &WorldScreenSize.y);
+		Controls.m_aMousePos[g_Config.m_ClDummy] += m_AccumulatedDelta * WorldScreenSize;
+		Controls.m_aMouseInputType[g_Config.m_ClDummy] = CControls::EMouseInputType::RELATIVE;
+		Controls.ClampMousePos();
 		m_AccumulatedDelta = vec2(0.0f, 0.0f);
 	}
 	else
@@ -646,6 +655,12 @@ int CTouchControls::CJoystickActionTouchButtonBehavior::SelectedAction() const
 
 // Joystick that only aims.
 int CTouchControls::CJoystickAimTouchButtonBehavior::SelectedAction() const
+{
+	return ACTION_AIM;
+}
+
+// Joystick that only aims and moves the mouse pointer relatively.
+int CTouchControls::CJoystickAimRelativeTouchButtonBehavior::SelectedAction() const
 {
 	return ACTION_AIM;
 }
@@ -962,6 +977,7 @@ int CTouchControls::NextDirectTouchAction() const
 		case EDirectTouchIngameMode::ACTION:
 			return m_ActionSelected;
 		case EDirectTouchIngameMode::AIM:
+		case EDirectTouchIngameMode::AIM_RELATIVE:
 			return ACTION_AIM;
 		case EDirectTouchIngameMode::FIRE:
 			return ACTION_FIRE;
@@ -1158,6 +1174,12 @@ void CTouchControls::UpdateButtonsGame(const std::vector<IInput::CTouchFingerSta
 			Controls.m_aMouseInputType[g_Config.m_ClDummy] = CControls::EMouseInputType::RELATIVE;
 			Controls.m_aMousePos[g_Config.m_ClDummy].x = std::clamp(Controls.m_aMousePos[g_Config.m_ClDummy].x, -201.0f * 32, (Collision()->GetWidth() + 201.0f) * 32.0f);
 			Controls.m_aMousePos[g_Config.m_ClDummy].y = std::clamp(Controls.m_aMousePos[g_Config.m_ClDummy].y, -201.0f * 32, (Collision()->GetHeight() + 201.0f) * 32.0f);
+		}
+		else if(m_DirectTouchIngame == EDirectTouchIngameMode::AIM_RELATIVE)
+		{
+			Controls.m_aMousePos[g_Config.m_ClDummy] += DirectFingerState.m_Delta * WorldScreenSize;
+			Controls.m_aMouseInputType[g_Config.m_ClDummy] = CControls::EMouseInputType::RELATIVE;
+			Controls.ClampMousePos();
 		}
 		else
 		{
@@ -1555,6 +1577,7 @@ std::unique_ptr<CTouchControls::CPredefinedTouchButtonBehavior> CTouchControls::
 		{CUseActionTouchButtonBehavior::BEHAVIOR_ID, [](const json_value *pBehavior) { return std::make_unique<CUseActionTouchButtonBehavior>(); }},
 		{CJoystickActionTouchButtonBehavior::BEHAVIOR_ID, [](const json_value *pBehavior) { return std::make_unique<CJoystickActionTouchButtonBehavior>(); }},
 		{CJoystickAimTouchButtonBehavior::BEHAVIOR_ID, [](const json_value *pBehavior) { return std::make_unique<CJoystickAimTouchButtonBehavior>(); }},
+		{CJoystickAimRelativeTouchButtonBehavior::BEHAVIOR_ID, [](const json_value *pBehavior) { return std::make_unique<CJoystickAimRelativeTouchButtonBehavior>(); }},
 		{CJoystickFireTouchButtonBehavior::BEHAVIOR_ID, [](const json_value *pBehavior) { return std::make_unique<CJoystickFireTouchButtonBehavior>(); }},
 		{CJoystickHookTouchButtonBehavior::BEHAVIOR_ID, [](const json_value *pBehavior) { return std::make_unique<CJoystickHookTouchButtonBehavior>(); }}};
 	for(const CBehaviorFactory &BehaviorFactory : BEHAVIOR_FACTORIES)

--- a/src/game/client/components/touch_controls.h
+++ b/src/game/client/components/touch_controls.h
@@ -31,6 +31,7 @@ public:
 		DISABLED,
 		ACTION,
 		AIM,
+		AIM_RELATIVE,
 		FIRE,
 		HOOK,
 		NUM_STATES
@@ -143,7 +144,7 @@ public:
 	};
 
 private:
-	static constexpr const char *const DIRECT_TOUCH_INGAME_MODE_NAMES[(int)EDirectTouchIngameMode::NUM_STATES] = {"disabled", "action", "aim", "fire", "hook"};
+	static constexpr const char *const DIRECT_TOUCH_INGAME_MODE_NAMES[(int)EDirectTouchIngameMode::NUM_STATES] = {"disabled", "action", "aim", "aim-relative", "fire", "hook"};
 	static constexpr const char *const DIRECT_TOUCH_SPECTATE_MODE_NAMES[(int)EDirectTouchSpectateMode::NUM_STATES] = {"disabled", "aim"};
 	static constexpr const char *const SHAPE_NAMES[(int)EButtonShape::NUM_SHAPES] = {"rect", "circle"};
 
@@ -368,6 +369,7 @@ public:
 		void OnUpdate() override;
 		int ActiveAction() const { return m_ActiveAction; }
 		virtual int SelectedAction() const = 0;
+		virtual bool IsRelative() const { return false; }
 
 	private:
 		int m_ActiveAction = NUM_ACTIONS;
@@ -393,6 +395,18 @@ public:
 			CJoystickTouchButtonBehavior(BEHAVIOR_ID) {}
 
 		int SelectedAction() const override;
+	};
+
+	class CJoystickAimRelativeTouchButtonBehavior : public CJoystickTouchButtonBehavior
+	{
+	public:
+		static constexpr const char *const BEHAVIOR_ID = "joystick-aim-relative";
+
+		CJoystickAimRelativeTouchButtonBehavior() :
+			CJoystickTouchButtonBehavior(BEHAVIOR_ID) {}
+
+		int SelectedAction() const override;
+		bool IsRelative() const override { return true; }
 	};
 
 	class CJoystickFireTouchButtonBehavior : public CJoystickTouchButtonBehavior


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
This PR adds Aim-relative joystick and relative direct in-game input. Please review this PR. I will fix any bugs you find.
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
