### PR TITLE
Fix ci smoke_test timeout again

### DIFF
--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -791,7 +791,7 @@ def smoke_test(test_env):
 	""".strip().split("\n")
 		)
 	)
-	client1.wait_for_log_exact("chat/server: *** the end", timeout=3)
+	client1.wait_for_log_exact("chat/server: *** the end", timeout=15)
 
 	server.command("stoprecord")
 	client1.command("stoprecord")


### PR DESCRIPTION
Raise the timeout of the `*** the end` wait in `smoke_test` to match the other waits around it, since 3 (75s under Valgrind) is usually not enough.

<details>
<summary>longer explanation, written by Claude</summary>

Two of the last three `smoke_test` failures on master timed out on this line: runs 31978130135 and 31909214426. The wait starts when the server logs the rcon auth, but the `say "/mc; ..."` line and the seven `rcon ...` commands are still queued in the client at that point. In 31978130135 the server logged `rcon='say the end'` 40s after the auth line (23:38:51 → 23:39:31), and in 31909214426 45s after it (22:33:12 → 22:33:57), so most of the 75s budget was already spent before the server ran the command. In both runs the client then printed `*** hello from admin` and `broadcast: test` and logged nothing at all until the deadline; earlier in 31978130135 the same client went 93s without a log line (23:35:29 → 23:37:02), which is normal for a Debug + gcov client under Memcheck. 3 is also the outlier here: edf3e529a raised the surrounding waits to 15 and 30 but left this one, and every other wait in `smoke_test` is between 10 and 40. Related: #12598, #12631.

</details>

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude diagnosed the CI failure from the workflow logs, wrote this change and the collapsed explanation above.
