### PR TITLE
Make `time_freq` constexpr

### DIFF
--- a/src/base/time.cpp
+++ b/src/base/time.cpp
@@ -44,12 +44,6 @@ int64_t time_get()
 	return last;
 }
 
-int64_t time_freq()
-{
-	using namespace std::chrono_literals;
-	return std::chrono::nanoseconds(1s).count();
-}
-
 int64_t time_timestamp()
 {
 	return time(nullptr);

--- a/src/base/time.h
+++ b/src/base/time.h
@@ -75,7 +75,11 @@ int64_t time_get();
  *
  * @return The frequency of the high resolution timer.
  */
-int64_t time_freq();
+constexpr int64_t time_freq()
+{
+	using namespace std::chrono_literals;
+	return std::chrono::nanoseconds(1s).count();
+}
 
 /**
  * Retrieves the current time as a UNIX timestamp.


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
Despite just returning a constexpr value, `time_freq` is not a constexpr function, nor is it automatically inlined. This PR just makes it constexpr

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
