### PR TITLE
Map load speedup

### DIFF
--- a/src/base/sphore.cpp
+++ b/src/base/sphore.cpp
@@ -9,12 +9,6 @@
 #include <windows.h>
 
 #include <limits>
-#elif defined(CONF_PLATFORM_MACOS)
-#include "process.h"
-#include "str.h"
-
-#include <fcntl.h> // O_* constants
-#include <sys/stat.h> // S_* constants
 #elif defined(CONF_FAMILY_UNIX)
 #include "str.h"
 
@@ -42,30 +36,20 @@ void sphore_destroy(SEMAPHORE *sem)
 #elif defined(CONF_PLATFORM_MACOS)
 void sphore_init(SEMAPHORE *sem)
 {
-	char aBuf[64];
-	str_format(aBuf, sizeof(aBuf), "/%d.%p", process_id(), (void *)sem);
-	*sem = sem_open(aBuf, O_CREAT | O_EXCL, S_IRWXU | S_IRWXG, 0);
-	dbg_assert(*sem != SEM_FAILED, "sem_open failure, errno=%d, name='%s'", errno, aBuf);
+	*sem = dispatch_semaphore_create(0);
+	dbg_assert(*sem != nullptr, "dispatch_semaphore_create failure");
 }
 void sphore_wait(SEMAPHORE *sem)
 {
-	while(true)
-	{
-		if(sem_wait(*sem) == 0)
-			break;
-		dbg_assert(errno == EINTR, "sem_wait failure");
-	}
+	dispatch_semaphore_wait(*sem, DISPATCH_TIME_FOREVER);
 }
 void sphore_signal(SEMAPHORE *sem)
 {
-	dbg_assert(sem_post(*sem) == 0, "sem_post failure");
+	dispatch_semaphore_signal(*sem);
 }
 void sphore_destroy(SEMAPHORE *sem)
 {
-	dbg_assert(sem_close(*sem) == 0, "sem_close failure");
-	char aBuf[64];
-	str_format(aBuf, sizeof(aBuf), "/%d.%p", process_id(), (void *)sem);
-	dbg_assert(sem_unlink(aBuf) == 0, "sem_unlink failure");
+	dispatch_release(*sem);
 }
 #elif defined(CONF_FAMILY_UNIX)
 void sphore_init(SEMAPHORE *sem)

--- a/src/base/sphore.h
+++ b/src/base/sphore.h
@@ -20,11 +20,15 @@
  */
 typedef void *SEMAPHORE;
 #elif defined(CONF_PLATFORM_MACOS)
-#include <semaphore.h>
+#include <dispatch/dispatch.h>
 /**
  * @ingroup Semaphore
+ *
+ * Unnamed POSIX semaphores are not implemented on macOS and named ones leak a
+ * system-wide kernel name when a process exits without destroying them, so use
+ * GCD semaphores instead.
  */
-typedef sem_t *SEMAPHORE;
+typedef dispatch_semaphore_t SEMAPHORE;
 #elif defined(CONF_FAMILY_UNIX)
 #include <semaphore.h>
 /**

--- a/src/base/thread.cpp
+++ b/src/base/thread.cpp
@@ -6,6 +6,11 @@
 #include "dbg.h"
 #include "windows.h"
 
+#include <algorithm>
+#include <atomic>
+#include <thread>
+#include <vector>
+
 #if defined(CONF_FAMILY_UNIX)
 #include <pthread.h>
 #include <sched.h>
@@ -156,4 +161,57 @@ void thread_init_and_detach(void (*threadfunc)(void *), void *u, const char *nam
 {
 	void *thread = thread_init(threadfunc, u, name);
 	thread_detach(thread);
+}
+
+namespace {
+class CParallelForState
+{
+public:
+	const std::function<void(size_t)> *m_pFunction;
+	std::atomic<size_t> m_NextIndex;
+	size_t m_Count;
+};
+
+void ParallelForWorker(void *pUser)
+{
+	CParallelForState *pState = static_cast<CParallelForState *>(pUser);
+	while(true)
+	{
+		const size_t Index = pState->m_NextIndex.fetch_add(1);
+		if(Index >= pState->m_Count)
+			break;
+		(*pState->m_pFunction)(Index);
+	}
+}
+} // namespace
+
+void thread_parallel_for(size_t Count, const std::function<void(size_t)> &Function)
+{
+	if(Count == 0)
+		return;
+
+	const unsigned HardwareConcurrency = std::thread::hardware_concurrency();
+	const size_t NumThreads = std::min<size_t>(Count, HardwareConcurrency == 0 ? 1 : HardwareConcurrency);
+	if(NumThreads <= 1)
+	{
+		for(size_t Index = 0; Index < Count; ++Index)
+			Function(Index);
+		return;
+	}
+
+	CParallelForState State;
+	State.m_pFunction = &Function;
+	State.m_NextIndex.store(0);
+	State.m_Count = Count;
+
+	std::vector<void *> vpThreads;
+	vpThreads.reserve(NumThreads - 1);
+	for(size_t i = 0; i < NumThreads - 1; ++i)
+		vpThreads.push_back(thread_init(ParallelForWorker, &State, "parallel_for"));
+
+	// the calling thread works too, so that a single item never costs an extra thread
+	ParallelForWorker(&State);
+
+	for(void *pThread : vpThreads)
+		thread_wait(pThread);
 }

--- a/src/base/thread.h
+++ b/src/base/thread.h
@@ -4,6 +4,9 @@
 #ifndef BASE_THREAD_H
 #define BASE_THREAD_H
 
+#include <cstddef>
+#include <functional>
+
 /**
  * Threading related functions.
  *
@@ -63,5 +66,22 @@ void thread_detach(void *thread);
  * @param name Name describing the use of the thread.
  */
 void thread_init_and_detach(void (*threadfunc)(void *), void *user, const char *name);
+
+/**
+ * Calls `Function(Index)` once for every index in `[0, Count)`, distributing the
+ * indices over worker threads, and returns when all of them have completed.
+ *
+ * Indices are handed out dynamically, so this also balances work when the
+ * individual items take very different amounts of time.
+ *
+ * @ingroup Threads
+ *
+ * @param Count Number of items to process.
+ * @param Function Work to perform for one item. Must be safe to call concurrently.
+ *
+ * @remark Must be called on a thread that may block, as it waits for completion.
+ * The calling thread participates in the work.
+ */
+void thread_parallel_for(size_t Count, const std::function<void(size_t Index)> &Function);
 
 #endif

--- a/src/engine/client/backend/opengl/backend_opengl.h
+++ b/src/engine/client/backend/opengl/backend_opengl.h
@@ -57,6 +57,10 @@ protected:
 	TWGLint m_MaxTexSize;
 
 	bool m_Has2DArrayTextures;
+	// Immutable texture storage. Allocating the whole mipmap chain up front is much
+	// faster than letting `glGenerateMipmap` grow a mutable texture, especially for
+	// the 256 layer arrays that tile layers use.
+	bool m_HasTextureStorage = false;
 	bool m_Has2DArrayTexturesAsExtension;
 	TWGLenum m_2DArrayTarget;
 	bool m_Has3DTextures;

--- a/src/engine/client/backend/opengl/backend_opengl3.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl3.cpp
@@ -3,6 +3,8 @@
 #include <base/detect.h>
 #include <base/log.h>
 
+#include <limits>
+
 #if defined(BACKEND_AS_OPENGL_ES) || !defined(CONF_BACKEND_OPENGL_ES)
 
 #ifndef BACKEND_AS_OPENGL_ES
