### PR TITLE
Avoid marking datafile data as unloaded when it failed to be loaded

### DIFF
--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -767,6 +767,10 @@ void CDataFileReader::UnloadData(int Index)
 	if(Index < 0 || Index >= m_pDataFile->m_Header.m_NumRawData)
 		return;
 
+	// Don't try to load the data again if it previously failed
+	if(m_pDataFile->m_pDataSizes[Index] < 0)
+		return;
+
 	free(m_pDataFile->m_ppDataPtrs[Index]);
 	m_pDataFile->m_ppDataPtrs[Index] = nullptr;
 	m_pDataFile->m_pDataSizes[Index] = 0;


### PR DESCRIPTION
Otherwise, unloading and then loading a data item again causes unnecessary work because loading would only fail again.

For reference:

https://github.com/ddnet/ddnet/blob/0e0485bf6231e2ca66e36d18cc4605564a2b3d9f/src/engine/shared/datafile.cpp#L205-L209

https://github.com/ddnet/ddnet/blob/0e0485bf6231e2ca66e36d18cc4605564a2b3d9f/src/engine/shared/datafile.cpp#L262-L265

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
