### PR TITLE
Fix str_comp_filenames' correctness

### DIFF
--- a/src/base/str.cpp
+++ b/src/base/str.cpp
@@ -276,8 +276,10 @@ int str_comp_filenames(const char *a, const char *b)
 				return 1;
 			else if(str_isnum(*b))
 				return -1;
-			else if(result || *a == '\0' || *b == '\0')
+			else if(result)
 				return result;
+			else if(*a == '\0' || *b == '\0')
+				return *a - *b;
 		}
 
 		result = tolower(*a) - tolower(*b);

--- a/src/test/str_test.cpp
+++ b/src/test/str_test.cpp
@@ -1212,6 +1212,12 @@ TEST(Str, CompFilename)
 	EXPECT_GT(str_comp_filenames("file1337.ext", "file42.ext"), 0);
 	EXPECT_GT(str_comp_filenames("file4414520", "file2055"), 0);
 	EXPECT_LT(str_comp_filenames("file4414520", "file205523151812419"), 0);
+	EXPECT_LT(str_comp_filenames("file1", "file1a"), 0);
+	EXPECT_GT(str_comp_filenames("file1a", "file1"), 0);
+	EXPECT_LT(str_comp_filenames("Kobra 1", "Kobra 1 v2"), 0);
+	EXPECT_GT(str_comp_filenames("Kobra 1 v2", "Kobra 1"), 0);
+	EXPECT_LT(str_comp_filenames("Kobra 1 v2", "Kobra 1 v3"), 0);
+	EXPECT_GT(str_comp_filenames("Kobra 1 v3", "Kobra 1 v2"), 0);
 }
 
 TEST(Str, RightChar)


### PR DESCRIPTION
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code wrote the change, I reviewed it.