@@ -87,6 +89,11 @@ bool CCommandProcessorFragment_OpenGL3_3::Cmd_Init(const SCommand_Init *pCommand
 	m_HasMipMaps = true;
 	m_HasNPOTTextures = true;
 	m_HasShaders = true;
+#ifdef BACKEND_AS_OPENGL_ES
+	m_HasTextureStorage = true; // core since OpenGL ES 3.0, which this backend requires
+#else
+	m_HasTextureStorage = GLEW_ARB_texture_storage || pCommand->m_GlewMajor > 4 || (pCommand->m_GlewMajor == 4 && pCommand->m_GlewMinor >= 2);
+#endif
 
 	m_pTextureMemoryUsage = pCommand->m_pTextureMemoryUsage;
 	m_pTextureMemoryUsage->store(0, std::memory_order_relaxed);
@@ -562,6 +569,29 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Texture_Destroy(const CCommandBuff
 	DestroyTexture(pCommand->m_Slot);
 }
 
+// `glTexStorage*` requires a sized internal format, unlike `glTexImage*`.
+static int TextureStorageFormat(int GLStoreFormat)
+{
+	switch(GLStoreFormat)
+	{
+	case GL_RGBA:
+		return GL_RGBA8;
+	case GL_RED:
+		return GL_R8;
+	default:
+		return GLStoreFormat;
+	}
+}
+
+// Number of mipmap levels of a texture of this size, at most `MaxLevel` + 1.
+static int TextureNumLevels(int Width, int Height, int MaxLevel)
+{
+	int Levels = 1;
+	for(int Size = std::max(Width, Height); Size > 1 && Levels <= MaxLevel; Size >>= 1)
+		++Levels;
+	return Levels;
+}
+
 void CCommandProcessorFragment_OpenGL3_3::TextureCreate(int Slot, int Width, int Height, int GLFormat, int GLStoreFormat, int Flags, uint8_t *pTexData)
 {
 	while(Slot >= (int)m_vTextures.size())
@@ -612,7 +642,15 @@ void CCommandProcessorFragment_OpenGL3_3::TextureCreate(int Slot, int Width, int
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 			glSamplerParameteri(m_vTextures[Slot].m_Sampler, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 			glSamplerParameteri(m_vTextures[Slot].m_Sampler, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-			glTexImage2D(GL_TEXTURE_2D, 0, GLStoreFormat, Width, Height, 0, GLFormat, GL_UNSIGNED_BYTE, pTexData);
+			if(m_HasTextureStorage)
+			{
+				glTexStorage2D(GL_TEXTURE_2D, 1, TextureStorageFormat(GLStoreFormat), Width, Height);
+				glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, Width, Height, GLFormat, GL_UNSIGNED_BYTE, pTexData);
+			}
+			else
+			{
+				glTexImage2D(GL_TEXTURE_2D, 0, GLStoreFormat, Width, Height, 0, GLFormat, GL_UNSIGNED_BYTE, pTexData);
+			}
 		}
 	}
 	else
@@ -628,12 +666,22 @@ void CCommandProcessorFragment_OpenGL3_3::TextureCreate(int Slot, int Width, int
 #endif
 
 			// prevent mipmap display bugs, when zooming out far
+			int MaxLevel = std::numeric_limits<int>::max();
 			if(Width >= 1024 && Height >= 1024)
 			{
+				MaxLevel = 5;
 				glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 5.f);
 				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LOD, 5);
 			}
-			glTexImage2D(GL_TEXTURE_2D, 0, GLStoreFormat, Width, Height, 0, GLFormat, GL_UNSIGNED_BYTE, pTexData);
+			if(m_HasTextureStorage)
+			{
+				glTexStorage2D(GL_TEXTURE_2D, TextureNumLevels(Width, Height, MaxLevel), TextureStorageFormat(GLStoreFormat), Width, Height);
+				glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, Width, Height, GLFormat, GL_UNSIGNED_BYTE, pTexData);
+			}
+			else
+			{
+				glTexImage2D(GL_TEXTURE_2D, 0, GLStoreFormat, Width, Height, 0, GLFormat, GL_UNSIGNED_BYTE, pTexData);
+			}
 			glGenerateMipmap(GL_TEXTURE_2D);
 		}
 
@@ -675,7 +723,15 @@ void CCommandProcessorFragment_OpenGL3_3::TextureCreate(int Slot, int Width, int
 			int Image3DWidth, Image3DHeight;
 			uint8_t *pImageData3D = static_cast<uint8_t *>(malloc((size_t)PixelSize * ConvertWidth * ConvertHeight));
 			Texture2DTo3D(pTexData, ConvertWidth, ConvertHeight, PixelSize, 16, 16, pImageData3D, Image3DWidth, Image3DHeight);
-			glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GLStoreFormat, Image3DWidth, Image3DHeight, 256, 0, GLFormat, GL_UNSIGNED_BYTE, pImageData3D);
+			if(m_HasTextureStorage)
+			{
+				glTexStorage3D(GL_TEXTURE_2D_ARRAY, TextureNumLevels(Image3DWidth, Image3DHeight, std::numeric_limits<int>::max()), TextureStorageFormat(GLStoreFormat), Image3DWidth, Image3DHeight, 256);
+				glTexSubImage3D(GL_TEXTURE_2D_ARRAY, 0, 0, 0, 0, Image3DWidth, Image3DHeight, 256, GLFormat, GL_UNSIGNED_BYTE, pImageData3D);
+			}
+			else
+			{
+				glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GLStoreFormat, Image3DWidth, Image3DHeight, 256, 0, GLFormat, GL_UNSIGNED_BYTE, pImageData3D);
+			}
 			glGenerateMipmap(GL_TEXTURE_2D_ARRAY);
 			free(pImageData3D);
 		}

--- a/src/engine/map.h
+++ b/src/engine/map.h
@@ -6,6 +6,7 @@
 #include <base/hash.h>
 #include <base/types.h>
 
+#include <cstddef>
 #include <memory>
 
 class IStorage;
@@ -26,6 +27,9 @@ public:
 	virtual void *GetDataSwapped(int Index) = 0;
 	virtual const char *GetDataString(int Index) = 0;
 	virtual void UnloadData(int Index) = 0;
+	// Loads the given data items in parallel. Purely an optimization: the items are
+	// cached exactly as if they had been fetched individually with `GetData`.
+	virtual void PreloadData(const int *pIndices, size_t Count) = 0;
 	virtual int NumData() const = 0;
 
 	virtual int GetItemSize(int Index) = 0;

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -14,6 +14,7 @@
 #include <base/math.h>
 #include <base/mem.h>
 #include <base/str.h>
+#include <base/thread.h>
 
 #include <engine/storage.h>
 
@@ -22,6 +23,7 @@
 #include <cstdlib>
 #include <limits>
 #include <unordered_set>
+#include <vector>
 
 static constexpr int MAX_ITEM_TYPE = 0xFFFF;
 static constexpr int MAX_ITEM_ID = 0xFFFF;
@@ -297,6 +299,104 @@ public:
 			SwapEndianInPlace(m_ppDataPtrs[Index], m_pDataSizes[Index]);
 		}
 		return m_ppDataPtrs[Index];
+	}
+
+	// Loads several data items at once, decompressing them on multiple threads.
+	// Decompression dominates map loading and the items are independent, but they
+	// share one file handle, so the compressed bytes are read up front.
+	void PreloadData(const int *pIndices, size_t Count)
+	{
+		if(m_Info.m_pDataSizes == nullptr)
+		{
+			// Uncompressed datafile, there is nothing to parallelize
+			return;
+		}
+
+		class CPending
+		{
+		public:
+			int m_Index;
+			void *m_pCompressedData;
+			unsigned m_CompressedSize;
+			unsigned m_UncompressedSize;
+		};
+		std::vector<CPending> vPending;
+
+		for(size_t i = 0; i < Count; i++)
+		{
+			const int Index = pIndices[i];
+			if(Index < 0 || Index >= m_Header.m_NumRawData)
+			{
+				continue;
+			}
+			// Already loaded, previously failed, or requested twice
+			if(m_ppDataPtrs[Index] != nullptr || m_pDataSizes[Index] != 0)
+			{
+				continue;
+			}
+
+			const unsigned UncompressedSize = m_Info.m_pDataSizes[Index];
+			if(UncompressedSize == 0)
+			{
+				log_error("datafile", "data size invalid. data will be ignored. index=%d uncompressed=%d", Index, UncompressedSize);
+				m_pDataSizes[Index] = -1;
+				continue;
+			}
+
+			const unsigned CompressedSize = GetFileDataSize(Index);
+			void *pCompressedData = malloc(CompressedSize);
+			if(pCompressedData == nullptr)
+			{
+				log_error("datafile", "out of memory. could not allocate memory for compressed data. index=%d size=%d", Index, CompressedSize);
+				m_pDataSizes[Index] = -1;
+				continue;
+			}
+
+			unsigned ActualDataSize = 0;
+			if(io_seek(m_File, m_DataStartOffset + m_Info.m_pDataOffsets[Index], EIoSeekOrigin::START) == 0)
+			{
+				ActualDataSize = io_read(m_File, pCompressedData, CompressedSize);
+			}
+			if(CompressedSize != ActualDataSize)
+			{
+				log_error("datafile", "truncation error. could not read all compressed data. index=%d wanted=%d got=%d", Index, CompressedSize, ActualDataSize);
+				free(pCompressedData);
+				m_pDataSizes[Index] = -1;
+				continue;
+			}
+
+			// Marks the item as pending so that a repeated index is not read twice
+			m_pDataSizes[Index] = -1;
+			vPending.push_back({Index, pCompressedData, CompressedSize, UncompressedSize});
+		}
+
+		// Every item writes only its own element of `m_ppDataPtrs` and `m_pDataSizes`
+		thread_parallel_for(vPending.size(), [&](size_t i) {
+			const CPending &Pending = vPending[i];
+			void *pUncompressedData = malloc(Pending.m_UncompressedSize);
+			if(pUncompressedData == nullptr)
+			{
+				log_error("datafile", "out of memory. could not allocate memory for uncompressed data. index=%d size=%d", Pending.m_Index, Pending.m_UncompressedSize);
+				return;
+			}
+
+			unsigned long UncompressedSize = Pending.m_UncompressedSize;
+			const int Result = uncompress(static_cast<Bytef *>(pUncompressedData), &UncompressedSize, static_cast<Bytef *>(Pending.m_pCompressedData), Pending.m_CompressedSize);
+			if(Result != Z_OK || UncompressedSize != Pending.m_UncompressedSize)
+			{
+				log_error("datafile", "failed to uncompress data. index=%d result=%d wanted=%d got=%ld", Pending.m_Index, Result, Pending.m_UncompressedSize, UncompressedSize);
+				free(pUncompressedData);
+				return;
+			}
+
+			m_ppDataPtrs[Pending.m_Index] = pUncompressedData;
+			m_pDataSizes[Pending.m_Index] = Pending.m_UncompressedSize;
+		});
+
+		for(const CPending &Pending : vPending)
+		{
+			free(Pending.m_pCompressedData);
+		}
 	}
 
 	int GetFileItemSize(int Index) const
