### PR TITLE
Fix UB when typing slash in editor save filename input

### DIFF
--- a/src/game/editor/file_browser.cpp
+++ b/src/game/editor/file_browser.cpp
@@ -191,15 +191,6 @@ void CFileBrowser::Render()
 		Ui()->DoLabel(&FileBoxLabel, "Filename:", 10.0f, TEXTALIGN_ML);
 		if(Ui()->DoEditBox(&m_FilenameInput, &FileBox, 10.0f))
 		{
-			// Remove '/' and '\'
-			for(int i = 0; m_FilenameInput.GetString()[i]; ++i)
-			{
-				if(m_FilenameInput.GetString()[i] == '/' || m_FilenameInput.GetString()[i] == '\\')
-				{
-					m_FilenameInput.SetRange(m_FilenameInput.GetString() + i + 1, i, m_FilenameInput.GetLength());
-					--i;
-				}
-			}
 			UpdateSelectedIndex(m_FilenameInput.GetString());
 		}
 	}
@@ -366,15 +357,17 @@ void CFileBrowser::Render()
 		else // file
 		{
 			const int StorageType = m_SelectedFileIndex >= 0 ? m_vpFilteredFileList[m_SelectedFileIndex]->m_StorageType : m_StorageType;
-			char aSaveFilePath[IO_MAX_PATH_LENGTH];
-			str_format(aSaveFilePath, sizeof(aSaveFilePath), "%s/%s", m_pCurrentPath, m_FilenameInput.GetString());
-			if(!str_endswith(aSaveFilePath, FILETYPE_EXTENSIONS[(int)m_FileType]))
-			{
-				str_append(aSaveFilePath, FILETYPE_EXTENSIONS[(int)m_FileType]);
-			}
 
 			char aFilename[IO_MAX_PATH_LENGTH];
-			fs_split_file_extension(fs_filename(aSaveFilePath), aFilename, sizeof(aFilename));
+			str_copy(aFilename, m_FilenameInput.GetString());
+			if(!str_endswith(aFilename, FILETYPE_EXTENSIONS[(int)m_FileType]))
+			{
+				str_append(aFilename, FILETYPE_EXTENSIONS[(int)m_FileType]);
+			}
+
+			char aSaveFilePath[IO_MAX_PATH_LENGTH];
+			str_format(aSaveFilePath, sizeof(aSaveFilePath), "%s/%s", m_pCurrentPath, aFilename);
+
 			if(m_SaveAction && !str_valid_filename(aFilename))
 			{
 				Editor()->ShowFileDialogError("This name cannot be used for files and folders.");


### PR DESCRIPTION
The `CLineInput::SetRange` call to dynamically remove slashes and backslashes from the editor save filename input was using `mem_copy` with overlapping source and target ranges, which is undefined behavior.

However, removing slashes and backslashes while typing is inconvenient and unnecessary. Instead, the filename was already validated when saving a file in the editor.

Cleanup filename validation by constructing and validating the filename first, instead of extracting it from the full path.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions: AI found the undefined behavior of overlapping `mem_copy` ranges.
