### PR TITLE
server: Fix missing names for 0.7 clients on 128 player servers

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -83,6 +83,12 @@ public:
 	 * On errors, VERSION_NONE is returned.
 	 */
 	virtual int GetClientVersion(int ClientId) const = 0;
+
+	bool Supports128Players(int ClientId) const
+	{
+		return GetClientVersion(ClientId) >= VERSION_DDNET_128_PLAYERS && !IsSixup(ClientId);
+	}
+
 	virtual int SendMsg(CMsgPacker *pMsg, int Flags, int ClientId) = 0;
 
 	template<class T>
@@ -152,7 +158,7 @@ public:
 
 		// 128 player translation
 		char aBuf[512];
-		if(GetClientVersion(ClientId) < VERSION_DDNET_128_PLAYERS)
+		if(!Supports128Players(ClientId))
 		{
 			// force "Name: message" for team messages from other players to not show duplicate messages when dummy is connected
 			if(*pId >= 0 && ((MsgCopy.m_Mode == protocol7::CHAT_TEAM && *pId != ClientId) || MsgCopy.m_Mode == WhisperRecv || !Translate(*pId, ClientId)))
@@ -282,7 +288,7 @@ public:
 		// console and server demo pseudo clients operate on untranslated ids (SERVER_DEMO_CLIENT == IConsole::CLIENT_ID_UNSPECIFIED)
 		if(ClientId == SERVER_DEMO_CLIENT || ClientId == IConsole::CLIENT_ID_GAME || ClientId == IConsole::CLIENT_ID_NO_GAME)
 			return true;
-		if(GetClientVersion(ClientId) >= VERSION_DDNET_128_PLAYERS)
+		if(Supports128Players(ClientId))
 			return true;
 		if(Target < 0 || Target >= MAX_CLIENTS)
 			return false;
@@ -298,7 +304,7 @@ public:
 		// console and server demo pseudo clients operate on untranslated ids (SERVER_DEMO_CLIENT == IConsole::CLIENT_ID_UNSPECIFIED)
 		if(ClientId == SERVER_DEMO_CLIENT || ClientId == IConsole::CLIENT_ID_GAME || ClientId == IConsole::CLIENT_ID_NO_GAME)
 			return true;
-		if(GetClientVersion(ClientId) >= VERSION_DDNET_128_PLAYERS)
+		if(Supports128Players(ClientId))
 			return true;
 		if(Target < 0 || Target >= LEGACY_MAX_CLIENTS)
 			return false;

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1338,7 +1338,7 @@ void CCharacter::Snap(int SnappingClient)
 	DDNetCharacter.m_TeleCheckpoint = m_TeleCheckpoint;
 
 	int StrongWeakId = m_StrongWeakId;
-	if(SnappingClientVersion < VERSION_DDNET_128_PLAYERS && SnappingClient >= 0 && GameServer()->m_apPlayers[SnappingClient])
+	if(!Server()->Supports128Players(SnappingClient) && SnappingClient >= 0 && GameServer()->m_apPlayers[SnappingClient])
 		StrongWeakId = GameServer()->m_apPlayers[SnappingClient]->m_aStrongWeakId[TranslatedId];
 	DDNetCharacter.m_StrongWeakId = StrongWeakId;
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1082,7 +1082,7 @@ void CGameContext::SendVoteStatus(int ClientId, int Total, int Yes, int No)
 		return;
 	}
 
