### PR TITLE
DNM: websockets: Redesign the wire protocol to carry network chunks (#12481)

### DIFF
--- a/.github/workflows/clang-sanitizer.yml
+++ b/.github/workflows/clang-sanitizer.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Prepare Linux
       run: |
         sudo apt-get update -y
-        sudo apt-get install pkg-config cmake ninja-build libfreetype6-dev libnotify-dev libsdl2-dev libsqlite3-dev libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev libx264-dev libglew-dev -y
+        sudo apt-get install pkg-config cmake ninja-build libfreetype6-dev libnotify-dev libsdl2-dev libsqlite3-dev libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev libx264-dev libglew-dev libwebsockets-dev -y
 
     - name: Install Vulkan SDK
       uses: humbletim/install-vulkan-sdk@v1.2
@@ -54,7 +54,7 @@ jobs:
         SAN_FLAGS="-fsanitize=address,undefined,leak -fsanitize-recover=all -fno-omit-frame-pointer -fno-common"
         export CXXFLAGS="$SAN_FLAGS"
         export CFLAGS="$SAN_FLAGS"
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DHEADLESS_CLIENT=ON -Werror=dev -DDOWNLOAD_GTEST=ON -DDEV=ON ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DHEADLESS_CLIENT=ON -DWEBSOCKETS=ON -Werror=dev -DDOWNLOAD_GTEST=ON -DDEV=ON ..
         cmake --build . --config Debug --target everything
 
     - name: Run server and headless client with ASan and UBSan
@@ -119,7 +119,7 @@ jobs:
       run: |
         cd clang-sanitizer
         set +e
-        python ../scripts/integration_test.py --show-full-output --test-mastersrv .
+        python ../scripts/integration_test.py --show-full-output --test-mastersrv --test-websockets .
         integration_test_result=$?
         set -e
         if [ $integration_test_result -ne 0 ]; then

--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -690,16 +690,79 @@ def client_can_connect_websockets(test_env):
 	server = test_env.server(["dbg_websockets 1", "stdout_output_level 1"])
 	wait_for_startup([client, server])
 	client.command(f"connect ws://127.0.0.1:{server.port}")  # FIXME(#11693): Work around missing domain support.
-	server.wait_for_log_prefix("websockets: I: lws_handshake_server", timeout=15)  # Connection established
-	client.wait_for_log_prefix("websockets: I: lws_http_client_socket_service", timeout=15)  # Connection established
-	join = server.wait_for_log_prefix("server: player has entered the game", timeout=5).line
+	join = server.wait_for_log_prefix("server: player has entered the game", timeout=15).line
 	if "sixup=0" not in join:
 		raise AssertionError(f"sixup=0 not found in {join!r}")
 	server.exit()
+	# The disconnect reason is carried by the websocket close frame.
 	client.wait_for_log_exact("client: offline error='Server shutdown'")
 	client.exit()
 	server.wait_for_exit()
 	client.wait_for_exit()
+
+
+@test(requires_websockets=True)
+def server_notices_websocket_disconnect(test_env):
+	client = test_env.client(["dbg_websockets 1", "stdout_output_level 1"])
+	server = test_env.server(["dbg_websockets 1", "stdout_output_level 1"])
+	wait_for_startup([client, server])
+	client.command(f"connect ws://127.0.0.1:{server.port}")  # FIXME(#11693): Work around missing domain support.
+	server.wait_for_log_prefix("server: player has entered the game", timeout=15)
+	client.command("disconnect")
+	# The server must notice the close immediately, without unrelated traffic
+	# waking it up.
+	server.wait_for_log_prefix("server: client dropped", timeout=5)
+	client.exit()
+	server.exit()
+	client.wait_for_exit()
+	server.wait_for_exit()
+
+
+@test(requires_websockets=True)
+def client_can_reconnect_websockets(test_env):
+	client = test_env.client(["dbg_websockets 1", "stdout_output_level 1"])
+	server = test_env.server(["dbg_websockets 1", "stdout_output_level 1"])
+	wait_for_startup([client, server])
+	client.command(f"connect ws://127.0.0.1:{server.port}")  # FIXME(#11693): Work around missing domain support.
+	server.wait_for_log_prefix("server: player has entered the game", timeout=15)
+	# Reconnecting to the same address must not be killed by a stale close
+	# event of the connection that is being left.
+	client.command(f"connect ws://127.0.0.1:{server.port}")
+	server.wait_for_log_prefix("server: player has entered the game", timeout=15)
+	client.exit()
+	server.exit()
+	client.wait_for_exit()
+	server.wait_for_exit()
+
+
+@test(requires_websockets=True)
+def websocket_client_can_use_timeout_protection(test_env):
+	# The same seed makes both clients generate the same timeout code.
+	timeout_seed = "cl_timeout_seed integrationtest"
+	client = test_env.client(["dbg_websockets 1", "stdout_output_level 1", "player_name wsprot", timeout_seed])
+	server = test_env.server(["dbg_websockets 1", "stdout_output_level 2"])
+	wait_for_startup([client, server])
+	client.command(f"connect ws://127.0.0.1:{server.port}")  # FIXME(#11693): Work around missing domain support.
+	server.wait_for_log_prefix("server: player has entered the game", timeout=15)
+	# The timeout code that the client sends on join enables the protection.
+	server.wait_for_log_prefix("chat-command: 0 used /timeout ", timeout=15)
+	# Killing the client ends the connection without a websocket close frame,
+	# just like a crashing or killed client does. The connection must then be
+	# treated as a timeout instead of being dropped right away.
+	client.process.kill()
+	server.wait_for_log_exact("chat: *** 'wsprot' would have timed out, but can use timeout protection now", timeout=10)
+	# The kept connection can be reclaimed by reconnecting with the same code.
+	client2 = test_env.client(["dbg_websockets 1", "stdout_output_level 1", "player_name wsprot", timeout_seed])
+	wait_for_startup([client2])
+	client2.command(f"connect ws://127.0.0.1:{server.port}")  # FIXME(#11693): Work around missing domain support.
+	server.wait_for_log_suffix("reason='Timeout Protection used'", timeout=15)
+	# The reclaimed connection is the one that keeps being used.
+	client2.command("say reclaimed")
+	server.wait_for_log_suffix(":wsprot: reclaimed", timeout=10)
+	client2.exit()
+	server.exit()
+	client2.wait_for_exit()
+	server.wait_for_exit()
 
 
 @test

--- a/src/base/net.cpp
+++ b/src/base/net.cpp
@@ -92,19 +92,6 @@ static void net_buffer_reinit(NETSOCKET_BUFFER *buffer)
 }
 #endif
 
-#if defined(CONF_WEBSOCKETS)
-static void net_buffer_simple(NETSOCKET_BUFFER *buffer, char **buf, int *size)
-{
-#if defined(CONF_PLATFORM_LINUX)
-	*buf = buffer->bufs[0];
-	*size = sizeof(buffer->bufs[0]);
-#else
-	*buf = buffer->buf;
-	*size = sizeof(buffer->buf);
-#endif
-}
-#endif
-
 struct NETSOCKET_INTERNAL
 {
 	int type;
@@ -1036,27 +1023,6 @@ int net_udp_send(NETSOCKET sock, const NETADDR *addr, const void *data, int size
 		}
 	}
 
-#if defined(CONF_WEBSOCKETS)
-	if(addr->type & NETTYPE_WEBSOCKET_IPV4)
-	{
-		if(sock->web_ipv4sock >= 0)
-		{
-			if(addr->type & NETTYPE_LINK_BROADCAST)
-			{
-				log_error("net", "Cannot send broadcasts to Websocket IPv4");
-			}
-			else
-			{
-				d = websocket_send(sock->web_ipv4sock, (const unsigned char *)data, size, addr);
-			}
-		}
-		else
-		{
-			log_error("net", "Cannot send Websocket IPv4 traffic to this socket");
-		}
-	}
-#endif
-
 	if(addr->type & NETTYPE_IPV6)
 	{
 		if(sock->ipv6sock >= 0)
@@ -1084,26 +1050,12 @@ int net_udp_send(NETSOCKET sock, const NETADDR *addr, const void *data, int size
 		}
 	}
 
