### PR TITLE
Fix editor font typer newline column desyncing at layer borders

### DIFF
--- a/src/game/editor/font_typer.cpp
+++ b/src/game/editor/font_typer.cpp
@@ -45,6 +45,8 @@ void CFontTyper::SetTile(ivec2 Pos, unsigned char Index, const std::shared_ptr<C
 void CFontTyper::PlaceTile(unsigned char Index, const std::shared_ptr<CLayerTiles> &pLayer)
 {
 	CState &State = Map()->m_FontTyperState;
+	if(Index != 0 && State.m_TextIndex.x < State.m_LineStart)
+		State.m_LineStart = State.m_TextIndex.x;
 	SetTile(State.m_TextIndex, Index, pLayer);
 	State.m_TextIndex.x++;
 }

--- a/src/game/editor/font_typer.cpp
+++ b/src/game/editor/font_typer.cpp
@@ -18,7 +18,7 @@ void CFontTyper::CState::Reset()
 {
 	m_Active = false;
 	m_TextIndex = ivec2(0, 0);
-	m_TextLineLen = 0;
+	m_LineStart = 0;
 	m_pLastLayer = nullptr;
 	m_TilesPlacedSinceActivate = 0;
 }
@@ -40,6 +40,13 @@ void CFontTyper::SetTile(ivec2 Pos, unsigned char Index, const std::shared_ptr<C
 	};
 	pLayer->SetTile(Pos.x, Pos.y, Tile);
 	Map()->m_FontTyperState.m_TilesPlacedSinceActivate++;
+}
+
+void CFontTyper::PlaceTile(unsigned char Index, const std::shared_ptr<CLayerTiles> &pLayer)
+{
+	CState &State = Map()->m_FontTyperState;
+	SetTile(State.m_TextIndex, Index, pLayer);
+	State.m_TextIndex.x++;
 }
 
 bool CFontTyper::OnInput(const IInput::CEvent &Event)
@@ -81,71 +88,45 @@ bool CFontTyper::OnInput(const IInput::CEvent &Event)
 
 	// letters
 	if(Event.m_Key >= KEY_A && Event.m_Key <= KEY_Z)
-	{
-		SetTile(State.m_TextIndex, Event.m_Key - KEY_A + LETTER_OFFSET, pLayer);
-		State.m_TextIndex.x++;
-		State.m_TextLineLen++;
-	}
+		PlaceTile(Event.m_Key - KEY_A + LETTER_OFFSET, pLayer);
 	// numbers
 	if(Event.m_Key >= KEY_1 && Event.m_Key <= KEY_0)
-	{
-		SetTile(State.m_TextIndex, Event.m_Key - KEY_1 + NUMBER_OFFSET, pLayer);
-		State.m_TextIndex.x++;
-		State.m_TextLineLen++;
-	}
+		PlaceTile(Event.m_Key - KEY_1 + NUMBER_OFFSET, pLayer);
 	if(Event.m_Key >= KEY_KP_1 && Event.m_Key <= KEY_KP_0)
-	{
-		SetTile(State.m_TextIndex, Event.m_Key - KEY_KP_1 + NUMBER_OFFSET, pLayer);
-		State.m_TextIndex.x++;
-		State.m_TextLineLen++;
-	}
+		PlaceTile(Event.m_Key - KEY_KP_1 + NUMBER_OFFSET, pLayer);
 
 	// deletion
 	if(Event.m_Key == KEY_BACKSPACE && State.m_TextIndex.x > 0)
 	{
 		State.m_TextIndex.x--;
-		State.m_TextLineLen--;
 		SetTile(State.m_TextIndex, 0, pLayer);
 	}
 	// space
 	if(Event.m_Key == KEY_SPACE)
