### PR TITLE
editor: Fix undo size checks

### DIFF
--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -1216,19 +1216,19 @@ void CEditorActionAppendMap::Undo()
 	// - delete added sounds
 
 	// Delete added groups
-	while((int)Map()->m_vpGroups.size() != m_PrevInfo.m_Groups)
+	while((int)Map()->m_vpGroups.size() > m_PrevInfo.m_Groups)
 	{
 		Map()->m_vpGroups.pop_back();
 	}
 
 	// Delete added envelopes
-	while((int)Map()->m_vpEnvelopes.size() != m_PrevInfo.m_Envelopes)
+	while((int)Map()->m_vpEnvelopes.size() > m_PrevInfo.m_Envelopes)
 	{
 		Map()->m_vpEnvelopes.pop_back();
 	}
 
 	// Delete added sounds
-	while((int)Map()->m_vpSounds.size() != m_PrevInfo.m_Sounds)
+	while((int)Map()->m_vpSounds.size() > m_PrevInfo.m_Sounds)
 	{
 		Map()->m_vpSounds.pop_back();
 	}
@@ -1260,7 +1260,7 @@ void CEditorActionAppendMap::Undo()
 		});
 	}
 
-	while((int)Map()->m_vpImages.size() != m_PrevInfo.m_Images)
+	while((int)Map()->m_vpImages.size() > m_PrevInfo.m_Images)
 	{
 		Map()->m_vpImages.pop_back();
 	}
@@ -1319,7 +1319,7 @@ void CEditorActionTileArt::Undo()
 		});
 	}
 
-	while((int)Map()->m_vpImages.size() != m_PreviousImageCount)
+	while((int)Map()->m_vpImages.size() > m_PreviousImageCount)
 	{
 		Map()->m_vpImages.pop_back();
 	}


### PR DESCRIPTION
to prevent crashing

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Fable 5) wrote this, I reviewed.