### PR TITLE
Fix snapshot crash

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1039,7 +1039,8 @@ void CClient::RenderDebug()
 				Row++;
 			}
 		}
-		for(int i = CSnapshot::MAX_TYPE; i > (CSnapshot::MAX_TYPE - 64); i--)
+		// Extended item types count down from 0x7fff
+		for(int i = 0x7fff; i > (0x7fff - 64); i--)
 		{
 			if(SnapshotDelta()->GetDataRate(i) && m_aapSnapshots[g_Config.m_ClDummy][IClient::SNAP_CURRENT])
 			{

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -132,7 +132,7 @@ private:
 
 	// Depending on the chunk header
 	// this is either a full CSnapshot or a CSnapshotDelta.
-	unsigned char m_aChunkData[CSnapshot::MAX_SIZE];
+	alignas(int32_t) unsigned char m_aChunkData[CSnapshot::MAX_SIZE];
 	// Storage for the full snapshot
 	// where the delta gets unpacked into.
 	CSnapshotBuffer m_Snapshot;

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -430,7 +430,7 @@ int CSnapshotDelta::DebugDumpDelta(const void *pSrcData, int DataSize)
 	// (all other items should be copied from the last full snap)
 	for(int d = 0; d < pDelta->m_NumDeletedItems; d++)
 	{
-		int Type = pDeleted[d] >> 16;
+		int Type = (pDeleted[d] >> 16) & 0xffff;
 		int Id = pDeleted[d] & 0xffff;
 		dbg_msg("delta_dump", "  %3d %12d %08x deleted Type=%d Id=%d", DumpIndex++, pDeleted[d], pDeleted[d], Type, Id);
 	}
@@ -824,7 +824,9 @@ int CSnapshotBuilder::Finish(CSnapshotBuffer *pBuffer)
 
 int CSnapshotBuilder::GetTypeFromIndex(int Index) const
 {
-	return CSnapshot::MAX_TYPE - Index;
+	// Extended item types count down from 0x7fff, which is the highest item
+	// type id supported by earlier versions.
+	return 0x7fff - Index;
 }
 
 bool CSnapshotBuilder::AddExtendedItemType(int Index)
@@ -931,7 +933,7 @@ void *CSnapshotBuilder::NewItemRaw(int Type, int Id, int Size)
 	else if(Type < 0)
 		return nullptr;
 
-	pObj->m_TypeAndId = (Type << 16) | Id;
+	pObj->m_TypeAndId = ((unsigned)Type << 16) | (unsigned)Id;
 	m_aOffsets[m_NumItems] = m_DataSize;
 	m_DataSize += ItemSize;
 	m_NumItems++;

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -19,7 +19,7 @@ public:
 	int m_TypeAndId;
 
 	const int *Data() const { return (int *)(this + 1); }
-	int InternalType() const { return m_TypeAndId >> 16; }
+	int InternalType() const { return (m_TypeAndId >> 16) & 0xffff; }
 	int Id() const { return m_TypeAndId & 0xffff; }
 	int Key() const { return m_TypeAndId; }
 	void Invalidate() { m_TypeAndId = -1; }
@@ -43,7 +43,10 @@ public:
 	enum
 	{
 		OFFSET_UUID_TYPE = 0x4000,
-		MAX_TYPE = 0x7fff,
+		// The item type is the upper 16 bits of the item key, so any item key
+		// results in a valid item type. Earlier versions only used to support
+		// item type ids up to 0x7fff.
+		MAX_TYPE = 0xffff,
 		MAX_ID = 0xffff,
 		MAX_ITEMS = 1024,
 		MAX_PARTS = 64,
@@ -167,7 +170,7 @@ class CSnapshotBuilder
 		MAX_EXTENDED_ITEM_TYPES = 64,
 	};
 
-	char m_aData[CSnapshot::MAX_SIZE];
+	alignas(int32_t) char m_aData[CSnapshot::MAX_SIZE];
 	int m_DataSize;
 
 	int m_aOffsets[CSnapshot::MAX_ITEMS];


### PR DESCRIPTION
Closes: #12560

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Opus 5 and Fable 5) wrote this, I reviewed
