### PR TITLE
server: Support clients based on old DDNet

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1034,6 +1034,10 @@ void CServer::DoSnapshot()
 		if(m_aClients[i].m_State != CClient::STATE_INGAME)
 			continue;
 
+		// don't send snapshots to clients that haven't identified as DDNet-based yet, can crash them.
+		if(!m_aClients[i].m_Sixup && m_aClients[i].m_DDNetVersion < VERSION_DDNET_OLD)
+			continue;
+
 		// this client is trying to recover, don't spam snapshots
 		if(m_aClients[i].m_SnapRate == CClient::SNAPRATE_RECOVER && (Tick() % TickSpeed()) != 0)
 			continue;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1229,6 +1229,16 @@ void CGameContext::OnTick()
 	{
 		if(m_apPlayers[i])
 		{
+			// By supporting 128 players with full backwards compatibility (in +spectate menu too), it's basically impossible and
+			// really unnecessary to have old 16 player clients supported
+			IServer::CClientInfo Info;
+			if(Server()->Tick() >= m_apPlayers[i]->m_DDNetVersionKickTick && !Server()->IsSixup(i) &&
+				Server()->GetClientInfo(i, &Info) && Info.m_DDNetVersion < VERSION_DDNET_OLD)
+			{
+				Server()->Kick(i, "Old Teeworlds 0.6 versions are unsupported. Use DDNet client or Teeworlds 0.7");
+				continue;
+			}
+
 			// send vote options
 			ProgressVoteOptions(i);
 
@@ -1771,16 +1781,12 @@ void CGameContext::OnClientEnter(int ClientId)
 	if(Server()->GetClientInfo(ClientId, &Info))
 	{
 		// 0.7 clients can send ddnet message, F-Client does that for example
-		if(!Info.m_GotDDNetVersion && !Server()->IsSixup(ClientId))
+		if(Info.m_GotDDNetVersion)
 		{
-			// By supporting 128 players with full backwards compatibility (in +spectate menu too), it's basically impossible and
-			// really unnecessary to have old 16 player clients supported
-			Server()->Kick(ClientId, "Old Teeworlds 0.6 versions are unsupported. Use DDNet client or Teeworlds 0.7");
-			return;
-		}
-		else if(OnClientDDNetVersionKnown(ClientId))
-		{
-			return; // kicked
+			if(OnClientDDNetVersionKnown(ClientId))
+			{
+				return; // kicked
+			}
 		}
 	}
 

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -51,6 +51,7 @@ void CPlayer::Reset()
 	m_DieTick = Server()->Tick();
 	m_PreviousDieTick = m_DieTick;
 	m_JoinTick = Server()->Tick();
+	m_DDNetVersionKickTick = Server()->Tick() + 3 * Server()->TickSpeed();
 	delete m_pCharacter;
 	m_pCharacter = nullptr;
 	SetSpectatorId(SPEC_FREEVIEW);

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -231,6 +231,9 @@ public:
 	bool m_EyeEmoteEnabled;
 	int m_TimerType;
 
+	// Tick at which to kick the client if it still hasn't identified as a DDNet-based client
+	int m_DDNetVersionKickTick;
+
 	int GetDefaultEmote() const;
 	void OverrideDefaultEmote(int Emote, int Tick);
 	bool CanOverrideDefaultEmote() const;


### PR DESCRIPTION
Reported by ChillerDragon on Discord: https://discord.com/channels/252358080522747904/293493549758939136/1537059984179859486 CC @fokkonaut 

One concern is that not all of them might support 64 players, impossible to find out since they didn't send version number.

On Teeworlds 0.6.5 we now don't crash anymore:
<img width="3440" height="1440" alt="Screenshot 2026-08-14 at 14 06 43" src="https://github.com/user-attachments/assets/562b73d6-663d-4687-ac42-0f7b015576a4" />

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Fable 5) wrote this, I reviewed