### PR TITLE
Allow passing `all` as argument to `kick`

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3584,11 +3584,11 @@ void CServer::ConKick(IConsole::IResult *pResult, void *pUser)
 	{
 		char aBuf[128];
 		str_format(aBuf, sizeof(aBuf), "Kicked (%s)", pResult->GetString(1));
-		((CServer *)pUser)->Kick(pResult->GetInteger(0), aBuf);
+		((CServer *)pUser)->Kick(pResult->GetVictim(), aBuf);
 	}
 	else
 	{
-		((CServer *)pUser)->Kick(pResult->GetInteger(0), "Kicked by console");
+		((CServer *)pUser)->Kick(pResult->GetVictim(), "Kicked by console");
 	}
 }
 
@@ -4484,7 +4484,7 @@ void CServer::RegisterCommands()
 	m_pAntibot = Kernel()->RequestInterface<IEngineAntibot>();
 
 	// register console commands
-	Console()->Register("kick", "i[id] ?r[reason]", CFGFLAG_SERVER, ConKick, this, "Kick player with specified id for any reason");
+	Console()->Register("kick", "v[id] ?r[reason]", CFGFLAG_SERVER, ConKick, this, "Kick player with specified id for any reason");
 	Console()->Register("status", "?r[name]", CFGFLAG_SERVER, ConStatus, this, "List players containing name or all players");
 	Console()->Register("shutdown", "?r[reason]", CFGFLAG_SERVER, ConShutdown, this, "Shut down");
 	Console()->Register("logout", "", CFGFLAG_SERVER, ConLogout, this, "Logout of rcon");


### PR DESCRIPTION
Thanks to a recent console victim handling refactor `kick all` no longer will log `server: invalid client id to kick` 127 times on an empty server but actually only get run for connected players.

I just was missing this on my local server where I had a bunch of crashed clients on my server that I wanted to clear out.

Some moderator voiced concerns about this being bad because now staff can kick the entire server. Which I find a weak argument. Anyone with access to the `kick` command can already copy paste the output of this bash command into the remote console `for i in {0..64}; do printf "kick $i;"; done` I mean ideally we finally get proper access management for arguments anyways to cover cases like these (CC https://github.com/ddnet/ddnet/issues/10047).

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
