### PR TITLE
Also check tests with clang-tidy in CI

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -81,6 +81,7 @@ jobs:
           -DANTIBOT=ON \
           -DAUTOUPDATE=ON \
           -DDISCORD=ON \
+          -DDOWNLOAD_GTEST=ON \
           -DMYSQL=ON \
           -DSTEAM=ON \
           -DUPNP=ON \
@@ -88,4 +89,4 @@ jobs:
           -DVULKAN=ON \
           -DWEBSOCKETS=ON \
           -Werror=dev ..
-        cmake --build . --config Debug --target everything -- -k 0
+        cmake --build . --config Debug --target everything testrunner -- -k 0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -834,6 +834,9 @@ if(NOT(GTEST_FOUND) AND DOWNLOAD_GTEST)
           # when MSVS adds new warnings.
           target_compile_options(${target} PRIVATE /w)
         endif()
+        # Do not apply clang-tidy to googletest targets.
+        set_property(TARGET ${target} PROPERTY C_CLANG_TIDY "")
+        set_property(TARGET ${target} PROPERTY CXX_CLANG_TIDY "")
       endforeach()
 
       set(GTEST_LIBRARIES gtest gmock)

--- a/src/base/mem.cpp
+++ b/src/base/mem.cpp
@@ -30,3 +30,16 @@ bool mem_has_null(const void *block, size_t size)
 	}
 	return false;
 }
+
+bool mem_is_null(const void *block, size_t size)
+{
+	const unsigned char *bytes = (const unsigned char *)block;
+	for(size_t i = 0; i < size; i++)
+	{
+		if(bytes[i] != 0)
+		{
+			return false;
+		}
+	}
+	return true;
+}

--- a/src/base/mem.h
+++ b/src/base/mem.h
@@ -75,7 +75,7 @@ inline void mem_zero(T *block, size_t size)
 int mem_comp(const void *a, const void *b, size_t size);
 
 /**
- * Checks whether a block of memory contains null bytes.
+ * Checks whether a block of memory contains any null bytes.
  *
  * @ingroup Memory
  *
@@ -85,5 +85,17 @@ int mem_comp(const void *a, const void *b, size_t size);
  * @return `true` if the block has a null byte, `false` otherwise.
  */
 bool mem_has_null(const void *block, size_t size);
+
+/**
+ * Checks whether a block of memory contains exclusively null bytes.
+ *
+ * @ingroup Memory
+ *
+ * @param block Pointer to the block to check for nulls.
+ * @param size Size of the block.
+ *
+ * @return `true` if the block is all null bytes, `false` otherwise.
+ */
+bool mem_is_null(const void *block, size_t size);
 
 #endif

--- a/src/test/aio_test.cpp
+++ b/src/test/aio_test.cpp
@@ -10,24 +10,24 @@
 
 static const int BUF_SIZE = 64 * 1024;
 
-class Async : public ::testing::Test
+class Async : public ::testing::Test // NOLINT(readability-identifier-naming)
 {
 protected:
 	ASYNCIO *m_pAio;
 	CTestInfo m_Info;
-	bool Delete;
+	bool m_Delete;
 
 	void SetUp() override
 	{
 		IOHANDLE File = io_open(m_Info.m_aFilename, IOFLAG_WRITE);
 		ASSERT_TRUE(File);
 		m_pAio = aio_new(File);
-		Delete = false;
+		m_Delete = false;
 	}
 
 	void TearDown() override
 	{
-		if(Delete)
+		if(m_Delete)
 		{
 			EXPECT_FALSE(fs_remove(m_Info.m_aFilename));
 		}
@@ -52,7 +52,7 @@ protected:
 
 		ASSERT_EQ(str_length(pOutput), Read);
 		ASSERT_TRUE(mem_comp(aBuf, pOutput, Read) == 0);
-		Delete = true;
+		m_Delete = true;
 	}
 };
 

--- a/src/test/compression_test.cpp
+++ b/src/test/compression_test.cpp
@@ -37,7 +37,7 @@ TEST(CVariableInt, UnpackInvalid)
 TEST(CVariableInt, PackBufferTooSmall)
 {
 	unsigned char aPacked[CVariableInt::MAX_BYTES_PACKED / 2]; // too small
-	EXPECT_EQ(CVariableInt::Pack(aPacked, 2147483647, sizeof(aPacked)), (const unsigned char *)0x0);
+	EXPECT_EQ(CVariableInt::Pack(aPacked, 2147483647, sizeof(aPacked)), nullptr);
 }
 
 TEST(CVariableInt, UnpackBufferTooSmall)
@@ -47,7 +47,7 @@ TEST(CVariableInt, UnpackBufferTooSmall)
 		Byte = 0xFF; // extended bits are set, but buffer ends too early
 
 	int UnusedResult;
-	EXPECT_EQ(CVariableInt::Unpack(aPacked, &UnusedResult, sizeof(aPacked)), (const unsigned char *)0x0);
+	EXPECT_EQ(CVariableInt::Unpack(aPacked, &UnusedResult, sizeof(aPacked)), nullptr);
 }
 
 TEST(CVariableInt, RoundtripCompressDecompress)

--- a/src/test/editor_test.cpp
+++ b/src/test/editor_test.cpp
@@ -2,9 +2,12 @@
 
 #include <gtest/gtest.h>
 
