### PR TITLE
Release ground hooks that lost their tile when loading a tee

### DIFF
--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -9,6 +9,7 @@
 #include <engine/shared/config.h>
 #include <engine/shared/protocol.h>
 
+#include <game/mapitems.h>
 #include <game/server/entities/character.h>
 #include <game/server/gamecontext.h>
 #include <game/server/gamemodes/ddnet.h>
@@ -240,6 +241,13 @@ bool CSaveTee::Load(CCharacter *pChr, std::optional<int> Team)
 	else
 	{
 		pChr->m_Core.SetHookedPlayer(m_HookedPlayer);
+	}
+	// A hook attached to the ground requires a hookable tile at its position.
+	if(pChr->m_Core.m_HookState == HOOK_GRABBED && pChr->m_Core.HookedPlayer() == -1 &&
+		pChr->Collision()->GetCollisionAt(pChr->m_Core.m_HookPos.x, pChr->m_Core.m_HookPos.y) != TILE_SOLID)
+	{
+		pChr->m_Core.m_HookState = HOOK_RETRACTED;
+		pChr->m_Core.m_HookPos = pChr->m_Core.m_Pos;
 	}
 	pChr->m_Core.m_NewHook = m_NewHook;
 	pChr->m_SavedInput.m_Direction = m_InputDirection;


### PR DESCRIPTION
A tee restored by `hot_reload` or `/load` keeps a hook that is grabbed on ground, so when a map edit removes the block it was hanging on, the tee stays suspended in mid air on geometry that no longer exists

bug reported on discord

<details>
<summary>longer explanation, written by Claude</summary>

`hot_reload` saves every tee and restores it after the new map is loaded, and `CSaveTee::Load` copies `m_HookState`, `m_HookPos` and `m_HookDir` back verbatim. A hook grabbed on ground is never re-checked against the tiles afterwards, since `CCharacterCore::Tick` only re-validates hooks attached to players, so the anchor from the previous map stays valid until the player lets go.

Saving in the editor runs `hot_reload` on the local server by default (`ed_auto_map_reload`), so this shows up while mapping: delete the block you are hanging from, press Ctrl+S, and you keep hanging there.

Reproduced with a local server and the client: hook into a ceiling, replace the map file, `hot_reload`. The tee hovers in the air pulled towards the missing block, still there 35 seconds later, and only drops once the hook key is released. With this change it falls immediately and lands on the new map's ground.

The check reads the tile at the hook position from the freshly loaded collision and only retracts when it is no longer `TILE_SOLID`. A grab always happens on a `TILE_SOLID` game layer tile, `TILE_NOHOOK` retracts the hook instead and hook blockers are front layer tiles that never produce a grab, so the condition cannot fire on an unchanged map and `/save` plus `/load` on the same map behaves as before. Retracting instead of releasing matches what a hook that hits nothing does: it stays retracted until the hook key is released.

</details>

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude investigated the bug, reproduced it against a local server, wrote this change and the collapsed explanation above.
