### PR TITLE
DRAFT/Do not Review: Add Playwright UI test harness for the emscripten client (#12461)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -453,6 +453,33 @@ jobs:
         mkdir artifacts
         mv build-emscripten-release/*-Emscripten.tar.xz artifacts
 
+    - name: Build websocket-enabled server for UI tests
+      run: |
+        export PATH=/home/runner/cmake/bin:$PATH
+        sudo apt-get update -y
+        sudo apt-get install -y libcurl4-openssl-dev libsqlite3-dev libwebsockets-dev
+        cmake -G "Unix Makefiles" -S . -B build-native-server -DCMAKE_BUILD_TYPE=Release -DCLIENT=OFF -DTOOLS=OFF -DVIDEORECORDER=OFF -DVULKAN=OFF -DWEBSOCKETS=ON
+        cmake --build build-native-server --target game-server -j$(nproc)
+
+    - name: Run Playwright UI tests
+      run: |
+        cd other/emscripten/playwright
+        npm install
+        npx playwright install --with-deps chromium
+        (cd ../../../build-emscripten-release && exec python3 ../other/emscripten/server.py 8000) &
+        (cd ../../.. && exec build-native-server/DDNet-Server "sv_register 0" "sv_map dm1" "sv_name UI-Test") &
+        sleep 3
+        node run-scenario.js scenarios/menu-settings.json
+        node run-scenario.js scenarios/gameplay-local-server.json
+
+    - name: Upload UI test screenshots
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ddnet-ui-test-screenshots
+        path: other/emscripten/playwright/out
+        if-no-files-found: ignore
+
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/other/emscripten/playwright/.gitignore
+++ b/other/emscripten/playwright/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+package-lock.json
+out/
+shots/
+cmds.jsonl
+record.jsonl
+driver-console.log

--- a/other/emscripten/playwright/README.md
+++ b/other/emscripten/playwright/README.md
@@ -1,0 +1,101 @@
+# Playwright harness for the emscripten client
+
+Drives the DDNet emscripten (WebAssembly) client in headless Chromium:
+scripted UI/gameplay scenarios with screenshots, usable interactively for
+exploratory testing and as regression tests in CI.
+
+## Setup
+
+```sh
+npm install
+npx playwright install chromium
+```
+
+Serve an emscripten client build (the regular build, not `HEADLESS_CLIENT` —
+that one has no graphics) with the COOP/COEP headers the client needs:
+
+```sh
+cd <dir with index.html, DDNet.js, DDNet.wasm, DDNet.data>
+python3 other/emscripten/server.py 8000
+```
+
+Without a local build, download the `ddnet-emscripten` artifact of a CI run
+(`gh run download <run-id> --repo ddnet/ddnet --name ddnet-emscripten`) and
+serve the extracted directory. Note: client.ddnet.org rejects automated
+clients with 403, so always test against a locally served build.
+
+## Replaying scenarios
+
+```sh
+node run-scenario.js scenarios/menu-settings.json [--url http://localhost:8000]
+```
+
+A scenario is a JSON file with startup console commands (`args`) and a list of
+`steps`. Each `shot` step saves a screenshot to `out/<scenario>/<name>.png`.
+If `goldens/<scenario>/<name>.png` exists, the screenshot is compared against
+it (`maxDiffPct` per step, default 1.0; `"compare": false` for volatile views
+such as ingame footage with timers — those still verify that the steps and
+`waitlog` assertions succeed). Any failed step or mismatch exits non-zero,
+with a `.diff.png` written next to the actual image.
+
+Create or refresh goldens locally with `--update-golden`. Goldens used by CI
+must be rendered by CI itself (rasterization differs between hosts): after a
+run that uploaded the `ddnet-ui-test-screenshots` artifact, seed them with
+
+```sh
+node seed-goldens.js <run-id>
+```
+
+and commit the `goldens/` directory. Each run writes `out/<scenario>/report.html`
+into the artifact with side-by-side golden/actual/diff images for review, and
+prints a per-shot table into the GitHub Actions job summary.
+
+`scenarios/gameplay-local-server.json` needs a websocket-enabled server on
+port 8303: build with `-DWEBSOCKETS=ON`, then run `DDNet-Server "sv_register 0"`.
+The client connects with a plain `ip:port` address — emscripten's socket
+emulation tunnels the UDP traffic over a WebSocket to the same port.
+
+## Recording new scenarios
+
+```sh
+node repl-driver.js [--url http://localhost:8000]
+```
+
+Boots the client to the main menu and then executes JSON commands appended to
+`cmds.jsonl`, one per line, e.g.:
+
+```sh
+echo '{"id":"01","action":"click","x":1196,"y":26}' >> cmds.jsonl
+```
+
+After each command it writes `shots/<id>.png` and `shots/<id>.done.json`, so
+you (or an agent) can inspect the result before choosing the next command.
+Every successful command is also appended to `record.jsonl` — curate that into
+`scenarios/<name>.json` (drop exploratory dead ends, add `shot` steps with
+meaningful names). End the session with `{"id":"zz","action":"quit"}`.
+
+Available actions (`lib.js`): `key`, `keydown`, `keyup`, `type`, `move`,
+`click`, `down`, `up`, `wheel` (mouse buttons: `+fire`/`+hook` defaults work
+ingame), `console` (runs a command via the F1 console), `connect` (joins a
+server and waits until fully loaded — use this instead of a `console` connect,
+whose console toggle races with map loading), `wait`, `waitlog` (assert on
+client log output), `shot`, `quit`.
+
+## Environment notes
+
+- All coordinates are game-screen pixels at the fixed 1280x720 viewport. The
+  client only consumes *relative* mouse input (at 2x scale, from the 200
+  mouse sensitivity defaults); `lib.js` makes clicks deterministic by clamping
+  the game cursor to the top-left corner before each positioning move.
+- The client log (`Module.print`) is captured from the browser console; use
+  `waitlog` steps as functional assertions (connects, chat round-trips, ...).
+- Master servers and skin/community downloads are unreachable under the COOP/
+  COEP headers from a localhost origin; the server browser stays empty. Menu
+  screenshots are made deterministic via `cl_menu_map ""` in scenario `args`.
+- Headless Chromium rejects pointer-lock requests, which logs recurring
+  `PAGEERROR: ... not valid for pointer lock` lines; input works regardless.
+- The F1 console toggle is swallowed while a map is loading — close the
+  console only after loading finished.
+- To test IndexedDB persistence across reloads, use
+  `chromium.launchPersistentContext(userDataDir)` and two runs of the same
+  profile; on clean quit the client saves the config and syncs IDBFS.

--- a/other/emscripten/playwright/lib.js
+++ b/other/emscripten/playwright/lib.js
@@ -1,0 +1,160 @@
+// Shared helpers for driving the DDNet emscripten client with Playwright.
+const fs = require('fs');
+const path = require('path');
+const { chromium } = require('playwright');
+
+// The game consumes relative mouse deltas at 2x (ui_mousesens/cl_mousesens
+// default to 200 in this build), so Playwright coordinates are half the
+// game-screen coordinates. Positioning is made deterministic by first
+// clamping the game cursor to (0,0) with one large negative move.
+const CURSOR_SCALE = 2;
+const VIEWPORT = { width: 1280, height: 720 };
+
+async function bootClient(opts) {
+	const browser = await chromium.launch({
+		headless: true,
+		// SwiftShader software WebGL, needed for headless rendering
+		args: ['--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+	});
+	const page = await browser.newPage({ viewport: VIEWPORT });
+	const logs = [];
+	page.on('console', msg => { logs.push(msg.text()); if (opts.onLog) opts.onLog(msg.text()); });
+	page.on('pageerror', err => { logs.push(`PAGEERROR: ${err.message}`); if (opts.onLog) opts.onLog(`PAGEERROR: ${err.message}`); });
+
+	await page.goto(opts.url, { waitUntil: 'domcontentloaded' });
+	await page.waitForSelector('#launch-button:not([disabled])', { timeout: 180000 });
+	if (opts.args) {
+		// Each entry of Module.arguments is executed as a console command line
+		await page.evaluate(a => Module.arguments.push(a), opts.args);
+	}
+	await page.click('#launch-button');
+	// Log-driven readiness instead of a fixed delay, for slow CI runners
+	const start = Date.now();
+	while (!logs.some(l => l.includes('on emscripten wasm32'))) {
+		if (Date.now() - start > 120000) throw new Error('timeout waiting for client to boot');
+		await page.waitForTimeout(250);
+	}
+	await page.waitForTimeout(3000);
+	// Fresh browser profiles get the language selection popup; Enter confirms it.
+	await page.keyboard.press('Enter');
+	await page.waitForTimeout(2000);
+	return { browser, page, logs };
+}
+
+async function moveTo(page, x, y) {
+	await page.mouse.move(VIEWPORT.width - 1, VIEWPORT.height - 1);
+	await page.mouse.move(0, 0); // large negative delta clamps the game cursor to (0,0)
+	await page.mouse.move(x / CURSOR_SCALE, y / CURSOR_SCALE);
+}
+
+// Executes one step; returns false when the step requests termination.
+// Steps use game-screen coordinates (1280x720).
+async function executeStep(page, logs, step) {
+	switch (step.action) {
+		case 'key':
+			await page.keyboard.press(step.key);
+			break;
+		case 'keydown':
+			await page.keyboard.down(step.key);
+			break;
+		case 'keyup':
+			await page.keyboard.up(step.key);
+			break;
+		case 'type':
+			await page.keyboard.type(step.text, { delay: 25 });
+			break;
+		case 'move':
+			await moveTo(page, step.x, step.y);
+			break;
+		case 'click':
+			await moveTo(page, step.x, step.y);
+			await page.waitForTimeout(150);
+			await page.mouse.down({ button: step.button || 'left' });
+			await page.waitForTimeout(80);
+			await page.mouse.up({ button: step.button || 'left' });
+			break;
+		case 'down':
+			await page.mouse.down({ button: step.button || 'left' });
+			break;
+		case 'up':
+			await page.mouse.up({ button: step.button || 'left' });
+			break;
+		case 'wheel':
+			await page.mouse.wheel(0, step.dy);
+			break;
+		case 'console':
+			// Only reliable for commands that do not trigger a map load; the
+			// trailing toggle races with loading otherwise (use 'connect' then).
+			await page.keyboard.press('F1');
+			await page.waitForTimeout(300);
+			await page.keyboard.type(step.cmd, { delay: 20 });
+			await page.keyboard.press('Enter');
+			await page.waitForTimeout(300);
+			await page.keyboard.press('F1');
+			break;
+		case 'connect': {
+			// Connects via the console, leaving the console open during map
+			// loading (a close pressed during loading is swallowed; one pressed
+			// before it re-opens later). Close only after the first ping
+			// round-trip confirms the game is fully up.
+			await page.keyboard.press('F1');
+			await page.waitForTimeout(300);
+			await page.keyboard.type(`connect ${step.address}`, { delay: 20 });
+			await page.keyboard.press('Enter');
+			const start = Date.now();
+			while (!logs.some(l => l.includes('got pong from current server'))) {
+				if (Date.now() - start > (step.timeout || 60000)) {
+					throw new Error(`timeout connecting to ${step.address}`);
+				}
+				await page.waitForTimeout(200);
+			}
+			await page.waitForTimeout(1000);
+			await page.keyboard.press('F1');
+			await page.waitForTimeout(500);
+			break;
+		}
+		case 'wait':
+			await page.waitForTimeout(step.ms);
+			break;
+		case 'waitlog': {
+			const start = Date.now();
+			while (!logs.some(l => l.includes(step.pattern))) {
+				if (Date.now() - start > (step.timeout || 30000)) {
+					throw new Error(`timeout waiting for log: ${step.pattern}`);
+				}
+				await page.waitForTimeout(200);
+			}
+			break;
+		}
+		case 'shot':
+			break; // handled by the caller
+		case 'quit':
+			return false;
+		default:
+			throw new Error(`unknown action: ${step.action}`);
+	}
+	return true;
+}
+
+// Compares a screenshot against a golden image. Returns {match, reason, diffPct}
+// and writes a visual diff next to the actual image on mismatch.
+function compareShot(actualPath, goldenPath, maxDiffPct) {
+	const { PNG } = require('pngjs');
+	const pixelmatch = require('pixelmatch');
+	const actual = PNG.sync.read(fs.readFileSync(actualPath));
+	const golden = PNG.sync.read(fs.readFileSync(goldenPath));
+	if (actual.width !== golden.width || actual.height !== golden.height) {
+		return { match: false, reason: 'size mismatch', diffPct: 100 };
+	}
+	const diff = new PNG({ width: actual.width, height: actual.height });
+	const numDiff = pixelmatch(actual.data, golden.data, diff.data, actual.width, actual.height, { threshold: 0.1 });
+	const diffPct = (numDiff / (actual.width * actual.height)) * 100;
+	if (diffPct > maxDiffPct) {
+		const diffPath = actualPath.replace(/\.png$/, '.diff.png');
+		fs.writeFileSync(diffPath, PNG.sync.write(diff));
+		return { match: false, reason: `${diffPct.toFixed(2)}% pixels differ (max ${maxDiffPct}%)`, diffPct };
+	}
+	return { match: true, diffPct };
+}
+
+module.exports = { bootClient, executeStep, moveTo, compareShot, CURSOR_SCALE, VIEWPORT };

--- a/other/emscripten/playwright/package.json
+++ b/other/emscripten/playwright/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "ddnet-emscripten-playwright",
+	"private": true,
+	"description": "Playwright-based UI test harness for the DDNet emscripten client",
+	"dependencies": {
+		"pixelmatch": "5.3.0",
+		"playwright": "1.62.0",
+		"pngjs": "7.0.0"
+	}
+}

--- a/other/emscripten/playwright/repl-driver.js
+++ b/other/emscripten/playwright/repl-driver.js
@@ -1,0 +1,75 @@
+// Interactive driver / scenario recorder for the DDNet emscripten client.
+//
+//   node repl-driver.js [--url http://localhost:8000]
+//
+// Boots the client to the main menu, then executes JSON commands appended to
+// cmds.jsonl (one per line, shared step format from lib.js, plus an "id"):
+//
+//   {"id":"01","action":"click","x":1196,"y":26}
+//   {"id":"02","action":"console","cmd":"echo hi"}
+//   {"id":"03","action":"shot","name":"settings"}
+//   {"id":"99","action":"quit"}
+//
+// After each command it saves shots/<id>.png and shots/<id>.done.json, so a
+// human or agent can look at the result before choosing the next command.
+// Every successfully executed command is appended to record.jsonl (without
+// the id) — curate that file into scenarios/<name>.json for run-scenario.js.
+const fs = require('fs');
+const path = require('path');
+const { bootClient, executeStep } = require('./lib');
+
+const argv = process.argv.slice(2);
+const urlArg = argv.indexOf('--url');
+const url = urlArg >= 0 ? argv[urlArg + 1] : 'http://localhost:8000';
+
+const shotsDir = path.join(__dirname, 'shots');
+const cmdFile = path.join(__dirname, 'cmds.jsonl');
+const recordFile = path.join(__dirname, 'record.jsonl');
+const logFile = path.join(__dirname, 'driver-console.log');
+fs.mkdirSync(shotsDir, { recursive: true });
+fs.writeFileSync(cmdFile, '');
+fs.writeFileSync(recordFile, '');
+fs.writeFileSync(logFile, '');
+
+(async () => {
+	const { browser, page, logs } = await bootClient({
+		url,
+		args: 'cl_show_welcome 0; player_name Playwright',
+		onLog: line => fs.appendFileSync(logFile, line + '\n'),
+	});
+	await page.screenshot({ path: path.join(shotsDir, 'boot.png') });
+	console.log('READY - client at main menu, polling cmds.jsonl');
+
+	let offset = 0;
+	let running = true;
+	while (running) {
+		const content = fs.readFileSync(cmdFile, 'utf8');
+		const fresh = content.slice(offset);
+		const nl = fresh.lastIndexOf('\n');
+		if (nl >= 0) {
+			const lines = fresh.slice(0, nl).split('\n').filter(l => l.trim());
+			offset += nl + 1;
+			for (const line of lines) {
+				const cmd = JSON.parse(line);
+				let result = { ok: true };
+				try {
+					running = await executeStep(page, logs, cmd);
+					const { id, ...step } = cmd;
+					fs.appendFileSync(recordFile, JSON.stringify(step) + '\n');
+				} catch (err) {
+					result = { ok: false, error: err.message };
+				}
+				await page.waitForTimeout(250);
+				await page.screenshot({ path: path.join(shotsDir, `${cmd.id}.png`) }).catch(() => {});
+				fs.writeFileSync(path.join(shotsDir, `${cmd.id}.done.json`), JSON.stringify(result));
+				if (!running) break;
+			}
+		}
+		await new Promise(r => setTimeout(r, 200));
+	}
+	console.log('driver exiting');
+	await browser.close();
+})().catch(err => {
+	console.error('DRIVER FAILED:', err.message);
+	process.exit(1);
+});

--- a/other/emscripten/playwright/run-scenario.js
+++ b/other/emscripten/playwright/run-scenario.js
@@ -1,0 +1,130 @@
+// Replays a recorded scenario against the emscripten client and verifies it.
+//
+//   node run-scenario.js scenarios/menu-settings.json [--url http://localhost:8000] [--update-golden]
+//
+// Scenario format: { "name": ..., "args": "console cmds", "steps": [...] }.
+// Steps are the shared step format from lib.js; "shot" steps save a screenshot
+// to out/<name>/ and compare it against goldens/<name>/ when a golden exists.
+// A shot step can set "maxDiffPct" (default 1.0) or "compare": false for
+// volatile content (e.g. ingame views with timers). Exits non-zero when any
+// step fails or any comparison mismatches.
+const fs = require('fs');
+const path = require('path');
+const { bootClient, executeStep, compareShot } = require('./lib');
+
+const argv = process.argv.slice(2);
+const scenarioPath = argv.find(a => !a.startsWith('--'));
+const urlArg = argv.indexOf('--url');
+const url = urlArg >= 0 ? argv[urlArg + 1] : 'http://localhost:8000';
+const updateGolden = argv.includes('--update-golden');
+
+if (!scenarioPath) {
+	console.error('usage: node run-scenario.js <scenario.json> [--url <url>] [--update-golden]');
+	process.exit(2);
+}
+const scenario = JSON.parse(fs.readFileSync(scenarioPath, 'utf8'));
+const outDir = path.join(__dirname, 'out', scenario.name);
+const goldenDir = path.join(__dirname, 'goldens', scenario.name);
+fs.mkdirSync(outDir, { recursive: true });
+
+(async () => {
+	const failures = [];
+	const shots = [];
+	console.log(`scenario '${scenario.name}': booting client at ${url}`);
+	const { browser, page, logs } = await bootClient({ url, args: scenario.args });
+
+	for (const [i, step] of scenario.steps.entries()) {
+		const label = `step ${i + 1}/${scenario.steps.length} ${JSON.stringify(step)}`;
+		try {
+			if (step.action === 'shot') {
+				await page.waitForTimeout(250);
+				const actualPath = path.join(outDir, `${step.name}.png`);
+				await page.screenshot({ path: actualPath });
+				const goldenPath = path.join(goldenDir, `${step.name}.png`);
+				if (updateGolden) {
+					fs.mkdirSync(goldenDir, { recursive: true });
+					fs.copyFileSync(actualPath, goldenPath);
+					shots.push({ name: step.name, status: 'golden updated' });
+					console.log(`${label} -> golden updated`);
+				} else if (step.compare !== false && fs.existsSync(goldenPath)) {
+					const result = compareShot(actualPath, goldenPath, step.maxDiffPct ?? 1.0);
+					if (!result.match) {
+						// Copy the golden next to the actual so the uploaded
+						// artifact is self-contained for comparison
+						fs.copyFileSync(goldenPath, path.join(outDir, `${step.name}.golden.png`));
+						shots.push({ name: step.name, status: 'MISMATCH', diffPct: result.diffPct, mismatch: true });
+						failures.push(`${step.name}: ${result.reason}`);
+						console.log(`${label} -> MISMATCH: ${result.reason}`);
+					} else {
+						shots.push({ name: step.name, status: 'ok', diffPct: result.diffPct });
+						console.log(`${label} -> ok (${result.diffPct.toFixed(2)}% diff)`);
+					}
+				} else {
+					shots.push({ name: step.name, status: 'no golden' });
+					console.log(`${label} -> saved (no golden comparison)`);
+				}
+			} else {
+				const cont = await executeStep(page, logs, step);
+				console.log(`${label} -> ok`);
+				if (!cont) break;
+			}
+		} catch (err) {
+			failures.push(`step ${i + 1} (${step.action}): ${err.message}`);
+			console.log(`${label} -> FAILED: ${err.message}`);
+			await page.screenshot({ path: path.join(outDir, `failure-step-${i + 1}.png`) }).catch(() => {});
+			break; // later steps depend on earlier ones
+		}
+	}
+
+	fs.writeFileSync(path.join(outDir, 'console.log'), logs.join('\n'));
+	writeReport(shots, failures);
+	await browser.close();
+	if (failures.length > 0) {
+		console.error(`\nscenario '${scenario.name}' FAILED:\n- ${failures.join('\n- ')}`);
+		process.exit(1);
+	}
+	console.log(`\nscenario '${scenario.name}' passed`);
+})().catch(err => {
+	console.error('FAILED:', err.message);
+	process.exit(1);
+});
+
+// Writes a side-by-side HTML report into the output directory (part of the CI
+// artifact) and, when running in GitHub Actions, a summary table for the job.
+function writeReport(shots, failures) {
+	const esc = s => s.replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]));
+	const rows = shots.map(s => {
+		const diff = s.diffPct !== undefined ? `${s.diffPct.toFixed(2)}% diff` : '';
+		let imgs = `<figure><figcaption>actual</figcaption><img src="${s.name}.png"></figure>`;
+		if (s.mismatch) {
+			imgs = `<figure><figcaption>golden</figcaption><img src="${s.name}.golden.png"></figure>` + imgs +
+				`<figure><figcaption>diff</figcaption><img src="${s.name}.diff.png"></figure>`;
+		}
+		return `<h2>${esc(s.name)} — ${esc(s.status)} ${diff}</h2><div class="row">${imgs}</div>`;
+	}).join('\n');
+	const html = `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>${esc(scenario.name)} UI test report</title><style>
+body { font-family: sans-serif; margin: 20px; }
+.row { display: flex; gap: 10px; }
+figure { margin: 0; flex: 1; min-width: 0; }
+figcaption { font-weight: bold; margin-bottom: 4px; }
+img { max-width: 100%; border: 1px solid #ccc; }
+h2 { margin: 25px 0 8px 0; }
+</style></head><body><h1>${esc(scenario.name)}</h1>
+${failures.length > 0 ? `<p><b>${failures.length} failure(s)</b></p>` : '<p>passed</p>'}
+${rows}</body></html>`;
+	fs.writeFileSync(path.join(outDir, 'report.html'), html);
+
+	if (process.env.GITHUB_STEP_SUMMARY) {
+		const lines = [`### UI test: ${scenario.name} — ${failures.length > 0 ? 'FAILED' : 'passed'}`, '', '| shot | status | diff |', '| --- | --- | --- |'];
+		for (const s of shots) {
+			const icon = s.mismatch ? ':x:' : s.status === 'ok' ? ':white_check_mark:' : '';
+			lines.push(`| ${s.name} | ${icon} ${s.status} | ${s.diffPct !== undefined ? s.diffPct.toFixed(2) + '%' : ''} |`);
+		}
+		for (const f of failures.filter(f => !shots.some(s => f.startsWith(s.name + ':')))) {
+			lines.push(`| | :x: ${f} | |`);
+		}
+		lines.push('', `Download the \`ddnet-ui-test-screenshots\` artifact and open \`${scenario.name}/report.html\` for side-by-side images.`, '');
+		fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n'));
+	}
+}

--- a/other/emscripten/playwright/scenarios/gameplay-local-server.json
+++ b/other/emscripten/playwright/scenarios/gameplay-local-server.json
@@ -1,0 +1,22 @@
+{
+	"name": "gameplay-local-server",
+	"args": "cl_show_welcome 0; player_name CI-Test; cl_menu_map \"\"",
+	"steps": [
+		{ "action": "connect", "address": "127.0.0.1:8303" },
+		{ "action": "waitlog", "pattern": "entered and joined the game", "timeout": 5000 },
+		{ "action": "shot", "name": "ingame", "compare": false },
+		{ "action": "keydown", "key": "d" },
+		{ "action": "wait", "ms": 600 },
+		{ "action": "key", "key": "Space" },
+		{ "action": "keyup", "key": "d" },
+		{ "action": "shot", "name": "after-move", "compare": false },
+		{ "action": "key", "key": "t" },
+		{ "action": "wait", "ms": 500 },
+		{ "action": "type", "text": "scenario chat test" },
+		{ "action": "key", "key": "Enter" },
+		{ "action": "waitlog", "pattern": "scenario chat test", "timeout": 10000 },
+		{ "action": "shot", "name": "chat", "compare": false },
+		{ "action": "console", "cmd": "disconnect" },
+		{ "action": "waitlog", "pattern": "disconnecting", "timeout": 10000 }
+	]
+}

--- a/other/emscripten/playwright/scenarios/menu-settings.json
+++ b/other/emscripten/playwright/scenarios/menu-settings.json
@@ -1,0 +1,31 @@
+{
+	"name": "menu-settings",
+	"args": "cl_show_welcome 0; player_name CI-Test; cl_menu_map \"\"",
+	"steps": [
+		{ "action": "shot", "name": "server-browser" },
+		{ "action": "click", "x": 1196, "y": 26 },
+		{ "action": "shot", "name": "settings-language" },
+		{ "action": "click", "x": 1197, "y": 171 },
+		{ "action": "shot", "name": "settings-general" },
+		{ "action": "click", "x": 1197, "y": 214 },
+		{ "action": "shot", "name": "settings-player" },
+		{ "action": "click", "x": 1196, "y": 258 },
+		{ "action": "shot", "name": "settings-tee", "compare": false },
+		{ "action": "click", "x": 1196, "y": 301 },
+		{ "action": "shot", "name": "settings-appearance" },
+		{ "action": "click", "x": 1196, "y": 344 },
+		{ "action": "shot", "name": "settings-controls" },
+		{ "action": "click", "x": 1196, "y": 387 },
+		{ "action": "shot", "name": "settings-graphics" },
+		{ "action": "click", "x": 1195, "y": 431 },
+		{ "action": "shot", "name": "settings-sound" },
+		{ "action": "click", "x": 1195, "y": 474 },
+		{ "action": "shot", "name": "settings-ddnet" },
+		{ "action": "click", "x": 1195, "y": 517 },
+		{ "action": "shot", "name": "settings-assets" },
+		{ "action": "click", "x": 31, "y": 26 },
+		{ "action": "shot", "name": "start-page" },
+		{ "action": "console", "cmd": "quit" },
+		{ "action": "waitlog", "pattern": "config: saved", "timeout": 15000 }
+	]
+}

--- a/other/emscripten/playwright/seed-goldens.js
+++ b/other/emscripten/playwright/seed-goldens.js
@@ -1,0 +1,53 @@
+// Seeds golden screenshots from the ddnet-ui-test-screenshots artifact of a
+// CI run, so goldens are rendered by the same environment that compares them.
+//
+//   node seed-goldens.js <run-id> [repo]      (default repo: ddnet/ddnet)
+//
+// Only shots that scenarios actually compare are copied (volatile
+// "compare": false shots and failure/diff images are skipped). Review and
+// commit the resulting goldens/ directory.
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const runId = process.argv[2];
+const repo = process.argv[3] || 'ddnet/ddnet';
+if (!runId) {
+	console.error('usage: node seed-goldens.js <run-id> [repo]');
+	process.exit(2);
+}
+
+const comparedShots = {};
+for (const file of fs.readdirSync(path.join(__dirname, 'scenarios'))) {
+	const scenario = JSON.parse(fs.readFileSync(path.join(__dirname, 'scenarios', file), 'utf8'));
+	comparedShots[scenario.name] = scenario.steps
+		.filter(s => s.action === 'shot' && s.compare !== false)
+		.map(s => s.name);
+}
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ddnet-goldens-'));
+console.log(`downloading artifact of run ${runId} from ${repo} ...`);
+execFileSync('gh', ['run', 'download', runId, '--repo', repo, '--name', 'ddnet-ui-test-screenshots', '--dir', tmp], { stdio: 'inherit' });
+
+let seeded = 0;
+for (const [name, shotNames] of Object.entries(comparedShots)) {
+	const srcDir = path.join(tmp, name);
+	if (!fs.existsSync(srcDir)) {
+		console.log(`scenario '${name}': no screenshots in artifact, skipped`);
+		continue;
+	}
+	const goldenDir = path.join(__dirname, 'goldens', name);
+	fs.mkdirSync(goldenDir, { recursive: true });
+	for (const shotName of shotNames) {
+		const src = path.join(srcDir, `${shotName}.png`);
+		if (!fs.existsSync(src)) {
+			console.log(`scenario '${name}': shot '${shotName}' missing in artifact`);
+			continue;
+		}
+		fs.copyFileSync(src, path.join(goldenDir, `${shotName}.png`));
+		seeded++;
+	}
+}
+fs.rmSync(tmp, { recursive: true, force: true });
+console.log(`seeded ${seeded} goldens - review and commit the goldens/ directory`);


### PR DESCRIPTION
Drives the emscripten client in headless Chromium: scripted scenarios with screenshot capture and golden comparison, plus an interactive driver for recording new scenarios. Two scenarios run in CI as part of the build-emscripten job: a menu/settings sweep and a gameplay test against a local websocket-enabled server (connect, movement, chat round-trip asserted via client log). Screenshots are uploaded as a CI artifact; goldens can be seeded from them later to enable pixel comparison.

(Unreviewed, just an experiment; seems pretty hack on a first glance, so I'm not happy with it)
## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->

Written with Claude Code (Fable 5)