### PR TITLE
Move Sixup determination out of UnpackPacket to separate func

### DIFF
--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -263,7 +263,7 @@ std::optional<int> CNetBase::UnpackPacketFlags(unsigned char *pBuffer, int Size)
 }
 
 // TODO: rename this function
-int CNetBase::UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct *pPacket, bool &Sixup, SECURITY_TOKEN *pSecurityToken, SECURITY_TOKEN *pResponseToken)
+int CNetBase::UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct *pPacket, bool Sixup, SECURITY_TOKEN *pSecurityToken, SECURITY_TOKEN *pResponseToken)
 {
 	if(pResponseToken != nullptr)
 	{
@@ -291,7 +291,6 @@ int CNetBase::UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct
 
 	if(pPacket->m_Flags & NET_PACKETFLAG_CONNLESS)
 	{
-		Sixup = (pBuffer[0] & 0x3) == 1;
 		if(Sixup && (pSecurityToken == nullptr || pResponseToken == nullptr))
 			return -1;
 		int Offset = Sixup ? 9 : 6;
@@ -318,8 +317,6 @@ int CNetBase::UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct
 	}
 	else
 	{
-		if(pPacket->m_Flags & NET_PACKETFLAG_UNUSED)
-			Sixup = true;
 		if(Sixup && pSecurityToken == nullptr)
 			return -1;
 		int DataStart = Sixup ? 7 : NET_PACKETHEADERSIZE;

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -11,7 +11,6 @@
 
 #include <array>
 #include <optional>
-#include <tuple>
 
 class CHuffman;
 class CNetBan;
@@ -459,9 +458,9 @@ class CNetServer
 	int OnSixupCtrlMsg(NETADDR &Addr, CNetChunk *pChunk, int ControlMsg, const CNetPacketConstruct &Packet, SECURITY_TOKEN &ResponseToken, SECURITY_TOKEN Token);
 	void OnPreConnMsg(NETADDR &Addr, CNetPacketConstruct &Packet);
 	void OnConnCtrlMsg(NETADDR &Addr, int ClientId, int ControlMsg, const CNetPacketConstruct &Packet);
-	bool ClientExists(const NETADDR &Addr) { return GetClientSlot(Addr) != -1; }
-	int GetClientSlot(const NETADDR &Addr);
-	std::tuple<int, bool> DetermineConnState(const NETADDR &Addr, std::optional<int> Flags, unsigned char *pBuffer);
+	bool ClientExists(const NETADDR &Addr) { return GetClientSlot(Addr).has_value(); }
+	std::optional<int> GetClientSlot(const NETADDR &Addr);
+	std::optional<int> FindSlot(const NETADDR &Addr, int Flags, unsigned char *pBuffer, bool *pSixup);
 	void SendControl(NETADDR &Addr, int ControlMsg, const void *pExtra, int ExtraSize, SECURITY_TOKEN SecurityToken);
 
 	int TryAcceptClient(NETADDR &Addr, SECURITY_TOKEN SecurityToken, bool VanillaAuth = false, bool Sixup = false, SECURITY_TOKEN Token = 0);

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -11,6 +11,7 @@
 
 #include <array>
 #include <optional>
+#include <tuple>
 
 class CHuffman;
 class CNetBan;
@@ -460,6 +461,7 @@ class CNetServer
 	void OnConnCtrlMsg(NETADDR &Addr, int ClientId, int ControlMsg, const CNetPacketConstruct &Packet);
 	bool ClientExists(const NETADDR &Addr) { return GetClientSlot(Addr) != -1; }
 	int GetClientSlot(const NETADDR &Addr);
+	std::tuple<int, bool> DetermineConnState(const NETADDR &Addr, std::optional<int> Flags, unsigned char *pBuffer);
 	void SendControl(NETADDR &Addr, int ControlMsg, const void *pExtra, int ExtraSize, SECURITY_TOKEN SecurityToken);
 
 	int TryAcceptClient(NETADDR &Addr, SECURITY_TOKEN SecurityToken, bool VanillaAuth = false, bool Sixup = false, SECURITY_TOKEN Token = 0);
@@ -656,7 +658,7 @@ public:
 	static void SendPacket(NETSOCKET Socket, NETADDR *pAddr, CNetPacketConstruct *pPacket, SECURITY_TOKEN SecurityToken, bool Sixup = false);
 
 	static std::optional<int> UnpackPacketFlags(unsigned char *pBuffer, int Size);
-	static int UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct *pPacket, bool &Sixup, SECURITY_TOKEN *pSecurityToken = nullptr, SECURITY_TOKEN *pResponseToken = nullptr);
+	static int UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct *pPacket, bool Sixup, SECURITY_TOKEN *pSecurityToken = nullptr, SECURITY_TOKEN *pResponseToken = nullptr);
 
 	// The backroom is ack-NET_MAX_SEQUENCE/2. Used for knowing if we acked a packet or not
 	static bool IsSeqInBackroom(int Seq, int Ack);

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -565,7 +565,7 @@ int CNetServer::OnSixupCtrlMsg(NETADDR &Addr, CNetChunk *pChunk, int ControlMsg,
 	return 0;
 }
 
-int CNetServer::GetClientSlot(const NETADDR &Addr)
+std::optional<int> CNetServer::GetClientSlot(const NETADDR &Addr)
 {
 	for(int i = 0; i < MaxClients(); i++)
 	{
@@ -576,26 +576,29 @@ int CNetServer::GetClientSlot(const NETADDR &Addr)
 			return i;
 		}
 	}
-	return -1;
+	return std::nullopt;
 }
 
