### PR TITLE
map_replace_image: Fix loading png

### DIFF
--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -14,6 +14,8 @@
 
 #include <game/mapitems.h>
 
+#include <utility>
+
 /*
 	Usage: map_replace_image <source map filepath> <dest map filepath> <current image name> <new image filepath>
 	Notes: map filepath must be relative to user default teeworlds folder
@@ -26,8 +28,7 @@ static CDataFileReader g_DataReader;
 static int g_NewNameId = -1;
 static char g_aNewName[128];
 static int g_NewDataId = -1;
-static int g_NewDataSize = 0;
-static void *g_pNewData = nullptr;
+static CImageInfo g_NewImageInfo;
 
 static void *ReplaceImageItem(int Index, CMapItemImage *pImgItem, const char *pImgName, const char *pImgFile, CMapItemImage *pNewImgItem)
 {
@@ -45,7 +46,7 @@ static void *ReplaceImageItem(int Index, CMapItemImage *pImgItem, const char *pI
 
 	CImageInfo ImgInfo;
 	int PngliteIncompatible;
-	if(!CImageLoader::LoadPng(io_open(pImgName, IOFLAG_READ), pImgName, ImgInfo, PngliteIncompatible))
+	if(!CImageLoader::LoadPng(io_open(pImgFile, IOFLAG_READ), pImgFile, ImgInfo, PngliteIncompatible))
 		return nullptr;
 
 	if(ImgInfo.m_Format != CImageInfo::FORMAT_RGBA)
@@ -63,8 +64,7 @@ static void *ReplaceImageItem(int Index, CMapItemImage *pImgItem, const char *pI
 	g_NewNameId = pImgItem->m_ImageName;
 	fs_split_file_extension(fs_filename(pImgFile), g_aNewName, sizeof(g_aNewName));
 	g_NewDataId = pImgItem->m_ImageData;
-	g_pNewData = ImgInfo.m_pData;
-	g_NewDataSize = ImgInfo.DataSize();
+	g_NewImageInfo = std::move(ImgInfo);
 
 	return (void *)pNewImgItem;
 }
@@ -149,8 +149,8 @@ int main(int argc, const char **argv)
 		int Size;
 		if(Index == g_NewDataId)
 		{
-			pData = g_pNewData;
-			Size = g_NewDataSize;
+			pData = g_NewImageInfo.m_pData;
+			Size = g_NewImageInfo.DataSize();
 		}
 		else if(Index == g_NewNameId)
 		{


### PR DESCRIPTION
Running `map_replace_image bug_src.map out.map mytileset replacement.png`

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Fable 5 and Opus 5) wrote the change, I reviewed it.
