### PR TITLE
client: Fix "Show own name plate"

### DIFF
--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -863,7 +863,7 @@ void CNamePlates::OnRender()
 	if(IVideo::Current())
 		ShowDirection = g_Config.m_ClVideoShowDirection;
 #endif
-	if(!g_Config.m_ClNamePlates && ShowDirection == 0)
+	if(!g_Config.m_ClNamePlates && !g_Config.m_ClNamePlatesOwn && ShowDirection == 0)
 		return;
 
 	for(int i = 0; i < MAX_CLIENTS; i++)


### PR DESCRIPTION
Reported by Tropo on Discord: https://discord.com/channels/252358080522747904/757720336274948198/1538307777867550781

Reproduced with `cl_show_direction 0`:

> I Just noticed that the Option "Own" doesnt work for Name Plates.
It sets "cl_nameplates 0" and "cl_nameplates_own 1". But this combination seems to have never worked on any DDNet version in the first place and doesnt show anything. Is this a bug or what is Own supposed to do?

Before:
<img width="912" height="744" alt="Screenshot 2026-08-16 at 07 14 36" src="https://github.com/user-attachments/assets/36276852-367f-43b4-aef2-6d8db1b1ba58" />
After:
<img width="912" height="744" alt="Screenshot 2026-08-16 at 07 15 09" src="https://github.com/user-attachments/assets/655fd8da-13d5-4265-a48a-3d5c8d22f33a" />


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5).
