### PR TITLE
Improve versioning schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ generated
 target
 
 /build*
+/git_revision
 /integration_test/*
 /source_date_epoch
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,9 @@ else()
   message(FATAL_ERROR "Couldn't parse version from src/game/version.h")
 endif()
 
+# Full version including any suffix like `-dev` or `-rc1`
+string(REGEX REPLACE "^[^\"]*\"([^\"]*)\".*$" "\\1" VERSION_FULL "${VERSION_LINE}")
+
 if(VERSION_PATCH STREQUAL "0")
   project(DDNet VERSION ${VERSION_MAJOR}.${VERSION_MINOR})
 else()
@@ -166,7 +169,7 @@ endif()
 
 # Set version if not explicitly set
 if(NOT VERSION)
-  set(VERSION ${PROJECT_VERSION})
+  set(VERSION ${VERSION_FULL})
 endif()
 
 set(OpenGL_GL_PREFERENCE LEGACY)
@@ -2153,7 +2156,8 @@ endif()
 add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/src/generated/git_revision.cpp
   COMMAND ${Python3_EXECUTABLE}
     scripts/git_revision.py
-    > ${PROJECT_BINARY_DIR}/src/generated/git_revision.cpp
+    ${VERSION}
+    ${PROJECT_BINARY_DIR}/src/generated/git_revision.cpp
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   DEPENDS
     ${GIT_REVISION_EXTRA_DEPS}
@@ -4224,9 +4228,6 @@ foreach(target ${TARGETS_OWN})
     if(DISCORD_DYNAMIC)
       target_compile_definitions(${target} PRIVATE CONF_DISCORD_DYNAMIC)
     endif()
-  endif()
-  if(VERSION)
-    target_compile_definitions(${target} PRIVATE GAME_RELEASE_VERSION_INTERNAL=${VERSION})
   endif()
   if(TARGET_OS STREQUAL "android")
     if(ANDROID_PACKAGE_NAME)

--- a/scripts/android/cmake_android.sh
+++ b/scripts/android/cmake_android.sh
@@ -101,7 +101,7 @@ export TW_VERSION_CODE=$ANDROID_VERSION_CODE
 
 ANDROID_VERSION_NAME="1.0"
 if [ -z ${TW_VERSION_NAME+x} ]; then
-	ANDROID_VERSION_NAME="$(grep '#define GAME_RELEASE_VERSION_INTERNAL' src/game/version.h | awk '{print $3}')"
+	ANDROID_VERSION_NAME="$(grep '#define GAME_RELEASE_VERSION_INTERNAL' src/game/version.h | cut -d'"' -f2)"
 	if [ -z ${ANDROID_VERSION_NAME+x} ]; then
 		ANDROID_VERSION_NAME="1.0"
 	fi

--- a/scripts/git_revision.py
+++ b/scripts/git_revision.py
@@ -2,15 +2,49 @@
 
 import os
 import subprocess
+import sys
+
+version, source = sys.argv[1:]
 
 git_hash = os.environ.get("DDNET_GIT_SHORTREV_HASH")
 try:
 	git_hash = git_hash or subprocess.check_output(["git", "rev-parse", "--short=16", "HEAD"], stderr=subprocess.DEVNULL).decode().strip()
 except (FileNotFoundError, subprocess.CalledProcessError):
 	pass
+if git_hash is None:
+	# Official source downloads don't contain the git repository
+	try:
+		with open("git_revision", encoding="utf-8") as f:
+			git_hash = f.read().strip()
+	except FileNotFoundError:
+		pass
 if git_hash is not None:
 	definition = f'"{git_hash}"'
 else:
 	definition = "0"
-print("#include <game/version.h>")
-print(f"const char *GIT_SHORTREV_HASH = {definition};")
+if git_hash is not None and version.endswith("-dev"):
+	version = f"{version.removesuffix('-dev')}-{git_hash}"
+
+
+def update(path, contents):
+	try:
+		with open(path, encoding="utf-8") as f:
+			if f.read() == contents:
+				return
+	except FileNotFoundError:
+		pass
+	with open(path, "w", encoding="utf-8") as f:
+		f.write(contents)
+
+
+# For compatibility with DDNet client 15.8 and older GAME_VERSION needs to
+# include the prefix `0.6` because this was used for a "Compatible version"
+# filter in the server browser.
+update(
+	source,
+	f"""#include <game/version.h>
+const char *GIT_SHORTREV_HASH = {definition};
+const char *GAME_RELEASE_VERSION = "{version}";
+const char *GAME_VERSION = "0.6, {version}";
+""",
+)

--- a/scripts/parse_crashlog_drmingw.py
+++ b/scripts/parse_crashlog_drmingw.py
@@ -15,7 +15,7 @@ import urllib.parse
 import urllib.request
 
 # TODO: 2027 or later: remove backwards compatibility for parsing filename without version and architecture
-CRASH_FILENAME_PATTERN = re.compile(r"(DDNet|DDNet-Server)(_([0-9\.\-]+))?_((win32|win64)(-steam)?)(_([a-zA-Z0-9]+))?_crash_log_([0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}-[0-9]{2}-[0-9]{2})_([0-9]+)_([0-9A-Fa-f]*)")
+CRASH_FILENAME_PATTERN = re.compile(r"(DDNet|DDNet-Server)(_([0-9A-Za-z\.\-]+))?_((win32|win64)(-steam)?)(_([a-zA-Z0-9]+))?_crash_log_([0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}-[0-9]{2}-[0-9]{2})_([0-9]+)_([0-9A-Fa-f]*)")
 IMAGE_BASE_PATTERN = re.compile(r"^ImageBase\s+([0-9A-Fa-f]+)$", re.MULTILINE)
 DATE_TIME_PATTERN = re.compile(r"^Error occurred on (.+)\.$")
 ERROR_MESSAGE_PATTERN = re.compile(r"^.+?\.exe caused .+\.$")

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2553,6 +2553,11 @@ static const TVersion gs_InvalidVersion = std::make_tuple(-1, -1, -1);
 
 static TVersion ToVersion(char *pStr)
 {
+	// Cut off suffixes like `-rc1`, `-20260816` and `-3977cdf82ec1dece`
+	const char *pSuffix = str_find(pStr, "-");
+	if(pSuffix != nullptr)
+		pStr[pSuffix - pStr] = '\0';
+
 	int aVersion[3] = {0, 0, 0};
 	const char *p = strtok(pStr, ".");
 
@@ -3289,10 +3294,11 @@ void CClient::Run()
 
 	m_Fifo.Init(m_pConsole, g_Config.m_ClInputFifo, CFGFLAG_CLIENT);
 
-	m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "client", "version " GAME_RELEASE_VERSION " on " CONF_PLATFORM_STRING " " CONF_ARCH_STRING, ColorRGBA(0.7f, 0.7f, 1.0f, 1.0f));
+	char aBuf[128];
+	str_format(aBuf, sizeof(aBuf), "version %s on %s %s", GAME_RELEASE_VERSION, CONF_PLATFORM_STRING, CONF_ARCH_STRING);
+	m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "client", aBuf, ColorRGBA(0.7f, 0.7f, 1.0f, 1.0f));
 	if(GIT_SHORTREV_HASH)
 	{
-		char aBuf[64];
 		str_format(aBuf, sizeof(aBuf), "git revision hash: %s", GIT_SHORTREV_HASH);
 		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "client", aBuf, ColorRGBA(0.7f, 0.7f, 1.0f, 1.0f));
 	}
@@ -3467,7 +3473,6 @@ void CClient::Run()
 
 				if(m_BenchmarkFile)
 				{
-					char aBuf[64];
 					str_format(aBuf, sizeof(aBuf), "Frametime %d us\n", (int)(m_RenderFrameTime * 1000000));
 					io_write(m_BenchmarkFile, aBuf, str_length(aBuf));
 					if(time_get() > m_BenchmarkStopTime)
@@ -4352,7 +4357,7 @@ void CClient::InitChecksum()
 {
 	CChecksumData *pData = &m_Checksum.m_Data;
 	pData->m_SizeofData = sizeof(*pData);
-	str_copy(pData->m_aVersionStr, GAME_NAME " " GAME_RELEASE_VERSION " (" CONF_PLATFORM_STRING "; " CONF_ARCH_STRING ")");
+	str_format(pData->m_aVersionStr, sizeof(pData->m_aVersionStr), "%s %s (%s; %s)", GAME_NAME, GAME_RELEASE_VERSION, CONF_PLATFORM_STRING, CONF_ARCH_STRING);
 	pData->m_Start = time_get();
 	os_version_str(pData->m_aOsVersion, sizeof(pData->m_aOsVersion));
 	secure_random_fill(&pData->m_Random, sizeof(pData->m_Random));

--- a/src/engine/http.cpp
+++ b/src/engine/http.cpp
@@ -15,6 +15,7 @@
 #include <game/version.h>
 
 #include <algorithm>
+#include <string>
 
 IHttpRequest::IHttpRequest(const char *pUrl)
 {
@@ -209,7 +210,11 @@ static bool CalculateSha256(const char *pAbsoluteFilename, SHA256_DIGEST *pSha25
 	return true;
 }
 
-const char *const IHttpRequest::USER_AGENT_STRING = GAME_NAME " " GAME_RELEASE_VERSION " (" CONF_PLATFORM_STRING "; " CONF_ARCH_STRING ")";
+const char *IHttpRequest::UserAgent()
+{
+	static const std::string s_UserAgent = std::string(GAME_NAME " ") + GAME_RELEASE_VERSION + " (" CONF_PLATFORM_STRING "; " CONF_ARCH_STRING ")";
+	return s_UserAgent.c_str();
+}
 
 const char *IHttpRequest::GetRequestType(REQUEST Type)
 {

--- a/src/engine/http.h
+++ b/src/engine/http.h
@@ -129,7 +129,7 @@ public:
 	std::optional<int64_t> ResultLastModified() const;
 
 protected:
-	static const char *const USER_AGENT_STRING;
+	static const char *UserAgent();
 	enum class REQUEST
 	{
 		GET,

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3404,7 +3404,8 @@ int CServer::Run()
 	{
 		m_RunServer = STOPPING;
 	}
-	Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", "version " GAME_RELEASE_VERSION " on " CONF_PLATFORM_STRING " " CONF_ARCH_STRING);
+	str_format(aBuf, sizeof(aBuf), "version %s on %s %s", GAME_RELEASE_VERSION, CONF_PLATFORM_STRING, CONF_ARCH_STRING);
+	Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
 	if(GIT_SHORTREV_HASH)
 	{
 		str_format(aBuf, sizeof(aBuf), "git revision hash: %s", GIT_SHORTREV_HASH);

--- a/src/engine/server/upnp.cpp
+++ b/src/engine/server/upnp.cpp
@@ -44,9 +44,11 @@ void CUPnP::Open(NETADDR Address)
 			m_Enabled = true;
 			dbg_msg("upnp", "found valid IGD: %s", m_pUpnpUrls->controlURL);
 			str_format(aPort, sizeof(aPort), "%d", m_Addr.port);
+			char aDescription[64];
+			str_format(aDescription, sizeof(aDescription), "DDNet Server %s", GAME_RELEASE_VERSION);
 			Error = UPNP_AddPortMapping(m_pUpnpUrls->controlURL, m_pUpnpData->first.servicetype,
 				aPort, aPort, aLanAddr,
-				"DDNet Server " GAME_RELEASE_VERSION,
+				aDescription,
 				"UDP", nullptr, "0");
 
 			if(Error)

--- a/src/engine/shared/http_curl.cpp
+++ b/src/engine/shared/http_curl.cpp
@@ -113,7 +113,7 @@ bool CHttpRequestCurl::ConfigureHandle(CURL *pHandle)
 	}
 	curl_easy_setopt(pHandle, CURLOPT_URL, m_aUrl);
 	curl_easy_setopt(pHandle, CURLOPT_NOSIGNAL, 1L);
-	curl_easy_setopt(pHandle, CURLOPT_USERAGENT, USER_AGENT_STRING);
+	curl_easy_setopt(pHandle, CURLOPT_USERAGENT, UserAgent());
 	curl_easy_setopt(pHandle, CURLOPT_ACCEPT_ENCODING, ""); // Use any compression algorithm supported by libcurl.
 
 	curl_easy_setopt(pHandle, CURLOPT_HEADERDATA, this);

--- a/src/engine/shared/http_emscripten.cpp
+++ b/src/engine/shared/http_emscripten.cpp
@@ -65,7 +65,7 @@ bool CHttpRequestEmscripten::ConfigureAndRun()
 		return false;
 	}
 
-	HeaderString("User-Agent", USER_AGENT_STRING);
+	HeaderString("User-Agent", UserAgent());
 
 	if(m_Type == REQUEST::POST_JSON)
 	{

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -1629,7 +1629,7 @@ void CGameConsole::OnRender()
 		}
 
 		// render version
-		str_copy(aBuf, "v" GAME_VERSION " on " CONF_PLATFORM_STRING " " CONF_ARCH_STRING);
+		str_format(aBuf, sizeof(aBuf), "v%s on %s %s", GAME_VERSION, CONF_PLATFORM_STRING, CONF_ARCH_STRING);
 		TextRender()->Text(ButtonBar.x + ButtonBar.w - TextRender()->TextWidth(FONT_SIZE, aBuf) - 10.0f, FONT_SIZE / 2.f, FONT_SIZE, aBuf);
 	}
 }

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1235,7 +1235,13 @@ void CMenus::RenderServerbrowserInfo(CUIRect View)
 		Ui()->DoLabel(&Row, Localize("Version"), FontSize, TEXTALIGN_ML);
 
 		RightColumn.HSplitTop(15.0f, &Row, &RightColumn);
-		Ui()->DoLabel(&Row, pSelectedServer->m_aVersion, FontSize, TEXTALIGN_ML);
+		const SLabelProperties VersionLabelProps = {.m_MaxWidth = Row.w, .m_EllipsisAtEnd = true, .m_EnableWidthCheck = false};
+		if(Ui()->DoLabel(&Row, pSelectedServer->m_aVersion, FontSize, TEXTALIGN_ML, VersionLabelProps).m_Truncated)
+		{
+			static char s_VersionTooltipButtonId;
+			Ui()->DoButtonLogic(&s_VersionTooltipButtonId, 0, &Row, BUTTONFLAG_NONE);
+			GameClient()->m_Tooltips.DoToolTip(&s_VersionTooltipButtonId, &Row, pSelectedServer->m_aVersion);
+		}
 
 		LeftColumn.HSplitTop(15.0f, &Row, &LeftColumn);
 		Ui()->DoLabel(&Row, Localize("Game type"), FontSize, TEXTALIGN_ML);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -345,14 +345,7 @@ void CGameClient::OnInit()
 	m_RenderTools.Init(Graphics(), TextRender());
 	m_RenderMap.Init(Graphics(), TextRender());
 
-	if(GIT_SHORTREV_HASH)
-	{
-		str_format(m_aDDNetVersionStr, sizeof(m_aDDNetVersionStr), "%s %s (%s)", GAME_NAME, GAME_RELEASE_VERSION, GIT_SHORTREV_HASH);
-	}
-	else
-	{
-		str_format(m_aDDNetVersionStr, sizeof(m_aDDNetVersionStr), "%s %s", GAME_NAME, GAME_RELEASE_VERSION);
-	}
+	str_format(m_aDDNetVersionStr, sizeof(m_aDDNetVersionStr), "%s %s", GAME_NAME, GAME_RELEASE_VERSION);
 
 	// TODO: this should be different
 	// setup item sizes

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -19,13 +19,7 @@
 
 void CGameContext::ConInfo(IConsole::IResult *pResult, void *pUserData)
 {
-	log_info("chatresp", "DDraceNetwork Mod. Version: " GAME_VERSION);
-	if(GIT_SHORTREV_HASH)
-	{
-		char aBuf[64];
-		str_format(aBuf, sizeof(aBuf), "Git revision hash: %s", GIT_SHORTREV_HASH);
-		log_info("chatresp", "%s", aBuf);
-	}
+	log_info("chatresp", "DDraceNetwork Mod. Version: %s", GAME_VERSION);
 	log_info("chatresp", "Official site: DDNet.org");
 	log_info("chatresp", "For more info: /cmdlist");
 	log_info("chatresp", "Or visit DDNet.org");

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -120,13 +120,6 @@ CGameContext::CGameContext(bool Resetting) :
 	m_LatestLog = 0;
 	mem_zero(&m_aLogs, sizeof(m_aLogs));
 
-	str_copy(m_aVersionString, GAME_VERSION);
-	if(GIT_SHORTREV_HASH != nullptr)
-	{
-		str_append(m_aVersionString, " ");
-		str_append(m_aVersionString, GIT_SHORTREV_HASH);
-	}
-
 	if(!Resetting)
 	{
 		m_pMap = CreateMap();
@@ -4243,18 +4236,9 @@ void CGameContext::OnInit(const void *pPersistentData)
 		}
 		m_pTeeHistorianFile = aio_new(THFile);
 
-		char aVersion[128];
-		if(GIT_SHORTREV_HASH)
-		{
-			str_format(aVersion, sizeof(aVersion), "%s (%s)", GAME_VERSION, GIT_SHORTREV_HASH);
-		}
-		else
-		{
-			str_copy(aVersion, GAME_VERSION);
-		}
 		CTeeHistorian::CGameInfo GameInfo;
 		GameInfo.m_GameUuid = m_GameUuid;
-		GameInfo.m_pServerVersion = aVersion;
+		GameInfo.m_pServerVersion = GAME_VERSION;
 		GameInfo.m_StartTime = time(nullptr);
 		GameInfo.m_pPrngDescription = m_Prng.Description();
 
@@ -4685,7 +4669,7 @@ const char *CGameContext::GameType() const
 	dbg_assert(m_pController->m_pGameType, "no gametype");
 	return m_pController->m_pGameType;
 }
-const char *CGameContext::Version() const { return m_aVersionString; }
+const char *CGameContext::Version() const { return GAME_VERSION; }
 const char *CGameContext::NetVersion() const { return GAME_NETVERSION; }
 
 IGameServer *CreateGameServer() { return new CGameContext; }

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -404,7 +404,6 @@ public:
 
 	CUuid GameUuid() const override;
 	const char *GameType() const override;
-	char m_aVersionString[32];
 	const char *Version() const override;
 	const char *NetVersion() const override;
 

--- a/src/game/server/gamemodes/ddnet.cpp
+++ b/src/game/server/gamemodes/ddnet.cpp
@@ -198,7 +198,8 @@ void CGameControllerDDNet::OnPlayerConnect(CPlayer *pPlayer)
 		str_format(aBuf, sizeof(aBuf), "'%s' entered and joined the %s", Server()->ClientName(ClientId), GetTeamName(pPlayer->GetTeam()));
 		GameServer()->SendChat(-1, TEAM_ALL, aBuf, -1);
 
-		GameServer()->SendChatTarget(ClientId, "DDraceNetwork Mod. Version: " GAME_VERSION);
+		str_format(aBuf, sizeof(aBuf), "DDraceNetwork Mod. Version: %s", GAME_VERSION);
+		GameServer()->SendChatTarget(ClientId, aBuf);
 		GameServer()->SendChatTarget(ClientId, "please visit DDNet.org or say /info and make sure to read our /rules");
 	}
 }

--- a/src/game/version.h
+++ b/src/game/version.h
@@ -7,16 +7,14 @@
 #define GAME_NAME "DDNet"
 #define DDNET_VERSION_NUMBER 20010
 extern const char *GIT_SHORTREV_HASH;
-#ifndef GAME_RELEASE_VERSION_INTERNAL
-#define GAME_RELEASE_VERSION_INTERNAL 20.1
-#endif
-#define GAME_RELEASE_VERSION STRINGIFY(GAME_RELEASE_VERSION_INTERNAL)
+// Set this to the version being tagged, e.g. `20.1-rc1` or `20.1`. In versions
+// ending in `-dev` the `-dev` is replaced by the git revision hash.
+#define GAME_RELEASE_VERSION_INTERNAL "20.1-dev"
+extern const char *GAME_RELEASE_VERSION;
 
 // teeworlds
 #define CLIENT_VERSION7 0x0705
-// For compatibility with DDNet client 15.8 and older we need to include the prefix `0.6` in the version string
-// because this was used for a "Compatible version" filter in the server browser.
-#define GAME_VERSION "0.6, " GAME_RELEASE_VERSION
+extern const char *GAME_VERSION;
 #define GAME_NETVERSION "0.6 626fce9a778df4d4"
 #define GAME_NETVERSION7 "0.7 802f1be60a05665f"
 


### PR DESCRIPTION
Released version: `20.1`
Release candidate: `20.1-rc1` (before in client: `20.1`)
Nightly: `20.1-20260816` (before in client: `20.1-20260816`)
Build on master/PR: `20.1-3977cdf8fcbd01a1` (before in client: `20.1`)

The goal is to make it very obvious what you're running, and consistent in both client + server

Opinions?
<img width="1832" height="1522" alt="Screenshot 2026-08-16 at 23 35 32" src="https://github.com/user-attachments/assets/4cbb34e5-3080-4d8d-8cd7-b183758b5fbc" />
<img width="1832" height="1522" alt="Screenshot 2026-08-16 at 23 35 39" src="https://github.com/user-attachments/assets/5472880f-686d-4367-ae89-5d41c4c7d83e" />
<img width="1832" height="1522" alt="Screenshot 2026-08-16 at 23 35 47" src="https://github.com/user-attachments/assets/bb96860f-b4f8-486b-9eb6-024ad36b6069" />


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5)
