### PR TITLE
DNM: Support running a local server in the Emscripten client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2821,6 +2821,17 @@ if(CLIENT)
     set(CLIENT_MANIFEST)
   endif()
 
+  # On Emscripten the server is linked into the client, because the browser
+  # cannot run the server as a separate process. The client starts the server
+  # on a thread instead, reachable via the in-memory loopback transport.
+  set(CLIENT_SERVER_SRC)
+  if(TARGET_OS STREQUAL "emscripten" AND SERVER)
+    set(CLIENT_SERVER_SRC
+      "${PROJECT_SOURCE_DIR}/src/engine/server/main.cpp"
+      $<TARGET_OBJECTS:game-server-without-main>
+    )
+  endif()
+
   # Target
   if(TARGET_OS STREQUAL "android")
     add_library(game-client SHARED
@@ -2842,6 +2853,7 @@ if(CLIENT)
       ${CLIENT_ICON}
       ${CLIENT_VERSIONINFO}
       ${CLIENT_MANIFEST}
+      ${CLIENT_SERVER_SRC}
       ${DEPS_CLIENT}
       # tidy-alphabetical-start
       $<TARGET_OBJECTS:engine-gfx>
@@ -2852,6 +2864,10 @@ if(CLIENT)
     )
   endif()
   add_dependencies(game-client generate_content_types)
+  if(CLIENT_SERVER_SRC)
+    add_dependencies(game-client generate_protocol)
+    target_compile_definitions(game-client PRIVATE CONF_INTEGRATED_SERVER)
+  endif()
   if(VULKAN)
     add_dependencies(game-client build_vulkan_shaders)
   endif()
@@ -2947,6 +2963,7 @@ if(SERVER)
     databases/connection_pool.h
     databases/mysql.cpp
     databases/sqlite.cpp
+    emscripten_server.h
     main.cpp
     name_ban.cpp
     name_ban.h
@@ -3068,6 +3085,25 @@ if(SERVER)
   add_dependencies(game-server-without-main generate_content_types)
   add_dependencies(game-server-without-main generate_protocol)
   # tidy-alphabetical-end
+  if(TARGET_OS STREQUAL "emscripten")
+    # The server is linked into the client on Emscripten. These class names
+    # exist both in the server and in the client prediction code, so rename
+    # the server's classes to avoid duplicate symbols.
+    target_compile_definitions(game-server-without-main PRIVATE
+      # tidy-alphabetical-start
+      CCharacter=CServerCharacter
+      CDoor=CServerDoor
+      CDragger=CServerDragger
+      CEntity=CServerEntity
+      CGameWorld=CServerGameWorld
+      CLaser=CServerLaser
+      CPickup=CServerPickup
+      CPlasma=CServerPlasma
+      CProjectile=CServerProjectile
+      g_pData=g_pServerData
+      # tidy-alphabetical-end
+    )
+  endif()
   set_property(TARGET game-server-without-main
       PROPERTY OUTPUT_NAME ${SERVER_EXECUTABLE}
   )
@@ -3076,6 +3112,8 @@ if(SERVER)
   list(APPEND TARGETS_LINK game-server-without-main)
 
   # Target
+  # On Emscripten no standalone server is built, the server is linked into the
+  # client instead.
   if(TARGET_OS STREQUAL "android")
     add_library(game-server SHARED
       ${DEPS}
@@ -3089,7 +3127,7 @@ if(SERVER)
       $<TARGET_OBJECTS:rust-bridge-shared>
       # tidy-alphabetical-sort
     )
-  else()
+  elseif(NOT TARGET_OS STREQUAL "emscripten")
     add_executable(game-server
       ${DEPS}
       "${PROJECT_SOURCE_DIR}/src/engine/server/main.cpp"
@@ -3103,12 +3141,14 @@ if(SERVER)
       # tidy-alphabetical-sort
     )
   endif()
-  set_property(TARGET game-server
-      PROPERTY OUTPUT_NAME ${SERVER_EXECUTABLE}
-  )
-  target_link_libraries(game-server ${LIBS_SERVER})
-  list(APPEND TARGETS_OWN game-server)
-  list(APPEND TARGETS_LINK game-server)
+  if(TARGET game-server)
+    set_property(TARGET game-server
+        PROPERTY OUTPUT_NAME ${SERVER_EXECUTABLE}
+    )
+    target_link_libraries(game-server ${LIBS_SERVER})
+    list(APPEND TARGETS_OWN game-server)
+    list(APPEND TARGETS_LINK game-server)
+  endif()
 
   if(TARGET_OS AND TARGET_OS STREQUAL "mac")
     set(SERVER_LAUNCHER_SRC src/macos/server.mm)
@@ -3253,6 +3293,7 @@ if((GTEST_FOUND OR DOWNLOAD_GTEST) AND SERVER)
     chunk_header_test.cpp
     color_test.cpp
     compression_test.cpp
+    config_test.cpp
     csv_test.cpp
     datafile_test.cpp
     dbg_test.cpp

--- a/cmake/toolchains/Emscripten.toolchain
+++ b/cmake/toolchains/Emscripten.toolchain
@@ -6,9 +6,11 @@ set(WASM_CXX_FLAGS "")
 set(WASM_LINKER_FLAGS "")
 
 # Enable pthreads. Use thread pool of fixed sized, as workers cannot be created while our code is running.
+# The pool must also accommodate the threads of the integrated server (server main
+# thread, database worker, job pool).
 set(WASM_CXX_FLAGS "${WASM_CXX_FLAGS} -pthread")
 set(WASM_LINKER_FLAGS "-s LLD_REPORT_UNDEFINED -s USE_PTHREADS=1 -pthread")
-set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s PTHREAD_POOL_SIZE=10")
+set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s PTHREAD_POOL_SIZE=24")
 # Abort if we try to create too many threads, instead of likely causing a deadlock in our code.
 set(WASM_LINKER_FLAGS "${WASM_LINKER_FLAGS} -s PTHREAD_POOL_SIZE_STRICT=2")
 # TODO: Not supported in SDL2 currently. May also require `OFFSCREENCANVAS_SUPPORT` and/or `OFFSCREEN_FRAMEBUFFER` but canvas/context cannot be proxied to the thread.

--- a/src/base/net.cpp
+++ b/src/base/net.cpp
@@ -10,11 +10,19 @@
 #include "windows.h"
 
 #include <chrono>
+#include <condition_variable>
+#include <deque>
 #include <iterator> // std::size
+#include <map>
+#include <mutex>
 #include <string_view>
 
 #if defined(CONF_WEBSOCKETS)
 #include <engine/shared/websockets.h>
+#endif
+
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+#include <emscripten/threading.h>
 #endif
 
 #if defined(CONF_FAMILY_UNIX)
@@ -105,6 +113,8 @@ static void net_buffer_simple(NETSOCKET_BUFFER *buffer, char **buf, int *size)
 }
 #endif
 
+struct NETLOOPBACK;
+
 struct NETSOCKET_INTERNAL
 {
 	int type;
@@ -112,10 +122,150 @@ struct NETSOCKET_INTERNAL
 	int ipv6sock;
 	int web_ipv4sock;
 	int web_ipv6sock;
+	NETLOOPBACK *loopback;
 
 	NETSOCKET_BUFFER buffer;
 };
