### PR TITLE
macOS: Improve DDNet-Server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3753,6 +3753,7 @@ if(CLIENT AND DMGBUILD_FOUND)
   if(SERVER)
     set(DMG_SERVER_COMMANDS
       COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/data/maps ${DMG_TMPDIR}/${SERVER_EXECUTABLE}.app/Contents/Resources/data/maps
+      COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/data/autoexec_server.cfg ${DMG_TMPDIR}/${SERVER_EXECUTABLE}.app/Contents/Resources/data/
       COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/other/icons/${SERVER_EXECUTABLE}.icns ${DMG_TMPDIR}/${SERVER_EXECUTABLE}.app/Contents/Resources/
       COMMAND ${CMAKE_COMMAND} -E copy bundle/server/Info.plist ${PROJECT_SOURCE_DIR}/other/bundle/server/PkgInfo ${DMG_TMPDIR}/${SERVER_EXECUTABLE}.app/Contents/
       COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:game-server> $<TARGET_FILE:game-server-launcher> ${DMG_TMPDIR}/${SERVER_EXECUTABLE}.app/Contents/MacOS/

--- a/src/macos/server.mm
+++ b/src/macos/server.mm
@@ -26,7 +26,11 @@
 {
 	NSData *pData = [[[notification userInfo] objectForKey: NSFileHandleNotificationDataItem] retain];
 	NSString *pString = [[NSString alloc] initWithData: pData encoding: NSASCIIStringEncoding];
-	NSAttributedString *pAttrStr = [[NSAttributedString alloc] initWithString: pString];
+	NSDictionary *pAttributes = @{
+		NSForegroundColorAttributeName: [NSColor whiteColor],
+		NSFontAttributeName: [NSFont monospacedSystemFontOfSize: [NSFont systemFontSize] weight: NSFontWeightRegular],
+	};
+	NSAttributedString *pAttrStr = [[NSAttributedString alloc] initWithString: pString attributes: pAttributes];
 
 	[[self textStorage] appendAttributedString: pAttrStr];
 	int length = [[self textStorage] length];
@@ -97,6 +101,7 @@ void runServer()
 
 	pView = [[[ServerView alloc] initWithFrame: GraphicsRect] autorelease];
 	[pView setEditable: NO];
+	[pView setBackgroundColor: [NSColor blackColor]];
 	[pView setRulerVisible: YES];
 
 	[pWindow setContentView: pView];


### PR DESCRIPTION
- white text on black background for console
- use monospace font for console
- use autoexec_server.cfg

<img width="712" height="544" alt="Screenshot 2026-08-15 at 20 58 43" src="https://github.com/user-attachments/assets/372148be-e335-49fd-a25e-47cacf285586" />


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5).