-bool is_letter(char c) { return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'); }
+static bool IsLetter(char c)
+{
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
 
-bool IsValidEditorTooltip(const char *pTooltip, char *pErrorMsg, int ErrorMsgSize)
+static bool IsValidEditorTooltip(const char *pTooltip, char *pErrorMsg, int ErrorMsgSize)
 {
 	pErrorMsg[0] = '\0';
 	char aHotkey[512];
@@ -28,7 +31,7 @@ bool IsValidEditorTooltip(const char *pTooltip, char *pErrorMsg, int ErrorMsgSiz
 			{
 				ExpectLowerCase = false;
 			}
-			else if(!is_letter(aHotkey[i - 1]))
+			else if(!IsLetter(aHotkey[i - 1]))
 			{
 				// the first character of a word should be uppercase
 				ExpectLowerCase = false;
@@ -75,7 +78,7 @@ bool IsValidEditorTooltip(const char *pTooltip, char *pErrorMsg, int ErrorMsgSiz
 	return true;
 }
 
-void AssertTooltip(const char *pTooltip)
+static void AssertTooltip(const char *pTooltip)
 {
 	char aError[512];
 	EXPECT_TRUE(IsValidEditorTooltip(pTooltip, aError, sizeof(aError))) << "Invalid tooltip: " << pTooltip << "\nError: " << aError;

--- a/src/test/gameworld_test.cpp
+++ b/src/test/gameworld_test.cpp
@@ -33,13 +33,14 @@ bool IsInterrupted()
 	return false;
 }
 
-std::vector<std::string> FakeQueue;
+#if defined(CONF_PLATFORM_ANDROID)
 std::vector<std::string> FetchAndroidServerCommandQueue()
 {
-	return FakeQueue;
+	return {};
 }
+#endif
 
-class CTestGameWorld : public ::testing::Test
+class GameWorld : public ::testing::Test // NOLINT(readability-identifier-naming)
 {
 public:
 	IGameServer *m_pGameServer = nullptr;
@@ -48,12 +49,12 @@ public:
 	CTestInfo m_TestInfo;
 	std::unique_ptr<IStorage> m_pStorage;
 
-	CGameContext *GameServer()
+	CGameContext *GameServer() // NOLINT(readability-make-member-function-const)
 	{
 		return (CGameContext *)m_pGameServer;
 	}
 
-	CTestGameWorld()
+	GameWorld()
 	{
 		CServer *pServer = CreateServer();
 		m_pServer = pServer;
@@ -126,7 +127,7 @@ public:
 		pServer->InitMaplist();
 	}
 
-	~CTestGameWorld() override
+	~GameWorld() override
 	{
 		m_pServer->m_Econ.Shutdown();
 		m_pServer->m_Fifo.Shutdown();
@@ -135,7 +136,7 @@ public:
 	}
 };
 
-TEST_F(CTestGameWorld, ClosestCharacter)
+TEST_F(GameWorld, ClosestCharacter)
 {
 	CNetObj_PlayerInput Input = {};
 	CCharacter *pChr1 = new(0) CCharacter(&GameServer()->m_World, Input);
@@ -150,7 +151,7 @@ TEST_F(CTestGameWorld, ClosestCharacter)
 	EXPECT_EQ(pClosest, pChr1);
 }
 
-TEST_F(CTestGameWorld, IntersectEntity)
+TEST_F(GameWorld, IntersectEntity)
 {
 	CNetObj_PlayerInput Input = {};
 	CCharacter *pChrLeft = new(0) CCharacter(&GameServer()->m_World, Input);
@@ -251,7 +252,7 @@ TEST_F(CTestGameWorld, IntersectEntity)
 	EXPECT_EQ(pIntersectedChar, pChrRight);
 }
 
-TEST_F(CTestGameWorld, BasicTick)
+TEST_F(GameWorld, BasicTick)
 {
 	int ClientId = 0;
 	bool Afk = true;
@@ -262,7 +263,7 @@ TEST_F(CTestGameWorld, BasicTick)
 	GameServer()->OnTick();
 }
 
-TEST_F(CTestGameWorld, CharacterEmote)
+TEST_F(GameWorld, CharacterEmote)
 {
 	int ClientId = 0;
 	bool Afk = true;

--- a/src/test/hash_test.cpp
+++ b/src/test/hash_test.cpp
@@ -11,42 +11,41 @@ static void ExpectSha256(SHA256_DIGEST Actual, const char *pWanted)
 	EXPECT_STREQ(aActual, pWanted);
 }
 
+constexpr static const char QUICK_BROWN_FOX[] = "The quick brown fox jumps over the lazy dog.";
+
 TEST(Hash, Sha256)
 {
 	// https://en.wikipedia.org/w/index.php?title=SHA-2&oldid=840187620#Test_vectors
 	ExpectSha256(sha256("", 0), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
-	SHA256_CTX ctxt;
+	SHA256_CTX Context;
 
-	sha256_init(&ctxt);
-	ExpectSha256(sha256_finish(&ctxt), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+	sha256_init(&Context);
+	ExpectSha256(sha256_finish(&Context), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 
 	// printf 'The quick brown fox jumps over the lazy dog.' | sha256sum
-	char QUICK_BROWN_FOX[] = "The quick brown fox jumps over the lazy dog.";
 	ExpectSha256(sha256(QUICK_BROWN_FOX, str_length(QUICK_BROWN_FOX)), "ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c");
 
-	sha256_init(&ctxt);
-	sha256_update(&ctxt, "The ", 4);
-	sha256_update(&ctxt, "quick ", 6);
-	sha256_update(&ctxt, "brown ", 6);
-	sha256_update(&ctxt, "fox ", 4);
-	sha256_update(&ctxt, "jumps ", 6);
-	sha256_update(&ctxt, "over ", 5);
-	sha256_update(&ctxt, "the ", 4);
-	sha256_update(&ctxt, "lazy ", 5);
-	sha256_update(&ctxt, "dog.", 4);
-	ExpectSha256(sha256_finish(&ctxt), "ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c");
+	sha256_init(&Context);
+	sha256_update(&Context, "The ", 4);
+	sha256_update(&Context, "quick ", 6);
+	sha256_update(&Context, "brown ", 6);
+	sha256_update(&Context, "fox ", 4);
+	sha256_update(&Context, "jumps ", 6);
+	sha256_update(&Context, "over ", 5);
+	sha256_update(&Context, "the ", 4);
+	sha256_update(&Context, "lazy ", 5);
+	sha256_update(&Context, "dog.", 4);
+	ExpectSha256(sha256_finish(&Context), "ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c");
 }
 
 TEST(Hash, Sha256ToStringSmallBuffer)
 {
-	char QUICK_BROWN_FOX[] = "The quick brown fox jumps over the lazy dog.";
 	ExpectSha256<1>(sha256(QUICK_BROWN_FOX, str_length(QUICK_BROWN_FOX)), "");
 	ExpectSha256<16 + 1>(sha256(QUICK_BROWN_FOX, str_length(QUICK_BROWN_FOX)), "ef537f25c895bfa7");
 }
 
 TEST(Hash, Sha256ToStringLargeBuffer)
 {
-	char QUICK_BROWN_FOX[] = "The quick brown fox jumps over the lazy dog.";
 	ExpectSha256<SHA256_MAXSTRSIZE + 64>(sha256(QUICK_BROWN_FOX, str_length(QUICK_BROWN_FOX)), "ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c");
 }
 
@@ -116,37 +115,34 @@ TEST(Hash, Md5)
 {
 	// https://en.wikipedia.org/w/index.php?title=MD5&oldid=889664074#MD5_hashes
 	ExpectMd5(md5("", 0), "d41d8cd98f00b204e9800998ecf8427e");
-	MD5_CTX ctxt;
+	MD5_CTX Context;
 
-	md5_init(&ctxt);
-	ExpectMd5(md5_finish(&ctxt), "d41d8cd98f00b204e9800998ecf8427e");
+	md5_init(&Context);
+	ExpectMd5(md5_finish(&Context), "d41d8cd98f00b204e9800998ecf8427e");
 
-	char QUICK_BROWN_FOX[] = "The quick brown fox jumps over the lazy dog.";
 	ExpectMd5(md5(QUICK_BROWN_FOX, str_length(QUICK_BROWN_FOX)), "e4d909c290d0fb1ca068ffaddf22cbd0");
 
-	md5_init(&ctxt);
-	md5_update(&ctxt, "The ", 4);
-	md5_update(&ctxt, "quick ", 6);
-	md5_update(&ctxt, "brown ", 6);
-	md5_update(&ctxt, "fox ", 4);
-	md5_update(&ctxt, "jumps ", 6);
-	md5_update(&ctxt, "over ", 5);
-	md5_update(&ctxt, "the ", 4);
-	md5_update(&ctxt, "lazy ", 5);
-	md5_update(&ctxt, "dog.", 4);
-	ExpectMd5(md5_finish(&ctxt), "e4d909c290d0fb1ca068ffaddf22cbd0");
+	md5_init(&Context);
+	md5_update(&Context, "The ", 4);
+	md5_update(&Context, "quick ", 6);
+	md5_update(&Context, "brown ", 6);
+	md5_update(&Context, "fox ", 4);
+	md5_update(&Context, "jumps ", 6);
+	md5_update(&Context, "over ", 5);
+	md5_update(&Context, "the ", 4);
+	md5_update(&Context, "lazy ", 5);
+	md5_update(&Context, "dog.", 4);
+	ExpectMd5(md5_finish(&Context), "e4d909c290d0fb1ca068ffaddf22cbd0");
 }
 
 TEST(Hash, Md5ToStringSmallBuffer)
 {
-	char QUICK_BROWN_FOX[] = "The quick brown fox jumps over the lazy dog.";
 	ExpectMd5<1>(md5(QUICK_BROWN_FOX, str_length(QUICK_BROWN_FOX)), "");
 	ExpectMd5<16 + 1>(md5(QUICK_BROWN_FOX, str_length(QUICK_BROWN_FOX)), "e4d909c290d0fb1c");
 }
 
 TEST(Hash, Md5ToStringLargeBuffer)
 {
-	char QUICK_BROWN_FOX[] = "The quick brown fox jumps over the lazy dog.";
 	ExpectMd5<MD5_MAXSTRSIZE + 64>(md5(QUICK_BROWN_FOX, str_length(QUICK_BROWN_FOX)), "e4d909c290d0fb1ca068ffaddf22cbd0");
 }
 

--- a/src/test/jobs_test.cpp
+++ b/src/test/jobs_test.cpp
@@ -12,7 +12,7 @@
 
 static const int TEST_NUM_THREADS = 4;
 
-class Jobs : public ::testing::Test
+class Jobs : public ::testing::Test // NOLINT(readability-identifier-naming)
 {
 protected:
 	CJobPool m_Pool;
@@ -59,11 +59,11 @@ TEST_F(Jobs, Simple)
 
 TEST_F(Jobs, Wait)
 {
-	SEMAPHORE sphore;
-	sphore_init(&sphore);
-	Add(std::make_shared<CJob>([&] { sphore_signal(&sphore); }));
-	sphore_wait(&sphore);
-	sphore_destroy(&sphore);
+	SEMAPHORE Sphore;
+	sphore_init(&Sphore);
+	Add(std::make_shared<CJob>([&] { sphore_signal(&Sphore); }));
+	sphore_wait(&Sphore);
+	sphore_destroy(&Sphore);
 }
 
 TEST_F(Jobs, AbortAbortable)
@@ -88,7 +88,7 @@ TEST_F(Jobs, AbortUnabortable)
 
 TEST_F(Jobs, LookupHost)
 {
-	static const char *HOST = "example.com";
+	static const char *const HOST = "example.com";
 	static const int NETTYPE = NETTYPE_ALL;
 	auto pJob = std::make_shared<CHostLookup>(HOST, NETTYPE);
 
@@ -112,7 +112,7 @@ TEST_F(Jobs, LookupHost)
 
 TEST_F(Jobs, LookupHostWebsocket)
 {
-	static const char *HOST = "ws://example.com";
+	static const char *const HOST = "ws://example.com";
 	static const int NETTYPE = NETTYPE_ALL;
 	auto pJob = std::make_shared<CHostLookup>(HOST, NETTYPE);
 
@@ -138,15 +138,15 @@ TEST_F(Jobs, Many)
 {
 	std::atomic<int> ThreadsRunning(0);
 	std::vector<std::shared_ptr<IJob>> vpJobs;
-	SEMAPHORE sphore;
-	sphore_init(&sphore);
+	SEMAPHORE Sphore;
+	sphore_init(&Sphore);
 	for(int i = 0; i < TEST_NUM_THREADS; i++)
 	{
 		std::shared_ptr<IJob> pJob = std::make_shared<CJob>([&] {
 			int Prev = ThreadsRunning.fetch_add(1);
 			if(Prev == TEST_NUM_THREADS - 1)
 			{
-				sphore_signal(&sphore);
+				sphore_signal(&Sphore);
 			}
 		});
 		EXPECT_EQ(pJob->State(), IJob::STATE_QUEUED);
@@ -156,8 +156,8 @@ TEST_F(Jobs, Many)
 	{
 		Add(pJob);
 	}
-	sphore_wait(&sphore);
-	sphore_destroy(&sphore);
+	sphore_wait(&Sphore);
+	sphore_destroy(&Sphore);
 	TearDown();
 	for(auto &pJob : vpJobs)
 	{

--- a/src/test/jsonwriter_test.cpp
+++ b/src/test/jsonwriter_test.cpp
@@ -12,7 +12,7 @@
 
 #include <limits>
 
-class JsonFileWriter
+class JsonFileWriter // NOLINT(readability-identifier-naming)
 {
 public:
 	CTestInfo m_Info;
@@ -59,7 +59,7 @@ public:
 	}
 };
 
-class JsonStringWriter
+class JsonStringWriter // NOLINT(readability-identifier-naming)
 {
 public:
 	CJsonStringWriter *m_pJson;
@@ -81,10 +81,10 @@ public:
 };
 
 template<typename T>
-class JsonWriters : public testing::Test
+class JsonWriters : public testing::Test // NOLINT(readability-identifier-naming)
 {
 public:
-	T Impl;
+	T m_Impl;
 };
 
 using JsonWriterTestFixures = ::testing::Types<JsonFileWriter, JsonStringWriter>;
@@ -92,32 +92,32 @@ TYPED_TEST_SUITE(JsonWriters, JsonWriterTestFixures);
 
 TYPED_TEST(JsonWriters, Empty)
 {
-	this->Impl.Expect("\n");
+	this->m_Impl.Expect("\n");
 }
 
 TYPED_TEST(JsonWriters, EmptyObject)
 {
-	this->Impl.m_pJson->BeginObject();
-	this->Impl.m_pJson->EndObject();
-	this->Impl.Expect("{\n}\n");
+	this->m_Impl.m_pJson->BeginObject();
+	this->m_Impl.m_pJson->EndObject();
+	this->m_Impl.Expect("{\n}\n");
 }
 
 TYPED_TEST(JsonWriters, EmptyArray)
 {
-	this->Impl.m_pJson->BeginArray();
-	this->Impl.m_pJson->EndArray();
-	this->Impl.Expect("[\n]\n");
+	this->m_Impl.m_pJson->BeginArray();
+	this->m_Impl.m_pJson->EndArray();
+	this->m_Impl.Expect("[\n]\n");
 }
 
 TYPED_TEST(JsonWriters, SpecialCharacters)
 {
-	this->Impl.m_pJson->BeginObject();
-	this->Impl.m_pJson->WriteAttribute("\x01\"'\r\n\t");
-	this->Impl.m_pJson->BeginArray();
-	this->Impl.m_pJson->WriteStrValue(" \"'abc\x01\n");
-	this->Impl.m_pJson->EndArray();
-	this->Impl.m_pJson->EndObject();
-	this->Impl.Expect(
+	this->m_Impl.m_pJson->BeginObject();
+	this->m_Impl.m_pJson->WriteAttribute("\x01\"'\r\n\t");
+	this->m_Impl.m_pJson->BeginArray();
+	this->m_Impl.m_pJson->WriteStrValue(" \"'abc\x01\n");
+	this->m_Impl.m_pJson->EndArray();
+	this->m_Impl.m_pJson->EndObject();
+	this->m_Impl.Expect(
 		"{\n"
 		"\t\"\\u0001\\\"'\\r\\n\\t\": [\n"
 		"\t\t\" \\\"'abc\\u0001\\n\"\n"
@@ -127,90 +127,90 @@ TYPED_TEST(JsonWriters, SpecialCharacters)
 
 TYPED_TEST(JsonWriters, HelloWorld)
 {
-	this->Impl.m_pJson->WriteStrValue("hello world");
-	this->Impl.Expect("\"hello world\"\n");
+	this->m_Impl.m_pJson->WriteStrValue("hello world");
+	this->m_Impl.Expect("\"hello world\"\n");
 }
 
 TYPED_TEST(JsonWriters, Unicode)
 {
-	this->Impl.m_pJson->WriteStrValue("Heizölrückstoßabdämpfung");
-	this->Impl.Expect("\"Heizölrückstoßabdämpfung\"\n");
+	this->m_Impl.m_pJson->WriteStrValue("Heizölrückstoßabdämpfung");
+	this->m_Impl.Expect("\"Heizölrückstoßabdämpfung\"\n");
 }
 
 TYPED_TEST(JsonWriters, True)
 {
-	this->Impl.m_pJson->WriteBoolValue(true);
-	this->Impl.Expect("true\n");
+	this->m_Impl.m_pJson->WriteBoolValue(true);
+	this->m_Impl.Expect("true\n");
 }
 
 TYPED_TEST(JsonWriters, False)
 {
-	this->Impl.m_pJson->WriteBoolValue(false);
-	this->Impl.Expect("false\n");
+	this->m_Impl.m_pJson->WriteBoolValue(false);
+	this->m_Impl.Expect("false\n");
 }
 
 TYPED_TEST(JsonWriters, Null)
 {
-	this->Impl.m_pJson->WriteNullValue();
-	this->Impl.Expect("null\n");
+	this->m_Impl.m_pJson->WriteNullValue();
+	this->m_Impl.Expect("null\n");
 }
 
 TYPED_TEST(JsonWriters, EmptyString)
 {
-	this->Impl.m_pJson->WriteStrValue("");
-	this->Impl.Expect("\"\"\n");
+	this->m_Impl.m_pJson->WriteStrValue("");
+	this->m_Impl.Expect("\"\"\n");
 }
 
 TYPED_TEST(JsonWriters, EscapeNewline)
 {
-	this->Impl.m_pJson->WriteStrValue("\n");
-	this->Impl.Expect("\"\\n\"\n");
+	this->m_Impl.m_pJson->WriteStrValue("\n");
+	this->m_Impl.Expect("\"\\n\"\n");
 }
 
 TYPED_TEST(JsonWriters, EscapeBackslash)
 {
-	this->Impl.m_pJson->WriteStrValue("\\");
-	this->Impl.Expect("\"\\\\\"\n"); // https://www.xkcd.com/1638/
+	this->m_Impl.m_pJson->WriteStrValue("\\");
+	this->m_Impl.Expect("\"\\\\\"\n"); // https://www.xkcd.com/1638/
 }
 
 TYPED_TEST(JsonWriters, EscapeControl)
 {
-	this->Impl.m_pJson->WriteStrValue("\x1b");
-	this->Impl.Expect("\"\\u001b\"\n");
+	this->m_Impl.m_pJson->WriteStrValue("\x1b");
+	this->m_Impl.Expect("\"\\u001b\"\n");
 }
 
 TYPED_TEST(JsonWriters, EscapeUnicode)
 {
-	this->Impl.m_pJson->WriteStrValue("愛😂");
-	this->Impl.Expect("\"愛😂\"\n");
+	this->m_Impl.m_pJson->WriteStrValue("愛😂");
+	this->m_Impl.Expect("\"愛😂\"\n");
 }
 
 TYPED_TEST(JsonWriters, Zero)
 {
-	this->Impl.m_pJson->WriteIntValue(0);
-	this->Impl.Expect("0\n");
+	this->m_Impl.m_pJson->WriteIntValue(0);
+	this->m_Impl.Expect("0\n");
 }
 
 TYPED_TEST(JsonWriters, One)
 {
-	this->Impl.m_pJson->WriteIntValue(1);
-	this->Impl.Expect("1\n");
+	this->m_Impl.m_pJson->WriteIntValue(1);
+	this->m_Impl.Expect("1\n");
 }
 
 TYPED_TEST(JsonWriters, MinusOne)
 {
-	this->Impl.m_pJson->WriteIntValue(-1);
-	this->Impl.Expect("-1\n");
+	this->m_Impl.m_pJson->WriteIntValue(-1);
+	this->m_Impl.Expect("-1\n");
 }
 
 TYPED_TEST(JsonWriters, Large)
 {
-	this->Impl.m_pJson->WriteIntValue(std::numeric_limits<int>::max());
-	this->Impl.Expect("2147483647\n");
+	this->m_Impl.m_pJson->WriteIntValue(std::numeric_limits<int>::max());
+	this->m_Impl.Expect("2147483647\n");
 }
 
 TYPED_TEST(JsonWriters, Small)
 {
-	this->Impl.m_pJson->WriteIntValue(std::numeric_limits<int>::min());
-	this->Impl.Expect("-2147483648\n");
+	this->m_Impl.m_pJson->WriteIntValue(std::numeric_limits<int>::min());
+	this->m_Impl.Expect("-2147483648\n");
 }

--- a/src/test/linereader_test.cpp
+++ b/src/test/linereader_test.cpp
@@ -8,14 +8,14 @@
 
 #include <gtest/gtest.h>
 
-void TestFileLineReaderRaw(const char *pWritten, unsigned WrittenLength, std::initializer_list<const char *> pExpectedLines, bool ExpectSuccess, bool WriteBom)
+static void TestFileLineReaderRaw(const char *pWritten, unsigned WrittenLength, std::initializer_list<const char *> pExpectedLines, bool ExpectSuccess, bool WriteBom)
 {
 	CTestInfo Info;
 	IOHANDLE File = io_open(Info.m_aFilename, IOFLAG_WRITE);
 	ASSERT_TRUE(File);
 	if(WriteBom)
 	{
-		constexpr const unsigned char UTF8_BOM[] = {0xEF, 0xBB, 0xBF};
+		constexpr static const unsigned char UTF8_BOM[] = {0xEF, 0xBB, 0xBF};
 		EXPECT_EQ(io_write(File, UTF8_BOM, sizeof(UTF8_BOM)), sizeof(UTF8_BOM));
 	}
 	EXPECT_EQ(io_write(File, pWritten, WrittenLength), WrittenLength);
@@ -39,13 +39,13 @@ void TestFileLineReaderRaw(const char *pWritten, unsigned WrittenLength, std::in
 	EXPECT_FALSE(fs_remove(Info.m_aFilename));
 }
 
-void TestFileLineReaderRaw(const char *pWritten, unsigned WrittenLength, std::initializer_list<const char *> pReads, bool ExpectSuccess)
+static void TestFileLineReaderRaw(const char *pWritten, unsigned WrittenLength, std::initializer_list<const char *> pReads, bool ExpectSuccess)
 {
 	TestFileLineReaderRaw(pWritten, WrittenLength, pReads, ExpectSuccess, false);
 	TestFileLineReaderRaw(pWritten, WrittenLength, pReads, ExpectSuccess, true);
 }
 
-void TestFileLineReader(const char *pWritten, std::initializer_list<const char *> pReads)
+static void TestFileLineReader(const char *pWritten, std::initializer_list<const char *> pReads)
 {
 	TestFileLineReaderRaw(pWritten, str_length(pWritten), pReads, true);
 }

--- a/src/test/mem_test.cpp
+++ b/src/test/mem_test.cpp
@@ -4,20 +4,6 @@
 
 #include <gtest/gtest.h>
 
-static bool mem_is_null(const void *block, size_t size)
-{
-	const unsigned char *bytes = (const unsigned char *)block;
-	size_t i;
-	for(i = 0; i < size; i++)
-	{
-		if(bytes[i] != 0)
-		{
-			return false;
-		}
-	}
-	return true;
-}
-
 TEST(Memory, BaseTypes)
 {
 	void *aVoid[123];

--- a/src/test/packer_test.cpp
+++ b/src/test/packer_test.cpp
@@ -10,14 +10,14 @@
 // pExpected is nullptr if an error is expected
 static void ExpectAddString5(const char *pString, int Limit, bool AllowTruncation, const char *pExpected)
 {
-	static char ZEROS[CPacker::PACKER_BUFFER_SIZE] = {0};
-	static const int OFFSET = CPacker::PACKER_BUFFER_SIZE - 5;
+	constexpr static const char ZEROS[CPacker::PACKER_BUFFER_SIZE] = {0};
+	constexpr static const int OFFSET = CPacker::PACKER_BUFFER_SIZE - 5;
 	CPacker Packer;
 	Packer.Reset();
 	Packer.AddRaw(ZEROS, OFFSET);
 	Packer.AddString(pString, Limit, AllowTruncation);
 
-	EXPECT_EQ(pExpected == 0, Packer.Error()) << "for String='" << pString << "', Limit='" << Limit << "', AllowTruncation='" << AllowTruncation << "'";
+	EXPECT_EQ(pExpected == nullptr, Packer.Error()) << "for String='" << pString << "', Limit='" << Limit << "', AllowTruncation='" << AllowTruncation << "'";
 	if(pExpected)
 	{
 		// Include null termination.

--- a/src/test/score_test.cpp
+++ b/src/test/score_test.cpp
@@ -21,7 +21,7 @@ TEST(SQLite, Version)
 	ASSERT_GE(sqlite3_libversion_number(), 3025000) << "SQLite >= 3.25.0 required for Window functions";
 }
 
-struct Score : public testing::TestWithParam<IDbConnection *>
+struct Score : public testing::TestWithParam<IDbConnection *> // NOLINT(readability-identifier-naming)
 {
 	Score()
 	{
@@ -30,7 +30,7 @@ struct Score : public testing::TestWithParam<IDbConnection *>
 		InsertMap("Kobra 3", "Zerodin", "Novice", 5, 5);
 	}
 
-	~Score()
+	~Score() override
 	{
 		m_pConn->Disconnect();
 	}
@@ -55,9 +55,9 @@ struct Score : public testing::TestWithParam<IDbConnection *>
 
 	void LoadBestTime()
 	{
-		CSqlLoadBestTimeRequest loadBestTimeReq(std::make_shared<CScoreLoadBestTimeResult>());
-		str_copy(loadBestTimeReq.m_aMap, "Kobra 3");
-		ASSERT_TRUE(CScoreWorker::LoadBestTime(m_pConn, &loadBestTimeReq, m_aError, sizeof(m_aError))) << m_aError;
+		CSqlLoadBestTimeRequest LoadBestTimeReq(std::make_shared<CScoreLoadBestTimeResult>());
+		str_copy(LoadBestTimeReq.m_aMap, "Kobra 3");
+		ASSERT_TRUE(CScoreWorker::LoadBestTime(m_pConn, &LoadBestTimeReq, m_aError, sizeof(m_aError))) << m_aError;
 	}
 
 	void InsertMap(const char *pName, const char *pMapper, const char *pServer, int Points, int Stars)
@@ -115,7 +115,7 @@ struct Score : public testing::TestWithParam<IDbConnection *>
 	CSqlPlayerRequest m_PlayerRequest{m_pPlayerResult};
 };
 
-struct SingleScore : public Score
+struct SingleScore : public Score // NOLINT(readability-identifier-naming)
 {
 	SingleScore()
 	{
@@ -263,7 +263,7 @@ TEST_P(SingleScore, TimesDoesntExist)
 	ExpectLines(m_pPlayerResult, {"There are no times in the specified range"});
 }
 
-struct TeamScore : public Score
+struct TeamScore : public Score // NOLINT(readability-identifier-naming)
 {
 	void SetUp() override
 	{
@@ -273,22 +273,21 @@ struct TeamScore : public Score
 	void InsertTeamRank(float Time = 100.0)
 	{
 		str_copy(g_Config.m_SvSqlServerName, "USA");
-		CSqlTeamScoreData teamScoreData;
+		CSqlTeamScoreData TeamScoreData;
 		CSqlScoreData ScoreData(std::make_shared<CScorePlayerResult>());
-		str_copy(teamScoreData.m_aMap, "Kobra 3");
+		str_copy(TeamScoreData.m_aMap, "Kobra 3");
 		str_copy(ScoreData.m_aMap, "Kobra 3");
-		str_copy(teamScoreData.m_aGameUuid, "8d300ecf-5873-4297-bee5-95668fdff320");
+		str_copy(TeamScoreData.m_aGameUuid, "8d300ecf-5873-4297-bee5-95668fdff320");
 		str_copy(ScoreData.m_aGameUuid, "8d300ecf-5873-4297-bee5-95668fdff320");
-		teamScoreData.m_Size = 2;
-		str_copy(teamScoreData.m_aaNames[0], "nameless tee");
-		str_copy(teamScoreData.m_aaNames[1], "brainless tee");
-		teamScoreData.m_Time = Time;
+		TeamScoreData.m_Size = 2;
+		str_copy(TeamScoreData.m_aaNames[0], "nameless tee");
+		str_copy(TeamScoreData.m_aaNames[1], "brainless tee");
+		TeamScoreData.m_Time = Time;
 		ScoreData.m_Time = Time;
-		str_copy(teamScoreData.m_aTimestamp, "2021-11-24 19:24:08");
+		str_copy(TeamScoreData.m_aTimestamp, "2021-11-24 19:24:08");
 		str_copy(ScoreData.m_aTimestamp, "2021-11-24 19:24:08");
-		for(int i = 0; i < NUM_CHECKPOINTS; i++)
-			ScoreData.m_aCurrentTimeCp[i] = 0;
-		ASSERT_TRUE(CScoreWorker::SaveTeamScore(m_pConn, &teamScoreData, Write::NORMAL, m_aError, sizeof(m_aError))) << m_aError;
+		std::fill(std::begin(ScoreData.m_aCurrentTimeCp), std::end(ScoreData.m_aCurrentTimeCp), 0);
+		ASSERT_TRUE(CScoreWorker::SaveTeamScore(m_pConn, &TeamScoreData, Write::NORMAL, m_aError, sizeof(m_aError))) << m_aError;
 
 		str_copy(m_PlayerRequest.m_aMap, "Kobra 3");
 		str_copy(m_PlayerRequest.m_aRequestingPlayer, "brainless tee");
@@ -354,7 +353,7 @@ TEST_P(TeamScore, RankUpdates)
 			"---------------------------------"});
 }
 
-struct MapInfo : public Score
+struct MapInfo : public Score // NOLINT(readability-identifier-naming)
 {
 	MapInfo()
 	{
@@ -425,7 +424,7 @@ TEST_P(MapInfo, DoesntExit)
 	ExpectLines(m_pPlayerResult, {"No map like \"f\" found."});
 }
 
-struct MapVote : public Score
+struct MapVote : public Score // NOLINT(readability-identifier-naming)
 {
 	MapVote()
 	{
@@ -472,7 +471,7 @@ TEST_P(MapVote, DoesntExist)
 	ExpectLines(m_pPlayerResult, {"No map like \"f\" found. Try adding a '%' at the start if you don't know the first character. Example: /map %castle for \"Out of Castle\""});
 }
 
-struct Points : public Score
+struct Points : public Score // NOLINT(readability-identifier-naming)
 {
 	Points()
 	{
@@ -554,7 +553,7 @@ TEST_P(Points, EqualPointsTop)
 			"-------------------------------"});
 }
 
-struct RandomMap : public Score
+struct RandomMap : public Score // NOLINT(readability-identifier-naming)
 {
 	std::shared_ptr<CScoreRandomMapResult> m_pRandomMapResult{std::make_shared<CScoreRandomMapResult>(0)};
 	CSqlRandomMapRequest m_RandomMapRequest{m_pRandomMapResult};
@@ -626,7 +625,7 @@ TEST_P(RandomMap, UnfinishedDoesntExist)
 	EXPECT_STREQ(m_pRandomMapResult->m_aMessage, "nameless tee has no more unfinished maps on this server!");
 }
 
-auto g_pSqliteConn = CreateSqliteConnection(":memory:", true);
+static auto g_pSqliteConn = CreateSqliteConnection(":memory:", true);
 #if defined(CONF_TEST_MYSQL)
 CMysqlConfig gMysqlConfig{
 	"ddnet", // database
@@ -638,10 +637,10 @@ CMysqlConfig gMysqlConfig{
 	3306, // port
 	true, // setup
 };
-auto g_pMysqlConn = CreateMysqlConnection(gMysqlConfig);
+static auto g_pMysqlConn = CreateMysqlConnection(gMysqlConfig);
 #endif
 
-auto g_TestValues{
+static auto g_TestValues{
 	testing::Values(
 #if defined(CONF_TEST_MYSQL)
 		g_pMysqlConn.get(),

--- a/src/test/str_test.cpp
+++ b/src/test/str_test.cpp
@@ -548,7 +548,7 @@ TEST(Str, HexDecode)
 	EXPECT_STREQ(aOut, "ABCD");
 }
 
-void StrBase64Str(char *pBuffer, int BufferSize, const char *pString)
+static void StrBase64Str(char *pBuffer, int BufferSize, const char *pString)
 {
 	str_base64(pBuffer, BufferSize, pString, str_length(pString));
 }

--- a/src/test/teehistorian_test.cpp
+++ b/src/test/teehistorian_test.cpp
@@ -16,7 +16,7 @@
 
 void RegisterGameUuids(CUuidManager *pManager);
 
-class TeeHistorian : public ::testing::Test
+class TeeHistorian : public ::testing::Test // NOLINT(readability-identifier-naming)
 {
 protected:
 	CTeeHistorian m_TH;
@@ -109,7 +109,7 @@ protected:
 
 	void Expect(const unsigned char *pOutput, size_t OutputSize)
 	{
-		static CUuid TEEHISTORIAN_UUID = CalculateUuid("teehistorian@ddnet.tw");
+		static const CUuid TEEHISTORIAN_UUID = CalculateUuid("teehistorian@ddnet.tw");
 		static const char PREFIX1[] = "{\"comment\":\"teehistorian@ddnet.tw\",\"version\":\"2\",\"version_minor\":\"22\",\"game_uuid\":\"a1eb7182-796e-3b3e-941d-38ca71b2a4a8\",\"server_version\":\"DDNet test\",\"start_time\":\"";
 		static const char PREFIX2[] = "\",\"server_name\":\"server name\",\"server_port\":\"8303\",\"game_type\":\"game type\",\"map_name\":\"Kobra 3 Solo\",\"map_size\":\"903514\",\"map_sha256\":\"0123456789012345678901234567890123456789012345678901234567890123\",\"map_crc\":\"eceaf25c\",\"prng_description\":\"test-prng:02468ace\",\"config\":{},\"tuning\":{},\"uuids\":[";
 		static const char PREFIX3[] = "]}";

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -81,7 +81,7 @@ public:
 	std::vector<CTestInfoPath> *m_pvEntries;
 };
 
-int TestCollect(const char *pName, int IsDir, int Unused, void *pUser)
+static int TestCollect(const char *pName, int IsDir, int Unused, void *pUser)
 {
 	CTestCollectData *pData = (CTestCollectData *)pUser;
 
@@ -104,7 +104,7 @@ int TestCollect(const char *pName, int IsDir, int Unused, void *pUser)
 	return 0;
 }
 
-void TestDeleteTestStorageFiles(const char *pPath)
+static void TestDeleteTestStorageFiles(const char *pPath)
 {
 	std::vector<CTestInfoPath> vEntries;
 	CTestCollectData Data;

--- a/src/test/timestamp_test.cpp
+++ b/src/test/timestamp_test.cpp
@@ -5,7 +5,7 @@
 
 #include <cstdlib>
 
-class TimestampTest : public testing::Test
+class TimestampTest : public testing::Test // NOLINT(readability-identifier-naming)
 {
 protected:
 	void SetUp() override

--- a/src/test/windows_test.cpp
+++ b/src/test/windows_test.cpp
@@ -9,43 +9,43 @@
 TEST(ArgumentsToWide, SingleArgumentNoQuotes)
 {
 	const char *apArguments[] = {"change_map ctf5"};
-	std::wstring result = windows_args_to_wide(apArguments, std::size(apArguments));
-	EXPECT_EQ(result, LR"("change_map ctf5")");
+	std::wstring Result = windows_args_to_wide(apArguments, std::size(apArguments));
+	EXPECT_EQ(Result, LR"("change_map ctf5")");
 }
 
 TEST(ArgumentsToWide, SingleArgumentWithQuotes)
 {
 	const char *apArguments[] = {"change_map \"ctf5\""};
-	std::wstring result = windows_args_to_wide(apArguments, std::size(apArguments));
-	EXPECT_EQ(result, L"\"change_map \\\"ctf5\\\"\"");
+	std::wstring Result = windows_args_to_wide(apArguments, std::size(apArguments));
+	EXPECT_EQ(Result, L"\"change_map \\\"ctf5\\\"\"");
 }
 
 TEST(ArgumentsToWide, MultipleArguments)
 {
 	const char *apArguments[] = {"change_map ctf5", "sv_register 0"};
-	std::wstring result = windows_args_to_wide(apArguments, std::size(apArguments));
-	EXPECT_EQ(result, LR"("change_map ctf5" "sv_register 0")");
+	std::wstring Result = windows_args_to_wide(apArguments, std::size(apArguments));
+	EXPECT_EQ(Result, LR"("change_map ctf5" "sv_register 0")");
 }
 
 TEST(ArgumentsToWide, SingleArgumentWithSlashes)
 {
 	const char *apArguments[] = {R"(sv_name te\st)"};
-	std::wstring result = windows_args_to_wide(apArguments, std::size(apArguments));
-	EXPECT_EQ(result, L"\"sv_name te\\st\"");
+	std::wstring Result = windows_args_to_wide(apArguments, std::size(apArguments));
+	EXPECT_EQ(Result, L"\"sv_name te\\st\"");
 }
 
 TEST(ArgumentsToWide, MultipleArgumentsWithSlashesAndQuotes)
 {
 	const char *apArguments[] = {R"(sv_name "te\\st")", R"(sv_motd "fo\\o")"};
-	std::wstring result = windows_args_to_wide(apArguments, std::size(apArguments));
-	EXPECT_EQ(result, L"\"sv_name \\\"te\\\\st\\\"\" \"sv_motd \\\"fo\\\\o\\\"\"");
+	std::wstring Result = windows_args_to_wide(apArguments, std::size(apArguments));
+	EXPECT_EQ(Result, L"\"sv_name \\\"te\\\\st\\\"\" \"sv_motd \\\"fo\\\\o\\\"\"");
 }
 
 TEST(ArgumentsToWide, MultipleArgumentsWithEndSlash)
 {
 	const char *apArguments[] = {R"(sv_name "te\\st\\")", R"(sv_motd foo\)"};
-	std::wstring result = windows_args_to_wide(apArguments, std::size(apArguments));
-	EXPECT_EQ(result, L"\"sv_name \\\"te\\\\st\\\\\\\\\\\"\" \"sv_motd foo\\\\\"");
+	std::wstring Result = windows_args_to_wide(apArguments, std::size(apArguments));
+	EXPECT_EQ(Result, L"\"sv_name \\\"te\\\\st\\\\\\\\\\\"\" \"sv_motd foo\\\\\"");
 }
 
 #endif


### PR DESCRIPTION
- Make functions and variables `static` when possible.
- Move `mem_is_null` function from `mem_test.cpp` to `base/mem.h/cpp` as complement to `mem_has_null` function, instead of changing the function and variable names in `mem_test.cpp`.
- Make constants `const` so variable names in `SCREAMING_SNAKE_CASE` are correct.
- Fix various variable and function names.
- Use `nullptr` instead of `0` and `0x0`.
- Add missing `override` for virtual destructor.
- Add `NOLINT` for names of test fixures that do not have a `C` or `S` prefix because they appear in the testrunner output.
- Do not apply clang-tidy to googletest targets.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
