### PR TITLE
Bound the work unauthenticated packets can cost

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2859,7 +2859,7 @@ void CServer::UpdateServerInfo(bool Resend)
 	m_ServerInfoNeedsUpdate = false;
 }
 
-void CServer::PumpNetwork(bool PacketWaiting)
+void CServer::PumpNetwork()
 {
 	CNetChunk Packet;
 	SECURITY_TOKEN ResponseToken;
@@ -2871,7 +2871,8 @@ void CServer::PumpNetwork(bool PacketWaiting)
 	// per recipient, flushed once all packets have been handled below.
 	m_NetServer.BeginFlushBatch();
 
-	if(PacketWaiting)
+	// Receive unconditionally, `net_udp_recv()` can hold packets that
+	// `net_socket_read_wait()` does not see.
 	{
 		// process packets
 		ResponseToken = NET_SECURITY_TOKEN_UNKNOWN;
@@ -3263,7 +3264,6 @@ int CServer::Run()
 	// start game
 	{
 		bool NonActive = false;
-		bool PacketWaiting = false;
 
 		m_GameStartTime = time_get();
 
@@ -3271,7 +3271,7 @@ int CServer::Run()
 		while(m_RunServer < STOPPING)
 		{
 			if(NonActive)
-				PumpNetwork(PacketWaiting);
+				PumpNetwork();
 
 			set_new_tick();
 
@@ -3489,7 +3489,7 @@ int CServer::Run()
 			}
 
 			if(!NonActive)
-				PumpNetwork(PacketWaiting);
+				PumpNetwork();
 
 			NonActive = true;
 			for(const auto &Client : m_aClients)
@@ -3528,14 +3528,15 @@ int CServer::Run()
 				!m_aDemoRecorder[RECORDER_MANUAL].IsRecording() &&
 				!m_aDemoRecorder[RECORDER_AUTO].IsRecording())
 			{
-				PacketWaiting = net_socket_read_wait(m_NetServer.Socket(), 1s);
+				net_socket_read_wait(m_NetServer.Socket(), 1s);
 			}
 			else
 			{
 				set_new_tick();
 				LastTime = time_get();
 				const auto MicrosecondsToWait = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::nanoseconds(TickStartTime(m_CurrentGameTick + 1) - LastTime)) + 1us;
-				PacketWaiting = MicrosecondsToWait > 0us ? net_socket_read_wait(m_NetServer.Socket(), MicrosecondsToWait) : true;
+				if(MicrosecondsToWait > 0us)
+					net_socket_read_wait(m_NetServer.Socket(), MicrosecondsToWait);
 			}
 			if(IsInterrupted())
 			{

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -420,7 +420,7 @@ public:
 	void UpdateRegisterServerInfo();
 	void UpdateServerInfo(bool Resend);
 
-	void PumpNetwork(bool PacketWaiting);
+	void PumpNetwork();
 
 	void ChangeMap(const char *pMap) override;
 	void ReloadMap() override;

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -707,7 +707,7 @@ MACRO_CONFIG_STR(SvBannedVersions, sv_banned_versions, 128, "", CFGFLAG_SERVER, 
 MACRO_CONFIG_INT(SvNetlimit, sv_netlimit, 0, 0, 10000, CFGFLAG_SERVER, "Netlimit: Maximum amount of traffic a client is allowed to use (in kb/s)")
 MACRO_CONFIG_INT(SvNetlimitAlpha, sv_netlimit_alpha, 50, 1, 100, CFGFLAG_SERVER, "Netlimit: Alpha of Exponentiation moving average")
 
-MACRO_CONFIG_INT(SvConnlimit, sv_connlimit, 5, 0, 100, CFGFLAG_SERVER, "Connlimit: Number of connections an IP is allowed to do in a timespan")
+MACRO_CONFIG_INT(SvConnlimit, sv_connlimit, 5, 1, 100, CFGFLAG_SERVER, "Connlimit: Number of connections an IP is allowed to do in a timespan")
 MACRO_CONFIG_INT(SvConnlimitTime, sv_connlimit_time, 20, 0, 1000, CFGFLAG_SERVER, "Connlimit: Time in which IP's connections are counted")
 
 #if defined(CONF_FAMILY_UNIX)

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -493,9 +493,9 @@ MACRO_CONFIG_INT(SvPlayerDemoRecord, sv_player_demo_record, 0, 0, 1, CFGFLAG_SER
 MACRO_CONFIG_INT(SvDemoChat, sv_demo_chat, 0, 0, 1, CFGFLAG_SERVER, "Record chat for demos")
 MACRO_CONFIG_INT(SvServerInfoPerSecond, sv_server_info_per_second, 50, 0, 10000, CFGFLAG_SERVER, "Maximum number of complete server info responses that are sent out per second (0 for no limit)")
 MACRO_CONFIG_INT(SvVanConnPerSecond, sv_van_conn_per_second, 10, 0, 10000, CFGFLAG_SERVER, "Antispoof specific ratelimit (0 for no limit)")
-MACRO_CONFIG_INT(SvMaxPacketsPerTick, sv_max_packets_per_tick, 2048, 0, 1000000, CFGFLAG_SERVER, "Maximum number of packets that are received per tick, the rest is left for the operating system to drop (0 for no limit)")
-MACRO_CONFIG_INT(SvPreConnDecompressPerTick, sv_preconn_decompress_per_tick, 16, 0, 10000, CFGFLAG_SERVER, "Maximum number of compressed packets from addresses without a connection that are decompressed per tick, only the vanilla antispoof handshake needs these (0 for no limit)")
-MACRO_CONFIG_INT(SvBanRepliesPerTick, sv_ban_replies_per_tick, 4, 0, 10000, CFGFLAG_SERVER, "Maximum number of banned addresses that are told about their ban per tick (0 for no limit)")
+MACRO_CONFIG_INT(SvMaxPacketsPerRecv, sv_max_packets_per_recv, 2048, 0, 1000000, CFGFLAG_SERVER, "Maximum number of packets that are received in one batch before returning to the main loop, the rest is left for the operating system to drop (0 for no limit)")
+MACRO_CONFIG_INT(SvPreConnDecompressPerSecond, sv_preconn_decompress_per_second, 800, 0, 1000000, CFGFLAG_SERVER, "Maximum number of compressed packets from addresses without a connection that are decompressed per second, only the vanilla antispoof handshake needs these (0 for no limit)")
+MACRO_CONFIG_INT(SvBanRepliesPerSecond, sv_ban_replies_per_second, 200, 0, 1000000, CFGFLAG_SERVER, "Maximum number of banned addresses that are told about their ban per second (0 for no limit)")
 MACRO_CONFIG_INT(SvSixup, sv_sixup, 1, 0, 1, CFGFLAG_SERVER, "Enable sixup connections")
 MACRO_CONFIG_INT(SvSkillLevel, sv_skill_level, 1, SERVERINFO_LEVEL_MIN, SERVERINFO_LEVEL_MAX, CFGFLAG_SERVER, "Difficulty level for Teeworlds 0.7 (0: Casual, 1: Normal, 2: Competitive)")
 

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -493,6 +493,9 @@ MACRO_CONFIG_INT(SvPlayerDemoRecord, sv_player_demo_record, 0, 0, 1, CFGFLAG_SER
 MACRO_CONFIG_INT(SvDemoChat, sv_demo_chat, 0, 0, 1, CFGFLAG_SERVER, "Record chat for demos")
 MACRO_CONFIG_INT(SvServerInfoPerSecond, sv_server_info_per_second, 50, 0, 10000, CFGFLAG_SERVER, "Maximum number of complete server info responses that are sent out per second (0 for no limit)")
 MACRO_CONFIG_INT(SvVanConnPerSecond, sv_van_conn_per_second, 10, 0, 10000, CFGFLAG_SERVER, "Antispoof specific ratelimit (0 for no limit)")
+MACRO_CONFIG_INT(SvMaxPacketsPerTick, sv_max_packets_per_tick, 2048, 0, 1000000, CFGFLAG_SERVER, "Maximum number of packets that are received per tick, the rest is left for the operating system to drop (0 for no limit)")
+MACRO_CONFIG_INT(SvPreConnDecompressPerTick, sv_preconn_decompress_per_tick, 16, 0, 10000, CFGFLAG_SERVER, "Maximum number of compressed packets from addresses without a connection that are decompressed per tick, only the vanilla antispoof handshake needs these (0 for no limit)")
+MACRO_CONFIG_INT(SvBanRepliesPerTick, sv_ban_replies_per_tick, 4, 0, 10000, CFGFLAG_SERVER, "Maximum number of banned addresses that are told about their ban per tick (0 for no limit)")
 MACRO_CONFIG_INT(SvSixup, sv_sixup, 1, 0, 1, CFGFLAG_SERVER, "Enable sixup connections")
 MACRO_CONFIG_INT(SvSkillLevel, sv_skill_level, 1, SERVERINFO_LEVEL_MIN, SERVERINFO_LEVEL_MAX, CFGFLAG_SERVER, "Difficulty level for Teeworlds 0.7 (0: Casual, 1: Normal, 2: Competitive)")
 

--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -275,8 +275,13 @@ std::optional<int> CNetBase::UnpackPacketFlags(unsigned char *pBuffer, int Size)
 }
 
 // TODO: rename this function
-int CNetBase::UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct *pPacket, bool &Sixup, SECURITY_TOKEN *pSecurityToken, SECURITY_TOKEN *pResponseToken)
+int CNetBase::UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct *pPacket, bool &Sixup, bool AllowDecompression, SECURITY_TOKEN *pSecurityToken, SECURITY_TOKEN *pResponseToken, bool *pDecompressed)
 {
+	if(pDecompressed != nullptr)
+	{
+		*pDecompressed = false;
+	}
+
 	if(pResponseToken != nullptr)
 	{
 		*pResponseToken = NET_SECURITY_TOKEN_UNKNOWN;
@@ -356,6 +361,14 @@ int CNetBase::UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct
 
 		if((pPacket->m_Flags & NET_PACKETFLAG_COMPRESSION) != 0)
 		{
+			if(!AllowDecompression)
+			{
+				return -1;
+			}
+			if(pDecompressed != nullptr)
+			{
+				*pDecompressed = true;
+			}
 			pPacket->m_DataSize = ms_Huffman.Decompress(&pBuffer[DataStart], pPacket->m_DataSize, pPacket->m_aChunkData, sizeof(pPacket->m_aChunkData));
 			if(pPacket->m_DataSize < 0)
 			{

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -451,6 +451,11 @@ class CNetServer
 	int64_t m_VConnFirst;
 	int m_VConnNum;
 
+	// per-tick budgets for work unauthenticated peers can request, reset in Update()
+	int m_NumRecvPackets = 0;
+	int m_NumPreConnDecompress = 0;
+	int m_NumBanReplies = 0;
+
 	CSpamConn m_aSpamConns[NET_CONNLIMIT_IPS];
 
 	CPacketChunkUnpacker m_PacketChunkUnpacker;
@@ -658,7 +663,10 @@ public:
 	static void SendPacket(NETSOCKET Socket, NETADDR *pAddr, CNetPacketConstruct *pPacket, SECURITY_TOKEN SecurityToken, bool Sixup = false);
 
 	static std::optional<int> UnpackPacketFlags(unsigned char *pBuffer, int Size);
-	static int UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct *pPacket, bool &Sixup, SECURITY_TOKEN *pSecurityToken = nullptr, SECURITY_TOKEN *pResponseToken = nullptr);
+	// `AllowDecompression` false rejects compressed packets instead of decompressing them,
+	// decompression being the most expensive part of receiving a packet. `pDecompressed` is
+	// set when decompression was attempted, successfully or not.
+	static int UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct *pPacket, bool &Sixup, bool AllowDecompression, SECURITY_TOKEN *pSecurityToken = nullptr, SECURITY_TOKEN *pResponseToken = nullptr, bool *pDecompressed = nullptr);
 
 	// The backroom is ack-NET_MAX_SEQUENCE/2. Used for knowing if we acked a packet or not
 	static bool IsSeqInBackroom(int Seq, int Ack);

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -101,7 +101,9 @@ enum
 
 	NET_CONN_BUFFERSIZE = 1024 * 32,
 
-	NET_CONNLIMIT_IPS = 16,
+	// Addresses tracked for `sv_connlimit`, evicted least recently used. The limit stops
+	// applying once addresses are evicted before they reach `sv_connlimit`.
+	NET_CONNLIMIT_IPS = 256,
 
 	NET_TOKENCACHE_ADDRESSEXPIRY = 64,
 	NET_TOKENCACHE_PACKETEXPIRY = 5,
@@ -425,7 +427,10 @@ class CNetServer
 	struct CSpamConn
 	{
 		NETADDR m_Addr;
+		// start of the timespan the connections are counted in
 		int64_t m_Time;
+		// last connection, only used to pick the entry to evict
+		int64_t m_LastSeen;
 		int m_Conns;
 	};
 
@@ -456,7 +461,7 @@ class CNetServer
 	int m_NumPreConnDecompress = 0;
 	int m_NumBanReplies = 0;
 
-	CSpamConn m_aSpamConns[NET_CONNLIMIT_IPS];
+	CSpamConn m_aSpamConns[NET_CONNLIMIT_IPS] = {};
 
 	CPacketChunkUnpacker m_PacketChunkUnpacker;
 	CNetPacketConstruct m_RecvBuffer;

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -456,8 +456,10 @@ class CNetServer
 	int64_t m_VConnFirst;
 	int m_VConnNum;
 
-	// per-tick budgets for work unauthenticated peers can request, reset in Update()
+	// budgets for work unauthenticated peers can request, reset in Update():
+	// `m_NumRecvPackets` per Recv() batch, the others per second
 	int m_NumRecvPackets = 0;
+	int64_t m_BudgetStart = 0;
 	int m_NumPreConnDecompress = 0;
 	int m_NumBanReplies = 0;
 

--- a/src/engine/shared/network_client.cpp
+++ b/src/engine/shared/network_client.cpp
@@ -97,7 +97,7 @@ int CNetClient::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken, bool Six
 		}
 
 		SECURITY_TOKEN Token;
-		if(CNetBase::UnpackPacket(pData, Bytes, &m_RecvBuffer, Sixup, &Token, pResponseToken) == 0)
+		if(CNetBase::UnpackPacket(pData, Bytes, &m_RecvBuffer, Sixup, true, &Token, pResponseToken) == 0)
 		{
 			if(Sixup)
 			{

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -110,10 +110,15 @@ void CNetServer::Drop(int ClientId, const char *pReason)
 
 void CNetServer::Update()
 {
-	// called once per tick, before that tick's packets are received
 	m_NumRecvPackets = 0;
-	m_NumPreConnDecompress = 0;
-	m_NumBanReplies = 0;
+
+	const int64_t Now = time_get();
+	if(Now > m_BudgetStart + time_freq())
+	{
+		m_BudgetStart = Now;
+		m_NumPreConnDecompress = 0;
+		m_NumBanReplies = 0;
+	}
 
 	for(int i = 0; i < MaxClients(); i++)
 	{
@@ -617,9 +622,9 @@ int CNetServer::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken)
 		if(m_PacketChunkUnpacker.UnpackNextChunk(pChunk))
 			return 1;
 
-		// Stop draining the socket once this tick's budget is used up, otherwise traffic
+		// Stop draining the socket once this batch's budget is used up, otherwise traffic
 		// arriving faster than it can be processed keeps this loop from ever returning.
-		if(g_Config.m_SvMaxPacketsPerTick != 0 && m_NumRecvPackets >= g_Config.m_SvMaxPacketsPerTick)
+		if(g_Config.m_SvMaxPacketsPerRecv != 0 && m_NumRecvPackets >= g_Config.m_SvMaxPacketsPerRecv)
 		{
 			break;
 		}
@@ -638,9 +643,9 @@ int CNetServer::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken)
 		char aBuf[128];
 		if(NetBan() && NetBan()->IsBanned(&Addr, aBuf, sizeof(aBuf)))
 		{
-			// Banned, reply with a message. Budgeted per tick, unlimited replies would
+			// Banned, reply with a message. Rate limited, unlimited replies would
 			// make a banned flooder cost more to handle than an unbanned one.
-			if(g_Config.m_SvBanRepliesPerTick == 0 || m_NumBanReplies < g_Config.m_SvBanRepliesPerTick)
+			if(g_Config.m_SvBanRepliesPerSecond == 0 || m_NumBanReplies < g_Config.m_SvBanRepliesPerSecond)
 			{
 				m_NumBanReplies++;
 				CNetBase::SendControlMsg(m_Socket, &Addr, 0, NET_CTRLMSG_CLOSE, aBuf, str_length(aBuf) + 1, NET_SECURITY_TOKEN_UNSUPPORTED);
@@ -671,8 +676,8 @@ int CNetServer::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken)
 			AllowDecompression =
 				g_Config.m_SvVanillaAntiSpoof &&
 				g_Config.m_Password[0] == '\0' &&
-				(g_Config.m_SvPreConnDecompressPerTick == 0 ||
-					m_NumPreConnDecompress < g_Config.m_SvPreConnDecompressPerTick);
+				(g_Config.m_SvPreConnDecompressPerSecond == 0 ||
+					m_NumPreConnDecompress < g_Config.m_SvPreConnDecompressPerSecond);
 		}
 		else if(Sixup)
 		{

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -199,6 +199,7 @@ bool CNetServer::Connlimit(NETADDR Addr)
 	{
 		if(!net_addr_comp_noport(&m_aSpamConns[i].m_Addr, &Addr))
 		{
+			m_aSpamConns[i].m_LastSeen = Now;
 			if(m_aSpamConns[i].m_Time > Now - time_freq() * g_Config.m_SvConnlimitTime)
 			{
 				if(m_aSpamConns[i].m_Conns >= g_Config.m_SvConnlimit)
@@ -213,12 +214,13 @@ bool CNetServer::Connlimit(NETADDR Addr)
 			return false;
 		}
 
-		if(m_aSpamConns[i].m_Time < m_aSpamConns[Oldest].m_Time)
+		if(m_aSpamConns[i].m_LastSeen < m_aSpamConns[Oldest].m_LastSeen)
 			Oldest = i;
 	}
 
 	m_aSpamConns[Oldest].m_Addr = Addr;
 	m_aSpamConns[Oldest].m_Time = Now;
+	m_aSpamConns[Oldest].m_LastSeen = Now;
 	m_aSpamConns[Oldest].m_Conns = 1;
 	return false;
 }

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -110,6 +110,11 @@ void CNetServer::Drop(int ClientId, const char *pReason)
 
 void CNetServer::Update()
 {
+	// called once per tick, before that tick's packets are received
+	m_NumRecvPackets = 0;
+	m_NumPreConnDecompress = 0;
+	m_NumBanReplies = 0;
+
 	for(int i = 0; i < MaxClients(); i++)
 	{
 		m_aSlots[i].m_Connection.Update();
@@ -610,6 +615,13 @@ int CNetServer::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken)
 		if(m_PacketChunkUnpacker.UnpackNextChunk(pChunk))
 			return 1;
 
+		// Stop draining the socket once this tick's budget is used up, otherwise traffic
+		// arriving faster than it can be processed keeps this loop from ever returning.
+		if(g_Config.m_SvMaxPacketsPerTick != 0 && m_NumRecvPackets >= g_Config.m_SvMaxPacketsPerTick)
+		{
+			break;
+		}
+
 		// TODO: empty the recvinfo
 		NETADDR Addr;
 		unsigned char *pData;
@@ -618,13 +630,19 @@ int CNetServer::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken)
 		// no more packets for now
 		if(Bytes <= 0)
 			break;
+		m_NumRecvPackets++;
 
 		// check if we just should drop the packet
 		char aBuf[128];
 		if(NetBan() && NetBan()->IsBanned(&Addr, aBuf, sizeof(aBuf)))
 		{
-			// banned, reply with a message
-			CNetBase::SendControlMsg(m_Socket, &Addr, 0, NET_CTRLMSG_CLOSE, aBuf, str_length(aBuf) + 1, NET_SECURITY_TOKEN_UNSUPPORTED);
+			// Banned, reply with a message. Budgeted per tick, unlimited replies would
+			// make a banned flooder cost more to handle than an unbanned one.
+			if(g_Config.m_SvBanRepliesPerTick == 0 || m_NumBanReplies < g_Config.m_SvBanRepliesPerTick)
+			{
+				m_NumBanReplies++;
+				CNetBase::SendControlMsg(m_Socket, &Addr, 0, NET_CTRLMSG_CLOSE, aBuf, str_length(aBuf) + 1, NET_SECURITY_TOKEN_UNSUPPORTED);
+			}
 			continue;
 		}
 
@@ -639,7 +657,40 @@ int CNetServer::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken)
 		SECURITY_TOKEN Token;
 		int Slot = (*Flags & NET_PACKETFLAG_CONNLESS) == 0 ? GetClientSlot(Addr) : -1;
 		bool Sixup = Slot != -1 && m_aSlots[Slot].m_Connection.m_Sixup;
-		if(CNetBase::UnpackPacket(pData, Bytes, &m_RecvBuffer, Sixup, &Token, pResponseToken) == 0)
+
+		// Decompressing costs far more than everything else done per packet, so only do it
+		// for packets that can still turn out to be authentic. In 0.7 the security token is
+		// in the packet header and is compared first. In 0.6 it is inside the payload, so
+		// packets from addresses without a connection can only be attributed after decoding;
+		// the vanilla anti-spoof handshake is the only legitimate one and gets a budget.
+		bool AllowDecompression;
+		if(Slot == -1)
+		{
+			AllowDecompression =
+				g_Config.m_SvVanillaAntiSpoof &&
+				g_Config.m_Password[0] == '\0' &&
+				(g_Config.m_SvPreConnDecompressPerTick == 0 ||
+					m_NumPreConnDecompress < g_Config.m_SvPreConnDecompressPerTick);
+		}
+		else if(Sixup)
+		{
+			AllowDecompression =
+				Bytes >= NET_PACKETHEADERSIZE + (int)sizeof(SECURITY_TOKEN) &&
+				ToSecurityToken(pData + NET_PACKETHEADERSIZE) == m_aSlots[Slot].m_Connection.m_Token;
+		}
+		else
+		{
+			AllowDecompression = true;
+		}
+
+		bool Decompressed = false;
+		const int UnpackResult = CNetBase::UnpackPacket(pData, Bytes, &m_RecvBuffer, Sixup, AllowDecompression, &Token, pResponseToken, &Decompressed);
+		if(Slot == -1 && Decompressed)
+		{
+			m_NumPreConnDecompress++;
+		}
+
+		if(UnpackResult == 0)
 		{
 			if(m_RecvBuffer.m_Flags & NET_PACKETFLAG_CONNLESS)
 			{

--- a/src/test/network_test.cpp
+++ b/src/test/network_test.cpp
@@ -2,14 +2,29 @@
 
 #include <gtest/gtest.h>
 
-static int UnpackUncompressedPacket(int Size, CNetPacketConstruct *pPacket)
+static int UnpackUncompressedPacket(int Size, CNetPacketConstruct *pPacket, bool AllowDecompression = true)
 {
 	unsigned char aBuffer[NET_MAX_PACKETSIZE] = {};
 	aBuffer[0] = 0; // no flags, ack 0
 	aBuffer[1] = 0; // ack 0
 	aBuffer[2] = 1; // one chunk
 	bool Sixup = false;
-	return CNetBase::UnpackPacket(aBuffer, Size, pPacket, Sixup);
+	return CNetBase::UnpackPacket(aBuffer, Size, pPacket, Sixup, AllowDecompression);
+}
+
+static int UnpackCompressedPacket(CNetPacketConstruct *pPacket, bool AllowDecompression, bool *pDecompressed = nullptr, int PayloadSize = 64)
+{
+	CNetBase::Init();
+
+	const unsigned char aPayload[4 * NET_MAX_PACKETSIZE] = {};
+	unsigned char aBuffer[NET_MAX_PACKETSIZE] = {};
+	aBuffer[0] = (NET_PACKETFLAG_COMPRESSION << 2) & 0xfc; // compression, ack 0
+	aBuffer[1] = 0; // ack 0
+	aBuffer[2] = 1; // one chunk
+	const int CompressedSize = CNetBase::Compress(aPayload, PayloadSize,
+		&aBuffer[NET_PACKETHEADERSIZE], NET_MAX_PACKETSIZE - NET_PACKETHEADERSIZE);
+	bool Sixup = false;
+	return CNetBase::UnpackPacket(aBuffer, NET_PACKETHEADERSIZE + CompressedSize, pPacket, Sixup, AllowDecompression, nullptr, nullptr, pDecompressed);
 }
 
 TEST(Network, UnpackMaximumUncompressedPacket)
@@ -24,4 +39,37 @@ TEST(Network, UnpackOversizedUncompressedPacket)
 {
 	CNetPacketConstruct Packet;
 	EXPECT_EQ(UnpackUncompressedPacket(NET_PACKETHEADERSIZE + (int)sizeof(Packet.m_aChunkData) + 1, &Packet), -1);
+}
+
+TEST(Network, UnpackCompressedPacket)
+{
+	CNetPacketConstruct Packet;
+	bool Decompressed = false;
+	EXPECT_EQ(UnpackCompressedPacket(&Packet, true, &Decompressed), 0);
+	EXPECT_EQ(Packet.m_DataSize, 64);
+	EXPECT_TRUE(Decompressed);
+}
+
+TEST(Network, UnpackCompressedPacketWithoutDecompression)
+{
+	CNetPacketConstruct Packet;
+	bool Decompressed = true;
+	EXPECT_EQ(UnpackCompressedPacket(&Packet, false, &Decompressed), -1);
+	EXPECT_FALSE(Decompressed);
+}
+
+TEST(Network, UnpackOversizedCompressedPacket)
+{
+	// Decoding data that does not fit the packet buffer costs the same, so it counts
+	// as a decompression all the same.
+	CNetPacketConstruct Packet;
+	bool Decompressed = false;
+	EXPECT_EQ(UnpackCompressedPacket(&Packet, true, &Decompressed, (int)sizeof(Packet.m_aChunkData) + 1), -1);
+	EXPECT_TRUE(Decompressed);
+}
+
+TEST(Network, UnpackUncompressedPacketWithoutDecompression)
+{
+	CNetPacketConstruct Packet;
+	EXPECT_EQ(UnpackUncompressedPacket(NET_MAX_PACKETSIZE, &Packet, false), 0);
 }


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

I saw a user on discord report this:

> Filtered over a 100 GB of traffic over the past 30 minutes. They exploit compressed packets spoofing, which I cannot safely fingerprint (filter), it starves the DDNet process and knocks it unresponsive. 

So i got curious if smth could be done within the code, this pr makes it so the server only decompresses packets that can still be authentic and bounds the work an unauthenticated address can ask for per tick


This may be a complex topic so if its not wanted feel free to close the pr

<details>
  <summary>longer explanation, written by Claude</summary>

  Measured cost of one 557 byte packet: 2026ns compressed against 20ns uncompressed, all of the difference in `CHuffman::Decompress`, and decoding invalid data costs the same as decoding valid data.

  `CNetBase::UnpackPacket` gains an `AllowDecompression` flag and reports back whether a decompression was attempted:

  - 0.7: the security token is in the packet header, so it is compared against the slot's token before anything is decompressed.
  - 0.6: the token is inside the compressed payload, so a packet from an address without a connection cannot be attributed before paying for the decode. The only such packet that is ever legitimate is the `NETMSG_INPUT` of the vanilla anti-spoof handshake, so decompression for
  slotless addresses is gated on that handshake being reachable at all (`sv_vanilla_antispoof` on, no server password) and given a budget of `sv_preconn_decompress_per_tick` (16). The budget counts attempts, not successes.

  Two adjacent limits, both cases where unauthenticated input drives unbounded work:

  - `sv_max_packets_per_tick` (2048): `CNetServer::Recv` only returned once the socket was empty, so traffic arriving faster than it can be processed stopped the server from ticking at all. The rest is left for the OS to drop.
  - `sv_ban_replies_per_tick` (4): every packet from a banned address got a `NET_CTRLMSG_CLOSE` reply, which made a banned flooder cost the server more than an unbanned one.

  The second commit fixes `sv_connlimit`, which did not apply under the flood it exists to stop. The table held 16 addresses and evicted the entry with the earliest timespan start; a connection inside the timespan does not refresh that start, so the entry of the address that keeps
  connecting is exactly the one evicted. A flood spread over more than 16 addresses evicted every entry before it could reach `sv_connlimit`. It now evicts the least recently used entry and tracks 256 addresses.

  All three limits are configurable and can be turned off with 0. `src/test/network_test.cpp` covers the unpacking behaviour.

  </details>

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
