### PR TITLE
Cleanup: Save screenshots as RGB instead of RGBA

### DIFF
--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -1017,33 +1017,32 @@ void CCommandProcessorFragment_OpenGL::Cmd_Screenshot(const CCommandBuffer::SCom
 
 	pCommand->m_pImage->m_Width = w;
 	pCommand->m_pImage->m_Height = h;
-	pCommand->m_pImage->m_Format = CImageInfo::FORMAT_RGBA;
+	pCommand->m_pImage->m_Format = CImageInfo::FORMAT_RGB;
 	pCommand->m_pImage->Allocate();
 
 	uint8_t *pPixelData = pCommand->m_pImage->m_pData;
 
 	// we create a tmp row to use when we are flipping the texture
-	std::vector<uint8_t> vTmpRow(w * 4);
+	size_t RowByteSize = static_cast<size_t>(w) * 3;
+	std::vector<uint8_t> vTmpRow(RowByteSize);
 	uint8_t *pTempRow = vTmpRow.data();
 
 	// fetch the pixels
 	GLint Alignment;
 	glGetIntegerv(GL_PACK_ALIGNMENT, &Alignment);
 	glPixelStorei(GL_PACK_ALIGNMENT, 1);
-	glReadPixels(0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE, pPixelData);
+	glReadPixels(0, 0, w, h, GL_RGB, GL_UNSIGNED_BYTE, pPixelData);
 	glPixelStorei(GL_PACK_ALIGNMENT, Alignment);
 
 	// flip the pixel because opengl works from bottom left corner
 	for(int y = 0; y < h / 2; y++)
 	{
-		mem_copy(pTempRow, pPixelData + y * w * 4, w * 4);
-		mem_copy(pPixelData + y * w * 4, pPixelData + (h - y - 1) * w * 4, w * 4);
-		mem_copy(pPixelData + (h - y - 1) * w * 4, pTempRow, w * 4);
-		for(int x = 0; x < w; x++)
-		{
-			pPixelData[y * w * 4 + x * 4 + 3] = 255;
-			pPixelData[(h - y - 1) * w * 4 + x * 4 + 3] = 255;
-		}
+		uint8_t *pTopRow = pPixelData + y * RowByteSize;
+		uint8_t *pBottomRow = pPixelData + (h - 1 - y) * RowByteSize;
+
+		mem_copy(pTempRow, pTopRow, RowByteSize);
+		mem_copy(pTopRow, pBottomRow, RowByteSize);
+		mem_copy(pBottomRow, pTempRow, RowByteSize);
 	}
 }
 

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -1,3 +1,6 @@
+#include <engine/image.h>
+
+#include <cstdint>
 #if defined(CONF_BACKEND_VULKAN)
 
 #include <base/dbg.h>
@@ -915,6 +918,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 	uint32_t m_MinUniformAlign;
 
 	std::vector<uint8_t> m_vReadPixelHelper;
+	// avoid having to allocate and free the buffer for every screenshot
 	std::vector<uint8_t> m_vScreenshotHelper;
 
 	SDeviceMemoryBlock m_GetPresentedImgDataHelperMem;
@@ -6938,13 +6942,22 @@ public:
 		uint32_t Height;
 		CImageInfo::EImageFormat Format;
 
-		if(GetPresentedImageDataImpl(Width, Height, Format, m_vScreenshotHelper, true, {}))
+		if(GetPresentedImageDataImpl(Width, Height, Format, m_vScreenshotHelper, false, {}))
 		{
+			dbg_assert(Format == CImageInfo::FORMAT_RGBA, "Vulkan backend returned unexpected image format");
+
 			pCommand->m_pImage->m_Width = (int)Width;
 			pCommand->m_pImage->m_Height = (int)Height;
-			pCommand->m_pImage->m_Format = Format;
+			pCommand->m_pImage->m_Format = CImageInfo::FORMAT_RGB;
 			pCommand->m_pImage->Allocate();
-			mem_copy(pCommand->m_pImage->m_pData, m_vScreenshotHelper.data(), pCommand->m_pImage->DataSize());
+			const unsigned char *pScreenshotData = m_vScreenshotHelper.data();
+			uint8_t *pImageData = pCommand->m_pImage->m_pData;
+
+			// RGBA to RGB
+			for(size_t PixelIndex = 0; PixelIndex < static_cast<size_t>(Width) * Height; ++PixelIndex)
+			{
+				mem_copy(&pImageData[PixelIndex * 3], &pScreenshotData[PixelIndex * 4], 3);
+			}
 		}
 		else
 		{


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This PR lets screenshot save in RGB instead of RGBA. We never ever want transparency in the screenshots as the game should at no point have any transparency on the viewport.

This has the side effect of producing slightly smaller screenshots:

<img width="1077" height="155" alt="Bildschirmfoto_20260819_093903" src="https://github.com/user-attachments/assets/90877ff1-8956-4dbb-b533-11f4bde5cd79" />

This also fixes the issue from #12530.

## Tested manually:

Vulkan:
<img width="2560" height="1440" alt="screenshot_2026-08-19_09-34-05" src="https://github.com/user-attachments/assets/a78f23a1-7cce-4654-b439-0c6568a0e53b" />

OpenGL 3.3:
<img width="2560" height="1440" alt="screenshot_2026-08-19_08-57-08" src="https://github.com/user-attachments/assets/ca59a737-4301-45cd-a07c-467a4d0e6029" />


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
