### PR TITLE
net: Fix timeout protection resending other clients' data

### DIFF
--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -586,6 +586,7 @@ void CNetConnection::ResumeConnection(const NETADDR *pAddr, int Sequence, int Ac
 
 		CNetChunkResend *pResend = m_Buffer.Allocate(sizeof(CNetChunkResend) + pFirst->m_DataSize);
 		mem_copy(pResend, pFirst, sizeof(CNetChunkResend) + pFirst->m_DataSize);
+		pResend->m_pData = (unsigned char *)(pResend + 1);
 
 		pResendBuffer->PopFirst();
 	}


### PR DESCRIPTION
After mem_copying the resend buffer its m_pData pointer has to be updated. I've always wondered why timeout protection rejoining has these weird lags, finally figured it out I guess...

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5)