-#if defined(CONF_WEBSOCKETS)
-	if(addr->type & NETTYPE_WEBSOCKET_IPV6)
+	if(addr->type & (NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6))
 	{
-		if(sock->web_ipv6sock >= 0)
-		{
-			if(addr->type & NETTYPE_LINK_BROADCAST)
-			{
-				log_error("net", "Cannot send broadcasts to Websocket IPv6");
-			}
-			else
-			{
-				d = websocket_send(sock->web_ipv6sock, (const unsigned char *)data, size, addr);
-			}
-		}
-		else
-		{
-			log_error("net", "Cannot send Websocket IPv6 traffic to this socket");
-		}
+		// Websocket connections carry network chunks instead of whole packets,
+		// so packets cannot be sent to them; see engine/shared/websockets.h.
+		log_error("net", "Cannot send packets to websocket addresses");
 	}
-#endif
 
 	network_stats.sent_bytes += size;
 	network_stats.sent_packets++;
@@ -1188,37 +1140,22 @@ int net_udp_recv(NETSOCKET sock, NETADDR *addr, unsigned char **data)
 	}
 #endif
 
-#if defined(CONF_WEBSOCKETS)
-	if(sock->web_ipv4sock >= 0)
-	{
-		char *buf;
-		int size;
-		net_buffer_simple(&sock->buffer, &buf, &size);
-		bytes = websocket_recv(sock->web_ipv4sock, (unsigned char *)buf, size, addr);
-		*data = (unsigned char *)buf;
-		if(bytes > 0)
-		{
-			update_stats(bytes);
-			return bytes;
-		}
-	}
+	return bytes < 0 ? -1 : 0;
+}
 
-	if(sock->web_ipv6sock >= 0)
+int net_socket_websocket(NETSOCKET sock, int nettype)
+{
+#if defined(CONF_WEBSOCKETS)
+	if(nettype & NETTYPE_WEBSOCKET_IPV4)
 	{
-		char *buf;
-		int size;
-		net_buffer_simple(&sock->buffer, &buf, &size);
-		bytes = websocket_recv(sock->web_ipv6sock, (unsigned char *)buf, size, addr);
-		*data = (unsigned char *)buf;
-		if(bytes > 0)
-		{
-			update_stats(bytes);
-			return bytes;
-		}
+		return sock->web_ipv4sock;
+	}
+	if(nettype & NETTYPE_WEBSOCKET_IPV6)
+	{
+		return sock->web_ipv6sock;
 	}
 #endif
-
-	return bytes < 0 ? -1 : 0;
+	return -1;
 }
 
 void net_udp_close(NETSOCKET sock)

--- a/src/base/net.h
+++ b/src/base/net.h
@@ -201,6 +201,19 @@ void net_stats(NETSTATS *stats);
 int net_socket_type(NETSOCKET sock);
 
 /**
+ * Retrieve the websocket transport handle of a socket, for use with the
+ * functions in `engine/shared/websockets.h`.
+ *
+ * @ingroup Network-General
+ *
+ * @param sock Socket whose websocket handle should be retrieved.
+ * @param nettype `NETTYPE_WEBSOCKET_IPV4` or `NETTYPE_WEBSOCKET_IPV6`.
+ *
+ * @return The websocket handle, or `-1` if the socket has none of the given type.
+ */
+int net_socket_websocket(NETSOCKET sock, int nettype);
+
+/**
  * Make a socket not block on operations.
  *
  * @ingroup Network-General

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -312,6 +312,17 @@ public:
 
 	const char *ErrorString();
 	void SignalResend();
+
+	// Websocket connections carry network chunks directly instead of whole
+	// packets, with reliability and ordering provided by the transport; see
+	// engine/shared/websockets.h for the protocol.
+	bool IsWebsocket() const;
+	bool WebsocketOnOpen(const NETADDR *pAddr);
+	// An abrupt close, i.e. one the peer did not announce, is handled like a
+	// timeout, so timeout protection applies to it
+	void WebsocketOnClose(const NETADDR *pAddr, const char *pReason, bool Abrupt);
+	void WebsocketOnRecv();
+
 	EState State() const { return m_State; }
 	const NETADDR *PeerAddress() const { return &m_PeerAddr; }
 	const std::array<char, NETADDR_MAXSTRSIZE> &PeerAddressString(bool IncludePort) const
@@ -466,6 +477,7 @@ class CNetServer
 	int NumClientsWithAddr(NETADDR Addr);
 	bool Connlimit(NETADDR Addr);
 	void SendMsgs(NETADDR &Addr, const CPacker **ppMsgs, int Num);
+	int RecvWebsocket(CNetChunk *pChunk);
 
 public:
 	int SetCallbacks(NETFUNC_NEWCLIENT pfnNewClient, NETFUNC_DELCLIENT pfnDelClient, void *pUser);
@@ -597,6 +609,8 @@ class CNetClient
 	CNetTokenCache m_TokenCache;
 
 	CStun *m_pStun = nullptr;
+
+	int RecvWebsocket(CNetChunk *pChunk);
 
 public:
 	NETSOCKET m_Socket = nullptr;

--- a/src/engine/shared/network_client.cpp
+++ b/src/engine/shared/network_client.cpp
@@ -9,6 +9,7 @@
 #include <base/types.h>
 
 #include <engine/shared/protocol7.h>
+#include <engine/shared/websockets.h>
 
 bool CNetClient::Open(NETADDR BindAddr)
 {
@@ -74,6 +75,53 @@ void CNetClient::ResetErrorString()
 	m_Connection.ResetErrorString();
 }
 
+int CNetClient::RecvWebsocket(CNetChunk *pChunk)
+{
+	websocket_event Event;
+	int Handle;
+	while(websocket_recv_next(m_Socket, &Event, &Handle))
+	{
+		if(Event.type == WEBSOCKET_EVENT_OPEN)
+		{
+			if(!m_Connection.WebsocketOnOpen(&Event.addr))
+			{
+				// Not the connection we are waiting for, e.g. an aborted
+				// connect that completed late
+				websocket_close(Handle, &Event.addr, nullptr);
+			}
+		}
+		else if(Event.type == WEBSOCKET_EVENT_MESSAGE)
+		{
+			if(m_Connection.State() != CNetConnection::EState::ONLINE || Event.addr != *m_Connection.PeerAddress())
+				continue;
+			m_Connection.WebsocketOnRecv();
+			if(Event.size == 0) // keepalive
+				continue;
+			const int Flags = Event.data[0];
+			if((Flags & ~NET_CHUNKFLAG_VITAL) != 0 || Event.size - 1 > (size_t)NET_MAX_PAYLOAD)
+			{
+				// No close event comes back for websocket_close, so take
+				// the connection down directly
+				websocket_close(Handle, &Event.addr, "Invalid message");
+				m_Connection.WebsocketOnClose(&Event.addr, "Invalid message", false);
+				continue;
+			}
+			mem_copy(m_RecvBuffer.m_aChunkData, &Event.data[1], Event.size - 1);
+			pChunk->m_ClientId = 0;
+			pChunk->m_Address = Event.addr;
+			pChunk->m_Flags = Flags;
+			pChunk->m_DataSize = Event.size - 1;
+			pChunk->m_pData = m_RecvBuffer.m_aChunkData;
+			return 1;
+		}
+		else if(Event.type == WEBSOCKET_EVENT_CLOSE)
+		{
+			m_Connection.WebsocketOnClose(&Event.addr, Event.close_reason, Event.abrupt);
+		}
+	}
+	return 0;
+}
+
 int CNetClient::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken, bool Sixup)
 {
 	while(true)
@@ -89,7 +137,11 @@ int CNetClient::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken, bool Six
 
 		// no more packets for now
 		if(Bytes <= 0)
+		{
+			if(RecvWebsocket(pChunk))
+				return 1;
 			break;
+		}
 
 		if(m_pStun->OnPacket(Addr, pData, Bytes))
 		{
@@ -154,6 +206,11 @@ int CNetClient::Send(CNetChunk *pChunk)
 
 	if(pChunk->m_Flags & NETSENDFLAG_CONNLESS)
 	{
+		if(pChunk->m_Address.type & (NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6))
+		{
+			// Websockets carry only connection-oriented chunks
+			return -1;
+		}
 		// send connectionless packet
 		if(pChunk->m_Address.type & NETTYPE_TW7)
 		{

--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -10,6 +10,78 @@
 #include <base/str.h>
 #include <base/time.h>
 
+#include <engine/shared/websockets.h>
+
+bool CNetConnection::IsWebsocket() const
+{
+	// While connecting, the peer address is not determined yet
+	const NETADDR *pAddr = m_State == EState::CONNECT ? &m_aConnectAddrs[0] : &m_PeerAddr;
+	return (pAddr->type & (NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6)) != 0;
+}
+
+bool CNetConnection::WebsocketOnOpen(const NETADDR *pAddr)
+{
+	if(m_State != EState::CONNECT || !IsPeerAddress(*pAddr))
+		return false;
+
+	// The established websocket connection is the completed connect handshake
+	SetPeerAddr(pAddr);
+	const int64_t Now = time_get();
+	m_LastSendTime = Now;
+	m_LastRecvTime = Now;
+	m_LastUpdateTime = Now;
+	m_SecurityToken = NET_SECURITY_TOKEN_UNSUPPORTED;
+	m_State = EState::ONLINE;
+	if(g_Config.m_Debug)
+		dbg_msg("connection", "websocket connected, connection online");
+	return true;
+}
+
+void CNetConnection::WebsocketOnClose(const NETADDR *pAddr, const char *pReason, bool Abrupt)
+{
+	if(m_State == EState::OFFLINE || m_State == EState::ERROR || !IsPeerAddress(*pAddr))
+		return;
+
+	m_State = EState::ERROR;
+	m_RemoteClosed = 1;
+
+	char aStr[256] = {0};
+	if(pReason != nullptr && pReason[0] != '\0')
+	{
+		// make sure to sanitize the error string from the other party
+		str_copy(aStr, pReason);
+		str_sanitize_cc(aStr);
+		if(!str_utf8_check(aStr))
+		{
+			str_copy(aStr, "(Invalid error message)");
+		}
+	}
+
+	if(!m_BlockCloseMsg)
+	{
+		SetError(aStr);
+	}
+
+	if(Abrupt)
+	{
+		// The connection was lost without the peer announcing the close, which
+		// is what timeout protection exists for, so treat it like a timeout
+		// instead of ending the connection right away. The reason of an abrupt
+		// close is generated locally, so it is safe to report regardless of
+		// m_BlockCloseMsg.
+		m_TimeoutSituation = true;
+		SetError(aStr[0] == '\0' ? "Timeout" : aStr);
+	}
+
+	if(g_Config.m_Debug)
+		dbg_msg("conn", "websocket closed reason='%s' abrupt=%d", aStr, Abrupt ? 1 : 0);
+}
+
+void CNetConnection::WebsocketOnRecv()
+{
+	m_LastRecvTime = time_get();
+}
+
 bool CNetConnection::IsPeerAddress(const NETADDR &Addr) const
 {
 	// While connecting, the peer address is not determined yet, so any of the
@@ -121,6 +193,10 @@ void CNetConnection::SignalResend()
 
 int CNetConnection::Flush()
 {
+	// Websocket chunks are sent immediately, there is nothing to flush
+	if(IsWebsocket())
+		return 0;
+
 	// Only flush the connection if there is at least one chunk to flush,
 	// or if a resend should be signaled.
 	const int NumChunks = m_Construct.m_NumChunks;
@@ -145,6 +221,22 @@ int CNetConnection::QueueChunkEx(int Flags, int DataSize, const void *pData, int
 {
 	if(m_State == EState::OFFLINE || m_State == EState::ERROR)
 		return -1;
+
+	if(IsWebsocket())
+	{
+		// The chunk is sent as one websocket message immediately, a flags
+		// byte followed by the payload; the transport provides reliability
+		// and ordering
+		if(m_State != EState::ONLINE || DataSize < 0 || DataSize > NET_MAX_PAYLOAD)
+			return -1;
+		unsigned char aMessage[1 + NET_MAX_PAYLOAD];
+		aMessage[0] = Flags & NET_CHUNKFLAG_VITAL;
+		mem_copy(&aMessage[1], pData, DataSize);
+		if(websocket_send(net_socket_websocket(m_Socket, m_PeerAddr.type), aMessage, 1 + DataSize, &m_PeerAddr, (Flags & NET_CHUNKFLAG_VITAL) != 0) < 0)
+			return -1;
+		m_LastSendTime = time_get();
+		return 0;
+	}
 
 	unsigned char *pChunkData;
 
@@ -247,6 +339,16 @@ int CNetConnection::Connect(const NETADDR *pAddr, int NumAddrs)
 	m_NumConnectAddrs = NumAddrs;
 	m_aErrorString[0] = '\0';
 	m_State = EState::CONNECT;
+	if(IsWebsocket())
+	{
+		// Establishing the websocket connection is the connect handshake
+		const int Handle = net_socket_websocket(m_Socket, m_aConnectAddrs[0].type);
+		if(Handle >= 0 && websocket_connect(Handle, &m_aConnectAddrs[0]) == 0)
+			return 0;
+		m_State = EState::ERROR;
+		SetError("Websockets are not supported");
+		return -1;
+	}
 	SendConnect();
 	return 0;
 }
@@ -302,7 +404,22 @@ void CNetConnection::Disconnect(const char *pReason)
 
 	if(m_RemoteClosed == 0)
 	{
-		if(!m_TimeoutSituation)
+		if(IsWebsocket())
+		{
+			if(m_State == EState::CONNECT)
+			{
+				// The connect handshake has not completed, so there is no peer
+				// address yet and no close frame to send; cancel the pending
+				// attempt so it cannot complete or error out later
+				websocket_connect_abort(net_socket_websocket(m_Socket, m_aConnectAddrs[0].type));
+			}
+			else
+			{
+				// The websocket close frame carries the disconnect reason
+				websocket_close(net_socket_websocket(m_Socket, m_PeerAddr.type), &m_PeerAddr, pReason);
+			}
+		}
+		else if(!m_TimeoutSituation)
 		{
 			if(pReason)
 				SendControl(NET_CTRLMSG_CLOSE, pReason, str_length(pReason) + 1);
@@ -584,11 +701,23 @@ int CNetConnection::Update()
 		}
 
 		if(time_get() - m_LastSendTime > time_freq())
-			SendControl(NET_CTRLMSG_KEEPALIVE, nullptr, 0);
+		{
+			if(IsWebsocket())
+			{
+				// An empty websocket message is the keepalive
+				websocket_send(net_socket_websocket(m_Socket, m_PeerAddr.type), nullptr, 0, &m_PeerAddr, false);
+				m_LastSendTime = time_get();
+			}
+			else
+			{
+				SendControl(NET_CTRLMSG_KEEPALIVE, nullptr, 0);
+			}
+		}
 	}
 	else if(State() == EState::CONNECT)
 	{
-		if(time_get() - m_LastSendTime > time_freq() / 2) // send a new connect every 500ms
+		// Websocket connects are retried by the transport
+		if(!IsWebsocket() && time_get() - m_LastSendTime > time_freq() / 2) // send a new connect every 500ms
 			SendConnect();
 	}
 	else if(State() == EState::PENDING)

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -14,6 +14,7 @@
 #include <engine/shared/compression.h>
 #include <engine/shared/packer.h>
 #include <engine/shared/protocol.h>
+#include <engine/shared/websockets.h>
 
 const int g_DummyMapCrc = 0x6AF73DAF;
 const unsigned char g_aDummyMapData[] = {
@@ -220,17 +221,22 @@ bool CNetServer::Connlimit(NETADDR Addr)
 
 int CNetServer::TryAcceptClient(NETADDR &Addr, SECURITY_TOKEN SecurityToken, bool VanillaAuth, bool Sixup, SECURITY_TOKEN Token)
 {
+	const auto &&RejectClient = [&](const char *pMsg) {
+		if(Addr.type & (NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6))
+			websocket_close(net_socket_websocket(m_Socket, Addr.type), &Addr, pMsg);
+		else
+			CNetBase::SendControlMsg(m_Socket, &Addr, 0, NET_CTRLMSG_CLOSE, pMsg, str_length(pMsg) + 1, SecurityToken, Sixup);
+	};
+
 	if(Sixup && !g_Config.m_SvSixup)
 	{
-		const char aMsg[] = "0.7 connections are not accepted at this time";
-		CNetBase::SendControlMsg(m_Socket, &Addr, 0, NET_CTRLMSG_CLOSE, aMsg, sizeof(aMsg), SecurityToken, Sixup);
+		RejectClient("0.7 connections are not accepted at this time");
 		return -1; // failed to add client?
 	}
 
 	if(Connlimit(Addr))
 	{
-		const char aMsg[] = "Too many connections in a short time";
-		CNetBase::SendControlMsg(m_Socket, &Addr, 0, NET_CTRLMSG_CLOSE, aMsg, sizeof(aMsg), SecurityToken, Sixup);
+		RejectClient("Too many connections in a short time");
 		return -1; // failed to add client
 	}
 
@@ -239,7 +245,7 @@ int CNetServer::TryAcceptClient(NETADDR &Addr, SECURITY_TOKEN SecurityToken, boo
 	{
 		char aBuf[128];
 		str_format(aBuf, sizeof(aBuf), "Only %d players with the same IP are allowed", m_MaxClientsPerIp);
-		CNetBase::SendControlMsg(m_Socket, &Addr, 0, NET_CTRLMSG_CLOSE, aBuf, str_length(aBuf) + 1, SecurityToken, Sixup);
+		RejectClient(aBuf);
 		return -1; // failed to add client
 	}
 
@@ -255,9 +261,7 @@ int CNetServer::TryAcceptClient(NETADDR &Addr, SECURITY_TOKEN SecurityToken, boo
 
 	if(Slot == -1)
 	{
-		const char aFullMsg[] = "This server is full";
-		CNetBase::SendControlMsg(m_Socket, &Addr, 0, NET_CTRLMSG_CLOSE, aFullMsg, sizeof(aFullMsg), SecurityToken, Sixup);
-
+		RejectClient("This server is full");
 		return -1; // failed to add client
 	}
 
@@ -599,6 +603,64 @@ static bool IsDDNetControlMsg(const CNetPacketConstruct *pPacket)
 	return false;
 }
 
+int CNetServer::RecvWebsocket(CNetChunk *pChunk)
+{
+	websocket_event Event;
+	int Handle;
+	while(websocket_recv_next(m_Socket, &Event, &Handle))
+	{
+		if(Event.type == WEBSOCKET_EVENT_OPEN)
+		{
+			char aBanMsg[128];
+			if(NetBan() && NetBan()->IsBanned(&Event.addr, aBanMsg, sizeof(aBanMsg)))
+				websocket_close(Handle, &Event.addr, aBanMsg);
+			else
+				TryAcceptClient(Event.addr, NET_SECURITY_TOKEN_UNSUPPORTED);
+		}
+		else if(Event.type == WEBSOCKET_EVENT_MESSAGE)
+		{
+			const int Slot = GetClientSlot(Event.addr);
+			if(Slot == -1)
+			{
+				// Message from a connection without client slot, e.g.
+				// arriving after the client was dropped
+				websocket_close(Handle, &Event.addr, nullptr);
+				continue;
+			}
+			m_aSlots[Slot].m_Connection.WebsocketOnRecv();
+			if(Event.size == 0) // keepalive
+				continue;
+			const int Flags = Event.data[0];
+			if((Flags & ~NET_CHUNKFLAG_VITAL) != 0 || Event.size - 1 > (size_t)NET_MAX_PAYLOAD)
+			{
+				// Drop closes the websocket, carrying the reason in the
+				// close frame; no close event comes back for it
+				Drop(Slot, "Invalid message");
+				continue;
+			}
+			mem_copy(m_RecvBuffer.m_aChunkData, &Event.data[1], Event.size - 1);
+			pChunk->m_ClientId = Slot;
+			pChunk->m_Address = Event.addr;
+			pChunk->m_Flags = Flags;
+			pChunk->m_DataSize = Event.size - 1;
+			pChunk->m_pData = m_RecvBuffer.m_aChunkData;
+			return 1;
+		}
+		else if(Event.type == WEBSOCKET_EVENT_CLOSE)
+		{
+			const int Slot = GetClientSlot(Event.addr);
+			if(Slot != -1)
+			{
+				// The connection is not dropped here: CNetServer::Update does
+				// that, so a connection that was lost abruptly keeps its
+				// timeout protection like a timed out UDP connection does
+				m_aSlots[Slot].m_Connection.WebsocketOnClose(&Event.addr, Event.close_reason, Event.abrupt);
+			}
+		}
+	}
+	return 0;
+}
+
 /*
 	TODO: chopp up this function into smaller working parts
 */
