### PR TITLE
server: Only update antibot data of affected client

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -374,7 +374,7 @@ public:
 	virtual void SetErrorShutdown(const char *pReason) = 0;
 	virtual void ExpireServerInfo() = 0;
 
-	virtual void FillAntibot(CAntibotRoundData *pData) = 0;
+	virtual void FillAntibot(CAntibotRoundData *pData, int ClientId) = 0;
 
 	virtual void SendMsgRaw(int ClientId, const void *pData, int Size, int Flags) = 0;
 
@@ -472,7 +472,7 @@ public:
 	virtual void TeehistorianRecordTeamFinish(int TeamId, int TimeTicks) = 0;
 	virtual void TeehistorianRecordAuthLogin(int ClientId, int Level, const char *pAuthName) = 0;
 
-	virtual void FillAntibot(CAntibotRoundData *pData) = 0;
+	virtual void FillAntibot(CAntibotRoundData *pData, int ClientId) = 0;
 
 	/**
 	 * Used to report custom player info to the master server.

--- a/src/engine/server/antibot.cpp
+++ b/src/engine/server/antibot.cpp
@@ -91,7 +91,7 @@ void CAntibot::RoundStart(IGameServer *pGameServer)
 	mem_zero(&m_RoundData, sizeof(m_RoundData));
 	m_RoundData.m_Map.m_pTiles = nullptr;
 	AntibotRoundStart(&m_RoundData);
-	Update();
+	UpdateAll();
 }
 void CAntibot::RoundEnd()
 {
@@ -105,83 +105,104 @@ void CAntibot::ConsoleCommand(const char *pCommand)
 {
 	AntibotConsoleCommand(pCommand);
 }
-void CAntibot::Update()
+void CAntibot::Update(int ClientId)
 {
 	m_Data.m_Now = time_get();
 	m_Data.m_Freq = time_freq();
 
-	Server()->FillAntibot(&m_RoundData);
+	Server()->FillAntibot(&m_RoundData, ClientId);
 	if(GameServer())
 	{
-		GameServer()->FillAntibot(&m_RoundData);
+		GameServer()->FillAntibot(&m_RoundData, ClientId);
+		AntibotUpdateData();
+	}
+}
+void CAntibot::UpdateAll()
+{
+	m_Data.m_Now = time_get();
+	m_Data.m_Freq = time_freq();
+
+	for(int ClientId = 0; ClientId < MAX_CLIENTS; ClientId++)
+	{
+		Server()->FillAntibot(&m_RoundData, ClientId);
+		if(GameServer())
+		{
+			GameServer()->FillAntibot(&m_RoundData, ClientId);
+		}
+	}
+	if(GameServer())
+	{
 		AntibotUpdateData();
 	}
 }
 
 void CAntibot::OnPlayerInit(int ClientId)
 {
-	Update();
+	UpdateAll();
 	AntibotOnPlayerInit(ClientId);
 }
 void CAntibot::OnPlayerDestroy(int ClientId)
 {
-	Update();
+	UpdateAll();
 	AntibotOnPlayerDestroy(ClientId);
 }
 void CAntibot::OnSpawn(int ClientId)
 {
-	Update();
+	Update(ClientId);
 	AntibotOnSpawn(ClientId);
 }
 void CAntibot::OnHammerFireReloading(int ClientId)
 {
-	Update();
+	Update(ClientId);
 	AntibotOnHammerFireReloading(ClientId);
 }
 void CAntibot::OnHammerFire(int ClientId)
 {
-	Update();
+	Update(ClientId);
 	AntibotOnHammerFire(ClientId);
 }
 void CAntibot::OnHammerHit(int ClientId, int TargetId)
 {
-	Update();
+	// The module may inspect the target's data, so update it as well
+	Update(ClientId);
+	Update(TargetId);
 	AntibotOnHammerHit(ClientId, TargetId);
 }
 void CAntibot::OnDirectInput(int ClientId)
 {
-	Update();
+	Update(ClientId);
 	AntibotOnDirectInput(ClientId);
 }
 void CAntibot::OnCharacterTick(int ClientId)
 {
-	Update();
+	Update(ClientId);
 	AntibotOnCharacterTick(ClientId);
 }
 void CAntibot::OnHookAttach(int ClientId, bool Player)
 {
-	Update();
+	// The module may inspect the hooked player's data, so update all clients
+	UpdateAll();
 	AntibotOnHookAttach(ClientId, Player);
 }
 
 void CAntibot::OnEngineTick()
 {
-	Update();
+	UpdateAll();
 	AntibotOnEngineTick();
 }
 void CAntibot::OnEngineClientJoin(int ClientId)
 {
-	Update();
+	UpdateAll();
 	AntibotOnEngineClientJoin(ClientId);
 }
 void CAntibot::OnEngineClientDrop(int ClientId, const char *pReason)
 {
-	Update();
+	UpdateAll();
 	AntibotOnEngineClientDrop(ClientId, pReason);
 }
 bool CAntibot::OnEngineClientMessage(int ClientId, const void *pData, int Size, int Flags)
 {
-	Update();
+	Update(ClientId);
 	int AntibotFlags = 0;
 	if((Flags & MSGFLAG_VITAL) == 0)
 	{
@@ -191,7 +212,7 @@ bool CAntibot::OnEngineClientMessage(int ClientId, const void *pData, int Size, 
 }
 bool CAntibot::OnEngineServerMessage(int ClientId, const void *pData, int Size, int Flags)
 {
-	Update();
+	Update(ClientId);
 	int AntibotFlags = 0;
 	if((Flags & MSGFLAG_VITAL) == 0)
 	{
@@ -244,7 +265,10 @@ void CAntibot::ConsoleCommand(const char *pCommand)
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "antibot", "unknown command");
 	}
 }
-void CAntibot::Update()
+void CAntibot::Update(int ClientId)
+{
+}
+void CAntibot::UpdateAll()
 {
 }
 

--- a/src/engine/server/antibot.h
+++ b/src/engine/server/antibot.h
@@ -19,7 +19,8 @@ class CAntibot : public IEngineAntibot
 	CAntibotRoundData m_RoundData;
 	bool m_Initialized;
 
-	void Update();
+	void Update(int ClientId);
+	void UpdateAll();
 	static void Kick(int ClientId, const char *pMessage, void *pUser);
 	static void Log(const char *pMessage, void *pUser);
 	static void Report(int ClientId, const char *pMessage, void *pUser);

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2648,28 +2648,25 @@ void CServer::GetServerInfoSixup(CPacker *pPacker, bool SendClients)
 	pPacker->AddRaw(FirstChunk.m_vData.data(), FirstChunk.m_vData.size());
 }
 
-void CServer::FillAntibot(CAntibotRoundData *pData)
+void CServer::FillAntibot(CAntibotRoundData *pData, int ClientId)
 {
-	for(int ClientId = 0; ClientId < MAX_CLIENTS; ClientId++)
+	CAntibotPlayerData *pPlayer = &pData->m_aPlayers[ClientId];
+	if(m_aClients[ClientId].m_State == CServer::CClient::STATE_EMPTY)
 	{
-		CAntibotPlayerData *pPlayer = &pData->m_aPlayers[ClientId];
-		if(m_aClients[ClientId].m_State == CServer::CClient::STATE_EMPTY)
-		{
-			pPlayer->m_aAddress[0] = '\0';
-		}
-		else
-		{
-			// No need for expensive str_copy since we don't truncate and the string is
-			// ASCII anyway
-			static_assert(std::size((CAntibotPlayerData{}).m_aAddress) >= NETADDR_MAXSTRSIZE);
-			static_assert(std::is_same_v<decltype(CServer{}.ClientAddrStringImpl(ClientId, true)), const std::array<char, NETADDR_MAXSTRSIZE> &>);
-			mem_copy(pPlayer->m_aAddress, ClientAddrStringImpl(ClientId, true).data(), NETADDR_MAXSTRSIZE);
-			pPlayer->m_Sixup = m_aClients[ClientId].m_Sixup;
-			pPlayer->m_DnsblNone = m_aClients[ClientId].m_DnsblState == EDnsblState::NONE;
-			pPlayer->m_DnsblPending = m_aClients[ClientId].m_DnsblState == EDnsblState::PENDING;
-			pPlayer->m_DnsblBlacklisted = m_aClients[ClientId].m_DnsblState == EDnsblState::BLACKLISTED;
-			pPlayer->m_Authed = IsRconAuthed(ClientId);
-		}
+		pPlayer->m_aAddress[0] = '\0';
+	}
+	else
+	{
+		// No need for expensive str_copy since we don't truncate and the string is
+		// ASCII anyway
+		static_assert(std::size((CAntibotPlayerData{}).m_aAddress) >= NETADDR_MAXSTRSIZE);
+		static_assert(std::is_same_v<decltype(CServer{}.ClientAddrStringImpl(ClientId, true)), const std::array<char, NETADDR_MAXSTRSIZE> &>);
+		mem_copy(pPlayer->m_aAddress, ClientAddrStringImpl(ClientId, true).data(), NETADDR_MAXSTRSIZE);
+		pPlayer->m_Sixup = m_aClients[ClientId].m_Sixup;
+		pPlayer->m_DnsblNone = m_aClients[ClientId].m_DnsblState == EDnsblState::NONE;
+		pPlayer->m_DnsblPending = m_aClients[ClientId].m_DnsblState == EDnsblState::PENDING;
+		pPlayer->m_DnsblBlacklisted = m_aClients[ClientId].m_DnsblState == EDnsblState::BLACKLISTED;
+		pPlayer->m_Authed = IsRconAuthed(ClientId);
 	}
 }
 

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -407,7 +407,7 @@ public:
 	bool m_ServerInfoNeedsUpdate = false;
 	bool m_ServerInfoNeedsResend = false;
 
-	void FillAntibot(CAntibotRoundData *pData) override;
+	void FillAntibot(CAntibotRoundData *pData, int ClientId) override;
 
 	void ExpireServerInfo() override;
 	void ExpireServerInfoAndQueueResend();

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -297,52 +297,49 @@ bool CGameContext::EmulateBug(int Bug) const
 	return m_MapBugs.Contains(Bug);
 }
 
-void CGameContext::FillAntibot(CAntibotRoundData *pData)
+void CGameContext::FillAntibot(CAntibotRoundData *pData, int ClientId)
 {
 	if(!pData->m_Map.m_pTiles)
 	{
 		Collision()->FillAntibot(&pData->m_Map);
 	}
 	pData->m_Tick = Server()->Tick();
-	mem_zero(pData->m_aCharacters, sizeof(pData->m_aCharacters));
-	for(int i = 0; i < MAX_CLIENTS; i++)
+	CAntibotCharacterData *pChar = &pData->m_aCharacters[ClientId];
+	mem_zero(pChar, sizeof(*pChar));
+	for(auto &LatestInput : pChar->m_aLatestInputs)
 	{
-		CAntibotCharacterData *pChar = &pData->m_aCharacters[i];
-		for(auto &LatestInput : pChar->m_aLatestInputs)
-		{
-			LatestInput.m_Direction = 0;
-			LatestInput.m_TargetX = -1;
-			LatestInput.m_TargetY = -1;
-			LatestInput.m_Jump = -1;
-			LatestInput.m_Fire = -1;
-			LatestInput.m_Hook = -1;
-			LatestInput.m_PlayerFlags = -1;
-			LatestInput.m_WantedWeapon = -1;
-			LatestInput.m_NextWeapon = -1;
-			LatestInput.m_PrevWeapon = -1;
-		}
-		pChar->m_Alive = false;
-		pChar->m_Pause = false;
-		pChar->m_Team = -1;
+		LatestInput.m_Direction = 0;
+		LatestInput.m_TargetX = -1;
+		LatestInput.m_TargetY = -1;
+		LatestInput.m_Jump = -1;
+		LatestInput.m_Fire = -1;
+		LatestInput.m_Hook = -1;
+		LatestInput.m_PlayerFlags = -1;
+		LatestInput.m_WantedWeapon = -1;
+		LatestInput.m_NextWeapon = -1;
+		LatestInput.m_PrevWeapon = -1;
+	}
+	pChar->m_Alive = false;
+	pChar->m_Pause = false;
+	pChar->m_Team = -1;
 
-		pChar->m_Pos = vec2(-1, -1);
-		pChar->m_Vel = vec2(0, 0);
-		pChar->m_Angle = -1;
-		pChar->m_HookedPlayer = -1;
-		pChar->m_SpawnTick = -1;
-		pChar->m_WeaponChangeTick = -1;
+	pChar->m_Pos = vec2(-1, -1);
+	pChar->m_Vel = vec2(0, 0);
+	pChar->m_Angle = -1;
+	pChar->m_HookedPlayer = -1;
+	pChar->m_SpawnTick = -1;
+	pChar->m_WeaponChangeTick = -1;
 
-		if(m_apPlayers[i])
+	if(m_apPlayers[ClientId])
+	{
+		str_copy(pChar->m_aName, Server()->ClientName(ClientId));
+		CCharacter *pGameChar = m_apPlayers[ClientId]->GetCharacter();
+		pChar->m_Alive = (bool)pGameChar;
+		pChar->m_Pause = m_apPlayers[ClientId]->IsPaused();
+		pChar->m_Team = m_apPlayers[ClientId]->GetTeam();
+		if(pGameChar)
 		{
-			str_copy(pChar->m_aName, Server()->ClientName(i));
-			CCharacter *pGameChar = m_apPlayers[i]->GetCharacter();
-			pChar->m_Alive = (bool)pGameChar;
-			pChar->m_Pause = m_apPlayers[i]->IsPaused();
-			pChar->m_Team = m_apPlayers[i]->GetTeam();
-			if(pGameChar)
-			{
-				pGameChar->FillAntibot(pChar);
-			}
+			pGameChar->FillAntibot(pChar);
 		}
 	}
 }

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -412,7 +412,7 @@ public:
 	// DDRace
 	void OnPreTickTeehistorian() override;
 	bool OnClientDDNetVersionKnown(int ClientId);
-	void FillAntibot(CAntibotRoundData *pData) override;
+	void FillAntibot(CAntibotRoundData *pData, int ClientId) override;
 	bool ProcessSpamProtection(int ClientId, bool RespectChatInitialDelay = true);
 	int GetDDRaceTeam(int ClientId) const;
 	// Describes the time when the first player joined the server.


### PR DESCRIPTION
Uses ~20% of CPU on prod. servers. This should reduce it by a bit.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Fable 5) wrote this, I reviewed