### PR TITLE
Add editor quick action for "Goto position"

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -185,6 +185,7 @@ public:
 	bool IsNonGameTileLayerSelected() const;
 	void MapDetails();
 	void TestMapLocally();
+	void GotoPosition();
 #define REGISTER_QUICK_ACTION(name, text, callback, disabled, active, button_color, description) CQuickAction m_QuickAction##name;
 #include <game/editor/quick_actions.h>
 #undef REGISTER_QUICK_ACTION

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -189,13 +189,11 @@ CUi::EPopupMenuFunctionResult CEditor::PopupMenuTools(void *pContext, CUIRect Vi
 		}
 	}
 
-	static int s_GotoButton = 0;
 	View.HSplitTop(2.0f, nullptr, &View);
 	View.HSplitTop(12.0f, &Slot, &View);
-	if(pEditor->DoButton_MenuItem(&s_GotoButton, "Goto position", 0, &Slot, BUTTONFLAG_LEFT, "Go to a specified coordinate point on the map."))
+	if(pEditor->DoButton_MenuItem(&pEditor->m_QuickActionGotoPosition, pEditor->m_QuickActionGotoPosition.Label(), 0, &Slot, BUTTONFLAG_LEFT, pEditor->m_QuickActionGotoPosition.Description()))
 	{
-		static SPopupMenuId s_PopupGotoId;
-		pEditor->Ui()->DoPopupMenu(&s_PopupGotoId, Slot.x, Slot.y + Slot.h, 120, 52, pEditor, PopupGoto);
+		pEditor->m_QuickActionGotoPosition.Call();
 	}
 
 	static int s_TileArtButton = 0;

--- a/src/game/editor/quick_actions.cpp
+++ b/src/game/editor/quick_actions.cpp
@@ -190,6 +190,13 @@ void CEditor::MapDetails()
 	Ui()->SetActiveItem(nullptr);
 }
 
+void CEditor::GotoPosition()
+{
+	static SPopupMenuId s_PopupGotoId;
+	Ui()->DoPopupMenu(&s_PopupGotoId, Ui()->MouseX(), Ui()->MouseY(), 120.0f, 52.0f, this, PopupGoto);
+	Ui()->SetActiveItem(nullptr);
+}
+
 void CEditor::DeleteSelectedLayer()
 {
 	std::shared_ptr<CLayer> pCurrentLayer = Map()->SelectedLayer(0);

--- a/src/game/editor/quick_actions.h
+++ b/src/game/editor/quick_actions.h
@@ -182,6 +182,14 @@ REGISTER_QUICK_ACTION(
 	DEFAULT_BTN,
 	"[Home] Restore map focus.")
 REGISTER_QUICK_ACTION(
+	GotoPosition,
+	"Goto position",
+	[&]() { GotoPosition(); },
+	ALWAYS_FALSE,
+	ALWAYS_FALSE,
+	DEFAULT_BTN,
+	"Go to a specified coordinate point on the map.")
+REGISTER_QUICK_ACTION(
 	Proof,
 	"Proof",
 	[&]() { MapView()->ProofMode()->Toggle(); },


### PR DESCRIPTION
Makes Goto position reachable from the editor basically

Related to https://github.com/ddnet/ddnet/issues/10148 

Written with Claude AI

<img width="526" height="288" alt="imagen" src="https://github.com/user-attachments/assets/0509299b-e5ea-4b51-903a-35905a56efbd" />

<img width="1979" height="276" alt="imagen" src="https://github.com/user-attachments/assets/2ee1d7c9-36f6-4e4b-bd6e-baf36f9a89ec" />


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
