### PR TITLE
client: Fix text alignment in credits settings page

### DIFF
--- a/src/game/client/components/menus_settings_credits.cpp
+++ b/src/game/client/components/menus_settings_credits.cpp
@@ -49,20 +49,20 @@ void CMenus::RenderSettingsCredits(CUIRect MainView)
 		s_ScrollRegion.AddRect(Line);
 		if(PrefixOwnLine)
 		{
-			Ui()->DoLabel(&Line, pPrefix, FontSize, TEXTALIGN_ML);
+			Ui()->DoLabel(&Line, pPrefix, FontSize, TEXTALIGN_TL);
 			MainView.HSplitTop(LineHeight, &Line, &MainView);
 			s_ScrollRegion.AddRect(Line);
 		}
 		else
 		{
 			Line.VSplitLeft(PrefixWidth, &Prefix, &Line);
-			Ui()->DoLabel(&Prefix, pPrefix, FontSize, TEXTALIGN_ML);
+			Ui()->DoLabel(&Prefix, pPrefix, FontSize, TEXTALIGN_TL);
 		}
 
 		Line.VSplitLeft(TextRender()->TextWidth(FontSize, pLink), &LinkRect, &Line);
 		const ColorRGBA LinkColor = Ui()->HotItem() == pLinkId ? ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f) : ColorRGBA(0.4f, 0.7f, 1.0f, 1.0f);
 		TextRender()->TextColor(LinkColor);
-		Ui()->DoLabel(&LinkRect, pLink, FontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&LinkRect, pLink, FontSize, TEXTALIGN_TL);
 		TextRender()->TextColor(TextRender()->DefaultTextColor());
 
 		CUIRect Underline;
@@ -74,7 +74,7 @@ void CMenus::RenderSettingsCredits(CUIRect MainView)
 			Client()->ViewLink(pUrl);
 		}
 
-		Ui()->DoLabel(&Line, pSuffix, FontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Line, pSuffix, FontSize, TEXTALIGN_TL);
 	};
 
 	static char s_StaffLinkId;


### PR DESCRIPTION
Fixes: #12610 
Before:
<img width="1832" height="1522" alt="Screenshot 2026-08-15 at 13 06 11" src="https://github.com/user-attachments/assets/34c32929-20e7-4d36-adda-8de0107b447a" />
After:
<img width="1832" height="1522" alt="Screenshot 2026-08-15 at 13 01 27" src="https://github.com/user-attachments/assets/8d57dfd6-907d-4646-83a8-6130cece927b" />

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5).
