### PR TITLE
Rename `CTile::m_Reserved` to `m_MustBe0`, cleanup construction

### DIFF
--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -195,7 +195,7 @@ void CMap::ExtractTiles(CTile *pDest, size_t DestSize, const CTile *pSrc, size_t
 			pDest[DestIndex].m_Index = pSrc[SrcIndex].m_Index;
 			pDest[DestIndex].m_Flags = pSrc[SrcIndex].m_Flags;
 			pDest[DestIndex].m_Skip = 0;
-			pDest[DestIndex].m_Reserved = 0;
+			pDest[DestIndex].m_MustBe0 = 0;
 			DestIndex++;
 		}
 		SrcIndex++;

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -147,7 +147,7 @@ void CLayerTiles::ExtractTiles(const CTile *pSavedTiles, size_t SavedTilesSize) 
 		for(size_t TileIndex = 0; TileIndex < DestSize; ++TileIndex)
 		{
 			m_pTiles[TileIndex].m_Skip = 0;
-			m_pTiles[TileIndex].m_Reserved = 0;
+			m_pTiles[TileIndex].m_MustBe0 = 0;
 		}
 	}
 }

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -353,7 +353,7 @@ public:
 	unsigned char m_Index;
 	unsigned char m_Flags;
 	unsigned char m_Skip;
-	unsigned char m_Reserved;
+	unsigned char m_MustBe0;
 };
 
 class CMapItemInfo

--- a/src/tools/dummy_map.cpp
+++ b/src/tools/dummy_map.cpp
@@ -34,13 +34,7 @@ static void CreateEmptyMap(IStorage *pStorage)
 	constexpr int LayerWidth = 2;
 	constexpr int LayerHeight = 2;
 	CTile aTiles[LayerWidth * LayerHeight];
-	for(auto &Tile : aTiles)
-	{
-		Tile.m_Index = 1;
-		Tile.m_Flags = 0;
-		Tile.m_Skip = 0;
-		Tile.m_Reserved = 0;
-	}
+	std::fill(std::begin(aTiles), std::end(aTiles), CTile{.m_Index = TILE_SOLID, .m_Flags = 0, .m_Skip = 0, .m_MustBe0 = 0});
 	const int TilesData = Writer.AddData(sizeof(aTiles), &aTiles);
 
 	CMapItemLayerTilemap GameLayer;

--- a/src/tools/map_replace_area.cpp
+++ b/src/tools/map_replace_area.cpp
@@ -304,8 +304,7 @@ void RemoveDestinationTiles(CMapItemLayerTilemap *pTilemap, CTile *pTile, float 
 	int aaRange[2][2];
 	ConvertToTiles(aaReplaceableArea, aaRange);
 
-	CTile EmptyTile;
-	EmptyTile.m_Index = EmptyTile.m_Flags = EmptyTile.m_Skip = EmptyTile.m_Reserved = 0;
+	const CTile EmptyTile = {.m_Index = TILE_AIR, .m_Flags = 0, .m_Skip = 0, .m_MustBe0 = 0};
 
 	for(int y = aaRange[1][0]; y < aaRange[1][1]; y++)
 		for(int x = aaRange[0][0]; x < aaRange[0][1]; x++)


### PR DESCRIPTION
Make it clear with the name that the padding byte must be zero.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
