### PR TITLE
client: Fix crash in render_map

### DIFF
--- a/src/game/map/render_map.cpp
+++ b/src/game/map/render_map.cpp
@@ -109,7 +109,7 @@ CMapBasedEnvelopePointAccess::CMapBasedEnvelopePointAccess(IMap *pMap)
 void CMapBasedEnvelopePointAccess::SetPointsRange(int StartPoint, int NumPoints)
 {
 	m_StartPoint = std::clamp(StartPoint, 0, m_NumPointsMax);
-	m_NumPoints = std::clamp(NumPoints, 0, std::max(m_NumPointsMax - StartPoint, 0));
+	m_NumPoints = std::clamp(NumPoints, 0, m_NumPointsMax - m_StartPoint);
 }
 
 int CMapBasedEnvelopePointAccess::StartPoint() const


### PR DESCRIPTION
Before:
```
==69431==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x61f00000a70c at pc 0x000105756810 bp 0x00016b4861e0 sp 0x00016b4861d8 READ of size 4 at 0x61f00000a70c thread T0
    #0 0x00010575680c in CFixedTime::GetInternal() const mapitems.h:270
    #1 0x000105965a40 in CRenderMap::RenderEvalEnvelope(IEnvelopePointAccess const*, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l>>, ColorRGBA&, unsigned long) render_map.cpp:268
    #2 0x000104fbef60 in CEnvelopeState::EnvelopeEval(int, int, ColorRGBA&, unsigned long) envelope_state.cpp:77
    #3 0x000105967524 in CRenderMap::ForceRenderQuads(CQuad*, int, int, IEnvelopeEval*, float) render_map.cpp:381
    #4 0x000105936044 in CRenderLayerQuads::Render(CRenderLayerParams const&) render_layer.cpp:1434
    #5 0x000105916864 in CMapRenderer::Render(CRenderLayerParams const&) map_renderer.cpp:158
    #6 0x00010502c074 in CMapLayers::OnRender() maplayers.cpp:64
    #7 0x000105039b14 in CMenuBackground::Render() menu_background.cpp:352
    #8 0x00010504f870 in CMenus::RenderLoading(char const*, char const*, int) menus.cpp:711
    #9 0x0001050537f8 in CMenus::MenuImageScan(char const*, int, int, void*) menus.cpp:2544
    #10 0x000104b350d8 in CStorage::ListDirectoryUniqueCallback(char const*, int, int, void*) storage.cpp:461
    #11 0x000104b8d794 in fs_listdir(char const*, int (*)(char const*, int, int, void*), int, void*) fs.cpp:175
    #12 0x000104b312fc in CStorage::ListDirectory(int, char const*, int (*)(char const*, int, int, void*), void*) storage.cpp:475
    #13 0x000105052b78 in CMenus::OnInit() menus.cpp:858
    #14 0x00010534fb74 in CGameClient::OnInit() gameclient.cpp:387
    #15 0x000104cbc40c in CClient::Run() client.cpp:3251
    #16 0x000104cddaf8 in TWMain client.cpp:5204
    #17 0x000104ef61ec in main client.mm:35
    #18 0x00018c0204e0 in start+0x1b4c (dyld:arm64e+0x204e0)

0x61f00000a70c is located 0 bytes after 3212-byte region [0x61f000009a80,0x61f00000a70c) allocated by thread T0 here:
    #0 0x000109ced164 in malloc+0x78 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x41164)
    #1 0x000104a43e34 in CDataFileReader::Open(char const*, IStorage*, char const*, int) datafile.cpp:606
    #2 0x000104ae1f64 in CMap::Load(char const*, IStorage*, char const*, int) map.cpp:84
    #3 0x000105036c80 in CMenuBackground::LoadMenuBackground(bool, bool) menu_background.cpp:245
    #4 0x000105036030 in CMenuBackground::OnInit() menu_background.cpp:87
    #5 0x00010534fb74 in CGameClient::OnInit() gameclient.cpp:387
    #6 0x000104cbc40c in CClient::Run() client.cpp:3251
    #7 0x000104cddaf8 in TWMain client.cpp:5204
    #8 0x000104ef61ec in main client.mm:35
    #9 0x00018c0204e0 in start+0x1b4c (dyld:arm64e+0x204e0)

SUMMARY: AddressSanitizer: heap-buffer-overflow mapitems.h:270 in CFixedTime::GetInternal() const Shadow bytes around the buggy address:
  0x61f00000a480: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x61f00000a500: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x61f00000a580: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x61f00000a600: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x61f00000a680: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x61f00000a700: 00[04]fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x61f00000a780: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x61f00000a800: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x61f00000a880: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x61f00000a900: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x61f00000a980: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==69431==ABORTING
```

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Opus 5 and Fable 5) wrote this, I reviewed.