### PR TITLE
serverbrowser: reset prepared sqlite statement

### DIFF
--- a/src/engine/client/serverbrowser_ping_cache.cpp
+++ b/src/engine/client/serverbrowser_ping_cache.cpp
@@ -72,6 +72,7 @@ void CServerBrowserPingCache::Load()
 		bool Error = false;
 		bool WarnedForBadAddress = false;
 		Error = Error || !m_pLoadStmt;
+		Error = Error || SQLITE_HANDLE_ERROR(sqlite3_reset(m_pLoadStmt.get())) != SQLITE_OK;
 		while(!Error)
 		{
 			int StepResult = SQLITE_HANDLE_ERROR(sqlite3_step(m_pLoadStmt.get()));


### PR DESCRIPTION
This error kept annoying me:
```
2026-08-12 17:14:50 E sqlite3: no more rows available at sqlite3_step(m_pLoadStmt.get())
```
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Opus 5) wrote this, I reviewed.
