### PR TITLE
Scale conn_timeout with the integration test timeout multiplier

### DIFF
--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -127,6 +127,11 @@ class TestRunner:
 		self.valgrind_memcheck = valgrind_memcheck
 		if self.valgrind_memcheck:
 			self.timeout_multiplier *= 25
+		# `conn_timeout` is wall clock inside the engine, so it has to be scaled like
+		# the test timeouts, otherwise a slowed down client or server drops its own
+		# connection while the test is still waiting. 100 is the default of the config
+		# variable, 1000 its maximum.
+		self.conn_timeout = min(1000, round(100 * self.timeout_multiplier))
 
 	def run_test(self, test):
 		tmp_dir = tempfile.mkdtemp(prefix=f"integration_{test.name}_", dir=self.test_dir)
@@ -466,6 +471,7 @@ class Client(Runnable):
 				f"cl_input_fifo {self.fifo_name}",
 				"gfx_fullscreen 0",
 				"cl_save_settings 0",
+				f"conn_timeout {test_env.runner.conn_timeout}",
 			]
 			+ extra_args,
 		)
@@ -497,6 +503,7 @@ class Server(Runnable):
 				test_env.ddnet_server,
 				f"sv_input_fifo {self.fifo_name}",
 				"sv_register 0",
+				f"conn_timeout {test_env.runner.conn_timeout}",
 			]
 			+ extra_args,
 		)


### PR DESCRIPTION
Scale `conn_timeout` with the integration test timeout multiplier, so a client or server slowed down by Valgrind stops dropping its own connection while the test is still waiting for it.

<details>
<summary>longer explanation, written by Claude</summary>

`smoke_test` has failed three times in the last few days, always on `build-cmake (ubuntu-latest-fancy)`, the only job that runs the suite under Valgrind Memcheck and gcov:

- https://github.com/ddnet/ddnet/actions/runs/31469576631/job/93709804390
- https://github.com/ddnet/ddnet/actions/runs/31494116963/job/93787455734
- https://github.com/ddnet/ddnet/actions/runs/31580018895/job/94060766834

Every one is the same stall. The client connects to the local server, reaches state 2, never reaches state 3, and then the connection dies:

```
09:26:11 client: connecting to 'localhost:8303'
09:27:03 client: connected, sending info
09:29:59 client: offline error='Too weak connection (not acked for 100 seconds)'
```

```
14:10:42 client: connected, sending info
14:18:47 client: offline error='Timeout'
```

Both of those errors come from `g_Config.m_ConnTimeout` in `CNetConnection::Update`, which is 100 seconds of wall clock. `TestRunner` multiplies its own timeouts by 25 under Valgrind, but nothing scaled the engine's deadline, so an instrumented client can kill the connection while the Python side still has most of its budget left.

That is also why raising the Python timeouts does not help. The middle run already had `timeout=30` on the `client: state change. last=2 current=3` wait, giving the harness 750 seconds; the client gave up 408 seconds in, with almost six minutes of that budget unused.

`conn_timeout` maxes out at 1000, so the Valgrind run gets 1000 instead of 100 and a plain run is unchanged.

Verified locally against a `-DHEADLESS_CLIENT=ON` build: the full suite still passes, both binaries accept the argument, and the derived value is 100 without the multiplier and 1000 with it. I could not run the Valgrind path itself, valgrind is not installed on the machine I tested on, so that side rests on the CI logs above and on this PR's own run.

One thing I did not touch: the test clients still fetch the live serverlist from master1 to master4, which cost 25 seconds on one master and a stalled transfer on another in the most recent failure. Dropping a `ddnet-serverlist-urls.cfg` into the client tmp dir would take that out of the loop, but the masters answered in under a second in the two older failures, so it is an aggravator rather than the cause.

</details>

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude investigated the CI failures, wrote this change and the collapsed explanation above.
