### PR TITLE
server: Check single client instead of building full team mask

### DIFF
--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -11,6 +11,7 @@
 #include <game/mapitems.h>
 #include <game/server/gamecontext.h>
 #include <game/server/gamemodes/ddnet.h>
+#include <game/server/teams.h>
 
 CProjectile::CProjectile(
 	CGameWorld *pGameWorld,
@@ -384,15 +385,12 @@ void CProjectile::Snap(int SnappingClient)
 	}
 
 	CCharacter *pOwnerChar = nullptr;
-	CClientMask TeamMask = CClientMask().set();
 
 	if(m_Owner >= 0)
 		pOwnerChar = GameServer()->GetPlayerChar(m_Owner);
 
-	if(pOwnerChar && pOwnerChar->IsAlive())
-		TeamMask = pOwnerChar->TeamMask();
-
-	if(SnappingClient != SERVER_DEMO_CLIENT && m_Owner != -1 && !TeamMask.test(SnappingClient))
+	if(SnappingClient != SERVER_DEMO_CLIENT && pOwnerChar && pOwnerChar->IsAlive() &&
+		!pOwnerChar->Teams()->CanSee(pOwnerChar->Team(), m_Owner, SnappingClient))
 		return;
 
 	if(SnappingClientVersion >= VERSION_DDNET_ENTITY_NETOBJS)

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -594,6 +594,24 @@ CClientMask CGameTeams::TeamMask(int Team, int ExceptId, int Asker, int VersionF
 	return Mask;
 }
 
+bool CGameTeams::CanSee(int Team, int Asker, int ClientId)
+{
+	if(Team == TEAM_SUPER)
+		return true;
+
+	CPlayer *pAsker = GetPlayer(Asker);
+	CInteractions Interact;
+	Interact.Init(Asker, pAsker ? pAsker->GetUniqueCid() : 0);
+	Interact.FillOwnerConnected(
+		pAsker && pAsker->GetCharacter() && pAsker->GetCharacter()->IsAlive(),
+		m_Core.Team(Asker),
+		m_Core.GetSolo(Asker),
+		false,
+		false); // TODO: these false values make little sense
+
+	return GetPlayer(ClientId) && Interact.CanSee(GameServer(), ClientId);
+}
+
 void CGameTeams::SendTeamsState(int ClientId)
 {
 	if(g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO)

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -87,6 +87,9 @@ public:
 
 	CClientMask TeamMask(int Team, int ExceptId = -1, int Asker = -1, int VersionFlags = CGameContext::FLAG_SIX | CGameContext::FLAG_SIXUP);
 
+	// whether ClientId can see actions of Asker.
+	bool CanSee(int Team, int Asker, int ClientId);
+
 	int TeamSize(int Team) const;
 
 	// need to be very careful using this method. SERIOUSLY...


### PR DESCRIPTION
currently projectiles are expensive on a busy server, this helps. The TODO is copy-pasta from the full team mask version.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Fable 5) wrote this, I reviewed.
