### PR TITLE
network: Use sendmmsg

### DIFF
--- a/src/base/net.cpp
+++ b/src/base/net.cpp
@@ -57,6 +57,13 @@ typedef struct
 	struct iovec iovecs[VLEN];
 	char bufs[VLEN][PACKETSIZE];
 	char sockaddrs[VLEN][128];
+
+	int send_size;
+	int send_fds[VLEN];
+	struct mmsghdr send_msgs[VLEN];
+	struct iovec send_iovecs[VLEN];
+	char send_bufs[VLEN][PACKETSIZE];
+	char send_sockaddrs[VLEN][128];
 #else
 	char buf[PACKETSIZE];
 #endif
@@ -78,6 +85,18 @@ static void net_buffer_init(NETSOCKET_BUFFER *buffer)
 		buffer->msgs[i].msg_hdr.msg_iovlen = 1;
 		buffer->msgs[i].msg_hdr.msg_name = &(buffer->sockaddrs[i]);
 		buffer->msgs[i].msg_hdr.msg_namelen = sizeof(buffer->sockaddrs[i]);
+	}
+
+	buffer->send_size = 0;
+	mem_zero(buffer->send_msgs, sizeof(buffer->send_msgs));
+	mem_zero(buffer->send_iovecs, sizeof(buffer->send_iovecs));
+	mem_zero(buffer->send_sockaddrs, sizeof(buffer->send_sockaddrs));
+	for(size_t i = 0; i < VLEN; ++i)
+	{
+		buffer->send_iovecs[i].iov_base = buffer->send_bufs[i];
+		buffer->send_msgs[i].msg_hdr.msg_iov = &(buffer->send_iovecs[i]);
+		buffer->send_msgs[i].msg_hdr.msg_iovlen = 1;
+		buffer->send_msgs[i].msg_hdr.msg_name = &(buffer->send_sockaddrs[i]);
 	}
 #endif
 }
@@ -1007,6 +1026,63 @@ NETSOCKET net_udp_create(NETADDR bindaddr)
 	return sock;
 }
 
