### PR TITLE
editor: Fix state recording for undo

### DIFF
--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -921,7 +921,7 @@ void CLayerTiles::FillGameTiles(EGameTileOp Fill)
 							pTLayer->m_pTeleTile[TileIndex].m_Type,
 							pTLayer->m_pTiles[TileIndex].m_Index};
 
-						pTLayer->RecordStateChange(x, y, Previous, Current);
+						pTLayer->RecordStateChange(x + OffsetX, y + OffsetY, Previous, Current);
 					}
 				}
 			}

--- a/src/game/editor/mapitems/layer_tune.cpp
+++ b/src/game/editor/mapitems/layer_tune.cpp
@@ -128,6 +128,13 @@ void CLayerTune::BrushDraw(CLayer *pBrush, vec2 WorldPos)
 						m_pTuneTile[TgtIndex].m_Number = 0;
 						m_pTuneTile[TgtIndex].m_Type = 0;
 						m_pTiles[TgtIndex].m_Index = 0;
+
+						STuneTileStateChange::SData Current{
+							m_pTuneTile[TgtIndex].m_Number,
+							m_pTuneTile[TgtIndex].m_Type,
+							m_pTiles[TgtIndex].m_Index};
+
+						RecordStateChange(fx, fy, Previous, Current);
 						continue;
 					}
 					else

--- a/src/game/editor/mapitems/map.cpp
+++ b/src/game/editor/mapitems/map.cpp
@@ -1055,8 +1055,7 @@ void CEditorMap::PlaceBorderTiles()
 		}
 	}
 
-	int GameGroupIndex = std::find(m_vpGroups.begin(), m_vpGroups.end(), m_pGameGroup) - m_vpGroups.begin();
-	m_EditorHistory.RecordAction(std::make_shared<CEditorBrushDrawAction>(this, GameGroupIndex), "Tool 'Make borders'");
+	m_EditorHistory.RecordAction(std::make_shared<CEditorBrushDrawAction>(this, m_SelectedGroup), "Tool 'Make borders'");
 
 	OnModify();
 }


### PR DESCRIPTION
Broken since we had undo I guess, so not a regression.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude (Fable 5) wrote this, I reviewed.