### PR TITLE
Clean up LLM-generated snapshot storage code

### DIFF
--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -694,9 +694,14 @@ void CSnapshotStorage::Add(int Tick, int64_t Tagtime, size_t DataSize, const voi
 	pHolder->m_pNext = nullptr;
 	pHolder->m_pPrev = m_pLast;
 	if(m_pLast)
+	{
+		dbg_assert(m_pLast->m_Tick < Tick, "snapshots inserted into CSnapshotStorage with non-increasing tick %d >= %d", m_pLast->m_Tick, Tick);
 		m_pLast->m_pNext = pHolder;
+	}
 	else
+	{
 		m_pFirst = pHolder;
+	}
 	m_pLast = pHolder;
 }
 

--- a/src/test/snapshot_test.cpp
+++ b/src/test/snapshot_test.cpp
@@ -72,14 +72,9 @@ TEST(Snapshot, CrcOverflow)
 
 TEST(Snapshot, StorageGet)
 {
-	// CSnapshotStorage::Get searches backwards from the newest holder and
-	// stops as soon as it passes a tick older than the requested one. That
-	// early return is only correct because all callers Add ticks in strictly
-	// increasing order, keeping the list sorted by tick. This test inserts
-	// monotonically and checks that lookups respect that invariant.
 	CSnapshotStorage Storage;
 
-	// distinct sizes and tag times so we can tell the holders apart
+	// `CSnapshotStorage` needs snapshots in increasing tick order.
 	const char aData[8] = {0};
 	Storage.Add(10, 1000, 1, aData, 0, nullptr);
 	Storage.Add(20, 2000, 2, aData, 0, nullptr);
@@ -88,7 +83,7 @@ TEST(Snapshot, StorageGet)
 
 	int64_t Tagtime = -1;
 
-	// newest, oldest and a middle tick all resolve to their own holder
+	// Retrieve existing snapshots.
 	EXPECT_EQ(Storage.Get(40, &Tagtime, nullptr, nullptr), 4);
 	EXPECT_EQ(Tagtime, 4000);
 	EXPECT_EQ(Storage.Get(10, &Tagtime, nullptr, nullptr), 1);
@@ -96,10 +91,8 @@ TEST(Snapshot, StorageGet)
 	EXPECT_EQ(Storage.Get(30, &Tagtime, nullptr, nullptr), 3);
 	EXPECT_EQ(Tagtime, 3000);
 
-	// newer than the newest: early return on the very first holder
+	// Check non-existing snapshots in before, within and after the range.
 	EXPECT_EQ(Storage.Get(50, nullptr, nullptr, nullptr), -1);
-	// older than the oldest: search walks off the front of the list
 	EXPECT_EQ(Storage.Get(5, nullptr, nullptr, nullptr), -1);
-	// gap between two stored ticks: early return before reaching the oldest
 	EXPECT_EQ(Storage.Get(25, nullptr, nullptr, nullptr), -1);
 }


### PR DESCRIPTION
Add an assertion for the assumption about callers, change the test to not talk about implementation details, but only about what we test.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
