### PR TITLE
sql: don't read 1 byte past buffer in FuzzyString

### DIFF
--- a/src/engine/server/sql_string_helpers.cpp
+++ b/src/engine/server/sql_string_helpers.cpp
@@ -15,7 +15,7 @@ void sqlstr::FuzzyString(char *pString, int Size)
 			break;
 
 		pNewString[OutPos++] = pString[i];
-		if(pString[i] != '\\' && str_utf8_isstart(pString[i + 1]))
+		if(pString[i] != '\\' && str_utf8_isstart(i + 1 < Size ? pString[i + 1] : '\0'))
 			pNewString[OutPos++] = '%';
 	}
 


### PR DESCRIPTION
## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5)
