### PR TITLE
Add setting to reset emote wheel mouse position.

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -94,6 +94,7 @@ MACRO_CONFIG_INT(ClShowfps, cl_showfps, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, 
 MACRO_CONFIG_INT(ClShowpred, cl_showpred, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame prediction time in milliseconds")
 MACRO_CONFIG_INT(ClEyeWheel, cl_eye_wheel, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show eye wheel along together with emotes")
 MACRO_CONFIG_INT(ClEyeWheelMouseReset, cl_eye_wheel_mouse_reset, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Reset mouse cursor position when opening the emote selector")
+MACRO_CONFIG_INT(ClEyeWheelLastEmoteTimeout, cl_eye_wheel_last_emote_timeout, 10, 0, 999999, CFGFLAG_CLIENT | CFGFLAG_SAVE, "How long in seconds the last selected emote stays selectable in the center of the emote wheel, 0 to never expire")
 MACRO_CONFIG_INT(ClEyeDuration, cl_eye_duration, 999999, 1, 999999, CFGFLAG_CLIENT | CFGFLAG_SAVE, "How long the eyes emotes last")
 MACRO_CONFIG_INT(ClFreezeStars, cl_freeze_stars, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show old star particles for frozen tees")
 

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -93,6 +93,7 @@ MACRO_CONFIG_INT(ClShowLocalTimeAlways, cl_show_local_time_always, 0, 0, 1, CFGF
 MACRO_CONFIG_INT(ClShowfps, cl_showfps, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame FPS counter")
 MACRO_CONFIG_INT(ClShowpred, cl_showpred, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame prediction time in milliseconds")
 MACRO_CONFIG_INT(ClEyeWheel, cl_eye_wheel, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show eye wheel along together with emotes")
+MACRO_CONFIG_INT(ClEyeWheelMouseReset, cl_eye_wheel_mouse_reset, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Reset mouse cursor position when opening the emote selector")
 MACRO_CONFIG_INT(ClEyeDuration, cl_eye_duration, 999999, 1, 999999, CFGFLAG_CLIENT | CFGFLAG_SAVE, "How long the eyes emotes last")
 MACRO_CONFIG_INT(ClFreezeStars, cl_freeze_stars, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show old star particles for frozen tees")
 

--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -27,6 +27,9 @@ void CEmoticon::ConKeyEmoticon(IConsole::IResult *pResult, void *pUserData)
 
 	if(!pSelf->GameClient()->m_Snap.m_SpecInfo.m_Active && pSelf->Client()->State() != IClient::STATE_DEMOPLAYBACK)
 		pSelf->m_Active = pResult->GetInteger(0) != 0;
+
+	if(pSelf->m_Active && g_Config.m_ClEyeWheelMouseReset)
+		pSelf->m_SelectorMouse = vec2(0, 0);
 }
 
 void CEmoticon::ConEmote(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -50,6 +50,8 @@ void CEmoticon::OnReset()
 	m_SelectedEmote = -1;
 	m_SelectedEyeEmote = -1;
 	m_TouchPressedOutside = false;
+	m_LastEmote = -1;
+	m_LastEmoteTime = -1.0f;
 }
 
 void CEmoticon::OnRelease()
@@ -81,6 +83,9 @@ void CEmoticon::OnRender()
 {
 	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 		return;
+
+	if(m_LastEmote != -1 && g_Config.m_ClEyeWheelLastEmoteTimeout != 0 && Client()->LocalTime() - m_LastEmoteTime > g_Config.m_ClEyeWheelLastEmoteTimeout)
+		m_LastEmote = -1;
 
 	if(!m_Active)
 	{
@@ -144,6 +149,11 @@ void CEmoticon::OnRender()
 		m_SelectedEmote = (int)(SelectedAngle / (2 * pi) * (float)NUM_EMOTICONS);
 	else if(length(m_SelectorMouse) > 40.0f)
 		m_SelectedEyeEmote = (int)(SelectedAngle / (2 * pi) * (float)NUM_EMOTES);
+	else if(g_Config.m_ClEyeWheelMouseReset && m_LastEmote != -1)
+		m_SelectedEmote = m_LastEmote;
+
+	if(length(m_SelectorMouse) > 40.0f)
+		m_LastEmote = -1; // leaving the center deselects the remembered last emote
 
 	const vec2 ScreenCenter = Screen.Center();
 
@@ -201,13 +211,38 @@ void CEmoticon::OnRender()
 		Graphics()->QuadsEnd();
 	}
 	else
+	{
 		m_SelectedEyeEmote = -1;
+
+		if(m_LastEmote != -1)
+		{
+			Graphics()->TextureClear();
+			Graphics()->QuadsBegin();
+			Graphics()->SetColor(0, 0, 0, 0.3f);
+			Graphics()->DrawCircle(ScreenCenter.x, ScreenCenter.y, 36.0f, 64);
+			Graphics()->QuadsEnd();
+		}
+	}
+
+	if(m_LastEmote != -1)
+	{
+		Graphics()->TextureSet(GameClient()->m_EmoticonsSkin.m_aSpriteEmoticons[m_LastEmote]);
+		Graphics()->QuadsSetSubset(0, 0, 1, 1);
+		Graphics()->QuadsBegin();
+		const float Size = m_SelectedEmote == m_LastEmote ? 48.0f : 32.0f;
+		IGraphics::CQuadItem QuadItem(ScreenCenter.x, ScreenCenter.y, Size, Size);
+		Graphics()->QuadsDraw(&QuadItem, 1);
+		Graphics()->QuadsEnd();
+	}
 
 	RenderTools()->RenderCursor(ScreenCenter + m_SelectorMouse, 24.0f);
 }
 
 void CEmoticon::Emote(int Emoticon)
 {
+	m_LastEmote = Emoticon;
+	m_LastEmoteTime = Client()->LocalTime();
+
 	CNetMsg_Cl_Emoticon Msg;
 	Msg.m_Emoticon = Emoticon;
 	Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);

--- a/src/game/client/components/emoticon.h
+++ b/src/game/client/components/emoticon.h
@@ -18,6 +18,9 @@ class CEmoticon : public CComponent
 	int m_SelectedEmote;
 	int m_SelectedEyeEmote;
 
+	int m_LastEmote;
+	float m_LastEmoteTime;
+
 	CUi::CTouchState m_TouchState;
 	bool m_TouchPressedOutside;
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Just adds a setting to reset the position of the cursor when opening the emote wheel.  If enabled, then the middle of the wheel will have the previously selected emote (reset after 10 seconds; defined by another timeout setting) for spamming purposes
Quick demo:
https://github.com/user-attachments/assets/219999b1-869b-404d-84c7-cffe7485c2f4

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
