### PR TITLE
server: Fix team ranks of large teams being cut off & Fail saving teams instead of corrupting savegame

### DIFF
--- a/src/engine/shared/protocol.h
+++ b/src/engine/shared/protocol.h
@@ -109,6 +109,7 @@ enum
 	MAX_NAME_LENGTH = 16,
 	MAX_CLAN_LENGTH = 12,
 	MAX_SKIN_LENGTH = 24,
+	MAX_CHAT_LENGTH = 256,
 
 	// message packing
 	/**

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -27,7 +27,7 @@
 #include <game/client/gameclient.h>
 #include <game/localization.h>
 
-char CChat::ms_aDisplayText[MAX_LINE_LENGTH] = "";
+char CChat::ms_aDisplayText[MAX_CHAT_LENGTH] = "";
 
 CChat::CLine::CLine()
 {
@@ -366,7 +366,7 @@ bool CChat::OnInput(const IInput::CEvent &Event)
 			// insert the command
 			if(pCompletionCommand)
 			{
-				char aBuf[MAX_LINE_LENGTH];
+				char aBuf[MAX_CHAT_LENGTH];
 				// add part before the name
 				str_truncate(aBuf, sizeof(aBuf), m_Input.GetString(), m_PlaceholderOffset);
 
@@ -425,7 +425,7 @@ bool CChat::OnInput(const IInput::CEvent &Event)
 			// insert the name
 			if(pCompletionString)
 			{
-				char aBuf[MAX_LINE_LENGTH];
+				char aBuf[MAX_CHAT_LENGTH];
 				// add part before the name
 				str_truncate(aBuf, sizeof(aBuf), m_Input.GetString(), m_PlaceholderOffset);
 
@@ -556,7 +556,7 @@ void CChat::OnMessage(int MsgType, void *pRawMsg)
 		/*
 		if(g_Config.m_ClCensorChat)
 		{
-			char aMessage[MAX_LINE_LENGTH];
+			char aMessage[MAX_CHAT_LENGTH];
 			str_copy(aMessage, pMsg->m_pMessage);
 			GameClient()->m_Censor.CensorMessage(aMessage);
 			AddLine(pMsg->m_ClientId, pMsg->m_Team, aMessage);
@@ -686,7 +686,7 @@ void CChat::AddLine(int ClientId, int Team, const char *pLine)
 			pEnd = pStrOld;
 		}
 
-		if(++Length >= MAX_LINE_LENGTH)
+		if(++Length >= MAX_CHAT_LENGTH)
 		{
 			*(const_cast<char *>(pStr)) = '\0';
 			break;

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -29,10 +29,9 @@ class CChat : public CComponent
 	enum
 	{
 		MAX_LINES = 64,
-		MAX_LINE_LENGTH = 256
 	};
 
-	CLineInputBuffered<MAX_LINE_LENGTH> m_Input;
+	CLineInputBuffered<MAX_CHAT_LENGTH> m_Input;
 	class CLine
 	{
 	public:
@@ -48,7 +47,7 @@ class CChat : public CComponent
 		bool m_Whisper;
 		int m_NameColor;
 		char m_aName[64];
-		char m_aText[MAX_LINE_LENGTH];
+		char m_aText[MAX_CHAT_LENGTH];
 		bool m_Friend;
 		bool m_Highlighted;
 		std::optional<ColorRGBA> m_CustomColor;
@@ -95,10 +94,10 @@ class CChat : public CComponent
 	bool m_Show;
 	bool m_CompletionUsed;
 	int m_CompletionChosen;
-	char m_aCompletionBuffer[MAX_LINE_LENGTH];
+	char m_aCompletionBuffer[MAX_CHAT_LENGTH];
 	int m_PlaceholderOffset;
 	int m_PlaceholderLength;
-	static char ms_aDisplayText[MAX_LINE_LENGTH];
+	static char ms_aDisplayText[MAX_CHAT_LENGTH];
 	class CRateablePlayer
 	{
 	public:
@@ -141,7 +140,7 @@ class CChat : public CComponent
 	int64_t m_LastChatSend;
 	int64_t m_aLastSoundPlayed[CHAT_NUM];
 	bool m_IsInputCensored;
-	char m_aCurrentInputText[MAX_LINE_LENGTH];
+	char m_aCurrentInputText[MAX_CHAT_LENGTH];
 	bool m_EditingNewLine;
 
 	bool m_ServerSupportsCommandInfo;

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -609,14 +609,20 @@ void CGameContext::ConDrySave(IConsole::IResult *pResult, void *pUserData)
 
 	char aTimestamp[32];
 	str_timestamp(aTimestamp, sizeof(aTimestamp));
+	const char *pSaveState = SavedTeam.GetString();
+	if(!pSaveState)
+	{
+		pSelf->SendChatTarget(pResult->m_ClientId, "Your team is too large to save");
+		return;
+	}
+
 	char aBuf[64];
 	str_format(aBuf, sizeof(aBuf), "%s_%s_%s.save", pSelf->Map()->BaseName(), aTimestamp, pSelf->Server()->GetAuthName(pResult->m_ClientId));
 	IOHANDLE File = pSelf->Storage()->OpenFile(aBuf, IOFLAG_WRITE, IStorage::TYPE_SAVE);
 	if(!File)
 		return;
 
-	int Len = str_length(SavedTeam.GetString());
-	io_write(File, SavedTeam.GetString(), Len);
+	io_write(File, pSaveState, str_length(pSaveState));
 	io_close(File);
 }
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -708,7 +708,7 @@ void CGameContext::SendChat(int ChatterClientId, int Team, const char *pText, in
 		if(ProcessSpamProtection(SpamProtectionClientId))
 			return;
 
-	char aText[256];
+	char aText[MAX_CHAT_LENGTH];
 	str_copy(aText, pText);
 	const char *pTeamString = Team == TEAM_ALL ? "chat" : "teamchat";
 	if(ChatterClientId == -1)
@@ -2345,7 +2345,7 @@ void CGameContext::OnSayNetMessage(const CNetMsg_Cl_Say *pMsg, int ClientId, con
 		else if(pEnd == nullptr)
 			pEnd = pStrOld;
 
-		if(++Length >= 256)
+		if(++Length >= MAX_CHAT_LENGTH)
 		{
 			*(const_cast<char *>(p)) = 0;
 			break;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -998,7 +998,9 @@ void CPlayer::ProcessScoreResult(CScorePlayerResult &Result)
 				if(aMessage[0] == 0)
 					break;
 
-				if(GameServer()->ProcessSpamProtection(m_ClientId) && PrimaryMessage)
+				// Only the primary message counts towards the chat score, the
+				// follow-up messages of one command must not mute the player.
+				if(PrimaryMessage && GameServer()->ProcessSpamProtection(m_ClientId))
 					break;
 
 				GameServer()->SendChat(-1, TEAM_ALL, aMessage, -1);

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -553,11 +553,6 @@ bool CSaveHotReloadTee::Load(CCharacter *pChr, int Team)
 	return Result;
 }
 
-CSaveTeam::CSaveTeam()
-{
-	m_aString[0] = '\0';
-}
-
 CSaveTeam::~CSaveTeam()
 {
 	delete[] m_pSwitchers;
@@ -717,15 +712,20 @@ CCharacter *CSaveTeam::MatchCharacter(CGameContext *pGameServer, int ClientId, i
 	return pGameServer->m_apPlayers[ClientId]->ForceSpawn(m_pSavedTees[SaveId].GetPos());
 }
 
-char *CSaveTeam::GetString()
+const char *CSaveTeam::GetString()
 {
-	str_format(m_aString, sizeof(m_aString), "%d\t%d\t%d\t%d\t%d", static_cast<int>(m_TeamState), m_MembersCount, m_HighestSwitchNumber, m_TeamLocked, m_Practice);
+	// Appending a truncated line would corrupt the savegame, so refuse to
+	// serialize a team that does not fit instead.
+	int Length = str_format(m_aString, sizeof(m_aString), "%d\t%d\t%d\t%d\t%d", static_cast<int>(m_TeamState), m_MembersCount, m_HighestSwitchNumber, m_TeamLocked, m_Practice);
 
 	for(int i = 0; i < m_MembersCount; i++)
 	{
-		char aBuf[1024];
+		char aBuf[1 + MAX_SAVE_TEE_STRING_LENGTH];
 		str_format(aBuf, sizeof(aBuf), "\n%s", m_pSavedTees[i].GetString(this));
+		if(Length + str_length(aBuf) >= (int)sizeof(m_aString))
+			return nullptr;
 		str_append(m_aString, aBuf);
+		Length += str_length(aBuf);
 	}
 
 	if(m_pSwitchers && m_HighestSwitchNumber)
@@ -734,7 +734,10 @@ char *CSaveTeam::GetString()
 		{
 			char aBuf[64];
 			str_format(aBuf, sizeof(aBuf), "\n%d\t%d\t%d", m_pSwitchers[i].m_Status, m_pSwitchers[i].m_EndTime, m_pSwitchers[i].m_Type);
+			if(Length + str_length(aBuf) >= (int)sizeof(m_aString))
+				return nullptr;
 			str_append(m_aString, aBuf);
+			Length += str_length(aBuf);
 		}
 	}
 
@@ -745,21 +748,19 @@ int CSaveTeam::FromString(const char *pString)
 {
 	char aTeamStats[MAX_CLIENTS];
 	char aSwitcher[64];
-	char aSaveTee[1024];
+	char aSaveTee[MAX_SAVE_TEE_STRING_LENGTH];
 
-	char *pCopyPos;
+	const char *pCopyPos;
 	unsigned int Pos = 0;
 	unsigned int LastPos = 0;
 	unsigned int StrSize;
 
-	str_copy(m_aString, pString);
-
-	while(m_aString[Pos] != '\n' && Pos < sizeof(m_aString) && m_aString[Pos]) // find next \n or \0
+	while(pString[Pos] != '\n' && pString[Pos]) // find next \n or \0
 		Pos++;
 
-	pCopyPos = m_aString + LastPos;
+	pCopyPos = pString + LastPos;
 	StrSize = Pos - LastPos + 1;
-	if(m_aString[Pos] == '\n')
+	if(pString[Pos] == '\n')
 	{
 		Pos++; // skip \n
 		LastPos = Pos;
@@ -814,12 +815,12 @@ int CSaveTeam::FromString(const char *pString)
 
 	for(int n = 0; n < m_MembersCount; n++)
 	{
-		while(m_aString[Pos] != '\n' && Pos < sizeof(m_aString) && m_aString[Pos]) // find next \n or \0
+		while(pString[Pos] != '\n' && pString[Pos]) // find next \n or \0
 			Pos++;
 
-		pCopyPos = m_aString + LastPos;
+		pCopyPos = pString + LastPos;
 		StrSize = Pos - LastPos + 1;
-		if(m_aString[Pos] == '\n')
+		if(pString[Pos] == '\n')
 		{
 			Pos++; // skip \n
 			LastPos = Pos;
@@ -864,12 +865,12 @@ int CSaveTeam::FromString(const char *pString)
 
 	for(int n = 1; n < m_HighestSwitchNumber + 1; n++)
 	{
-		while(m_aString[Pos] != '\n' && Pos < sizeof(m_aString) && m_aString[Pos]) // find next \n or \0
+		while(pString[Pos] != '\n' && pString[Pos]) // find next \n or \0
 			Pos++;
 
-		pCopyPos = m_aString + LastPos;
+		pCopyPos = pString + LastPos;
 		StrSize = Pos - LastPos + 1;
-		if(m_aString[Pos] == '\n')
+		if(pString[Pos] == '\n')
 		{
 			Pos++; // skip \n
 			LastPos = Pos;

--- a/src/game/server/save.h
+++ b/src/game/server/save.h
@@ -35,6 +35,12 @@ enum class ESaveResult
 	DRAGGER_ACTIVE
 };
 
+enum
+{
+	MAX_SAVE_TEE_STRING_LENGTH = 2048,
+	MAX_SAVE_STRING_LENGTH = 65536,
+};
+
 class CSaveTee
 {
 public:
@@ -64,7 +70,7 @@ public:
 private:
 	int m_ClientId;
 
-	char m_aString[2048];
+	char m_aString[MAX_SAVE_TEE_STRING_LENGTH];
 	char m_aName[16];
 
 	int m_Alive;
@@ -174,9 +180,9 @@ private:
 class CSaveTeam
 {
 public:
-	CSaveTeam();
 	~CSaveTeam();
-	char *GetString();
+	// Returns nullptr if the team is too large to be saved
+	const char *GetString();
 	int GetMembersCount() const { return m_MembersCount; }
 	// MatchPlayers has to be called afterwards
 	int FromString(const char *pString);
@@ -193,7 +199,7 @@ public:
 private:
 	CCharacter *MatchCharacter(CGameContext *pGameServer, int ClientId, int SaveId, bool KeepCurrentCharacter) const;
 
-	char m_aString[65536];
+	char m_aString[MAX_SAVE_STRING_LENGTH];
 
 	struct SSimpleSwitchers
 	{

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -80,8 +80,11 @@ bool CTeamrank::NextSqlResult(IDbConnection *pSqlServer, bool *pEnd, char *pErro
 			*pEnd = false;
 			return true;
 		}
-		pSqlServer->GetString(2, m_aaNames[m_NumNames], sizeof(m_aaNames[m_NumNames]));
-		m_NumNames++;
+		if(m_NumNames < MAX_CLIENTS)
+		{
+			pSqlServer->GetString(2, m_aaNames[m_NumNames], sizeof(m_aaNames[m_NumNames]));
+			m_NumNames++;
+		}
 	}
 	if(!End)
 	{
@@ -103,6 +106,44 @@ bool CTeamrank::SamePlayers(const std::vector<std::string> *pvSortedNames)
 	return true;
 }
 
+void CTeamrank::FormatNames(char *pBuf, int BufSize) const
+{
+	// Reserve room for the longest suffix that could be needed.
+	char aMore[16];
+	str_format(aMore, sizeof(aMore), " & %d more", (int)m_NumNames);
+	const int NamesSize = BufSize - str_length(aMore);
+
+	pBuf[0] = '\0';
+	int Length = 0;
+	unsigned int Name = 0;
+	for(; Name < m_NumNames; Name++)
+	{
+		char aName[3 + MAX_NAME_LENGTH];
+		str_format(aName, sizeof(aName), "%s%s",
+			Length == 0 ? "" : (Name == m_NumNames - 1 ? " & " : ", "),
+			m_aaNames[Name]);
+		if(Length + str_length(aName) >= NamesSize)
+			break;
+		str_append(pBuf, aName, NamesSize);
+		Length += str_length(aName);
+	}
+	if(Name < m_NumNames)
+	{
+		str_format(aMore, sizeof(aMore), " & %d more", (int)(m_NumNames - Name));
+		str_append(pBuf, aMore, BufSize);
+	}
+}
+
+void CTeamrank::FormatTeamTopLine(char *pMessage, int MessageSize, int Rank, const char *pTime) const
+{
+	// Format without any names first to measure how much room the names have
+	// in the chat message they share with the rank and the time.
+	const int EmptyLength = str_format(pMessage, MessageSize, "%d. %s Team Time: %s", Rank, "", pTime);
+	char aFormattedNames[MAX_TEAM_NAMES_LENGTH];
+	FormatNames(aFormattedNames, MAX_CHAT_LENGTH - EmptyLength);
+	str_format(pMessage, MessageSize, "%d. %s Team Time: %s", Rank, aFormattedNames, pTime);
+}
+
 bool CTeamrank::GetSqlTop5Team(IDbConnection *pSqlServer, bool *pEnd, char *pError, int ErrorSize, char (*paMessages)[512], int *Line, int Count)
 {
 	char aTime[32];
@@ -115,16 +156,14 @@ bool CTeamrank::GetSqlTop5Team(IDbConnection *pSqlServer, bool *pEnd, char *pErr
 		int Rank = pSqlServer->GetInt(3);
 		int TeamSize = pSqlServer->GetInt(4);
 
-		char aNames[2300] = {0};
+		CTeamrank Teamrank;
 		for(int i = 0; i < TeamSize; i++)
 		{
-			char aName[MAX_NAME_LENGTH];
-			pSqlServer->GetString(1, aName, sizeof(aName));
-			str_append(aNames, aName);
-			if(i < TeamSize - 2)
-				str_append(aNames, ", ");
-			else if(i == TeamSize - 2)
-				str_append(aNames, " & ");
+			if(Teamrank.m_NumNames < MAX_CLIENTS)
+			{
+				pSqlServer->GetString(1, Teamrank.m_aaNames[Teamrank.m_NumNames], sizeof(Teamrank.m_aaNames[0]));
+				Teamrank.m_NumNames++;
+			}
 			if(!pSqlServer->Step(&Last, pError, ErrorSize))
 			{
 				return false;
@@ -134,8 +173,7 @@ bool CTeamrank::GetSqlTop5Team(IDbConnection *pSqlServer, bool *pEnd, char *pErr
 				break;
 			}
 		}
-		str_format(paMessages[*Line], sizeof(paMessages[*Line]), "%d. %s Team Time: %s",
-			Rank, aNames, aTime);
+		Teamrank.FormatTeamTopLine(paMessages[*Line], sizeof(paMessages[*Line]), Rank, aTime);
 		if(Last)
 		{
 			(*Line)++;
@@ -1013,17 +1051,6 @@ bool CScoreWorker::ShowTeamRank(IDbConnection *pSqlServer, const ISqlData *pGame
 			return false;
 		}
 
-		char aFormattedNames[512] = "";
-		for(unsigned int Name = 0; Name < Teamrank.m_NumNames; Name++)
-		{
-			str_append(aFormattedNames, Teamrank.m_aaNames[Name]);
-
-			if(Name < Teamrank.m_NumNames - 2)
-				str_append(aFormattedNames, ", ");
-			else if(Name < Teamrank.m_NumNames - 1)
-				str_append(aFormattedNames, " & ");
-		}
-
 		if(g_Config.m_SvHideScore)
 		{
 			str_format(pResult->m_Data.m_aaMessages[0], sizeof(pResult->m_Data.m_aaMessages[0]),
@@ -1032,6 +1059,13 @@ bool CScoreWorker::ShowTeamRank(IDbConnection *pSqlServer, const ISqlData *pGame
 		else
 		{
 			pResult->m_MessageKind = CScorePlayerResult::ALL;
+
+			// Format without any names first to measure how much room the names have.
+			const int EmptyLength = str_format(pResult->m_Data.m_aaMessages[0], sizeof(pResult->m_Data.m_aaMessages[0]),
+				"%d. %s Team time: %s, better than %d%%, requested by %s",
+				Rank, "", aBuf, BetterThanPercent, pData->m_aRequestingPlayer);
+			char aFormattedNames[MAX_TEAM_NAMES_LENGTH];
+			Teamrank.FormatNames(aFormattedNames, MAX_CHAT_LENGTH - EmptyLength);
 			str_format(pResult->m_Data.m_aaMessages[0], sizeof(pResult->m_Data.m_aaMessages[0]),
 				"%d. %s Team time: %s, better than %d%%, requested by %s",
 				Rank, aFormattedNames, aBuf, BetterThanPercent, pData->m_aRequestingPlayer);
@@ -1329,19 +1363,7 @@ bool CScoreWorker::ShowPlayerTeamTop5(IDbConnection *pSqlServer, const ISqlData 
 				return false;
 			}
 
-			char aFormattedNames[512] = "";
-			for(unsigned int Name = 0; Name < Teamrank.m_NumNames; Name++)
-			{
-				str_append(aFormattedNames, Teamrank.m_aaNames[Name]);
-
-				if(Name < Teamrank.m_NumNames - 2)
-					str_append(aFormattedNames, ", ");
-				else if(Name < Teamrank.m_NumNames - 1)
-					str_append(aFormattedNames, " & ");
-			}
-
-			str_format(paMessages[Line], sizeof(paMessages[Line]), "%d. %s Team Time: %s",
-				Rank, aFormattedNames, aBuf);
+			Teamrank.FormatTeamTopLine(paMessages[Line], sizeof(paMessages[Line]), Rank, aBuf);
 			if(Last)
 			{
 				Line++;

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -136,8 +136,7 @@ void CTeamrank::FormatNames(char *pBuf, int BufSize) const
 
 void CTeamrank::FormatTeamTopLine(char *pMessage, int MessageSize, int Rank, const char *pTime) const
 {
-	// Format without any names first to measure how much room the names have
-	// in the chat message they share with the rank and the time.
+	// format without names to measure remaining space for names
 	const int EmptyLength = str_format(pMessage, MessageSize, "%d. %s Team Time: %s", Rank, "", pTime);
 	char aFormattedNames[MAX_TEAM_NAMES_LENGTH];
 	FormatNames(aFormattedNames, MAX_CHAT_LENGTH - EmptyLength);
@@ -1060,7 +1059,7 @@ bool CScoreWorker::ShowTeamRank(IDbConnection *pSqlServer, const ISqlData *pGame
 		{
 			pResult->m_MessageKind = CScorePlayerResult::ALL;
 
-			// Format without any names first to measure how much room the names have.
+			// format without names to measure remaining space for names
 			const int EmptyLength = str_format(pResult->m_Data.m_aaMessages[0], sizeof(pResult->m_Data.m_aaMessages[0]),
 				"%d. %s Team time: %s, better than %d%%, requested by %s",
 				Rank, "", aBuf, BetterThanPercent, pData->m_aRequestingPlayer);
@@ -1761,7 +1760,13 @@ bool CScoreWorker::SaveTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 	char aSaveId[UUID_MAXSTRSIZE];
 	FormatUuid(pResult->m_SaveId, aSaveId, UUID_MAXSTRSIZE);
 
-	char *pSaveState = pResult->m_SavedTeam.GetString();
+	const char *pSaveState = pResult->m_SavedTeam.GetString();
+	if(!pSaveState)
+	{
+		pResult->m_Status = CScoreSaveResult::SAVE_FAILED;
+		str_copy(pResult->m_aMessage, "Your team is too large to save");
+		return true;
+	}
 	char aBuf[65536];
 
 	dbg_msg("score/dbg", "code=%s failure=%d", pData->m_aCode, (int)w);
@@ -1886,7 +1891,7 @@ bool CScoreWorker::LoadTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 		}
 	}
 
-	char aSaveString[65536];
+	char aSaveString[MAX_SAVE_STRING_LENGTH];
 	pSqlServer->GetString(1, aSaveString, sizeof(aSaveString));
 	int Num = pResult->m_SavedTeam.FromString(aSaveString);
 

--- a/src/game/server/scoreworker.h
+++ b/src/game/server/scoreworker.h
@@ -24,6 +24,8 @@ enum
 {
 	NUM_CHECKPOINTS = MAX_CHECKPOINTS,
 	TIMESTAMP_STR_LENGTH = 20, // 2019-04-02 19:38:36
+	// Every team member name at maximum length, joined by ", " and " & ".
+	MAX_TEAM_NAMES_LENGTH = MAX_CLIENTS * (MAX_NAME_LENGTH + 2),
 };
 
 struct CScorePlayerResult : ISqlResult
@@ -285,6 +287,12 @@ struct CTeamrank
 	bool NextSqlResult(IDbConnection *pSqlServer, bool *pEnd, char *pError, int ErrorSize);
 
 	bool SamePlayers(const std::vector<std::string> *pvSortedNames);
+
+	// Formats the names into pBuf, joined by ", " and " & ". Names that don't
+	// fit are summarized as " & %d more".
+	void FormatNames(char *pBuf, int BufSize) const;
+
+	void FormatTeamTopLine(char *pMessage, int MessageSize, int Rank, const char *pTime) const;
 
 	static bool GetSqlTop5Team(IDbConnection *pSqlServer, bool *pEnd, char *pError, int ErrorSize, char (*paMessages)[512], int *StartLine, int Count);
 };

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -1169,10 +1169,14 @@ void CGameTeams::ProcessSaveTeam()
 		{
 			if(GameServer()->TeeHistorianActive())
 			{
-				GameServer()->TeeHistorian()->RecordTeamSaveSuccess(
-					Team,
-					m_apSaveTeamResult[Team]->m_SaveId,
-					m_apSaveTeamResult[Team]->m_SavedTeam.GetString());
+				const char *pSaveState = m_apSaveTeamResult[Team]->m_SavedTeam.GetString();
+				if(pSaveState)
+				{
+					GameServer()->TeeHistorian()->RecordTeamSaveSuccess(
+						Team,
+						m_apSaveTeamResult[Team]->m_SaveId,
+						pSaveState);
+				}
 			}
 			for(int i = 0; i < Size; i++)
 			{
@@ -1202,10 +1206,14 @@ void CGameTeams::ProcessSaveTeam()
 		{
 			if(GameServer()->TeeHistorianActive())
 			{
-				GameServer()->TeeHistorian()->RecordTeamLoadSuccess(
-					Team,
-					m_apSaveTeamResult[Team]->m_SaveId,
-					m_apSaveTeamResult[Team]->m_SavedTeam.GetString());
+				const char *pSaveState = m_apSaveTeamResult[Team]->m_SavedTeam.GetString();
+				if(pSaveState)
+				{
+					GameServer()->TeeHistorian()->RecordTeamLoadSuccess(
+						Team,
+						m_apSaveTeamResult[Team]->m_SaveId,
+						pSaveState);
+				}
 			}
 
 			bool TeamValid = false;

--- a/src/test/score_test.cpp
+++ b/src/test/score_test.cpp
@@ -364,6 +364,96 @@ TEST_P(TeamScore, RankUpdates)
 			"---------------------------------"});
 }
 
+// A team of MAX_CLIENTS players with names of maximum length, which is the
+// worst case for the chat messages that show team ranks.
+struct BigTeamScore : public Score // NOLINT(readability-identifier-naming)
+{
+	void SetUp() override
+	{
+		str_copy(g_Config.m_SvSqlServerName, "USA");
+		CSqlTeamScoreData TeamScoreData;
+		str_copy(TeamScoreData.m_aMap, "Kobra 3");
+		str_copy(TeamScoreData.m_aGameUuid, "8d300ecf-5873-4297-bee5-95668fdff320");
+		TeamScoreData.m_Size = MAX_CLIENTS;
+		TeamScoreData.m_Time = 100.0f;
+		str_copy(TeamScoreData.m_aTimestamp, "2021-11-24 19:24:08");
+		for(int i = 0; i < MAX_CLIENTS; i++)
+		{
+			str_format(TeamScoreData.m_aaNames[i], sizeof(TeamScoreData.m_aaNames[i]), "playertee12_%03d", i);
+			ASSERT_EQ(str_length(TeamScoreData.m_aaNames[i]), MAX_NAME_LENGTH - 1);
+		}
+		ASSERT_TRUE(CScoreWorker::SaveTeamScore(m_pConn, &TeamScoreData, Write::NORMAL, m_aError, sizeof(m_aError))) << m_aError;
+
+		CSqlScoreData ScoreData(std::make_shared<CScorePlayerResult>());
+		str_copy(ScoreData.m_aMap, "Kobra 3");
+		str_copy(ScoreData.m_aGameUuid, "8d300ecf-5873-4297-bee5-95668fdff320");
+		ScoreData.m_Time = 100.0f;
+		str_copy(ScoreData.m_aTimestamp, "2021-11-24 19:24:08");
+		std::fill(std::begin(ScoreData.m_aCurrentTimeCp), std::end(ScoreData.m_aCurrentTimeCp), 0);
+		str_copy(ScoreData.m_aRequestingPlayer, TeamScoreData.m_aaNames[0]);
+		for(int i = 0; i < MAX_CLIENTS; i++)
+		{
+			str_copy(ScoreData.m_aName, TeamScoreData.m_aaNames[i]);
+			ScoreData.m_ClientId = i;
+			ASSERT_TRUE(CScoreWorker::SaveScore(m_pConn, &ScoreData, Write::NORMAL, m_aError, sizeof(m_aError))) << m_aError;
+		}
+
+		str_copy(m_PlayerRequest.m_aMap, "Kobra 3");
+		str_copy(m_PlayerRequest.m_aRequestingPlayer, TeamScoreData.m_aaNames[0]);
+		str_copy(m_PlayerRequest.m_aName, TeamScoreData.m_aaNames[0]);
+		str_copy(m_PlayerRequest.m_aServer, "USA");
+		m_PlayerRequest.m_Offset = 0;
+	}
+
+	// Messages longer than this are truncated before they reach the client.
+	void ExpectMessagesFitIntoChat()
+	{
+		for(const auto &aMessage : m_pPlayerResult->m_Data.m_aaMessages)
+		{
+			EXPECT_LT(str_length(aMessage), MAX_CHAT_LENGTH) << aMessage;
+		}
+	}
+};
+
+TEST_P(BigTeamScore, TeamRankShortensNames)
+{
+	ASSERT_TRUE(CScoreWorker::ShowTeamRank(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ExpectMessagesFitIntoChat();
+
+	// The names that don't fit into the chat message are summarized.
+	EXPECT_STREQ(m_pPlayerResult->m_Data.m_aaMessages[0],
+		"1. playertee12_000, playertee12_001, playertee12_002, playertee12_003, "
+		"playertee12_004, playertee12_005, playertee12_006, playertee12_007, "
+		"playertee12_008, playertee12_009 & 118 more Team time: 01:40.00, "
+		"better than 100%, requested by playertee12_000");
+}
+
+TEST_P(BigTeamScore, TeamTop5ShortensNames)
+{
+	g_Config.m_SvRegionalRankings = false;
+	ASSERT_TRUE(CScoreWorker::ShowTeamTop5(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ExpectMessagesFitIntoChat();
+
+	// Five teams can't be wrapped, so the names that don't fit are summarized.
+	EXPECT_STREQ(m_pPlayerResult->m_Data.m_aaMessages[1],
+		"1. playertee12_000, playertee12_001, playertee12_002, playertee12_003, "
+		"playertee12_004, playertee12_005, playertee12_006, playertee12_007, "
+		"playertee12_008, playertee12_009, playertee12_010, playertee12_011, "
+		"playertee12_012 & 115 more Team Time: 01:40.00");
+}
+
+TEST_P(BigTeamScore, PlayerTeamTop5ShortensNames)
+{
+	ASSERT_TRUE(CScoreWorker::ShowPlayerTeamTop5(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
+	ExpectMessagesFitIntoChat();
+
+	EXPECT_STREQ(m_pPlayerResult->m_Data.m_aaMessages[1],
+		"1. playertee12_000, playertee12_001, playertee12_002, playertee12_003, "
+		"playertee12_004, playertee12_005, playertee12_006, playertee12_007, "
+		"playertee12_008, playertee12_009, playertee12_010, playertee12_011, "
+		"playertee12_012 & 115 more Team Time: 01:40.00");
+}
+
 struct MapInfo : public Score // NOLINT(readability-identifier-naming)
 {
 	MapInfo()
@@ -672,6 +762,7 @@ static auto g_TestValues{
 
 INSTANTIATE(SingleScore);
 INSTANTIATE(TeamScore);
+INSTANTIATE(BigTeamScore);
 INSTANTIATE(MapInfo);
 INSTANTIATE(MapVote);
 INSTANTIATE(Points);


### PR DESCRIPTION
Reported on Discord by Rekin: https://discord.com/channels/252358080522747904/757720336274948198/1538928188632203327

Saves failed with ~ 70 players.

Another 128 player followup.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5).