-	{
-		SetTile(State.m_TextIndex, 0, pLayer);
-		State.m_TextIndex.x++;
-		State.m_TextLineLen++;
-	}
+		PlaceTile(0, pLayer);
 	// newline
 	if(Event.m_Key == KEY_RETURN)
 	{
 		State.m_TextIndex.y++;
-		State.m_TextIndex.x -= State.m_TextLineLen;
-		State.m_TextLineLen = 0;
+		State.m_TextIndex.x = State.m_LineStart;
 	}
 	// arrow key navigation
 	if(Event.m_Key == KEY_LEFT)
 	{
 		State.m_TextIndex.x--;
-		State.m_TextLineLen--;
 		if(Input()->KeyIsPressed(KEY_LCTRL))
 		{
 			while(State.m_TextIndex.x >= 1 && State.m_TextIndex.x <= pLayer->m_Width - 2 && pLayer->GetTile(State.m_TextIndex.x, State.m_TextIndex.y).m_Index)
-			{
 				State.m_TextIndex.x--;
-				State.m_TextLineLen--;
-			}
 		}
 	}
 	if(Event.m_Key == KEY_RIGHT)
 	{
 		State.m_TextIndex.x++;
-		State.m_TextLineLen++;
 		if(Input()->KeyIsPressed(KEY_LCTRL))
 		{
 			while(State.m_TextIndex.x >= 1 && State.m_TextIndex.x <= pLayer->m_Width - 2 && pLayer->GetTile(State.m_TextIndex.x, State.m_TextIndex.y).m_Index)
-			{
 				State.m_TextIndex.x++;
-				State.m_TextLineLen++;
-			}
 		}
 	}
 	if(Event.m_Key == KEY_UP)
@@ -197,7 +178,7 @@ void CFontTyper::SetCursor()
 {
 	Map()->m_FontTyperState.m_TextIndex.x = (int)(Editor()->MapView()->MouseWorldPos().x / 32);
 	Map()->m_FontTyperState.m_TextIndex.y = (int)(Editor()->MapView()->MouseWorldPos().y / 32);
-	Map()->m_FontTyperState.m_TextLineLen = 0;
+	Map()->m_FontTyperState.m_LineStart = Map()->m_FontTyperState.m_TextIndex.x;
 	m_CursorRenderTime = time_get_nanoseconds() - 501ms;
 }
 

--- a/src/game/editor/font_typer.h
+++ b/src/game/editor/font_typer.h
@@ -23,7 +23,8 @@ public:
 	public:
 		bool m_Active;
 		ivec2 m_TextIndex;
-		int m_TextLineLen;
+		// column a newline returns to
+		int m_LineStart;
 		std::shared_ptr<CLayer> m_pLastLayer;
 		int m_TilesPlacedSinceActivate;
 
@@ -50,6 +51,7 @@ private:
 	void TextModeOff();
 	void TextModeOn();
 	void SetTile(ivec2 Pos, unsigned char Index, const std::shared_ptr<CLayerTiles> &pLayer);
+	void PlaceTile(unsigned char Index, const std::shared_ptr<CLayerTiles> &pLayer);
 };
 
 #endif


### PR DESCRIPTION
title

<!-- What is the motivation for the changes of this pull request? -->

Used AI 

<details>
  <summary>longer explanation, written by Claude</summary>

  m_TextLineLen was incremented on every rightward caret move and decremented on every leftward one, and its only consumer was KEY_RETURN, which did m_TextIndex.x -= m_TextLineLen to get back to the start of the line. OnInput ends by clamping m_TextIndex.x to the layer, but the
  clamp never touched the counter, so any keypress clamped at a border left the two permanently out of step.
  
  Pressing Left at column 0 sets the counter to -1 while the index clamps back to 0, so a newline afterwards lands one column right of where the line began. At the right border it goes the other way: every letter typed at the last column, and every Right pressed there, inflates
  the counter while the index stays put, so a newline lands left of the start.
 
  m_TextLineLen was only ever x minus the column at the last SetCursor(), so storing that column as m_LineStart is the same information with nothing to keep in sync. It is written in Reset() and SetCursor() and read by KEY_RETURN, and the twelve counter updates scattered through
  the input handler are gone. PlaceTile folds the SetTile(); x++; pattern that letters, numbers, keypad numbers and space each repeated.
  
  Both caret state machines were lifted out and run side by side. Over every key sequence of length 1 to 5 across 8 keys from all 4 start columns on a 4x4 layer, 149792 sequences, a newline lands off the line start in 10.5% of them before this change and in none of them after.
  Interior sequences where no clamp fires are identical, so nothing changes anywhere the old code was already correct.
  
  </details>

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
