### PR TITLE
Ensure snapshot item offsets and sizes are aligned with `int32_t`

### DIFF
--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -152,13 +152,25 @@ bool CSnapshot::IsValid(size_t ActualSize) const
 	// validate item offsets
 	const int *pOffsets = Offsets();
 	for(int Index = 0; Index < m_NumItems; Index++)
-		if(pOffsets[Index] < 0 || pOffsets[Index] > m_DataSize)
+	{
+		if(pOffsets[Index] < 0 ||
+			pOffsets[Index] > m_DataSize ||
+			pOffsets[Index] % sizeof(int32_t) != 0)
+		{
 			return false;
+		}
+	}
 
 	// validate item sizes
 	for(int Index = 0; Index < m_NumItems; Index++)
-		if(GetItemSize(Index) < 0) // the offsets must be validated before using this
+	{
+		const int ItemSize = GetItemSize(Index); // the offsets must be validated before using this
+		if(ItemSize < 0 ||
+			ItemSize % sizeof(int32_t) != 0)
+		{
 			return false;
+		}
+	}
 
 	return true;
 }
@@ -878,7 +890,7 @@ void *CSnapshotBuilder::NewItemRaw(int Type, int Id, int Size)
 	const bool Extended = Type >= OFFSET_UUID;
 	dbg_assert((Type >= 0 && Type <= CSnapshot::MAX_TYPE) || Extended || (m_Sixup && Type >= -CSnapshot::MAX_TYPE && Type < 0), "Invalid snap item Type: %d", Type);
 	dbg_assert(Id >= 0 && Id <= CSnapshot::MAX_ID, "Invalid snap item Id: %d", Id);
-	dbg_assert(Size >= 0 && (size_t)Size <= CSnapshot::MAX_SIZE - sizeof(CSnapshot) - sizeof(CSnapshotItem) - sizeof(int), "Invalid snap item Size: %d", Size);
+	dbg_assert(Size >= 0 && (size_t)Size <= CSnapshot::MAX_SIZE - sizeof(CSnapshot) - sizeof(CSnapshotItem) - sizeof(int) && Size % sizeof(int32_t) == 0, "Invalid snap item Size: %d", Size);
 
 	if(m_NumItems >= CSnapshot::MAX_ITEMS)
 	{


### PR DESCRIPTION
Fix member calls with misaligned address for type `CSnapshotItem`. Found by fuzzing snapshot validation and delta unpacking with AFL++.

```
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ddnet/src/engine/shared/snapshot.cpp:539:35 in
ddnet/src/engine/shared/snapshot.cpp:539:35: runtime error: member call on misaligned address 0x60c00000012a for type 'CSnapshotItem', which requires 4 byte alignment
0x60c00000012a: note: pointer points here
 01 01  01 01 01 01 01 93 01 0f  01 01 01 01 01 01 01 01  01 01 01 01 01 01 01 00  00 00 01 00 00 00
              ^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ddnet/src/engine/shared/snapshot.cpp:920:8 in
ddnet/src/engine/shared/snapshot.cpp:539:35: runtime error: member call on misaligned address 0x60c00000014a for type 'CSnapshotItem', which requires 4 byte alignment
0x60c00000014a: note: pointer points here
 01 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00
              ^
```

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions