### PR TITLE
Fix undefined shift in the team start time check

### DIFF
--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -19,6 +19,8 @@
 #include <game/server/interactions.h>
 #include <game/team_state.h>
 
+#include <bitset>
+
 CGameTeams::CGameTeams(CGameContext *pGameContext) :
 	m_pGameContext(pGameContext)
 {
@@ -261,7 +263,7 @@ void CGameTeams::Tick()
 
 	int Frequency = Server()->TickSpeed() * 60;
 	int Remainder = Server()->TickSpeed() * 30;
-	uint64_t TeamHasWantedStartTime = 0;
+	std::bitset<NUM_DDRACE_TEAMS> TeamHasWantedStartTime;
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		CCharacter *pChar = GameServer()->m_apPlayers[i] ? GameServer()->m_apPlayers[i]->GetCharacter() : nullptr;
@@ -272,17 +274,17 @@ void CGameTeams::Tick()
 		}
 		if((Now - pChar->m_StartTime) % Frequency == Remainder)
 		{
-			TeamHasWantedStartTime |= ((uint64_t)1) << m_Core.Team(i);
+			TeamHasWantedStartTime.set(m_Core.Team(i));
 		}
 	}
-	TeamHasWantedStartTime &= ~(uint64_t)1;
-	if(!TeamHasWantedStartTime)
+	TeamHasWantedStartTime.reset(TEAM_FLOCK);
+	if(TeamHasWantedStartTime.none())
 	{
 		return;
 	}
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
-		if(((TeamHasWantedStartTime >> i) & 1) == 0)
+		if(!TeamHasWantedStartTime.test(i))
 		{
 			continue;
 		}


### PR DESCRIPTION
DDRace teams range up to MAX_CLIENTS, so indexing a uint64_t bitmask by the team number is undefined once a team number reaches 64.

<details>
<summary>what actually goes wrong, written by Claude</summary>

`CGameTeams::Tick` collects teams whose start time has come round into a `uint64_t`, then walks it back out:

```cpp
TeamHasWantedStartTime |= ((uint64_t)1) << m_Core.Team(i);
...
if(((TeamHasWantedStartTime >> i) & 1) == 0)
```

`m_Core.Team(i)` goes up to `TEAM_SUPER`, which is `MAX_CLIENTS`, so both shifts are undefined for teams 64 and above. On x86 they wrap mod 64, which gives two behaviours: team 64 lands on bit 0 and is dropped by the `&= ~(uint64_t)1` on the next line, and team 65 lands on bit 1, so team 1 gets flagged instead.

The consequence is limited to one chat line. The flagged path only reaches `SendChatTeam` with the "players that have not started yet" reminder, so team 1 can receive it at the wrong moment and teams 64 and above never receive it at all. `KillTeam` is reached from the loop above this one, which uses no bitmask and is unaffected.

`std::bitset<NUM_DDRACE_TEAMS>` matches how the other team indexed members are already sized (`m_aTeamState`, `m_aTeamFlock`, `m_aPractice`), so the container now covers the same range as the index. Teams 0 to 63 behave exactly as before.

No test covers `CGameTeams::Tick`, so this is not backed by one. Reproducing it needs more than 64 teams and therefore more than 64 players.

</details>

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude found this while profiling the server at 128 players, wrote the change and the collapsed explanation above.
