### PR TITLE
Attach editor brushes to separate internal map, fix invalid texture used for tile layer brush with quad image, refactoring

### DIFF
--- a/src/game/client/components/envelope_state.cpp
+++ b/src/game/client/components/envelope_state.cpp
@@ -16,7 +16,7 @@ CEnvelopeState::CEnvelopeState(IMap *pMap, bool OnlineOnly) :
 	m_OnlineOnly = OnlineOnly;
 }
 
-void CEnvelopeState::EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels)
+void CEnvelopeState::EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels) const
 {
 	using namespace std::chrono;
 

--- a/src/game/client/components/envelope_state.h
+++ b/src/game/client/components/envelope_state.h
@@ -13,7 +13,7 @@ public:
 	CEnvelopeState() :
 		m_pEnvelopePoints(nullptr), m_pMap(nullptr) {}
 	CEnvelopeState(IMap *pMap, bool OnlineOnly);
-	void EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels) override;
+	void EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels) const override;
 
 	int Sizeof() const override { return sizeof(*this); }
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4478,16 +4478,18 @@ void CEditor::Init()
 	m_aCursorTextures[CURSOR_RESIZE_H] = Graphics()->LoadTexture("editor/cursor_resize.png", IStorage::TYPE_ALL);
 	m_aCursorTextures[CURSOR_RESIZE_V] = m_aCursorTextures[CURSOR_RESIZE_H];
 
-	m_pTilesetPicker = std::make_shared<CLayerTiles>(Map(), 16, 16);
+	m_pToolsMap = std::make_unique<CEditorMap>(this);
+
+	m_pTilesetPicker = std::make_shared<CLayerTiles>(m_pToolsMap.get(), 16, 16);
 	m_pTilesetPicker->MakePalette();
 	m_pTilesetPicker->m_Readonly = true;
 	m_pTilesetPicker->m_RenderOverlays = false;
 
-	m_pQuadsetPicker = std::make_shared<CLayerQuads>(Map());
+	m_pQuadsetPicker = std::make_shared<CLayerQuads>(m_pToolsMap.get());
 	m_pQuadsetPicker->NewQuad(0, 0, 64, 64);
 	m_pQuadsetPicker->m_Readonly = true;
 
-	m_pBrush = std::make_shared<CLayerGroup>(Map());
+	m_pBrush = std::make_shared<CLayerGroup>(m_pToolsMap.get());
 
 	Reset(false);
 }

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4481,6 +4481,7 @@ void CEditor::Init()
 	m_pTilesetPicker = std::make_shared<CLayerTiles>(Map(), 16, 16);
 	m_pTilesetPicker->MakePalette();
 	m_pTilesetPicker->m_Readonly = true;
+	m_pTilesetPicker->m_RenderOverlays = false;
 
 	m_pQuadsetPicker = std::make_shared<CLayerQuads>(Map());
 	m_pQuadsetPicker->NewQuad(0, 0, 64, 64);

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -448,6 +448,7 @@ public:
 
 	IGraphics::CTextureHandle GetEntitiesTexture();
 
+	std::unique_ptr<CEditorMap> m_pToolsMap;
 	std::shared_ptr<CLayerGroup> m_pBrush;
 	std::shared_ptr<CLayerTiles> m_pTilesetPicker;
 	std::shared_ptr<CLayerQuads> m_pQuadsetPicker;

--- a/src/game/editor/map_view.cpp
+++ b/src/game/editor/map_view.cpp
@@ -96,7 +96,7 @@ void CMapView::RenderEditorMap()
 	for(auto &pGroup : Map()->m_vpGroups)
 	{
 		if(pGroup->m_Visible)
-			pGroup->Render();
+			pGroup->Render(Map());
 	}
 
 	// render the game, tele, speedup, front, tune and switch above everything else
@@ -106,7 +106,7 @@ void CMapView::RenderEditorMap()
 		for(auto &pLayer : Map()->m_pGameGroup->m_vpLayers)
 		{
 			if(pLayer->m_Visible && pLayer->IsEntitiesLayer())
-				pLayer->Render();
+				pLayer->Render(Map());
 		}
 	}
 
@@ -177,7 +177,7 @@ void CMapView::Render(CUIRect View)
 			Editor()->m_pTilesetPicker->m_HasSwitch = pTileLayer->m_HasSwitch;
 			Editor()->m_pTilesetPicker->m_HasTune = pTileLayer->m_HasTune;
 
-			Editor()->m_pTilesetPicker->Render();
+			Editor()->m_pTilesetPicker->Render(Map());
 
 			if(Editor()->m_ShowTileInfo != CEditor::SHOW_TILE_OFF)
 				Editor()->m_pTilesetPicker->ShowInfo();
@@ -200,7 +200,7 @@ void CMapView::Render(CUIRect View)
 				Editor()->m_pQuadsetPicker->m_vQuads[0].m_aPoints[3].y = f2fx((View.y + View.h));
 				Editor()->m_pQuadsetPicker->m_vQuads[0].m_aPoints[4].x = f2fx((View.x + View.w / 2));
 				Editor()->m_pQuadsetPicker->m_vQuads[0].m_aPoints[4].y = f2fx((View.y + View.h / 2));
-				Editor()->m_pQuadsetPicker->Render();
+				Editor()->m_pQuadsetPicker->Render(Map());
 			}
 		}
 	}
@@ -504,7 +504,7 @@ void CMapView::Render(CUIRect View)
 						Editor()->m_pBrush->m_OffsetY += pGroup->m_OffsetY;
 						Editor()->m_pBrush->m_ParallaxX = pGroup->m_ParallaxX;
 						Editor()->m_pBrush->m_ParallaxY = pGroup->m_ParallaxY;
-						Editor()->m_pBrush->Render();
+						Editor()->m_pBrush->Render(Map());
 
 						CUIRect BorderRect;
 						BorderRect.x = 0.0f;

--- a/src/game/editor/map_view.cpp
+++ b/src/game/editor/map_view.cpp
@@ -177,7 +177,7 @@ void CMapView::Render(CUIRect View)
 			Editor()->m_pTilesetPicker->m_HasSwitch = pTileLayer->m_HasSwitch;
 			Editor()->m_pTilesetPicker->m_HasTune = pTileLayer->m_HasTune;
 
-			Editor()->m_pTilesetPicker->Render(true);
+			Editor()->m_pTilesetPicker->Render();
 
 			if(Editor()->m_ShowTileInfo != CEditor::SHOW_TILE_OFF)
 				Editor()->m_pTilesetPicker->ShowInfo();

--- a/src/game/editor/mapitems/envelope.cpp
+++ b/src/game/editor/mapitems/envelope.cpp
@@ -98,7 +98,7 @@ std::pair<float, float> CEnvelope::GetValueRange(int ChannelMask)
 	return {Bottom, Top};
 }
 
-void CEnvelope::Eval(float Time, ColorRGBA &Result, size_t Channels)
+void CEnvelope::Eval(float Time, ColorRGBA &Result, size_t Channels) const
 {
 	Channels = std::min({Channels, (size_t)GetChannels(), (size_t)CEnvPoint::MAX_CHANNELS});
 	CRenderMap::RenderEvalEnvelope(&m_PointsAccess, std::chrono::nanoseconds((int64_t)((double)Time * (double)std::chrono::nanoseconds(1s).count())), Result, Channels);

--- a/src/game/editor/mapitems/envelope.h
+++ b/src/game/editor/mapitems/envelope.h
@@ -24,7 +24,7 @@ public:
 	explicit CEnvelope(int NumChannels);
 
 	std::pair<float, float> GetValueRange(int ChannelMask);
-	void Eval(float Time, ColorRGBA &Result, size_t Channels);
+	void Eval(float Time, ColorRGBA &Result, size_t Channels) const;
 	void AddPoint(CFixedTime Time, std::array<int, CEnvPoint::MAX_CHANNELS> aValues);
 	float EndTime() const;
 	int FindPointIndex(CFixedTime Time) const;

--- a/src/game/editor/mapitems/envelope_evaluator.cpp
+++ b/src/game/editor/mapitems/envelope_evaluator.cpp
@@ -8,7 +8,7 @@ CMapEnvelopeEvaluator::CMapEnvelopeEvaluator(CEditorMap *pMap) :
 {
 }
 
-void CMapEnvelopeEvaluator::EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels)
+void CMapEnvelopeEvaluator::EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels) const
 {
 	if(EnvelopeIndex < 0 || EnvelopeIndex >= (int)Map()->m_vpEnvelopes.size())
 		return;

--- a/src/game/editor/mapitems/envelope_evaluator.h
+++ b/src/game/editor/mapitems/envelope_evaluator.h
@@ -11,7 +11,7 @@ class CMapEnvelopeEvaluator : public CMapObject, public IEnvelopeEval
 public:
 	explicit CMapEnvelopeEvaluator(CEditorMap *pMap);
 
-	void EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels) override;
+	void EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels) const override;
 
 	bool m_Animate = false;
 	float m_AnimateStart = 0.0f;

