### PR TITLE
Remove duplicate assignment of `CLayerTiles::m_HasGame`

### DIFF
--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -760,7 +760,6 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 
 					pGroup->AddLayer(pTiles);
 					pTiles->m_Image = pTilemapItem->m_Image;
-					pTiles->m_HasGame = pTilemapItem->m_Flags & TILESLAYERFLAG_GAME;
 
 					// validate image index
 					if(pTiles->m_Image < -1 || pTiles->m_Image >= (int)m_vpImages.size())


### PR DESCRIPTION
This variable is already set to `false` in the `CLayerTiles` constructor and set to `true` in the `CLayerGame` constructor.

https://github.com/ddnet/ddnet/blob/0e0485bf6231e2ca66e36d18cc4605564a2b3d9f/src/game/editor/mapitems/layer_tiles.cpp#L26

https://github.com/ddnet/ddnet/blob/0e0485bf6231e2ca66e36d18cc4605564a2b3d9f/src/game/editor/mapitems/layer_game.cpp#L12

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
