### PR TITLE
Fix: font typer does not allow to delete from last column with backspace

### DIFF
--- a/src/game/editor/font_typer.cpp
+++ b/src/game/editor/font_typer.cpp
@@ -45,8 +45,23 @@ void CFontTyper::SetTile(ivec2 Pos, unsigned char Index, const std::shared_ptr<C
 void CFontTyper::PlaceTile(unsigned char Index, const std::shared_ptr<CLayerTiles> &pLayer)
 {
 	CState &State = Map()->m_FontTyperState;
-	if(Index != 0 && State.m_TextIndex.x < State.m_LineStart)
+	// handle cursor behind right column and do line break
+	if(State.m_TextIndex.x == pLayer->m_Width)
+	{
+		if(Index == 0)
+			return;
+		State.m_TextIndex.x = State.m_LineStart;
+		State.m_TextIndex.y++;
+
+		// corner case
+		if(State.m_TextIndex.y >= pLayer->m_Height)
+			return;
+	}
+	// handle writing left of the line start
+	else if(Index != 0 && State.m_TextIndex.x < State.m_LineStart)
+	{
 		State.m_LineStart = State.m_TextIndex.x;
+	}
 	SetTile(State.m_TextIndex, Index, pLayer);
 	State.m_TextIndex.x++;
 }
@@ -135,7 +150,7 @@ bool CFontTyper::OnInput(const IInput::CEvent &Event)
 		State.m_TextIndex.y--;
 	if(Event.m_Key == KEY_DOWN)
 		State.m_TextIndex.y++;
-	State.m_TextIndex.x = std::clamp(State.m_TextIndex.x, 0, pLayer->m_Width - 1);
+	State.m_TextIndex.x = std::clamp(State.m_TextIndex.x, 0, pLayer->m_Width);
 	State.m_TextIndex.y = std::clamp(State.m_TextIndex.y, 0, pLayer->m_Height - 1);
 	m_CursorRenderTime = time_get_nanoseconds() - 501ms;
 	float Dist = distance(
@@ -221,7 +236,7 @@ void CFontTyper::Render()
 		return;
 	}
 	State.m_pLastLayer = pLayer;
-	State.m_TextIndex.x = std::clamp(State.m_TextIndex.x, 0, pLayer->m_Width - 1);
+	State.m_TextIndex.x = std::clamp(State.m_TextIndex.x, 0, pLayer->m_Width);
 	State.m_TextIndex.y = std::clamp(State.m_TextIndex.y, 0, pLayer->m_Height - 1);
 
 	const auto CurTime = time_get_nanoseconds();


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This allows the font typer to delete from the last column of a layer. This is an artifact of the cursor always being **behind** the tile with backspace which is not allowed for the last column. If you press any button (except) space here the tool will now automatically do a line break if possible

<img width="2560" height="1440" alt="screenshot_2026-08-18_00-53-55" src="https://github.com/user-attachments/assets/fbdaf89a-19da-4862-921a-211479a37663" />

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
