### PR TITLE
Feature: Add more editor font typer binds and other improvements

### DIFF
--- a/src/game/editor/font_typer.cpp
+++ b/src/game/editor/font_typer.cpp
@@ -18,7 +18,7 @@ void CFontTyper::CState::Reset()
 {
 	m_Active = false;
 	m_TextIndex = ivec2(0, 0);
-	m_LineStart = 0;
+	m_LineStart = std::nullopt;
 	m_pLastLayer = nullptr;
 	m_TilesPlacedSinceActivate = 0;
 }
@@ -50,18 +50,20 @@ void CFontTyper::PlaceTile(unsigned char Index, const std::shared_ptr<CLayerTile
 	{
 		if(Index == 0)
 			return;
-		State.m_TextIndex.x = State.m_LineStart;
+		State.m_TextIndex.x = State.m_LineStart.value_or(0);
 		State.m_TextIndex.y++;
 
 		// corner case
 		if(State.m_TextIndex.y >= pLayer->m_Height)
+		{
+			State.m_TextIndex.x = pLayer->m_Width;
+			State.m_TextIndex.y = pLayer->m_Height - 1;
 			return;
+		}
 	}
-	// handle writing left of the line start
-	else if(Index != 0 && State.m_TextIndex.x < State.m_LineStart)
-	{
+
+	if(Index != 0 && (!State.m_LineStart.has_value() || State.m_TextIndex.x < State.m_LineStart))
 		State.m_LineStart = State.m_TextIndex.x;
-	}
 	SetTile(State.m_TextIndex, Index, pLayer);
 	State.m_TextIndex.x++;
 }
@@ -103,6 +105,70 @@ bool CFontTyper::OnInput(const IInput::CEvent &Event)
 	if(!(Event.m_Flags & IInput::FLAG_PRESS))
 		return false;
 
+	if(State.m_LineStart.has_value())
+		State.m_LineStart = std::clamp(State.m_LineStart.value(), 0, pLayer->m_Width - 1);
+
+	// handle all ctrl+S binds instead of writing "S"
+	if(Input()->ModifierIsPressed() && Input()->KeyIsPressed(KEY_S))
+	{
+		TextModeOff();
+		return false;
+	}
+
+	if(Input()->ModifierIsPressed() && Input()->KeyIsPressed(KEY_V))
+	{
+		std::string Clipboard = Input()->GetClipboardText();
+		if(!Clipboard.empty())
+		{
+			if(Clipboard.size() > 10000)
+			{
+				Editor()->ShowFileDialogError("The clipboard contains %" PRIzu " characters, please post it in chunks", Clipboard.size());
+				return false;
+			}
+			str_sanitize(Clipboard.data());
+			for(auto &Char : Clipboard)
+			{
+				if(Char == '\r')
+					continue;
+				if(Char == '\t')
+					Char = ' ';
+
+				// handle space
+				if(Char == ' ')
+				{
+					PlaceTile(0, pLayer);
+				}
+				// handle linebreaks
+				else if(Char == '\n')
+				{
+					if(State.m_TextIndex.y < pLayer->m_Height - 1)
+					{
+						State.m_TextIndex.y++;
+						if(State.m_LineStart.has_value())
+							State.m_TextIndex.x = State.m_LineStart.value();
+					}
+				}
+				// handle numbers
+				else if(str_isnum(Char))
+				{
+					if(Char == '0')
+						PlaceTile(KEY_0 - KEY_1 + NUMBER_OFFSET, pLayer);
+					else
+						PlaceTile(Char - '1' + NUMBER_OFFSET, pLayer);
+				}
+				else
+				{
+					Char = str_uppercase(Char);
+					if(Char >= 'A' && Char <= 'Z')
+					{
+						PlaceTile(Char - 'A' + LETTER_OFFSET, pLayer);
+					}
+				}
+			}
+		}
+		return false;
+	}
+
 	// letters
 	if(Event.m_Key >= KEY_A && Event.m_Key <= KEY_Z)
 		PlaceTile(Event.m_Key - KEY_A + LETTER_OFFSET, pLayer);
@@ -118,6 +184,12 @@ bool CFontTyper::OnInput(const IInput::CEvent &Event)
 		State.m_TextIndex.x--;
 		SetTile(State.m_TextIndex, 0, pLayer);
 	}
+	else if(Event.m_Key == KEY_DELETE)
+	{
+		if(State.m_TextIndex.x < pLayer->m_Width)
+			SetTile(State.m_TextIndex, 0, pLayer);
+	}
+
 	// space
 	if(Event.m_Key == KEY_SPACE)
 		PlaceTile(0, pLayer);
@@ -125,13 +197,39 @@ bool CFontTyper::OnInput(const IInput::CEvent &Event)
 	if(Event.m_Key == KEY_RETURN)
 	{
 		State.m_TextIndex.y++;
-		State.m_TextIndex.x = State.m_LineStart;
+		if(State.m_LineStart.has_value())
+			State.m_TextIndex.x = State.m_LineStart.value();
 	}
