### PR TITLE
Cleanup: use combined condition in IsEvilTeleport and IsTeleCheckpoint

### DIFF
--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -673,9 +673,7 @@ int CCollision::IsTeleport(int Index) const
 
 int CCollision::IsEvilTeleport(int Index) const
 {
-	if(Index < 0)
-		return 0;
-	if(!m_pTele)
+	if(Index < 0 || !m_pTele)
 		return 0;
 
 	if(m_pTele[Index].m_Type == TILE_TELEINEVIL)
@@ -700,10 +698,7 @@ bool CCollision::IsCheckEvilTeleport(int Index) const
 
 int CCollision::IsTeleCheckpoint(int Index) const
 {
-	if(Index < 0)
-		return 0;
-
-	if(!m_pTele)
+	if(Index < 0 || !m_pTele)
 		return 0;
 
 	if(m_pTele[Index].m_Type == TILE_TELECHECK)


### PR DESCRIPTION
Unifies the style of index and pointer checks in `CCollision` teleport functions.

Before:
```cpp
if(Index < 0)
	return 0;
if(!m_pTele)
	return 0;
```

After:
```cpp
if(Index < 0 || !m_pTele)
	return 0;
```