### PR TITLE
Fix debug graphs not showing negative maximum value correctly, fix incorrect quad clipping with negative offsets 

### DIFF
--- a/src/engine/client/graph.cpp
+++ b/src/engine/client/graph.cpp
@@ -95,7 +95,7 @@ void CGraph::Scale(int64_t WantedTotalTime)
 	m_MinAxis = m_MinRange;
 	m_MaxAxis = m_MaxRange;
 	m_MinValue = std::numeric_limits<float>::max();
-	m_MaxValue = std::numeric_limits<float>::min();
+	m_MaxValue = std::numeric_limits<float>::lowest();
 	for(CEntry *pEntry = m_pFirstScaled; pEntry != nullptr; pEntry = m_Entries.Next(pEntry))
 	{
 		const float Value = pEntry->m_Value;

--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -1298,7 +1298,7 @@ bool CRenderLayerQuads::CalculateQuadClipping(const CQuadCluster &QuadCluster, f
 	for(int Channel = 0; Channel < 2; ++Channel)
 	{
 		aQuadOffsetMin[Channel] = std::numeric_limits<float>::max(); // minimum of channel
-		aQuadOffsetMax[Channel] = std::numeric_limits<float>::min(); // maximum of channel
+		aQuadOffsetMax[Channel] = std::numeric_limits<float>::lowest(); // maximum of channel
 	}
 
 	for(int QuadId = QuadCluster.m_StartIndex; QuadId < QuadCluster.m_StartIndex + QuadCluster.m_NumQuads; ++QuadId)


### PR DESCRIPTION
See commit messages.

## Checklist

- [X] Tested the change ingame: by temporarily adding FPS with negative values to the graph, which showed that the maximum was not being updated.
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions: AI found these issues.
