### PR TITLE
macOS: Fix semaphore leaks

### DIFF
--- a/src/base/sphore.cpp
+++ b/src/base/sphore.cpp
@@ -11,6 +11,7 @@
 #include <limits>
 #elif defined(CONF_PLATFORM_MACOS)
 #include "process.h"
+#include "secure.h"
 #include "str.h"
 
 #include <fcntl.h> // O_* constants
@@ -42,10 +43,13 @@ void sphore_destroy(SEMAPHORE *sem)
 #elif defined(CONF_PLATFORM_MACOS)
 void sphore_init(SEMAPHORE *sem)
 {
-	char aBuf[64];
-	str_format(aBuf, sizeof(aBuf), "/%d.%p", process_id(), (void *)sem);
+	unsigned Random;
+	secure_random_fill(&Random, sizeof(Random));
+	char aBuf[32];
+	str_format(aBuf, sizeof(aBuf), "/%d.%08x", process_id(), Random);
 	*sem = sem_open(aBuf, O_CREAT | O_EXCL, S_IRWXU | S_IRWXG, 0);
 	dbg_assert(*sem != SEM_FAILED, "sem_open failure, errno=%d, name='%s'", errno, aBuf);
+	dbg_assert(sem_unlink(aBuf) == 0, "sem_unlink failure, errno=%d, name='%s'", errno, aBuf);
 }
 void sphore_wait(SEMAPHORE *sem)
 {
@@ -63,9 +67,6 @@ void sphore_signal(SEMAPHORE *sem)
 void sphore_destroy(SEMAPHORE *sem)
 {
 	dbg_assert(sem_close(*sem) == 0, "sem_close failure");
-	char aBuf[64];
-	str_format(aBuf, sizeof(aBuf), "/%d.%p", process_id(), (void *)sem);
-	dbg_assert(sem_unlink(aBuf) == 0, "sem_unlink failure");
 }
 #elif defined(CONF_FAMILY_UNIX)
 void sphore_init(SEMAPHORE *sem)


### PR DESCRIPTION
Annoying when testing crashes on macOS, because `sphore_destroy` wouldn't run, and the semaphore leaks. At some point my system was out of semaphores.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

As with all of my changes, written by Claude Code (Opus 5 and Fable 5), reviewed and manually edited by me. (Do I have to keep writing that or can we just assume that's the case for each PR I'll open? If it's not pre-reviewed by me yet I make it a draft or say so explicitly.)