### PR TITLE
Dont unfreeze player on skipped rescue

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1677,8 +1677,8 @@ void CGameContext::ConRescue(IConsole::IResult *pResult, void *pUserData)
 
 	if(GoRescue)
 	{
-		pChr->Rescue();
-		pChr->Unfreeze();
+		if(pChr->Rescue())
+			pChr->Unfreeze();
 	}
 }
 
@@ -1751,8 +1751,8 @@ void CGameContext::ConBack(IConsole::IResult *pResult, void *pUserData)
 			return;
 		}
 		pChr->GetLastRescueTeeRef(pPlayer->m_RescueMode) = pPlayer->m_LastDeath.value();
-		pChr->Rescue();
-		pChr->Unfreeze();
+		if(pChr->Rescue())
+			pChr->Unfreeze();
 	}
 }
 

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2501,7 +2501,7 @@ void CCharacter::DDRaceInit()
 	}
 }
 
-void CCharacter::Rescue()
+bool CCharacter::Rescue()
 {
 	if(m_SetSavePos[GetPlayer()->m_RescueMode] && !m_Core.m_Super && !m_Core.m_Invincible)
 	{
@@ -2510,7 +2510,7 @@ void CCharacter::Rescue()
 			char aBuf[256];
 			str_format(aBuf, sizeof(aBuf), "You have to wait %d seconds until you can rescue yourself", (int)((m_LastRescue + (int64_t)g_Config.m_SvRescueDelay * Server()->TickSpeed() - Server()->Tick()) / Server()->TickSpeed()));
 			GameServer()->SendChatTarget(GetPlayer()->GetCid(), aBuf);
-			return;
+			return false;
 		}
 
 		m_LastRescue = Server()->Tick();
@@ -2530,7 +2530,9 @@ void CCharacter::Rescue()
 		m_SavedInput.m_Fire &= INPUT_STATE_MASK;
 		m_SavedInput.m_Hook = 0;
 		m_pPlayer->Pause(CPlayer::PAUSE_NONE, true);
+		return true;
 	}
+	return false;
 }
 
 CClientMask CCharacter::TeamMask()

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -95,7 +95,7 @@ public:
 	void SetEmote(int Emote, int Tick);
 	int DetermineEyeEmote();
 
-	void Rescue();
+	bool Rescue();
 
 	int NeededFaketuning() const { return m_NeededFaketuning; }
 	bool IsAlive() const { return m_Alive; }


### PR DESCRIPTION
Currently unfreeze logic is called unconditionally after `Rescue()` regardless of whether the player's position was actually reset. This allows players to skip parts by either using [rescue during cooldown](https://github.com/user-attachments/assets/a86a4837-53d0-4e54-b270-3ee44572bb14), or [without having a rescue position](https://github.com/user-attachments/assets/f8620bfd-1ef3-4aef-9766-c7787f195e63). My proposed change is for `Rescue()` to return a boolean on whether rescue (teleport) was actually performed, and only run unfreeze logic if it did.

Due to #9135 this bug is partially fixed for servers using practice (instead of `sv_rescue 1`) as it ignores `sv_rescue_delay`. However, this does only fix the bug when using rescue on cooldown. If no rescue position exist in the first place, this bug can even be "abused" in practice mode for maps that have non-grounded spawn positions.

I tried to keep changes minimal, but if you prefer early returns i can also restructure it more cleanly.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options (`sv_rescue 1`, `sv_practice 1`)
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions