### PR TITLE
Fix `CLaser`/`CPlasma` `m_Layer`/`m_Number` being uninitialized

### DIFF
--- a/src/game/client/prediction/entities/laser.cpp
+++ b/src/game/client/prediction/entities/laser.cpp
@@ -184,10 +184,12 @@ void CLaser::Tick()
 	}
 }
 
-CLaser::CLaser(CGameWorld *pGameWorld, int Id, CLaserData *pLaser) :
+CLaser::CLaser(CGameWorld *pGameWorld, int Id, const CLaserData *pLaser) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_LASER)
 {
 	m_Pos = pLaser->m_To;
+	m_Number = pLaser->m_SwitchNumber;
+	m_Layer = m_Number > 0 ? LAYER_SWITCH : LAYER_GAME;
 	m_From = pLaser->m_From;
 	m_EvalTick = pLaser->m_StartTick;
 	m_TuneZone = GameWorld()->m_WorldConfig.m_UseTuneZones ? Collision()->IsTune(Collision()->GetMapIndex(m_Pos)) : 0;

--- a/src/game/client/prediction/entities/laser.h
+++ b/src/game/client/prediction/entities/laser.h
@@ -19,7 +19,7 @@ public:
 	const vec2 &GetFrom() const { return m_From; }
 	const int &GetOwner() const { return m_Owner; }
 	const int &GetEvalTick() const { return m_EvalTick; }
-	CLaser(CGameWorld *pGameWorld, int Id, CLaserData *pLaser);
+	CLaser(CGameWorld *pGameWorld, int Id, const CLaserData *pLaser);
 	bool Match(CLaser *pLaser);
 	CLaserData GetData() const;
 

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -18,6 +18,8 @@ CLaser::CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEner
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_LASER, true)
 {
 	m_Pos = Pos;
+	m_Number = 0;
+	m_Layer = LAYER_GAME;
 	m_Owner = Owner;
 	m_Energy = StartEnergy;
 	m_Dir = Direction;

--- a/src/game/server/entities/plasma.cpp
+++ b/src/game/server/entities/plasma.cpp
@@ -7,6 +7,7 @@
 
 #include <generated/protocol.h>
 
+#include <game/mapitems.h>
 #include <game/server/gamecontext.h>
 #include <game/teamscore.h>
 
@@ -17,6 +18,8 @@ CPlasma::CPlasma(CGameWorld *pGameWorld, vec2 Pos, vec2 Dir, bool Freeze,
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_LASER, true)
 {
 	m_Pos = Pos;
+	m_Number = 0;
+	m_Layer = LAYER_GAME;
 	m_Core = Dir;
 	m_Freeze = Freeze;
 	m_Explosive = Explosive;


### PR DESCRIPTION
The unintialized `m_Number` was included in the snapshot object for `CLaser` and `CPlasma`. The `m_Layer` member is unused in these classes and only initialized for completeness.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions: AI found the issue.