### PR TITLE
Speed up integration test by disabling --track-origins in valgrind

### DIFF
--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -230,7 +230,7 @@ add_path {relpath(self.runner.data_dir, tmp_dir)}
 				"--tool=memcheck",
 				"--gen-suppressions=all",
 				"--suppressions={}".format(relpath(os.path.join(runner.repo_dir, "memcheck.supp"), self.tmp_dir)),
-				"--track-origins=yes",
+				# "--track-origins=yes", # too expensive, makes CI flaky
 			]
 		self.name = name
 		self.num_clients = 0


### PR DESCRIPTION
More minimal than https://github.com/ddnet/ddnet/pull/12457

From: https://man7.org/linux/man-pages/man1/valgrind.1.html

> Performance overhead: origin tracking is expensive. It halves
> Memcheck's speed and increases memory use by a minimum of
> 100MB, and possibly more. Nevertheless it can drastically
> reduce the effort required to identify the root cause of
> uninitialised value errors, and so is often a programmer
> productivity win, despite running more slowly.

Fixes: #12598

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code
