### PR TITLE
Don't return stale chunks from already-disconnected peers

### DIFF
--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -127,6 +127,11 @@ bool CPacketChunkUnpacker::UnpackNextChunk(CNetChunk *pChunk)
 	}
 }
 
+void CPacketChunkUnpacker::Reset()
+{
+	m_Valid = false;
+}
+
 bool CNetBase::IsValidConnectionOrientedPacket(const CNetPacketConstruct *pPacket)
 {
 	if((pPacket->m_Flags & ~(NET_PACKETFLAG_CONTROL | NET_PACKETFLAG_RESEND | NET_PACKETFLAG_COMPRESSION)) != 0)

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -403,6 +403,7 @@ class CPacketChunkUnpacker
 public:
 	void FeedPacket(const NETADDR &Addr, const CNetPacketConstruct &Packet, CNetConnection *pConnection, int ClientId);
 	bool UnpackNextChunk(CNetChunk *pChunk);
+	void Reset();
 
 private:
 	bool m_Valid = false;

--- a/src/engine/shared/network_client.cpp
+++ b/src/engine/shared/network_client.cpp
@@ -80,7 +80,19 @@ int CNetClient::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken, bool Six
 	{
 		// Unpack next chunk from stored packet if available
 		if(m_PacketChunkUnpacker.UnpackNextChunk(pChunk))
-			return 1;
+		{
+			// Only return the pending packet if the peer is still
+			// available, the caller might have dropped them in
+			// response to the previous chunk.
+			if(m_Connection.State() != CNetConnection::EState::OFFLINE)
+			{
+				return 1;
+			}
+			else
+			{
+				m_PacketChunkUnpacker.Reset();
+			}
+		}
 
 		// TODO: empty the recvinfo
 		NETADDR Addr;

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -608,7 +608,19 @@ int CNetServer::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken)
 	{
 		// Unpack next chunk from stored packet if available
 		if(m_PacketChunkUnpacker.UnpackNextChunk(pChunk))
-			return 1;
+		{
+			// Only return the pending packet if the client is
+			// still available, the caller might have dropped them
+			// in response to the previous chunk.
+			if(m_aSlots[pChunk->m_ClientId].m_Connection.State() != CNetConnection::EState::OFFLINE)
+			{
+				return 1;
+			}
+			else
+			{
+				m_PacketChunkUnpacker.Reset();
+			}
+		}
 
 		// TODO: empty the recvinfo
 		NETADDR Addr;


### PR DESCRIPTION
Previously, the client or server might have dropped a peer in response to a chunk, but would then continue to receive packets from a now-invalid peer.

Thanks to @swarfeya for finding this bug.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
