### PR TITLE
client: Fix lineinput backwards selection

### DIFF
--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -276,6 +276,8 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 						m_SelectionStart = m_CursorPos;
 					else if(m_SelectionEnd == OldCursorPos)
 						m_SelectionEnd = m_CursorPos;
+					if(m_SelectionStart > m_SelectionEnd)
+						std::swap(m_SelectionStart, m_SelectionEnd);
 				}
 			}
 
@@ -300,6 +302,8 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 						m_SelectionEnd = m_CursorPos;
 					else if(m_SelectionStart == OldCursorPos)
 						m_SelectionStart = m_CursorPos;
+					if(m_SelectionStart > m_SelectionEnd)
+						std::swap(m_SelectionStart, m_SelectionEnd);
 				}
 			}
 


### PR DESCRIPTION
Using shift+option+left
before:

https://github.com/user-attachments/assets/cf31b897-14ac-46ba-99fa-d25fb326e1c4

after:

https://github.com/user-attachments/assets/da9d4f29-31b1-4b54-b373-df1c55445488


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Fable 5) wrote the change, I reviewed it.
