### PR TITLE
Improve renaming files on Windows

### DIFF
--- a/src/base/fs.cpp
+++ b/src/base/fs.cpp
@@ -589,17 +589,26 @@ int fs_remove(const char *filename)
 int fs_rename(const char *oldname, const char *newname)
 {
 #if defined(CONF_FAMILY_WINDOWS)
-	// Target file must be deleted first, else rename fails on Windows when the target file has open handles.
-	// Ignore the result and try to perform the rename anyway.
-	(void)fs_remove(newname);
-
 	const std::wstring wide_oldname = windows_utf8_to_wide(oldname);
 	const std::wstring wide_newname = windows_utf8_to_wide(newname);
 	if(MoveFileExW(wide_oldname.c_str(), wide_newname.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED | MOVEFILE_WRITE_THROUGH) != 0)
 	{
 		return 0;
 	}
-	const DWORD error = GetLastError();
+
+	// Can't rename on Windows when target file has open handles, delete target
+	// file and retry. We can't retry it before renaming because for a rename of
+	// foo to FOO the source file would be deleted.
+	DWORD error = GetLastError();
+	if(error == ERROR_ACCESS_DENIED)
+	{
+		(void)fs_remove(newname);
+		if(MoveFileExW(wide_oldname.c_str(), wide_newname.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED | MOVEFILE_WRITE_THROUGH) != 0)
+		{
+			return 0;
+		}
+		error = GetLastError();
+	}
 	log_error("filesystem", "Failed to rename file '%s' to '%s' (%ld '%s')", oldname, newname, error, windows_format_system_message(error).c_str());
 	return 1;
 #else

--- a/src/test/fs_test.cpp
+++ b/src/test/fs_test.cpp
@@ -239,6 +239,45 @@ TEST(Filesystem, RenameFile)
 	EXPECT_FALSE(fs_remove(aNewFilename));
 }
 
+TEST(Filesystem, RenameFileCaseOnly)
+{
+	char aOldFilename[IO_MAX_PATH_LENGTH];
+	char aNewFilename[IO_MAX_PATH_LENGTH];
+	CTestInfo Info;
+	Info.Filename(aOldFilename, sizeof(aOldFilename), ".case.tmp");
+	Info.Filename(aNewFilename, sizeof(aNewFilename), ".CASE.tmp");
+
+	IOHANDLE FileWrite = io_open(aOldFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(FileWrite);
+	EXPECT_FALSE(io_close(FileWrite));
+
+	EXPECT_TRUE(fs_is_file(aOldFilename));
+	EXPECT_FALSE(fs_rename(aOldFilename, aNewFilename));
+	EXPECT_TRUE(fs_is_file(aNewFilename));
+
+	EXPECT_FALSE(fs_remove(aNewFilename));
+}
+
+TEST(Filesystem, RenameOpenFileCaseOnly)
+{
+	char aOldFilename[IO_MAX_PATH_LENGTH];
+	char aNewFilename[IO_MAX_PATH_LENGTH];
+	CTestInfo Info;
+	Info.Filename(aOldFilename, sizeof(aOldFilename), ".case.tmp");
+	Info.Filename(aNewFilename, sizeof(aNewFilename), ".CASE.tmp");
+
+	IOHANDLE FileWrite = io_open(aOldFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(FileWrite);
+
+	EXPECT_TRUE(fs_is_file(aOldFilename));
+	EXPECT_FALSE(fs_rename(aOldFilename, aNewFilename));
+	EXPECT_TRUE(fs_is_file(aNewFilename));
+
+	EXPECT_FALSE(io_close(FileWrite));
+
+	EXPECT_FALSE(fs_remove(aNewFilename));
+}
+
 TEST(Filesystem, RenameFolder)
 {
 	char aNewFilename[IO_MAX_PATH_LENGTH];


### PR DESCRIPTION
Follow-up to https://github.com/ddnet/ddnet/pull/12254, which can cause FOO -> foo renames to cause the file to be deleted.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude (Fable 5 and Opus 5) wrote this, I reviewed and edited.
