### PR TITLE
Fix: Add no screenshot created error message

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -718,6 +718,10 @@ void CGraphics_Threaded::ScreenshotDirect(bool *pSwapped)
 	{
 		m_pEngine->AddJob(std::make_shared<CScreenshotSaveJob>(m_pStorage, m_aScreenshotName, std::move(Image)));
 	}
+	else
+	{
+		log_error("graphics", "Failed to create screenshot");
+	}
 }
 
 void CGraphics_Threaded::TextureSet(CTextureHandle TextureId)


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

If the backend _somehow_ manages to create no screenshot, which is possible as you can see in https://github.com/ddnet/ddnet/blob/82cb1cc309850c0fdb718338fdf5958d9f8712ff/src/engine/client/backend/vulkan/backend_vulkan.cpp#L6815 , the screenshot is silently dropped without an error message. Another way to fix this would be putting `m_DoScreenshot = true`, **but** if this fails every time we would also need a failure counter so I prefer just an error message.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
