### PR TITLE
Predict static laser doors without antiping

### DIFF
--- a/src/game/client/prediction/entities/door.cpp
+++ b/src/game/client/prediction/entities/door.cpp
@@ -69,21 +69,37 @@ void CDoor::ResetCollision()
 
 	m_Active = true;
 
-	vec2 Dir = m_To - m_Pos;
-	m_Length = length(Dir);
-	m_Direction = m_Length > 0 ? normalize_pre_length(Dir, static_cast<float>(m_Length)) : vec2(0.0f, 0.0f);
+	const vec2 Dir = m_To - m_Pos;
+	const float DirLength = length(Dir);
+	m_Direction = DirLength > 0.0f ? normalize_pre_length(Dir, DirLength) : vec2(0.0f, 0.0f);
 
 	// The snapshot only carries the endpoint CCollision::IntersectNoLaser produced, which
 	// also stops at TILE_NOLASER, while the server lays down door collision along the full
 	// length configured in the map and stops only at solid tiles. Recover that length the
 	// way IGameController::OnEntity derives it, from the ENTITY_LASER_* tile next to the
 	// door's tile on the side the door points at.
-	const int Side = m_Length > 0 ? MapSide() : -1;
+	const int Side = DirLength > 0.0f ? MapSide() : -1;
 	const int ConfiguredLength = Side == -1 ? -1 : MapLength(Side);
 	if(ConfiguredLength != -1)
 	{
 		m_Length = ConfiguredLength;
 		m_Direction = vec2(std::sin(pi / 4 * Side), std::cos(pi / 4 * Side));
+	}
+	else
+	{
+		// No configured length: the length comes straight off the wire, so a server can
+		// snap a door whose endpoints are billions of units apart and spin the walk below
+		// (which never breaks while it clamps to an off-map air tile) at 100% CPU on every
+		// snapshot. A door's collision can only ever matter inside the map, since both
+		// CheckPoint and SetDoorCollisionAt clamp to it, so refuse to walk anything longer
+		// than the map itself. This also keeps the float length in int range.
+		const float MaxLength = (Collision()->GetWidth() + Collision()->GetHeight()) * 32.0f;
+		if(DirLength <= 0.0f || DirLength > MaxLength)
+		{
+			m_Active = false;
+			return;
+		}
+		m_Length = round_to_int(DirLength);
 	}
 
 	for(int i = 0; i < m_Length - 1; i++)

--- a/src/game/client/prediction/entities/door.cpp
+++ b/src/game/client/prediction/entities/door.cpp
@@ -7,6 +7,8 @@
 #include <game/collision.h>
 #include <game/mapitems.h>
 
+#include <cmath>
+
 CDoor::CDoor(CGameWorld *pGameWorld, int Id, const CLaserData *pData) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_DOOR)
 {
@@ -19,6 +21,47 @@ CDoor::CDoor(CGameWorld *pGameWorld, int Id, const CLaserData *pData) :
 	Read(pData);
 }
 
+// The eight tiles IGameController::OnEntity checks around a door tile, in its order: the
+// door's rotation is pi / 4 * side, so side n points along (sin, cos) of that angle.
+static const int s_aSideOffsetX[8] = {0, 1, 1, 1, 0, -1, -1, -1};
+static const int s_aSideOffsetY[8] = {1, 1, 0, -1, -1, -1, 0, 1};
+
+int CDoor::MapSide() const
+{
+	const int OffsetX = round_to_int(m_Direction.x);
+	const int OffsetY = round_to_int(m_Direction.y);
+	for(int Side = 0; Side < 8; Side++)
+	{
+		if(s_aSideOffsetX[Side] == OffsetX && s_aSideOffsetY[Side] == OffsetY)
+			return Side;
+	}
+	return -1;
+}
+
+int CDoor::MapLength(int Side)
+{
+	const int Nx = round_to_int(m_Pos.x) / 32;
+	const int Ny = round_to_int(m_Pos.y) / 32;
+	int Length = -1;
+	for(const int Layer : {LAYER_GAME, LAYER_FRONT, LAYER_SWITCH})
+	{
+		if(Layer == LAYER_FRONT && Collision()->FrontLayer() == nullptr)
+			continue;
+		if(Layer == LAYER_SWITCH && Collision()->SwitchLayer() == nullptr)
+			continue;
+		if(Collision()->Entity(Nx, Ny, Layer) != ENTITY_DOOR)
+			continue;
+		const int Index = Collision()->Entity(Nx + s_aSideOffsetX[Side], Ny + s_aSideOffsetY[Side], Layer);
+		if(Index < ENTITY_LASER_SHORT || Index > ENTITY_LASER_LONG)
+			continue;
+		const int Candidate = 32 * 3 + 32 * (Index - ENTITY_LASER_SHORT) * 3;
+		if(Length != -1 && Length != Candidate)
+			return -1;
+		Length = Candidate;
+	}
+	return Length;
+}
+
 void CDoor::ResetCollision()
 {
 	if(Collision()->GetTile(m_Pos.x, m_Pos.y) || Collision()->GetFrontTile(m_Pos.x, m_Pos.y))
@@ -28,18 +71,24 @@ void CDoor::ResetCollision()
 
 	vec2 Dir = m_To - m_Pos;
 	m_Length = length(Dir);
-	m_Direction = normalize_pre_length(Dir, static_cast<float>(m_Length));
+	m_Direction = m_Length > 0 ? normalize_pre_length(Dir, static_cast<float>(m_Length)) : vec2(0.0f, 0.0f);
+
+	// The snapshot only carries the endpoint CCollision::IntersectNoLaser produced, which
+	// also stops at TILE_NOLASER, while the server lays down door collision along the full
+	// length configured in the map and stops only at solid tiles. Recover that length the
+	// way IGameController::OnEntity derives it, from the ENTITY_LASER_* tile next to the
+	// door's tile on the side the door points at.
+	const int Side = m_Length > 0 ? MapSide() : -1;
+	const int ConfiguredLength = Side == -1 ? -1 : MapLength(Side);
+	if(ConfiguredLength != -1)
+	{
+		m_Length = ConfiguredLength;
+		m_Direction = vec2(std::sin(pi / 4 * Side), std::cos(pi / 4 * Side));
+	}
 
 	for(int i = 0; i < m_Length - 1; i++)
 	{
 		vec2 CurrentPos = m_Pos + m_Direction * i;
-
-		CDoorTile DoorTile;
-		Collision()->GetDoorTile(Collision()->GetPureMapIndex(CurrentPos), &DoorTile);
-		// switch door always has priority, because it can turn off doors on all layers if they intersect
-		if(DoorTile.m_Index && DoorTile.m_Number > 0)
-			continue;
-
 		if(Collision()->CheckPoint(CurrentPos))
 			break;
 		else

--- a/src/game/client/prediction/entities/door.h
+++ b/src/game/client/prediction/entities/door.h
@@ -13,6 +13,9 @@ class CDoor : public CEntity
 	int m_Length;
 	bool m_Active;
 
+	int MapSide() const;
+	int MapLength(int Side);
+
 public:
 	CDoor(CGameWorld *pGameWorld, int Id, const CLaserData *pData);
 	void ResetCollision();

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -608,12 +608,18 @@ void CGameWorld::ResetDoorCollision()
 	// rather than keeping them on the entity, so the grid is rebuilt after every snapshot:
 	// a destroyed door clears its entire span, including tiles another door still occupies.
 	// Doors are applied in map order, the order the server creates them in, so intersecting
-	// doors resolve to the same tile on both sides.
+	// doors resolve to the same tile on both sides. Two doors originating on the same tile
+	// share a map index; the server creates the game/front-layer door before the switch-layer
+	// one, so the switch door (m_Number > 0) stamps the shared origin tile last and wins.
 	std::vector<CDoor *> vpDoors;
 	for(CEntity *pEnt = FindFirst(ENTTYPE_DOOR); pEnt; pEnt = pEnt->TypeNext())
 		vpDoors.push_back(static_cast<CDoor *>(pEnt));
 	std::stable_sort(vpDoors.begin(), vpDoors.end(), [this](const CDoor *pLeft, const CDoor *pRight) {
-		return Collision()->GetPureMapIndex(pLeft->m_Pos) < Collision()->GetPureMapIndex(pRight->m_Pos);
+		const int LeftIndex = Collision()->GetPureMapIndex(pLeft->m_Pos);
+		const int RightIndex = Collision()->GetPureMapIndex(pRight->m_Pos);
+		if(LeftIndex != RightIndex)
+			return LeftIndex < RightIndex;
+		return (pLeft->m_Number > 0) < (pRight->m_Number > 0);
 	});
 	for(CDoor *pDoor : vpDoors)
 		pDoor->ResetCollision();

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -17,6 +17,7 @@
 #include <game/client/laser_data.h>
 #include <game/client/pickup_data.h>
 #include <game/client/projectile_data.h>
+#include <game/collision.h>
 #include <game/mapbugs.h>
 #include <game/mapitems.h>
 
@@ -510,10 +511,17 @@ void CGameWorld::NetObjAdd(int ObjId, int ObjType, const void *pObjData, const C
 		CEntity *pEnt = new CPickup(NetPickup);
 		InsertEntity(pEnt, true);
 	}
-	else if((ObjType == NETOBJTYPE_LASER || ObjType == NETOBJTYPE_DDNETLASER) && m_WorldConfig.m_PredictWeapons)
+	else if(ObjType == NETOBJTYPE_LASER || ObjType == NETOBJTYPE_DDNETLASER)
 	{
 		CLaserData Data = ExtractLaserInfo(ObjType, pObjData, this, pDataEx);
 		if(!IsLocalTeam(Data.m_Owner) || !Data.m_Predict)
+		{
+			return;
+		}
+
+		// Doors are static world geometry that only ever adds move restrictions to tiles,
+		// so they follow the tile physics config rather than the weapon prediction config.
+		if(!(Data.m_Type == LASERTYPE_DOOR ? m_WorldConfig.m_PredictTiles : m_WorldConfig.m_PredictWeapons))
 		{
 			return;
 		}
@@ -576,7 +584,6 @@ void CGameWorld::NetObjAdd(int ObjId, int ObjType, const void *pObjData, const C
 				return;
 			}
 			CDoor *pEnt = new CDoor(NetDoor);
-			pEnt->ResetCollision();
 			InsertEntity(pEnt);
 		}
 		else if(Data.m_Type == LASERTYPE_PLASMA)
@@ -593,6 +600,23 @@ void CGameWorld::NetObjAdd(int ObjId, int ObjType, const void *pObjData, const C
 			InsertEntity(pEnt);
 		}
 	}
+}
+
+void CGameWorld::ResetDoorCollision()
+{
+	// Doors add their move restrictions to the collision grid shared by the whole client
+	// rather than keeping them on the entity, so the grid is rebuilt after every snapshot:
+	// a destroyed door clears its entire span, including tiles another door still occupies.
+	// Doors are applied in map order, the order the server creates them in, so intersecting
+	// doors resolve to the same tile on both sides.
+	std::vector<CDoor *> vpDoors;
+	for(CEntity *pEnt = FindFirst(ENTTYPE_DOOR); pEnt; pEnt = pEnt->TypeNext())
+		vpDoors.push_back(static_cast<CDoor *>(pEnt));
+	std::stable_sort(vpDoors.begin(), vpDoors.end(), [this](const CDoor *pLeft, const CDoor *pRight) {
+		return Collision()->GetPureMapIndex(pLeft->m_Pos) < Collision()->GetPureMapIndex(pRight->m_Pos);
+	});
+	for(CDoor *pDoor : vpDoors)
+		pDoor->ResetCollision();
 }
 
 void CGameWorld::NetObjEnd()
@@ -612,6 +636,7 @@ void CGameWorld::NetObjEnd()
 						pHookedChar->m_MarkedForDestroy = false;
 					}
 	RemoveEntities();
+	ResetDoorCollision();
 
 	// Update character IDs and pointers
 	for(int i = 0; i < MAX_CLIENTS; i++)

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -97,6 +97,7 @@ public:
 	void NetObjBegin(CTeamsCore Teams, int LocalClientId);
 	void NetCharAdd(int ObjId, CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, int GameTeam, bool IsLocal);
 	void NetObjAdd(int ObjId, int ObjType, const void *pObjData, const CNetObj_EntityEx *pDataEx);
+	void ResetDoorCollision();
 	void NetObjEnd();
 	void CopyWorld(CGameWorld *pFrom);
 	CEntity *FindMatch(int ObjId, int ObjType, const void *pObjData);


### PR DESCRIPTION
static laser doors aren't predicted currently when antiping is off, but they aren't dynamic besides turning on or off via a switch, this makes it gate door prediction on m_PredictTiles instead

videos with `cl_antiping 0`:

before:

https://github.com/user-attachments/assets/dd1b146a-cb11-4e03-9f1c-22bc818d0251

after


https://github.com/user-attachments/assets/d4beb1cc-141b-418e-a5e1-d37b5c0fc7ec


Made with claude

<details><summary>Claude long explanation</summary>

Door creation sat behind m_PredictWeapons, so a default-config client had no door collision at all and predicted the local tee walking through doors the server treats as solid. Doors are static world geometry, so gate them on m_PredictTiles instead; draggers and plasma keep the weapon gate.

Rebuild door collision after RemoveEntities: the collision grid is shared, and a destroyed door clears its whole span including tiles another door occupies. Apply doors in map order so intersecting doors resolve like they do on the server, which also lets the client drop its switch-door priority guard.

Derive the door's length and direction from the map instead of the snapshot's endpoint. That endpoint comes from IntersectNoLaser, which also stops at TILE_NOLASER, while the server lays down collision along the full configured length and stops only at solid tiles.

</details>

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
