### PR TITLE
Fix rejoin with 128 player translation

### DIFF
--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -733,7 +733,7 @@ def smoke_test(test_env):
 	client1.command("stdout_output_level 2; loglevel 2")
 	client1.command(f"connect localhost:{server.port}")
 	server.wait_for_log_prefix("server: player has entered the game", timeout=10)
-	client1.wait_for_log_exact("client: state change. last=2 current=3", timeout=30)
+	client1.wait_for_log_exact("client: state change. last=3 current=4", timeout=30)
 	client1.command("stdout_output_level 0; loglevel 0")
 	client1.command("debug 0")
 	client1.command("record client1")

--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -10,7 +10,9 @@ import io
 import json
 import os
 import queue
+import select
 import shutil
+import socket
 import sqlite3
 import subprocess
 import sys
@@ -360,7 +362,9 @@ def run_test_timeout_thread(name, test_env, input_queue, param):
 
 
 class Runnable:
-	def __init__(self, test_env, name, args, *, extra_env_vars={}, log_is_stderr=False, allow_unclean_exit=False):  # noqa: B006 mutable-default-arguments
+	def __init__(self, test_env, name, args, *, extra_env_vars=None, log_is_stderr=False, allow_unclean_exit=False):
+		if extra_env_vars is None:
+			extra_env_vars = {}
 		self.name = name
 		cur_env_vars = dict(os.environ)
 		intersection = set(cur_env_vars) & (set(test_env.runner.extra_env_vars) | set(extra_env_vars))
@@ -457,7 +461,9 @@ def open_fifo(name):
 
 
 class Client(Runnable):
-	def __init__(self, test_env, extra_args=[]):  # noqa: B006 mutable-default-arguments
+	def __init__(self, test_env, extra_args=None, *, allow_unclean_exit=False):
+		if extra_args is None:
+			extra_args = []
 		name = f"client{test_env.num_clients}"
 		self.fifo_name, self.fifo_path = fifo_name_path(test_env, name)
 		# Delay opening the FIFO until the client has started, because it will
@@ -474,6 +480,7 @@ class Client(Runnable):
 				f"conn_timeout {test_env.runner.conn_timeout}",
 			]
 			+ extra_args,
+			allow_unclean_exit=allow_unclean_exit,
 		)
 		test_env.num_clients += 1
 
@@ -490,7 +497,9 @@ class Client(Runnable):
 
 
 class Server(Runnable):
-	def __init__(self, test_env, extra_args=[]):  # noqa: B006 mutable-default-arguments
+	def __init__(self, test_env, extra_args=None):
+		if extra_args is None:
+			extra_args = []
 		name = f"server{test_env.num_servers}"
 		self.fifo_name, self.fifo_path = fifo_name_path(test_env, name)
 		# Delay opening the FIFO until the server has started, because it will
@@ -533,7 +542,9 @@ class Server(Runnable):
 
 
 class Mastersrv(Runnable):
-	def __init__(self, test_env, extra_args=[], config=None, communities_json=None):  # noqa: B006 mutable-default-arguments
+	def __init__(self, test_env, extra_args=None, config=None, communities_json=None):
+		if extra_args is None:
+			extra_args = []
 		name = f"mastersrv{test_env.num_mastersrvs}"
 		if communities_json is not None:
 			communities_json_filename = f"{name}-communities.json"
@@ -589,6 +600,35 @@ json = {communities_json_filename!r}
 
 	def servers_json(self):
 		return json.loads(urlopen(f"http://[::1]:{self.port}/ddnet/15/test-servers.json").read())
+
+
+class UdpRelay:
+	"""Keeps the address a server sees stable across client restarts."""
+
+	def __init__(self, server_port):
+		self.server_addr = ("127.0.0.1", server_port)
+		self.from_client = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+		self.from_client.bind(("127.0.0.1", 0))
+		self.to_server = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+		self.to_server.bind(("127.0.0.1", 0))
+		self.port = self.from_client.getsockname()[1]
+		Thread(name="udp_relay", target=self.run, daemon=True).start()
+
+	def run(self):
+		client_addr = None
+		while True:
+			ready, _, _ = select.select([self.from_client, self.to_server], [], [])
+			for sock in ready:
+				try:
+					data, addr = sock.recvfrom(65535)
+					if sock is self.from_client:
+						client_addr = addr
+						self.to_server.sendto(data, self.server_addr)
+					elif client_addr is not None:
+						self.from_client.sendto(data, client_addr)
+				except OSError:
+					# The client is gone while it is being restarted.
+					pass
 
 
 ALL_TESTS = []
