### PR TITLE
Fix uninitialized reads in CCharacterCore::Reset()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3291,6 +3291,7 @@ if((GTEST_FOUND OR DOWNLOAD_GTEST) AND SERVER)
     dbg_test.cpp
     editor_test.cpp
     fs_test.cpp
+    gamecore_test.cpp
     gameworld_test.cpp
     git_revision_test.cpp
     hash_test.cpp

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -631,7 +631,7 @@ void CHud::RenderCursor()
 	if(Client()->State() != IClient::STATE_DEMOPLAYBACK && GameClient()->m_Snap.m_pLocalCharacter)
 	{
 		// Render local cursor
-		CurWeapon = std::max(0, GameClient()->m_aClients[GameClient()->m_Snap.m_LocalClientId].m_Predicted.m_ActiveWeapon);
+		CurWeapon = std::max(0, GameClient()->m_aClients[GameClient()->m_Snap.m_LocalClientId].m_Predicted.m_ActiveWeapon % NUM_WEAPONS);
 		TargetPos = GameClient()->m_Controls.m_aTargetPos[g_Config.m_ClDummy];
 	}
 	else

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -53,7 +53,7 @@ void CCharacter::HandleJetpack()
 	if(m_NumInputs < 2)
 		return;
 
-	if(m_Core.m_ActiveWeapon < 0)
+	if(!HasValidActiveWeapon())
 		return;
 
 	vec2 Direction = normalize(vec2(m_LatestInput.m_TargetX, m_LatestInput.m_TargetY));
@@ -283,7 +283,7 @@ void CCharacter::FireWeapon()
 	if(CountInput(m_LatestPrevInput.m_Fire, m_LatestInput.m_Fire).m_Presses)
 		WillFire = true;
 
-	if(FullAuto && (m_LatestInput.m_Fire & 1) && m_Core.m_ActiveWeapon >= 0 && m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo)
+	if(FullAuto && (m_LatestInput.m_Fire & 1) && HasValidActiveWeapon() && m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo)
 		WillFire = true;
 
 	if(!WillFire)
@@ -301,7 +301,7 @@ void CCharacter::FireWeapon()
 	}
 
 	// check for ammo
-	if(m_Core.m_ActiveWeapon < 0 || !m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo || m_FreezeTime)
+	if(!HasValidActiveWeapon() || !m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo || m_FreezeTime)
 	{
 		return;
 	}
@@ -493,7 +493,7 @@ void CCharacter::FireWeapon()
 	m_AttackTick = GameWorld()->GameTick(); // NOLINT(clang-analyzer-unix.Malloc)
 
 	// -1 is no weapon, handled here so pain sound still plays when firing in freeze
-	if(!m_ReloadTimer && m_Core.m_ActiveWeapon != -1)
+	if(!m_ReloadTimer && HasValidActiveWeapon())
 	{
 		m_ReloadTimer = GetTuning(GetOverriddenTuneZone())->GetWeaponFireDelay(m_Core.m_ActiveWeapon) * GameWorld()->GameTickSpeed();
 	}
