### PR TITLE
client: Fix resetting quad cluster during loop iterations

### DIFF
--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -1180,12 +1180,12 @@ void CRenderLayerQuads::Init()
 	};
 
 	m_vQuadClusters.clear();
-	CQuadCluster QuadCluster;
 
 	// create quad clusters
 	int QuadStart = 0;
 	while(QuadStart < m_pLayerQuads->m_NumQuads)
 	{
+		CQuadCluster QuadCluster;
 		QuadCluster.m_StartIndex = QuadStart;
 		QuadCluster.m_Grouped = true;
 		QuadCluster.m_ColorEnv = m_pQuads[QuadStart].m_ColorEnv;


### PR DESCRIPTION
To reset clip box
before:
<img width="1720" height="1376" alt="screenshot_2026-07-30_14-48-07" src="https://github.com/user-attachments/assets/c27f355a-2aad-4e2e-8a11-72f8c5badb68" />
after:
<img width="1720" height="1376" alt="screenshot_2026-07-30_14-48-38" src="https://github.com/user-attachments/assets/099a597d-f89e-444d-9fc7-bbc166d2d0b1" />
Using OpenGL 3.3 renderer, map:
[quadclip.map.zip](https://github.com/user-attachments/files/30546327/quadclip.map.zip)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Fable 5) wrote the change, I reviewed it.