### PR TITLE
Rename `NET_MAX_PAYLOAD` to disentangle its uses

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2466,7 +2466,7 @@ void CServer::CacheServerInfo(CCache *pCache, int Type, bool SendClients)
 
 			if(Type == SERVERINFO_EXTENDED)
 			{
-				if(q.Size() >= NET_MAX_PAYLOAD - 18) // 8 bytes for type, 10 bytes for the largest token
+				if(q.Size() >= NET_MAX_CONNLESS_PAYLOAD - 18) // 8 bytes for type, 10 bytes for the largest token
 				{
 					// Retry current player.
 					i--;
@@ -2557,7 +2557,7 @@ void CServer::CacheServerInfoSixup(CCache *pCache, bool SendClients, int MaxCons
 				Packer.AddInt(m_aClients[i].m_Score.value_or(-1)); // client score
 				Packer.AddInt(GameServer()->IsClientPlayer(i) ? 0 : 1); // flag spectator=1, bot=2 (player=0)
 
-				const int MaxPacketSize = NET_MAX_PAYLOAD - 128;
+				const int MaxPacketSize = NET_MAX_CONNLESS_PAYLOAD - 128;
 				if(MaxConsideredClients == MAX_CLIENTS)
 				{
 					if(Packer.Size() > MaxPacketSize - 32) // -32 because repacking will increase the length of the name
@@ -2940,7 +2940,7 @@ void CServer::PumpNetwork(bool PacketWaiting)
 		}
 	}
 	{
-		unsigned char aBuffer[NET_MAX_PAYLOAD];
+		unsigned char aBuffer[NET_MAX_CHUNK_SIZE];
 		int Flags;
 		mem_zero(&Packet, sizeof(Packet));
 		Packet.m_pData = aBuffer;

--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -28,6 +28,18 @@ void WriteSecurityToken(unsigned char *pData, SECURITY_TOKEN Token)
 	uint_to_bytes_be(pData, Token);
 }
 
+void CNetChunk::AssertSizeSanity() const
+{
+	if(m_Flags & NETSENDFLAG_CONNLESS)
+	{
+		dbg_assert(m_DataSize <= NET_MAX_CONNLESS_PAYLOAD, "connless packet too large, size=%d", m_DataSize);
+	}
+	else
+	{
+		dbg_assert(m_DataSize <= NET_MAX_CHUNK_SIZE, "chunk too large, size=%d", m_DataSize);
+	}
+}
+
 void CPacketChunkUnpacker::FeedPacket(const NETADDR &Addr, const CNetPacketConstruct &Packet, CNetConnection *pConnection, int ClientId)
 {
 	dbg_assert(!m_Valid, "Chunk unpacker is already unpacking");
@@ -308,6 +320,7 @@ int CNetBase::UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct
 		pPacket->m_Ack = 0;
 		pPacket->m_NumChunks = 0;
 		pPacket->m_DataSize = Size - Offset;
+		dbg_assert((size_t)pPacket->m_DataSize <= sizeof(pPacket->m_aChunkData), "invalid packet size reached mem_copy, size=%d", pPacket->m_DataSize);
 		mem_copy(pPacket->m_aChunkData, pBuffer + Offset, pPacket->m_DataSize);
 
 		if(!Sixup && mem_comp(pBuffer, NET_HEADER_EXTENDED, sizeof(NET_HEADER_EXTENDED)) == 0)
@@ -351,10 +364,7 @@ int CNetBase::UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct
 		}
 		else
 		{
-			if(pPacket->m_DataSize > (int)sizeof(pPacket->m_aChunkData))
-			{
-				return -1;
-			}
+			dbg_assert((size_t)pPacket->m_DataSize <= sizeof(pPacket->m_aChunkData), "invalid packet size reached mem_copy, size=%d", pPacket->m_DataSize);
 			mem_copy(pPacket->m_aChunkData, &pBuffer[DataStart], pPacket->m_DataSize);
 		}
 	}

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -66,7 +66,7 @@ enum
 enum
 {
 	NET_MAX_PACKETSIZE = 1400,
-	NET_MAX_PAYLOAD = NET_MAX_PACKETSIZE - 6,
+	NET_MAX_CONNLESS_PAYLOAD = NET_MAX_PACKETSIZE - 6,
 	/**
 	 * The maximum size of a chunk within a connection-oriented packet.
 	 *
@@ -146,6 +146,8 @@ struct CNetChunk
 	const void *m_pData;
 	// only used if the flags contain NETSENDFLAG_EXTENDED and NETSENDFLAG_CONNLESS
 	unsigned char m_aExtraData[NET_CONNLESS_EXTRA_SIZE];
+
+	void AssertSizeSanity() const;
 };
 
 class CNetChunkHeader
@@ -178,7 +180,7 @@ public:
 	int m_Ack;
 	int m_NumChunks;
 	int m_DataSize;
-	unsigned char m_aChunkData[NET_MAX_PAYLOAD];
+	unsigned char m_aChunkData[NET_MAX_PACKETSIZE - NET_PACKETHEADERSIZE];
 	unsigned char m_aExtraData[NET_CONNLESS_EXTRA_SIZE];
 };
 
@@ -571,7 +573,7 @@ private:
 	public:
 		NETADDR m_Addr;
 		int m_DataSize;
-		unsigned char m_aData[NET_MAX_PAYLOAD];
+		unsigned char m_aData[NET_MAX_CONNLESS_PAYLOAD];
 		int64_t m_Expiry;
 	};
 

--- a/src/engine/shared/network_client.cpp
+++ b/src/engine/shared/network_client.cpp
@@ -146,11 +146,7 @@ int CNetClient::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken, bool Six
 
 int CNetClient::Send(CNetChunk *pChunk)
 {
-	if(pChunk->m_DataSize >= NET_MAX_PAYLOAD)
-	{
-		dbg_msg("netclient", "chunk payload too big. %d. dropping chunk", pChunk->m_DataSize);
-		return -1;
-	}
+	pChunk->AssertSizeSanity();
 
 	if(pChunk->m_Flags & NETSENDFLAG_CONNLESS)
 	{

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -707,11 +707,7 @@ int CNetServer::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken)
 
 int CNetServer::Send(CNetChunk *pChunk)
 {
-	if(pChunk->m_DataSize >= NET_MAX_PAYLOAD)
-	{
-		dbg_msg("netserver", "packet payload too big. %d. dropping packet", pChunk->m_DataSize);
-		return -1;
-	}
+	pChunk->AssertSizeSanity();
 
 	if(pChunk->m_Flags & NETSENDFLAG_CONNLESS)
 	{

--- a/src/game/client/sixup_translate_connless.cpp
+++ b/src/game/client/sixup_translate_connless.cpp
@@ -98,7 +98,7 @@ bool CClient::PreprocessConnlessPacket7(CNetChunk *pPacket)
 			}
 		}
 
-		if(Packer.Error() || SERVERBROWSE_SIZE + Packer.Size() > NET_MAX_PAYLOAD)
+		if(Packer.Error() || SERVERBROWSE_SIZE + Packer.Size() > NET_MAX_CONNLESS_PAYLOAD)
 		{
 			return false;
 		}

--- a/src/test/network_test.cpp
+++ b/src/test/network_test.cpp
@@ -17,11 +17,11 @@ TEST(Network, UnpackMaximumUncompressedPacket)
 	CNetPacketConstruct Packet;
 	EXPECT_EQ(UnpackUncompressedPacket(NET_PACKETHEADERSIZE + (int)sizeof(Packet.m_aChunkData), &Packet), 0);
 	EXPECT_EQ(Packet.m_DataSize, (int)sizeof(Packet.m_aChunkData));
+	EXPECT_EQ(UnpackUncompressedPacket(NET_MAX_PACKETSIZE, &Packet), 0);
 }
 
 TEST(Network, UnpackOversizedUncompressedPacket)
 {
 	CNetPacketConstruct Packet;
 	EXPECT_EQ(UnpackUncompressedPacket(NET_PACKETHEADERSIZE + (int)sizeof(Packet.m_aChunkData) + 1, &Packet), -1);
-	EXPECT_EQ(UnpackUncompressedPacket(NET_MAX_PACKETSIZE, &Packet), -1);
 }


### PR DESCRIPTION
- The maximum chunk size already had a name, `NET_MAX_CHUNK_SIZE`.
- Allow the full `NET_PACKETSIZE` for uncompressed connection-oriented packets.
- `dbg_assert` that sizes were correctly checked earlier in `CNetBase::UnpackPacket`

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
