### PR TITLE
Fix snap ID reuse timeout

### DIFF
--- a/src/engine/server/snap_id_pool.h
+++ b/src/engine/server/snap_id_pool.h
@@ -4,6 +4,7 @@
 #ifndef ENGINE_SERVER_SNAP_ID_POOL_H
 #define ENGINE_SERVER_SNAP_ID_POOL_H
 
+#include <cstdint>
 #include <optional>
 
 class CSnapIdPool
@@ -26,7 +27,7 @@ class CSnapIdPool
 	public:
 		short m_Next;
 		short m_State; // 0 = free, 1 = allocated, 2 = timed
-		int m_Timeout;
+		int64_t m_Timeout;
 	};
 
 	CID m_aIds[MAX_IDS];


### PR DESCRIPTION
Truncating to int means wrong results after 2^31 ns

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Fable 5) wrote the change, I reviewed it.