@@ -689,6 +729,44 @@ def client_can_connect_7(test_env):
 	client.exit()
 	server.wait_for_exit()
 	client.wait_for_exit()
+
+
+@test
+def client_can_rejoin_existing_slot(test_env):
+	server = test_env.server()
+	wait_for_startup([server])
+	relay = UdpRelay(server.port)
+
+	client = test_env.client(["player_name rejoiner"], allow_unclean_exit=True)
+	wait_for_startup([client])
+	client.command(f"connect 127.0.0.1:{relay.port}")
+	server.wait_for_log_prefix("server: player has entered the game", timeout=10)
+
+	# Kill instead of disconnect so the server keeps the slot and the reconnect
+	# goes through `CServer::ClientRejoinCallback`.
+	client.process.kill()
+
+	rejoined = test_env.client(["player_name rejoiner"])
+	wait_for_startup([rejoined])
+	rejoined.command("debug 1")
+	rejoined.command("stdout_output_level 2; loglevel 2")
+	rejoined.command(f"connect 127.0.0.1:{relay.port}")
+	rejoined.wait_for_log_exact("client: state change. last=3 current=4", timeout=30)
+	rejoined.command("stdout_output_level 0; loglevel 0")
+	rejoined.command("debug 0")
+
+	# If the rejoin lost the client version or the player id map, the server
+	# cannot translate the client's own id and the line arrives as
+	# " : rejoiner: hello" from the nameless placeholder client.
+	rejoined.command("say hello")
+	server.wait_for_log_suffix("rejoiner: hello", timeout=15)
+	rejoined.wait_for_log_exact("chat/all: rejoiner: hello", timeout=15)
+
+	server.exit()
+	rejoined.wait_for_log_exact("client: offline error='Server shutdown'")
+	rejoined.exit()
+	server.wait_for_exit()
+	rejoined.wait_for_exit()
 
 
 @test(requires_websockets=True)

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -46,6 +46,7 @@ public:
 		STATE_OFFLINE - The client is offline.
 		STATE_CONNECTING - The client is trying to connect to a server.
 		STATE_LOADING - The client has connected to a server and is loading resources.
+		STATE_READY - The client has initialized the game logic, waiting for the first snapshot.
 		STATE_ONLINE - The client is connected to a server and running the game.
 		STATE_DEMOPLAYBACK - The client is playing a demo
 		STATE_QUITTING - The client is quitting.
@@ -56,6 +57,7 @@ public:
 		STATE_OFFLINE = 0,
 		STATE_CONNECTING,
 		STATE_LOADING,
