### PR TITLE
server: Fix GetOptionalFloat db getter

### DIFF
--- a/src/engine/server/databases/connection.cpp
+++ b/src/engine/server/databases/connection.cpp
@@ -11,7 +11,7 @@ std::optional<float> IDbConnection::GetOptionalFloat(int Col)
 {
 	if(IsNull(Col))
 		return std::nullopt;
-	return GetInt(Col);
+	return GetFloat(Col);
 }
 
 std::optional<int> IDbConnection::GetOptionalInt(int Col)

--- a/src/test/score_test.cpp
+++ b/src/test/score_test.cpp
@@ -377,12 +377,13 @@ TEST_P(MapInfo, ExactNoFinish)
 
 TEST_P(MapInfo, ExactFinish)
 {
-	InsertRank();
+	InsertRank(42.87f);
+	str_copy(m_PlayerRequest.m_aRequestingPlayer, "nameless tee");
 	str_copy(m_PlayerRequest.m_aName, "Kobra 3");
 	ASSERT_TRUE(CScoreWorker::MapInfo(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 
 	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::DIRECT);
-	EXPECT_THAT(m_pPlayerResult->m_Data.m_aaMessages[0], testing::MatchesRegex("\"Kobra 3\" by Zerodin on Novice, ★★★★★, 5 points, released .* ago, 1 finish by 1 tee in 01:40 median"));
+	EXPECT_THAT(m_pPlayerResult->m_Data.m_aaMessages[0], testing::MatchesRegex("\"Kobra 3\" by Zerodin on Novice, ★★★★★, 5 points, released .* ago, 1 finish by 1 tee in 00:42 median, your time: 42\\.87"));
 	for(int i = 1; i < CScorePlayerResult::MAX_MESSAGES; i++)
 	{
 		EXPECT_STREQ(m_pPlayerResult->m_Data.m_aaMessages[i], "");


### PR DESCRIPTION
Broken in https://github.com/ddnet/ddnet/pull/12259

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude (Fable 5) wrote this, I reviewed