-std::tuple<int, bool> CNetServer::DetermineConnState(const NETADDR &Addr, std::optional<int> Flags, unsigned char *pBuffer)
+std::optional<int> CNetServer::FindSlot(const NETADDR &Addr, int Flags, unsigned char *pBuffer, bool *pSixup)
 {
-	int Slot = -1;
-	bool Sixup = false;
-	if((*Flags & NET_PACKETFLAG_CONNLESS) == 0)
+	std::optional<int> Slot = std::nullopt;
+	if((Flags & NET_PACKETFLAG_CONNLESS) == 0)
 	{
 		Slot = GetClientSlot(Addr);
-		if(Slot != -1)
-			Sixup = m_aSlots[Slot].m_Connection.m_Sixup;
-		else if((*Flags & NET_PACKETFLAG_UNUSED) != 0)
-			Sixup = true;
+		if(Slot.has_value())
+		{
+			*pSixup = m_aSlots[*Slot].m_Connection.m_Sixup;
+		}
+		else
+		{
+			*pSixup = (Flags & NET_PACKETFLAG_UNUSED) != 0;
+		}
 	}
 	else
 	{
-		Sixup = (pBuffer[0] & 0x3) == 1;
+		*pSixup = (pBuffer[0] & 0x3) == 1;
 	}
-	return {Slot, Sixup};
+	return Slot;
 }
 
 static bool IsDDNetControlMsg(const CNetPacketConstruct *pPacket)
@@ -655,7 +658,8 @@ int CNetServer::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken)
 		}
 
 		SECURITY_TOKEN Token;
-		auto [Slot, Sixup] = DetermineConnState(Addr, Flags, pData);
+		bool Sixup;
+		std::optional<int> Slot = FindSlot(Addr, *Flags, pData, &Sixup);
 		if(CNetBase::UnpackPacket(pData, Bytes, &m_RecvBuffer, Sixup, &Token, pResponseToken) == 0)
 		{
 			if(m_RecvBuffer.m_Flags & NET_PACKETFLAG_CONNLESS)
@@ -679,21 +683,21 @@ int CNetServer::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken)
 			}
 			else // connection-oriented packet
 			{
-				if(Slot != -1) // connection found
+				if(Slot.has_value()) // connection found
 				{
 					const bool Control = (m_RecvBuffer.m_Flags & NET_PACKETFLAG_CONTROL) != 0;
 					if(Control)
 					{
-						OnConnCtrlMsg(Addr, Slot, m_RecvBuffer.m_aChunkData[0], m_RecvBuffer);
+						OnConnCtrlMsg(Addr, *Slot, m_RecvBuffer.m_aChunkData[0], m_RecvBuffer);
 					}
 
-					if(m_aSlots[Slot].m_Connection.Feed(&m_RecvBuffer, &Addr, Token, *pResponseToken))
+					if(m_aSlots[*Slot].m_Connection.Feed(&m_RecvBuffer, &Addr, Token, *pResponseToken))
 					{
 						if(!Control &&
 							m_RecvBuffer.m_DataSize > 0 &&
 							m_RecvBuffer.m_NumChunks > 0)
 						{
-							m_PacketChunkUnpacker.FeedPacket(Addr, m_RecvBuffer, &m_aSlots[Slot].m_Connection, Slot);
+							m_PacketChunkUnpacker.FeedPacket(Addr, m_RecvBuffer, &m_aSlots[*Slot].m_Connection, *Slot);
 						}
 					}
 				}

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -579,6 +579,25 @@ int CNetServer::GetClientSlot(const NETADDR &Addr)
 	return -1;
 }
 
+std::tuple<int, bool> CNetServer::DetermineConnState(const NETADDR &Addr, std::optional<int> Flags, unsigned char *pBuffer)
+{
+	int Slot = -1;
+	bool Sixup = false;
+	if((*Flags & NET_PACKETFLAG_CONNLESS) == 0)
+	{
+		Slot = GetClientSlot(Addr);
+		if(Slot != -1)
+			Sixup = m_aSlots[Slot].m_Connection.m_Sixup;
+		else if((*Flags & NET_PACKETFLAG_UNUSED) != 0)
+			Sixup = true;
+	}
+	else
+	{
+		Sixup = (pBuffer[0] & 0x3) == 1;
+	}
+	return {Slot, Sixup};
+}
+
 static bool IsDDNetControlMsg(const CNetPacketConstruct *pPacket)
 {
 	if(!(pPacket->m_Flags & NET_PACKETFLAG_CONTROL) || pPacket->m_DataSize < 1)
@@ -636,8 +655,7 @@ int CNetServer::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken)
 		}
 
 		SECURITY_TOKEN Token;
-		int Slot = (*Flags & NET_PACKETFLAG_CONNLESS) == 0 ? GetClientSlot(Addr) : -1;
-		bool Sixup = Slot != -1 && m_aSlots[Slot].m_Connection.m_Sixup;
+		auto [Slot, Sixup] = DetermineConnState(Addr, Flags, pData);
 		if(CNetBase::UnpackPacket(pData, Bytes, &m_RecvBuffer, Sixup, &Token, pResponseToken) == 0)
 		{
 			if(m_RecvBuffer.m_Flags & NET_PACKETFLAG_CONNLESS)


### PR DESCRIPTION


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