@@ -758,6 +858,12 @@ void CDataFileReader::ReplaceData(int Index, char *pData, size_t Size)
 	free(m_pDataFile->m_ppDataPtrs[Index]);
 	m_pDataFile->m_ppDataPtrs[Index] = pData;
 	m_pDataFile->m_pDataSizes[Index] = Size;
+}
+
+void CDataFileReader::PreloadData(const int *pIndices, size_t Count)
+{
+	dbg_assert(m_pDataFile != nullptr, "File not open");
+	m_pDataFile->PreloadData(pIndices, Count);
 }
 
 void CDataFileReader::UnloadData(int Index)

--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -43,6 +43,9 @@ public:
 	const char *GetDataString(int Index);
 	void ReplaceData(int Index, char *pData, size_t Size); // memory for data must have been allocated with malloc
 	void UnloadData(int Index);
+	// Loads the given data items in parallel. Purely an optimization: the items are
+	// cached exactly as if they had been fetched individually with `GetData`.
+	void PreloadData(const int *pIndices, size_t Count);
 	int NumData() const;
 
 	int GetItemSize(int Index) const;

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -41,6 +41,11 @@ void CMap::UnloadData(int Index)
 	m_DataFile.UnloadData(Index);
 }
 
+void CMap::PreloadData(const int *pIndices, size_t Count)
+{
+	m_DataFile.PreloadData(pIndices, Count);
+}
+
 int CMap::NumData() const
 {
 	return m_DataFile.NumData();
@@ -97,6 +102,24 @@ bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, in
 	int GroupsStart, GroupsNum, LayersStart, LayersNum;
 	NewDataFile.GetType(MAPITEMTYPE_GROUP, &GroupsStart, &GroupsNum);
 	NewDataFile.GetType(MAPITEMTYPE_LAYER, &LayersStart, &LayersNum);
+
+	// Decompressing the tile data of every layer up front is a lot faster than
+	// letting each layer decompress its own data when it is first used
+	std::vector<int> vTileDataIndices;
+	for(int g = 0; g < GroupsNum; g++)
+	{
+		const CMapItemGroup *pGroup = static_cast<CMapItemGroup *>(NewDataFile.GetItem(GroupsStart + g));
+		for(int l = 0; l < pGroup->m_NumLayers; l++)
+		{
+			const CMapItemLayer *pLayer = static_cast<CMapItemLayer *>(NewDataFile.GetItem(LayersStart + pGroup->m_StartLayer + l));
+			if(pLayer->m_Type == LAYERTYPE_TILES)
+			{
+				vTileDataIndices.push_back(reinterpret_cast<const CMapItemLayerTilemap *>(pLayer)->m_Data);
+			}
+		}
+	}
+	NewDataFile.PreloadData(vTileDataIndices.data(), vTileDataIndices.size());
+
 	for(int g = 0; g < GroupsNum; g++)
 	{
 		const CMapItemGroup *pGroup = static_cast<CMapItemGroup *>(NewDataFile.GetItem(GroupsStart + g));

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -22,6 +22,7 @@ public:
 	void *GetDataSwapped(int Index) override;
 	const char *GetDataString(int Index) override;
 	void UnloadData(int Index) override;
+	void PreloadData(const int *pIndices, size_t Count) override;
 	int NumData() const override;
 
 	int GetItemSize(int Index) override;

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -6,6 +6,7 @@
 #include <base/log.h>
 #include <base/math.h>
 #include <base/mem.h>
+#include <base/thread.h>
 
 #include <engine/gfx/image_manipulation.h>
 #include <engine/graphics.h>
@@ -56,6 +57,22 @@ void CMapImages::Unload()
 	}
 }
 
+void CMapImages::FormatExternalImagePath(const char *pName, char *pBuffer, size_t BufferSize) const
+{
+	bool Translated = false;
+	if(Client()->IsSixup())
+	{
+		Translated =
+			!str_comp(pName, "grass_doodads") ||
+			!str_comp(pName, "grass_main") ||
+			!str_comp(pName, "winter_main") ||
+			!str_comp(pName, "generic_shadows") ||
+			!str_comp(pName, "generic_unhookable") ||
+			!str_comp(pName, "easter");
+	}
+	str_format(pBuffer, BufferSize, "mapres/%s%s.png", pName, Translated ? "_0.7" : "");
+}
+
 void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
 {
 	Unload();
@@ -100,6 +117,63 @@ void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
 		}
 	}
 
+	// Decompressing the embedded images in parallel is a lot faster than letting each
+	// one decompress its own data when it is loaded. They are decompressed in batches
+	// of a limited total size, because an image is freed again right after it has been
+	// handed to the graphics backend and decompressing all of them at once would keep
+	// every image of the map in memory at the same time.
+	int NextPreloadImage = 0;
+	const auto PreloadImagesFrom = [&](int FirstImage) {
+		constexpr size_t MaxPendingSize = 64 * 1024 * 1024;
+		std::vector<int> vImageDataIndices;
+		size_t PendingSize = 0;
+		int i;
+		for(i = FirstImage; i < m_Count && PendingSize < MaxPendingSize; i++)
+		{
+			if(aTextureUsedByTileOrQuadLayerFlag[i] == 0)
+				continue;
+			const CMapItemImage_v2 *pImg = static_cast<const CMapItemImage_v2 *>(pMap->GetItem(Start + i));
+			if(pImg->m_External)
+				continue;
+			vImageDataIndices.push_back(pImg->m_ImageData);
+			PendingSize += pMap->GetDataSize(pImg->m_ImageData);
+		}
+		NextPreloadImage = i;
+		pMap->PreloadData(vImageDataIndices.data(), vImageDataIndices.size());
+	};
+	PreloadImagesFrom(0);
+
+	// The external images are separate files, so they can be decoded concurrently.
+	// Only handing the decoded image to the graphics backend has to happen here.
+	class CExternalImage
+	{
+	public:
+		char m_aPath[IO_MAX_PATH_LENGTH];
+		CImageInfo m_Image;
+	};
+	std::vector<CExternalImage> vExternalImages;
+	int aExternalImageIndex[MAX_MAPIMAGES];
+	std::fill(std::begin(aExternalImageIndex), std::end(aExternalImageIndex), -1);
+	vExternalImages.reserve(m_Count);
+	for(int i = 0; i < m_Count; i++)
+	{
+		if(aTextureUsedByTileOrQuadLayerFlag[i] == 0)
+			continue;
+		const CMapItemImage_v2 *pImg = static_cast<const CMapItemImage_v2 *>(pMap->GetItem(Start + i));
+		if(!pImg->m_External)
+			continue;
+		const char *pName = pMap->GetDataString(pImg->m_ImageName);
+		if(pName == nullptr || pName[0] == '\0')
+			continue;
+
+		aExternalImageIndex[i] = vExternalImages.size();
+		vExternalImages.emplace_back();
+		FormatExternalImagePath(pName, vExternalImages.back().m_aPath, sizeof(vExternalImages.back().m_aPath));
+	}
+	thread_parallel_for(vExternalImages.size(), [&](size_t Index) {
+		Graphics()->LoadPng(vExternalImages[Index].m_Image, vExternalImages[Index].m_aPath, IStorage::TYPE_ALL);
+	});
+
 	// load new textures
 	bool ShowWarning = false;
 	for(int i = 0; i < m_Count; i++)
@@ -109,6 +183,9 @@ void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
 			// skip loading unused images
 			continue;
 		}
+
+		if(i >= NextPreloadImage)
+			PreloadImagesFrom(i);
 
 		const int LoadFlag = (((aTextureUsedByTileOrQuadLayerFlag[i] & 1) != 0) ? Graphics()->TextureLoadFlags() : 0) | (((aTextureUsedByTileOrQuadLayerFlag[i] & 2) != 0) ? 0 : (Graphics()->HasTextureArraysSupport() ? IGraphics::TEXLOAD_NO_2D_TEXTURE : 0));
 		const CMapItemImage_v2 *pImg = static_cast<const CMapItemImage_v2 *>(pMap->GetItem(Start + i));
