### PR TITLE
server: Fix mutes with initial delay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3270,6 +3270,7 @@ if((GTEST_FOUND OR DOWNLOAD_GTEST) AND SERVER)
     mapitems_test.cpp
     math_test.cpp
     mem_test.cpp
+    mutes_test.cpp
     name_ban_test.cpp
     net_test.cpp
     netaddr_test.cpp

--- a/src/game/server/mutes.cpp
+++ b/src/game/server/mutes.cpp
@@ -112,7 +112,7 @@ std::optional<CMute> CMutes::IsMuted(const NETADDR *pAddr, bool RespectInitialDe
 	{
 		return std::nullopt;
 	}
-	if(!RespectInitialDelay && !It->second.m_InitialDelay)
+	if(!RespectInitialDelay && It->second.m_InitialDelay)
 	{
 		return std::nullopt;
 	}

--- a/src/test/mutes_test.cpp
+++ b/src/test/mutes_test.cpp
@@ -1,0 +1,33 @@
+#include <base/types.h>
+
+#include <game/server/gamecontext.h>
+
+#include <gtest/gtest.h>
+
+static NETADDR TestAddr()
+{
+	NETADDR Addr = {};
+	Addr.type = NETTYPE_IPV4;
+	Addr.ip[0] = 127;
+	Addr.ip[3] = 1;
+	Addr.port = 12345;
+	return Addr;
+}
+
+TEST(Mutes, RegularMuteAppliesWhenIgnoringInitialDelay)
+{
+	CMutes Mutes("mutes_test");
+	const NETADDR Addr = TestAddr();
+	ASSERT_TRUE(Mutes.Mute(&Addr, 60, "Spam protection", "nameless tee", false));
+	EXPECT_TRUE(Mutes.IsMuted(&Addr, true).has_value());
+	EXPECT_TRUE(Mutes.IsMuted(&Addr, false).has_value());
+}
+
+TEST(Mutes, InitialDelayMuteIgnoredWhenIgnoringInitialDelay)
+{
+	CMutes Mutes("mutes_test");
+	const NETADDR Addr = TestAddr();
+	ASSERT_TRUE(Mutes.Mute(&Addr, 60, "Initial chat delay", "nameless tee", true));
+	EXPECT_TRUE(Mutes.IsMuted(&Addr, true).has_value());
+	EXPECT_FALSE(Mutes.IsMuted(&Addr, false).has_value());
+}


### PR DESCRIPTION

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Opus 5) wrote this, I reviewed.