--- a/src/game/editor/mapitems/layer.h
+++ b/src/game/editor/mapitems/layer.h
@@ -29,7 +29,7 @@ public:
 
 	virtual bool IsEntitiesLayer() const { return false; }
 
-	virtual void Render(bool Tileset = false) {}
+	virtual void Render() {}
 	virtual CUi::EPopupMenuFunctionResult RenderProperties(CUIRect *pToolbox) { return CUi::POPUP_KEEP_OPEN; }
 
 	virtual bool IsEnvelopeUsed(int EnvelopeIndex) const { return false; }

--- a/src/game/editor/mapitems/layer.h
+++ b/src/game/editor/mapitems/layer.h
@@ -29,7 +29,7 @@ public:
 
 	virtual bool IsEntitiesLayer() const { return false; }
 
-	virtual void Render() {}
+	virtual void Render(const CEditorMap *pRenderMap) {}
 	virtual CUi::EPopupMenuFunctionResult RenderProperties(CUIRect *pToolbox) { return CUi::POPUP_KEEP_OPEN; }
 
 	virtual bool IsEnvelopeUsed(int EnvelopeIndex) const { return false; }

--- a/src/game/editor/mapitems/layer_group.cpp
+++ b/src/game/editor/mapitems/layer_group.cpp
@@ -62,7 +62,7 @@ void CLayerGroup::MapScreen()
 	Graphics()->MapScreen(ScreenRect);
 }
 
-void CLayerGroup::Render()
+void CLayerGroup::Render(const CEditorMap *pRenderMap)
 {
 	MapScreen();
 
@@ -104,7 +104,7 @@ void CLayerGroup::Render()
 					continue;
 			}
 			if(Editor()->m_ShowDetail || !(pLayer->m_Flags & LAYERFLAG_DETAIL))
-				pLayer->Render();
+				pLayer->Render(pRenderMap);
 		}
 	}
 
@@ -115,7 +115,7 @@ void CLayerGroup::Render()
 			std::shared_ptr<CLayerTiles> pTiles = std::static_pointer_cast<CLayerTiles>(pLayer);
 			if(pTiles->m_HasGame || pTiles->m_HasFront || pTiles->m_HasTele || pTiles->m_HasSpeedup || pTiles->m_HasTune || pTiles->m_HasSwitch)
 			{
-				pLayer->Render();
+				pLayer->Render(pRenderMap);
 			}
 		}
 	}

