### PR TITLE
Feature/Optimization: Clip hookline on maps without telehooks

### DIFF
--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -23,6 +23,7 @@
 #include <game/client/components/skins.h>
 #include <game/client/components/sounds.h>
 #include <game/client/gameclient.h>
+#include <game/collision.h>
 #include <game/gamecore.h>
 #include <game/mapitems.h>
 
@@ -159,6 +160,7 @@ float CPlayers::GetPlayerTargetAngle(
 }
 
 void CPlayers::RenderHookCollLine(
+	const CScreenRect &ScreenRect,
 	const CNetObj_Character *pPrevChar,
 	const CNetObj_Character *pPlayerChar,
 	int ClientId)
@@ -214,8 +216,20 @@ void CPlayers::RenderHookCollLine(
 	float Intra = GameClient()->m_aClients[ClientId].m_IsPredicted ? Client()->PredIntraGameTick(g_Config.m_ClDummy) : Client()->IntraGameTick(g_Config.m_ClDummy);
 	float Angle = GetPlayerTargetAngle(&Prev, &Player, ClientId, Intra);
 
-	vec2 Direction = direction(Angle);
 	vec2 Position = GameClient()->m_aClients[ClientId].m_RenderPos;
+	vec2 Direction = direction(Angle);
+
+	// Check, if the player is outside the screen-rect and is aiming away from us.
+	// We don't know how long the hook collision line will be.
+	// If the map contains hook teleports, we are out of luck since we don't know if it will enter the screen at any point.
+	if(!Collision()->HasHookTeleIns() &&
+		((Position.x < ScreenRect.m_TopLeft.x && Direction.x <= 0) ||
+			(Position.x > ScreenRect.m_BottomRight.x && Direction.x >= 0) ||
+			(Position.y < ScreenRect.m_TopLeft.y && Direction.y <= 0) ||
+			(Position.y > ScreenRect.m_BottomRight.y && Direction.y >= 0)))
+	{
+		return;
+	}
 
 	static constexpr float HOOK_START_DISTANCE = CCharacterCore::PhysicalSize() * 1.5f;
 
@@ -1037,13 +1051,13 @@ void CPlayers::OnRender()
 			continue;
 		}
 
-		RenderHookCollLine(&GameClient()->m_aClients[ClientId].m_RenderPrev, &GameClient()->m_aClients[ClientId].m_RenderCur, ClientId);
+		RenderHookCollLine(ScreenRect, &GameClient()->m_aClients[ClientId].m_RenderPrev, &GameClient()->m_aClients[ClientId].m_RenderCur, ClientId);
 		RenderPlayer(ScreenRect, &GameClient()->m_aClients[ClientId].m_RenderPrev, &GameClient()->m_aClients[ClientId].m_RenderCur, &aRenderInfo[ClientId], ClientId);
 	}
 	if(RenderLastId != -1 && IsPlayerInfoAvailable(RenderLastId))
 	{
 		const CGameClient::CClientData *pClientData = &GameClient()->m_aClients[RenderLastId];
-		RenderHookCollLine(&pClientData->m_RenderPrev, &pClientData->m_RenderCur, RenderLastId);
+		RenderHookCollLine(ScreenRect, &pClientData->m_RenderPrev, &pClientData->m_RenderCur, RenderLastId);
 		RenderPlayer(ScreenRect, &pClientData->m_RenderPrev, &pClientData->m_RenderCur, &aRenderInfo[RenderLastId], RenderLastId);
 	}
 }

--- a/src/game/client/components/players.h
+++ b/src/game/client/components/players.h
@@ -30,6 +30,7 @@ class CPlayers : public CComponent
 		int ClientId,
 		float Intra = 0.f);
 	void RenderHookCollLine(
+		const CScreenRect &ScreenRect,
 		const CNetObj_Character *pPrevChar,
 		const CNetObj_Character *pPlayerChar,
 		int ClientId);

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -56,6 +56,7 @@ void CCollision::Init(class CLayers *pLayers)
 	m_Width = m_pLayers->GameLayer()->m_Width;
 	m_Height = m_pLayers->GameLayer()->m_Height;
 	m_pTiles = static_cast<CTile *>(m_pLayers->Map()->GetData(m_pLayers->GameLayer()->m_Data));
+	m_HasHookTeleIns = false;
 
 	if(m_pLayers->TeleLayer())
 	{
@@ -147,6 +148,8 @@ void CCollision::Init(class CLayers *pLayers)
 				else
 				{
 					m_TeleOthers[Number - 1].push_back(TelePos);
+					if(Type == TILE_TELEINHOOK)
+						m_HasHookTeleIns = true;
 				}
 			}
 		}

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -111,6 +111,7 @@ public:
 	int IsFrontTimeCheckpoint(int Index) const;
 
 	int MoverSpeed(int x, int y, vec2 *pSpeed) const;
+	bool HasHookTeleIns() const { return m_HasHookTeleIns; }
 
 	const CLayers *Layers() const { return m_pLayers; }
 	const CTile *GameLayer() const { return m_pTiles; }
@@ -165,8 +166,9 @@ private:
 	std::map<int, std::vector<vec2>> m_TeleOuts;
 	// TILE_TELECHECKOUT
 	std::map<int, std::vector<vec2>> m_TeleCheckOuts;
-	// TILE_TELEINEVIL, TILE_TELECHECK, TILE_TELECHECKIN, TILE_TELECHECKINEVIL
+	// TILE_TELEINEVIL, TILE_TELECHECK, TILE_TELECHECKIN, TILE_TELECHECKINEVIL, TILE_TELEINHOOK
 	std::map<int, std::vector<vec2>> m_TeleOthers;
+	bool m_HasHookTeleIns;
 };
 
 void ThroughOffset(vec2 Pos0, vec2 Pos1, int *pOffsetX, int *pOffsetY);


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This is the last followup of #12527 and #12275 . Calculating the hookline can be **very expensive** especially if we are doing it for 64/128 players and with `cl_show_hook_coll_other 2`, which renders the hook collision line of other players **always** and you client can end up calculating `250 HookTicks (5 seconds) * 64 (players) = 16000 HookTicks` per frame. Having an early exit for offscreen players is desirable.

I tested in detail ingame:

<img width="2560" height="1440" alt="screenshot_2026-08-06_09-38-42" src="https://github.com/user-attachments/assets/a699e095-1649-4d21-a0e5-152e8e52a969" />

Other hookline coming into screen while player is not rendered:

<img width="2560" height="1440" alt="screenshot_2026-08-06_09-35-51" src="https://github.com/user-attachments/assets/bb8e6dd4-ee91-49b9-99ab-aef2572cfb0f" />

A map with a hook telein where the hook appears onscreen while the player is aiming away from us (the weird line top right)

<img width="2560" height="1440" alt="screenshot_2026-08-06_09-46-29" src="https://github.com/user-attachments/assets/67cb703e-9431-4dc4-bc30-c1686611a3eb" />

Setup for the last one:

<img width="2560" height="1440" alt="screenshot_2026-08-06_09-46-26" src="https://github.com/user-attachments/assets/3e041ad6-5d2b-4efb-be88-4205e305c9f3" />

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
