### PR TITLE
Generate less code for int configs

### DIFF
--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -288,22 +288,26 @@ void CConfigManager::Init()
 		pVariable->Register();
 	};
 
+	const auto &&AddIntVariable = [this, AddVariable](const char *pScriptName, int Flags, const char *pDesc, int *pVariable, int Default, int Min, int Max) {
+		dbg_assert(Min == 0 || Max == 0 || Min < Max, "MACRO_CONFIG_INT(%s): minimum (%d) must be less than maximum (%d)", pScriptName, Min, Max);
+		dbg_assert((Min == 0 || Default >= Min) && (Max == 0 || Default <= Max), "MACRO_CONFIG_INT(%s): default (%d) must be in range of minimum (%d) and maximum (%d)", pScriptName, Default, Min, Max);
+		char aHelp[512];
+		size_t HelpSize;
+		if(Min == 0 && Max == 0)
+			HelpSize = str_format(aHelp, sizeof(aHelp), "%s (default: %d)", pDesc, Default);
+		else if(Max == 0)
+			HelpSize = str_format(aHelp, sizeof(aHelp), "%s (default: %d, min: %d)", pDesc, Default, Min);
+		else
+			HelpSize = str_format(aHelp, sizeof(aHelp), "%s (default: %d, min: %d, max: %d)", pDesc, Default, Min, Max);
+		dbg_assert(HelpSize < sizeof(aHelp) - UTF8_BYTE_LENGTH - 1, "MACRO_CONFIG_INT(%s): help text possibly truncated. Increase size of aHelp.", pScriptName);
+
+		AddVariable(m_ConfigHeap.Allocate<SIntConfigVariable>(
+			m_pConsole, pScriptName, SConfigVariable::VAR_INT, Flags, m_ConfigHeap.StoreString(aHelp), pVariable, Default, Min, Max));
+	};
+
 #define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Flags, Desc) \
 	{ \
-		const char *pScriptName = #ScriptName; \
-		dbg_assert(Min == 0 || Max == 0 || Min < Max, "MACRO_CONFIG_INT(%s): minimum (%d) must be less than maximum (%d)", pScriptName, Min, Max); \
-		dbg_assert((Min == 0 || Def >= Min) && (Max == 0 || Def <= Max), "MACRO_CONFIG_INT(%s): default (%d) must be in range of minimum (%d) and maximum (%d)", pScriptName, Def, Min, Max); \
-		char aHelp[512]; \
-		size_t HelpSize; \
-		if(Min == 0 && Max == 0) \
-			HelpSize = str_format(aHelp, sizeof(aHelp), "%s (default: %d)", Desc, Def); \
-		else if(Max == 0) \
-			HelpSize = str_format(aHelp, sizeof(aHelp), "%s (default: %d, min: %d)", Desc, Def, Min); \
-		else \
-			HelpSize = str_format(aHelp, sizeof(aHelp), "%s (default: %d, min: %d, max: %d)", Desc, Def, Min, Max); \
-		dbg_assert(HelpSize < sizeof(aHelp) - UTF8_BYTE_LENGTH - 1, "MACRO_CONFIG_INT(%s): help text possibly truncated. Increase size of aHelp.", pScriptName); \
-		AddVariable(m_ConfigHeap.Allocate<SIntConfigVariable>( \
-			m_pConsole, pScriptName, SConfigVariable::VAR_INT, Flags, m_ConfigHeap.StoreString(aHelp), &g_Config.m_##Name, Def, Min, Max)); \
+		AddIntVariable(#ScriptName, Flags, Desc, &g_Config.m_##Name, Def, Min, Max); \
 	}
 
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Flags, Desc) \


### PR DESCRIPTION
Closes #12460

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
