### PR TITLE
Strip newline after Rust version

### DIFF
--- a/src/engine/shared/build.rs
+++ b/src/engine/shared/build.rs
@@ -14,5 +14,10 @@ fn main() {
     if !rustc_output.status.success() {
         panic!("rustc --version: exit status {}", rustc_output.status);
     }
-    fs::write(&out, rustc_output.stdout).expect("file write");
+    let rustc_version = rustc_output
+        .stdout
+        .strip_suffix(b"\n")
+        .expect("rustc version output ends with newline");
+    assert!(!rustc_version.contains(&b'\n'));
+    fs::write(&out, rustc_version).expect("file write");
 }


### PR DESCRIPTION
Fixes #12434.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