-static NETSOCKET_INTERNAL invalid_socket = {NETTYPE_INVALID, -1, -1, -1, -1};
+static NETSOCKET_INTERNAL invalid_socket = {NETTYPE_INVALID, -1, -1, -1, -1, nullptr};
+
+// In-memory loopback transport. Browsers offer no real loopback sockets, so on
+// Emscripten packets to localhost are exchanged through in-process queues instead,
+// which allows the client to talk to a server running on a thread in the same
+// process. Disabled on other platforms except for tests.
+struct NETLOOPBACK_PACKET
+{
+	NETADDR from;
+	int size;
+	unsigned char data[PACKETSIZE];
+};
+
+struct NETLOOPBACK
+{
+	int port;
+	std::deque<NETLOOPBACK_PACKET> queue;
+	NETLOOPBACK_PACKET current;
+	std::condition_variable cond;
+};
+
+static std::mutex loopback_lock;
+static std::map<int, NETLOOPBACK *> loopback_sockets;
+static int loopback_next_ephemeral_port = 61000;
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+static bool loopback_enabled = true;
+#else
+static bool loopback_enabled = false;
+#endif
+static constexpr size_t LOOPBACK_MAX_QUEUE = 1024;
+
+void net_loopback_set_enabled(bool enabled)
+{
+	loopback_enabled = enabled;
+}
+
+static bool loopback_addr_match(const NETADDR *addr)
+{
+	if(addr->type & NETTYPE_LINK_BROADCAST)
+		return true;
+	if(addr->type & (NETTYPE_IPV4 | NETTYPE_WEBSOCKET_IPV4))
+		return addr->ip[0] == 127;
+	if(addr->type & (NETTYPE_IPV6 | NETTYPE_WEBSOCKET_IPV6))
+	{
+		for(int i = 0; i < 15; i++)
+		{
+			if(addr->ip[i] != 0)
+				return false;
+		}
+		return addr->ip[15] == 1;
+	}
+	return false;
+}
+
+static bool loopback_registered(int port)
+{
+	const std::unique_lock lock(loopback_lock);
+	return loopback_sockets.contains(port);
+}
+
+static void loopback_register(NETSOCKET sock, int port)
+{
+	const std::unique_lock lock(loopback_lock);
+	if(port == 0)
+	{
+		while(loopback_sockets.contains(loopback_next_ephemeral_port))
+		{
+			loopback_next_ephemeral_port = loopback_next_ephemeral_port >= 65535 ? 61000 : loopback_next_ephemeral_port + 1;
+		}
+		port = loopback_next_ephemeral_port;
+		loopback_next_ephemeral_port = port >= 65535 ? 61000 : port + 1;
+	}
+	else if(loopback_sockets.contains(port))
+	{
+		log_error("net", "loopback port %d already in use", port);
+		return;
+	}
+	sock->loopback = new NETLOOPBACK();
+	sock->loopback->port = port;
+	loopback_sockets[port] = sock->loopback;
+}
+
+static void loopback_unregister(NETSOCKET sock)
+{
+	if(sock->loopback == nullptr)
+		return;
+	{
+		const std::unique_lock lock(loopback_lock);
+		loopback_sockets.erase(sock->loopback->port);
+	}
+	delete sock->loopback;
+	sock->loopback = nullptr;
+}
+
+static int loopback_send(NETSOCKET sock, const NETADDR *addr, const void *data, int size)
+{
+	if(size <= 0 || (size_t)size > PACKETSIZE)
+		return -1;
+	// Fabricate the sender address in the family the destination address uses,
+	// so that connection peer address checks on both sides are consistent.
+	NETADDR from;
+	mem_zero(&from, sizeof(from));
+	if(addr->type & (NETTYPE_IPV6 | NETTYPE_WEBSOCKET_IPV6))
+	{
+		from.type = NETTYPE_IPV6;
+		from.ip[15] = 1;
+	}
+	else
+	{
+		from.type = NETTYPE_IPV4;
+		from.ip[0] = 127;
+		from.ip[3] = 1;
+	}
+	from.port = sock->loopback->port;
+
+	const std::unique_lock lock(loopback_lock);
+	auto it = loopback_sockets.find(addr->port);
+	if(it != loopback_sockets.end() && it->second != sock->loopback && it->second->queue.size() < LOOPBACK_MAX_QUEUE)
+	{
+		NETLOOPBACK_PACKET &packet = it->second->queue.emplace_back();
+		packet.from = from;
+		packet.size = size;
+		mem_copy(packet.data, data, size);
+		it->second->cond.notify_one();
+	}
+	// Destination not registered or queue full: silently dropped, like UDP.
+	return size;
+}
+
+static int loopback_recv(NETSOCKET sock, NETADDR *addr, unsigned char **data)
+{
+	const std::unique_lock lock(loopback_lock);
+	if(sock->loopback->queue.empty())
+		return 0;
+	sock->loopback->current = sock->loopback->queue.front();
+	sock->loopback->queue.pop_front();
+	*addr = sock->loopback->current.from;
+	*data = sock->loopback->current.data;
+	return sock->loopback->current.size;
+}
 
 const NETADDR NETADDR_ZEROED = {NETTYPE_INVALID, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0};
 
@@ -577,6 +727,18 @@ static int net_host_lookup_impl(const char *hostname, NETADDR *addr, int types)
 
 	log_trace("host_lookup", "host='%s' port='%d' types='%d'", host, port, types);
 
+	// When the loopback transport is active (Emscripten), "localhost" must map
+	// to 127.0.0.1, as the resolver may return a synthetic address instead.
+	if(loopback_enabled && str_comp(host, "localhost") == 0 && (types & NETTYPE_IPV4) != 0)
+	{
+		mem_zero(addr, sizeof(*addr));
+		addr->type = NETTYPE_IPV4;
+		addr->ip[0] = 127;
+		addr->ip[3] = 1;
+		addr->port = port;
+		return 0;
+	}
+
 	struct addrinfo hints;
 	mem_zero(&hints, sizeof(hints));
 
@@ -720,11 +882,8 @@ int net_would_block()
 #endif
 }
 
-int net_socket_read_wait(NETSOCKET sock, std::chrono::nanoseconds nanoseconds)
+static int net_socket_read_wait_select(NETSOCKET sock, int64_t microseconds)
 {
-	const int64_t microseconds = std::chrono::duration_cast<std::chrono::microseconds>(nanoseconds).count();
-	dbg_assert(microseconds >= 0, "Negative wait duration %" PRId64 " not allowed", microseconds);
-
 	fd_set readfds;
 	FD_ZERO(&readfds);
 
@@ -779,6 +938,39 @@ int net_socket_read_wait(NETSOCKET sock, std::chrono::nanoseconds nanoseconds)
 	}
 #endif
 	return 0;
+}
+
+int net_socket_read_wait(NETSOCKET sock, std::chrono::nanoseconds nanoseconds)
+{
+	const int64_t microseconds = std::chrono::duration_cast<std::chrono::microseconds>(nanoseconds).count();
+	dbg_assert(microseconds >= 0, "Negative wait duration %" PRId64 " not allowed", microseconds);
+
+	if(sock->loopback != nullptr)
+	{
+		// Wait on the loopback queue, but poll the real sockets in short slices
+		// so their traffic is not delayed for the entire wait duration.
+		const bool has_real_sockets = sock->ipv4sock >= 0 || sock->ipv6sock >= 0 || sock->web_ipv4sock >= 0 || sock->web_ipv6sock >= 0;
+		const auto deadline = std::chrono::steady_clock::now() + nanoseconds;
+		while(true)
+		{
+			{
+				std::unique_lock lock(loopback_lock);
+				if(!sock->loopback->queue.empty())
+					return 1;
+				const auto now = std::chrono::steady_clock::now();
+				if(now >= deadline)
+					return 0;
+				const std::chrono::nanoseconds remaining = deadline - now;
+				sock->loopback->cond.wait_for(lock, has_real_sockets ? std::min<std::chrono::nanoseconds>(remaining, std::chrono::milliseconds(1)) : remaining);
+				if(!sock->loopback->queue.empty())
+					return 1;
+			}
+			if(has_real_sockets && net_socket_read_wait_select(sock, 0))
+				return 1;
+		}
+	}
+
+	return net_socket_read_wait_select(sock, microseconds);
 }
 
 static void priv_net_close_socket(int sock)
@@ -902,6 +1094,18 @@ NETSOCKET net_udp_create(NETADDR bindaddr)
 	NETSOCKET sock = (NETSOCKET_INTERNAL *)malloc(sizeof(*sock));
 	*sock = invalid_socket;
 
+	const int loopback_types = bindaddr.type & (NETTYPE_IPV4 | NETTYPE_IPV6);
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+	// Emscripten proxies socket syscalls to the browser main thread, which can
+	// abort when the main thread is suspended by Asyncify. Only the main thread
+	// may therefore use real sockets. Other threads (the integrated server)
+	// only get the in-memory loopback transport.
+	if(!emscripten_is_main_runtime_thread())
+	{
+		bindaddr.type = 0;
+	}
+#endif
+
 	if(bindaddr.type & NETTYPE_IPV4)
 	{
 		NETADDR bindaddr_ipv4 = bindaddr;
@@ -993,6 +1197,16 @@ NETSOCKET net_udp_create(NETADDR bindaddr)
 	}
 #endif
 
+	if(loopback_enabled && loopback_types != 0)
+	{
+		loopback_register(sock, bindaddr.port);
+		if(sock->loopback != nullptr)
+		{
+			// The socket is usable even if no real socket could be created.
+			sock->type |= loopback_types;
+		}
+	}
+
 	if(sock->type == NETTYPE_INVALID)
 	{
 		free(sock);
@@ -1010,6 +1224,21 @@ NETSOCKET net_udp_create(NETADDR bindaddr)
 int net_udp_send(NETSOCKET sock, const NETADDR *addr, const void *data, int size)
 {
 	int d = -1;
+
+	// Only divert the packet to the loopback transport if an in-process socket
+	// is actually bound on the destination port, so localhost traffic can still
+	// reach servers outside this process through the real sockets. Broadcasts
+	// are delivered to the in-process socket in addition to the real send.
+	if(sock->loopback != nullptr && loopback_addr_match(addr) && loopback_registered(addr->port))
+	{
+		d = loopback_send(sock, addr, data, size);
+		if((addr->type & NETTYPE_LINK_BROADCAST) == 0)
+		{
+			network_stats.sent_bytes += size;
+			network_stats.sent_packets++;
+			return d;
+		}
+	}
 
 	if(addr->type & NETTYPE_IPV4)
 	{
@@ -1118,6 +1347,17 @@ int net_udp_recv(NETSOCKET sock, NETADDR *addr, unsigned char **data)
 	};
 
 	int bytes = 0;
+
+	if(sock->loopback != nullptr)
+	{
+		bytes = loopback_recv(sock, addr, data);
+		if(bytes > 0)
+		{
+			update_stats(bytes);
+			return bytes;
+		}
+	}
+
 #if defined(CONF_PLATFORM_LINUX)
 	if(sock->ipv4sock >= 0)
 	{
@@ -1223,6 +1463,7 @@ int net_udp_recv(NETSOCKET sock, NETADDR *addr, unsigned char **data)
 
 void net_udp_close(NETSOCKET sock)
 {
+	loopback_unregister(sock);
 	priv_net_close_all_sockets(sock);
 }
 

--- a/src/base/net.h
+++ b/src/base/net.h
@@ -250,6 +250,19 @@ int net_socket_read_wait(NETSOCKET sock, std::chrono::nanoseconds nanoseconds);
  */
 
 /**
+ * Enables or disables the in-memory loopback transport for UDP sockets. When
+ * enabled, packets to localhost addresses are exchanged through in-process
+ * queues instead of real sockets, allowing a client and server in the same
+ * process to communicate. Enabled by default only on Emscripten, where no
+ * real loopback sockets exist. This function is intended for tests.
+ *
+ * @ingroup Network-UDP
+ *
+ * @param enabled Whether the loopback transport should be enabled.
+ */
+void net_loopback_set_enabled(bool enabled);
+
+/**
  * Creates a UDP socket and binds it to a port.
  *
  * @ingroup Network-UDP

--- a/src/engine/config.h
+++ b/src/engine/config.h
@@ -12,7 +12,18 @@ public:
 	typedef void (*SAVECALLBACKFUNC)(IConfigManager *pConfig, void *pUserData);
 	typedef void (*POSSIBLECFGFUNC)(const struct SConfigVariable *, void *pUserData);
 
-	virtual void Init() = 0;
+	enum class EInitializationType
+	{
+		// Set all config variables to their default values.
+		STANDALONE,
+		// For an integrated server sharing the process-global config with a
+		// running client: set only the variables exclusive to the server to
+		// their default values, so every server start begins from a clean
+		// server configuration without touching the client's configuration.
+		INTEGRATED_SERVER,
+	};
+
+	virtual void Init(EInitializationType InitializationType = EInitializationType::STANDALONE) = 0;
 	virtual void Reset(const char *pScriptName) = 0;
 	virtual void ResetGameSettings() = 0;
 	virtual void SetReadOnly(const char *pScriptName, bool ReadOnly) = 0;

--- a/src/engine/server/emscripten_server.h
+++ b/src/engine/server/emscripten_server.h
@@ -1,0 +1,35 @@
+#ifndef ENGINE_SERVER_EMSCRIPTEN_SERVER_H
+#define ENGINE_SERVER_EMSCRIPTEN_SERVER_H
+
+#include <base/detect.h>
+
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+
+#include <cstddef>
+
+/**
+ * Starts the server on a separate thread in the current process. The server is
+ * reachable via the in-memory loopback transport, see `net_loopback_set_enabled`.
+ *
+ * @param ppArguments The command line arguments to pass to the server.
+ * @param NumArguments The number of command line arguments.
+ *
+ * @return `true` if the server was started, `false` if it is already running.
+ */
+bool StartEmscriptenServer(const char **ppArguments, size_t NumArguments);
+
+/**
+ * Executes a command in the console of the running server.
+ *
+ * @param pCommand The command to execute.
+ */
+void ExecuteEmscriptenServerCommand(const char *pCommand);
+
+/**
+ * @return `true` if the server thread is currently running, `false` otherwise.
+ */
+bool IsEmscriptenServerRunning();
+
+#endif
+
+#endif

--- a/src/engine/server/main.cpp
+++ b/src/engine/server/main.cpp
@@ -31,6 +31,14 @@
 #include <base/fs.h>
 
 #include <jni.h>
+#elif defined(CONF_PLATFORM_EMSCRIPTEN)
+#include "emscripten_server.h"
+
+#include <base/thread.h>
+
+#include <atomic>
+#include <string>
+#include <thread>
 #endif
 
 #include <csignal>
@@ -51,7 +59,29 @@ static void HandleSigIntTerm(int Param)
 	signal(SIGTERM, SIG_DFL);
 }
 
+#if defined(CONF_PLATFORM_ANDROID) || defined(CONF_PLATFORM_EMSCRIPTEN)
+std::mutex LocalServerCommandMutex;
+std::vector<std::string> vLocalServerCommandQueue;
+
+std::vector<std::string> FetchLocalServerCommandQueue()
+{
+	std::vector<std::string> vResult;
+	{
+		const std::unique_lock Lock(LocalServerCommandMutex);
+		vResult.swap(vLocalServerCommandQueue);
+	}
+	return vResult;
+}
+#endif
+
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+// The server is linked into the client binary on Emscripten, which provides its
+// own main function. The server main function is instead run on a separate
+// thread, started with StartEmscriptenServer.
+static int ddnet_server_main(int argc, const char **argv)
+#else
 int main(int argc, const char **argv)
+#endif
 {
 	const int64_t MainStart = time_get();
 
@@ -97,7 +127,13 @@ int main(int argc, const char **argv)
 	vpLoggers.push_back(pFutureConsoleLogger);
 	std::shared_ptr<CFutureLogger> pFutureAssertionLogger = std::make_shared<CFutureLogger>();
 	vpLoggers.push_back(pFutureAssertionLogger);
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+	// The client already set the global logger for this process, which logs to
+	// the browser console.
+	(void)vpLoggers;
+#else
 	log_set_global_logger(log_logger_collection(std::move(vpLoggers)).release());
+#endif
 
 	if(MysqlInit() != 0)
 	{
@@ -166,7 +202,17 @@ int main(int argc, const char **argv)
 
 	pEngine->Init();
 	pConsole->Init();
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+	// The integrated server shares the process-global g_Config with the
+	// running client. Writing all defaults again would reset the client's
+	// entire configuration mid-session and the client would persist the wipe
+	// on exit. Resetting nothing would leak the settings of one local-server
+	// run into the next. So only the variables exclusive to the server are
+	// set to their default values.
+	pConfigManager->Init(IConfigManager::EInitializationType::INTEGRATED_SERVER);
+#else
 	pConfigManager->Init();
+#endif
 
 	// register all console commands
 	pServer->RegisterCommands();
@@ -239,19 +285,6 @@ int main(int argc, const char **argv)
 #define JNI_EXPORTED_FUNCTION(PACKAGE, CLASS, FUNCTION, RETURN_TYPE, ...) \
 	extern "C" JNIEXPORT RETURN_TYPE JNICALL EXPAND_MACRO(JNI_MAKE_NAME(PACKAGE, CLASS, FUNCTION))(__VA_ARGS__)
 
-std::mutex AndroidNativeMutex;
-std::vector<std::string> vAndroidCommandQueue;
-
-std::vector<std::string> FetchAndroidServerCommandQueue()
-{
-	std::vector<std::string> vResult;
-	{
-		const std::unique_lock Lock(AndroidNativeMutex);
-		vResult.swap(vAndroidCommandQueue);
-	}
-	return vResult;
-}
-
 JNI_EXPORTED_FUNCTION(ANDROID_PACKAGE_NAME_JNI, NativeServer, runServer, jint, JNIEnv *pEnv, jobject Object, jstring WorkingDirectory, jobjectArray ArgumentsArray)
 {
 	// Set working directory to external storage location. This is not possible
@@ -291,8 +324,8 @@ JNI_EXPORTED_FUNCTION(ANDROID_PACKAGE_NAME_JNI, NativeServer, executeCommand, vo
 {
 	const char *pCommand = pEnv->GetStringUTFChars(Command, nullptr);
 	{
-		const std::unique_lock Lock(AndroidNativeMutex);
-		vAndroidCommandQueue.emplace_back(pCommand);
+		const std::unique_lock Lock(LocalServerCommandMutex);
+		vLocalServerCommandQueue.emplace_back(pCommand);
 	}
 	pEnv->ReleaseStringUTFChars(Command, pCommand);
 }
@@ -300,4 +333,60 @@ JNI_EXPORTED_FUNCTION(ANDROID_PACKAGE_NAME_JNI, NativeServer, executeCommand, vo
 #undef EXPAND_MACRO
 #undef JNI_MAKE_NAME
 #undef JNI_EXPORTED_FUNCTION
+#endif
+
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+static std::atomic_bool EmscriptenServerRunning = false;
+
+static void EmscriptenServerThread(void *pUser)
+{
+	auto *pvArguments = static_cast<std::vector<std::string> *>(pUser);
+	std::vector<const char *> vpArguments;
+	vpArguments.reserve(pvArguments->size() + 1);
+	vpArguments.push_back(GAME_NAME "-Server");
+	for(const std::string &Argument : *pvArguments)
+	{
+		vpArguments.push_back(Argument.c_str());
+	}
+	ddnet_server_main(vpArguments.size(), vpArguments.data());
+	delete pvArguments;
+	EmscriptenServerRunning = false;
+}
+
+bool StartEmscriptenServer(const char **ppArguments, size_t NumArguments)
+{
+	// Wait for a previous server to finish shutting down, so its port and
+	// other global state are released before the new instance starts.
+	for(int Attempt = 0; Attempt < 200 && EmscriptenServerRunning; Attempt++)
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+	}
+	if(EmscriptenServerRunning.exchange(true))
+	{
+		return false;
+	}
+	{
+		const std::unique_lock Lock(LocalServerCommandMutex);
+		vLocalServerCommandQueue.clear();
+	}
+	auto *pvArguments = new std::vector<std::string>();
+	pvArguments->reserve(NumArguments);
+	for(size_t ArgumentIndex = 0; ArgumentIndex < NumArguments; ArgumentIndex++)
+	{
+		pvArguments->emplace_back(ppArguments[ArgumentIndex]);
+	}
+	thread_init_and_detach(EmscriptenServerThread, pvArguments, "server");
+	return true;
+}
+
+void ExecuteEmscriptenServerCommand(const char *pCommand)
+{
+	const std::unique_lock Lock(LocalServerCommandMutex);
+	vLocalServerCommandQueue.emplace_back(pCommand);
+}
+
+bool IsEmscriptenServerRunning()
+{
+	return EmscriptenServerRunning;
+}
 #endif

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -52,8 +52,8 @@
 
 using namespace std::chrono_literals;
 
-#if defined(CONF_PLATFORM_ANDROID)
-extern std::vector<std::string> FetchAndroidServerCommandQueue();
+#if defined(CONF_PLATFORM_ANDROID) || defined(CONF_PLATFORM_EMSCRIPTEN)
+extern std::vector<std::string> FetchLocalServerCommandQueue();
 #endif
 
 void CServerBan::InitServerBan(IConsole *pConsole, IStorage *pStorage, CServer *pServer)
@@ -3160,7 +3160,15 @@ int CServer::Run()
 			return -1;
 		}
 		char aFullPath[IO_MAX_PATH_LENGTH];
+#if defined(CONF_PLATFORM_EMSCRIPTEN)
+		// The save directory is backed by IDBFS, whose fsync suspends the
+		// browser main thread with Asyncify. This is not supported when the
+		// fsync is proxied from a database thread, so store the database in
+		// the in-memory filesystem instead.
+		str_format(aFullPath, sizeof(aFullPath), "/tmp/%s", Config()->m_SvSqliteFile);
+#else
 		Storage()->GetCompletePath(IStorage::TYPE_SAVE, Config()->m_SvSqliteFile, aFullPath, sizeof(aFullPath));
+#endif
 
 		if(Config()->m_SvUseSql)
 		{
@@ -3407,9 +3415,9 @@ int CServer::Run()
 
 				m_Fifo.Update();
 
-#if defined(CONF_PLATFORM_ANDROID)
-				std::vector<std::string> vAndroidCommandQueue = FetchAndroidServerCommandQueue();
-				for(const std::string &Command : vAndroidCommandQueue)
+#if defined(CONF_PLATFORM_ANDROID) || defined(CONF_PLATFORM_EMSCRIPTEN)
+				std::vector<std::string> vLocalServerCommandQueue = FetchLocalServerCommandQueue();
+				for(const std::string &Command : vLocalServerCommandQueue)
 				{
 					Console()->ExecuteLineFlag(Command.c_str(), CFGFLAG_SERVER, IConsole::CLIENT_ID_UNSPECIFIED);
 				}

--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -190,14 +190,17 @@ void SColorConfigVariable::ResetToOld()
 
 // -----
 
-SStringConfigVariable::SStringConfigVariable(IConsole *pConsole, const char *pScriptName, EVariableType Type, int Flags, const char *pHelp, char *pStr, const char *pDefault, size_t MaxSize, char *pOldValue) :
+SStringConfigVariable::SStringConfigVariable(IConsole *pConsole, const char *pScriptName, EVariableType Type, int Flags, const char *pHelp, char *pStr, const char *pDefault, size_t MaxSize, char *pOldValue, bool SetDefault) :
 	SConfigVariable(pConsole, pScriptName, Type, Flags, pHelp),
 	m_pStr(pStr),
 	m_pDefault(pDefault),
 	m_MaxSize(MaxSize),
 	m_pOldValue(pOldValue)
 {
-	str_copy(m_pStr, m_pDefault, m_MaxSize);
+	if(SetDefault)
+	{
+		str_copy(m_pStr, m_pDefault, m_MaxSize);
+	}
 	str_copy(m_pOldValue, m_pDefault, m_MaxSize);
 }
 
@@ -276,10 +279,19 @@ CConfigManager::CConfigManager()
 	m_Failed = false;
 }
 
-void CConfigManager::Init()
+void CConfigManager::Init(EInitializationType InitializationType)
 {
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
+
+	const auto &&SetDefault = [InitializationType](int Flags) {
+		// The integrated server shares the process-global config with the
+		// running client, so it only sets the defaults of the variables it
+		// exclusively owns and leaves the client's configuration untouched.
+		if(InitializationType == EInitializationType::INTEGRATED_SERVER)
+			return (Flags & (CFGFLAG_SERVER | CFGFLAG_ECON)) != 0 && (Flags & CFGFLAG_CLIENT) == 0;
+		return true;
+	};
 
 	const auto &&AddVariable = [this](SConfigVariable *pVariable) {
 		m_vpAllVariables.push_back(pVariable);
@@ -288,7 +300,7 @@ void CConfigManager::Init()
 		pVariable->Register();
 	};
 
-	const auto &&AddIntVariable = [this, AddVariable](const char *pScriptName, int Flags, const char *pDesc, int *pVariable, int Default, int Min, int Max) {
+	const auto &&AddIntVariable = [this, AddVariable, SetDefault](const char *pScriptName, int Flags, const char *pDesc, int *pVariable, int Default, int Min, int Max) {
 		dbg_assert(Min == 0 || Max == 0 || Min < Max, "MACRO_CONFIG_INT(%s): minimum (%d) must be less than maximum (%d)", pScriptName, Min, Max);
 		dbg_assert((Min == 0 || Default >= Min) && (Max == 0 || Default <= Max), "MACRO_CONFIG_INT(%s): default (%d) must be in range of minimum (%d) and maximum (%d)", pScriptName, Default, Min, Max);
 		char aHelp[512];
@@ -302,7 +314,7 @@ void CConfigManager::Init()
 		dbg_assert(HelpSize < sizeof(aHelp) - UTF8_BYTE_LENGTH - 1, "MACRO_CONFIG_INT(%s): help text possibly truncated. Increase size of aHelp.", pScriptName);
 
 		AddVariable(m_ConfigHeap.Allocate<SIntConfigVariable>(
-			m_pConsole, pScriptName, SConfigVariable::VAR_INT, Flags, m_ConfigHeap.StoreString(aHelp), pVariable, Default, Min, Max));
+			m_pConsole, pScriptName, SConfigVariable::VAR_INT, Flags, m_ConfigHeap.StoreString(aHelp), pVariable, Default, Min, Max, SetDefault(Flags)));
 	};
 
 #define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Flags, Desc) \
@@ -318,7 +330,7 @@ void CConfigManager::Init()
 		const size_t HelpSize = str_format(aHelp, sizeof(aHelp), "%s (default: $%0*X)", Desc, Alpha ? 8 : 6, color_cast<ColorRGBA>(ColorHSLA(Def, Alpha)).Pack(Alpha)); \
 		dbg_assert(HelpSize < sizeof(aHelp) - UTF8_BYTE_LENGTH - 1, "MACRO_CONFIG_COL(%s): help text possibly truncated. Increase size of aHelp.", pScriptName); \
 		AddVariable(m_ConfigHeap.Allocate<SColorConfigVariable>( \
-			m_pConsole, pScriptName, SConfigVariable::VAR_COLOR, Flags, m_ConfigHeap.StoreString(aHelp), &g_Config.m_##Name, Def)); \
+			m_pConsole, pScriptName, SConfigVariable::VAR_COLOR, Flags, m_ConfigHeap.StoreString(aHelp), &g_Config.m_##Name, Def, SetDefault(Flags))); \
 	}
 
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Flags, Desc) \
@@ -329,7 +341,7 @@ void CConfigManager::Init()
 		dbg_assert(HelpSize < sizeof(aHelp) - UTF8_BYTE_LENGTH - 1, "MACRO_CONFIG_STR(%s): help text possibly truncated. Increase size of aHelp.", pScriptName); \
 		char *pOldValue = static_cast<char *>(m_ConfigHeap.Allocate(Len)); \
 		AddVariable(m_ConfigHeap.Allocate<SStringConfigVariable>( \
-			m_pConsole, pScriptName, SConfigVariable::VAR_STRING, Flags, m_ConfigHeap.StoreString(aHelp), g_Config.m_##Name, Def, Len, pOldValue)); \
+			m_pConsole, pScriptName, SConfigVariable::VAR_STRING, Flags, m_ConfigHeap.StoreString(aHelp), g_Config.m_##Name, Def, Len, pOldValue, SetDefault(Flags))); \
 	}
 
 #include "config_variables.h"

--- a/src/engine/shared/config.h
+++ b/src/engine/shared/config.h
@@ -153,7 +153,7 @@ struct SIntConfigVariable : public SConfigVariable
 	int m_Max;
 	int m_OldValue;
 
-	SIntConfigVariable(IConsole *pConsole, const char *pScriptName, EVariableType Type, int Flags, const char *pHelp, int *pVariable, int Default, int Min, int Max) :
+	SIntConfigVariable(IConsole *pConsole, const char *pScriptName, EVariableType Type, int Flags, const char *pHelp, int *pVariable, int Default, int Min, int Max, bool SetDefault) :
 		SConfigVariable(pConsole, pScriptName, Type, Flags, pHelp),
 		m_pVariable(pVariable),
 		m_Default(Default),
@@ -161,7 +161,10 @@ struct SIntConfigVariable : public SConfigVariable
 		m_Max(Max),
 		m_OldValue(Default)
 	{
-		*m_pVariable = m_Default;
+		if(SetDefault)
+		{
+			*m_pVariable = m_Default;
+		}
 	}
 
 	~SIntConfigVariable() override = default;
@@ -184,14 +187,17 @@ struct SColorConfigVariable : public SConfigVariable
 	bool m_Alpha;
 	unsigned m_OldValue;
 
-	SColorConfigVariable(IConsole *pConsole, const char *pScriptName, EVariableType Type, int Flags, const char *pHelp, unsigned *pVariable, unsigned Default) :
+	SColorConfigVariable(IConsole *pConsole, const char *pScriptName, EVariableType Type, int Flags, const char *pHelp, unsigned *pVariable, unsigned Default, bool SetDefault) :
 		SConfigVariable(pConsole, pScriptName, Type, Flags, pHelp),
 		m_pVariable(pVariable),
 		m_Default(Default),
 		m_Alpha(Flags & CFGFLAG_COLALPHA),
 		m_OldValue(Default)
 	{
-		*m_pVariable = m_Default;
+		if(SetDefault)
+		{
+			*m_pVariable = m_Default;
+		}
 		if(Flags & CFGFLAG_COLLIGHT)
 		{
 			m_DarkestLighting = ColorHSLA::DARKEST_LGT;
@@ -225,7 +231,7 @@ struct SStringConfigVariable : public SConfigVariable
 	size_t m_MaxSize;
 	char *m_pOldValue;
 
-	SStringConfigVariable(IConsole *pConsole, const char *pScriptName, EVariableType Type, int Flags, const char *pHelp, char *pStr, const char *pDefault, size_t MaxSize, char *pOldValue);
+	SStringConfigVariable(IConsole *pConsole, const char *pScriptName, EVariableType Type, int Flags, const char *pHelp, char *pStr, const char *pDefault, size_t MaxSize, char *pOldValue, bool SetDefault);
 	~SStringConfigVariable() override = default;
 
 	static void CommandCallback(IConsole::IResult *pResult, void *pUserData);
@@ -271,7 +277,7 @@ class CConfigManager : public IConfigManager
 public:
 	CConfigManager();
 
-	void Init() override;
+	void Init(EInitializationType InitializationType) override;
 	void Reset(const char *pScriptName) override;
 	void ResetGameSettings() override;
 	void SetReadOnly(const char *pScriptName, bool ReadOnly) override;

--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -16,6 +16,8 @@
 
 #include <engine/shared/protocolglue.h>
 
+#include <mutex>
+
 const unsigned char SECURITY_TOKEN_MAGIC[4] = {'T', 'K', 'E', 'N'};
 
 SECURITY_TOKEN ToSecurityToken(const unsigned char *pData)
@@ -512,7 +514,10 @@ int CNetBase::Decompress(const void *pData, int DataSize, void *pOutput, int Out
 
 void CNetBase::Init()
 {
-	ms_Huffman.Init();
+	// May be called concurrently when client and server run in the same
+	// process, so make sure the huffman table is only initialized once.
+	static std::once_flag s_OnceFlag;
+	std::call_once(s_OnceFlag, []() { ms_Huffman.Init(); });
 }
 
 void CNetTokenCache::Init(NETSOCKET Socket)

--- a/src/game/client/components/local_server.cpp
+++ b/src/game/client/components/local_server.cpp
@@ -10,6 +10,8 @@
 
 #if defined(CONF_PLATFORM_ANDROID)
 #include <android/android_main.h>
+#elif defined(CONF_INTEGRATED_SERVER)
+#include <engine/server/emscripten_server.h>
 #else
 #include <base/process.h>
 #endif
@@ -32,6 +34,21 @@ bool CLocalServer::RunServer(const std::vector<const char *> &vpArguments)
 	else
 	{
 		Client()->AddWarning(SWarning(Localize("Server could not be started. Make sure to grant the notification permission in the app settings so the server can run in the background.")));
+		mem_zero(m_aRconPassword, sizeof(m_aRconPassword));
+		return false;
+	}
+#elif defined(CONF_INTEGRATED_SERVER)
+	// Registering is pointless as the server is only reachable within this
+	// browser tab via the in-memory loopback transport.
+	vpArgumentsWithAuth.push_back("sv_register 0");
+	if(StartEmscriptenServer(vpArgumentsWithAuth.data(), vpArgumentsWithAuth.size()))
+	{
+		GameClient()->m_Menus.ForceRefreshLanPage();
+		return true;
+	}
+	else
+	{
+		Client()->AddWarning(SWarning(Localize("Server could not be started")));
 		mem_zero(m_aRconPassword, sizeof(m_aRconPassword));
 		return false;
 	}
@@ -75,6 +92,9 @@ void CLocalServer::KillServer()
 #if defined(CONF_PLATFORM_ANDROID)
 	ExecuteAndroidServerCommand("shutdown");
 	GameClient()->m_Menus.ForceRefreshLanPage();
+#elif defined(CONF_INTEGRATED_SERVER)
+	ExecuteEmscriptenServerCommand("shutdown");
+	GameClient()->m_Menus.ForceRefreshLanPage();
 #else
 	if(m_Process != INVALID_PROCESS && process_kill(m_Process))
 	{
@@ -89,6 +109,8 @@ bool CLocalServer::IsServerRunning()
 {
 #if defined(CONF_PLATFORM_ANDROID)
 	return IsAndroidServerRunning();
+#elif defined(CONF_INTEGRATED_SERVER)
+	return IsEmscriptenServerRunning();
 #else
 	if(m_Process != INVALID_PROCESS && !process_is_alive(m_Process))
 	{

--- a/src/game/client/components/local_server.h
+++ b/src/game/client/components/local_server.h
@@ -18,7 +18,7 @@ public:
 private:
 	char m_aRconPassword[sizeof(g_Config.m_SvRconPassword)] = "";
 
-#if !defined(CONF_PLATFORM_ANDROID)
+#if !defined(CONF_PLATFORM_ANDROID) && !defined(CONF_INTEGRATED_SERVER)
 	PROCESS m_Process = INVALID_PROCESS;
 #endif
 };

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -601,8 +601,30 @@ void CGameClient::OnConnected()
 		pComponent->OnReset();
 	}
 
-	ConfigManager()->ResetGameSettings();
+	// The integrated server shares the process-global g_Config with this
+	// client, so while it is running it owns the game config variables. The
+	// client must neither restore its own values nor apply the settings of the
+	// map being loaded here, as that would change the settings of the running
+	// server, which is serving a possibly different map and whose settings may
+	// have been changed via rcon. When connected to the integrated server, the
+	// values it already loaded from its own map are the ones the client needs.
+#if defined(CONF_INTEGRATED_SERVER)
+	const bool GameSettingsOwnedByLocalServer = m_LocalServer.IsServerRunning();
+#else
+	const bool GameSettingsOwnedByLocalServer = false;
+#endif
+	if(GameSettingsOwnedByLocalServer)
+	{
+		// The map's tunings and map bugs are client-local, so they are still
+		// loaded, only the game config variables are protected.
+		ConfigManager()->SetGameSettingsReadOnly(true);
+	}
+	else
+	{
+		ConfigManager()->ResetGameSettings();
+	}
 	LoadMapSettings();
+	ConfigManager()->SetGameSettingsReadOnly(false);
 
 	if(Client()->State() != IClient::STATE_DEMOPLAYBACK)
 	{

--- a/src/test/config_test.cpp
+++ b/src/test/config_test.cpp
@@ -1,0 +1,113 @@
+#include "test.h"
+
+#include <base/str.h>
+
+#include <engine/config.h>
+#include <engine/console.h>
+#include <engine/kernel.h>
+#include <engine/shared/config.h>
+#include <engine/storage.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+static void RunConfigManagerInit(IStorage *pStorage, IConfigManager::EInitializationType InitializationType)
+{
+	std::unique_ptr<IKernel> pKernel(IKernel::Create());
+	std::unique_ptr<IConsole> pConsole = CreateConsole(CFGFLAG_SERVER);
+	std::unique_ptr<IConfigManager> pConfigManager(CreateConfigManager());
+	pKernel->RegisterInterface(pStorage, false);
+	pKernel->RegisterInterface(pConsole.get(), false);
+	pKernel->RegisterInterface(pConfigManager.get(), false);
+	pConsole->Init();
+	pConfigManager->Init(InitializationType);
+}
+
+// Reproduces what the integrated Emscripten server does while the client is
+// already running: it initializes a second CConfigManager in the same process.
+// Both config managers point at the single global g_Config, so the second
+// initialization must only set the defaults of the variables exclusive to the
+// server. Setting all defaults would reset the running client's entire
+// configuration (and the client would persist the wipe on exit); setting none
+// would leak the server settings of one local-server run into the next.
+TEST(Config, SecondConfigManagerForIntegratedServerOnlyResetsServerValues)
+{
+	CTestInfo Info;
+	std::unique_ptr<IStorage> pStorage = Info.CreateTestStorage();
+	ASSERT_TRUE(pStorage);
+
+	// The first config manager in the process sets the defaults, like the
+	// client does on startup.
+	RunConfigManagerInit(pStorage.get(), IConfigManager::EInitializationType::STANDALONE);
+
+	// The running client's settings, including a variable shared between
+	// client and server (password).
+	str_copy(g_Config.m_PlayerName, "MyName");
+	str_copy(g_Config.m_ClPlayerSkin, "pinky");
+	g_Config.m_SndVolume = 42;
+	str_copy(g_Config.m_Password, "hunter2");
+
+	// What a previous local-server run left behind.
+	str_copy(g_Config.m_SvMap, "Tutorial");
+	str_copy(g_Config.m_SvMotd, "Tutorial MOTD");
+	g_Config.m_SvHit = 0;
+	g_Config.m_EcPort = 1234;
+
+	RunConfigManagerInit(pStorage.get(), IConfigManager::EInitializationType::INTEGRATED_SERVER);
+
+	// The client's variables and shared variables keep their values.
+	EXPECT_STREQ(g_Config.m_PlayerName, "MyName");
+	EXPECT_STREQ(g_Config.m_ClPlayerSkin, "pinky");
+	EXPECT_EQ(g_Config.m_SndVolume, 42);
+	EXPECT_STREQ(g_Config.m_Password, "hunter2");
+
+	// The variables exclusive to the server are reset to their defaults.
+	EXPECT_STREQ(g_Config.m_SvMap, DefaultConfig::SvMap);
+	EXPECT_STREQ(g_Config.m_SvMotd, DefaultConfig::SvMotd);
+	EXPECT_EQ(g_Config.m_SvHit, DefaultConfig::SvHit);
+	EXPECT_EQ(g_Config.m_EcPort, DefaultConfig::EcPort);
+
+	// Initializing with all defaults resets the remaining values, which also
+	// restores the defaults for the other tests in this process.
+	RunConfigManagerInit(pStorage.get(), IConfigManager::EInitializationType::STANDALONE);
+	EXPECT_STREQ(g_Config.m_PlayerName, DefaultConfig::PlayerName);
+	EXPECT_STREQ(g_Config.m_ClPlayerSkin, DefaultConfig::ClPlayerSkin);
+	EXPECT_EQ(g_Config.m_SndVolume, DefaultConfig::SndVolume);
+	EXPECT_STREQ(g_Config.m_Password, DefaultConfig::Password);
+}
+
+// While the integrated Emscripten server is running it owns the game config
+// variables of the shared g_Config, so the client marks them read-only while
+// loading the settings of a map (a demo's or another server's map). Map
+// settings are executed with CLIENT_ID_GAME, which widens the console's flag
+// mask to reach the game variables, so this only works because the read-only
+// check is independent of the flag mask.
+TEST(Config, ReadOnlyGameSettingsCannotBeChangedByMapSettings)
+{
+	CTestInfo Info;
+	std::unique_ptr<IStorage> pStorage = Info.CreateTestStorage();
+	ASSERT_TRUE(pStorage);
+
+	std::unique_ptr<IKernel> pKernel(IKernel::Create());
+	std::unique_ptr<IConsole> pConsole = CreateConsole(CFGFLAG_CLIENT);
+	std::unique_ptr<IConfigManager> pConfigManager(CreateConfigManager());
+	pKernel->RegisterInterface(pStorage.get(), false);
+	pKernel->RegisterInterface(pConsole.get(), false);
+	pKernel->RegisterInterface(pConfigManager.get(), false);
+	pConsole->Init();
+	pConfigManager->Init(IConfigManager::EInitializationType::STANDALONE);
+
+	// The value that the running server loaded from its own map.
+	g_Config.m_SvHit = 1;
+
+	pConfigManager->SetGameSettingsReadOnly(true);
+	pConsole->ExecuteLine("sv_hit 0", IConsole::CLIENT_ID_GAME);
+	EXPECT_EQ(g_Config.m_SvHit, 1);
+
+	pConfigManager->SetGameSettingsReadOnly(false);
+	pConsole->ExecuteLine("sv_hit 0", IConsole::CLIENT_ID_GAME);
+	EXPECT_EQ(g_Config.m_SvHit, 0);
+
+	g_Config.m_SvHit = DefaultConfig::SvHit;
+}

--- a/src/test/net_test.cpp
+++ b/src/test/net_test.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <thread>
 
 using namespace std::chrono_literals;
 
@@ -53,4 +54,111 @@ TEST(Net, Ipv4AndIpv6Work)
 
 	net_udp_close(Socket1);
 	net_udp_close(Socket2);
+}
+
+TEST(Net, Loopback)
+{
+	net_loopback_set_enabled(true);
+
+	NETADDR Bindaddr = {};
+	Bindaddr.type = NETTYPE_IPV4 | NETTYPE_IPV6;
+	NETSOCKET ClientSocket = net_udp_create(Bindaddr);
+	NETSOCKET ServerSocket;
+	do
+	{
+		Bindaddr.port = secure_rand_below(65535 - 1024) + 1024;
+	} while(!(ServerSocket = net_udp_create(Bindaddr)));
+
+	NETADDR TargetV4;
+	ASSERT_FALSE(net_addr_from_str(&TargetV4, "127.0.0.1"));
+	TargetV4.port = Bindaddr.port;
+
+	NETADDR Addr;
+	unsigned char *pData;
+
+	// Client to server, reply from server to client using the sender address.
+	EXPECT_EQ(net_udp_send(ClientSocket, &TargetV4, "abc", 3), 3);
+	EXPECT_EQ(net_socket_read_wait(ServerSocket, 10s), 1);
+	ASSERT_EQ(net_udp_recv(ServerSocket, &Addr, &pData), 3);
+	EXPECT_EQ(mem_comp(pData, "abc", 3), 0);
+	EXPECT_EQ(Addr.type, NETTYPE_IPV4);
+	EXPECT_EQ(Addr.ip[0], 127);
+
+	EXPECT_EQ(net_udp_send(ServerSocket, &Addr, "def", 3), 3);
+	EXPECT_EQ(net_socket_read_wait(ClientSocket, 10s), 1);
+	ASSERT_EQ(net_udp_recv(ClientSocket, &Addr, &pData), 3);
+	EXPECT_EQ(mem_comp(pData, "def", 3), 0);
+	// The sender address must match the address the client sent to, so that
+	// connection peer address checks are consistent.
+	EXPECT_EQ(Addr, TargetV4);
+
+	// The sender address is fabricated in the family of the destination address.
+	NETADDR TargetV6;
+	ASSERT_FALSE(net_addr_from_str(&TargetV6, "[::1]"));
+	TargetV6.port = Bindaddr.port;
+	EXPECT_EQ(net_udp_send(ClientSocket, &TargetV6, "ghi", 3), 3);
+	EXPECT_EQ(net_socket_read_wait(ServerSocket, 10s), 1);
+	ASSERT_EQ(net_udp_recv(ServerSocket, &Addr, &pData), 3);
+	EXPECT_EQ(mem_comp(pData, "ghi", 3), 0);
+	EXPECT_EQ(Addr.type, NETTYPE_IPV6);
+	EXPECT_EQ(Addr.ip[15], 1);
+
+	// A waiting socket is woken up by a packet from another thread.
+	std::thread SendThread([&] {
+		std::this_thread::sleep_for(50ms);
+		net_udp_send(ClientSocket, &TargetV4, "jkl", 3);
+	});
+	const auto Start = std::chrono::steady_clock::now();
+	EXPECT_EQ(net_socket_read_wait(ServerSocket, 10s), 1);
+	EXPECT_LT(std::chrono::steady_clock::now() - Start, 5s);
+	SendThread.join();
+	ASSERT_EQ(net_udp_recv(ServerSocket, &Addr, &pData), 3);
+	EXPECT_EQ(mem_comp(pData, "jkl", 3), 0);
+
+	// Sending to a port without an in-process socket goes to the real socket
+	// instead of the loopback transport.
+	NETADDR Unbound = TargetV4;
+	Unbound.port = 1;
+	EXPECT_EQ(net_udp_send(ClientSocket, &Unbound, "mno", 3), 3);
+
+	net_udp_close(ServerSocket);
+	// After closing, its port has no in-process socket anymore either.
+	EXPECT_EQ(net_udp_send(ClientSocket, &TargetV4, "pqr", 3), 3);
+	net_udp_close(ClientSocket);
+
+	net_loopback_set_enabled(false);
+}
+
+TEST(Net, LoopbackDoesNotSwallowRealLocalhostTraffic)
+{
+	// A real socket without a loopback registration, like a server running in
+	// another process on the same machine.
+	NETADDR Bindaddr = {};
+	Bindaddr.type = NETTYPE_IPV4;
+	NETSOCKET RealSocket;
+	do
+	{
+		Bindaddr.port = secure_rand_below(65535 - 1024) + 1024;
+	} while(!(RealSocket = net_udp_create(Bindaddr)));
+
+	net_loopback_set_enabled(true);
+	NETADDR ClientBindaddr = {};
+	ClientBindaddr.type = NETTYPE_IPV4;
+	NETSOCKET ClientSocket = net_udp_create(ClientBindaddr);
+
+	// No in-process socket is bound on the target port, so the packet must
+	// reach the real socket instead of being dropped by the loopback transport.
+	NETADDR Target;
+	ASSERT_FALSE(net_addr_from_str(&Target, "127.0.0.1"));
+	Target.port = Bindaddr.port;
+	EXPECT_EQ(net_udp_send(ClientSocket, &Target, "abc", 3), 3);
+	EXPECT_EQ(net_socket_read_wait(RealSocket, 10s), 1);
+	NETADDR Addr;
+	unsigned char *pData;
+	ASSERT_EQ(net_udp_recv(RealSocket, &Addr, &pData), 3);
+	EXPECT_EQ(mem_comp(pData, "abc", 3), 0);
+
+	net_udp_close(ClientSocket);
+	net_udp_close(RealSocket);
+	net_loopback_set_enabled(false);
 }


### PR DESCRIPTION
Browsers cannot spawn processes, so the server is linked into the client binary on Emscripten and runs on a thread in the same process, mirroring how the server reuses the command queue on Android. The client talks to it through a new in-memory loopback transport at the bottom of net.cpp: sends to localhost addresses are exchanged through in-process queues, so the entire connection machinery on both sides works unchanged. This makes the start menu "Run server" button and the editor "Test map" flow work in the browser, including automatic rcon auth and server restarts.

Details:
- The loopback transport registers every UDP socket under its bound port (ephemeral ports are assigned for port 0) and fabricates sender addresses in the family of the destination address, so connection peer address checks are consistent on both sides. net_socket_read_wait waits on a condition variable and polls real sockets in short slices.
- Only the browser main thread may create real sockets: Emscripten proxies socket syscalls to the main thread, which can abort when the main thread is suspended by Asyncify.
- The server's SQLite database is stored in the in-memory filesystem instead of the IDBFS-backed save directory, because fsync on IDBFS suspends the main thread with Asyncify, which is not supported when proxied from a database thread.
- "localhost" resolves to 127.0.0.1 directly when the loopback transport is active, as Emscripten's resolver returns synthetic addresses for hostnames.
- The server classes that also exist in the client prediction code are renamed via compile definitions to avoid duplicate symbols.
- CNetBase::Init is guarded with std::call_once since client and server now initialize it concurrently in the same process.
- The server main function reuses the existing main() with the global logger setup skipped, as the client already set the process logger.

Verified end-to-end with a headless browser: start server via start menu hotkey, connect over loopback (4 ms ping), play, auto rcon auth, stop and restart the server, reconnect via localhost and 127.0.0.1. Native builds and all 353 tests unaffected, including a new loopback transport test.

I might use this for some experiments in the browser. Not reviewed.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Opus 5 and Fable 5) wrote this.