### PR TITLE
Validate game layer dimensions against tile data size

### DIFF
--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -57,6 +57,18 @@ void CCollision::Init(class CLayers *pLayers)
 	m_Height = m_pLayers->GameLayer()->m_Height;
 	m_pTiles = static_cast<CTile *>(m_pLayers->Map()->GetData(m_pLayers->GameLayer()->m_Data));
 
+	// The width and height are used to index m_pTiles and to size allocations
+	// derived from them. Reject dimensions that the game layer's tile data cannot
+	// back, so a malformed map cannot cause out-of-bounds access or overflow.
+	const unsigned int GameLayerSize = m_pLayers->Map()->GetDataSize(m_pLayers->GameLayer()->m_Data);
+	if(m_pTiles == nullptr || m_Width < 0 || m_Height < 0 ||
+		(size_t)m_Width * m_Height * sizeof(CTile) > GameLayerSize)
+	{
+		m_Width = 0;
+		m_Height = 0;
+		m_pTiles = nullptr;
+	}
+
 	if(m_pLayers->TeleLayer())
 	{
 		unsigned int Size = m_pLayers->Map()->GetDataSize(m_pLayers->TeleLayer()->m_Tele);


### PR DESCRIPTION
Fixes a OOB read crash


Made with AI

<details><summary>Claude explanation</summary>

CCollision::Init trusted the game layer's width and height from the map without checking them against the size of the layer's tile data. A map declaring dimensions larger than the tile blob it ships caused out-of-bounds reads (e.g. in CCollision::Entity via CreateAllEntities) and an oversized/overflowing allocation in new CDoorTile[m_Width * m_Height].

Because the client runs the same collision init after downloading a map, a malicious server could crash connecting clients. Reject dimensions that the tile data cannot back, matching the existing checks for the tele, speedup, switch, tune and front layers.


</details>

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