+		STATE_READY,
 		STATE_ONLINE,
 		STATE_DEMOPLAYBACK,
 		STATE_QUITTING,

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1591,6 +1591,11 @@ static CServerCapabilities GetServerCapabilities(int Version, int Flags, bool Si
 
 void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 {
+	if(State() >= IClient::STATE_QUITTING)
+	{
+		return;
+	}
+
 	CUnpacker Unpacker;
 	Unpacker.Reset(pPacket->m_pData, pPacket->m_DataSize);
 	CMsgPacker Packer(NETMSG_EX, true);
@@ -1854,6 +1859,10 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 				return;
 			}
 			GameClient()->OnConnected();
+			if(State() == IClient::STATE_LOADING)
+			{
+				SetState(IClient::STATE_READY);
+			}
 			if(m_DummyReconnectOnReload)
 			{
 				m_DummySendConnInfo = true;
@@ -2057,8 +2066,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 		else if(Msg == NETMSG_SNAP || Msg == NETMSG_SNAPSINGLE || Msg == NETMSG_SNAPEMPTY)
 		{
 			// We are not allowed to process snapshots yet.
-			if(State() < IClient::STATE_LOADING ||
-				!GameClient()->Map()->IsLoaded())
+			if(State() < IClient::STATE_READY)
 			{
 				return;
 			}

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -587,7 +587,9 @@ static void GenerateTimeoutCode(char *pBuffer, unsigned Size, char *pSeed, const
 	md5_update(&Md5, (unsigned char *)pSeed, str_length(pSeed) + 1);
 	for(int i = 0; i < NumAddrs; i++)
 	{
-		md5_update(&Md5, (unsigned char *)&pAddrs[i], sizeof(pAddrs[i]));
+		md5_update(&Md5, (unsigned char *)&pAddrs[i].type, sizeof(pAddrs[i].type));
+		md5_update(&Md5, (unsigned char *)pAddrs[i].ip, sizeof(pAddrs[i].ip));
+		md5_update(&Md5, (unsigned char *)&pAddrs[i].port, sizeof(pAddrs[i].port));
 	}
 	MD5_DIGEST Digest = md5_finish(&Md5);
 

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -338,7 +338,9 @@ int CServerBrowser::GenerateToken(const NETADDR &Addr) const
 	SHA256_CTX Sha256;
 	sha256_init(&Sha256);
 	sha256_update(&Sha256, m_aTokenSeed, sizeof(m_aTokenSeed));
-	sha256_update(&Sha256, (unsigned char *)&Addr, sizeof(Addr));
+	sha256_update(&Sha256, (unsigned char *)&Addr.type, sizeof(Addr.type));
+	sha256_update(&Sha256, (unsigned char *)Addr.ip, sizeof(Addr.ip));
+	sha256_update(&Sha256, (unsigned char *)&Addr.port, sizeof(Addr.port));
 	SHA256_DIGEST Digest = sha256_finish(&Sha256);
 	return (Digest.data[0] << 16) | (Digest.data[1] << 8) | Digest.data[2];
 }

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -233,7 +233,10 @@ void CServer::CClient::Reset()
 	m_NextMapChunk = 0;
 	m_Flags = 0;
 	m_RedirectDropTime = 0;
+}
 
+void CServer::CClient::ResetIdMap()
+{
 	std::fill(std::begin(m_aIdMap), std::end(m_aIdMap), -1);
 	std::fill(std::begin(m_aReverseIdMap), std::end(m_aReverseIdMap), -1);
 }
@@ -1167,10 +1170,14 @@ int CServer::ClientRejoinCallback(int ClientId, void *pUser)
 	pThis->m_aClients[ClientId].m_AuthKey = -1;
 	pThis->m_aClients[ClientId].m_pRconCmdToSend = nullptr;
 	pThis->m_aClients[ClientId].m_MaplistEntryToSend = CClient::MAPLIST_UNINITIALIZED;
-	pThis->m_aClients[ClientId].m_DDNetVersion = VERSION_NONE;
-	pThis->m_aClients[ClientId].m_GotDDNetVersionPacket = false;
-	pThis->m_aClients[ClientId].m_DDNetVersionSettled = false;
 
+	// Do not clear the client version and the player id map here. The client keeps
+	// its session, so `OnClientEnter` will not be called again for it, and neither
+	// the resent `NETMSG_CLIENTVER` (ignored outside of `STATE_PREAUTH`) nor
+	// `CPlayerMapping::CPlayerMap::InitPlayer` would ever restore them. A client
+	// without version is treated as a vanilla client whose ids go through the id
+	// map, and an empty id map makes `Translate` fail for every id including the
+	// client's own one, which hides the client from itself entirely.
 	pThis->m_aClients[ClientId].Reset();
 
 	pThis->GameServer()->TeehistorianRecordPlayerRejoin(ClientId);
@@ -1211,6 +1218,7 @@ int CServer::NewClientNoAuthCallback(int ClientId, void *pUser)
 	pThis->m_aClients[ClientId].m_GotDDNetVersionPacket = false;
 	pThis->m_aClients[ClientId].m_DDNetVersionSettled = false;
 	pThis->m_aClients[ClientId].Reset();
+	pThis->m_aClients[ClientId].ResetIdMap();
 
 	pThis->GameServer()->TeehistorianRecordPlayerJoin(ClientId, false);
 	pThis->Antibot()->OnEngineClientJoin(ClientId);
@@ -1245,6 +1253,7 @@ int CServer::NewClientCallback(int ClientId, void *pUser, bool Sixup)
 	pThis->m_aClients[ClientId].m_GotDDNetVersionPacket = false;
 	pThis->m_aClients[ClientId].m_DDNetVersionSettled = false;
 	pThis->m_aClients[ClientId].Reset();
+	pThis->m_aClients[ClientId].ResetIdMap();
 	pThis->m_aClients[ClientId].m_Sixup = Sixup;
 
 	pThis->GameServer()->TeehistorianRecordPlayerJoin(ClientId, Sixup);
@@ -3321,6 +3330,7 @@ int CServer::Run()
 						SendMap(ClientId);
 						bool HasPersistentData = m_aClients[ClientId].m_HasPersistentData;
 						m_aClients[ClientId].Reset();
+						m_aClients[ClientId].ResetIdMap();
 						m_aClients[ClientId].m_HasPersistentData = HasPersistentData;
 						m_aClients[ClientId].m_State = CClient::STATE_CONNECTING;
 					}

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -700,7 +700,7 @@ bool CServer::GetClientInfo(int ClientId, CClientInfo *pInfo) const
 	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "Invalid ClientId: %d", ClientId);
 	dbg_assert(pInfo != nullptr, "pInfo cannot be null");
 