+
+	// special key navigation
+	if(Event.m_Key == KEY_HOME)
+	{
+		for(int StartIndex = State.m_LineStart.value_or(0); StartIndex < pLayer->m_Width; ++StartIndex)
+		{
+			State.m_TextIndex.x = StartIndex;
+			if(pLayer->GetTile(StartIndex, State.m_TextIndex.y).m_Index != 0)
+				break;
+		}
+		// no char found
+		if(pLayer->GetTile(State.m_TextIndex.x, State.m_TextIndex.y).m_Index == 0)
+			State.m_TextIndex.x = State.m_LineStart.value_or(0);
+	}
+	else if(Event.m_Key == KEY_END)
+	{
+		int LastIndex = -1;
+		for(int EndIndex = State.m_LineStart.value_or(0); EndIndex < pLayer->m_Width; ++EndIndex)
+		{
+			if(pLayer->GetTile(EndIndex, State.m_TextIndex.y).m_Index)
+				LastIndex = EndIndex;
+		}
+		State.m_TextIndex.x = LastIndex >= 0 ? LastIndex + 1 : State.m_LineStart.value_or(0);
+	}
+
 	// arrow key navigation
 	if(Event.m_Key == KEY_LEFT)
 	{
 		State.m_TextIndex.x--;
-		if(Input()->KeyIsPressed(KEY_LCTRL))
+		if(Input()->ModifierIsPressed())
 		{
 			while(State.m_TextIndex.x >= 1 && State.m_TextIndex.x <= pLayer->m_Width - 2 && pLayer->GetTile(State.m_TextIndex.x, State.m_TextIndex.y).m_Index)
 				State.m_TextIndex.x--;
@@ -140,7 +238,7 @@ bool CFontTyper::OnInput(const IInput::CEvent &Event)
 	if(Event.m_Key == KEY_RIGHT)
 	{
 		State.m_TextIndex.x++;
-		if(Input()->KeyIsPressed(KEY_LCTRL))
+		if(Input()->ModifierIsPressed())
 		{
 			while(State.m_TextIndex.x >= 1 && State.m_TextIndex.x <= pLayer->m_Width - 2 && pLayer->GetTile(State.m_TextIndex.x, State.m_TextIndex.y).m_Index)
 				State.m_TextIndex.x++;
@@ -195,7 +293,6 @@ void CFontTyper::SetCursor()
 {
 	Map()->m_FontTyperState.m_TextIndex.x = (int)(Editor()->MapView()->MouseWorldPos().x / 32);
 	Map()->m_FontTyperState.m_TextIndex.y = (int)(Editor()->MapView()->MouseWorldPos().y / 32);
-	Map()->m_FontTyperState.m_LineStart = Map()->m_FontTyperState.m_TextIndex.x;
 	m_CursorRenderTime = time_get_nanoseconds() - 501ms;
 }
 

--- a/src/game/editor/font_typer.h
+++ b/src/game/editor/font_typer.h
@@ -11,6 +11,7 @@
 
 #include <chrono>
 #include <memory>
+#include <optional>
 
 class CLayer;
 class CLayerTiles;
@@ -24,7 +25,7 @@ public:
 		bool m_Active;
 		ivec2 m_TextIndex;
 		// column a newline returns to
-		int m_LineStart;
+		std::optional<int> m_LineStart;
 		std::shared_ptr<CLayer> m_pLastLayer;
 		int m_TilesPlacedSinceActivate;
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This PR adds a different handling for the `m_LineStart` parameter. It can now be unset and will be set with the first character you post.

This PR switches from the hardcoded `L_CTRL` to `ModifierIsPressed`.

This PR adds handling for various keybinds in the font typer:
- `CTRL` + `S` which was previously only writing an S instead of saving the map
- `CTRL` + `V` so you can write text at a different place and can just paste it in. This of course will ignore unknown characters but handles tabs as spaces and newlines properly. It shows an error if you try to post more than 10.000 chars
- `POS1`/`HOME` button, which jumps to the start of the text in a line
- `END` button, which jumps to the end of the text in a line
- `DELETE` button, which deletes the current character

(Older, missing linebreaks:)
<img width="2560" height="1440" alt="screenshot_2026-08-18_09-54-20" src="https://github.com/user-attachments/assets/cb7528d7-3921-4546-81d5-9624be28b337" />
<img width="2560" height="1440" alt="screenshot_2026-08-18_09-51-20" src="https://github.com/user-attachments/assets/613c0e33-8ce4-4598-8266-da17c5595f3f" />

(Newer:)
<img width="2560" height="1440" alt="screenshot_2026-08-18_12-08-29" src="https://github.com/user-attachments/assets/b6ebb74d-a6ce-4d80-8521-934a33e2cee4" />
<img width="2560" height="1440" alt="screenshot_2026-08-18_12-12-34" src="https://github.com/user-attachments/assets/72d400e5-8801-4970-b8ed-ae490cbc9c44" />

for #12611

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
