### PR TITLE
client: When deleting demo/0.7 skin select the next demo/0.7 skin

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -351,6 +351,7 @@ protected:
 	std::chrono::nanoseconds m_DemoPopulateStartTime{0};
 
 	void DemolistOnUpdate(bool Reset);
+	void DemolistSelectNeighbor();
 	static int DemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int StorageType, void *pUser);
 
 	// friends

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -609,6 +609,8 @@ protected:
 	bool m_CustomSkinMenu = false;
 	int m_TeePartSelected = protocol7::SKINPART_BODY;
 	const CSkins7::CSkin *m_pSelectedSkin = nullptr;
+	int m_SelectedSkinIndex7 = -1;
+	int m_DeletedSkinIndex7 = -1;
 	CLineInputBuffered<protocol7::MAX_SKIN_ARRAY_SIZE, protocol7::MAX_SKIN_LENGTH> m_SkinNameInput;
 	bool m_SkinPartListNeedsUpdate = false;
 

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -1721,12 +1721,19 @@ void CMenus::PopupConfirmPlayDemo()
 	}
 }
 
+void CMenus::DemolistSelectNeighbor()
+{
+	const int NeighborIndex = m_DemolistSelectedIndex + 1 < (int)m_vpFilteredDemos.size() ? m_DemolistSelectedIndex + 1 : m_DemolistSelectedIndex - 1;
+	str_copy(m_aCurrentDemoSelectionName, NeighborIndex >= 0 ? m_vpFilteredDemos[NeighborIndex]->m_aName : "");
+}
+
 void CMenus::PopupConfirmDeleteDemo()
 {
 	char aBuf[IO_MAX_PATH_LENGTH];
 	str_format(aBuf, sizeof(aBuf), "%s/%s", m_aCurrentDemoFolder, m_vpFilteredDemos[m_DemolistSelectedIndex]->m_aFilename);
 	if(Storage()->RemoveFile(aBuf, m_vpFilteredDemos[m_DemolistSelectedIndex]->m_StorageType))
 	{
+		DemolistSelectNeighbor();
 		DemolistPopulate();
 		DemolistOnUpdate(false);
 	}
@@ -1744,6 +1751,7 @@ void CMenus::PopupConfirmDeleteFolder()
 	str_format(aBuf, sizeof(aBuf), "%s/%s", m_aCurrentDemoFolder, m_vpFilteredDemos[m_DemolistSelectedIndex]->m_aFilename);
 	if(Storage()->RemoveFolder(aBuf, m_vpFilteredDemos[m_DemolistSelectedIndex]->m_StorageType))
 	{
+		DemolistSelectNeighbor();
 		DemolistPopulate();
 		DemolistOnUpdate(false);
 	}

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -37,6 +37,7 @@
 #include <game/client/ui_scrollregion.h>
 #include <game/localization.h>
 
+#include <algorithm>
 #include <chrono>
 
 using namespace std::chrono_literals;
@@ -1607,6 +1608,8 @@ void CMenus::RenderGhost(CUIRect MainView)
 		if(pGhost->Active())
 			GameClient()->m_Ghost.Unload(pGhost->m_Slot);
 		DeleteGhostItem(s_SelectedIndex);
+		s_SelectedIndex = std::min(s_SelectedIndex, (int)m_vGhosts.size() - 1);
+		return;
 	}
 
 	Status.VSplitRight(5.0f, &Status, nullptr);

--- a/src/game/client/components/menus_settings_tee7.cpp
+++ b/src/game/client/components/menus_settings_tee7.cpp
@@ -229,6 +229,7 @@ void CMenus::PopupConfirmDeleteSkin7()
 		return;
 	}
 	m_pSelectedSkin = nullptr;
+	m_DeletedSkinIndex7 = m_SelectedSkinIndex7;
 }
 
 void CMenus::RenderSettingsTeeCustom7(CUIRect MainView)
@@ -317,18 +318,18 @@ void CMenus::RenderSkinSelection7(CUIRect MainView)
 	}
 
 	m_pSelectedSkin = nullptr;
-	int OldSelected = -1;
+	m_SelectedSkinIndex7 = -1;
 	for(int i = 0; i < (int)s_vpSkinList.size(); ++i)
 	{
 		const CSkins7::CSkin *pSkin = s_vpSkinList[i];
 		if(!str_comp(pSkin->m_aName, CSkins7::ms_apSkinNameVariables[m_Dummy]))
 		{
 			m_pSelectedSkin = pSkin;
-			OldSelected = i;
+			m_SelectedSkinIndex7 = i;
 			break;
 		}
 	}
-	s_ListBox.DoStart(50.0f, s_vpSkinList.size(), 4, 1, OldSelected, &MainView);
+	s_ListBox.DoStart(50.0f, s_vpSkinList.size(), 4, 1, m_SelectedSkinIndex7, &MainView);
 
 	for(const CSkins7::CSkin *pSkin : s_vpSkinList)
 	{
@@ -360,8 +361,14 @@ void CMenus::RenderSkinSelection7(CUIRect MainView)
 		Ui()->DoLabel(&Label, pSkin->m_aName, 12.0f, TEXTALIGN_ML, Props);
 	}
 
-	const int NewSelected = s_ListBox.DoEnd();
-	if(NewSelected != -1 && NewSelected != OldSelected)
+	int NewSelected = s_ListBox.DoEnd();
+	if(m_DeletedSkinIndex7 >= 0)
+	{
+		// Select the skin which took the place of the deleted skin, or the last skin
+		NewSelected = std::min(m_DeletedSkinIndex7, (int)s_vpSkinList.size() - 1);
+		m_DeletedSkinIndex7 = -1;
+	}
+	if(NewSelected != -1 && NewSelected != m_SelectedSkinIndex7)
 	{
 		s_LastSelectionTime = Client()->GlobalTime();
 		m_pSelectedSkin = s_vpSkinList[NewSelected];


### PR DESCRIPTION
Kept annoying me when trying to delete a bunch of demos in the UI.

https://github.com/user-attachments/assets/afe988b0-0350-477a-a86f-ab3234df6d71

https://github.com/user-attachments/assets/215286f3-1464-4ef5-9666-674c43feddda

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5)
