### PR TITLE
map_convert_07: Fix use-after-free

### DIFF
--- a/src/tools/map_convert_07.cpp
+++ b/src/tools/map_convert_07.cpp
@@ -15,6 +15,8 @@
 #include <game/gamecore.h>
 #include <game/mapitems.h>
 
+#include <utility>
+
 /*
 	Usage: map_convert_07 <source map filepath> <dest map filepath>
 */
@@ -23,8 +25,7 @@ static CDataFileReader g_DataReader;
 static CDataFileWriter g_DataWriter;
 
 // global new image data (set by ReplaceImageItem)
-static int g_aNewDataSize[MAX_MAPIMAGES];
-static void *g_apNewData[MAX_MAPIMAGES];
+static CImageInfo g_aNewImageInfos[MAX_MAPIMAGES];
 
 static int g_Index = 0;
 static int g_NextDataItemId = -1;
@@ -99,8 +100,7 @@ static void *ReplaceImageItem(int Index, CMapItemImage *pImgItem, CMapItemImage 
 	pNewImgItem->m_External = false;
 	pNewImgItem->m_ImageData = g_NextDataItemId++;
 
-	g_apNewData[g_Index] = ImgInfo.m_pData;
-	g_aNewDataSize[g_Index] = ImgInfo.DataSize();
+	g_aNewImageInfos[g_Index] = std::move(ImgInfo);
 	g_Index++;
 
 	return (void *)pNewImgItem;
@@ -221,7 +221,7 @@ int main(int argc, const char **argv)
 
 	for(int Index = 0; Index < g_Index; Index++)
 	{
-		g_DataWriter.AddData(g_aNewDataSize[Index], g_apNewData[Index]);
+		g_DataWriter.AddData(g_aNewImageInfos[Index].DataSize(), g_aNewImageInfos[Index].m_pData);
 	}
 
 	g_DataReader.Close();


### PR DESCRIPTION
Seen on official DDNet servers:
```
[9374951.062228] map_convert_07[936350]: segfault at 7f998bbff010 ip 00007f9991941b49 sp 00007ffd6c20aad8 error 4 in libc.so.6[162b49,7f9991807000+163000] likely on CPU 12 (core 24, socket 0)
```

Same fix as in map_replace_image

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5)
