### PR TITLE
server: Support TLS websockets & hot-reloading certificates

### DIFF
--- a/cmake/FindWebsockets.cmake
+++ b/cmake/FindWebsockets.cmake
@@ -5,7 +5,8 @@ endif()
 
 set_extra_dirs_lib(WEBSOCKETS websockets)
 find_library(WEBSOCKETS_LIBRARY
-  NAMES websockets websockets.17
+  NAMES websockets websockets.19
+  NAMES_PER_DIR
   HINTS ${HINTS_WEBSOCKETS_LIBDIR} ${PC_WEBSOCKETS_LIBDIR} ${PC_WEBSOCKETS_LIBRARY_DIRS}
   PATHS ${PATHS_WEBSOCKETS_LIBDIR}
   ${CROSSCOMPILING_NO_CMAKE_SYSTEM_PATH}
@@ -28,6 +29,14 @@ if(WEBSOCKETS_FOUND)
   set(WEBSOCKETS_INCLUDE_DIRS ${WEBSOCKETS_INCLUDEDIR})
 
   is_bundled(WEBSOCKETS_BUNDLED "${WEBSOCKETS_LIBRARY}")
+  if(WEBSOCKETS_BUNDLED AND TARGET_OS STREQUAL "linux" AND EXISTS "${WEBSOCKETS_INCLUDEDIR}/lws_config.h")
+    # The bundled Linux libwebsockets.a is built against the system OpenSSL,
+    # which a static library cannot link on its own
+    file(STRINGS "${WEBSOCKETS_INCLUDEDIR}/lws_config.h" WEBSOCKETS_WITH_TLS REGEX "^#define LWS_WITH_TLS$")
+    if(WEBSOCKETS_WITH_TLS)
+      list(APPEND WEBSOCKETS_LIBRARIES ssl crypto)
+    endif()
+  endif()
   set(WEBSOCKETS_COPY_FILES)
   if(WEBSOCKETS_BUNDLED)
     if(TARGET_OS STREQUAL "windows")

--- a/other/emscripten/index.html
+++ b/other/emscripten/index.html
@@ -183,6 +183,9 @@
 			}
 			var loadOnLaunch = { file: null, path: null, link: null };
 			var Module = {
+				websocket: {
+					url: location.protocol === "https:" ? "wss://" : "ws://",
+				},
 				noInitialRun: true,
 				arguments: [],
 				print: function(text) {

--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -696,7 +696,7 @@ def client_can_connect_websockets(test_env):
 	client = test_env.client(["dbg_websockets 1", "stdout_output_level 1"])
 	server = test_env.server(["dbg_websockets 1", "stdout_output_level 1"])
 	wait_for_startup([client, server])
-	client.command(f"connect ws://127.0.0.1:{server.port}")  # FIXME(#11693): Work around missing domain support.
+	client.command(f"connect ddnet-20+ws://127.0.0.1:{server.port}")  # FIXME(#11693): Work around missing domain support.
 	server.wait_for_log_prefix("websockets: I: lws_handshake_server", timeout=15)  # Connection established
 	client.wait_for_log_prefix("websockets: I: lws_http_client_socket_service", timeout=15)  # Connection established
 	join = server.wait_for_log_prefix("server: player has entered the game", timeout=5).line

--- a/src/base/net.cpp
+++ b/src/base/net.cpp
@@ -17,6 +17,10 @@
 #include <engine/shared/websockets.h>
 #endif
 
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+#include <emscripten.h>
+#endif
+
 #if defined(CONF_FAMILY_UNIX)
 #include <sys/time.h> // timeval
 #include <unistd.h> // close
@@ -362,15 +366,52 @@ static int parse_uint16(unsigned short *out, const char **str)
 	return 0;
 }
 
+// Applies the network types of a URL scheme to an address. The websocket types are
+// narrowed down to the address family of the address, unless it is not known yet.
+static void net_addr_apply_url_types(NETADDR *addr, int url_types)
+{
+	if(url_types & (NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6))
+	{
+		if(addr->type & NETTYPE_IPV4)
+		{
+			addr->type = (addr->type & ~NETTYPE_IPV4) | NETTYPE_WEBSOCKET_IPV4;
+		}
+		else if(addr->type & NETTYPE_IPV6)
+		{
+			addr->type = (addr->type & ~NETTYPE_IPV6) | NETTYPE_WEBSOCKET_IPV6;
+		}
+		else
+		{
+			addr->type |= NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6;
+		}
+	}
+	addr->type |= url_types & (NETTYPE_TW7 | NETTYPE_WEBSOCKET_TLS);
+}
+
 int net_addr_from_url(NETADDR *addr, const char *string, char *host_buf, size_t host_buf_size)
 {
-	bool sixup = false;
-	mem_zero(addr, sizeof(*addr));
-	const char *str = str_startswith(string, "tw-0.6+udp://");
-	if(!str && (str = str_startswith(string, "tw-0.7+udp://")))
+	static const struct
 	{
-		addr->type |= NETTYPE_TW7;
-		sixup = true;
+		const char *scheme;
+		int types;
+	} SCHEMES[] = {
+		{"tw-0.6+udp://", 0},
+		{"tw-0.7+udp://", NETTYPE_TW7},
+		{"ddnet-20+ws://", NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6},
+		{"ddnet-20+wss://", NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6 | NETTYPE_WEBSOCKET_TLS},
+	};
+
+	mem_zero(addr, sizeof(*addr));
+	const char *str = nullptr;
+	int url_types = 0;
+	for(const auto &scheme : SCHEMES)
+	{
+		str = str_startswith(string, scheme.scheme);
+		if(str)
+		{
+			url_types = scheme.types;
+			break;
+		}
 	}
 	if(!str)
 		return 1;
@@ -401,14 +442,62 @@ int net_addr_from_url(NETADDR *addr, const char *string, char *host_buf, size_t 
 	if(host_buf)
 		str_copy(host_buf, host, host_buf_size);
 
-	int failure = net_addr_from_str(addr, host);
-	if(failure)
-		return failure;
-
-	if(sixup)
-		addr->type |= NETTYPE_TW7;
+	const int failure = net_addr_from_str(addr, host);
+	// The types of the scheme are also reported when the host is not an IP address,
+	// so that they can be applied to the address after resolving the hostname.
+	net_addr_apply_url_types(addr, url_types);
 
 	return failure;
+}
+
+bool net_addr_from_url_lookup(NETADDR *addr, const char *string, int types)
+{
+	char host[128];
+	const int url_failure = net_addr_from_url(addr, string, host, sizeof(host));
+	if(url_failure == 0)
+		return true;
+
+	int url_types = 0;
+	if(url_failure > 0)
+	{
+		// A string with an unsupported scheme is not a hostname either,
+		// e.g. "ws://127.0.0.1:8303" would otherwise resolve the host "ws".
+		if(str_find(string, "://") != nullptr)
+			return false;
+		// Not a URL, so the entire string is the host.
+		str_copy(host, string);
+	}
+	else
+	{
+		url_types = addr->type;
+	}
+
+	if(net_host_lookup(host, addr, types) != 0)
+		return false;
+
+	net_addr_apply_url_types(addr, url_types);
+	return true;
+}
+
+void net_addr_url_str(const NETADDR *addr, char *string, int max_length, bool add_port)
+{
+	const char *scheme = "";
+	if(addr->type & NETTYPE_TW7)
+	{
+		scheme = "tw-0.7+udp://";
+	}
+	else if(addr->type & NETTYPE_WEBSOCKET_TLS)
+	{
+		scheme = "ddnet-20+wss://";
+	}
+	else if(addr->type & (NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6))
+	{
+		scheme = "ddnet-20+ws://";
+	}
+
+	char addr_str[NETADDR_MAXSTRSIZE];
+	net_addr_str(addr, addr_str, sizeof(addr_str), add_port);
+	str_format(string, max_length, "%s%s", scheme, addr_str);
 }
 
 bool net_addr_is_local(const NETADDR *addr)
@@ -569,8 +658,10 @@ static int net_host_lookup_fallback(const char *hostname, NETADDR *addr, int typ
 	return -1;
 }
 
-static int net_host_lookup_impl(const char *hostname, NETADDR *addr, int types)
+int net_host_lookup(const char *hostname, NETADDR *addr, int types)
 {
+	types &= ~(NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6);
+
 	char host[256];
 	int port = 0;
 	if(priv_net_extract(hostname, host, sizeof(host), &port))
@@ -607,34 +698,53 @@ static int net_host_lookup_impl(const char *hostname, NETADDR *addr, int types)
 	return 0;
 }
 
-int net_host_lookup(const char *hostname, NETADDR *addr, int types)
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+static bool websocket_secure_default = false;
+static bool websocket_secure = false;
+
+void net_websocket_set_secure(bool secure)
 {
-	const char *ws_hostname = str_startswith(hostname, "ws://");
-	if(ws_hostname)
+	if(secure == websocket_secure)
 	{
-		if((types & (NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6)) == 0)
-		{
-			return -1;
-		}
-		int result = net_host_lookup_impl(ws_hostname, addr, types & ~(NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6));
-		if(result == 0)
-		{
-			if(addr->type == NETTYPE_IPV4)
-			{
-				addr->type = NETTYPE_WEBSOCKET_IPV4;
-			}
-			else if(addr->type == NETTYPE_IPV6)
-			{
-				addr->type = NETTYPE_WEBSOCKET_IPV6;
-			}
-		}
-		return result;
+		return;
 	}
-	return net_host_lookup_impl(hostname, addr, types & ~(NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6));
+	websocket_secure = secure;
+	MAIN_THREAD_EM_ASM({
+		var url = $0 ? "wss://" : "ws://";
+		(Module["websocket"] = Module["websocket"] || {})["url"] = url;
+		if(typeof SOCKFS == "undefined" || !SOCKFS.websocketArgs)
+		{
+			return;
+		}
+		SOCKFS.websocketArgs["url"] = url;
+		// The URL is only used while establishing a connection. Existing connections
+		// were established with the previous scheme and would be reused for subsequent
+		// connections to the same address, so they must be closed.
+		for(var fd = 0; fd < FS.streams.length; fd++)
+		{
+			var sock = SOCKFS.getSocket(fd);
+			if(sock)
+			{
+				sock.sock_ops.close(sock);
+			}
+		} }, secure);
 }
+
+bool net_websocket_secure_default()
+{
+	return websocket_secure_default;
+}
+#endif
 
 void net_init()
 {
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+	websocket_secure_default = MAIN_THREAD_EM_ASM_INT({
+		var url = (Module["websocket"] && Module["websocket"]["url"]) || "";
+		return url.startsWith("wss") ? 1 : 0;
+	}) != 0;
+	websocket_secure = websocket_secure_default;
+#endif
 #if defined(CONF_FAMILY_WINDOWS)
 	WSADATA wsa_data;
 	dbg_assert(WSAStartup(MAKEWORD(1, 1), &wsa_data) == 0, "WSAStartup failure");

--- a/src/base/net.h
+++ b/src/base/net.h
@@ -91,7 +91,8 @@ void net_addr_str(const NETADDR *addr, char *string, int max_length, bool add_po
 
 /**
  * Turns url string into a network address struct.
- * The url format is tw-0.6+udp://{ipaddr}[:{port}]
+ * The url format is {scheme}://{ipaddr}[:{port}]
+ * scheme: one of tw-0.6+udp, tw-0.7+udp, ddnet-20+ws and ddnet-20+wss
  * ipaddr: can be ipv4 or ipv6
  * port: is a optional internet protocol port
  *
@@ -100,6 +101,8 @@ void net_addr_str(const NETADDR *addr, char *string, int max_length, bool add_po
  * Examples:
  *   tw-0.6+udp://127.0.0.1
  *   tw-0.6+udp://127.0.0.1:8303
+ *   ddnet-20+ws://127.0.0.1:8303
+ *   ddnet-20+wss://127.0.0.1:8303
  *
  * @ingroup Network-Address
  *
@@ -113,8 +116,51 @@ void net_addr_str(const NETADDR *addr, char *string, int max_length, bool add_po
  * @return `0` on success.
  * @return `> 0` if the input wasn't a valid DDNet URL,
  * @return `< 0` if the input is a valid DDNet URL but the host part was not a valid IPv4/IPv6 address
+ *
+ * @remark The network types of the scheme are set in `addr->type`, e.g. `NETTYPE_WEBSOCKET_IPV4`
+ * for `ddnet-20+ws://` with an IPv4 address. They are also set when the host part is not an IPv4/IPv6
+ * address, in which case both `NETTYPE_WEBSOCKET_IPV4` and `NETTYPE_WEBSOCKET_IPV6` are set for
+ * websocket schemes, as the address family is only known after resolving the hostname.
+ * Use `net_addr_from_url_lookup` to resolve hostnames.
  */
 int net_addr_from_url(NETADDR *addr, const char *string, char *host_buf, size_t host_buf_size);
+
+/**
+ * Turns a URL or a plain address string into a network address struct, resolving hostnames.
+ *
+ * @ingroup Network-Address
+ *
+ * @param addr Address to fill in.
+ * @param string URL (see `net_addr_from_url`) or plain address to parse, either of which may
+ *               contain a hostname instead of an IP address.
+ * @param types The types of IP that should be returned, see `net_host_lookup`.
+ *
+ * @return `true` on success.
+ *
+ * @remark The network types of the URL scheme are applied to the resolved address, so the
+ * result can be used with `net_udp_send` etc. without further conversion.
+ *
+ * @remark Strings with an unsupported URL scheme are rejected instead of being resolved
+ * as hostnames.
+ */
+bool net_addr_from_url_lookup(NETADDR *addr, const char *string, int types);
+
+/**
+ * Turns a network address into a representative string with the URL scheme of its type.
+ *
+ * Addresses without a specific scheme, i.e. 0.6 addresses using UDP, are formatted like
+ * `net_addr_str` does, for backward compatibility.
+ *
+ * @ingroup Network-Address
+ *
+ * @param addr Address to turn into a string.
+ * @param string Buffer to fill with the string, should be at least `NETADDR_URL_MAXSTRSIZE` bytes.
+ * @param max_length Maximum size of the string.
+ * @param add_port Whether to add the port to the string.
+ *
+ * @remark The string will always be null-terminated.
+ */
+void net_addr_url_str(const NETADDR *addr, char *string, int max_length, bool add_port);
 
 /**
  * Checks if an address is local.
@@ -149,8 +195,36 @@ int net_addr_from_str(NETADDR *addr, const char *string);
  * @param types The type of IP that should be returned.
  *
  * @return `0` on success.
+ *
+ * @remark The websocket types are ignored, as websockets are determined by the URL scheme
+ * and not by the hostname. Use `net_addr_from_url_lookup` to resolve websocket URLs.
  */
 int net_host_lookup(const char *hostname, NETADDR *addr, int types);
+
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+/**
+ * Selects whether websockets are opened as `wss` or `ws`.
+ *
+ * @ingroup Network-General
+ *
+ * @param secure Whether to use `wss`.
+ *
+ * @remark Emscripten tunnels all traffic through websockets, whose scheme is a
+ * single global setting instead of a per-socket one, so this affects all
+ * connections that are established afterwards.
+ */
+void net_websocket_set_secure(bool secure);
+
+/**
+ * Returns the default websocket scheme, which is determined by the protocol of the
+ * page, see `other/emscripten/index.html`.
+ *
+ * @ingroup Network-General
+ *
+ * @return Whether `wss` is the default.
+ */
+bool net_websocket_secure_default();
+#endif
 
 /**
  * Initializes network functionality.

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -147,6 +147,14 @@ inline constexpr auto NETTYPE_LINK_BROADCAST = 1 << 4;
 inline constexpr auto NETTYPE_TW7 = 1 << 5;
 
 /**
+ * TLS-secured websocket address (`wss`). This is a flag in addition to `NETTYPE_WEBSOCKET_IPV4`
+ * or `NETTYPE_WEBSOCKET_IPV6`, as TLS does not change the address itself.
+ *
+ * @ingroup Network-General
+ */
+inline constexpr auto NETTYPE_WEBSOCKET_TLS = 1 << 6;
+
+/**
  * @ingroup Network-General
  */
 inline constexpr auto NETTYPE_ALL = NETTYPE_IPV4 | NETTYPE_IPV6 | NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6;
@@ -154,12 +162,17 @@ inline constexpr auto NETTYPE_ALL = NETTYPE_IPV4 | NETTYPE_IPV6 | NETTYPE_WEBSOC
 /**
  * @ingroup Network-General
  */
-inline constexpr auto NETTYPE_MASK = NETTYPE_ALL | NETTYPE_LINK_BROADCAST | NETTYPE_TW7;
+inline constexpr auto NETTYPE_MASK = NETTYPE_ALL | NETTYPE_LINK_BROADCAST | NETTYPE_TW7 | NETTYPE_WEBSOCKET_TLS;
 
 /**
  * @ingroup Network-Address
  */
 inline constexpr auto NETADDR_MAXSTRSIZE = 1 + (8 * 4 + 7) + 1 + 1 + 5 + 1; // [XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX]:XXXXX
+
+/**
+ * @ingroup Network-Address
+ */
+inline constexpr auto NETADDR_URL_MAXSTRSIZE = NETADDR_MAXSTRSIZE + 15; // longest scheme is "ddnet-20+wss://"
 
 /**
  * @ingroup Network-Address

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -641,36 +641,64 @@ void CClient::Connect(const char *pAddress, const char *pPassword)
 	const char *pNextAddr = pAddress;
 	char aBuffer[128];
 	bool OnlySixup = true;
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+	bool SecureWebsockets = false;
+#endif
 	while((pNextAddr = str_next_token(pNextAddr, ",", aBuffer, sizeof(aBuffer))))
 	{
 		NETADDR NextAddr;
-		char aHost[128];
-		const int UrlParseResult = net_addr_from_url(&NextAddr, aBuffer, aHost, sizeof(aHost));
-		bool Sixup = NextAddr.type & NETTYPE_TW7;
-		if(UrlParseResult > 0)
-			str_copy(aHost, aBuffer);
-
-		if(net_host_lookup(aHost, &NextAddr, m_aNetClient[CONN_MAIN].NetType()) != 0)
+		if(!net_addr_from_url_lookup(&NextAddr, aBuffer, m_aNetClient[CONN_MAIN].NetType()))
 		{
-			log_error("client", "could not find address of %s", aHost);
+			log_error("client", "could not find address of %s", aBuffer);
 			continue;
 		}
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+		// Emscripten tunnels all traffic through websockets, so websocket addresses are
+		// used like normal addresses and only their scheme is applied. The scheme is a
+		// single global setting and all addresses are connected to at once, so they must
+		// agree on it.
+		bool Secure = net_websocket_secure_default();
+		if((NextAddr.type & (NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6)) != 0)
+		{
+			Secure = (NextAddr.type & NETTYPE_WEBSOCKET_TLS) != 0;
+			const bool Ipv4 = (NextAddr.type & NETTYPE_WEBSOCKET_IPV4) != 0;
+			NextAddr.type &= ~(NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6 | NETTYPE_WEBSOCKET_TLS);
+			NextAddr.type |= Ipv4 ? NETTYPE_IPV4 : NETTYPE_IPV6;
+		}
+		if(NumConnectAddrs != 0 && Secure != SecureWebsockets)
+		{
+			log_error("client", "connect addresses must all use the same websocket scheme, ignoring %s", aBuffer);
+			continue;
+		}
+		SecureWebsockets = Secure;
+#else
+		if((NextAddr.type & NETTYPE_WEBSOCKET_TLS) != 0)
+		{
+			log_error("client", "secure websockets (ddnet-20+wss://) are not supported by this client");
+			continue;
+		}
+		if((NextAddr.type & (NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6)) != 0 &&
+			(m_aNetClient[CONN_MAIN].NetType() & (NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6)) == 0)
+		{
+			log_error("client", "websockets (ddnet-20+ws://) are not supported by this client");
+			continue;
+		}
+#endif
+		const bool Sixup = (NextAddr.type & NETTYPE_TW7) != 0;
 		if(NumConnectAddrs == (int)std::size(aConnectAddrs))
 		{
-			log_warn("client", "too many connect addresses, ignoring %s", aHost);
+			log_warn("client", "too many connect addresses, ignoring %s", aBuffer);
 			continue;
 		}
 		if(NextAddr.port == 0)
 		{
 			NextAddr.port = 8303;
 		}
-		if(Sixup)
-			NextAddr.type |= NETTYPE_TW7;
-		else
+		if(!Sixup)
 			OnlySixup = false;
 
-		char aNextAddr[NETADDR_MAXSTRSIZE];
-		net_addr_str(&NextAddr, aNextAddr, sizeof(aNextAddr), true);
+		char aNextAddr[NETADDR_URL_MAXSTRSIZE];
+		net_addr_url_str(&NextAddr, aNextAddr, sizeof(aNextAddr), true);
 		log_debug("client", "resolved connect address '%s' to %s", aBuffer, aNextAddr);
 
 		if(NextAddr == LastAddr)
@@ -692,6 +720,10 @@ void CClient::Connect(const char *pAddress, const char *pPassword)
 		AddWarning(Warning);
 		return;
 	}
+
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+	net_websocket_set_secure(SecureWebsockets);
+#endif
 
 	m_ConnectionId = RandomUuid();
 	ServerInfoRequest();

--- a/src/engine/client/favorites.cpp
+++ b/src/engine/client/favorites.cpp
@@ -44,22 +44,9 @@ void CFavorites::OnConfigSave(IConfigManager *pConfigManager)
 		}
 		for(int i = 0; i < Entry.m_NumAddrs; i++)
 		{
-			char aAddr[NETADDR_MAXSTRSIZE];
+			char aAddr[NETADDR_URL_MAXSTRSIZE];
 			char aBuffer[128];
-			net_addr_str(&Entry.m_aAddrs[i], aBuffer, sizeof(aBuffer), true);
-
-			if(Entry.m_aAddrs[i].type & NETTYPE_TW7)
-			{
-				str_format(
-					aAddr,
-					sizeof(aAddr),
-					"tw-0.7+udp://%s",
-					aBuffer);
-			}
-			else
-			{
-				str_copy(aAddr, aBuffer);
-			}
+			net_addr_url_str(&Entry.m_aAddrs[i], aAddr, sizeof(aAddr), true);
 
 			if(!Entry.m_AllowPing)
 			{

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -729,12 +729,8 @@ static void ServerBrowserFormatAddresses(char *pBuffer, int BufferSize, NETADDR 
 		{
 			str_append(pBuffer, ",", BufferSize);
 		}
-		if(pAddrs[i].type & NETTYPE_TW7)
-		{
-			str_append(pBuffer, "tw-0.7+udp://", BufferSize);
-		}
-		char aIpAddr[NETADDR_MAXSTRSIZE];
-		net_addr_str(&pAddrs[i], aIpAddr, sizeof(aIpAddr), true);
+		char aIpAddr[NETADDR_URL_MAXSTRSIZE];
+		net_addr_url_str(&pAddrs[i], aIpAddr, sizeof(aIpAddr), true);
 		str_append(pBuffer, aIpAddr, BufferSize);
 	}
 }

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -40,6 +40,7 @@
 #include <engine/shared/protocol_ex.h>
 #include <engine/shared/rust_version.h>
 #include <engine/shared/snapshot.h>
+#include <engine/shared/websockets.h>
 #include <engine/storage.h>
 
 #include <game/version.h>
@@ -4283,6 +4284,13 @@ void CServer::ConReloadAnnouncement(IConsole::IResult *pResult, void *pUserData)
 	pThis->ReadAnnouncementsFile();
 }
 
+#if defined(CONF_WEBSOCKETS)
+void CServer::ConReloadWebsocketCert(IConsole::IResult *pResult, void *pUserData)
+{
+	websocket_reload_certs();
+}
+#endif
+
 void CServer::ConReloadMaplist(IConsole::IResult *pResult, void *pUserData)
 {
 	CServer *pThis = static_cast<CServer *>(pUserData);
@@ -4586,6 +4594,9 @@ void CServer::RegisterCommands()
 
 	Console()->Register("reload_announcement", "", CFGFLAG_SERVER, ConReloadAnnouncement, this, "Reload the announcements");
 	Console()->Register("reload_maplist", "", CFGFLAG_SERVER, ConReloadMaplist, this, "Reload the maplist");
+#if defined(CONF_WEBSOCKETS)
+	Console()->Register("reload_websocket_cert", "", CFGFLAG_SERVER, ConReloadWebsocketCert, this, "Reload the TLS certificate used for websocket connections");
+#endif
 
 	RustVersionRegister(*Console());
 

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -466,6 +466,9 @@ public:
 
 	static void ConReloadAnnouncement(IConsole::IResult *pResult, void *pUserData);
 	static void ConReloadMaplist(IConsole::IResult *pResult, void *pUserData);
+#if defined(CONF_WEBSOCKETS)
+	static void ConReloadWebsocketCert(IConsole::IResult *pResult, void *pUserData);
+#endif
 
 	static void ConchainSpecialInfoupdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainMaxclientsperipUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -461,6 +461,10 @@ MACRO_CONFIG_INT(ClContactPort, cl_contact_port, 0, 0, 65535, CFGFLAG_SAVE | CFG
 MACRO_CONFIG_STR(SvName, sv_name, 128, "unnamed server", CFGFLAG_SERVER, "Server name")
 MACRO_CONFIG_STR(Bindaddr, bindaddr, 128, "", CFGFLAG_CLIENT | CFGFLAG_SERVER, "Address to bind the client/server to")
 MACRO_CONFIG_INT(SvIpv4Only, sv_ipv4only, 0, 0, 1, CFGFLAG_SERVER, "Whether to bind only to ipv4, otherwise bind to all available interfaces")
+#if defined(CONF_WEBSOCKETS)
+MACRO_CONFIG_STR(SvWebsocketCert, sv_websocket_cert, 128, "", CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, "Path to the TLS certificate chain used for websocket connections, enables wss instead of ws (requires sv_websocket_key). Prefer an ECDSA certificate, its handshake is much cheaper than RSA")
+MACRO_CONFIG_STR(SvWebsocketKey, sv_websocket_key, 128, "", CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, "Path to the TLS private key used for websocket connections (requires sv_websocket_cert)")
+#endif
 MACRO_CONFIG_INT(SvPort, sv_port, 0, 0, 65535, CFGFLAG_SERVER, "Port to use for the server (Only ports 8303-8310 work in LAN server browser, 0 to automatically find a free port in 8303-8310). See sv_register_port for the external port if you're behind NAT")
 MACRO_CONFIG_STR(SvHostname, sv_hostname, 128, "", CFGFLAG_SERVER, "Server hostname (0.7 only)")
 MACRO_CONFIG_STR(SvMap, sv_map, 128, "Sunny Side Up", CFGFLAG_SERVER, "Map to use on the server")

--- a/src/engine/shared/websockets.cpp
+++ b/src/engine/shared/websockets.cpp
@@ -5,7 +5,9 @@
 #include <base/dbg.h>
 #include <base/log.h>
 #include <base/mem.h>
+#include <base/net.h>
 #include <base/str.h>
+#include <base/time.h>
 
 #include <engine/shared/config.h>
 #include <engine/shared/network.h>
@@ -21,6 +23,7 @@
 
 #include <cstdlib>
 #include <map>
+#include <set>
 #include <string>
 
 // NOLINTBEGIN(readability-identifier-naming)
@@ -47,13 +50,47 @@ struct per_session_data
 	TSendBuffer send_buffer;
 };
 
+// Accepting a connection completes its TLS handshake on the game loop's thread,
+// before any DDNet-level limit can apply, so this is what keeps an
+// unauthenticated peer from stalling the server's ticks by connecting in a loop.
+// Far above what legitimate joins need, far below what a flood achieves.
+static constexpr int WEBSOCKET_MAX_ACCEPTS_PER_SECOND = 50;
+// Checked before the limit above, so that a single peer connecting in a loop cannot
+// use up the budget of all other peers.
+static constexpr int WEBSOCKET_MAX_ACCEPTS_PER_SECOND_PER_IP = 10;
+// Peers tracked for the per peer limit, the one idle the longest is replaced.
+static constexpr int WEBSOCKET_ACCEPT_TRACKED_IPS = 256;
+#if defined(LWS_WITH_PEER_LIMITS)
+// Bounds concurrent connections per peer. Only available when lws was built with
+// peer limits, so the accept rate limits above cannot rely on it.
+static constexpr unsigned short WEBSOCKET_MAX_CONNECTIONS_PER_IP = 20;
+#endif
+
+// Accepts counted in a one second window, for a whole context or for one peer.
+struct accept_counter
+{
+	NETADDR addr; // Unused by the context wide counter.
+	int64_t window_start;
+	int count;
+};
+
 struct context_data
 {
 	char bindaddr_str[NETADDR_MAXSTRSIZE];
+	// Copies of the paths as they were when the context was created. lws keeps its
+	// own copy, which only these still match after the config has been changed.
+	char ssl_cert_path[IO_MAX_PATH_LENGTH];
+	char ssl_key_path[IO_MAX_PATH_LENGTH];
 	lws_context_creation_info creation_info;
 	lws_context *context;
 	std::map<NETADDR, per_session_data *> port_map;
+	// Accepted connections from adoption until destruction. Unlike port_map, this
+	// also covers connections still in the TLS/HTTP handshake phase, whose sockets
+	// must be watched for the handshake to progress between select() timeouts.
+	std::set<lws *> adopted_wsis;
 	TRecvBuffer recv_buffer;
+	accept_counter accepts_total;
+	accept_counter accepts_per_ip[WEBSOCKET_ACCEPT_TRACKED_IPS];
 };
 
 // Client has main, dummy and contact connections with IPv4 and IPv6
@@ -103,6 +140,40 @@ static void sockaddr_to_netaddr_websocket(const sockaddr *src, socklen_t src_len
 	}
 }
 
+// Counts one accept in the current window and reports whether it stays within the limit.
+static bool count_accept(accept_counter *counter, int limit, int64_t now)
+{
+	if(now - counter->window_start > time_freq())
+	{
+		counter->window_start = now;
+		counter->count = 0;
+	}
+	counter->count++;
+	return counter->count <= limit;
+}
+
+// Returns the counter of the given peer, replacing the counter whose window started
+// longest ago when the peer is not tracked yet.
+static accept_counter *accept_counter_for_addr(context_data *ctx_data, const NETADDR *addr, int64_t now)
+{
+	accept_counter *oldest = &ctx_data->accepts_per_ip[0];
+	for(accept_counter &counter : ctx_data->accepts_per_ip)
+	{
+		if(net_addr_comp_noport(&counter.addr, addr) == 0)
+		{
+			return &counter;
+		}
+		if(counter.window_start < oldest->window_start)
+		{
+			oldest = &counter;
+		}
+	}
+	oldest->addr = *addr;
+	oldest->window_start = now;
+	oldest->count = 0;
+	return oldest;
+}
+
 static int websocket_protocol_callback(lws *wsi, enum lws_callback_reasons reason, void *user, void *in, size_t len)
 {
 	per_session_data *pss = (per_session_data *)user;
@@ -110,17 +181,52 @@ static int websocket_protocol_callback(lws *wsi, enum lws_callback_reasons reaso
 	context_data *ctx_data = contexts_map[context];
 	switch(reason)
 	{
+	case LWS_CALLBACK_FILTER_NETWORK_CONNECTION:
+	{
+		// Issued right after accept(), before the TLS handshake is started, and
+		// returning non-zero closes the connection there. Rate limit it, because
+		// everything past this point runs on the game loop's thread.
+		const lws_filter_network_conn_args *filter_args = (const lws_filter_network_conn_args *)user;
+		NETADDR addr;
+		sockaddr_to_netaddr_websocket((const sockaddr *)&filter_args->cli_addr, filter_args->clilen, &addr);
+		const int64_t now = time_get();
+		if(!count_accept(accept_counter_for_addr(ctx_data, &addr, now), WEBSOCKET_MAX_ACCEPTS_PER_SECOND_PER_IP, now))
+		{
+			return 1;
+		}
+		return count_accept(&ctx_data->accepts_total, WEBSOCKET_MAX_ACCEPTS_PER_SECOND, now) ? 0 : 1;
+	}
+
+	case LWS_CALLBACK_SERVER_NEW_CLIENT_INSTANTIATED:
+		// Fires once the accepted connection has its socket attached. From here on
+		// every death of the wsi goes through LWS_CALLBACK_WSI_DESTROY, which is
+		// not guaranteed for wsis that failed adoption before this point.
+		ctx_data->adopted_wsis.insert(wsi);
+		return 0;
+
+	case LWS_CALLBACK_ESTABLISHED:
+		// Bit 0 of len marks a websocket running over an HTTP/2 stream (RFC 8441).
+		// All streams of an HTTP/2 connection share its peer address, which is the
+		// only identity the network layer knows a connection by, so they cannot be
+		// told apart and are refused by returning non-zero, which closes them.
+		if((len & 1) != 0)
+		{
+			return 1;
+		}
+		[[fallthrough]];
 	case LWS_CALLBACK_WSI_CREATE:
+	{
 		if(pss == nullptr)
 		{
 			return 0;
 		}
-		[[fallthrough]];
-	case LWS_CALLBACK_ESTABLISHED:
-	{
 		sockaddr_storage peersockaddr;
 		socklen_t peersockaddr_size = sizeof(peersockaddr);
-		getpeername(lws_get_socket_fd(wsi), (sockaddr *)&peersockaddr, &peersockaddr_size);
+		if(getpeername(lws_get_socket_fd(wsi), (sockaddr *)&peersockaddr, &peersockaddr_size) != 0)
+		{
+			log_warn("websockets", "Failed to determine peer address: %s", net_error_message().c_str());
+			return 0;
+		}
 		NETADDR addr;
 		sockaddr_to_netaddr_websocket((sockaddr *)&peersockaddr, peersockaddr_size, &addr);
 		if(addr.type == NETTYPE_INVALID)
@@ -143,6 +249,12 @@ static int websocket_protocol_callback(lws *wsi, enum lws_callback_reasons reaso
 		[[fallthrough]];
 	case LWS_CALLBACK_CLOSED:
 	{
+		if(pss == nullptr || pss->addr.type == NETTYPE_INVALID)
+		{
+			// Never registered in port_map, e.g. a refused ws-over-h2 stream or a
+			// failed handshake, so there is no connection to report as closed.
+			return 0;
+		}
 		char addr_str[NETADDR_MAXSTRSIZE];
 		net_addr_str(&pss->addr, addr_str, sizeof(addr_str), true);
 		log_trace("websockets", "Connection closed with '%s'", addr_str);
@@ -154,6 +266,7 @@ static int websocket_protocol_callback(lws *wsi, enum lws_callback_reasons reaso
 
 	case LWS_CALLBACK_WSI_DESTROY:
 	{
+		ctx_data->adopted_wsis.erase(wsi);
 		if(pss == nullptr)
 		{
 			return 0;
@@ -253,6 +366,35 @@ void websocket_init()
 	lws_set_log_level(LLL_ERR | LLL_WARN | LLL_NOTICE | LLL_INFO, websocket_log_callback);
 }
 
+void websocket_reload_certs()
+{
+#if defined(LWS_WITH_TLS)
+	for(context_data &ctx_data : contexts)
+	{
+		if(ctx_data.context == nullptr || ctx_data.creation_info.ssl_cert_filepath == nullptr)
+		{
+			continue;
+		}
+		if(str_comp(ctx_data.ssl_cert_path, g_Config.m_SvWebsocketCert) != 0 || str_comp(ctx_data.ssl_key_path, g_Config.m_SvWebsocketKey) != 0)
+		{
+			// lws can only reload a certificate under the path it was given at startup,
+			// so changing the config and reloading would silently keep the old one.
+			log_warn("websockets", "Cannot reload certificate from a different path than '%s', restart the server instead", ctx_data.ssl_cert_path);
+			continue;
+		}
+		log_info("websockets", "Reloading certificate '%s'", ctx_data.ssl_cert_path);
+		// lws reports a certificate that fails to load only in its own log and keeps
+		// serving the old one.
+		if(lws_tls_cert_updated(ctx_data.context, ctx_data.ssl_cert_path, ctx_data.ssl_key_path, nullptr, 0, nullptr, 0) != 0)
+		{
+			log_error("websockets", "Failed to reload certificate '%s'", ctx_data.ssl_cert_path);
+		}
+	}
+#else
+	log_error("websockets", "Cannot reload certificate: libwebsockets was built without TLS support");
+#endif
+}
+
 int websocket_create(const NETADDR *bindaddr)
 {
 	// find free context
@@ -289,6 +431,36 @@ int websocket_create(const NETADDR *bindaddr)
 	ctx_data->creation_info.iface = ctx_data->bindaddr_str;
 	ctx_data->creation_info.port = bindaddr->port;
 	ctx_data->creation_info.protocols = protocols;
+#if defined(LWS_WITH_TLS)
+	// Only offer HTTP/1.1. Browsers that negotiate HTTP/2 run websockets over it as
+	// streams (RFC 8441), which all share the peer address of their connection and
+	// therefore cannot be told apart. ALPN is a TLS extension, and the field only
+	// exists when lws was built with TLS support.
+	ctx_data->creation_info.alpn = "http/1.1";
+#endif
+#if defined(LWS_WITH_PEER_LIMITS)
+	ctx_data->creation_info.ip_limit_wsi = WEBSOCKET_MAX_CONNECTIONS_PER_IP;
+#endif
+	if(g_Config.m_SvWebsocketCert[0] != '\0' || g_Config.m_SvWebsocketKey[0] != '\0')
+	{
+#if defined(LWS_WITH_TLS)
+		if(g_Config.m_SvWebsocketCert[0] == '\0' || g_Config.m_SvWebsocketKey[0] == '\0')
+		{
+			log_error("websockets", "sv_websocket_cert and sv_websocket_key must both be set to serve wss");
+			return -1;
+		}
+		str_copy(ctx_data->ssl_cert_path, g_Config.m_SvWebsocketCert);
+		str_copy(ctx_data->ssl_key_path, g_Config.m_SvWebsocketKey);
+		ctx_data->creation_info.options |= LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
+		ctx_data->creation_info.ssl_cert_filepath = ctx_data->ssl_cert_path;
+		ctx_data->creation_info.ssl_private_key_filepath = ctx_data->ssl_key_path;
+#else
+		// lws without TLS support ignores the certificate config and would
+		// silently serve unencrypted websockets instead of wss.
+		log_error("websockets", "Cannot serve wss: libwebsockets was built without TLS support");
+		return -1;
+#endif
+	}
 	ctx_data->creation_info.gid = -1;
 	ctx_data->creation_info.uid = -1;
 	ctx_data->creation_info.user = ctx_data;
@@ -391,6 +563,16 @@ int websocket_fd_set(int socket, fd_set *set)
 
 	context_data *ctx_data = contexts_map[context];
 	int max = 0;
+	for(lws *wsi : ctx_data->adopted_wsis)
+	{
+		const int fd = lws_get_socket_fd(wsi);
+		if(fd < 0)
+		{
+			continue;
+		}
+		max = std::max(fd, max);
+		FD_SET(fd, set);
+	}
 	for(const auto &[_, pss] : ctx_data->port_map)
 	{
 		if(pss == nullptr)
@@ -410,6 +592,20 @@ int websocket_fd_get(int socket, fd_set *set)
 	lws_service(context, -1);
 
 	context_data *ctx_data = contexts_map[context];
+	if(ctx_data->recv_buffer.First() != nullptr)
+	{
+		// Packets already consumed by lws_service are no longer readable on the
+		// socket, so select cannot see them and they would never be processed.
+		return 1;
+	}
+	for(lws *wsi : ctx_data->adopted_wsis)
+	{
+		const int fd = lws_get_socket_fd(wsi);
+		if(fd >= 0 && FD_ISSET(fd, set))
+		{
+			return 1;
+		}
+	}
 	for(const auto &[_, pss] : ctx_data->port_map)
 	{
 		if(pss == nullptr)

--- a/src/engine/shared/websockets.h
+++ b/src/engine/shared/websockets.h
@@ -14,6 +14,7 @@
 
 // NOLINTBEGIN(readability-identifier-naming)
 void websocket_init();
+void websocket_reload_certs();
 int websocket_create(const NETADDR *bindaddr);
 void websocket_destroy(int socket);
 int websocket_recv(int socket, unsigned char *data, size_t maxsize, NETADDR *addr);

--- a/src/test/jobs_test.cpp
+++ b/src/test/jobs_test.cpp
@@ -110,30 +110,6 @@ TEST_F(Jobs, LookupHost)
 	}
 }
 
-TEST_F(Jobs, LookupHostWebsocket)
-{
-	static const char *const HOST = "ws://example.com";
-	static const int NETTYPE = NETTYPE_ALL;
-	auto pJob = std::make_shared<CHostLookup>(HOST, NETTYPE);
-
-	EXPECT_STREQ(pJob->Hostname(), HOST);
-	EXPECT_EQ(pJob->Nettype(), NETTYPE);
-
-	Add(pJob);
-	while(pJob->State() != IJob::STATE_DONE)
-	{
-		// yay, busy loop...
-		thread_yield();
-	}
-
-	EXPECT_STREQ(pJob->Hostname(), HOST);
-	EXPECT_EQ(pJob->Nettype(), NETTYPE);
-	if(pJob->Result() == 0)
-	{
-		EXPECT_EQ(pJob->Addr().type & (NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6), pJob->Addr().type);
-	}
-}
-
 TEST_F(Jobs, Many)
 {
 	std::atomic<int> ThreadsRunning(0);

--- a/src/test/netaddr_test.cpp
+++ b/src/test/netaddr_test.cpp
@@ -11,6 +11,14 @@ TEST(NetAddr, FromUrlStringInvalid)
 	EXPECT_EQ(net_addr_from_url(&Addr, "127.0.0.1", nullptr, 0), 1); // not a URL
 	EXPECT_EQ(net_addr_from_url(&Addr, "tw-0.9+udp://127.0.0.1", nullptr, 0), 1); // invalid tw protocol
 	EXPECT_EQ(net_addr_from_url(&Addr, "tw-0.6+tcp://127.0.0.1", nullptr, 0), 1); // invalid internet protocol
+	EXPECT_EQ(net_addr_from_url(&Addr, "ddnet-20+ws://127.0", nullptr, 0), -1); // invalid ip
+	EXPECT_EQ(net_addr_from_url(&Addr, "ddnet-20+wss://", nullptr, 0), -1); // missing ip
+	EXPECT_EQ(net_addr_from_url(&Addr, "ddnet-21+ws://127.0.0.1", nullptr, 0), 1); // invalid ddnet protocol
+	EXPECT_EQ(net_addr_from_url(&Addr, "ddnet-20+udp://127.0.0.1", nullptr, 0), 1); // invalid internet protocol
+	EXPECT_EQ(net_addr_from_url(&Addr, "wsss://127.0.0.1", nullptr, 0), 1); // invalid scheme
+	EXPECT_EQ(net_addr_from_url(&Addr, "http://127.0.0.1", nullptr, 0), 1); // invalid scheme
+	EXPECT_EQ(net_addr_from_url(&Addr, "ws://127.0.0.1:8303", nullptr, 0), 1); // only the ddnet-20+ schemes are supported
+	EXPECT_EQ(net_addr_from_url(&Addr, "wss://127.0.0.1:8303", nullptr, 0), 1); // only the ddnet-20+ schemes are supported
 }
 
 TEST(NetAddr, FromUrlStringValid)
@@ -43,9 +51,88 @@ TEST(NetAddr, FromUrlStringValid)
 	EXPECT_STREQ(aBuf1, "[123:4567:89ab:cdef:1:2:3:4]:5678");
 	EXPECT_STREQ(aBuf2, "[123:4567:89ab:cdef:1:2:3:4]");
 
+	EXPECT_EQ(net_addr_from_url(&Addr, "ddnet-20+ws://127.0.0.1:8303", nullptr, 0), 0);
+	EXPECT_EQ(Addr.type, NETTYPE_WEBSOCKET_IPV4);
+	net_addr_str(&Addr, aBuf1, sizeof(aBuf1), true);
+	EXPECT_STREQ(aBuf1, "127.0.0.1:8303");
+
+	EXPECT_EQ(net_addr_from_url(&Addr, "ddnet-20+wss://[0123:4567:89ab:cdef:1:2:3:4]:5678", nullptr, 0), 0);
+	EXPECT_EQ(Addr.type, NETTYPE_WEBSOCKET_IPV6 | NETTYPE_WEBSOCKET_TLS);
+	net_addr_str(&Addr, aBuf1, sizeof(aBuf1), true);
+	EXPECT_STREQ(aBuf1, "[123:4567:89ab:cdef:1:2:3:4]:5678");
+
 	char aHost[128];
 	EXPECT_EQ(net_addr_from_url(&Addr, "tw-0.6+udp://ger10.ddnet.org:5678", aHost, sizeof(aHost)), -1);
 	EXPECT_STREQ(aHost, "ger10.ddnet.org:5678");
+
+	// The types of the scheme are also reported when the host is not an IP address.
+	// The address family of websocket addresses is only known after resolving the host.
+	EXPECT_EQ(net_addr_from_url(&Addr, "tw-0.7+udp://ger10.ddnet.org:5678", aHost, sizeof(aHost)), -1);
+	EXPECT_EQ(Addr.type, NETTYPE_TW7);
+	EXPECT_EQ(net_addr_from_url(&Addr, "ddnet-20+ws://ger10.ddnet.org:5678", aHost, sizeof(aHost)), -1);
+	EXPECT_EQ(Addr.type, NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6);
+	EXPECT_EQ(net_addr_from_url(&Addr, "ddnet-20+wss://ger10.ddnet.org:5678", aHost, sizeof(aHost)), -1);
+	EXPECT_EQ(Addr.type, NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6 | NETTYPE_WEBSOCKET_TLS);
+}
+
+TEST(NetAddr, FromUrlLookup)
+{
+	NETADDR Addr;
+
+	EXPECT_TRUE(net_addr_from_url_lookup(&Addr, "127.0.0.1:8303", NETTYPE_ALL));
+	EXPECT_EQ(Addr.type, NETTYPE_IPV4);
+	EXPECT_EQ(Addr.port, 8303);
+
+	EXPECT_TRUE(net_addr_from_url_lookup(&Addr, "tw-0.7+udp://127.0.0.1:8303", NETTYPE_ALL));
+	EXPECT_EQ(Addr.type, NETTYPE_IPV4 | NETTYPE_TW7);
+
+	EXPECT_TRUE(net_addr_from_url_lookup(&Addr, "ddnet-20+ws://127.0.0.1:8303", NETTYPE_ALL));
+	EXPECT_EQ(Addr.type, NETTYPE_WEBSOCKET_IPV4);
+
+	EXPECT_TRUE(net_addr_from_url_lookup(&Addr, "ddnet-20+wss://[::1]:8303", NETTYPE_ALL));
+	EXPECT_EQ(Addr.type, NETTYPE_WEBSOCKET_IPV6 | NETTYPE_WEBSOCKET_TLS);
+}
+
+TEST(NetAddr, FromUrlLookupInvalid)
+{
+	NETADDR Addr;
+
+	// Unterminated IPv6 addresses are not valid hostnames either, with and without a URL scheme.
+	EXPECT_FALSE(net_addr_from_url_lookup(&Addr, "[::1", NETTYPE_ALL));
+	EXPECT_FALSE(net_addr_from_url_lookup(&Addr, "ddnet-20+wss://[::1", NETTYPE_ALL));
+
+	// Unsupported schemes must be rejected instead of resolving the scheme as a hostname,
+	// e.g. "ws" resolves globally because the ".ws" TLD has an apex A record.
+	EXPECT_FALSE(net_addr_from_url_lookup(&Addr, "ws://127.0.0.1:8303", NETTYPE_ALL));
+	EXPECT_FALSE(net_addr_from_url_lookup(&Addr, "wss://127.0.0.1:8303", NETTYPE_ALL));
+	EXPECT_FALSE(net_addr_from_url_lookup(&Addr, "localhost://ddnet.org:8303", NETTYPE_ALL));
+}
+
+TEST(NetAddr, UrlStr)
+{
+	NETADDR Addr;
+	char aBuf[NETADDR_URL_MAXSTRSIZE];
+
+	// 0.6 addresses using UDP are formatted without a scheme, for backward compatibility.
+	EXPECT_FALSE(net_addr_from_str(&Addr, "127.0.0.1:8303"));
+	net_addr_url_str(&Addr, aBuf, sizeof(aBuf), true);
+	EXPECT_STREQ(aBuf, "127.0.0.1:8303");
+	net_addr_url_str(&Addr, aBuf, sizeof(aBuf), false);
+	EXPECT_STREQ(aBuf, "127.0.0.1");
+
+	static const char *const apUrls[] = {
+		"tw-0.7+udp://127.0.0.1:8303",
+		"ddnet-20+ws://127.0.0.1:8303",
+		"ddnet-20+wss://127.0.0.1:8303",
+		"ddnet-20+ws://[::1]:8303",
+		"ddnet-20+wss://[123:4567:89ab:cdef:1:2:3:4]:5678",
+	};
+	for(const char *pUrl : apUrls)
+	{
+		EXPECT_EQ(net_addr_from_url(&Addr, pUrl, nullptr, 0), 0);
+		net_addr_url_str(&Addr, aBuf, sizeof(aBuf), true);
+		EXPECT_STREQ(aBuf, pUrl);
+	}
 }
 
 TEST(NetAddr, FromStr)


### PR DESCRIPTION
Required for https emscripten client on https://client.ddnet.org/nightly/

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Fable 5 and Opus 5) wrote this, I reviewed.