### PR TITLE
server: Disallow actions with ids for authed people with old client

### DIFF
--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -85,7 +85,7 @@ public:
 
 		// DDRace
 
-		virtual int GetVictim() const = 0;
+		virtual int GetVictim(unsigned Slot) const = 0;
 	};
 
 	class ICommandInfo
@@ -95,6 +95,8 @@ public:
 		virtual const char *Name() const = 0;
 		virtual const char *Help() const = 0;
 		virtual const char *Params() const = 0;
+		// Whether any parameter of this command is a client id, see `Register`
+		virtual bool TakesClientId() const = 0;
 		virtual int Flags() const = 0;
 		virtual EAccessLevel GetAccessLevel() const = 0;
 	};

--- a/src/engine/console.rs
+++ b/src/engine/console.rs
@@ -244,7 +244,7 @@ mod ffi {
         /// ```
         pub fn NumArguments(self: &IConsole_IResult) -> i32;
 
-        /// Get the value of the sole victim (`v`) parameter.
+        /// Get the value of the victim (`v`) parameter with the given index.
         ///
         /// This is mostly important for commands that have optional parameters
         /// and thus support variable numbers of arguments.
@@ -272,11 +272,11 @@ mod ffi {
         /// # unsafe { executed = *user.cast_mut::<u32>(); *user.cast_mut::<u32>() += 1; }
         /// let result: &IConsole_IResult /* = `command 42` */;
         /// # result = result_param;
-        /// assert_eq!(result.GetVictim(), 42);
+        /// assert_eq!(result.GetVictim(0), 42);
         /// # }
         /// # assert!(executed == 1);
         /// ```
-        pub fn GetVictim(self: &IConsole_IResult) -> i32;
+        pub fn GetVictim(self: &IConsole_IResult, Slot: u32) -> i32;
 
         /// Console interface, consists of logging output and command execution.
         ///

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -309,6 +309,11 @@ public:
 		return true;
 	}
 
+	bool ClientUsesRealClientIds(int ClientId) const
+	{
+		return ClientId < 0 || GetClientVersion(ClientId) >= VERSION_DDNET_128_PLAYERS;
+	}
+
 	virtual bool WouldClientNameChange(int ClientId, const char *pNameRequest) = 0;
 	virtual bool WouldClientClanChange(int ClientId, const char *pClanRequest) = 0;
 	virtual void SetClientName(int ClientId, const char *pName) = 0;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -155,7 +155,9 @@ void CServerBan::ConBanExt(IConsole::IResult *pResult, void *pUser)
 	if(str_isallnum(pStr))
 	{
 		int ClientId = str_toint(pStr);
-		if(ClientId < 0 || ClientId >= MAX_CLIENTS || pThis->Server()->m_aClients[ClientId].m_State == CServer::CClient::STATE_EMPTY)
+		if(!pThis->Server()->ClientUsesRealClientIds(pResult->m_ClientId))
+			pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "net_ban", "ban error (use a more recent DDNet client)");
+		else if(ClientId < 0 || ClientId >= MAX_CLIENTS || pThis->Server()->m_aClients[ClientId].m_State == CServer::CClient::STATE_EMPTY)
 			pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "net_ban", "ban error (invalid client id)");
 		else
 			pThis->BanAddr(pThis->Server()->ClientAddr(ClientId), Minutes * 60, pReason, false);
@@ -2233,6 +2235,11 @@ void CServer::OnNetMsgRconAuth(int ClientId, const char *pName, const char *pPw,
 			}
 			}
 
+			if(!ClientUsesRealClientIds(ClientId))
+			{
+				SendRconLine(ClientId, "Your client does not see the real client IDs of this server. Use a more recent DDNet client.");
+			}
+
 			// DDRace
 			GameServer()->OnSetAuthed(ClientId, AuthLevel);
 		}
