### PR TITLE
Make rcon cmd/maplist sending 10x faster

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3389,9 +3389,11 @@ int CServer::Run()
 			{
 				DoSnapshot();
 
-				const int CommandSendingClientId = Tick() % MAX_CLIENTS;
-				UpdateClientRconCommands(CommandSendingClientId);
-				UpdateClientMaplistEntries(CommandSendingClientId);
+				for(int ClientId = Tick() % MAX_RCONCMD_RATIO; ClientId < MAX_CLIENTS; ClientId += MAX_RCONCMD_RATIO)
+				{
+					UpdateClientRconCommands(ClientId);
+					UpdateClientMaplistEntries(ClientId);
+				}
 
 				m_Fifo.Update();
 

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -99,6 +99,7 @@ public:
 	enum
 	{
 		MAX_RCONCMD_SEND = 16,
+		MAX_RCONCMD_RATIO = 12,
 	};
 
 	enum class EDnsblState


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
