### PR TITLE
client: Fix two crashes in 0.7 translation

### DIFF
--- a/src/game/client/sixup_translate_game.cpp
+++ b/src/game/client/sixup_translate_game.cpp
@@ -225,6 +225,12 @@ void *CGameClient::TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn)
 	{
 		protocol7::CNetMsg_Sv_Team *pMsg7 = (protocol7::CNetMsg_Sv_Team *)pRawMsg;
 
+		if(pMsg7->m_ClientId < 0 || pMsg7->m_ClientId >= MAX_CLIENTS)
+		{
+			dbg_msg("sixup", "Sv_Team got invalid ClientId: %d", pMsg7->m_ClientId);
+			return nullptr;
+		}
+
 		if(Client()->State() != IClient::STATE_DEMOPLAYBACK)
 		{
 			m_aClients[pMsg7->m_ClientId].m_Team = pMsg7->m_Team;
@@ -591,7 +597,8 @@ void *CGameClient::TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn)
 		protocol7::CNetMsg_Sv_KillMsg *pMsg7 = (protocol7::CNetMsg_Sv_KillMsg *)pRawMsg;
 		::CNetMsg_Sv_KillMsg *pMsg = (::CNetMsg_Sv_KillMsg *)s_aRawMsg;
 
-		pMsg->m_Killer = pMsg7->m_Killer;
+		// 0.7 uses -1 and -2 for deaths without a killer, 0.6 uses the victim itself
+		pMsg->m_Killer = pMsg7->m_Killer < 0 ? pMsg7->m_Victim : pMsg7->m_Killer;
 		pMsg->m_Victim = pMsg7->m_Victim;
 		pMsg->m_Weapon = pMsg7->m_Weapon;
 		pMsg->m_ModeSpecial = pMsg7->m_ModeSpecial;

--- a/src/game/client/sixup_translate_snapshot.cpp
+++ b/src/game/client/sixup_translate_snapshot.cpp
@@ -68,6 +68,7 @@ int CGameClient::TranslateSnap(CSnapshotBuffer *pSnapDstSix, CSnapshot *pSnapSrc
 				Size,
 				pItem7->Id());
 			pSnapSrcSeven->InvalidateItem(i);
+			continue;
 		}
 
 		if(ItemType == protocol7::NETOBJTYPE_PLAYERINFORACE)


### PR DESCRIPTION
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Fable 5) wrote this, I reviewed