--- a/src/game/editor/mapitems/layer_group.h
+++ b/src/game/editor/mapitems/layer_group.h
@@ -11,8 +11,6 @@
 class CLayerGroup : public CMapObject
 {
 public:
-	class CEditorMap *m_pMap;
-
 	std::vector<std::shared_ptr<CLayer>> m_vpLayers;
 
 	int m_OffsetX;

--- a/src/game/editor/mapitems/layer_group.h
+++ b/src/game/editor/mapitems/layer_group.h
@@ -34,7 +34,7 @@ public:
 	void OnAttach(CEditorMap *pMap) override;
 
 	void Convert(CUIRect *pRect) const;
-	void Render();
+	void Render(const CEditorMap *pRenderMap);
 	void MapScreen();
 	CScreenRect Mapping() const;
 

--- a/src/game/editor/mapitems/layer_quads.cpp
+++ b/src/game/editor/mapitems/layer_quads.cpp
@@ -25,7 +25,7 @@ CLayerQuads::CLayerQuads(const CLayerQuads &Other) :
 
 CLayerQuads::~CLayerQuads() = default;
 
-void CLayerQuads::Render(bool QuadPicker)
+void CLayerQuads::Render()
 {
 	Graphics()->TextureClear();
 	if(m_Image >= 0 && (size_t)m_Image < Map()->m_vpImages.size())

--- a/src/game/editor/mapitems/layer_quads.cpp
+++ b/src/game/editor/mapitems/layer_quads.cpp
@@ -25,16 +25,21 @@ CLayerQuads::CLayerQuads(const CLayerQuads &Other) :
 
 CLayerQuads::~CLayerQuads() = default;
 
-void CLayerQuads::Render()
+void CLayerQuads::Render(const CEditorMap *pRenderMap)
 {
-	Graphics()->TextureClear();
-	if(m_Image >= 0 && (size_t)m_Image < Map()->m_vpImages.size())
-		Graphics()->TextureSet(Map()->m_vpImages[m_Image]->m_Texture);
+	if(m_Image >= 0 && (size_t)m_Image < pRenderMap->m_vpImages.size())
+	{
+		Graphics()->TextureSet(pRenderMap->m_vpImages[m_Image]->m_Texture);
+	}
+	else
+	{
+		Graphics()->TextureClear();
+	}
 
 	Graphics()->BlendNone();
-	Editor()->RenderMap()->ForceRenderQuads(m_vQuads.data(), m_vQuads.size(), LAYERRENDERFLAG_OPAQUE, &Map()->m_EnvelopeEvaluator);
+	Editor()->RenderMap()->ForceRenderQuads(m_vQuads.data(), m_vQuads.size(), LAYERRENDERFLAG_OPAQUE, &pRenderMap->m_EnvelopeEvaluator);
 	Graphics()->BlendNormal();
-	Editor()->RenderMap()->ForceRenderQuads(m_vQuads.data(), m_vQuads.size(), LAYERRENDERFLAG_TRANSPARENT, &Map()->m_EnvelopeEvaluator);
+	Editor()->RenderMap()->ForceRenderQuads(m_vQuads.data(), m_vQuads.size(), LAYERRENDERFLAG_TRANSPARENT, &pRenderMap->m_EnvelopeEvaluator);
 }
 
 CQuad *CLayerQuads::NewQuad(int x, int y, int Width, int Height)

--- a/src/game/editor/mapitems/layer_quads.h
+++ b/src/game/editor/mapitems/layer_quads.h
@@ -10,7 +10,7 @@ public:
 	CLayerQuads(const CLayerQuads &Other);
 	~CLayerQuads() override;
 
-	void Render() override;
+	void Render(const CEditorMap *pRenderMap) override;
 	CQuad *NewQuad(int x, int y, int Width, int Height);
 	int SwapQuads(int Index0, int Index1);
 

--- a/src/game/editor/mapitems/layer_quads.h
+++ b/src/game/editor/mapitems/layer_quads.h
@@ -10,7 +10,7 @@ public:
 	CLayerQuads(const CLayerQuads &Other);
 	~CLayerQuads() override;
 
-	void Render(bool QuadPicker = false) override;
+	void Render() override;
 	CQuad *NewQuad(int x, int y, int Width, int Height);
 	int SwapQuads(int Index0, int Index1);
 

--- a/src/game/editor/mapitems/layer_sounds.cpp
+++ b/src/game/editor/mapitems/layer_sounds.cpp
@@ -23,7 +23,7 @@ CLayerSounds::CLayerSounds(const CLayerSounds &Other) :
 
 CLayerSounds::~CLayerSounds() = default;
 
-void CLayerSounds::Render(bool Tileset)
+void CLayerSounds::Render()
 {
 	// TODO: nice texture
 	Graphics()->TextureClear();

--- a/src/game/editor/mapitems/layer_sounds.cpp
+++ b/src/game/editor/mapitems/layer_sounds.cpp
@@ -23,7 +23,7 @@ CLayerSounds::CLayerSounds(const CLayerSounds &Other) :
 
 CLayerSounds::~CLayerSounds() = default;
 
-void CLayerSounds::Render()
+void CLayerSounds::Render(const CEditorMap *pRenderMap)
 {
 	// TODO: nice texture
 	Graphics()->TextureClear();
@@ -34,7 +34,7 @@ void CLayerSounds::Render()
 	for(const auto &Source : m_vSources)
 	{
 		ColorRGBA Offset = ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f);
-		Map()->m_EnvelopeEvaluator.EnvelopeEval(Source.m_PosEnvOffset, Source.m_PosEnv, Offset, 2);
+		pRenderMap->m_EnvelopeEvaluator.EnvelopeEval(Source.m_PosEnvOffset, Source.m_PosEnv, Offset, 2);
 		const vec2 Position = vec2(fx2f(Source.m_Position.x) + Offset.r, fx2f(Source.m_Position.y) + Offset.g);
 		const float Falloff = Source.m_Falloff / 255.0f;
 
@@ -74,7 +74,7 @@ void CLayerSounds::Render()
 	for(const auto &Source : m_vSources)
 	{
 		ColorRGBA Offset = ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f);
-		Map()->m_EnvelopeEvaluator.EnvelopeEval(Source.m_PosEnvOffset, Source.m_PosEnv, Offset, 2);
+		pRenderMap->m_EnvelopeEvaluator.EnvelopeEval(Source.m_PosEnvOffset, Source.m_PosEnv, Offset, 2);
 		const vec2 Position = vec2(fx2f(Source.m_Position.x) + Offset.r, fx2f(Source.m_Position.y) + Offset.g);
 		Graphics()->DrawSprite(Position.x, Position.y, Editor()->MapView()->ScaleLength(s_SourceVisualSize));
 	}

--- a/src/game/editor/mapitems/layer_sounds.h
+++ b/src/game/editor/mapitems/layer_sounds.h
@@ -10,7 +10,7 @@ public:
 	CLayerSounds(const CLayerSounds &Other);
 	~CLayerSounds() override;
 
-	void Render() override;
+	void Render(const CEditorMap *pRenderMap) override;
 	CSoundSource *NewSource(int x, int y);
 
 	void BrushSelecting(CUIRect Rect) override;

--- a/src/game/editor/mapitems/layer_sounds.h
+++ b/src/game/editor/mapitems/layer_sounds.h
@@ -10,7 +10,7 @@ public:
 	CLayerSounds(const CLayerSounds &Other);
 	~CLayerSounds() override;
 
-	void Render(bool Tileset = false) override;
+	void Render() override;
 	CSoundSource *NewSource(int x, int y);
 
 	void BrushSelecting(CUIRect Rect) override;

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -159,27 +159,41 @@ void CLayerTiles::MakePalette() const
 			m_pTiles[y * m_Width + x].m_Index = y * 16 + x;
 }
 
-void CLayerTiles::Render()
+void CLayerTiles::Render(const CEditorMap *pRenderMap)
 {
 	IGraphics::CTextureHandle Texture;
-	if(m_Image >= 0 && (size_t)m_Image < Map()->m_vpImages.size())
-		Texture = Map()->m_vpImages[m_Image]->m_Texture;
-	else if(m_HasGame)
+	if(m_HasGame)
+	{
 		Texture = Editor()->GetEntitiesTexture();
+	}
 	else if(m_HasFront)
+	{
 		Texture = Editor()->GetFrontTexture();
+	}
 	else if(m_HasTele)
+	{
 		Texture = Editor()->GetTeleTexture();
+	}
 	else if(m_HasSpeedup)
+	{
 		Texture = Editor()->GetSpeedupTexture();
+	}
 	else if(m_HasSwitch)
+	{
 		Texture = Editor()->GetSwitchTexture();
+	}
 	else if(m_HasTune)
+	{
 		Texture = Editor()->GetTuneTexture();
+	}
+	else if(m_Image >= 0 && (size_t)m_Image < pRenderMap->m_vpImages.size())
+	{
+		Texture = pRenderMap->m_vpImages[m_Image]->m_Texture;
+	}
 	Graphics()->TextureSet(Texture);
 
 	ColorRGBA ColorEnv = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
-	Map()->m_EnvelopeEvaluator.EnvelopeEval(m_ColorEnvOffset, m_ColorEnv, ColorEnv, 4);
+	pRenderMap->m_EnvelopeEvaluator.EnvelopeEval(m_ColorEnvOffset, m_ColorEnv, ColorEnv, 4);
 	const ColorRGBA Color = ColorRGBA(m_Color.r / 255.0f, m_Color.g / 255.0f, m_Color.b / 255.0f, m_Color.a / 255.0f).Multiply(ColorEnv);
 
 	Graphics()->BlendNone();

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -159,7 +159,7 @@ void CLayerTiles::MakePalette() const
 			m_pTiles[y * m_Width + x].m_Index = y * 16 + x;
 }
 
-void CLayerTiles::Render(bool Tileset)
+void CLayerTiles::Render()
 {
 	IGraphics::CTextureHandle Texture;
 	if(m_Image >= 0 && (size_t)m_Image < Map()->m_vpImages.size())
@@ -188,7 +188,7 @@ void CLayerTiles::Render(bool Tileset)
 	Editor()->RenderMap()->RenderTilemap(m_pTiles, m_Width, m_Height, 32.0f, Color, LAYERRENDERFLAG_TRANSPARENT);
 
 	// Render DDRace Layers
-	if(!Tileset)
+	if(m_RenderOverlays)
 	{
 		int OverlayRenderFlags = (g_Config.m_ClTextEntitiesEditor ? OVERLAYRENDERFLAG_TEXT : 0) | OVERLAYRENDERFLAG_EDITOR;
 		if(m_HasTele)

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -188,7 +188,11 @@ void CLayerTiles::Render(const CEditorMap *pRenderMap)
 	}
 	else if(m_Image >= 0 && (size_t)m_Image < pRenderMap->m_vpImages.size())
 	{
-		Texture = pRenderMap->m_vpImages[m_Image]->m_Texture;
+		const auto &pImage = pRenderMap->m_vpImages[m_Image];
+		if(pImage->m_Width % 16 == 0 && pImage->m_Height % 16 == 0)
+		{
+			Texture = pImage->m_Texture;
+		}
 	}
 	Graphics()->TextureSet(Texture);
 

--- a/src/game/editor/mapitems/layer_tiles.h
+++ b/src/game/editor/mapitems/layer_tiles.h
@@ -120,7 +120,7 @@ public:
 	virtual void Shift(EShiftDirection Direction);
 
 	void MakePalette() const;
-	void Render() override;
+	void Render(const CEditorMap *pRenderMap) override;
 
 	int ConvertX(float x) const;
 	int ConvertY(float y) const;

--- a/src/game/editor/mapitems/layer_tiles.h
+++ b/src/game/editor/mapitems/layer_tiles.h
@@ -120,7 +120,7 @@ public:
 	virtual void Shift(EShiftDirection Direction);
 
 	void MakePalette() const;
-	void Render(bool Tileset = false) override;
+	void Render() override;
 
 	int ConvertX(float x) const;
 	int ConvertY(float y) const;
@@ -202,6 +202,7 @@ public:
 	bool m_HasTune;
 	char m_aFilename[IO_MAX_PATH_LENGTH];
 	bool m_KnownTextModeLayer = false;
+	bool m_RenderOverlays = true;
 
 	EditorTileStateChangeHistory<STileStateChange> m_TilesHistory;
 	virtual void ClearHistory() { m_TilesHistory.clear(); }

--- a/src/game/map/envelope_manager.h
+++ b/src/game/map/envelope_manager.h
@@ -11,14 +11,14 @@
 class CEnvelopeManager
 {
 public:
-	CEnvelopeManager(IEnvelopeEval *pEnvelopeEval, IMap *pMap) :
+	CEnvelopeManager(const IEnvelopeEval *pEnvelopeEval, IMap *pMap) :
 		m_pEnvelopeEval(pEnvelopeEval), m_EnvelopeExtrema(pMap) {}
 
-	IEnvelopeEval *EnvelopeEval() { return m_pEnvelopeEval; }
+	const IEnvelopeEval *EnvelopeEval() const { return m_pEnvelopeEval; }
 	const CEnvelopeExtrema *EnvelopeExtrema() const { return &m_EnvelopeExtrema; }
 
 private:
-	IEnvelopeEval *m_pEnvelopeEval;
+	const IEnvelopeEval *m_pEnvelopeEval;
 	CEnvelopeExtrema m_EnvelopeExtrema;
 };
 

--- a/src/game/map/map_renderer.cpp
+++ b/src/game/map/map_renderer.cpp
@@ -16,7 +16,7 @@ void CMapRenderer::Clear()
 	m_vpRenderLayers.clear();
 }
 
-void CMapRenderer::Load(ERenderType Type, CLayers *pLayers, IMapImages *pMapImages, IEnvelopeEval *pEnvelopeEval, std::optional<FRenderUploadCallback> RenderCallbackOptional)
+void CMapRenderer::Load(ERenderType Type, CLayers *pLayers, IMapImages *pMapImages, const IEnvelopeEval *pEnvelopeEval, std::optional<FRenderUploadCallback> RenderCallbackOptional)
 {
 	Clear();
 

--- a/src/game/map/map_renderer.h
+++ b/src/game/map/map_renderer.h
@@ -13,7 +13,7 @@ public:
 	CMapRenderer() = default;
 
 	void Clear();
-	void Load(ERenderType Type, CLayers *pLayers, IMapImages *pMapImages, IEnvelopeEval *pEnvelopeEval, std::optional<FRenderUploadCallback> RenderCallbackOptional);
+	void Load(ERenderType Type, CLayers *pLayers, IMapImages *pMapImages, const IEnvelopeEval *pEnvelopeEval, std::optional<FRenderUploadCallback> RenderCallbackOptional);
 	void Render(const CRenderLayerParams &Params);
 
 private:

--- a/src/game/map/render_interfaces.h
+++ b/src/game/map/render_interfaces.h
@@ -23,7 +23,7 @@ class IEnvelopeEval
 {
 public:
 	virtual ~IEnvelopeEval() = default;
-	virtual void EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels) = 0;
+	virtual void EnvelopeEval(int TimeOffsetMillis, int EnvelopeIndex, ColorRGBA &Result, size_t Channels) const = 0;
 };
 
 class IMapImages

--- a/src/game/map/render_map.cpp
+++ b/src/game/map/render_map.cpp
@@ -369,7 +369,7 @@ static void Rotate(const CPoint *pCenter, CPoint *pPoint, float Rotation)
 	pPoint->y = (int)(x * std::sin(Rotation) + y * std::cos(Rotation) + pCenter->y);
 }
 
-void CRenderMap::ForceRenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags, IEnvelopeEval *pEnvEval, float Alpha)
+void CRenderMap::ForceRenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags, const IEnvelopeEval *pEnvEval, float Alpha)
 {
 	Graphics()->TrianglesBegin();
 	float Conv = 1 / 255.0f;

--- a/src/game/map/render_map.h
+++ b/src/game/map/render_map.h
@@ -78,7 +78,7 @@ public:
 
 	// map render methods (render_map.cpp)
 	static void RenderEvalEnvelope(const IEnvelopePointAccess *pPoints, std::chrono::nanoseconds TimeNanos, ColorRGBA &Result, size_t Channels);
-	void ForceRenderQuads(CQuad *pQuads, int NumQuads, int Flags, IEnvelopeEval *pEnvEval, float Alpha = 1.0f);
+	void ForceRenderQuads(CQuad *pQuads, int NumQuads, int Flags, const IEnvelopeEval *pEnvEval, float Alpha = 1.0f);
 	void RenderTile(int x, int y, unsigned char Index, float Scale, ColorRGBA Color);
 	void RenderTilemap(CTile *pTiles, int w, int h, float Scale, ColorRGBA Color, int RenderFlags);
 


### PR DESCRIPTION
See commit messages.

For #11776.

CC #8426.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions