### PR TITLE
Reuse the text container buffer in CCachedText

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -2098,6 +2098,7 @@ public:
 	{
 		STextContainer &TextContainer = GetTextContainer(TextContainerIndex);
 		TextContainer.m_StringInfo.m_vCharacterQuads.clear();
+		TextContainer.m_aDebugText[0] = '\0';
 		// the text buffer gets then recreated by the appended quads
 		AppendTextContainer(TextContainerIndex, pCursor, pText, Length);
 	}

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -1585,7 +1585,10 @@ void CCachedText::Update(ITextRender *pTextRender, const char *pText, float Font
 	if(m_FontSize == FontSize && m_LineWidth == LineWidth && m_CursorFlags == CursorFlags && m_Text == pText)
 		return;
 
-	pTextRender->DeleteTextContainer(m_TextContainerIndex);
+	// The render flags of a text container are fixed when it is created and depend on the
+	// line width, so only text and font size changes can reuse the existing container and
+	// upload the new quads into its buffer instead of allocating a new one.
+	const bool ReuseContainer = m_TextContainerIndex.Valid() && m_LineWidth == LineWidth && m_CursorFlags == CursorFlags;
 
 	m_Text = pText;
 	m_FontSize = FontSize;
@@ -1600,7 +1603,10 @@ void CCachedText::Update(ITextRender *pTextRender, const char *pText, float Font
 	// The color is applied when rendering, so it must not be baked into the quads.
 	const ColorRGBA OldColor = pTextRender->GetTextColor();
 	pTextRender->TextColor(pTextRender->DefaultTextColor());
-	pTextRender->CreateTextContainer(m_TextContainerIndex, &Cursor, m_Text.c_str());
+	if(ReuseContainer)
+		pTextRender->RecreateTextContainerSoft(m_TextContainerIndex, &Cursor, m_Text.c_str());
+	else
+		pTextRender->RecreateTextContainer(m_TextContainerIndex, &Cursor, m_Text.c_str());
 	pTextRender->TextColor(OldColor);
 
 	m_BoundingBox = Cursor.BoundingBox();


### PR DESCRIPTION
Follow-up to #12463: update the existing text container buffer instead of deleting and recreating it whenever the cached text changes.

<details>
<summary>Explanation by claude</summary>

`CCachedText::Update` deleted and recreated its text container whenever the text
changed, so every score, ping or clan update in the scoreboard went through
`DeleteTextContainer` + `CreateTextContainer`. That frees and reallocates both
the buffer object and the buffer container, which on the OpenGL backend means a
`glDeleteVertexArrays` + `glGenVertexArrays` with full attribute setup per
changed string.

`RecreateTextContainerSoft` already covers this case: it clears the quads and
re-appends them, and `AppendTextContainer` uploads into the existing buffer via
`Graphics()->RecreateBufferObject` when the container already owns one. The HUD
FPS counter has been using this for a while. Use it in `CCachedText` when only
the text or the font size changed.

The container is still recreated from scratch when the line width or the cursor
flags change, since `m_RenderFlags` is only computed in `CreateTextContainer`
(from `pCursor->m_LineWidth <= 0.0f`) and the soft path would keep the stale
flags.

Also clear `m_aDebugText` in `RecreateTextContainerSoft`, so the "non empty text
container" error on window resize reports the text the container currently holds
instead of the first one it ever held.

</details>

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with ASan+UBSan or Valgrind's memcheck (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

AI reviewed the text container lifetime in `text.cpp` with me and drafted the
patch, which I checked against the backends and tested ingame.
