### PR TITLE
client: Reject invalid maps layers leading to crashes

### DIFF
--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -95,6 +95,7 @@ bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, in
 	int GroupsStart, GroupsNum, LayersStart, LayersNum;
 	NewDataFile.GetType(MAPITEMTYPE_GROUP, &GroupsStart, &GroupsNum);
 	NewDataFile.GetType(MAPITEMTYPE_LAYER, &LayersStart, &LayersNum);
+	const CMapItemLayerTilemap *pGameLayer = nullptr;
 	for(int g = 0; g < GroupsNum; g++)
 	{
 		const CMapItemGroup *pGroup = static_cast<CMapItemGroup *>(NewDataFile.GetItem(GroupsStart + g));
@@ -104,6 +105,11 @@ bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, in
 			if(pLayer->m_Type == LAYERTYPE_TILES)
 			{
 				CMapItemLayerTilemap *pTilemap = reinterpret_cast<CMapItemLayerTilemap *>(pLayer);
+				if(pTilemap->m_Flags & TILESLAYERFLAG_GAME)
+				{
+					// CLayers uses the last game layer, so this must match
+					pGameLayer = pTilemap;
+				}
 				if(pTilemap->m_Version >= CMapItemLayerTilemap::VERSION_TEEWORLDS_TILESKIP)
 				{
 					const size_t TilemapCount = (size_t)pTilemap->m_Width * pTilemap->m_Height;
@@ -122,6 +128,24 @@ bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, in
 				}
 			}
 		}
+	}
+
+	// The game layer determines the map size that the collision and all entity
+	// lookups are based on, which assume that its tile data is complete.
+	if(pGameLayer == nullptr)
+	{
+		log_error("map/load", "Map does not contain a game layer.");
+		NewDataFile.Close();
+		return false;
+	}
+	const int GameTileDataSize = NewDataFile.GetDataSize(pGameLayer->m_Data);
+	if(pGameLayer->m_Width <= 0 || pGameLayer->m_Height <= 0 ||
+		(int64_t)pGameLayer->m_Width * pGameLayer->m_Height > GameTileDataSize / (int)sizeof(CTile) ||
+		NewDataFile.GetData(pGameLayer->m_Data) == nullptr)
+	{
+		log_error("map/load", "Game layer size (%d * %d) does not match its tile data (%d bytes).", pGameLayer->m_Width, pGameLayer->m_Height, GameTileDataSize);
+		NewDataFile.Close();
+		return false;
 	}
 
 	// Replace existing datafile with new datafile

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -3,6 +3,7 @@
 #include <antibot/antibot_data.h>
 
 #include <base/dbg.h>
+#include <base/log.h>
 #include <base/math.h>
 #include <base/mem.h>
 #include <base/vmath.h>
@@ -53,9 +54,18 @@ void CCollision::Init(class CLayers *pLayers)
 	Unload();
 
 	m_pLayers = pLayers;
-	m_Width = m_pLayers->GameLayer()->m_Width;
-	m_Height = m_pLayers->GameLayer()->m_Height;
-	m_pTiles = static_cast<CTile *>(m_pLayers->Map()->GetData(m_pLayers->GameLayer()->m_Data));
+
+	const CMapItemLayerTilemap *pGameLayer = m_pLayers->GameLayer();
+	CTile *pTiles = pGameLayer == nullptr ? nullptr : static_cast<CTile *>(m_pLayers->Map()->GetData(pGameLayer->m_Data));
+	if(pTiles == nullptr || pGameLayer->m_Width <= 0 || pGameLayer->m_Height <= 0 ||
+		(int64_t)pGameLayer->m_Width * pGameLayer->m_Height > m_pLayers->Map()->GetDataSize(pGameLayer->m_Data) / (int)sizeof(CTile))
+	{
+		log_error("collision", "Map is missing a valid game layer");
+		return;
+	}
+	m_Width = pGameLayer->m_Width;
+	m_Height = pGameLayer->m_Height;
+	m_pTiles = pTiles;
 
 	if(m_pLayers->TeleLayer())
 	{


### PR DESCRIPTION
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Opus 5) wrote this, I reviewed
