### PR TITLE
network: validate tick of sv_preinput messages

### DIFF
--- a/datasrc/datatypes.py
+++ b/datasrc/datatypes.py
@@ -533,6 +533,11 @@ class NetTick(NetIntAny):
 		return NetVariable(self.name).emit_dump(offset) + [f'dbg_msg("snapshot", "%s\\t{self.name}=%d (NetTick)", aRawData, pObj->{self.name});']
 
 
+class NetTickStrict(NetIntRange):
+	def __init__(self, name, *, default=None):
+		NetIntRange.__init__(self, name, "MIN_TICK", "MAX_TICK", default=default)
+
+
 class NetArray(NetVariable):
 	def __init__(self, var, size):
 		NetVariable.__init__(self, var.name, default=var.default)

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -1,5 +1,5 @@
 from datatypes import Enum, Flags, NetArray, NetBool, NetEvent, NetEventEx, NetIntAny, NetTwIntString, NetIntRange
-from datatypes import NetMessage, NetMessageEx, NetObject, NetObjectEx, NetString, NetStringHalfStrict, NetStringStrict, NetTick
+from datatypes import NetMessage, NetMessageEx, NetObject, NetObjectEx, NetString, NetStringHalfStrict, NetStringStrict, NetTick, NetTickStrict
 
 Emotes = ["NORMAL", "PAIN", "HAPPY", "SURPRISE", "ANGRY", "BLINK"]
 PlayerFlags = ["PLAYING", "IN_MENU", "CHATTING", "SCOREBOARD", "AIM", "SPEC_CAM", "INPUT_ABSOLUTE", "INPUT_MANUAL"]
@@ -615,7 +615,7 @@ Messages = [
 	NetMessageEx("Sv_CommandInfoGroupEnd", "sv-commandinfo-group-end@netmsg.ddnet.org", []),
 
 	NetMessageEx("Sv_ChangeInfoCooldown", "change-info-cooldown@netmsg.ddnet.org", [
-		NetTick("m_WaitUntil")
+		NetTickStrict("m_WaitUntil")
 	]),
 
 	NetMessageEx("Sv_MapSoundGlobal", "map-sound-global@netmsg.ddnet.org", [
@@ -636,7 +636,7 @@ Messages = [
 		NetIntAny("m_PrevWeapon"),
 
 		NetIntRange("m_Owner", 0, 'MAX_CLIENTS-1'),
-		NetTick("m_IntendedTick"),
+		NetTickStrict("m_IntendedTick"),
 	]),
 
 	NetMessageEx("Sv_SaveCode", "save-code@netmsg.ddnet.org", [


### PR DESCRIPTION
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Fable 5 and Opus 5) wrote this, I reviewed and edited.