### PR TITLE
Keep state of editor history UI separate for each map and history

### DIFF
--- a/src/game/editor/editor_history.cpp
+++ b/src/game/editor/editor_history.cpp
@@ -98,19 +98,13 @@ void CEditorHistory::EndBulk(int DisplayToUse)
 
 void CEditor::RenderEditorHistory(CUIRect View)
 {
-	enum class EHistoryType
-	{
-		EDITOR,
-		ENVELOPE,
-		SERVER_SETTINGS,
-	};
+	CEditorHistoryUiState &State = Map()->m_EditorHistoryUiState;
+	CListBox &ListBox = State.m_aListBoxes[(int)State.m_HistoryType];
+	int &SelectedActionIndex = State.m_aSelectedActionIndices[(int)State.m_HistoryType];
 
-	static EHistoryType s_HistoryType = EHistoryType::EDITOR;
-	static int s_ActionSelectedIndex = 0;
-	static CListBox s_ListBox;
-	s_ListBox.SetActive(m_Dialog == DIALOG_NONE && !Ui()->IsPopupOpen());
+	ListBox.SetActive(m_Dialog == DIALOG_NONE && !Ui()->IsPopupOpen());
 
-	const bool GotSelection = s_ListBox.Active() && s_ActionSelectedIndex >= 0 && (size_t)s_ActionSelectedIndex < Map()->m_vSettings.size();
+	const bool GotSelection = ListBox.Active() && SelectedActionIndex >= 0 && (size_t)SelectedActionIndex < Map()->m_vSettings.size();
 
 	CUIRect ToolBar, Button, Label, List, DragBar;
 	View.HSplitTop(22.0f, &DragBar, nullptr);
@@ -129,24 +123,21 @@ void CEditor::RenderEditorHistory(CUIRect View)
 	// history type buttons
 	{
 		TypeButtons.VSplitLeft(HistoryTypeBtnSize, &HistoryTypeButton, &TypeButtons);
-		static int s_EditorHistoryButton = 0;
-		if(DoButton_Ex(&s_EditorHistoryButton, "Editor", s_HistoryType == EHistoryType::EDITOR, &HistoryTypeButton, BUTTONFLAG_LEFT, "Show map editor history.", IGraphics::CORNER_L))
+		if(DoButton_Ex(&State.m_aHistoryTypeButtonIds[(int)EHistoryType::EDITOR], "Editor", State.m_HistoryType == EHistoryType::EDITOR, &HistoryTypeButton, BUTTONFLAG_LEFT, "Show map editor history.", IGraphics::CORNER_L))
 		{
-			s_HistoryType = EHistoryType::EDITOR;
+			State.m_HistoryType = EHistoryType::EDITOR;
 		}
 
 		TypeButtons.VSplitLeft(HistoryTypeBtnSize, &HistoryTypeButton, &TypeButtons);
-		static int s_EnvelopeEditorHistoryButton = 0;
-		if(DoButton_Ex(&s_EnvelopeEditorHistoryButton, "Envelope", s_HistoryType == EHistoryType::ENVELOPE, &HistoryTypeButton, BUTTONFLAG_LEFT, "Show envelope editor history.", IGraphics::CORNER_NONE))
+		if(DoButton_Ex(&State.m_aHistoryTypeButtonIds[(int)EHistoryType::ENVELOPE], "Envelope", State.m_HistoryType == EHistoryType::ENVELOPE, &HistoryTypeButton, BUTTONFLAG_LEFT, "Show envelope editor history.", IGraphics::CORNER_NONE))
 		{
-			s_HistoryType = EHistoryType::ENVELOPE;
+			State.m_HistoryType = EHistoryType::ENVELOPE;
 		}
 
 		TypeButtons.VSplitLeft(HistoryTypeBtnSize, &HistoryTypeButton, &TypeButtons);
-		static int s_ServerSettingsHistoryButton = 0;
-		if(DoButton_Ex(&s_ServerSettingsHistoryButton, "Settings", s_HistoryType == EHistoryType::SERVER_SETTINGS, &HistoryTypeButton, BUTTONFLAG_LEFT, "Show server settings editor history.", IGraphics::CORNER_R))
+		if(DoButton_Ex(&State.m_aHistoryTypeButtonIds[(int)EHistoryType::SERVER_SETTINGS], "Settings", State.m_HistoryType == EHistoryType::SERVER_SETTINGS, &HistoryTypeButton, BUTTONFLAG_LEFT, "Show server settings editor history.", IGraphics::CORNER_R))
 		{
-			s_HistoryType = EHistoryType::SERVER_SETTINGS;
+			State.m_HistoryType = EHistoryType::SERVER_SETTINGS;
 		}
 	}
 
@@ -157,34 +148,42 @@ void CEditor::RenderEditorHistory(CUIRect View)
 	Ui()->DoLabel(&Label, "Editor history. Click on an action to undo all actions above.", 10.0f, TEXTALIGN_ML, InfoProps);
 
 	CEditorHistory *pCurrentHistory;
-	if(s_HistoryType == EHistoryType::EDITOR)
+	if(State.m_HistoryType == EHistoryType::EDITOR)
+	{
 		pCurrentHistory = &Map()->m_EditorHistory;
-	else if(s_HistoryType == EHistoryType::ENVELOPE)
+	}
+	else if(State.m_HistoryType == EHistoryType::ENVELOPE)
+	{
 		pCurrentHistory = &Map()->m_EnvelopeEditorHistory;
-	else if(s_HistoryType == EHistoryType::SERVER_SETTINGS)
+	}
+	else if(State.m_HistoryType == EHistoryType::SERVER_SETTINGS)
+	{
 		pCurrentHistory = &Map()->m_ServerSettingsHistory;
+	}
 	else
-		return;
+	{
+		dbg_assert_failed("Invalid State.m_HistoryType: %d", (int)State.m_HistoryType);
+	}
 
 	// delete button
 	ToolBar.VSplitRight(25.0f, &ToolBar, &Button);
 	ToolBar.VSplitRight(5.0f, &ToolBar, nullptr);
-	static int s_DeleteButton = 0;
-	if(DoButton_FontIcon(&s_DeleteButton, FontIcon::TRASH, (!pCurrentHistory->m_vpUndoActions.empty() || !pCurrentHistory->m_vpRedoActions.empty()) ? 0 : -1, &Button, BUTTONFLAG_LEFT, "Clear the history.", IGraphics::CORNER_ALL, 9.0f) || (GotSelection && CLineInput::GetActiveInput() == nullptr && m_Dialog == DIALOG_NONE && Ui()->ConsumeHotkey(CUi::HOTKEY_DELETE)))
+	if(DoButton_FontIcon(&State.m_DeleteButtonId, FontIcon::TRASH, (!pCurrentHistory->m_vpUndoActions.empty() || !pCurrentHistory->m_vpRedoActions.empty()) ? 0 : -1, &Button, BUTTONFLAG_LEFT, "Clear the history.", IGraphics::CORNER_ALL, 9.0f) ||
+		(GotSelection && CLineInput::GetActiveInput() == nullptr && m_Dialog == DIALOG_NONE && Ui()->ConsumeHotkey(CUi::HOTKEY_DELETE)))
 	{
 		pCurrentHistory->Clear();
-		s_ActionSelectedIndex = 0;
+		SelectedActionIndex = 0;
 	}
 
 	// actions list
 	int RedoSize = (int)pCurrentHistory->m_vpRedoActions.size();
 	int UndoSize = (int)pCurrentHistory->m_vpUndoActions.size();
-	s_ActionSelectedIndex = RedoSize;
-	s_ListBox.DoStart(15.0f, RedoSize + UndoSize, 1, 3, s_ActionSelectedIndex, &List);
+	SelectedActionIndex = RedoSize;
+	ListBox.DoStart(15.0f, RedoSize + UndoSize, 1, 3, SelectedActionIndex, &List);
 
 	for(int i = 0; i < RedoSize; i++)
 	{
-		const CListboxItem Item = s_ListBox.DoNextItem(&pCurrentHistory->m_vpRedoActions[i], s_ActionSelectedIndex >= 0 && s_ActionSelectedIndex == i);
+		const CListboxItem Item = ListBox.DoNextItem(&pCurrentHistory->m_vpRedoActions[i], SelectedActionIndex >= 0 && SelectedActionIndex == i);
 		if(!Item.m_Visible)
 			continue;
 
@@ -201,7 +200,7 @@ void CEditor::RenderEditorHistory(CUIRect View)
 
 	for(int i = 0; i < UndoSize; i++)
 	{
-		const CListboxItem Item = s_ListBox.DoNextItem(&pCurrentHistory->m_vpUndoActions[UndoSize - i - 1], s_ActionSelectedIndex >= RedoSize && s_ActionSelectedIndex == (i + RedoSize));
+		const CListboxItem Item = ListBox.DoNextItem(&pCurrentHistory->m_vpUndoActions[UndoSize - i - 1], SelectedActionIndex >= RedoSize && SelectedActionIndex == (i + RedoSize));
 		if(!Item.m_Visible)
 			continue;
 
@@ -214,8 +213,7 @@ void CEditor::RenderEditorHistory(CUIRect View)
 	}
 
 	{ // Base action "Loaded map" that cannot be undone
-		static int s_BaseAction;
-		const CListboxItem Item = s_ListBox.DoNextItem(&s_BaseAction, s_ActionSelectedIndex == RedoSize + UndoSize);
+		const CListboxItem Item = ListBox.DoNextItem(&State.m_BaseActionButtonId, SelectedActionIndex == RedoSize + UndoSize);
 		if(Item.m_Visible)
 		{
 			Item.m_Rect.VMargin(5.0f, &Label);
@@ -224,25 +222,25 @@ void CEditor::RenderEditorHistory(CUIRect View)
 		}
 	}
 
-	const int NewSelected = s_ListBox.DoEnd();
-	if(s_ActionSelectedIndex != NewSelected)
+	const int NewSelected = ListBox.DoEnd();
+	if(SelectedActionIndex != NewSelected)
 	{
 		// Figure out if we should undo or redo some actions
 		// Undo everything until the selected index
-		if(NewSelected > s_ActionSelectedIndex)
+		if(NewSelected > SelectedActionIndex)
 		{
-			for(int i = 0; i < (NewSelected - s_ActionSelectedIndex); i++)
+			for(int i = 0; i < (NewSelected - SelectedActionIndex); i++)
 			{
 				pCurrentHistory->Undo();
 			}
 		}
 		else
 		{
-			for(int i = 0; i < (s_ActionSelectedIndex - NewSelected); i++)
+			for(int i = 0; i < (SelectedActionIndex - NewSelected); i++)
 			{
 				pCurrentHistory->Redo();
 			}
 		}
-		s_ActionSelectedIndex = NewSelected;
+		SelectedActionIndex = NewSelected;
 	}
 }

--- a/src/game/editor/editor_history.h
+++ b/src/game/editor/editor_history.h
@@ -3,6 +3,7 @@
 
 #include "editor_action.h"
 
+#include <game/client/ui_listbox.h>
 #include <game/editor/map_object.h>
 
 #include <deque>
@@ -43,6 +44,24 @@ public:
 private:
 	std::vector<std::shared_ptr<IEditorAction>> m_vpBulkActions;
 	bool m_IsBulk = false;
+};
+
+enum class EHistoryType
+{
+	EDITOR,
+	ENVELOPE,
+	SERVER_SETTINGS,
+};
+
+class CEditorHistoryUiState
+{
+public:
+	EHistoryType m_HistoryType = EHistoryType::EDITOR;
+	CListBox m_aListBoxes[(int)EHistoryType::SERVER_SETTINGS + 1];
+	int m_aSelectedActionIndices[(int)EHistoryType::SERVER_SETTINGS + 1] = {0};
+	const char m_aHistoryTypeButtonIds[(int)EHistoryType::SERVER_SETTINGS + 1] = {0};
+	const char m_DeleteButtonId = 0;
+	const char m_BaseActionButtonId = 0;
 };
 
 #endif

--- a/src/game/editor/mapitems/map.h
+++ b/src/game/editor/mapitems/map.h
@@ -156,6 +156,7 @@ public:
 	CMapSettingsBackend::CContextWithInput m_MapSettingsCommandContext;
 	CFontTyper::CState m_FontTyperState;
 	CEditorUiElements m_EditorUiElements;
+	CEditorHistoryUiState m_EditorHistoryUiState;
 
 	// Housekeeping
 	void Clean();


### PR DESCRIPTION
For #11776. But also useful because the scroll position is now separate for each history type.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
