### PR TITLE
network: Don't send too large packets

### DIFF
--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -67,6 +67,7 @@ enum
 {
 	NET_MAX_PACKETSIZE = 1400,
 	NET_MAX_CONNLESS_PAYLOAD = NET_MAX_PACKETSIZE - 6,
+	NET_MAX_SEND_PAYLOAD = NET_MAX_PACKETSIZE - 6,
 	/**
 	 * The maximum size of a chunk within a connection-oriented packet.
 	 *

--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -149,7 +149,7 @@ int CNetConnection::QueueChunkEx(int Flags, int DataSize, const void *pData, int
 	unsigned char *pChunkData;
 
 	// check if we have space for it, if not, flush the connection
-	if(m_Construct.m_DataSize + DataSize + NET_MAX_CHUNKHEADERSIZE > (int)sizeof(m_Construct.m_aChunkData) - (int)sizeof(SECURITY_TOKEN) ||
+	if(m_Construct.m_DataSize + DataSize + NET_MAX_CHUNKHEADERSIZE > NET_MAX_SEND_PAYLOAD - (int)sizeof(SECURITY_TOKEN) ||
 		m_Construct.m_NumChunks == NET_MAX_PACKET_CHUNKS)
 	{
 		Flush();


### PR DESCRIPTION
Follow-up to https://github.com/ddnet/ddnet/pull/12569, which bumped the max packet size when sending from 1397 to 1400 bytes

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude Code (Opus 4.8 and Fable 5) wrote this, I reviewed