### PR TITLE
Fix timestamp_from_str with daylight saving time

### DIFF
--- a/src/base/time.cpp
+++ b/src/base/time.cpp
@@ -174,6 +174,7 @@ void str_timestamp_ex(time_t time_data, char *buffer, int buffer_size, const cha
 bool timestamp_from_str(const char *string, const char *format, time_t *timestamp)
 {
 	std::tm tm{};
+	tm.tm_isdst = -1; // determine DST from parsed date
 	std::istringstream ss(string);
 	ss >> std::get_time(&tm, format);
 	if(ss.fail() || !ss.eof())

--- a/src/test/timestamp_test.cpp
+++ b/src/test/timestamp_test.cpp
@@ -8,14 +8,30 @@
 class TimestampTest : public testing::Test // NOLINT(readability-identifier-naming)
 {
 protected:
-	void SetUp() override
+	static void SetTimezone(const char *pTimezone)
 	{
 #if defined(CONF_FAMILY_WINDOWS)
-		_putenv_s("TZ", "UTC");
+		_putenv_s("TZ", pTimezone);
 		_tzset();
 #else
-		setenv("TZ", "UTC", 1);
+		setenv("TZ", pTimezone, 1);
 		tzset();
+#endif
+	}
+
+	void SetUp() override
+	{
+		SetTimezone("UTC");
+#if defined(CONF_FAMILY_WINDOWS)
+		_dstbias = 0;
+#endif
+	}
+
+	void TearDown() override
+	{
+		SetTimezone("UTC");
+#if defined(CONF_FAMILY_WINDOWS)
+		_dstbias = 0;
 #endif
 	}
 };
@@ -31,6 +47,24 @@ TEST_F(TimestampTest, FromStr)
 
 	EXPECT_TRUE(timestamp_from_str("2004-05-15 18:13:53", TimestampFormat::SPACE, &Timestamp));
 	EXPECT_EQ(Timestamp, 1084644833);
+}
+
+TEST_F(TimestampTest, FromStrDaylightSavingTime)
+{
+	SetTimezone("CET-1CEST,M3.5.0,M10.5.0/3");
+#if defined(CONF_FAMILY_WINDOWS)
+	// Windows is annoying, workaround for test
+	_dstbias = -3600;
+#endif
+
+	// Format and parse must round trip during daylight saving time
+	char aTimestamp[20];
+	str_timestamp_ex(1690000000, aTimestamp, sizeof(aTimestamp), TimestampFormat::NOSPACE);
+	EXPECT_STREQ(aTimestamp, "2023-07-22_06-26-40");
+
+	time_t Timestamp;
+	EXPECT_TRUE(timestamp_from_str(aTimestamp, TimestampFormat::NOSPACE, &Timestamp));
+	EXPECT_EQ(Timestamp, 1690000000);
 }
 
 TEST_F(TimestampTest, FromStrFailing)


### PR DESCRIPTION
This has weird effects on screenshots, autosaves, etc.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude (Fable 5) wrote this, I reviewed and edited.