### PR TITLE
network: Validate tune zone of DDNetProjectile snapshot object

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -307,7 +307,7 @@ Objects = [
 		NetTick("m_StartTick"),
 		NetIntRange("m_Owner", -1, 'MAX_CLIENTS-1'),
 		NetIntAny("m_SwitchNumber"),
-		NetIntAny("m_TuneZone"),
+		NetIntRange("m_TuneZone", 0, 'TuneZone::NUM-1'),
 		NetIntAny("m_Flags"),
 	]),
 


### PR DESCRIPTION
to prevent client from crashing on garbage integer

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Fable 5) wrote this, I reviewed.