-	if(Total > LEGACY_MAX_CLIENTS && m_apPlayers[ClientId] && m_apPlayers[ClientId]->GetClientVersion() < VERSION_DDNET_128_PLAYERS)
+	if(Total > LEGACY_MAX_CLIENTS && m_apPlayers[ClientId] && !Server()->Supports128Players(ClientId))
 	{
 		Yes = (Yes * LEGACY_MAX_CLIENTS) / (float)Total;
 		No = (No * LEGACY_MAX_CLIENTS) / (float)Total;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -483,7 +483,7 @@ void CPlayer::Snap(int SnappingClient)
 void CPlayer::FakeSnap()
 {
 	m_SentSnaps++;
-	if(GetClientVersion() >= VERSION_DDNET_128_PLAYERS)
+	if(Server()->Supports128Players(m_ClientId))
 		return;
 
 	// see others in spec

--- a/src/game/server/playermapping.cpp
+++ b/src/game/server/playermapping.cpp
@@ -28,7 +28,7 @@ void CPlayerMapping::Tick()
 	bool NeedsLegacyMapping = false;
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
-		if(GameServer()->m_apPlayers[i] && GameServer()->GetClientVersion(i) < VERSION_DDNET_128_PLAYERS)
+		if(GameServer()->m_apPlayers[i] && !Server()->Supports128Players(i))
 		{
 			NeedsLegacyMapping = true;
 			break;
@@ -48,7 +48,7 @@ void CPlayerMapping::Tick()
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		CPlayer *pPlayer = GameServer()->m_apPlayers[i];
-		if(!pPlayer || GameServer()->GetClientVersion(i) >= VERSION_DDNET_128_PLAYERS)
+		if(!pPlayer || Server()->Supports128Players(i))
 			continue;
 
 		int StrongWeakId = 0;
@@ -228,7 +228,7 @@ void CPlayerMapping::CPlayerMap::Update()
 {
 	if(!m_pPlayerMapping->Server()->ClientIngame(m_ClientId) || !Player())
 		return;
-	if(m_pPlayerMapping->GameServer()->GetClientVersion(m_ClientId) >= VERSION_DDNET_128_PLAYERS)
+	if(m_pPlayerMapping->Server()->Supports128Players(m_ClientId))
 		return;
 
 	if(m_DoSeeOthersByVote)
@@ -359,7 +359,7 @@ int CPlayerMapping::SeeOthersId() const
 
 bool CPlayerMapping::DoSeeOthers(int ClientId, int SelectedId, bool DoByVote)
 {
-	if(GameServer()->GetClientVersion(ClientId) >= VERSION_DDNET_128_PLAYERS)
+	if(Server()->Supports128Players(ClientId))
 		return false;
 	if(SelectedId == SeeOthersId())
 	{

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -623,7 +623,7 @@ void CGameTeams::SendTeamsState(int ClientId)
 	CMsgPacker MsgLegacy(NETMSGTYPE_SV_TEAMSSTATELEGACY);
 
 	int ClientVersion = GameServer()->GetClientVersion(ClientId);
-	bool PlayerMappingRequired = ClientVersion < VERSION_DDNET_128_PLAYERS;
+	bool PlayerMappingRequired = !Server()->Supports128Players(ClientId);
 
 	for(unsigned i = 0; i < MAX_CLIENTS; i++)
 	{
@@ -710,7 +710,7 @@ int CGameTeams::TeamForClient(int Team, int ClientId) const
 	if(ClientVersion >= VERSION_DDNET_128_TEAMS)
 		return Team;
 	// If the team's slots are not reserved, dont highlight it. Causes mismatch between dummy and main when playermapping is active.
-	if(ClientVersion < VERSION_DDNET_128_PLAYERS && !GameServer()->m_PlayerMapping.ReserveTeamSlots(Team))
+	if(!GameServer()->Server()->Supports128Players(ClientId) && !GameServer()->m_PlayerMapping.ReserveTeamSlots(Team))
 		return TEAM_FLOCK;
 	return m_aLegacyTeamMap[Team];
 }


### PR DESCRIPTION
Reported by Hoco4ek on Discord:
https://discord.com/channels/252358080522747904/757720336274948198/1538575002876776459

Caused by #12018

Before:
<img width="1720" height="1378" alt="screenshot_2026-08-16_23-21-09" src="https://github.com/user-attachments/assets/cf7d4bfa-137e-4883-a859-8baf990dacde" />
After:
<img width="1720" height="1378" alt="screenshot_2026-08-16_23-16-52" src="https://github.com/user-attachments/assets/0367aaae-b1d8-42e6-9220-2413185f8935" />

closes #12641

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5)
