### PR TITLE
Fix touch and mouse position when the viewport is clamped to 5:4

### DIFF
--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -42,12 +42,16 @@
 // ------------ CCommandProcessorFragment_OpenGL
 void CCommandProcessorFragment_OpenGL::Cmd_Update_Viewport(const CCommandBuffer::SCommand_Update_Viewport *pCommand)
 {
+	// The viewport is given relative to the top left of the drawable area, whereas
+	// OpenGL places it relative to the bottom left.
+	m_ViewportX = pCommand->m_X;
+	m_ViewportY = pCommand->m_DrawableHeight - pCommand->m_Y - pCommand->m_Height;
 	if(pCommand->m_ByResize)
 	{
 		m_CanvasWidth = (uint32_t)pCommand->m_Width;
 		m_CanvasHeight = (uint32_t)pCommand->m_Height;
 	}
-	glViewport(pCommand->m_X, pCommand->m_Y, pCommand->m_Width, pCommand->m_Height);
+	glViewport(m_ViewportX, m_ViewportY, pCommand->m_Width, pCommand->m_Height);
 }
 
 size_t CCommandProcessorFragment_OpenGL::GLFormatToPixelSize(int GLFormat)
@@ -92,7 +96,9 @@ void CCommandProcessorFragment_OpenGL::SetState(const CCommandBuffer::SState &St
 	// clip
 	if(State.m_ClipEnable)
 	{
-		glScissor(State.m_ClipX, State.m_ClipY, State.m_ClipW, State.m_ClipH);
+		// The clip rectangle is relative to the viewport, whereas glScissor is
+		// relative to the drawable area.
+		glScissor(m_ViewportX + State.m_ClipX, m_ViewportY + State.m_ClipY, State.m_ClipW, State.m_ClipH);
 		glEnable(GL_SCISSOR_TEST);
 		m_LastClipEnable = true;
 	}
@@ -312,7 +318,7 @@ bool CCommandProcessorFragment_OpenGL::GetPresentedImageData(uint32_t &Width, ui
 		GLint Alignment;
 		glGetIntegerv(GL_PACK_ALIGNMENT, &Alignment);
 		glPixelStorei(GL_PACK_ALIGNMENT, 1);
-		glReadPixels(0, 0, m_CanvasWidth, m_CanvasHeight, GL_RGBA, GL_UNSIGNED_BYTE, vDstData.data());
+		glReadPixels(m_ViewportX, m_ViewportY, m_CanvasWidth, m_CanvasHeight, GL_RGBA, GL_UNSIGNED_BYTE, vDstData.data());
 		glPixelStorei(GL_PACK_ALIGNMENT, Alignment);
 
 		uint8_t *pTempRow = vDstData.data() + Width * Height * 4;
@@ -994,17 +1000,20 @@ void CCommandProcessorFragment_OpenGL::Cmd_Render(const CCommandBuffer::SCommand
 
 void CCommandProcessorFragment_OpenGL::Cmd_ReadPixel(const CCommandBuffer::SCommand_TrySwapAndReadPixel *pCommand)
 {
-	// get size of viewport
+	// get position and size of viewport
 	GLint aViewport[4] = {0, 0, 0, 0};
 	glGetIntegerv(GL_VIEWPORT, aViewport);
-	const int h = aViewport[3];
+	const int ViewportX = aViewport[0];
+	const int ViewportY = aViewport[1];
+	const int ViewportHeight = aViewport[3];
 
-	// fetch the pixel
+	// fetch the pixel. The position is relative to the top left of the viewport,
+	// whereas glReadPixels reads relative to the bottom left of the drawable area.
 	uint8_t aPixelData[3];
 	GLint Alignment;
 	glGetIntegerv(GL_PACK_ALIGNMENT, &Alignment);
 	glPixelStorei(GL_PACK_ALIGNMENT, 1);
-	glReadPixels(pCommand->m_Position.x, h - 1 - pCommand->m_Position.y, 1, 1, GL_RGB, GL_UNSIGNED_BYTE, aPixelData);
+	glReadPixels(ViewportX + pCommand->m_Position.x, ViewportY + ViewportHeight - 1 - pCommand->m_Position.y, 1, 1, GL_RGB, GL_UNSIGNED_BYTE, aPixelData);
 	glPixelStorei(GL_PACK_ALIGNMENT, Alignment);
 
 	// fill in the information
@@ -1017,6 +1026,8 @@ void CCommandProcessorFragment_OpenGL::Cmd_Screenshot(const CCommandBuffer::SCom
 	GLint aViewport[4] = {0, 0, 0, 0};
 	glGetIntegerv(GL_VIEWPORT, aViewport);
 
+	const int ViewportX = aViewport[0];
+	const int ViewportY = aViewport[1];
 	int w = aViewport[2];
 	int h = aViewport[3];
 
@@ -1035,7 +1046,7 @@ void CCommandProcessorFragment_OpenGL::Cmd_Screenshot(const CCommandBuffer::SCom
 	GLint Alignment;
 	glGetIntegerv(GL_PACK_ALIGNMENT, &Alignment);
 	glPixelStorei(GL_PACK_ALIGNMENT, 1);
-	glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pPixelData);
+	glReadPixels(ViewportX, ViewportY, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pPixelData);
 	glPixelStorei(GL_PACK_ALIGNMENT, Alignment);
 
 	// flip the pixel because opengl works from bottom left corner
@@ -1169,7 +1180,9 @@ void CCommandProcessorFragment_OpenGL2::SetState(const CCommandBuffer::SState &S
 	// clip
 	if(State.m_ClipEnable)
 	{
-		glScissor(State.m_ClipX, State.m_ClipY, State.m_ClipW, State.m_ClipH);
+		// The clip rectangle is relative to the viewport, whereas glScissor is
+		// relative to the drawable area.
+		glScissor(m_ViewportX + State.m_ClipX, m_ViewportY + State.m_ClipY, State.m_ClipW, State.m_ClipH);
 		glEnable(GL_SCISSOR_TEST);
 		m_LastClipEnable = true;
 	}
@@ -1332,6 +1345,8 @@ bool CCommandProcessorFragment_OpenGL2::DoAnalyzeStep(size_t CheckCount, size_t 
 	GLint aViewport[4] = {0, 0, 0, 0};
 	glGetIntegerv(GL_VIEWPORT, aViewport);
 
+	const int ViewportX = aViewport[0];
+	const int ViewportY = aViewport[1];
 	int w = aViewport[2];
 	int h = aViewport[3];
 
@@ -1344,7 +1359,7 @@ bool CCommandProcessorFragment_OpenGL2::DoAnalyzeStep(size_t CheckCount, size_t 
 	GLint Alignment;
 	glGetIntegerv(GL_PACK_ALIGNMENT, &Alignment);
 	glPixelStorei(GL_PACK_ALIGNMENT, 1);
-	glReadPixels(0, 0, w, h, GL_RGB, GL_UNSIGNED_BYTE, pPixelData);
+	glReadPixels(ViewportX, ViewportY, w, h, GL_RGB, GL_UNSIGNED_BYTE, pPixelData);
 	glPixelStorei(GL_PACK_ALIGNMENT, Alignment);
 
 	// now analyse the image data

--- a/src/engine/client/backend/opengl/backend_opengl.h
+++ b/src/engine/client/backend/opengl/backend_opengl.h
@@ -51,6 +51,11 @@ protected:
 	std::vector<CTexture> m_vTextures;
 	std::atomic<uint64_t> *m_pTextureMemoryUsage;
 
+	// Position of the viewport within the drawable area, with the bottom left origin
+	// that OpenGL uses. The rendered image is aligned to the top left, so this is not
+	// the origin of the drawable area when the viewport is clamped.
+	int m_ViewportX = 0;
+	int m_ViewportY = 0;
 	uint32_t m_CanvasWidth = 0;
 	uint32_t m_CanvasHeight = 0;
 

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -7003,11 +7003,9 @@ public:
 			{
 				m_HasDynamicViewport = true;
 
-				// convert viewport from OGL to vulkan
-				int32_t ViewportY = (int32_t)Viewport.height - ((int32_t)pCommand->m_Y + (int32_t)pCommand->m_Height);
-				uint32_t ViewportH = (int32_t)pCommand->m_Height;
-				m_DynamicViewportOffset = {(int32_t)pCommand->m_X, ViewportY};
-				m_DynamicViewportSize = {(uint32_t)pCommand->m_Width, ViewportH};
+				// The viewport rectangle and Vulkan both use a top left origin.
+				m_DynamicViewportOffset = {(int32_t)pCommand->m_X, (int32_t)pCommand->m_Y};
+				m_DynamicViewportSize = {(uint32_t)pCommand->m_Width, (uint32_t)pCommand->m_Height};
 			}
 			else
 			{

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1537,6 +1537,8 @@ int CGraphicsBackend_SDL_GL::Init(const char *pName, int *pScreen, int *pWidth, 
 		CmdSDL2.m_Y = 0;
 		CmdSDL2.m_Width = *pCurrentWidth;
 		CmdSDL2.m_Height = *pCurrentHeight;
+		CmdSDL2.m_DrawableWidth = *pCurrentWidth;
+		CmdSDL2.m_DrawableHeight = *pCurrentHeight;
 		CmdSDL2.m_ByResize = true;
 		CmdBuffer.AddCommandUnsafe(CmdSDL2);
 		RunBuffer(&CmdBuffer);

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -114,6 +114,8 @@ CGraphics_Threaded::CGraphics_Threaded()
 
 	m_ScreenWidth = -1;
 	m_ScreenHeight = -1;
+	m_DrawableWidth = -1;
+	m_DrawableHeight = -1;
 	m_ScreenRefreshRate = -1;
 
 	m_Rotation = 0;
@@ -2220,6 +2222,8 @@ int CGraphics_Threaded::IssueInit()
 	}
 
 	const int Result = m_pBackend->Init("DDNet Client", &g_Config.m_GfxScreen, &g_Config.m_GfxScreenWidth, &g_Config.m_GfxScreenHeight, &g_Config.m_GfxScreenRefreshRate, &g_Config.m_GfxFsaaSamples, Flags, &m_DesktopSize.x, &m_DesktopSize.y, &m_ScreenWidth, &m_ScreenHeight, m_pStorage);
+	m_DrawableWidth = m_ScreenWidth;
+	m_DrawableHeight = m_ScreenHeight;
 	AddBackEndWarningIfExists();
 	if(Result == 0)
 	{
@@ -2263,6 +2267,8 @@ void CGraphics_Threaded::UpdateViewport(int X, int Y, int W, int H, bool ByResiz
 	Cmd.m_Y = Y;
 	Cmd.m_Width = W;
 	Cmd.m_Height = H;
+	Cmd.m_DrawableWidth = m_DrawableWidth;
+	Cmd.m_DrawableHeight = m_DrawableHeight;
 	Cmd.m_ByResize = ByResize;
 	AddCmd(Cmd);
 }
@@ -2651,6 +2657,8 @@ void CGraphics_Threaded::GotResized(int w, int h, int RefreshRate)
 	auto PrevCanvasWidth = m_ScreenWidth;
 	auto PrevCanvasHeight = m_ScreenHeight;
 	m_pBackend->GetViewportSize(m_ScreenWidth, m_ScreenHeight);
+	m_DrawableWidth = m_ScreenWidth;
+	m_DrawableHeight = m_ScreenHeight;
 
 	AdjustViewport(false);
 

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -498,10 +498,14 @@ public:
 		SCommand_Update_Viewport() :
 			SCommand(CMD_UPDATE_VIEWPORT) {}
 
+		// Viewport rectangle, relative to the top left of the drawable area.
 		int m_X;
 		int m_Y;
 		int m_Width;
 		int m_Height;
+		// Size of the whole drawable area, which the viewport can be smaller than.
+		int m_DrawableWidth;
+		int m_DrawableHeight;
 		bool m_ByResize; // resized by an resize event.. a hint to make clear that the viewport update can be deferred if wanted
 	};
 

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -18,6 +18,8 @@
 
 #include <SDL.h>
 
+#include <algorithm>
+
 // support older SDL version (pre 2.0.6)
 #ifndef SDL_JOYSTICK_AXIS_MIN
 #define SDL_JOYSTICK_AXIS_MIN (-32768)
@@ -540,13 +542,29 @@ void CInput::HandleJoystickRemovedEvent(const SDL_JoyDeviceEvent &Event)
 	}
 }
 
+vec2 CInput::TouchPositionToViewport(vec2 Position) const
+{
+	// Touch positions are normalized to the drawable area, whereas the rendered image can
+	// be smaller than it and is aligned to its top left corner. Positions on the area that
+	// is not rendered to are clamped to the image.
+	const vec2 Scaled = Position * Graphics()->DrawableSize() / Graphics()->ScreenSize();
+	return vec2(std::clamp(Scaled.x, 0.0f, 1.0f), std::clamp(Scaled.y, 0.0f, 1.0f));
+}
+
+vec2 CInput::TouchDeltaToViewport(vec2 Delta) const
+{
+	// The scale between the drawable area and the rendered image applies to deltas as well.
+	const vec2 Scaled = Delta * Graphics()->DrawableSize() / Graphics()->ScreenSize();
+	return vec2(std::clamp(Scaled.x, -1.0f, 1.0f), std::clamp(Scaled.y, -1.0f, 1.0f));
+}
+
 void CInput::HandleTouchDownEvent(const SDL_TouchFingerEvent &Event)
 {
 	CTouchFingerState TouchFingerState;
 	TouchFingerState.m_Finger.m_DeviceId = Event.touchId;
 	TouchFingerState.m_Finger.m_FingerId = Event.fingerId;
-	TouchFingerState.m_Position = vec2(Event.x, Event.y);
-	TouchFingerState.m_Delta = vec2(Event.dx, Event.dy);
+	TouchFingerState.m_Position = TouchPositionToViewport(vec2(Event.x, Event.y));
+	TouchFingerState.m_Delta = TouchDeltaToViewport(vec2(Event.dx, Event.dy));
 	TouchFingerState.m_PressTime = time_get_nanoseconds();
 	m_vTouchFingerStates.emplace_back(TouchFingerState);
 }
@@ -569,8 +587,8 @@ void CInput::HandleTouchMotionEvent(const SDL_TouchFingerEvent &Event)
 	});
 	if(FoundState != m_vTouchFingerStates.end())
 	{
-		FoundState->m_Position = vec2(Event.x, Event.y);
-		FoundState->m_Delta += vec2(Event.dx, Event.dy);
+		FoundState->m_Position = TouchPositionToViewport(vec2(Event.x, Event.y));
+		FoundState->m_Delta += TouchDeltaToViewport(vec2(Event.dx, Event.dy));
 	}
 }
 

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -102,6 +102,8 @@ private:
 	void HandleJoystickHatMotionEvent(const SDL_JoyHatEvent &Event);
 	void HandleJoystickAddedEvent(const SDL_JoyDeviceEvent &Event);
 	void HandleJoystickRemovedEvent(const SDL_JoyDeviceEvent &Event);
+	vec2 TouchPositionToViewport(vec2 Position) const;
+	vec2 TouchDeltaToViewport(vec2 Delta) const;
 	void HandleTouchDownEvent(const SDL_TouchFingerEvent &Event);
 	void HandleTouchUpEvent(const SDL_TouchFingerEvent &Event);
 	void HandleTouchMotionEvent(const SDL_TouchFingerEvent &Event);

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -242,6 +242,8 @@ class IGraphics : public IInterface
 protected:
 	int m_ScreenWidth;
 	int m_ScreenHeight;
+	int m_DrawableWidth;
+	int m_DrawableHeight;
 	int m_ScreenRefreshRate;
 	float m_ScreenHiDPIScale;
 	ivec2 m_DesktopSize;
@@ -278,6 +280,12 @@ public:
 	float ScreenHiDPIScale() const { return m_ScreenHiDPIScale; }
 	int WindowWidth() const { return m_ScreenWidth / m_ScreenHiDPIScale; }
 	int WindowHeight() const { return m_ScreenHeight / m_ScreenHiDPIScale; }
+
+	// Size of the whole drawable area, in the same units as ScreenWidth()/ScreenHeight().
+	// The rendered image is clamped to an aspect ratio of at most 5:4 and aligned to the
+	// top left corner, so the area at the bottom can be larger than the image and is not
+	// rendered to.
+	vec2 DrawableSize() const { return vec2(m_DrawableWidth, m_DrawableHeight); }
 
 	virtual void WarnPngliteIncompatibleImages(bool Warn) = 0;
 	virtual void SetWindowParams(int FullscreenMode, bool IsBorderless) = 0;


### PR DESCRIPTION
Fixes #11199 by placing the clamped viewport at the top left with OpenGL as well, so that input positions, which the system reports relative to the whole drawable area, are correct on both backends.

<details>
<summary>longer explanation, written by Claude</summary>

`CGraphics_Threaded::AdjustViewport` clamps the canvas to an aspect ratio of at most 5:4 and sends both backends the same viewport rectangle with a Y of 0. `glViewport` measures from the bottom left and `VkViewport` from the top left, so the unrendered area ended up at the top with OpenGL and at the bottom with Vulkan.

Every consumer of a system reported position assumes the image starts at window (0, 0), so positions were correct with Vulkan except inside the unrendered area, and off by its full height with OpenGL. This is why the menus looked fine either way: `CUi` accumulates relative mouse motion and stays self consistent, whereas the console is the only place using the absolute `CInput::NativeMousePos`, which matches the report that it breaks specifically there.

The viewport rectangle is now passed together with the size of the drawable area, so the OpenGL backend can convert it into its own coordinate system, and the image ends up aligned to the top left on both backends. A 600x900 window, where the canvas is clamped to 600x480:

| OpenGL before | OpenGL after | Vulkan, unchanged |
| --- | --- | --- |
| ![before](https://edgl.dev/share/ddnet-11199-opengl-before.png) | ![after](https://edgl.dev/share/ddnet-11199-opengl-after.png) | ![vulkan](https://edgl.dev/share/ddnet-11199-vulkan.png) |

Moving the viewport means everything else that works in drawable coordinates has to follow it, so the resulting position is kept and used to offset:

- the scissor rectangle. `CGraphics_Threaded::ClipEnable` computes it relative to the viewport, while `glScissor` consumes drawable coordinates, so without this every clipped draw would be off by the height of the unrendered area.
- the reads for screenshots, the presented image data, single pixels (the editor colour pipette) and the tilemap analysis. These used a hardcoded origin, which was correct as long as the viewport was aligned to the bottom of the drawable area and is not once it moves.

Ingame screenshots at a clamped size were checked to still contain exactly the rendered image, byte for byte the same as before the change apart from the cursor position.

Touch positions arrive as a fraction of the drawable area rather than of the image, so they are rescaled to the viewport once in `CInput` rather than at each of the consumers. A finger on the area that is not rendered to is clamped onto the edge of the image, so positions and deltas keep the ranges `CTouchFingerState` documents and that interface is unchanged.

Also verified that dragging a text selection in the console at a window Y of 250 highlights the line under the pointer on both backends instead of one 160 pixels away.

Not tested on Android, so the touch change is verified by reading every consumer of `CTouchFingerState` rather than on a device. Not tested with a HiDPI scale either.

</details>

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude investigated the issue, wrote this change and the collapsed explanation above. Tested with both backends at windows smaller than 5:4; the configuration options exercised were `gfx_backend` and the window size, not a HiDPI scale.

