### PR TITLE
editor: Add index check using backspace in font typer

### DIFF
--- a/src/game/editor/font_typer.cpp
+++ b/src/game/editor/font_typer.cpp
@@ -101,7 +101,7 @@ bool CFontTyper::OnInput(const IInput::CEvent &Event)
 	}
 
 	// deletion
-	if(Event.m_Key == KEY_BACKSPACE)
+	if(Event.m_Key == KEY_BACKSPACE && State.m_TextIndex.x > 0)
 	{
 		State.m_TextIndex.x--;
 		State.m_TextLineLen--;
@@ -128,10 +128,8 @@ bool CFontTyper::OnInput(const IInput::CEvent &Event)
 		State.m_TextLineLen--;
 		if(Input()->KeyIsPressed(KEY_LCTRL))
 		{
-			while(pLayer->GetTile(State.m_TextIndex.x, State.m_TextIndex.y).m_Index)
+			while(State.m_TextIndex.x >= 1 && State.m_TextIndex.x <= pLayer->m_Width - 2 && pLayer->GetTile(State.m_TextIndex.x, State.m_TextIndex.y).m_Index)
 			{
-				if(State.m_TextIndex.x < 1 || State.m_TextIndex.x > pLayer->m_Width - 2)
-					break;
 				State.m_TextIndex.x--;
 				State.m_TextLineLen--;
 			}
@@ -143,10 +141,8 @@ bool CFontTyper::OnInput(const IInput::CEvent &Event)
 		State.m_TextLineLen++;
 		if(Input()->KeyIsPressed(KEY_LCTRL))
 		{
-			while(pLayer->GetTile(State.m_TextIndex.x, State.m_TextIndex.y).m_Index)
+			while(State.m_TextIndex.x >= 1 && State.m_TextIndex.x <= pLayer->m_Width - 2 && pLayer->GetTile(State.m_TextIndex.x, State.m_TextIndex.y).m_Index)
 			{
-				if(State.m_TextIndex.x < 1 || State.m_TextIndex.x > pLayer->m_Width - 2)
-					break;
 				State.m_TextIndex.x++;
 				State.m_TextLineLen++;
 			}


### PR DESCRIPTION
To prevent out of bounds access

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Fable 5 and Opus 5) wrote this, I reviewed.