### PR TITLE
Fix: Old telehooks are not beeing detected for the HasTeleHookIns-check

### DIFF
--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -841,6 +841,11 @@ int CCollision::MoverSpeed(int x, int y, vec2 *pSpeed) const
 	return Index;
 }
 
+bool CCollision::HasHookTeleIns() const
+{
+	return m_HasHookTeleIns || (g_Config.m_SvOldTeleportHook && !m_TeleIns.empty());
+}
+
 int CCollision::GetPureMapIndex(float x, float y) const
 {
 	int Nx = std::clamp(round_to_int(x) / 32, 0, m_Width - 1);

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -111,7 +111,7 @@ public:
 	int IsFrontTimeCheckpoint(int Index) const;
 
 	int MoverSpeed(int x, int y, vec2 *pSpeed) const;
-	bool HasHookTeleIns() const { return m_HasHookTeleIns; }
+	bool HasHookTeleIns() const;
 
 	const CLayers *Layers() const { return m_pLayers; }
 	const CTile *GameLayer() const { return m_pTiles; }


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Old telehooks are not beeing detected for the HasTeleHookIns-check, because I didn't know this exists. Followup of #12529

closes #12538

## Testing:

Setup:
<img width="2560" height="1440" alt="screenshot_2026-08-07_10-57-58" src="https://github.com/user-attachments/assets/ed97e0bb-b4db-4e68-a1e8-69334a91929a" />

Old:
<img width="2560" height="1440" alt="screenshot_2026-08-07_10-58-19" src="https://github.com/user-attachments/assets/ac34c7d9-9914-4983-9ed8-fd779f0e6d73" />

New:
<img width="2560" height="1440" alt="screenshot_2026-08-07_10-59-19" src="https://github.com/user-attachments/assets/895266f6-eff1-4ca7-ac6a-82ce06cd17e0" />

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
