### PR TITLE
Reject oversized uncompressed packets in UnpackPacket

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3275,6 +3275,7 @@ if((GTEST_FOUND OR DOWNLOAD_GTEST) AND SERVER)
     name_ban_test.cpp
     net_test.cpp
     netaddr_test.cpp
+    network_test.cpp
     os_test.cpp
     packer_test.cpp
     prng_test.cpp

--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -351,6 +351,10 @@ int CNetBase::UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct
 		}
 		else
 		{
+			if(pPacket->m_DataSize > (int)sizeof(pPacket->m_aChunkData))
+			{
+				return -1;
+			}
 			mem_copy(pPacket->m_aChunkData, &pBuffer[DataStart], pPacket->m_DataSize);
 		}
 	}

--- a/src/test/network_test.cpp
+++ b/src/test/network_test.cpp
@@ -1,0 +1,27 @@
+#include <engine/shared/network.h>
+
+#include <gtest/gtest.h>
+
+static int UnpackUncompressedPacket(int Size, CNetPacketConstruct *pPacket)
+{
+	unsigned char aBuffer[NET_MAX_PACKETSIZE] = {};
+	aBuffer[0] = 0; // no flags, ack 0
+	aBuffer[1] = 0; // ack 0
+	aBuffer[2] = 1; // one chunk
+	bool Sixup = false;
+	return CNetBase::UnpackPacket(aBuffer, Size, pPacket, Sixup);
+}
+
+TEST(Network, UnpackMaximumUncompressedPacket)
+{
+	CNetPacketConstruct Packet;
+	EXPECT_EQ(UnpackUncompressedPacket(NET_PACKETHEADERSIZE + (int)sizeof(Packet.m_aChunkData), &Packet), 0);
+	EXPECT_EQ(Packet.m_DataSize, (int)sizeof(Packet.m_aChunkData));
+}
+
+TEST(Network, UnpackOversizedUncompressedPacket)
+{
+	CNetPacketConstruct Packet;
+	EXPECT_EQ(UnpackUncompressedPacket(NET_PACKETHEADERSIZE + (int)sizeof(Packet.m_aChunkData) + 1, &Packet), -1);
+	EXPECT_EQ(UnpackUncompressedPacket(NET_MAX_PACKETSIZE, &Packet), -1);
+}


### PR DESCRIPTION
`CNetPacketConstruct::m_aChunkData` is sized `NET_MAX_PAYLOAD` (1394), but a plain 0.6
  connection-oriented packet has a 3-byte header, so `CNetBase::UnpackPacket` can compute
  `m_DataSize` up to 1397 and `mem_copy` that many bytes into the 1394-byte array.
  

Made and found with AI


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions
 
<details>
  <summary>Long Details</summary>
  
  ### The mismatch
  
  `network.h`:

  ```cpp
  NET_MAX_PACKETSIZE = 1400,
  NET_MAX_PAYLOAD = NET_MAX_PACKETSIZE - 6,   // 1394
  NET_PACKETHEADERSIZE = 3,
  ...
  unsigned char m_aChunkData[NET_MAX_PAYLOAD];
  unsigned char m_aExtraData[NET_CONNLESS_EXTRA_SIZE];

  The - 6 comes from the connectionless prefix (0xff ×6, or xe + 4 extra bytes), so
  1394 is the correct bound for connless payloads. m_aChunkData also holds
  connection-oriented payloads, and those have a smaller header:

  ┌─────────────────────────┬────────┬─────────────┐
  │       packet kind       │ header │ max payload │
  ├─────────────────────────┼────────┼─────────────┤
  │ connless 0.6            │      6 │        1394 │
  ├─────────────────────────┼────────┼─────────────┤
  │ connless 0.7            │      9 │        1391 │
  ├─────────────────────────┼────────┼─────────────┤
  │ connection-oriented 0.7 │      7 │        1393 │
  ├─────────────────────────┼────────┼─────────────┤
  │ connection-oriented 0.6 │      3 │        1397 │
  └─────────────────────────┴────────┴─────────────┘

  Only the last row exceeds the array.
 
  What happens

  In UnpackPacket:

  int DataStart = Sixup ? 7 : NET_PACKETHEADERSIZE;
  ...
  pPacket->m_DataSize = Size - DataStart;          // up to 1397
  ...
  mem_copy(pPacket->m_aChunkData, &pBuffer[DataStart], pPacket->m_DataSize);
A 1400-byte non-sixup packet without NET_PACKETFLAG_COMPRESSION writes 1397 bytes into
  m_aChunkData[1394]. The 3 extra bytes land in the adjacent m_aExtraData[4], so it stays
  inside the object and is not exploitable memory corruption today; it is still a broken
  buffer invariant, and it is only contained by the accident of the neighbouring field's size
  and the compiler's layout.

  The bad size then propagates. CPacketChunkUnpacker::UnpackNextChunk bounds its walk with
  
  const unsigned char *const pEnd = m_Data.m_aChunkData + m_Data.m_DataSize;
  
  which now points 3 bytes past the array, so its pData + Header.m_Size > pEnd check accepts
  a chunk whose payload extends into m_aExtraData.
  
  The compressed branch is unaffected: ms_Huffman.Decompress(..., sizeof(pPacket->m_aChunkData))
  already bounds the output.

  Why reject rather than grow the buffer
  
  The other candidate fix is sizing m_aChunkData to NET_MAX_PACKETSIZE - NET_PACKETHEADERSIZE
  (1397). That also removes the overflow, but it widens what's accepted for no benefit: the send
  path cannot emit more than 1394 payload bytes. CNetConnection::QueueChunkEx flushes at

  m_Construct.m_DataSize + DataSize + NET_MAX_CHUNKHEADERSIZE
      > (int)sizeof(m_Construct.m_aChunkData) - (int)sizeof(SECURITY_TOKEN)
      
  so m_DataSize stays ≤ 1390, and SendPacket appends the 4-byte security token for a wire
  payload of at most 1394. Anything larger is malformed by construction, and dropping it is the
  same treatment the function already gives other malformed packets.
  
  Fix
  
  else
  {
        if(pPacket->m_DataSize > (int)sizeof(pPacket->m_aChunkData))
        {
                return -1;
        }
        mem_copy(pPacket->m_aChunkData, &pBuffer[DataStart], pPacket->m_DataSize);
  }   
  
  Tests
  
  src/test/network_test.cpp drives UnpackPacket with a synthetic non-sixup, uncompressed,
  one-chunk packet:
 
  - 1397-byte payload (NET_PACKETHEADERSIZE + sizeof(m_aChunkData)) still unpacks and reports
  m_DataSize == 1394;
  - 1398 bytes and a full NET_MAX_PACKETSIZE packet are rejected with -1.

  The second test fails on master and passes with the fix.

</details>



