### PR TITLE
Fix assertion printing address instead of time value

### DIFF
--- a/src/base/time.cpp
+++ b/src/base/time.cpp
@@ -60,7 +60,7 @@ static tm time_localtime_threadlocal(time_t *time_data)
 	thread_local tm time_info_buf; // NOLINT(misc-use-internal-linkage) // TODO: remove NOLINT when updating clang-tidy version
 	tm *time = localtime_r(time_data, &time_info_buf);
 #endif
-	dbg_assert(time != nullptr, "Failed to get local time for time data %" PRId64, (int64_t)time_data);
+	dbg_assert(time != nullptr, "Failed to get local time for time data %" PRId64, (int64_t)*time_data);
 	return *time;
 }
 


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions: AI found the issue. AI also found this can happen if a file's modified/creation time is before 1970 though.