@@ -617,7 +679,11 @@ int CNetServer::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken)
 
 		// no more packets for now
 		if(Bytes <= 0)
+		{
+			if(RecvWebsocket(pChunk))
+				return 1;
 			break;
+		}
 
 		// check if we just should drop the packet
 		char aBuf[128];
@@ -715,6 +781,12 @@ int CNetServer::Send(CNetChunk *pChunk)
 
 	if(pChunk->m_Flags & NETSENDFLAG_CONNLESS)
 	{
+		if(pChunk->m_Address.type & (NETTYPE_WEBSOCKET_IPV4 | NETTYPE_WEBSOCKET_IPV6))
+		{
+			// Websockets carry only connection-oriented chunks; server info is
+			// available to websocket clients from the HTTPS masterserver
+			return -1;
+		}
 		// send connectionless packet
 		CNetBase::SendPacketConnless(m_Socket, &pChunk->m_Address, pChunk->m_pData, pChunk->m_DataSize,
 			pChunk->m_Flags & NETSENDFLAG_EXTENDED, pChunk->m_aExtraData);

--- a/src/engine/shared/websockets.cpp
+++ b/src/engine/shared/websockets.cpp
@@ -19,31 +19,47 @@
 #endif
 #include <libwebsockets.h>
 
+#include <algorithm>
 #include <cstdlib>
 #include <map>
 #include <string>
 
 // NOLINTBEGIN(readability-identifier-naming)
+static const char PROTOCOL_NAME[] = "ddnet-20";
+
 struct websocket_chunk
 {
+	int type; // websocket_event_type
+	bool abrupt; // WEBSOCKET_EVENT_CLOSE only
 	size_t size;
-	size_t read;
 	NETADDR addr;
-	unsigned char data[0];
+	unsigned char data[0]; // message payload or close reason
 };
 
-// Client opens two connections for whatever reason
-typedef CStaticRingBuffer<websocket_chunk, (MAX_CLIENTS * 2) * NET_CONN_BUFFERSIZE,
-	CRingBufferBase::FLAG_RECYCLE>
+// Shared by all sessions of a context (client opens two connections for
+// whatever reason). No FLAG_RECYCLE: recycling would evict other sessions'
+// still-undelivered events, and the protocol has no retransmission to recover
+// them, so a full buffer closes the offending connection instead (see the
+// push_event callers).
+typedef CStaticRingBuffer<websocket_chunk, (MAX_CLIENTS * 2) * NET_CONN_BUFFERSIZE>
 	TRecvBuffer;
-typedef CStaticRingBuffer<websocket_chunk, NET_CONN_BUFFERSIZE,
-	CRingBufferBase::FLAG_RECYCLE>
+// No FLAG_RECYCLE: recycling could evict a partially transmitted chunk, corrupting the frame stream
+typedef CStaticRingBuffer<websocket_chunk, NET_CONN_BUFFERSIZE>
 	TSendBuffer;
 
 struct per_session_data
 {
 	lws *wsi;
 	NETADDR addr;
+	bool registered;
+	bool close_requested;
+	bool notify_close; // deliver a CLOSE event when the session closes
+	bool peer_closed; // the peer announced the close with a close frame
+	char close_reason[128];
+	// One message is delivered by lws in multiple pieces when its frames span
+	// multiple socket reads, so it is reassembled here before delivery
+	size_t recv_size;
+	unsigned char recv_buffer[1 + NET_MAX_PAYLOAD];
 	TSendBuffer send_buffer;
 };
 
@@ -54,6 +70,9 @@ struct context_data
 	lws_context *context;
 	std::map<NETADDR, per_session_data *> port_map;
 	TRecvBuffer recv_buffer;
+	bool event_pending_pop;
+	lws *client_wsi; // in-flight client connect, until it establishes or fails
+	NETADDR client_target; // address the in-flight client connect was initiated to
 };
 
 // Client has main, dummy and contact connections with IPv4 and IPv6
@@ -62,20 +81,28 @@ static std::map<lws_context *, context_data *> contexts_map;
 
 static lws_context *websocket_context(int socket)
 {
-	dbg_assert(socket >= 0 && socket < (int)std::size(contexts), "socket index invalid: %d", socket);
+	if(socket < 0)
+		return nullptr;
+	dbg_assert(socket < (int)std::size(contexts), "socket index invalid: %d", socket);
 	lws_context *context = contexts[socket].context;
 	dbg_assert(context != nullptr, "socket context not initialized: %d", socket);
 	return context;
 }
 
-static void receive_chunk(context_data *ctx_data, per_session_data *pss, const void *in, size_t len)
+static bool push_event(context_data *ctx_data, int type, const NETADDR *addr, const void *data, size_t size, bool abrupt = false)
 {
-	websocket_chunk *chunk = ctx_data->recv_buffer.Allocate(len + sizeof(websocket_chunk));
-	dbg_assert(chunk != nullptr, "failed to allocate websocket receive buffer chunk of size %" PRIzu, len);
-	chunk->size = len;
-	chunk->read = 0;
-	chunk->addr = pss->addr;
-	mem_copy(&chunk->data[0], in, len);
+	websocket_chunk *chunk = ctx_data->recv_buffer.Allocate(size + sizeof(websocket_chunk));
+	if(chunk == nullptr)
+		return false;
+	chunk->type = type;
+	chunk->abrupt = abrupt;
+	chunk->size = size;
+	chunk->addr = *addr;
+	if(size > 0)
+	{
+		mem_copy(&chunk->data[0], data, size);
+	}
+	return true;
 }
 
 static void sockaddr_to_netaddr_websocket(const sockaddr *src, socklen_t src_len, NETADDR *dst)
@@ -103,6 +130,96 @@ static void sockaddr_to_netaddr_websocket(const sockaddr *src, socklen_t src_len
 	}
 }
 
+static bool protocol_offered(lws *wsi)
+{
+	char offers[256];
+	if(lws_hdr_copy(wsi, offers, sizeof(offers), WSI_TOKEN_PROTOCOL) <= 0)
+	{
+		return false;
+	}
+	const char *next = offers;
+	char offer[64];
+	while((next = str_next_token(next, ",", offer, sizeof(offer))))
+	{
+		if(str_comp(str_skip_whitespaces(offer), PROTOCOL_NAME) == 0)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+// Returns false when the OPEN event could not be queued (receive buffer full);
+// the caller must then close the connection so no half-registered session leaks
+static bool session_open(context_data *ctx_data, per_session_data *pss, lws *wsi, const NETADDR *addr)
+{
+	// Deliver OPEN before registering, so a failure leaves nothing behind
+	if(!push_event(ctx_data, WEBSOCKET_EVENT_OPEN, addr, nullptr, 0))
+	{
+		return false;
+	}
+	pss->wsi = wsi;
+	pss->addr = *addr;
+	pss->registered = true;
+	pss->close_requested = false;
+	pss->notify_close = true;
+	pss->peer_closed = false;
+	pss->close_reason[0] = '\0';
+	pss->recv_size = 0;
+	pss->send_buffer.Init();
+	ctx_data->port_map[*addr] = pss;
+
+	char addr_str[NETADDR_MAXSTRSIZE];
+	net_addr_str(addr, addr_str, sizeof(addr_str), true);
+	log_trace("websockets", "Connection established with '%s'", addr_str);
+	return true;
+}
+
+static void session_close(context_data *ctx_data, per_session_data *pss)
+{
+	if(!pss->registered)
+		return;
+	pss->registered = false;
+	pss->wsi = nullptr;
+	// Only remove our own entry: a new session may already have reused this
+	// address after an out-of-order reconnect
+	auto it = ctx_data->port_map.find(pss->addr);
+	if(it != ctx_data->port_map.end() && it->second == pss)
+	{
+		ctx_data->port_map.erase(it);
+	}
+
+	char addr_str[NETADDR_MAXSTRSIZE];
+	net_addr_str(&pss->addr, addr_str, sizeof(addr_str), true);
+	// No close event for closes the engine itself requested via
+	// websocket_close: the caller has already torn down its connection state,
+	// and delivering the event later would misattribute it to a new
+	// connection to the same address (e.g. an immediate reconnect)
+	if(pss->notify_close && !push_event(ctx_data, WEBSOCKET_EVENT_CLOSE, &pss->addr, pss->close_reason, str_length(pss->close_reason) + 1, !pss->peer_closed))
+	{
+		// The engine will not learn the session closed and drops it on timeout
+		log_error("websockets", "Failed to deliver close event for '%s', receive buffer full", addr_str);
+	}
+	log_trace("websockets", "Connection closed with '%s'", addr_str);
+}
+
+static void request_session_close(per_session_data *pss, const char *reason, bool notify_engine)
+{
+	if(pss->close_requested)
+	{
+		// A close is already pending, keep its reason and the writeable
+		// callback that was armed for it. Only the notification is downgraded:
+		// the engine must not get a close event for a close it requested
+		// itself, even when the transport requested one first.
+		pss->notify_close = pss->notify_close && notify_engine;
+		return;
+	}
+	pss->close_requested = true;
+	pss->notify_close = notify_engine;
+	str_copy(pss->close_reason, reason != nullptr ? reason : "");
+	lws_callback_on_writable(pss->wsi);
+}
+
 static int websocket_protocol_callback(lws *wsi, enum lws_callback_reasons reason, void *user, void *in, size_t len)
 {
 	per_session_data *pss = (per_session_data *)user;
@@ -110,12 +227,10 @@ static int websocket_protocol_callback(lws *wsi, enum lws_callback_reasons reaso
 	context_data *ctx_data = contexts_map[context];
 	switch(reason)
 	{
-	case LWS_CALLBACK_WSI_CREATE:
-		if(pss == nullptr)
-		{
-			return 0;
-		}
-		[[fallthrough]];
+	case LWS_CALLBACK_FILTER_PROTOCOL_CONNECTION:
+		// Require the client to explicitly request the ddnet-20 subprotocol
+		return protocol_offered(wsi) ? 0 : -1;
+
 	case LWS_CALLBACK_ESTABLISHED:
 	{
 		sockaddr_storage peersockaddr;
@@ -125,66 +240,93 @@ static int websocket_protocol_callback(lws *wsi, enum lws_callback_reasons reaso
 		sockaddr_to_netaddr_websocket((sockaddr *)&peersockaddr, peersockaddr_size, &addr);
 		if(addr.type == NETTYPE_INVALID)
 		{
+			return -1;
+		}
+		// Close the connection if the OPEN event cannot be delivered
+		return session_open(ctx_data, pss, wsi, &addr) ? 0 : -1;
+	}
+
+	case LWS_CALLBACK_CLIENT_ESTABLISHED:
+		// Only accept the connect we are currently waiting for. A stale attempt
+		// (aborted, or a second connect started meanwhile) that completes late
+		// must not be registered under the current target's address.
+		if(wsi != ctx_data->client_wsi)
+		{
+			return -1;
+		}
+		ctx_data->client_wsi = nullptr;
+		return session_open(ctx_data, pss, wsi, &ctx_data->client_target) ? 0 : -1;
+
+	case LWS_CALLBACK_CLIENT_CONNECTION_ERROR:
+	{
+		// Ignore errors from aborted or already-completed attempts, they no
+		// longer correspond to client_target
+		if(wsi != ctx_data->client_wsi)
+		{
 			return 0;
 		}
-
-		pss->wsi = wsi;
-		pss->addr = addr;
-		pss->send_buffer.Init();
-		ctx_data->port_map[addr] = pss;
-
-		char addr_str[NETADDR_MAXSTRSIZE];
-		net_addr_str(&addr, addr_str, sizeof(addr_str), true);
-		log_trace("websockets", "Connection established with '%s'", addr_str);
+		ctx_data->client_wsi = nullptr;
+		const char *error = in != nullptr ? (const char *)in : "connection failed";
+		push_event(ctx_data, WEBSOCKET_EVENT_CLOSE, &ctx_data->client_target, error, str_length(error) + 1);
 		return 0;
 	}
+
+	case LWS_CALLBACK_WS_PEER_INITIATED_CLOSE:
+		// The connection is over as soon as the peer announces the close, the
+		// transport finishes the close handshake underneath. The close frame
+		// payload is a two byte status code followed by the reason.
+		if(pss != nullptr)
+		{
+			pss->peer_closed = true;
+			if(len > 2)
+			{
+				const size_t reason_len = std::min(len - 2, sizeof(pss->close_reason) - 1);
+				mem_copy(pss->close_reason, (const char *)in + 2, reason_len);
+				pss->close_reason[reason_len] = '\0';
+				str_sanitize_cc(pss->close_reason);
+			}
+			session_close(ctx_data, pss);
+		}
+		return 0;
 
 	case LWS_CALLBACK_CLIENT_CLOSED:
 		[[fallthrough]];
 	case LWS_CALLBACK_CLOSED:
-	{
-		char addr_str[NETADDR_MAXSTRSIZE];
-		net_addr_str(&pss->addr, addr_str, sizeof(addr_str), true);
-		log_trace("websockets", "Connection closed with '%s'", addr_str);
-
-		static const unsigned char CLOSE_PACKET[] = {0x10, 0x0e, 0x00, 0x04};
-		receive_chunk(ctx_data, pss, &CLOSE_PACKET, sizeof(CLOSE_PACKET));
-		return 0;
-	}
-
+		[[fallthrough]];
 	case LWS_CALLBACK_WSI_DESTROY:
-	{
-		if(pss == nullptr)
+		// Never leave a dangling pointer to a destroyed in-flight connect
+		if(wsi == ctx_data->client_wsi)
 		{
-			return 0;
+			ctx_data->client_wsi = nullptr;
 		}
-		pss->wsi = nullptr;
-		ctx_data->port_map.erase(pss->addr);
+		if(pss != nullptr)
+		{
+			session_close(ctx_data, pss);
+		}
 		return 0;
-	}
 
 	case LWS_CALLBACK_CLIENT_WRITEABLE:
 		[[fallthrough]];
 	case LWS_CALLBACK_SERVER_WRITEABLE:
 	{
+		if(pss->close_requested)
+		{
+			lws_close_reason(wsi, LWS_CLOSE_STATUS_NORMAL, (unsigned char *)pss->close_reason, std::min<size_t>(str_length(pss->close_reason), 123));
+			return -1;
+		}
+
 		websocket_chunk *chunk = pss->send_buffer.First();
 		if(chunk == nullptr)
 		{
 			return 0;
 		}
 
-		int chunk_len = chunk->size - chunk->read;
-		int n = lws_write(wsi, &chunk->data[LWS_SEND_BUFFER_PRE_PADDING + chunk->read], chunk->size - chunk->read, LWS_WRITE_BINARY);
-		if(n < 0)
+		// lws buffers any unsent remainder of a websocket frame internally,
+		// so a short write means the connection is unusable
+		int n = lws_write(wsi, &chunk->data[LWS_SEND_BUFFER_PRE_PADDING], chunk->size, LWS_WRITE_BINARY);
+		if(n < (int)chunk->size)
 		{
-			return 1;
-		}
-
-		if(n < chunk_len)
-		{
-			chunk->read += n;
-			lws_callback_on_writable(wsi);
-			return 0;
+			return -1;
 		}
 
 		pss->send_buffer.PopFirst();
@@ -195,8 +337,36 @@ static int websocket_protocol_callback(lws *wsi, enum lws_callback_reasons reaso
 	case LWS_CALLBACK_CLIENT_RECEIVE:
 		[[fallthrough]];
 	case LWS_CALLBACK_RECEIVE:
-		receive_chunk(ctx_data, pss, in, len);
+	{
+		// Reassemble the message: lws delivers it in multiple pieces when its
+		// frames span multiple socket reads. Close the connection on messages
+		// larger than the flags byte plus the maximum chunk payload, they can
+		// never be valid chunks. An empty message is a keepalive.
+		if(pss->recv_size + len > sizeof(pss->recv_buffer))
+		{
+			char addr_str[NETADDR_MAXSTRSIZE];
+			net_addr_str(&pss->addr, addr_str, sizeof(addr_str), true);
+			log_error("websockets", "Closing connection with '%s' due to oversized message of size %" PRIzu, addr_str, pss->recv_size + len);
+			return -1;
+		}
+		if(len > 0)
+		{
+			mem_copy(&pss->recv_buffer[pss->recv_size], in, len);
+			pss->recv_size += len;
+		}
+		if(!lws_is_final_fragment(wsi) || lws_remaining_packet_payload(wsi) > 0)
+		{
+			return 0;
+		}
+		const bool pushed = push_event(ctx_data, WEBSOCKET_EVENT_MESSAGE, &pss->addr, pss->recv_buffer, pss->recv_size);
+		pss->recv_size = 0;
+		if(!pushed)
+		{
+			// Receive buffer full: the reliable stream cannot be preserved
+			return -1;
+		}
 		return 0;
+	}
 
 	default:
 		return 0;
@@ -204,8 +374,7 @@ static int websocket_protocol_callback(lws *wsi, enum lws_callback_reasons reaso
 }
 
 static const lws_protocols protocols[] = {
-	{"binary", websocket_protocol_callback, sizeof(per_session_data)},
-	{"base64", websocket_protocol_callback, sizeof(per_session_data)},
+	{PROTOCOL_NAME, websocket_protocol_callback, sizeof(per_session_data)},
 	{nullptr, nullptr, 0}};
 
 static LEVEL websocket_level_to_loglevel(int level)
@@ -300,93 +469,216 @@ int websocket_create(const NETADDR *bindaddr)
 	}
 	contexts_map[ctx_data->context] = ctx_data;
 	ctx_data->recv_buffer.Init();
+	ctx_data->event_pending_pop = false;
+	ctx_data->client_wsi = nullptr;
+	ctx_data->client_target = NETADDR_ZEROED;
 	return first_free;
 }
 
 void websocket_destroy(int socket)
 {
 	lws_context *context = websocket_context(socket);
+	if(context == nullptr)
+		return;
 	lws_context_destroy(context);
 	contexts_map.erase(context);
 	contexts[socket].context = nullptr;
 }
 
-int websocket_recv(int socket, unsigned char *data, size_t maxsize, NETADDR *addr)
+int websocket_connect(int socket, const NETADDR *addr)
 {
 	lws_context *context = websocket_context(socket);
-	const int service_result = lws_service(context, -1);
-	if(service_result < 0)
+	if(context == nullptr)
+		return -1;
+	context_data *ctx_data = contexts_map[context];
+
+	char addr_str[NETADDR_MAXSTRSIZE];
+	net_addr_str(addr, addr_str, sizeof(addr_str), false);
+	if(addr_str[0] == '[' && addr_str[str_length(addr_str) - 1] == ']')
 	{
-		return service_result;
+		// Address must not be enclosed in brackets for IPv6 Websockets.
+		addr_str[str_length(addr_str) - 1] = '\0';
+		mem_move(&addr_str[0], &addr_str[1], str_length(addr_str) + 1);
 	}
 
+	ctx_data->client_target = *addr;
+
+	lws_client_connect_info ccinfo = {};
+	ccinfo.context = context;
+	ccinfo.address = addr_str;
+	ccinfo.port = addr->port;
+	ccinfo.path = "/";
+	ccinfo.host = addr_str;
+	ccinfo.origin = addr_str;
+	ccinfo.protocol = PROTOCOL_NAME;
+	lws *wsi = lws_client_connect_via_info(&ccinfo);
+	if(wsi == nullptr)
+	{
+		ctx_data->client_target = NETADDR_ZEROED;
+		return -1;
+	}
+	ctx_data->client_wsi = wsi;
+	lws_service(context, -1);
+	return 0;
+}
+
+void websocket_connect_abort(int socket)
+{
+	lws_context *context = websocket_context(socket);
+	if(context == nullptr)
+		return;
 	context_data *ctx_data = contexts_map[context];
+	lws *wsi = ctx_data->client_wsi;
+	// Clear first so the resulting error/destroy callbacks treat it as stale
+	ctx_data->client_wsi = nullptr;
+	ctx_data->client_target = NETADDR_ZEROED;
+	if(wsi != nullptr)
+	{
+		// Without this the wsi lingers in lws for its full connect timeout, and
+		// its late completion or error would be misattributed to the next
+		// connect target. Closing synchronously is safe here: this is not
+		// called from within a callback for this wsi.
+		lws_set_timeout(wsi, PENDING_TIMEOUT_USER_OK, LWS_TO_KILL_SYNC);
+	}
+}
+
+int websocket_recv_event(int socket, websocket_event *event)
+{
+	lws_context *context = websocket_context(socket);
+	if(context == nullptr)
+		return -1;
+	context_data *ctx_data = contexts_map[context];
+
+	// Free the previously delivered event before servicing, so a re-entrant
+	// service (from a nested websocket_send/close) can never pop a live event
+	if(ctx_data->event_pending_pop)
+	{
+		ctx_data->recv_buffer.PopFirst();
+		ctx_data->event_pending_pop = false;
+	}
+
+	// Only service when nothing is buffered, so one service call drains every
+	// event it produced instead of costing one service (a poll over all
+	// sessions) per delivered event
+	if(ctx_data->recv_buffer.First() == nullptr)
+	{
+		const int service_result = lws_service(context, -1);
+		if(service_result < 0)
+		{
+			return service_result;
+		}
+	}
+
 	websocket_chunk *chunk = ctx_data->recv_buffer.First();
 	if(chunk == nullptr)
 	{
 		return 0;
 	}
+	ctx_data->event_pending_pop = true;
 
-	if(maxsize >= chunk->size - chunk->read)
+	event->type = (websocket_event_type)chunk->type;
+	event->addr = chunk->addr;
+	event->size = 0;
+	event->data = nullptr;
+	event->close_reason[0] = '\0';
+	event->abrupt = false;
+	if(chunk->type == WEBSOCKET_EVENT_MESSAGE)
 	{
-		const int len = chunk->size - chunk->read;
-		mem_copy(data, &chunk->data[chunk->read], len);
-		*addr = chunk->addr;
-		ctx_data->recv_buffer.PopFirst();
-		return len;
+		event->size = chunk->size;
+		event->data = &chunk->data[0];
 	}
-	else
+	else if(chunk->type == WEBSOCKET_EVENT_CLOSE)
 	{
-		mem_copy(data, &chunk->data[chunk->read], maxsize);
-		*addr = chunk->addr;
-		chunk->read += maxsize;
-		return maxsize;
+		event->abrupt = chunk->abrupt;
+		if(chunk->size > 0)
+		{
+			str_copy(event->close_reason, (const char *)&chunk->data[0], std::min(sizeof(event->close_reason), chunk->size));
+		}
 	}
+	return 1;
 }
 
-int websocket_send(int socket, const unsigned char *data, size_t size, const NETADDR *addr)
+int websocket_recv_next(NETSOCKET sock, websocket_event *event, int *handle)
+{
+	for(const int nettype : {NETTYPE_WEBSOCKET_IPV4, NETTYPE_WEBSOCKET_IPV6})
+	{
+		*handle = net_socket_websocket(sock, nettype);
+		if(*handle >= 0 && websocket_recv_event(*handle, event) > 0)
+			return 1;
+	}
+	return 0;
+}
+
+int websocket_send(int socket, const unsigned char *data, size_t size, const NETADDR *addr, bool vital)
 {
 	lws_context *context = websocket_context(socket);
+	if(context == nullptr)
+		return -1;
 	context_data *ctx_data = contexts_map[context];
-	per_session_data *pss = ctx_data->port_map[*addr];
-	if(pss == nullptr)
+	auto it = ctx_data->port_map.find(*addr);
+	if(it == ctx_data->port_map.end() || it->second == nullptr || it->second->wsi == nullptr)
 	{
-		char addr_str[NETADDR_MAXSTRSIZE];
-		net_addr_str(addr, addr_str, sizeof(addr_str), false);
-		lws_client_connect_info ccinfo = {};
-		ccinfo.context = context;
-		ccinfo.address = addr_str;
-		ccinfo.port = addr->port;
-		ccinfo.protocol = protocols[0].name;
-		lws *wsi = lws_client_connect_via_info(&ccinfo);
-		if(wsi == nullptr)
-		{
-			return -1;
-		}
-		lws_service(context, -1);
-		pss = ctx_data->port_map[*addr];
-		if(pss == nullptr)
-		{
-			return -1;
-		}
+		return -1;
 	}
+	per_session_data *pss = it->second;
 
 	const size_t chunk_size = size + sizeof(websocket_chunk) + LWS_SEND_BUFFER_PRE_PADDING + LWS_SEND_BUFFER_POST_PADDING;
 	websocket_chunk *chunk = pss->send_buffer.Allocate(chunk_size);
-	dbg_assert(chunk != nullptr, "failed to allocate websocket send buffer chunk of size %" PRIzu, size);
+	if(chunk == nullptr)
+	{
+		// The send buffer is full, so the transport is stalled. Drop the
+		// message if it may be lost, exactly like the network drops a UDP
+		// packet: the peer misses one snapshot and keeps playing.
+		if(!vital)
+		{
+			return size;
+		}
+		// Unlike UDP there is no retransmission, so dropping a vital message
+		// would silently and permanently break the reliable stream; close the
+		// connection instead. The engine did not ask for this close, so it
+		// gets the close event.
+		request_session_close(pss, "Too weak connection", true);
+		return -1;
+	}
 	mem_zero(chunk, chunk_size);
 	chunk->size = size;
-	chunk->read = 0;
 	chunk->addr = pss->addr;
-	mem_copy(&chunk->data[LWS_SEND_BUFFER_PRE_PADDING], data, size);
+	if(size > 0)
+	{
+		// data is null for the empty keepalive message
+		mem_copy(&chunk->data[LWS_SEND_BUFFER_PRE_PADDING], data, size);
+	}
 	lws_callback_on_writable(pss->wsi);
 	lws_service(context, -1);
 	return size;
 }
 
+void websocket_close(int socket, const NETADDR *addr, const char *reason)
+{
+	lws_context *context = websocket_context(socket);
+	if(context == nullptr)
+		return;
+	context_data *ctx_data = contexts_map[context];
+	auto it = ctx_data->port_map.find(*addr);
+	if(it == ctx_data->port_map.end() || it->second == nullptr || it->second->wsi == nullptr)
+	{
+		return;
+	}
+	per_session_data *pss = it->second;
+	request_session_close(pss, reason, false);
+	// Pump until the close frame is flushed; the session is removed from the
+	// port map once the connection is fully closed
+	for(int i = 0; i < 10 && ctx_data->port_map.contains(*addr); i++)
+	{
+		lws_service(context, -1);
+	}
+}
+
 int websocket_fd_set(int socket, fd_set *set)
 {
 	lws_context *context = websocket_context(socket);
+	if(context == nullptr)
+		return 0;
 	lws_service(context, -1);
 
 	context_data *ctx_data = contexts_map[context];
@@ -407,9 +699,18 @@ int websocket_fd_set(int socket, fd_set *set)
 int websocket_fd_get(int socket, fd_set *set)
 {
 	lws_context *context = websocket_context(socket);
+	if(context == nullptr)
+		return 0;
 	lws_service(context, -1);
 
 	context_data *ctx_data = contexts_map[context];
+	// Undelivered events must wake the engine even though the session they
+	// belong to may already be gone from the port map: the close event of a
+	// disconnected peer has no fd left that could report activity
+	if(ctx_data->recv_buffer.First() != nullptr)
+	{
+		return 1;
+	}
 	for(const auto &[_, pss] : ctx_data->port_map)
 	{
 		if(pss == nullptr)

--- a/src/engine/shared/websockets.h
+++ b/src/engine/shared/websockets.h
@@ -12,14 +12,71 @@
 
 #include <cstddef>
 
+// The websocket transport carries network chunks instead of whole Teeworlds
+// packets ("ddnet-20" subprotocol): each binary websocket message is exactly
+// one network chunk, a flags byte (`NET_CHUNKFLAG_VITAL`) followed by the
+// chunk payload. An empty message is a keepalive. Reliability and ordering
+// come from TCP, connect/close are the websocket connection itself, so there
+// are no packet headers, security tokens, acknowledgements, resends or
+// control messages; the vital flag is carried only for the message handlers
+// that check it.
+
 // NOLINTBEGIN(readability-identifier-naming)
+enum websocket_event_type
+{
+	WEBSOCKET_EVENT_OPEN = 1,
+	WEBSOCKET_EVENT_MESSAGE,
+	WEBSOCKET_EVENT_CLOSE,
+};
+
+struct websocket_event
+{
+	websocket_event_type type;
+	NETADDR addr;
+	size_t size; // WEBSOCKET_EVENT_MESSAGE only, 0 means keepalive
+	const unsigned char *data; // valid only until the next websocket_* call on this socket
+	char close_reason[128]; // WEBSOCKET_EVENT_CLOSE only
+	// WEBSOCKET_EVENT_CLOSE only: the connection was lost without the peer
+	// announcing the close, e.g. because it crashed, was killed or its network
+	// went away. The reason, if any, was then generated locally.
+	bool abrupt;
+};
+
+#if defined(CONF_WEBSOCKETS)
 void websocket_init();
 int websocket_create(const NETADDR *bindaddr);
 void websocket_destroy(int socket);
-int websocket_recv(int socket, unsigned char *data, size_t maxsize, NETADDR *addr);
-int websocket_send(int socket, const unsigned char *data, size_t size, const NETADDR *addr);
+int websocket_connect(int socket, const NETADDR *addr);
+// Cancel an in-flight client connect that has not completed yet
+void websocket_connect_abort(int socket);
+int websocket_recv_event(int socket, websocket_event *event);
+// Receive the next event from any of a network socket's websocket transports
+int websocket_recv_next(NETSOCKET sock, websocket_event *event, int *handle);
+// Non-vital messages are dropped when the send buffer is full, like UDP drops
+// packets; a vital message that does not fit closes the connection instead,
+// because there is no retransmission that could recover it
+int websocket_send(int socket, const unsigned char *data, size_t size, const NETADDR *addr, bool vital);
+// Close the connection, carrying the reason to the peer in the close frame.
+// Produces no WEBSOCKET_EVENT_CLOSE: the caller must tear down its own
+// connection state, and a deferred event would be misattributed to a new
+// connection to the same address (e.g. an immediate reconnect)
+void websocket_close(int socket, const NETADDR *addr, const char *reason);
 int websocket_fd_set(int socket, fd_set *set);
 int websocket_fd_get(int socket, fd_set *set);
+#else
+// Stubs so that the engine code needs no preprocessor guards
+inline void websocket_init() {}
+inline int websocket_create(const NETADDR *) { return -1; }
+inline void websocket_destroy(int) {}
+inline int websocket_connect(int, const NETADDR *) { return -1; }
+inline void websocket_connect_abort(int) {}
+inline int websocket_recv_event(int, websocket_event *) { return 0; }
+inline int websocket_recv_next(NETSOCKET, websocket_event *, int *) { return 0; }
+inline int websocket_send(int, const unsigned char *, size_t, const NETADDR *, bool) { return -1; }
+inline void websocket_close(int, const NETADDR *, const char *) {}
+inline int websocket_fd_set(int, fd_set *) { return 0; }
+inline int websocket_fd_get(int, fd_set *) { return 0; }
+#endif
 // NOLINTEND(readability-identifier-naming)
 
 #endif // ENGINE_SHARED_WEBSOCKETS_H


### PR DESCRIPTION
The websocket transport no longer tunnels whole Teeworlds packets with their UDP wrapping. The new "ddnet-20" subprotocol carries network chunks directly and leaves reliability, ordering, connecting and closing to the websocket layer:

- Each binary websocket message is exactly one network chunk: a flags byte (vital) followed by the chunk payload. An empty message is a keepalive, sent when the connection is idle. A message that can never be a valid chunk closes the connection.
- Establishing the websocket connection is the connect handshake: the server accepts the client as soon as the connection is established, so connections can no longer linger without the engine being notified. There are no packet headers, security tokens, acks, resends or control messages; the disconnect reason travels in the websocket close frame.
- Clients must request the "ddnet-20" Sec-WebSocket-Protocol instead of the made up "binary,base64" protocol names.
- Connless packets (server info) are not carried over websockets; websocket clients get server info from the HTTPS masterserver.
- The transport reassembles messages that libwebsockets delivers in multiple pieces when frames span multiple socket reads, and it drops packets like UDP would when a send buffer is full instead of crashing the whole server on a dbg_assert.
- src/base no longer sends or receives packets through the websocket code; the packet data path moved into the engine (CNetConnection, CNetServer, CNetClient), which talks to the transport through an event API (open/message/close) in engine/shared/websockets.h.

The integration test client_can_connect_websockets covers the native client over the new protocol and now also verifies that the disconnect reason arrives through the close frame.

The emscripten browser client needs a new websocket backend to use this protocol: it previously relied on emscripten's UDP-over-websocket bridging, which carried whole packets and always used the "binary" subprotocol.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

I didn't review yet.

Written with Claude Code (Fable 5, Opus 5 and Opus 4.8)