-	if(m_aClients[ClientId].m_State == CClient::STATE_INGAME)
+	if(m_aClients[ClientId].IsIngame())
 	{
 		pInfo->m_pName = m_aClients[ClientId].m_aName;
 		pInfo->m_Latency = m_aClients[ClientId].m_Latency;
@@ -725,7 +725,7 @@ void CServer::SetClientDDNetVersion(int ClientId, int DDNetVersion)
 {
 	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "Invalid ClientId: %d", ClientId);
 
-	if(m_aClients[ClientId].m_State == CClient::STATE_INGAME)
+	if(m_aClients[ClientId].IsIngame())
 	{
 		m_aClients[ClientId].m_DDNetVersion = DDNetVersion;
 		m_aClients[ClientId].m_DDNetVersionSettled = true;
@@ -758,7 +758,7 @@ const char *CServer::ClientName(int ClientId) const
 {
 	if(ClientId < 0 || ClientId >= MAX_CLIENTS || m_aClients[ClientId].m_State == CServer::CClient::STATE_EMPTY)
 		return "(invalid)";
-	if(m_aClients[ClientId].m_State == CServer::CClient::STATE_INGAME || m_aClients[ClientId].m_State == CServer::CClient::STATE_REDIRECTED)
+	if(m_aClients[ClientId].IsIngame() || m_aClients[ClientId].m_State == CServer::CClient::STATE_REDIRECTED)
 		return m_aClients[ClientId].m_aName;
 	else
 		return "(connecting)";
@@ -768,7 +768,7 @@ const char *CServer::ClientClan(int ClientId) const
 {
 	if(ClientId < 0 || ClientId >= MAX_CLIENTS || m_aClients[ClientId].m_State == CServer::CClient::STATE_EMPTY)
 		return "";
-	if(m_aClients[ClientId].m_State == CServer::CClient::STATE_INGAME)
+	if(m_aClients[ClientId].IsIngame())
 		return m_aClients[ClientId].m_aClan;
 	else
 		return "";
@@ -778,7 +778,7 @@ int CServer::ClientCountry(int ClientId) const
 {
 	if(ClientId < 0 || ClientId >= MAX_CLIENTS || m_aClients[ClientId].m_State == CServer::CClient::STATE_EMPTY)
 		return -1;
-	if(m_aClients[ClientId].m_State == CServer::CClient::STATE_INGAME)
+	if(m_aClients[ClientId].IsIngame())
 		return m_aClients[ClientId].m_Country;
 	else
 		return -1;
@@ -791,7 +791,7 @@ bool CServer::ClientSlotEmpty(int ClientId) const
 
 bool CServer::ClientIngame(int ClientId) const
 {
-	return ClientId >= 0 && ClientId < MAX_CLIENTS && m_aClients[ClientId].m_State == CServer::CClient::STATE_INGAME;
+	return ClientId >= 0 && ClientId < MAX_CLIENTS && m_aClients[ClientId].IsIngame();
 }
 
 int CServer::Port() const
@@ -939,7 +939,7 @@ int CServer::SendMsg(CMsgPacker *pMsg, int Flags, int ClientId)
 		{
 			for(int i = 0; i < MAX_CLIENTS; i++)
 			{
-				if(m_aClients[i].m_State == CClient::STATE_INGAME)
+				if(m_aClients[i].IsIngame())
 				{
 					CPacker *pPack = m_aClients[i].m_Sixup ? &Pack7 : &Pack6;
 					Packet.m_pData = pPack->Data();
@@ -1177,6 +1177,13 @@ int CServer::ClientRejoinCallback(int ClientId, void *pUser)
 	pThis->Antibot()->OnEngineClientDrop(ClientId, "rejoin");
 	pThis->Antibot()->OnEngineClientJoin(ClientId);
 
+	// A client that already has a session keeps its slot and session, but it has
+	// to load the map again before it can handle snapshots. A client that is
+	// still connecting keeps its state and simply repeats the handshake.
+	if(pThis->m_aClients[ClientId].m_State == CClient::STATE_INGAME)
+	{
+		pThis->m_aClients[ClientId].m_State = CClient::STATE_REJOINING;
+	}
 	pThis->SendMap(ClientId);
 
 	return 0;
@@ -2066,6 +2073,10 @@ void CServer::OnNetMsgReady(int ClientId)
 
 	// Make rejoining session possible before timeout protection triggers
 	// https://github.com/ddnet/ddnet/pull/301
+	if(m_aClients[ClientId].m_State == CClient::STATE_REJOINING)
+	{
+		m_aClients[ClientId].m_State = CClient::STATE_INGAME;
+	}
 	SendConnectionReady(ClientId);
 }
 
@@ -3290,7 +3301,7 @@ int CServer::Run()
 					// ask the game for the data it wants to persist past a map change
 					for(int i = 0; i < MAX_CLIENTS; i++)
 					{
-						if(m_aClients[i].m_State == CClient::STATE_INGAME)
+						if(m_aClients[i].IsIngame())
 						{
 							m_aClients[i].m_HasPersistentData = GameServer()->OnClientDataPersist(i, m_aClients[i].m_pPersistentData);
 						}
@@ -4725,6 +4736,9 @@ bool CServer::SetTimedOut(int ClientId, int OrigId)
 	m_aClients[ClientId].m_DDNetVersion = m_aClients[OrigId].m_DDNetVersion;
 	m_aClients[ClientId].m_GotDDNetVersionPacket = m_aClients[OrigId].m_GotDDNetVersionPacket;
 	m_aClients[ClientId].m_DDNetVersionSettled = m_aClients[OrigId].m_DDNetVersionSettled;
+	// The resumed connection belongs to a client that has already loaded the map,
+	// so the slot must not keep a pending map reload from the abandoned session.
+	m_aClients[ClientId].m_State = m_aClients[OrigId].m_State;
 
 	DelClientCallback(OrigId, "Timeout Protection used", this);
 

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -122,8 +122,12 @@ public:
 			STATE_AUTH,
 			STATE_CONNECTING,
 			STATE_READY,
+			STATE_REJOINING,
 			STATE_INGAME,
 		};
+
+		// Whether the client has an in-game session.
+		bool IsIngame() const { return m_State == STATE_REJOINING || m_State == STATE_INGAME; }
 
 		enum
 		{

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -192,6 +192,7 @@ public:
 		void *m_pPersistentData;
 
 		void Reset();
+		void ResetIdMap();
 
 		// DDRace
 

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -145,7 +145,9 @@ SECURITY_TOKEN CNetServer::GetToken(const NETADDR &Addr)
 	SHA256_CTX Sha256;
 	sha256_init(&Sha256);
 	sha256_update(&Sha256, (unsigned char *)m_aSecurityTokenSeed, sizeof(m_aSecurityTokenSeed));
-	sha256_update(&Sha256, (unsigned char *)&Addr, 20); // omit port, bad idea!
+	sha256_update(&Sha256, (unsigned char *)&Addr.type, sizeof(Addr.type));
+	sha256_update(&Sha256, (unsigned char *)Addr.ip, sizeof(Addr.ip));
+	// omit port, bad idea!
 
 	SECURITY_TOKEN SecurityToken = ToSecurityToken(sha256_finish(&Sha256).data);
 

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -1117,7 +1117,7 @@ void CGameConsole::Prompt(char (&aPrompt)[32])
 	}
 	else if(m_ConsoleType == CONSOLETYPE_REMOTE)
 	{
-		if(Client()->State() == IClient::STATE_LOADING || Client()->State() == IClient::STATE_ONLINE)
+		if(Client()->State() == IClient::STATE_LOADING || Client()->State() == IClient::STATE_READY || Client()->State() == IClient::STATE_ONLINE)
 		{
 			if(Client()->RconAuthed())
 				str_copy(aPrompt, "rcon> ");

--- a/src/game/client/components/mapsounds.cpp
+++ b/src/game/client/components/mapsounds.cpp
@@ -234,6 +234,6 @@ void CMapSounds::Clear()
 
 void CMapSounds::OnStateChange(int NewState, int OldState)
 {
-	if(NewState < IClient::STATE_ONLINE)
+	if(NewState < IClient::STATE_READY)
 		Clear();
 }

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1035,6 +1035,7 @@ void CMenus::Render()
 		break;
 
 	case IClient::STATE_LOADING:
+	case IClient::STATE_READY:
 		RenderPopupLoading(Screen);
 		break;
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1295,8 +1295,8 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 
 void CGameClient::OnStateChange(int NewState, int OldState)
 {
-	// reset everything when not already connected (to keep gathered stuff)
-	if(NewState < IClient::STATE_ONLINE)
+	// reset everything when the map logic is not initialized (to keep gathered stuff)
+	if(NewState < IClient::STATE_READY)
 		OnReset();
 
 	// then change the state


### PR DESCRIPTION
Reported by theanister on Discord: https://discord.com/channels/252358080522747904/342454474117218334/1537107307568177293

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Fable 5 and Opus 5) wrote this, I reviewed