@@ -3655,11 +3662,11 @@ void CServer::ConKick(IConsole::IResult *pResult, void *pUser)
 	{
 		char aBuf[128];
 		str_format(aBuf, sizeof(aBuf), "Kicked (%s)", pResult->GetString(1));
-		((CServer *)pUser)->Kick(pResult->GetVictim(), aBuf);
+		((CServer *)pUser)->Kick(pResult->GetVictim(0), aBuf);
 	}
 	else
 	{
-		((CServer *)pUser)->Kick(pResult->GetVictim(), "Kicked by console");
+		((CServer *)pUser)->Kick(pResult->GetVictim(0), "Kicked by console");
 	}
 }
 
@@ -3746,6 +3753,9 @@ bool CServer::CanClientUseCommandCallback(int ClientId, const IConsole::ICommand
 
 bool CServer::CanClientUseCommand(int ClientId, const IConsole::ICommandInfo *pCommand) const
 {
+	// make sure we don't affect the wrong client, disallow id targeting commands when a moderator is using id translation
+	if(pCommand->TakesClientId() && !ClientUsesRealClientIds(ClientId))
+		return false;
 	if(pCommand->Flags() & CFGFLAG_CHAT)
 		return true;
 	if(pCommand->Flags() & CMDFLAG_PRACTICE)

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -36,7 +36,8 @@ CConsole::CResult::CResult(int ClientId) :
 }
 
 CConsole::CResult::CResult(const CResult &Other) :
-	IResult(Other)
+	IResult(Other),
+	m_vVictims(Other.m_vVictims)
 {
 	mem_copy(m_aStringStorage, Other.m_aStringStorage, sizeof(m_aStringStorage));
 	m_pArgsStart = m_aStringStorage + (Other.m_pArgsStart - Other.m_aStringStorage);
@@ -87,6 +88,17 @@ ColorHSLA CConsole::CResult::GetColor(unsigned Index, float DarkestLighting) con
 	if(Index >= m_NumArgs)
 		return ColorHSLA(0, 0, 0);
 	return ColorParse(m_apArgs[Index], DarkestLighting).value_or(ColorHSLA(0, 0, 0));
+}
+
+bool CConsole::CCommand::TakesClientId() const
+{
+	const char *pFormat = m_pParams;
+	for(char Param = *pFormat; Param != '\0'; Param = NextParam(pFormat))
+	{
+		if(Param == 'v')
+			return true;
+	}
+	return false;
 }
 
 void CConsole::CCommand::SetAccessLevel(EAccessLevel AccessLevel)
@@ -189,7 +201,7 @@ int CConsole::ParseArgs(CResult *pResult, const char *pFormat)
 	char *pStr = pResult->m_pArgsStart;
 	bool Optional = false;
 
-	pResult->ResetVictim();
+	pResult->m_vVictims.clear();
 
 	for(char Command = *pFormat; Command != '\0'; Command = NextParam(pFormat))
 	{
@@ -212,7 +224,7 @@ int CConsole::ParseArgs(CResult *pResult, const char *pFormat)
 			{
 				if(Command == 'v')
 				{
-					pResult->SetVictim("me");
+					pResult->AddVictim("me");
 					break;
 				}
 				Command = NextParam(pFormat);
@@ -274,7 +286,7 @@ int CConsole::ParseArgs(CResult *pResult, const char *pFormat)
 			{
 				return PARSEARGS_MISSING_VALUE;
 			}
-			pResult->SetVictim(pVictim);
+			pResult->AddVictim(pVictim);
 		}
 		else if(Command == 'i')
 		{
@@ -603,32 +615,45 @@ void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientId, bo
 							m_pfnTeeHistorianCommandCallback(ClientId, m_FlagMask, pCommand->m_pName, &Result, m_pTeeHistorianCommandUserdata);
 						}
 
-						if(Result.m_aSpecialVictim[0])
+						int FanOutSlot = -1;
+						std::vector<int> vFanOutIds;
+						for(unsigned Slot = 0; Slot < Result.m_vVictims.size(); Slot++)
 						{
+							if(!Result.m_vVictims[Slot].m_aSpecialVictim[0])
+								continue;
 							std::optional<std::vector<int>> Victims;
 							if(m_pfnGetVictimsCommandCallback)
-							{
-								Victims = m_pfnGetVictimsCommandCallback(ClientId, Result.m_aSpecialVictim, m_pGetVictimsCommandUserData);
-							}
-							else
-							{
-								Victims = std::nullopt;
-							}
-
+								Victims = m_pfnGetVictimsCommandCallback(ClientId, Result.m_vVictims[Slot].m_aSpecialVictim, m_pGetVictimsCommandUserData);
 							if(!Victims.has_value())
 							{
-								log_error("console", "Invalid victim '%s'", Result.m_aSpecialVictim);
+								log_error("console", "Invalid victim '%s'", Result.m_vVictims[Slot].m_aSpecialVictim);
 								return;
 							}
-							for(const int VictimId : Victims.value())
+							if(Victims->size() != 1 && FanOutSlot >= 0)
 							{
-								Result.SetVictim(VictimId);
-								pCommand->m_pfnCallback(&Result, pCommand->m_pUserData);
+								log_error("console", "Only one parameter may target multiple clients");
+								return;
 							}
+							if(Victims->size() == 1)
+								Result.SetVictim(Slot, Victims->front());
+							else
+							{
+								FanOutSlot = Slot;
+								vFanOutIds = std::move(Victims.value());
+							}
+						}
+
+						if(FanOutSlot < 0)
+						{
+							pCommand->m_pfnCallback(&Result, pCommand->m_pUserData);
 						}
 						else
 						{
-							pCommand->m_pfnCallback(&Result, pCommand->m_pUserData);
+							for(const int VictimId : vFanOutIds)
+							{
+								Result.SetVictim(FanOutSlot, VictimId);
+								pCommand->m_pfnCallback(&Result, pCommand->m_pUserData);
+							}
 						}
 
 						if(pCommand->m_Flags & CMDFLAG_TEST)
@@ -1145,34 +1170,29 @@ const IConsole::ICommandInfo *CConsole::GetCommandInfo(const char *pName, int Fl
 
 std::unique_ptr<IConsole> CreateConsole(int FlagMask) { return std::make_unique<CConsole>(FlagMask); }
 
-int CConsole::CResult::GetVictim() const
+int CConsole::CResult::GetVictim(unsigned Slot) const
 {
-	dbg_assert(m_VictimId.has_value(), "m_VictimId has no value");
-	return m_VictimId.value();
+	dbg_assert(Slot < m_vVictims.size(), "victim slot %u out of range", Slot);
+	dbg_assert(m_vVictims[Slot].m_Id.has_value(), "victim %u has no value", Slot);
+	return m_vVictims[Slot].m_Id.value();
 }
 
-void CConsole::CResult::ResetVictim()
+void CConsole::CResult::SetVictim(unsigned Slot, int Victim)
 {
-	m_VictimId = std::nullopt;
-	m_aSpecialVictim[0] = '\0';
-}
-
-void CConsole::CResult::SetVictim(int Victim)
-{
+	dbg_assert(Slot < m_vVictims.size(), "victim slot %u out of range", Slot);
 	dbg_assert(in_range(Victim, 0, MAX_CLIENTS - 1), "Victim ID %d out of range [0, %d]", Victim, MAX_CLIENTS - 1);
-	m_VictimId = Victim;
+	m_vVictims[Slot].m_Id = Victim;
 }
 
-void CConsole::CResult::SetVictim(const char *pVictim)
+void CConsole::CResult::AddVictim(const char *pVictim)
 {
+	CVictim Victim;
 	int Value;
-	if(!str_toint(pVictim, &Value) || !in_range(Value, 0, MAX_CLIENTS - 1))
-	{
-		str_copy(m_aSpecialVictim, pVictim);
-		return;
-	}
-
-	SetVictim(Value);
+	if(str_toint(pVictim, &Value) && in_range(Value, 0, MAX_CLIENTS - 1))
+		Victim.m_Id = Value;
+	else
+		str_copy(Victim.m_aSpecialVictim, pVictim);
+	m_vVictims.push_back(Victim);
 }
 
 std::optional<ColorHSLA> CConsole::ColorParse(const char *pStr, float DarkestLighting)

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -34,6 +34,7 @@ class CConsole : public IConsole
 		const char *Name() const override { return m_pName; }
 		const char *Help() const override { return m_pHelp; }
 		const char *Params() const override { return m_pParams; }
+		bool TakesClientId() const override;
 		int Flags() const override { return m_Flags; }
 		EAccessLevel GetAccessLevel() const override { return m_AccessLevel; }
 		void SetAccessLevel(EAccessLevel AccessLevel);
@@ -119,12 +120,18 @@ class CConsole : public IConsole
 
 		// DDRace
 
-		char m_aSpecialVictim[16];
-		std::optional<int> m_VictimId;
-		void ResetVictim();
-		void SetVictim(int Victim);
-		void SetVictim(const char *pVictim);
-		int GetVictim() const override;
+		class CVictim
+		{
+		public:
+			static constexpr unsigned MAX_VICTIM_LENGTH = 16;
+			// symbolic victim like "me" or "all", resolved to ids before the command callback runs
+			char m_aSpecialVictim[MAX_VICTIM_LENGTH] = "";
+			std::optional<int> m_Id;
+		};
+		std::vector<CVictim> m_vVictims;
+		void AddVictim(const char *pVictim);
+		void SetVictim(unsigned Slot, int Victim);
+		int GetVictim(unsigned Slot) const override;
 	};
 
 	int ParseStart(CResult *pResult, const char *pString, int Length);
@@ -141,12 +148,12 @@ class CConsole : public IConsole
 	int ParseArgs(CResult *pResult, const char *pFormat);
 
 	/*
-	this function will set pFormat to the next parameter (i,s,r,v,?) it contains and
+	this function will set pFormat to the next parameter it contains and
 	return the parameter; descriptions in brackets like [file] will be skipped;
 	returns '\0' if there is no next parameter; expects pFormat to point at a
 	parameter
 	*/
-	char NextParam(const char *&pFormat);
+	static char NextParam(const char *&pFormat);
 
 	class CExecutionQueueEntry
 	{

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -90,7 +90,7 @@ void CGameContext::ConKillPlayer(IConsole::IResult *pResult, void *pUserData)
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	int Victim = pResult->GetVictim();
+	int Victim = pResult->GetVictim(0);
 
 	if(pSelf->m_apPlayers[Victim])
 	{
@@ -462,8 +462,9 @@ void CGameContext::ConTeleport(IConsole::IResult *pResult, void *pUserData)
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	int Tele = pResult->NumArguments() == 2 ? pResult->GetInteger(0) : pResult->m_ClientId;
-	int TeleTo = pResult->NumArguments() ? pResult->GetInteger(pResult->NumArguments() - 1) : pResult->m_ClientId;
+	const bool HasSource = pResult->NumArguments() == 2;
+	int Tele = HasSource ? pResult->GetVictim(0) : pResult->m_ClientId;
+	int TeleTo = pResult->NumArguments() ? pResult->GetVictim(HasSource ? 1 : 0) : pResult->m_ClientId;
 	int AuthLevel = pSelf->Server()->GetAuthedState(pResult->m_ClientId);
 
 	if(Tele != pResult->m_ClientId && AuthLevel < g_Config.m_SvTeleOthersAuthLevel)
@@ -508,7 +509,7 @@ void CGameContext::ConKill(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConForcePause(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	int Victim = pResult->GetVictim();
+	int Victim = pResult->GetVictim(0);
 	int Seconds = 0;
 	if(pResult->NumArguments() > 1)
 		Seconds = std::clamp(pResult->GetInteger(1), 0, 360);
@@ -555,7 +556,7 @@ void CGameContext::ConSetDDRTeam(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
-	const int Target = pResult->GetVictim();
+	const int Target = pResult->GetVictim(0);
 	CPlayer *pPlayer = pSelf->m_apPlayers[Target];
 	if(!pPlayer)
 		return;
@@ -578,7 +579,7 @@ void CGameContext::ConUninvite(IConsole::IResult *pResult, void *pUserData)
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	auto *pController = pSelf->m_pController;
 
-	const int Target = pResult->GetVictim();
+	const int Target = pResult->GetVictim(0);
 	if(!pSelf->m_apPlayers[Target])
 		return;
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -209,6 +209,8 @@ std::optional<std::vector<int>> CGameContext::ClientsForVictim(int ClientId, con
 
 	if(!str_comp(pVictim, "me"))
 	{
+		if(ClientId < 0)
+			return std::nullopt;
 		vClientIds.emplace_back(ClientId);
 	}
 	else if(!str_comp(pVictim, "all"))
@@ -3393,7 +3395,7 @@ void CGameContext::ConModAlert(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 
-	const int Victim = pResult->GetVictim();
+	const int Victim = pResult->GetVictim(0);
 	if(!CheckClientId(Victim) || !pSelf->m_apPlayers[Victim])
 	{
 		log_info("moderator_alert", "Client ID not found: %d", Victim);
@@ -3434,7 +3436,7 @@ void CGameContext::ConSetTeam(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
-	int ClientId = std::clamp(pResult->GetInteger(0), 0, (int)MAX_CLIENTS - 1);
+	int ClientId = pResult->GetVictim(0);
 	int Delay = pResult->NumArguments() > 2 ? pResult->GetInteger(2) : 0;
 	if(!pSelf->m_apPlayers[ClientId])
 		return;
@@ -3448,25 +3450,6 @@ void CGameContext::ConSetTeam(IConsole::IResult *pResult, void *pUserData)
 	pSelf->m_pController->DoTeamChange(pSelf->m_apPlayers[ClientId], Team, true);
 	if(Team == TEAM_SPECTATORS)
 		pSelf->m_apPlayers[ClientId]->Pause(CPlayer::PAUSE_NONE, true);
-}
-
-void CGameContext::ConSetTeamAll(IConsole::IResult *pResult, void *pUserData)
-{
-	CGameContext *pSelf = (CGameContext *)pUserData;
-	int Team = pResult->GetInteger(0);
-	if(!pSelf->m_pController->IsValidTeam(Team))
-	{
-		log_info("server", "Invalid Team: %d", Team);
-		return;
-	}
-
-	char aBuf[256];
-	str_format(aBuf, sizeof(aBuf), "All players were moved to the %s", pSelf->m_pController->GetTeamName(Team));
-	pSelf->SendChat(-1, TEAM_ALL, aBuf);
-
-	for(auto &pPlayer : pSelf->m_apPlayers)
-		if(pPlayer)
-			pSelf->m_pController->DoTeamChange(pPlayer, Team, false);
 }
 
 void CGameContext::ConHotReload(IConsole::IResult *pResult, void *pUserData)
@@ -3668,9 +3651,12 @@ void CGameContext::ConForceVote(IConsole::IResult *pResult, void *pUserData)
 	}
 	else if(str_comp_nocase(pType, "kick") == 0)
 	{
-		int KickId = str_toint(pValue);
-		if(!pSelf->Server()->ReverseTranslate(KickId, pResult->m_ClientId))
+		if(!pSelf->Server()->ClientUsesRealClientIds(pResult->m_ClientId))
+		{
+			pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", "Your client does not see the real client IDs of this server. Use a more recent DDNet client.");
 			return;
+		}
+		int KickId = str_toint(pValue);
 		if(KickId < 0 || KickId >= MAX_CLIENTS || !pSelf->m_apPlayers[KickId])
 		{
 			pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", "Invalid client id to kick");
@@ -3690,9 +3676,12 @@ void CGameContext::ConForceVote(IConsole::IResult *pResult, void *pUserData)
 	}
 	else if(str_comp_nocase(pType, "spectate") == 0)
 	{
-		int SpectateId = str_toint(pValue);
-		if(!pSelf->Server()->ReverseTranslate(SpectateId, pResult->m_ClientId))
+		if(!pSelf->Server()->ClientUsesRealClientIds(pResult->m_ClientId))
+		{
+			pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", "Your client does not see the real client IDs of this server. Use a more recent DDNet client.");
 			return;
+		}
+		int SpectateId = str_toint(pValue);
 		if(SpectateId < 0 || SpectateId >= MAX_CLIENTS || !pSelf->m_apPlayers[SpectateId] || pSelf->m_apPlayers[SpectateId]->GetTeam() == TEAM_SPECTATORS)
 		{
 			pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", "Invalid client id to move");
@@ -3937,8 +3926,7 @@ void CGameContext::OnConsoleInit()
 	Console()->Register("mod_alert", "v[id] r[message]", CFGFLAG_SERVER, ConModAlert, this, "Send a moderator alert message to player");
 	Console()->Register("broadcast", "r[message]", CFGFLAG_SERVER, ConBroadcast, this, "Broadcast message");
 	Console()->Register("say", "r[message]", CFGFLAG_SERVER, ConSay, this, "Say in chat");
-	Console()->Register("set_team", "i[id] i[team-id] ?i[delay in minutes]", CFGFLAG_SERVER, ConSetTeam, this, "Set team for a player (spectators = -1, game = 0)");
-	Console()->Register("set_team_all", "i[team-id]", CFGFLAG_SERVER, ConSetTeamAll, this, "Set team for all players (spectators = -1, game = 0)");
+	Console()->Register("set_team", "v[id] i[team-id] ?i[delay in minutes]", CFGFLAG_SERVER, ConSetTeam, this, "Set team for a player (spectators = -1, game = 0)");
 	Console()->Register("hot_reload", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConHotReload, this, "Reload the map while preserving the state of tees and teams");
 	Console()->Register("reload_censorlist", "", CFGFLAG_SERVER, ConReloadCensorlist, this, "Reload the censorlist");
 
@@ -3968,7 +3956,7 @@ void CGameContext::RegisterDDRaceCommands()
 	Console()->Register("kill_pl", "v[id] ?r[reason]", CFGFLAG_SERVER, ConKillPlayer, this, "Kills a player and announces the kill");
 	Console()->Register("totele", "i[number]", CFGFLAG_SERVER | CMDFLAG_TEST, ConToTeleporter, this, "Teleports you to teleporter i");
 	Console()->Register("totelecp", "i[number]", CFGFLAG_SERVER | CMDFLAG_TEST, ConToCheckTeleporter, this, "Teleports you to checkpoint teleporter i");
-	Console()->Register("tele", "?i[id] ?i[id]", CFGFLAG_SERVER | CMDFLAG_TEST, ConTeleport, this, "Teleports player i (or you) to player i (or you to where you look at)");
+	Console()->Register("tele", "?v[id] ?v[id]", CFGFLAG_SERVER | CMDFLAG_TEST, ConTeleport, this, "Teleports player i (or you) to player i (or you to where you look at)");
 	Console()->Register("addweapon", "i[weapon-id]", CFGFLAG_SERVER | CMDFLAG_TEST, ConAddWeapon, this, "Gives weapon with id i to you (all = -1, hammer = 0, gun = 1, shotgun = 2, grenade = 3, laser = 4, ninja = 5)");
 	Console()->Register("removeweapon", "i[weapon-id]", CFGFLAG_SERVER | CMDFLAG_TEST, ConRemoveWeapon, this, "removes weapon with id i from you (all = -1, hammer = 0, gun = 1, shotgun = 2, grenade = 3, laser = 4, ninja = 5)");
 	Console()->Register("shotgun", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConShotgun, this, "Gives a shotgun to you");

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -161,7 +161,6 @@ class CGameContext : public IGameServer
 	static void ConBroadcast(IConsole::IResult *pResult, void *pUserData);
 	static void ConSay(IConsole::IResult *pResult, void *pUserData);
 	static void ConSetTeam(IConsole::IResult *pResult, void *pUserData);
-	static void ConSetTeamAll(IConsole::IResult *pResult, void *pUserData);
 	static void ConHotReload(IConsole::IResult *pResult, void *pUserData);
 	static void ConAddVote(IConsole::IResult *pResult, void *pUserData);
 	static void ConRemoveVote(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/server/mutes.cpp
+++ b/src/game/server/mutes.cpp
@@ -246,7 +246,7 @@ void CGameContext::ConMuteId(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 
-	const int Victim = pResult->GetVictim();
+	const int Victim = pResult->GetVictim(0);
 	if(!CheckClientId(Victim) || !pSelf->m_apPlayers[Victim])
 	{
 		log_info("mutes", "Client ID not found: %d", Victim);
@@ -284,7 +284,7 @@ void CGameContext::ConUnmuteId(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 
-	const int Victim = pResult->GetVictim();
+	const int Victim = pResult->GetVictim(0);
 	if(!CheckClientId(Victim) || !pSelf->m_apPlayers[Victim])
 	{
 		log_info("mutes", "Client ID not found: %d", Victim);
@@ -324,7 +324,7 @@ void CGameContext::ConVoteMuteId(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 
-	const int Victim = pResult->GetVictim();
+	const int Victim = pResult->GetVictim(0);
 	if(!CheckClientId(Victim) || !pSelf->m_apPlayers[Victim])
 	{
 		log_info("votemutes", "Client ID not found: %d", Victim);
@@ -362,7 +362,7 @@ void CGameContext::ConVoteUnmuteId(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 
-	const int Victim = pResult->GetVictim();
+	const int Victim = pResult->GetVictim(0);
 	if(!CheckClientId(Victim) || !pSelf->m_apPlayers[Victim])
 	{
 		log_info("votemutes", "Client ID not found: %d", Victim);

--- a/src/rust-bridge/cpp/console.cpp
+++ b/src/rust-bridge/cpp/console.cpp
@@ -124,9 +124,9 @@ void cxxbridge1$194$IConsole_IResult$GetColor(::IConsole_IResult const &self, ::
   return (self.*NumArguments$)();
 }
 
-::std::int32_t cxxbridge1$194$IConsole_IResult$GetVictim(::IConsole_IResult const &self) noexcept {
-  ::std::int32_t (::IConsole_IResult::*GetVictim$)() const = &::IConsole_IResult::GetVictim;
-  return (self.*GetVictim$)();
+::std::int32_t cxxbridge1$194$IConsole_IResult$GetVictim(::IConsole_IResult const &self, ::std::uint32_t Slot) noexcept {
+  ::std::int32_t (::IConsole_IResult::*GetVictim$)(::std::uint32_t) const = &::IConsole_IResult::GetVictim;
+  return (self.*GetVictim$)(Slot);
 }
 
 void cxxbridge1$194$IConsole$ExecuteLine(::IConsole &self, ::StrRef *pStr, ::std::int32_t ClientId, bool InterpretSemicolons) noexcept {


### PR DESCRIPTION
Since the ids are translated, it's really easy to accidentally kick the wrong person.

<img width="1392" height="1168" alt="Screenshot 2026-08-19 at 18 50 27" src="https://github.com/user-attachments/assets/21b49cb3-0f18-4d42-b5bf-c20aa189d2c5" />


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5)