@@ -1207,7 +1207,7 @@ bool CCharacter::Unfreeze()
 {
 	if(m_FreezeTime > 0)
 	{
-		if(m_Core.m_ActiveWeapon >= 0 && !m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Got)
+		if(HasValidActiveWeapon() && !m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Got)
 			m_Core.m_ActiveWeapon = WEAPON_GUN;
 		m_FreezeTime = 0;
 		m_Core.m_FreezeStart = 0;
@@ -1442,7 +1442,7 @@ void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtende
 		// ddnetcharacter is not available, try to get some info from the tunings and the character netobject instead.
 
 		// remove weapons that are unavailable. if the current weapon is ninja just set ammo to zero in case the player is frozen
-		if(m_Core.m_ActiveWeapon >= 0 && pChar->m_Weapon != m_Core.m_ActiveWeapon)
+		if(HasValidActiveWeapon() && pChar->m_Weapon != m_Core.m_ActiveWeapon)
 		{
 			if(pChar->m_Weapon == WEAPON_NINJA)
 			{
@@ -1571,7 +1571,7 @@ void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtende
 
 	// in most cases the reload timer can be determined from the last attack tick
 	// (this is only needed for autofire weapons to prevent the predicted reload timer from desyncing)
-	if(IsLocal && m_Core.m_ActiveWeapon != -1 && m_Core.m_ActiveWeapon != WEAPON_HAMMER && !m_Core.m_aWeapons[WEAPON_NINJA].m_Got)
+	if(IsLocal && HasValidActiveWeapon() && m_Core.m_ActiveWeapon != WEAPON_HAMMER && !m_Core.m_aWeapons[WEAPON_NINJA].m_Got)
 	{
 		if(std::max(m_LastTuneZoneTick, m_LastWeaponSwitchTick) + GameWorld()->GameTickSpeed() < GameWorld()->GameTick())
 		{

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -88,6 +88,9 @@ public:
 	int GetLastWeapon() const { return m_LastWeapon; }
 	void SetLastWeapon(int LastWeap) { m_LastWeapon = LastWeap; }
 	int GetActiveWeapon() const { return m_Core.m_ActiveWeapon; }
+	// m_ActiveWeapon is -1 when no weapon is active, everything else has to be a
+	// valid index into m_aWeapons before it may be used as one
+	bool HasValidActiveWeapon() const { return m_Core.m_ActiveWeapon >= 0 && m_Core.m_ActiveWeapon < NUM_WEAPONS; }
 	void SetActiveWeapon(int ActiveWeapon);
 	CCharacterCore GetCore() { return m_Core; }
 	void SetCore(const CCharacterCore &Core) { m_Core = Core; }

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -165,6 +165,12 @@ void CCharacterCore::Reset()
 	m_Jumps = 2;
 	m_TriggeredEvents = 0;
 
+	// m_ActiveWeapon is used to index m_aWeapons, leaving it uninitialized causes
+	// out of bounds accesses in the client prediction (CCharacter::Unfreeze() etc.)
+	m_ActiveWeapon = WEAPON_GUN;
+	for(CWeaponStat &Weapon : m_aWeapons)
+		Weapon = CWeaponStat{};
+
 	// DDNet Character
 	m_Solo = false;
 	m_Jetpack = false;

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -243,7 +243,8 @@ public:
 	void Quantize();
 
 	// DDRace
-	int m_Id;
+	// -1 means no player, assigned by the owner after Reset()
+	int m_Id = -1;
 	bool m_Reset;
 	CCollision *Collision() { return m_pCollision; }
 
@@ -281,7 +282,9 @@ public:
 private:
 	CTeamsCore *m_pTeams;
 	int m_MoveRestrictions;
-	int m_HookedPlayer;
+	// Reset() passes this to SetHookedPlayer(), which reads it and m_Id before
+	// either has been assigned, so both need a defined value from the start
+	int m_HookedPlayer = -1;
 	static bool IsSwitchActiveCb(unsigned char Number, void *pUser);
 
 	FAntiPingInterfereCallback m_AntiPingInterfereCallback = [](int ClientId, bool DisallowReset) {};

--- a/src/test/gamecore_test.cpp
+++ b/src/test/gamecore_test.cpp
@@ -1,0 +1,30 @@
+#include <game/gamecore.h>
+
+#include <gtest/gtest.h>
+
+// Reset() has to leave the core in a fully initialized state. Both the server and
+// the client prediction index m_aWeapons with m_ActiveWeapon (CCharacter::Unfreeze(),
+// CCharacter::FireWeapon(), ...), so an uninitialized m_ActiveWeapon is an out of
+// bounds access waiting to happen.
+TEST(GameCore, ResetInitializesWeapons)
+{
+	CCharacterCore Core;
+	// values as found in uninitialized memory
+	Core.m_ActiveWeapon = 0x5105503e;
+	for(auto &Weapon : Core.m_aWeapons)
+	{
+		Weapon.m_AmmoRegenStart = 0x5105503e;
+		Weapon.m_Ammo = 0x5105503e;
+		Weapon.m_Ammocost = 0x5105503e;
+		Weapon.m_Got = true;
+	}
+
+	Core.Reset();
+
+	EXPECT_GE(Core.m_ActiveWeapon, 0);
+	EXPECT_LT(Core.m_ActiveWeapon, NUM_WEAPONS);
+	for(const auto &Weapon : Core.m_aWeapons)
+	{
+		EXPECT_FALSE(Weapon.m_Got);
+	}
+}


### PR DESCRIPTION
## Problem

`CCharacterCore::Reset()` leaves several members undefined, and reads two of them while doing so. Confirmed with valgrind memcheck on current master (`4ce18d3a`), on a default initialized core:

```
Conditional jump or move depends on uninitialised value(s)
   at CCharacterCore::SetHookedPlayer(int) (gamecore.cpp:711)
   by CCharacterCore::Reset() (gamecore.cpp:161)
 Uninitialised value was created by a heap allocation

Conditional jump or move depends on uninitialised value(s)
   at std::max<int>(int const&, int const&) (stl_algobase.h:261)
 Uninitialised value was created by a heap allocation

ERROR SUMMARY: 4 errors from 4 contexts
```

Two separate things:

**1. `Reset()` reads `m_HookedPlayer` and `m_Id` before anything assigns them.** Line 161 calls `SetHookedPlayer(-1)`, which compares against `m_HookedPlayer` and `m_Id` at `gamecore.cpp:711` and `:713`. Both are assigned by the owner *after* `Reset()` — `CCharacter::Spawn()` on the server, the prediction `CCharacter` constructor on the client. Today nothing worse happens because `m_pWorld` is still null there and short circuits the branch that would evaluate `m_pWorld->m_apCharacters[m_HookedPlayer]`.

**2. `Reset()` does not define `m_ActiveWeapon` or `m_aWeapons`.** That is the fourth report above — a read of `m_ActiveWeapon` after `Reset()` is undefined. Every construction path has to remember to assign it afterwards: `Spawn()` does, the prediction constructor does since #12547, `OnPredict()` does in the paused branch.

## Scope, honestly

This is not a live crash on master. I originally claimed `CHud::RenderCursor()` was reachable with a garbage `m_ActiveWeapon` via `m_aClients[].m_Predicted`; that was wrong, and valgrind is what showed it. `CGameClient` is created as `new CGameClient()` (`gameclient.cpp:3376`) and has no user-provided constructor, so the whole object — `m_aClients[]` included — is value-initialized, and `m_Predicted.m_ActiveWeapon` starts out defined at 0. A probe that value-initializes the enclosing object the same way reports 0 errors under memcheck.

The crash that led me here was on a downstream fork whose base predates #12547, where the prediction constructor does not assign `m_ActiveWeapon` and a `WEAPON_NINJA` snapshot leaves it as heap garbage until `Unfreeze()` indexes `m_aWeapons` with it.

So: item 1 is an uninitialized read that happens on master today, items 2 and 3 below are hardening.

## Changes

1. **`Give m_Id and m_HookedPlayer a defined initial value`** — default member initializers, so `Reset()` no longer reads them undefined. Initializing in the declaration rather than inside `Reset()` keeps `Reset()`'s detach logic intact for cores that really were hooked to someone. Takes memcheck from 4 errors to 0.
2. **`Initialize m_ActiveWeapon and m_aWeapons in CCharacterCore::Reset()`** — so a core is valid from the start instead of depending on each call site to patch it up afterwards.
3. **`Bound-check m_ActiveWeapon before using it as an index`** — the guards only checked `>= 0`. Adds `CCharacter::HasValidActiveWeapon()` and uses it everywhere `m_ActiveWeapon` indexes `m_aWeapons`, which also covers an out of bounds *write* in `Read()` and `CTuningParams::GetWeaponFireDelay()`'s `dbg_assert_failed("invalid weapon")`. `-1` still means "no weapon". `CHud::RenderCursor()` now clamps with `% NUM_WEAPONS` like the two other cursor sites in that file (`hud.cpp:657`, `:752`) — consistency, not a crash fix.

Happy to drop 3 if you would rather keep this to the initialization issues.

## Tests

`src/test/gamecore_test.cpp` fills a core with garbage, calls `Reset()`, and asserts `m_ActiveWeapon` is a valid index and no weapon is marked as got. Fails without change 2 on current master, passes with it. Full suite 359/359.

Memcheck was run with a throwaway probe that default-initializes a core, calls `Reset()` and reads `m_ActiveWeapon` the way `RenderCursor()` does; it is not part of this PR, I can attach it if useful.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

On the ingame box: the patch has been running in a downstream fork (TaterClient) built from these changes since 2026-08-15, in daily play, with no regressions.

On the physics box: `CCharacter::Spawn()` already assigns `m_Core.m_ActiveWeapon = WEAPON_GUN` immediately after `m_Core.Reset()`, and `m_aWeapons` is populated by `OnCharacterSpawn()` right afterwards — clearing it in `Reset()` only removes what placement-new left behind from the previous character in that slot.

On the AI box: AI was used to draft the patch and this description. I reviewed all of it and verified the change independently — the new unit test fails without the fix and passes with it, memcheck goes from 4 errors to 0, and the full suite passes against current master.
