### PR TITLE
client: Fix using a new libpng version than built against

### DIFF
--- a/src/engine/gfx/image_loader.cpp
+++ b/src/engine/gfx/image_loader.cpp
@@ -143,7 +143,7 @@ bool CImageLoader::LoadPng(CByteBufferReader &Reader, const char *pContextName, 
 		return false;
 	}
 
-	png_structp pPngStruct = png_create_read_struct(PNG_LIBPNG_VER_STRING, &UserErrorStruct, PngErrorCallback, PngWarningCallback);
+	png_structp pPngStruct = png_create_read_struct(png_get_libpng_ver(nullptr), &UserErrorStruct, PngErrorCallback, PngWarningCallback);
 	if(pPngStruct == nullptr)
 	{
 		log_error("png", "libpng internal failure: png_create_read_struct failed.");
@@ -340,7 +340,7 @@ static int PngColorTypeFromFormat(CImageInfo::EImageFormat Format)
 
 bool CImageLoader::SavePng(CByteBufferWriter &Writer, const CImageInfo &Image)
 {
-	png_structp pPngStruct = png_create_write_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+	png_structp pPngStruct = png_create_write_struct(png_get_libpng_ver(nullptr), nullptr, nullptr, nullptr);
 	if(pPngStruct == nullptr)
 	{
 		log_error("png", "libpng internal failure: png_create_write_struct failed.");


### PR DESCRIPTION
Seen in https://github.com/ddnet/ddnet/issues/12643#issuecomment-5353181581

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5)
