### PR TITLE
Size the snapshot delta buffers correctly

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2109,7 +2109,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 				if((NumParts < CSnapshot::MAX_PARTS && m_aSnapshotParts[Conn] == (((uint64_t)(1) << NumParts) - 1)) ||
 					(NumParts == CSnapshot::MAX_PARTS && m_aSnapshotParts[Conn] == std::numeric_limits<uint64_t>::max()))
 				{
-					unsigned char aTmpBuffer2[CSnapshot::MAX_SIZE];
+					CSnapshotDeltaBuffer TmpBuffer2;
 					CSnapshotBuffer TmpBuffer3;
 
 					// reset snapshotting
@@ -2143,12 +2143,12 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 
 					if(m_aSnapshotIncomingDataSize[Conn])
 					{
-						int IntSize = CVariableInt::Decompress(m_aaSnapshotIncomingData[Conn], m_aSnapshotIncomingDataSize[Conn], aTmpBuffer2, sizeof(aTmpBuffer2));
+						int IntSize = CVariableInt::Decompress(m_aaSnapshotIncomingData[Conn], m_aSnapshotIncomingDataSize[Conn], TmpBuffer2.m_aData, sizeof(TmpBuffer2.m_aData));
 
 						if(IntSize < 0) // failure during decompression
 							return;
 
-						pDeltaData = aTmpBuffer2;
+						pDeltaData = TmpBuffer2.m_aData;
 						DeltaSize = IntSize;
 					}
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1100,8 +1100,8 @@ void CServer::DoSnapshot()
 
 			// create delta
 			CSnapshotDelta *const pSnapshotDelta = IsSixup(i) ? &m_SnapshotDeltaSixup : &m_SnapshotDelta;
-			char aDeltaData[CSnapshot::MAX_SIZE];
-			int DeltaSize = pSnapshotDelta->CreateDelta(pDeltashot, Data.AsSnapshot(), aDeltaData);
+			CSnapshotDeltaBuffer DeltaData;
+			int DeltaSize = pSnapshotDelta->CreateDelta(pDeltashot, Data.AsSnapshot(), &DeltaData);
 
 			if(DeltaSize)
 			{
@@ -1109,7 +1109,16 @@ void CServer::DoSnapshot()
 				const int MaxSize = MAX_SNAPSHOT_PACKSIZE;
 
 				char aCompData[CSnapshot::MAX_SIZE];
-				SnapshotSize = CVariableInt::Compress(aDeltaData, DeltaSize, aCompData, sizeof(aCompData));
+				SnapshotSize = CVariableInt::Compress(DeltaData.m_aData, DeltaSize, aCompData, sizeof(aCompData));
+				if(SnapshotSize < 0)
+				{
+					// A delta can be larger than the snapshot it was created
+					// from and then not fit into the compression buffer. Such a
+					// snapshot cannot be sent at all, it would also not fit into
+					// CSnapshot::MAX_PARTS packets.
+					log_error("server", "snapshot delta too large to send. tick=%d cid=%d delta_size=%d", m_CurrentGameTick, i, DeltaSize);
+					continue;
+				}
 				int NumPackets = (SnapshotSize + MaxSize - 1) / MaxSize;
 
 				for(int n = 0, Left = SnapshotSize; Left > 0; n++)

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1107,8 +1107,8 @@ void CServer::DoSnapshot()
 
 			// create delta
 			CSnapshotDelta *const pSnapshotDelta = IsSixup(i) ? &m_SnapshotDeltaSixup : &m_SnapshotDelta;
-			char aDeltaData[CSnapshot::MAX_SIZE];
-			int DeltaSize = pSnapshotDelta->CreateDelta(pDeltashot, Data.AsSnapshot(), aDeltaData);
+			CSnapshotDeltaBuffer DeltaData;
+			int DeltaSize = pSnapshotDelta->CreateDelta(pDeltashot, Data.AsSnapshot(), &DeltaData);
 
 			if(DeltaSize)
 			{
@@ -1116,8 +1116,14 @@ void CServer::DoSnapshot()
 				const int MaxSize = MAX_SNAPSHOT_PACKSIZE;
 
 				char aCompData[CSnapshot::MAX_SIZE];
-				SnapshotSize = CVariableInt::Compress(aDeltaData, DeltaSize, aCompData, sizeof(aCompData));
-				int NumPackets = (SnapshotSize + MaxSize - 1) / MaxSize;
+				SnapshotSize = CVariableInt::Compress(DeltaData.m_aData, DeltaSize, aCompData, sizeof(aCompData));
+				const int NumPackets = (SnapshotSize + MaxSize - 1) / MaxSize;
+				if(SnapshotSize < 0 || NumPackets > CSnapshot::MAX_PARTS)
+				{
+					// the client cannot receive this snapshot, it will keep acking the old one
+					log_error("server", "snapshot for client %d is too large to send, delta_size=%d packed_size=%d", i, DeltaSize, SnapshotSize);
+					continue;
+				}
 
 				for(int n = 0, Left = SnapshotSize; Left > 0; n++)
 				{

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -278,13 +278,16 @@ void CDemoRecorder::WriteTickMarker(int Tick, bool Keyframe)
 		m_FirstTick = Tick;
 }
 
-void CDemoRecorder::Write(int Type, const void *pData, int Size)
+bool CDemoRecorder::Write(int Type, const void *pData, int Size)
 {
 	if(!m_File)
-		return;
+		return false;
 
 	if(Size > 64 * 1024)
-		return;
+	{
+		log_error("demo_recorder", "Dropped chunk of type %d, size %d is too large", Type, Size);
+		return false;
+	}
 
 	/* pad the data with 0 so we get an alignment of 4,
 	else the compression won't work and miss some bytes */
@@ -295,11 +298,11 @@ void CDemoRecorder::Write(int Type, const void *pData, int Size)
 		aBuffer2[Size++] = 0;
 	Size = CVariableInt::Compress(aBuffer2, Size, aBuffer, sizeof(aBuffer)); // buffer2 -> buffer
 	if(Size < 0)
-		return;
+		return false;
 
 	Size = CNetBase::Compress(aBuffer, Size, aBuffer2, sizeof(aBuffer2)); // buffer -> buffer2
 	if(Size < 0)
-		return;
+		return false;
 
 	unsigned char aChunk[3];
 	aChunk[0] = ((Type & 0x3) << 5);
@@ -326,17 +329,21 @@ void CDemoRecorder::Write(int Type, const void *pData, int Size)
 	}
 
 	io_write(m_File, aBuffer2, Size);
+	return true;
 }
 
 void CDemoRecorder::RecordSnapshot(int Tick, const void *pData, int Size)
 {
+	// only advance the delta base when the chunk ended up in the file,
+	// else playback decodes all following deltas against a snapshot it never saw
 	if(m_LastKeyFrame == -1 || (Tick - m_LastKeyFrame) > SERVER_TICK_SPEED * 5)
 	{
 		// write full tickmarker
 		WriteTickMarker(Tick, true);
 
 		// write snapshot
-		Write(CHUNKTYPE_SNAPSHOT, pData, Size);
+		if(!Write(CHUNKTYPE_SNAPSHOT, pData, Size))
+			return;
 
 		m_LastKeyFrame = Tick;
 		mem_copy(&m_LastSnapshotData, pData, Size);
@@ -347,13 +354,13 @@ void CDemoRecorder::RecordSnapshot(int Tick, const void *pData, int Size)
 		WriteTickMarker(Tick, false);
 
 		// create delta
-		char aDeltaData[CSnapshot::MAX_SIZE];
-		const int DeltaSize = m_pSnapshotDelta->CreateDelta(m_LastSnapshotData.AsSnapshot(), (CSnapshot *)pData, &aDeltaData);
+		CSnapshotDeltaBuffer DeltaData;
+		const int DeltaSize = m_pSnapshotDelta->CreateDelta(m_LastSnapshotData.AsSnapshot(), (CSnapshot *)pData, &DeltaData);
 		if(DeltaSize)
 		{
 			// record delta
-			Write(CHUNKTYPE_DELTA, aDeltaData, DeltaSize);
-			mem_copy(&m_LastSnapshotData, pData, Size);
+			if(Write(CHUNKTYPE_DELTA, DeltaData.m_aData, DeltaSize))
+				mem_copy(&m_LastSnapshotData, pData, Size);
 		}
 	}
 }

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -251,6 +251,8 @@ enum
 	CHUNKTYPE_SNAPSHOT = 1,
 	CHUNKTYPE_MESSAGE = 2,
 	CHUNKTYPE_DELTA = 3,
+
+	MAX_CHUNK_SIZE = 64 * 1024,
 };
 
 void CDemoRecorder::WriteTickMarker(int Tick, bool Keyframe)
@@ -283,7 +285,7 @@ void CDemoRecorder::Write(int Type, const void *pData, int Size)
 	if(!m_File)
 		return;
 
-	if(Size > 64 * 1024)
+	if(Size > MAX_CHUNK_SIZE)
 		return;
 
 	/* pad the data with 0 so we get an alignment of 4,
@@ -330,31 +332,36 @@ void CDemoRecorder::Write(int Type, const void *pData, int Size)
 
 void CDemoRecorder::RecordSnapshot(int Tick, const void *pData, int Size)
 {
-	if(m_LastKeyFrame == -1 || (Tick - m_LastKeyFrame) > SERVER_TICK_SPEED * 5)
+	CSnapshotDeltaBuffer DeltaData;
+	int DeltaSize = 0;
+	bool Keyframe = m_LastKeyFrame == -1 || (Tick - m_LastKeyFrame) > SERVER_TICK_SPEED * 5;
+	if(!Keyframe)
 	{
-		// write full tickmarker
-		WriteTickMarker(Tick, true);
+		// create delta
+		DeltaSize = m_pSnapshotDelta->CreateDelta(m_LastSnapshotData.AsSnapshot(), (CSnapshot *)pData, &DeltaData);
 
+		// A delta can be larger than the snapshot it was created from, so it
+		// does not necessarily fit into a chunk. Record a keyframe instead,
+		// else the demo would continue with deltas against a snapshot that was
+		// never written.
+		Keyframe = DeltaSize > MAX_CHUNK_SIZE;
+	}
+
+	WriteTickMarker(Tick, Keyframe);
+
+	if(Keyframe)
+	{
 		// write snapshot
 		Write(CHUNKTYPE_SNAPSHOT, pData, Size);
 
 		m_LastKeyFrame = Tick;
 		mem_copy(&m_LastSnapshotData, pData, Size);
 	}
-	else
+	else if(DeltaSize)
 	{
-		// write tickmarker
-		WriteTickMarker(Tick, false);
-
-		// create delta
-		char aDeltaData[CSnapshot::MAX_SIZE];
-		const int DeltaSize = m_pSnapshotDelta->CreateDelta(m_LastSnapshotData.AsSnapshot(), (CSnapshot *)pData, &aDeltaData);
-		if(DeltaSize)
-		{
-			// record delta
-			Write(CHUNKTYPE_DELTA, aDeltaData, DeltaSize);
-			mem_copy(&m_LastSnapshotData, pData, Size);
-		}
+		// record delta
+		Write(CHUNKTYPE_DELTA, DeltaData.m_aData, DeltaSize);
+		mem_copy(&m_LastSnapshotData, pData, Size);
 	}
 }
 

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -42,7 +42,7 @@ class CDemoRecorder : public IDemoRecorder
 	void *m_pUser;
 
 	void WriteTickMarker(int Tick, bool Keyframe);
-	void Write(int Type, const void *pData, int Size);
+	bool Write(int Type, const void *pData, int Size);
 
 public:
 	CDemoRecorder(CSnapshotDelta *pSnapshotDelta, bool NoMapData = false);

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -298,9 +298,9 @@ const CSnapshotDelta::CData *CSnapshotDelta::EmptyDelta() const
 }
 
 // TODO: OPT: this should be made much faster
-int CSnapshotDelta::CreateDelta(const CSnapshot *pFrom, const CSnapshot *pTo, void *pDstData)
+int CSnapshotDelta::CreateDelta(const CSnapshot *pFrom, const CSnapshot *pTo, CSnapshotDeltaBuffer *pDstData)
 {
-	CData *pDelta = (CData *)pDstData;
+	CData *pDelta = (CData *)pDstData->m_aData;
 	int *pData = (int *)pDelta->m_aData;
 
 	pDelta->m_NumDeletedItems = 0;
@@ -378,7 +378,7 @@ int CSnapshotDelta::CreateDelta(const CSnapshot *pFrom, const CSnapshot *pTo, vo
 	if(!pDelta->m_NumDeletedItems && !pDelta->m_NumUpdateItems && !pDelta->m_NumTempItems)
 		return 0;
 
-	return (int)((char *)pData - (char *)pDstData);
+	return (int)((char *)pData - (char *)pDelta);
 }
 
 int CSnapshotDelta::DebugDumpDelta(const void *pSrcData, int DataSize)

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -286,9 +286,9 @@ const CSnapshotDelta::CData *CSnapshotDelta::EmptyDelta() const
 }
 
 // TODO: OPT: this should be made much faster
-int CSnapshotDelta::CreateDelta(const CSnapshot *pFrom, const CSnapshot *pTo, void *pDstData)
+int CSnapshotDelta::CreateDelta(const CSnapshot *pFrom, const CSnapshot *pTo, CSnapshotDeltaBuffer *pDstData)
 {
-	CData *pDelta = (CData *)pDstData;
+	CData *pDelta = (CData *)pDstData->m_aData;
 	int *pData = (int *)pDelta->m_aData;
 
 	pDelta->m_NumDeletedItems = 0;
@@ -366,7 +366,7 @@ int CSnapshotDelta::CreateDelta(const CSnapshot *pFrom, const CSnapshot *pTo, vo
 	if(!pDelta->m_NumDeletedItems && !pDelta->m_NumUpdateItems && !pDelta->m_NumTempItems)
 		return 0;
 
-	return (int)((char *)pData - (char *)pDstData);
+	return (int)((char *)pData - (char *)pDelta);
 }
 
 int CSnapshotDelta::DebugDumpDelta(const void *pSrcData, int DataSize)

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -79,6 +79,15 @@ public:
 	const CSnapshot *AsSnapshot() const { return (const CSnapshot *)m_aData; }
 };
 
+class alignas(int32_t) CSnapshotDeltaBuffer
+{
+	// A delta always fits into twice the snapshot size.
+	static constexpr int MAX_SIZE = 2 * CSnapshot::MAX_SIZE;
+
+public:
+	unsigned char m_aData[MAX_SIZE];
+};
+
 // CSnapshotDelta
 
 class CSnapshotDelta
@@ -113,7 +122,7 @@ public:
 	uint64_t GetDataUpdates(int Index) const { return m_aSnapshotDataUpdates[Index]; }
 	void SetStaticsize(int ItemType, size_t Size);
 	const CData *EmptyDelta() const;
-	int CreateDelta(const CSnapshot *pFrom, const CSnapshot *pTo, void *pDstData);
+	int CreateDelta(const CSnapshot *pFrom, const CSnapshot *pTo, CSnapshotDeltaBuffer *pDstData);
 	int UnpackDelta(const CSnapshot *pFrom, CSnapshotBuffer *pTo, const void *pSrcData, int DataSize);
 	int DebugDumpDelta(const void *pSrcData, int DataSize);
 };

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -81,6 +81,8 @@ public:
 
 // CSnapshotDelta
 
+class CSnapshotDeltaBuffer;
+
 class CSnapshotDelta
 {
 public:
@@ -113,9 +115,17 @@ public:
 	uint64_t GetDataUpdates(int Index) const { return m_aSnapshotDataUpdates[Index]; }
 	void SetStaticsize(int ItemType, size_t Size);
 	const CData *EmptyDelta() const;
-	int CreateDelta(const CSnapshot *pFrom, const CSnapshot *pTo, void *pDstData);
+	int CreateDelta(const CSnapshot *pFrom, const CSnapshot *pTo, CSnapshotDeltaBuffer *pDstData);
 	int UnpackDelta(const CSnapshot *pFrom, CSnapshotBuffer *pTo, const void *pSrcData, int DataSize);
 	int DebugDumpDelta(const void *pSrcData, int DataSize);
+};
+
+class alignas(int32_t) CSnapshotDeltaBuffer
+{
+	static constexpr int MAX_SIZE = sizeof(CSnapshotDelta::CData) + CSnapshot::MAX_SIZE + CSnapshot::MAX_ITEMS * 8;
+
+public:
+	unsigned char m_aData[MAX_SIZE];
 };
 
 // CSnapshotStorage

--- a/src/test/snapshot_test.cpp
+++ b/src/test/snapshot_test.cpp
@@ -6,6 +6,8 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
+
 TEST(Snapshot, CrcOneInt)
 {
 	CSnapshotBuilder Builder;
@@ -95,4 +97,50 @@ TEST(Snapshot, StorageGet)
 	EXPECT_EQ(Storage.Get(50, nullptr, nullptr, nullptr), -1);
 	EXPECT_EQ(Storage.Get(5, nullptr, nullptr, nullptr), -1);
 	EXPECT_EQ(Storage.Get(25, nullptr, nullptr, nullptr), -1);
+}
+
+// A delta needs more space than the snapshot it was created from: each item of
+// the base snapshot that is gone costs a deletion key, and each item whose size
+// is not statically known costs an additional size int.
+TEST(Snapshot, DeltaWorstCase)
+{
+	// The buffers are allocated on the heap, together they are larger than the
+	// 1 MiB stack that Windows gives the main thread.
+	const auto pItemData = std::make_unique<char[]>(CSnapshot::MAX_SIZE);
+
+	// Base snapshot with as many items as possible. None of them is in the
+	// other snapshot, so each of them costs a deletion key in the delta.
+	const auto pFromBuilder = std::make_unique<CSnapshotBuilder>();
+	pFromBuilder->Init();
+	for(int Id = 0; Id < CSnapshot::MAX_ITEMS; Id++)
+		ASSERT_TRUE(pFromBuilder->NewItem(NETOBJTYPE_PICKUP, Id, pItemData.get(), sizeof(int)));
+	const auto pFromBuffer = std::make_unique<CSnapshotBuffer>();
+	pFromBuilder->Finish(pFromBuffer.get());
+	ASSERT_EQ(pFromBuffer->AsSnapshot()->NumItems(), CSnapshot::MAX_ITEMS);
+
+	// Snapshot at both of its limits: `MAX_ITEMS` items filling `MAX_SIZE`
+	// bytes. Each item costs an offset int and its header on top of its data.
+	const size_t ItemOverhead = sizeof(int) + sizeof(CSnapshotItem);
+	const size_t DataSize = CSnapshot::MAX_SIZE - sizeof(CSnapshot) - CSnapshot::MAX_ITEMS * ItemOverhead;
+	const size_t ItemSize = (DataSize / CSnapshot::MAX_ITEMS) & ~(sizeof(int) - 1);
+	const auto pToBuilder = std::make_unique<CSnapshotBuilder>();
+	pToBuilder->Init();
+	for(int Id = 0; Id < CSnapshot::MAX_ITEMS - 1; Id++)
+		ASSERT_TRUE(pToBuilder->NewItem(NETOBJTYPE_FLAG, Id, pItemData.get(), ItemSize));
+	ASSERT_TRUE(pToBuilder->NewItem(NETOBJTYPE_FLAG, CSnapshot::MAX_ITEMS - 1, pItemData.get(), DataSize - ItemSize * (CSnapshot::MAX_ITEMS - 1)));
+	const auto pToBuffer = std::make_unique<CSnapshotBuffer>();
+	const int ToSize = pToBuilder->Finish(pToBuffer.get());
+	ASSERT_EQ(pToBuffer->AsSnapshot()->NumItems(), CSnapshot::MAX_ITEMS);
+	ASSERT_EQ(ToSize, CSnapshot::MAX_SIZE);
+
+	const auto pDelta = std::make_unique<CSnapshotDelta>();
+	const auto pDeltaData = std::make_unique<CSnapshotDeltaBuffer>();
+	const int DeltaSize = pDelta->CreateDelta(pFromBuffer->AsSnapshot(), pToBuffer->AsSnapshot(), pDeltaData.get());
+	EXPECT_GT(DeltaSize, CSnapshot::MAX_SIZE);
+	EXPECT_LE(DeltaSize, (int)sizeof(CSnapshotDeltaBuffer));
+
+	// The delta is valid, it just does not fit into a snapshot sized buffer.
+	const auto pUnpackedBuffer = std::make_unique<CSnapshotBuffer>();
+	EXPECT_EQ(pDelta->UnpackDelta(pFromBuffer->AsSnapshot(), pUnpackedBuffer.get(), pDeltaData->m_aData, DeltaSize), ToSize);
+	EXPECT_EQ(mem_comp(pUnpackedBuffer->m_aData, pToBuffer->m_aData, ToSize), 0);
 }


### PR DESCRIPTION
We used CSnapshot size, which can be wrong with lots of small items. I'm wondering why we never noticed crashes from this in client...

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Opus 5) wrote this, I reviewed.