+void net_udp_flush(NETSOCKET sock)
+{
+#if defined(CONF_PLATFORM_LINUX)
+	if(sock == nullptr)
+		return;
+	NETSOCKET_BUFFER *buffer = &sock->buffer;
+	int start = 0;
+	while(start < buffer->send_size)
+	{
+		// sendmmsg operates on a single socket, so send consecutive runs of
+		// messages with the same target socket together
+		const int fd = buffer->send_fds[start];
+		int end = start + 1;
+		while(end < buffer->send_size && buffer->send_fds[end] == fd)
+			end++;
+		int sent = 0;
+		while(sent < end - start)
+		{
+			const int n = sendmmsg(fd, &buffer->send_msgs[start + sent], end - start - sent, 0);
+			if(n <= 0)
+			{
+				sent++;
+				continue;
+			}
+			sent += n;
+		}
+		start = end;
+	}
+	buffer->send_size = 0;
+#else
+	(void)sock;
+#endif
+}
+
+#if defined(CONF_PLATFORM_LINUX)
+static void net_send_enqueue(NETSOCKET sock, int fd, const sockaddr *sa, socklen_t salen, const void *data, int size)
+{
+	NETSOCKET_BUFFER *buffer = &sock->buffer;
+	if(size > (int)sizeof(buffer->send_bufs[0]))
+	{
+		sendto(fd, data, size, 0, sa, salen);
+		return;
+	}
+	if(buffer->send_size == (int)VLEN)
+	{
+		net_udp_flush(sock);
+	}
+	const int i = buffer->send_size;
+	buffer->send_fds[i] = fd;
+	mem_copy(buffer->send_bufs[i], data, size);
+	buffer->send_iovecs[i].iov_len = size;
+	mem_copy(buffer->send_sockaddrs[i], sa, salen);
+	buffer->send_msgs[i].msg_hdr.msg_namelen = salen;
+	buffer->send_size = i + 1;
+}
+#endif
+
 int net_udp_send(NETSOCKET sock, const NETADDR *addr, const void *data, int size)
 {
 	int d = -1;
@@ -1028,7 +1104,12 @@ int net_udp_send(NETSOCKET sock, const NETADDR *addr, const void *data, int size
 				netaddr_to_sockaddr_in(addr, &sa);
 			}
 
+#if defined(CONF_PLATFORM_LINUX)
+			net_send_enqueue(sock, sock->ipv4sock, (sockaddr *)&sa, sizeof(sa), data, size);
+			d = size;
+#else
 			d = sendto(sock->ipv4sock, (const char *)data, size, 0, (sockaddr *)&sa, sizeof(sa));
+#endif
 		}
 		else
 		{
@@ -1076,7 +1157,12 @@ int net_udp_send(NETSOCKET sock, const NETADDR *addr, const void *data, int size
 				netaddr_to_sockaddr_in6(addr, &sa);
 			}
 
+#if defined(CONF_PLATFORM_LINUX)
+			net_send_enqueue(sock, sock->ipv6sock, (sockaddr *)&sa, sizeof(sa), data, size);
+			d = size;
+#else
 			d = sendto(sock->ipv6sock, (const char *)data, size, 0, (sockaddr *)&sa, sizeof(sa));
+#endif
 		}
 		else
 		{
@@ -1223,6 +1309,7 @@ int net_udp_recv(NETSOCKET sock, NETADDR *addr, unsigned char **data)
 
 void net_udp_close(NETSOCKET sock)
 {
+	net_udp_flush(sock);
 	priv_net_close_all_sockets(sock);
 }
 

--- a/src/base/net.h
+++ b/src/base/net.h
@@ -263,6 +263,9 @@ NETSOCKET net_udp_create(NETADDR bindaddr);
 /**
  * Sends a packet over an UDP socket.
  *
+ * On Linux, the packet may be buffered instead of being sent immediately,
+ * call `net_udp_flush` to ensure that all buffered packets are sent.
+ *
  * @ingroup Network-UDP
  *
  * @param sock Socket to use.
@@ -270,9 +273,18 @@ NETSOCKET net_udp_create(NETADDR bindaddr);
  * @param data Pointer to the packet data to send.
  * @param size Size of the packet.
  *
- * @return On success it returns the number of bytes sent. Returns `-1` on error.
+ * @return On success it returns the number of bytes sent or buffered. Returns `-1` on error.
  */
 int net_udp_send(NETSOCKET sock, const NETADDR *addr, const void *data, int size);
+
+/**
+ * Sends all buffered packets of an UDP socket.
+ *
+ * @ingroup Network-UDP
+ *
+ * @param sock Socket to flush.
+ */
+void net_udp_flush(NETSOCKET sock);
 
 /**
  * Receives a packet over an UDP socket.

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3362,6 +3362,10 @@ void CClient::Run()
 			}
 
 			Update();
+			// flush before rendering so input packets are not delayed by a
+			// blocking buffer swap
+			for(auto &NetClient : m_aNetClient)
+				net_udp_flush(NetClient.m_Socket);
 			int64_t Now = time_get();
 
 			bool IsRenderActive = (g_Config.m_GfxBackgroundRender || m_pGraphics->WindowOpen());
@@ -3428,6 +3432,9 @@ void CClient::Run()
 
 		if(State() == IClient::STATE_QUITTING || State() == IClient::STATE_RESTARTING)
 			break;
+
+		for(auto &NetClient : m_aNetClient)
+			net_udp_flush(NetClient.m_Socket);
 
 		// beNice
 		auto Now = time_get_nanoseconds();

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3400,6 +3400,9 @@ int CServer::Run()
 			if(NewTicks)
 			{
 				DoSnapshot();
+				// flush immediately so snapshots are not delayed by the rest
+				// of the tick work
+				net_udp_flush(m_NetServer.Socket());
 
 				const int CommandSendingClientId = Tick() % MAX_CLIENTS;
 				UpdateClientRconCommands(CommandSendingClientId);
@@ -3507,6 +3510,8 @@ int CServer::Run()
 			{
 				m_ReloadedWhenEmpty = false;
 			}
+
+			net_udp_flush(m_NetServer.Socket());
 
 			// wait for incoming data
 			if(NonActive && Config()->m_SvShutdownWhenEmpty)

--- a/src/test/net_test.cpp
+++ b/src/test/net_test.cpp
@@ -36,6 +36,7 @@ TEST(Net, Ipv4AndIpv6Work)
 	unsigned char *pData;
 
 	EXPECT_EQ(net_udp_send(Socket2, &TargetV4, "abc", 3), 3);
+	net_udp_flush(Socket2);
 
 	EXPECT_EQ(net_socket_read_wait(Socket1, 10s), 1);
 	ASSERT_EQ(net_udp_recv(Socket1, &Addr, &pData), 3);
@@ -44,6 +45,7 @@ TEST(Net, Ipv4AndIpv6Work)
 	EXPECT_EQ(mem_comp(pData, "abc", 3), 0);
 
 	EXPECT_EQ(net_udp_send(Socket2, &TargetV6, "def", 3), 3);
+	net_udp_flush(Socket2);
 
 	EXPECT_EQ(net_socket_read_wait(Socket1, 10s), 1);
 	ASSERT_EQ(net_udp_recv(Socket1, &Addr, &pData), 3);

--- a/src/tools/crapnet.cpp
+++ b/src/tools/crapnet.cpp
@@ -196,6 +196,8 @@ static void Run(unsigned short Port, NETADDR Dest)
 			}
 		}
 
+		net_udp_flush(Socket);
+
 		std::this_thread::sleep_for(std::chrono::microseconds(1000));
 	}
 }

--- a/src/tools/packetgen.cpp
+++ b/src/tools/packetgen.cpp
@@ -30,6 +30,7 @@ static void Run(NETADDR Dest)
 		SocketToUse %= NUM_SOCKETS;
 		io_read(io_stdin(), aData, Size);
 		net_udp_send(aSockets[SocketToUse], &Dest, aData, Size);
+		net_udp_flush(aSockets[SocketToUse]);
 	}
 }
 

--- a/src/tools/stun.cpp
+++ b/src/tools/stun.cpp
@@ -46,6 +46,7 @@ int main(int argc, const char **argv)
 		log_error("stun", "failed sending stun request");
 		return 2;
 	}
+	net_udp_flush(Socket);
 
 	NETADDR ResponseAddr;
 	unsigned char *pResponse;

--- a/src/tools/twping.cpp
+++ b/src/tools/twping.cpp
@@ -54,6 +54,7 @@ int main(int argc, const char **argv)
 	Packet.m_pData = aBuffer;
 
 	NetClient.Send(&Packet);
+	net_udp_flush(NetClient.m_Socket);
 
 	const int64_t StartTime = time_get();
 


### PR DESCRIPTION
Similar to recvmmsg, might have a nice performance benefit to not do so many syscalls. With a full server I saw us going from 5k `sendto` syscalls to 61 `sendmmsg` syscalls per second. I'm not sure the extra complexity is worth it though, so will leave it as draft unless someone feels differently.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Fable 5) wrote this, I reviewed