@@ -134,20 +211,18 @@ void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
 
 		if(pImg->m_External)
 		{
-			char aPath[IO_MAX_PATH_LENGTH];
-			bool Translated = false;
-			if(Client()->IsSixup())
+			const int ExternalIndex = aExternalImageIndex[i];
+			if(ExternalIndex >= 0 && vExternalImages[ExternalIndex].m_Image.m_pData != nullptr)
 			{
-				Translated =
-					!str_comp(pName, "grass_doodads") ||
-					!str_comp(pName, "grass_main") ||
-					!str_comp(pName, "winter_main") ||
-					!str_comp(pName, "generic_shadows") ||
-					!str_comp(pName, "generic_unhookable") ||
-					!str_comp(pName, "easter");
+				m_aTextures[i] = Graphics()->LoadTextureRawMove(vExternalImages[ExternalIndex].m_Image, LoadFlag, vExternalImages[ExternalIndex].m_aPath);
 			}
-			str_format(aPath, sizeof(aPath), "mapres/%s%s.png", pName, Translated ? "_0.7" : "");
-			m_aTextures[i] = Graphics()->LoadTexture(aPath, IStorage::TYPE_ALL, LoadFlag);
+			else
+			{
+				// decoding failed, load it again to report the error the same way
+				char aPath[IO_MAX_PATH_LENGTH];
+				FormatExternalImagePath(pName, aPath, sizeof(aPath));
+				m_aTextures[i] = Graphics()->LoadTexture(aPath, IStorage::TYPE_ALL, LoadFlag);
+			}
 		}
 		else
 		{

--- a/src/game/client/components/mapimages.h
+++ b/src/game/client/components/mapimages.h
@@ -50,6 +50,7 @@ public:
 	IGraphics::CTextureHandle Get(int Index) const override { return m_aTextures[Index]; }
 	int Num() const override { return m_Count; }
 
+	void FormatExternalImagePath(const char *pName, char *pBuffer, size_t BufferSize) const;
 	void OnMapLoadImpl(class CLayers *pLayers, class IMap *pMap);
 	void OnMapLoad() override;
 	void OnInit() override;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -691,9 +691,11 @@ void CMenus::RenderLoading(const char *pCaption, const char *pContent, int Incre
 	dbg_assert(m_LoadingState.m_Current <= m_LoadingState.m_Total, "Invalid progress for RenderLoading");
 
 	// make sure that we don't render for each little thing we load
-	// because that will slow down loading if we have vsync
+	// because that will slow down loading if we have vsync. A progress screen does
+	// not benefit from a high refresh rate, and every frame drawn here is time not
+	// spent loading, so this is deliberately much lower than the ingame frame rate.
 	const std::chrono::nanoseconds Now = time_get_nanoseconds();
-	if(Now - m_LoadingState.m_LastRender < std::chrono::nanoseconds(1s) / 60l)
+	if(Now - m_LoadingState.m_LastRender < std::chrono::nanoseconds(1s) / 10l)
 		return;
 
 	// need up date this here to get correct

--- a/src/game/map/map_renderer.cpp
+++ b/src/game/map/map_renderer.cpp
@@ -2,6 +2,7 @@
 
 #include <base/dbg.h>
 #include <base/log.h>
+#include <base/thread.h>
 
 #include <game/map/envelope_manager.h>
 
@@ -20,8 +21,9 @@ void CMapRenderer::Load(ERenderType Type, CLayers *pLayers, IMapImages *pMapImag
 
 	std::shared_ptr<CEnvelopeManager> pEnvelopeManager = std::make_shared<CEnvelopeManager>(pEnvelopeEval, pLayers->Map());
 	bool PassedGameLayer = false;
+	bool LastLayerAdded = false;
 
-	for(int GroupId = 0; GroupId < pLayers->NumGroups(); GroupId++)
+	for(int GroupId = 0; GroupId < pLayers->NumGroups() && !LastLayerAdded; GroupId++)
 	{
 		CMapItemGroup *pGroup = pLayers->GetGroup(GroupId);
 		std::unique_ptr<CRenderLayer> pRenderLayerGroup = std::make_unique<CRenderLayerGroup>(GroupId, pGroup);
@@ -43,7 +45,11 @@ void CMapRenderer::Load(ERenderType Type, CLayers *pLayers, IMapImages *pMapImag
 			if(Type == ERenderType::RENDERTYPE_BACKGROUND_FORCE || Type == ERenderType::RENDERTYPE_BACKGROUND)
 			{
 				if(PassedGameLayer)
-					return;
+				{
+					// no more layers to add, but the ones already added still have to be built
+					LastLayerAdded = true;
+					break;
+				}
 			}
 			else if(Type == ERenderType::RENDERTYPE_FOREGROUND)
 			{
@@ -132,12 +138,34 @@ void CMapRenderer::Load(ERenderType Type, CLayers *pLayers, IMapImages *pMapImag
 				pRenderLayer->OnInit(Graphics(), TextRender(), RenderMap(), pEnvelopeManager, pLayers->Map(), pMapImages, RenderCallbackOptional);
 				if(pRenderLayer->IsValid())
 				{
-					pRenderLayer->Init();
+					pRenderLayer->PrepareBuild();
 					m_vpRenderLayers.push_back(std::move(pRenderLayer));
 				}
 			}
 		}
 	}
+
+	// Building the layers is by far the most expensive part of loading a map and the
+	// layers are independent of each other, so the ones that allow it are built
+	// concurrently. Everything that talks to the graphics backend stays on this
+	// thread and keeps the original order of the layers.
+	std::vector<CRenderLayer *> vpConcurrentLayers;
+	for(const auto &pRenderLayer : m_vpRenderLayers)
+	{
+		if(pRenderLayer->CanBuildConcurrently())
+			vpConcurrentLayers.push_back(pRenderLayer.get());
+	}
+	thread_parallel_for(vpConcurrentLayers.size(), [&](size_t Index) {
+		vpConcurrentLayers[Index]->Build();
+	});
+
+	for(const auto &pRenderLayer : m_vpRenderLayers)
+	{
+		if(!pRenderLayer->CanBuildConcurrently())
+			pRenderLayer->Build();
+		pRenderLayer->Upload();
+	}
+
 }
 
 void CMapRenderer::Render(const CRenderLayerParams &Params)

--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -661,82 +661,79 @@ void CRenderLayerTile::UploadTileData(std::optional<CTileLayerVisuals> &VisualsO
 	int DrawTop = m_pLayerTilemap->m_Height;
 	int DrawBottom = 0;
 
-	int x = 0;
-	int y = 0;
-	for(y = 0; y < m_pLayerTilemap->m_Height; ++y)
+	const int Width = m_pLayerTilemap->m_Width;
+	const int Height = m_pLayerTilemap->m_Height;
+
+	// Tile data is fetched a row at a time to keep the virtual dispatch out of the
+	// inner loop, which runs once per tile of the layer regardless of how many tiles
+	// are actually drawn.
+	std::vector<CTile> vRowBuffer(Width);
+	std::vector<int> vRowAngleRotates(Width, -1);
+
+	// the amount of tiles handled before the current tile
+	offset_ptr32 TilesHandledCount = 0;
+
+	for(int y = 0; y < Height; ++y)
 	{
-		for(x = 0; x < m_pLayerTilemap->m_Width; ++x)
+		const CTile *pRow = GetTileRow(vRowBuffer.data(), vRowAngleRotates.data(), y, CurOverlay);
+
+		CTileLayerVisuals::CTileVisual *pRowVisuals = &Visuals.m_vTilesOfLayer[(size_t)y * Width];
+		for(int x = 0; x < Width; ++x)
 		{
-			unsigned char Index = 0;
-			unsigned char Flags = 0;
-			int AngleRotate = -1;
-			GetTileData(&Index, &Flags, &AngleRotate, x, y, CurOverlay);
-
-			// the amount of tiles handled before this tile
-			int TilesHandledCount = vTmpTiles.size();
-			Visuals.m_vTilesOfLayer[y * m_pLayerTilemap->m_Width + x].SetIndexBufferByteOffset((offset_ptr32)(TilesHandledCount));
-
-			if(AddTile(vTmpTiles, vTmpTileTexCoords, Index, Flags, x, y, DoTextureCoords, AddAsSpeedup, AngleRotate))
+			// Empty tiles are by far the common case and are rejected here rather than
+			// inside `AddTile`, so that they cost nothing but this compare and the store.
+			if(pRow[x].m_Index == 0)
 			{
-				Visuals.m_vTilesOfLayer[y * m_pLayerTilemap->m_Width + x].Draw(true);
-
-				// calculate clip region boundaries based on draws
-				DrawLeft = std::min(DrawLeft, x);
-				DrawRight = std::max(DrawRight, x);
-				DrawTop = std::min(DrawTop, y);
-				DrawBottom = std::max(DrawBottom, y);
+				pRowVisuals[x].Set(TilesHandledCount, false);
+				continue;
 			}
 
-			// do the border tiles
-			if(x == 0)
-			{
-				if(y == 0)
-				{
-					Visuals.m_BorderTopLeft.SetIndexBufferByteOffset((offset_ptr32)(vTmpBorderCorners.size()));
-					if(AddTile(vTmpBorderCorners, vTmpBorderCornersTexCoords, Index, Flags, 0, 0, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{-32, -32}))
-						Visuals.m_BorderTopLeft.Draw(true);
-				}
-				else if(y == m_pLayerTilemap->m_Height - 1)
-				{
-					Visuals.m_BorderBottomLeft.SetIndexBufferByteOffset((offset_ptr32)(vTmpBorderCorners.size()));
-					if(AddTile(vTmpBorderCorners, vTmpBorderCornersTexCoords, Index, Flags, 0, 0, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{-32, 0}))
-						Visuals.m_BorderBottomLeft.Draw(true);
-				}
-				Visuals.m_vBorderLeft[y].SetIndexBufferByteOffset((offset_ptr32)(vTmpBorderLeftTiles.size()));
-				if(AddTile(vTmpBorderLeftTiles, vTmpBorderLeftTilesTexCoords, Index, Flags, 0, y, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{-32, 0}))
-					Visuals.m_vBorderLeft[y].Draw(true);
-			}
-			else if(x == m_pLayerTilemap->m_Width - 1)
-			{
-				if(y == 0)
-				{
-					Visuals.m_BorderTopRight.SetIndexBufferByteOffset((offset_ptr32)(vTmpBorderCorners.size()));
-					if(AddTile(vTmpBorderCorners, vTmpBorderCornersTexCoords, Index, Flags, 0, 0, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{0, -32}))
-						Visuals.m_BorderTopRight.Draw(true);
-				}
-				else if(y == m_pLayerTilemap->m_Height - 1)
-				{
-					Visuals.m_BorderBottomRight.SetIndexBufferByteOffset((offset_ptr32)(vTmpBorderCorners.size()));
-					if(AddTile(vTmpBorderCorners, vTmpBorderCornersTexCoords, Index, Flags, 0, 0, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{0, 0}))
-						Visuals.m_BorderBottomRight.Draw(true);
-				}
-				Visuals.m_vBorderRight[y].SetIndexBufferByteOffset((offset_ptr32)(vTmpBorderRightTiles.size()));
-				if(AddTile(vTmpBorderRightTiles, vTmpBorderRightTilesTexCoords, Index, Flags, 0, y, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{0, 0}))
-					Visuals.m_vBorderRight[y].Draw(true);
-			}
-			if(y == 0)
-			{
-				Visuals.m_vBorderTop[x].SetIndexBufferByteOffset((offset_ptr32)(vTmpBorderTopTiles.size()));
-				if(AddTile(vTmpBorderTopTiles, vTmpBorderTopTilesTexCoords, Index, Flags, x, 0, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{0, -32}))
-					Visuals.m_vBorderTop[x].Draw(true);
-			}
-			else if(y == m_pLayerTilemap->m_Height - 1)
-			{
-				Visuals.m_vBorderBottom[x].SetIndexBufferByteOffset((offset_ptr32)(vTmpBorderBottomTiles.size()));
-				if(AddTile(vTmpBorderBottomTiles, vTmpBorderBottomTilesTexCoords, Index, Flags, x, 0, DoTextureCoords, AddAsSpeedup, AngleRotate, ivec2{0, 0}))
-					Visuals.m_vBorderBottom[x].Draw(true);
-			}
+			pRowVisuals[x].Set(TilesHandledCount, true);
+			AddTile(vTmpTiles, vTmpTileTexCoords, pRow[x].m_Index, pRow[x].m_Flags, x, y, DoTextureCoords, AddAsSpeedup, vRowAngleRotates[x]);
+			TilesHandledCount++;
+
+			// calculate clip region boundaries based on draws
+			DrawLeft = std::min(DrawLeft, x);
+			DrawRight = std::max(DrawRight, x);
+			DrawTop = std::min(DrawTop, y);
+			DrawBottom = std::max(DrawBottom, y);
 		}
+	}
+
+	// Do the border tiles. They are visited in the same order as when this was
+	// interleaved with the loop above, because the offsets recorded for each border
+	// tile depend on how many border tiles were added before it.
+	const auto AddBorderTile = [&](std::vector<CGraphicTile> &vTiles, std::vector<CGraphicTileTextureCoords> &vTexCoords, CTileLayerVisuals::CTileVisual &Visual, int TileX, int TileY, int PosX, int PosY, const ivec2 &Offset) {
+		unsigned char Index = 0;
+		unsigned char Flags = 0;
+		int AngleRotate = -1;
+		GetTileData(&Index, &Flags, &AngleRotate, TileX, TileY, CurOverlay);
+		Visual.SetIndexBufferByteOffset((offset_ptr32)vTiles.size());
+		if(AddTile(vTiles, vTexCoords, Index, Flags, PosX, PosY, DoTextureCoords, AddAsSpeedup, AngleRotate, Offset))
+			Visual.Draw(true);
+	};
+
+	AddBorderTile(vTmpBorderCorners, vTmpBorderCornersTexCoords, Visuals.m_BorderTopLeft, 0, 0, 0, 0, ivec2{-32, -32});
+	if(Width > 1)
+		AddBorderTile(vTmpBorderCorners, vTmpBorderCornersTexCoords, Visuals.m_BorderTopRight, Width - 1, 0, 0, 0, ivec2{0, -32});
+	if(Height > 1)
+		AddBorderTile(vTmpBorderCorners, vTmpBorderCornersTexCoords, Visuals.m_BorderBottomLeft, 0, Height - 1, 0, 0, ivec2{-32, 0});
+	if(Width > 1 && Height > 1)
+		AddBorderTile(vTmpBorderCorners, vTmpBorderCornersTexCoords, Visuals.m_BorderBottomRight, Width - 1, Height - 1, 0, 0, ivec2{0, 0});
+
+	for(int y = 0; y < Height; ++y)
+		AddBorderTile(vTmpBorderLeftTiles, vTmpBorderLeftTilesTexCoords, Visuals.m_vBorderLeft[y], 0, y, 0, y, ivec2{-32, 0});
+	if(Width > 1)
+	{
+		for(int y = 0; y < Height; ++y)
+			AddBorderTile(vTmpBorderRightTiles, vTmpBorderRightTilesTexCoords, Visuals.m_vBorderRight[y], Width - 1, y, 0, y, ivec2{0, 0});
+	}
+	for(int x = 0; x < Width; ++x)
+		AddBorderTile(vTmpBorderTopTiles, vTmpBorderTopTilesTexCoords, Visuals.m_vBorderTop[x], x, 0, x, 0, ivec2{0, -32});
+	if(Height > 1)
+	{
+		for(int x = 0; x < Width; ++x)
+			AddBorderTile(vTmpBorderBottomTiles, vTmpBorderBottomTilesTexCoords, Visuals.m_vBorderBottom[x], x, Height - 1, x, 0, ivec2{0, 0});
 	}
 
 	// shrink clip region
@@ -776,11 +773,11 @@ void CRenderLayerTile::UploadTileData(std::optional<CTileLayerVisuals> &VisualsO
 	};
 
 	// add the border corners, then the borders and fix their byte offsets
-	int TilesHandledCount = vTmpTiles.size();
-	Visuals.m_BorderTopLeft.AddIndexBufferByteOffset(TilesHandledCount);
-	Visuals.m_BorderTopRight.AddIndexBufferByteOffset(TilesHandledCount);
-	Visuals.m_BorderBottomLeft.AddIndexBufferByteOffset(TilesHandledCount);
-	Visuals.m_BorderBottomRight.AddIndexBufferByteOffset(TilesHandledCount);
+	int CornerTilesHandledCount = vTmpTiles.size();
+	Visuals.m_BorderTopLeft.AddIndexBufferByteOffset(CornerTilesHandledCount);
+	Visuals.m_BorderTopRight.AddIndexBufferByteOffset(CornerTilesHandledCount);
+	Visuals.m_BorderBottomLeft.AddIndexBufferByteOffset(CornerTilesHandledCount);
+	Visuals.m_BorderBottomRight.AddIndexBufferByteOffset(CornerTilesHandledCount);
 
 	// add the Corners to the tiles
 	InsertTiles(vTmpBorderCorners, vTmpBorderCornersTexCoords);
@@ -985,6 +982,26 @@ void CRenderLayerTile::GetTileData(unsigned char *pIndex, unsigned char *pFlags,
 {
 	*pIndex = m_pTiles[y * m_pLayerTilemap->m_Width + x].m_Index;
 	*pFlags = m_pTiles[y * m_pLayerTilemap->m_Width + x].m_Flags;
+}
+
+const CTile *CRenderLayerTile::GetTileRow(CTile *pRowBuffer, int *pAngleRotates, unsigned int y, int CurOverlay) const
+{
+	return &m_pTiles[(size_t)y * m_pLayerTilemap->m_Width];
+}
+
+const CTile *CRenderLayerTile::GetTileRowFallback(CTile *pRowBuffer, int *pAngleRotates, unsigned int y, int CurOverlay) const
+{
+	for(int x = 0; x < m_pLayerTilemap->m_Width; ++x)
+	{
+		unsigned char Index = 0;
+		unsigned char Flags = 0;
+		int AngleRotate = -1;
+		GetTileData(&Index, &Flags, &AngleRotate, x, y, CurOverlay);
+		pRowBuffer[x].m_Index = Index;
+		pRowBuffer[x].m_Flags = Flags;
+		pAngleRotates[x] = AngleRotate;
+	}
+	return pRowBuffer;
 }
 
 /**************
@@ -1593,6 +1610,11 @@ void CRenderLayerEntityTele::RenderTileLayerNoTileBuffer(const ColorRGBA &Color,
 	RenderMap()->RenderTeleOverlay(m_pTeleTiles, m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height, 32.0f, OverlayRenderFlags, Color.a);
 }
 
+const CTile *CRenderLayerEntityTele::GetTileRow(CTile *pRowBuffer, int *pAngleRotates, unsigned int y, int CurOverlay) const
+{
+	return GetTileRowFallback(pRowBuffer, pAngleRotates, y, CurOverlay);
+}
+
 void CRenderLayerEntityTele::GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const
 {
 	*pIndex = m_pTeleTiles[y * m_pLayerTilemap->m_Width + x].m_Type;
@@ -1646,6 +1668,11 @@ void CRenderLayerEntitySpeedup::Unload()
 		m_VisualMaxSpeed->Unload();
 		m_VisualMaxSpeed = std::nullopt;
 	}
+}
+
+const CTile *CRenderLayerEntitySpeedup::GetTileRow(CTile *pRowBuffer, int *pAngleRotates, unsigned int y, int CurOverlay) const
+{
+	return GetTileRowFallback(pRowBuffer, pAngleRotates, y, CurOverlay);
 }
 
 void CRenderLayerEntitySpeedup::GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const
@@ -1728,6 +1755,11 @@ void CRenderLayerEntitySwitch::Unload()
 	}
 }
 
+const CTile *CRenderLayerEntitySwitch::GetTileRow(CTile *pRowBuffer, int *pAngleRotates, unsigned int y, int CurOverlay) const
+{
+	return GetTileRowFallback(pRowBuffer, pAngleRotates, y, CurOverlay);
+}
+
 void CRenderLayerEntitySwitch::GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const
 {
 	*pFlags = 0;
@@ -1773,6 +1805,11 @@ CRenderLayerEntityTune::CRenderLayerEntityTune(int GroupId, int LayerId, int Fla
 IGraphics::CTextureHandle CRenderLayerEntityTune::GetTexture() const
 {
 	return m_pMapImages->GetTuneColors();
+}
+
+const CTile *CRenderLayerEntityTune::GetTileRow(CTile *pRowBuffer, int *pAngleRotates, unsigned int y, int CurOverlay) const
+{
+	return GetTileRowFallback(pRowBuffer, pAngleRotates, y, CurOverlay);
 }
 
 void CRenderLayerEntityTune::GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const

--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -596,16 +596,75 @@ void CRenderLayerTile::RenderTileLayerNoTileBuffer(const ColorRGBA &Color, const
 	RenderMap()->RenderTilemap(m_pTiles, m_pLayerTilemap->m_Width, m_pLayerTilemap->m_Height, 32.0f, Color, (Params.m_RenderTileBorder ? TILERENDERFLAG_EXTEND : 0) | LAYERRENDERFLAG_TRANSPARENT);
 }
 
-void CRenderLayerTile::Init()
+void CRenderLayerTile::PrepareBuild()
 {
 	if(m_pLayerTilemap->m_Image >= 0 && m_pLayerTilemap->m_Image < m_pMapImages->Num())
 		m_TextureHandle = m_pMapImages->Get(m_pLayerTilemap->m_Image);
 	else
 		m_TextureHandle.Invalidate();
-	UploadTileData(m_VisualTiles, 0, false);
+
+	// Some of the entity textures are created on first use, which has to happen here
+	// instead of during the concurrent build
+	GetTexture();
 }
 
-void CRenderLayerTile::UploadTileData(std::optional<CTileLayerVisuals> &VisualsOptional, int CurOverlay, bool AddAsSpeedup, bool IsGameLayer)
+void CRenderLayerTile::Build()
+{
+	BuildTileData(m_VisualTiles, 0, false);
+}
+
+void CRenderLayerTile::Upload()
+{
+	for(CTileLayerVisuals *pVisuals : m_vpBuiltVisuals)
+	{
+		UploadTileVisuals(*pVisuals);
+	}
+	m_vpBuiltVisuals.clear();
+}
+
+void CRenderLayerTile::UploadTileVisuals(CTileLayerVisuals &Visuals)
+{
+	if(Visuals.m_UploadDataSize == 0)
+	{
+		RenderLoading();
+		return;
+	}
+
+	// first create the buffer object
+	const int BufferObjectIndex = Graphics()->CreateBufferObject(Visuals.m_UploadDataSize, Visuals.m_pUploadData, 0, true);
+	Visuals.m_pUploadData = nullptr;
+	Visuals.m_UploadDataSize = 0;
+
+	// then create the buffer container
+	SBufferContainerInfo ContainerInfo;
+	ContainerInfo.m_Stride = (Visuals.m_IsTextured ? (sizeof(float) * 2 + sizeof(ubvec4)) : 0);
+	ContainerInfo.m_VertBufferBindingIndex = BufferObjectIndex;
+	ContainerInfo.m_vAttributes.emplace_back();
+	SBufferContainerInfo::SAttribute *pAttr = &ContainerInfo.m_vAttributes.back();
+	pAttr->m_DataTypeCount = 2;
+	pAttr->m_Type = GRAPHICS_TYPE_FLOAT;
+	pAttr->m_Normalized = false;
+	pAttr->m_pOffset = nullptr;
+	pAttr->m_FuncType = 0;
+	if(Visuals.m_IsTextured)
+	{
+		ContainerInfo.m_vAttributes.emplace_back();
+		pAttr = &ContainerInfo.m_vAttributes.back();
+		pAttr->m_DataTypeCount = 4;
+		pAttr->m_Type = GRAPHICS_TYPE_UNSIGNED_BYTE;
+		pAttr->m_Normalized = false;
+		pAttr->m_pOffset = (void *)(sizeof(vec2));
+		pAttr->m_FuncType = 1;
+	}
+
+	Visuals.m_BufferContainerIndex = Graphics()->CreateBufferContainer(&ContainerInfo);
+	// and finally inform the backend how many indices are required
+	Graphics()->IndicesNumRequiredNotify(Visuals.m_NumTiles * 6);
+
+	RenderLoading();
+}
+
+void CRenderLayerTile::BuildTileData(std::optional<CTileLayerVisuals> &VisualsOptional, int CurOverlay, bool AddAsSpeedup, bool IsGameLayer)
 {
 	if(!Graphics()->IsTileBufferingEnabled())
 		return;
@@ -812,11 +871,12 @@ void CRenderLayerTile::UploadTileData(std::optional<CTileLayerVisuals> &VisualsO
 
 	Visuals.m_BufferContainerIndex = -1;
 
-	// upload data to gpu
-	size_t UploadDataSize = vTmpTileTexCoords.size() * sizeof(CGraphicTileTextureCoords) + vTmpTiles.size() * sizeof(CGraphicTile);
+	// build the vertex data, which `Upload` hands to the graphics backend
+	const size_t UploadDataSize = vTmpTileTexCoords.size() * sizeof(CGraphicTileTextureCoords) + vTmpTiles.size() * sizeof(CGraphicTile);
+	Visuals.m_NumTiles = vTmpTiles.size();
+	m_vpBuiltVisuals.push_back(&Visuals);
 	if(UploadDataSize == 0)
 	{
-		RenderLoading();
 		return;
 	}
 
@@ -854,36 +914,8 @@ void CRenderLayerTile::UploadTileData(std::optional<CTileLayerVisuals> &VisualsO
 		mem_copy(pUploadData, vTmpTiles.data(), vTmpTiles.size() * sizeof(CGraphicTile));
 	}
 
-	// first create the buffer object
-	int BufferObjectIndex = Graphics()->CreateBufferObject(UploadDataSize, pUploadData, 0, true);
-
-	// then create the buffer container
-	SBufferContainerInfo ContainerInfo;
-	ContainerInfo.m_Stride = (DoTextureCoords ? (sizeof(float) * 2 + sizeof(ubvec4)) : 0);
-	ContainerInfo.m_VertBufferBindingIndex = BufferObjectIndex;
-	ContainerInfo.m_vAttributes.emplace_back();
-	SBufferContainerInfo::SAttribute *pAttr = &ContainerInfo.m_vAttributes.back();
-	pAttr->m_DataTypeCount = 2;
-	pAttr->m_Type = GRAPHICS_TYPE_FLOAT;
-	pAttr->m_Normalized = false;
-	pAttr->m_pOffset = nullptr;
-	pAttr->m_FuncType = 0;
-	if(DoTextureCoords)
-	{
-		ContainerInfo.m_vAttributes.emplace_back();
-		pAttr = &ContainerInfo.m_vAttributes.back();
-		pAttr->m_DataTypeCount = 4;
-		pAttr->m_Type = GRAPHICS_TYPE_UNSIGNED_BYTE;
-		pAttr->m_Normalized = false;
-		pAttr->m_pOffset = (void *)(sizeof(vec2));
-		pAttr->m_FuncType = 1;
-	}
-
-	Visuals.m_BufferContainerIndex = Graphics()->CreateBufferContainer(&ContainerInfo);
-	// and finally inform the backend how many indices are required
-	Graphics()->IndicesNumRequiredNotify(vTmpTiles.size() * 6);
-
-	RenderLoading();
+	Visuals.m_pUploadData = pUploadData;
+	Visuals.m_UploadDataSize = UploadDataSize;
 }
 
 void CRenderLayerTile::Unload()
@@ -927,7 +959,7 @@ void CRenderLayerTile::OnInit(IGraphics *pGraphics, ITextRender *pTextRender, CR
 	// set clip region
 	if(!Graphics()->IsTileBufferingEnabled())
 	{
-		// shrink clip region, this is done in `UploadTileData` for buffered backends
+		// shrink clip region, this is done in `BuildTileData` for buffered backends
 		int MinX = m_pLayerTilemap->m_Width;
 		int MaxX = 0;
 		int MinY = m_pLayerTilemap->m_Height;
@@ -1109,7 +1141,7 @@ void CRenderLayerQuads::OnInit(IGraphics *pGraphics, ITextRender *pTextRender, C
 		m_pQuads = (CQuad *)m_pMap->GetDataSwapped(m_pLayerQuads->m_Data);
 }
 
-void CRenderLayerQuads::Init()
+void CRenderLayerQuads::Build()
 {
 	if(m_pLayerQuads->m_Image >= 0 && m_pLayerQuads->m_Image < m_pMapImages->Num())
 		m_TextureHandle = m_pMapImages->Get(m_pLayerQuads->m_Image);
@@ -1512,9 +1544,9 @@ IGraphics::CTextureHandle CRenderLayerEntityBase::GetTexture() const
 CRenderLayerEntityGame::CRenderLayerEntityGame(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap) :
 	CRenderLayerEntityBase(GroupId, LayerId, Flags, pLayerTilemap) {}
 
-void CRenderLayerEntityGame::Init()
+void CRenderLayerEntityGame::Build()
 {
-	UploadTileData(m_VisualTiles, 0, false, true);
+	BuildTileData(m_VisualTiles, 0, false, true);
 }
 
 void CRenderLayerEntityGame::RenderTileLayerWithTileBuffer(const ColorRGBA &Color, const CRenderLayerParams &Params)
@@ -1569,10 +1601,10 @@ int CRenderLayerEntityTele::GetDataIndex(unsigned int &TileSize) const
 	return m_pLayerTilemap->m_Tele;
 }
 
-void CRenderLayerEntityTele::Init()
+void CRenderLayerEntityTele::Build()
 {
-	UploadTileData(m_VisualTiles, 0, false);
-	UploadTileData(m_VisualTeleNumbers, 1, false);
+	BuildTileData(m_VisualTiles, 0, false);
+	BuildTileData(m_VisualTeleNumbers, 1, false);
 }
 
 void CRenderLayerEntityTele::InitTileData()
@@ -1643,11 +1675,11 @@ int CRenderLayerEntitySpeedup::GetDataIndex(unsigned int &TileSize) const
 	return m_pLayerTilemap->m_Speedup;
 }
 
-void CRenderLayerEntitySpeedup::Init()
+void CRenderLayerEntitySpeedup::Build()
 {
-	UploadTileData(m_VisualTiles, 0, true);
-	UploadTileData(m_VisualForce, 1, false);
-	UploadTileData(m_VisualMaxSpeed, 2, false);
+	BuildTileData(m_VisualTiles, 0, true);
+	BuildTileData(m_VisualForce, 1, false);
+	BuildTileData(m_VisualMaxSpeed, 2, false);
 }
 
 void CRenderLayerEntitySpeedup::InitTileData()
@@ -1728,11 +1760,11 @@ int CRenderLayerEntitySwitch::GetDataIndex(unsigned int &TileSize) const
 	return m_pLayerTilemap->m_Switch;
 }
 
-void CRenderLayerEntitySwitch::Init()
+void CRenderLayerEntitySwitch::Build()
 {
-	UploadTileData(m_VisualTiles, 0, false);
-	UploadTileData(m_VisualSwitchNumberTop, 1, false);
-	UploadTileData(m_VisualSwitchNumberBottom, 2, false);
+	BuildTileData(m_VisualTiles, 0, false);
+	BuildTileData(m_VisualSwitchNumberTop, 1, false);
+	BuildTileData(m_VisualSwitchNumberBottom, 2, false);
 }
 
 void CRenderLayerEntitySwitch::InitTileData()
@@ -1827,10 +1859,10 @@ void CRenderLayerEntityTune::GetTileData(unsigned char *pIndex, unsigned char *p
 	*pFlags = 0;
 }
 
-void CRenderLayerEntityTune::Init()
+void CRenderLayerEntityTune::Build()
 {
 	m_TuneColorMapper.Reset();
-	CRenderLayerTile::Init();
+	CRenderLayerTile::Build();
 }
 
 int CRenderLayerEntityTune::GetDataIndex(unsigned int &TileSize) const

--- a/src/game/map/render_layer.h
+++ b/src/game/map/render_layer.h
@@ -67,7 +67,22 @@ public:
 	CRenderLayer(int GroupId, int LayerId, int Flags);
 	virtual void OnInit(IGraphics *pGraphics, ITextRender *pTextRender, CRenderMap *pRenderMap, std::shared_ptr<CEnvelopeManager> &pEnvelopeManager, IMap *pMap, IMapImages *pMapImages, std::optional<FRenderUploadCallback> &FRenderUploadCallbackOptional);
 
-	virtual void Init() = 0;
+	// Builds the layer's data on the CPU. May run on a worker thread concurrently
+	// with other layers, so it must not touch the graphics backend or any state
+	// that is shared between layers.
+	virtual void Build() = 0;
+	// Resolves whatever `Build` needs that can only be done on the main thread.
+	virtual void PrepareBuild() {}
+	// Hands the built data to the graphics backend. Always runs on the main thread.
+	virtual void Upload() {}
+	// Whether `Build` may run on a worker thread.
+	virtual bool CanBuildConcurrently() const { return false; }
+	void Init()
+	{
+		PrepareBuild();
+		Build();
+		Upload();
+	}
 	virtual void Render(const CRenderLayerParams &Params) = 0;
 	virtual bool DoRender(const CRenderLayerParams &Params) = 0;
 	virtual bool IsValid() const { return true; }
@@ -98,7 +113,7 @@ class CRenderLayerGroup : public CRenderLayer
 public:
 	CRenderLayerGroup(int GroupId, CMapItemGroup *pGroup);
 	~CRenderLayerGroup() override = default;
-	void Init() override {}
+	void Build() override {}
 	void Render(const CRenderLayerParams &Params) override;
 	bool DoRender(const CRenderLayerParams &Params) override;
 	bool IsValid() const override { return m_pGroup != nullptr; }
@@ -118,7 +133,10 @@ public:
 	~CRenderLayerTile() override = default;
 	void Render(const CRenderLayerParams &Params) override;
 	bool DoRender(const CRenderLayerParams &Params) override;
-	void Init() override;
+	void Build() override;
+	void PrepareBuild() override;
+	void Upload() override;
+	bool CanBuildConcurrently() const override { return true; }
 	void OnInit(IGraphics *pGraphics, ITextRender *pTextRender, CRenderMap *pRenderMap, std::shared_ptr<CEnvelopeManager> &pEnvelopeManager, IMap *pMap, IMapImages *pMapImages, std::optional<FRenderUploadCallback> &FRenderUploadCallbackOptional) override;
 
 	virtual int GetDataIndex(unsigned int &TileSize) const;
@@ -156,6 +174,9 @@ protected:
 			m_Height = 0;
 			m_BufferContainerIndex = -1;
 			m_IsTextured = false;
+			m_pUploadData = nullptr;
+			m_UploadDataSize = 0;
+			m_NumTiles = 0;
 		}
 
 		bool Init(unsigned int Width, unsigned int Height);
@@ -222,9 +243,18 @@ protected:
 		unsigned int m_Height;
 		int m_BufferContainerIndex;
 		bool m_IsTextured;
+
+		// Vertex data produced by `BuildTileData`, owned until `Upload` hands it to
+		// the graphics backend
+		void *m_pUploadData;
+		size_t m_UploadDataSize;
+		size_t m_NumTiles;
 	};
 
-	void UploadTileData(std::optional<CTileLayerVisuals> &VisualsOptional, int CurOverlay, bool AddAsSpeedup, bool IsGameLayer = false);
+	void BuildTileData(std::optional<CTileLayerVisuals> &VisualsOptional, int CurOverlay, bool AddAsSpeedup, bool IsGameLayer = false);
+	void UploadTileVisuals(CTileLayerVisuals &Visuals);
+	// Visuals built by `BuildTileData`, waiting to be handed to the graphics backend
+	std::vector<CTileLayerVisuals *> m_vpBuiltVisuals;
 
 	virtual void RenderTileLayerWithTileBuffer(const ColorRGBA &Color, const CRenderLayerParams &Params);
 	virtual void RenderTileLayerNoTileBuffer(const ColorRGBA &Color, const CRenderLayerParams &Params);
@@ -243,7 +273,7 @@ class CRenderLayerQuads : public CRenderLayer
 public:
 	CRenderLayerQuads(int GroupId, int LayerId, int Flags, CMapItemLayerQuads *pLayerQuads);
 	void OnInit(IGraphics *pGraphics, ITextRender *pTextRender, CRenderMap *pRenderMap, std::shared_ptr<CEnvelopeManager> &pEnvelopeManager, IMap *pMap, IMapImages *pMapImages, std::optional<FRenderUploadCallback> &FRenderUploadCallbackOptional) override;
-	void Init() override;
+	void Build() override;
 	bool IsValid() const override { return m_pLayerQuads->m_NumQuads > 0 && m_pQuads; }
 	void Render(const CRenderLayerParams &Params) override;
 	bool DoRender(const CRenderLayerParams &Params) override;
@@ -309,7 +339,7 @@ class CRenderLayerEntityGame final : public CRenderLayerEntityBase
 {
 public:
 	CRenderLayerEntityGame(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
-	void Init() override;
+	void Build() override;
 
 protected:
 	void RenderTileLayerWithTileBuffer(const ColorRGBA &Color, const CRenderLayerParams &Params) override;
@@ -331,7 +361,7 @@ class CRenderLayerEntityTele final : public CRenderLayerEntityBase
 public:
 	CRenderLayerEntityTele(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
 	int GetDataIndex(unsigned int &TileSize) const override;
-	void Init() override;
+	void Build() override;
 	void InitTileData() override;
 	void Unload() override;
 
@@ -351,7 +381,7 @@ class CRenderLayerEntitySpeedup final : public CRenderLayerEntityBase
 public:
 	CRenderLayerEntitySpeedup(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
 	int GetDataIndex(unsigned int &TileSize) const override;
-	void Init() override;
+	void Build() override;
 	void InitTileData() override;
 	void Unload() override;
 
@@ -373,7 +403,7 @@ class CRenderLayerEntitySwitch final : public CRenderLayerEntityBase
 public:
 	CRenderLayerEntitySwitch(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
 	int GetDataIndex(unsigned int &TileSize) const override;
-	void Init() override;
+	void Build() override;
 	void InitTileData() override;
 	void Unload() override;
 
@@ -395,7 +425,7 @@ class CRenderLayerEntityTune final : public CRenderLayerEntityBase
 public:
 	CRenderLayerEntityTune(int GroupId, int LayerId, int Flags, CMapItemLayerTilemap *pLayerTilemap);
 	int GetDataIndex(unsigned int &TileSize) const override;
-	void Init() override;
+	void Build() override;
 	void InitTileData() override;
 
 protected:

--- a/src/game/map/render_layer.h
+++ b/src/game/map/render_layer.h
@@ -133,6 +133,13 @@ protected:
 	virtual ColorRGBA GetRenderColor(const CRenderLayerParams &Params) const;
 	virtual void InitTileData();
 	virtual void GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const;
+	// Returns an entire row of tile data at once, so that building the visuals of a
+	// layer costs one virtual call per row instead of one per tile. Either points
+	// straight into the layer's own tile data or fills `pRowBuffer`, which must hold
+	// at least one row. `pAngleRotates` is only written by layers that have angles.
+	virtual const CTile *GetTileRow(CTile *pRowBuffer, int *pAngleRotates, unsigned int y, int CurOverlay) const;
+	// Row accessor for layer types whose tile data cannot be read straight from `m_pTiles`.
+	const CTile *GetTileRowFallback(CTile *pRowBuffer, int *pAngleRotates, unsigned int y, int CurOverlay) const;
 	IGraphics::CTextureHandle GetTexture() const override { return m_TextureHandle; }
 	CTile *m_pTiles;
 
@@ -182,6 +189,13 @@ protected:
 			void SetIndexBufferByteOffset(offset_ptr32 IndexBufferByteOff)
 			{
 				m_IndexBufferByteOffset = IndexBufferByteOff | (m_IndexBufferByteOffset & 0x10000000);
+			}
+
+			// Sets offset and draw flag at once, so building the visuals only stores
+			// to each tile once instead of read-modify-writing it twice.
+			void Set(offset_ptr32 IndexBufferByteOff, bool SetDraw)
+			{
+				m_IndexBufferByteOffset = IndexBufferByteOff | (SetDraw ? 0x10000000 : (offset_ptr32)0);
 			}
 
 			void AddIndexBufferByteOffset(offset_ptr32 IndexBufferByteOff)
@@ -325,6 +339,7 @@ protected:
 	void RenderTileLayerWithTileBuffer(const ColorRGBA &Color, const CRenderLayerParams &Params) override;
 	void RenderTileLayerNoTileBuffer(const ColorRGBA &Color, const CRenderLayerParams &Params) override;
 	void GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const override;
+	const CTile *GetTileRow(CTile *pRowBuffer, int *pAngleRotates, unsigned int y, int CurOverlay) const override;
 
 private:
 	std::optional<CRenderLayerTile::CTileLayerVisuals> m_VisualTeleNumbers;
@@ -344,6 +359,7 @@ protected:
 	void RenderTileLayerWithTileBuffer(const ColorRGBA &Color, const CRenderLayerParams &Params) override;
 	void RenderTileLayerNoTileBuffer(const ColorRGBA &Color, const CRenderLayerParams &Params) override;
 	void GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const override;
+	const CTile *GetTileRow(CTile *pRowBuffer, int *pAngleRotates, unsigned int y, int CurOverlay) const override;
 	IGraphics::CTextureHandle GetTexture() const override;
 
 private:
@@ -365,6 +381,7 @@ protected:
 	void RenderTileLayerWithTileBuffer(const ColorRGBA &Color, const CRenderLayerParams &Params) override;
 	void RenderTileLayerNoTileBuffer(const ColorRGBA &Color, const CRenderLayerParams &Params) override;
 	void GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const override;
+	const CTile *GetTileRow(CTile *pRowBuffer, int *pAngleRotates, unsigned int y, int CurOverlay) const override;
 	IGraphics::CTextureHandle GetTexture() const override;
 
 private:
@@ -384,6 +401,7 @@ public:
 protected:
 	void RenderTileLayerNoTileBuffer(const ColorRGBA &Color, const CRenderLayerParams &Params) override;
 	void GetTileData(unsigned char *pIndex, unsigned char *pFlags, int *pAngleRotate, unsigned int x, unsigned int y, int CurOverlay) const override;
+	const CTile *GetTileRow(CTile *pRowBuffer, int *pAngleRotates, unsigned int y, int CurOverlay) const override;
 	IGraphics::CTextureHandle GetTexture() const override;
 
 private:


### PR DESCRIPTION
Just a draft, I haven't checked the code. As an example map Everdeen went from 106 ms to 34 ms until `OnConnected`.

Thought about this when I saw https://github.com/ddnet/ddnet/pull/12415, shouldn't we make map loading faster instead of adding a loading screen? Feel free to take this over and fix it up or review if anyone is interested. I'm busy, this was more of an experiment than something I am passionate about.