### PR TITLE
server: Handle snapshot id pool being empty

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -57,7 +57,8 @@ CCharacter::CCharacter(CGameWorld *pWorld, CNetObj_PlayerInput LastInput) :
 CCharacter::~CCharacter()
 {
 	for(auto Id : m_aUntranslatedId)
-		Server()->SnapFreeId(Id.value());
+		if(Id)
+			Server()->SnapFreeId(*Id);
 }
 
 void CCharacter::Reset()
@@ -1278,12 +1279,13 @@ void CCharacter::Snap(int SnappingClient)
 
 		int Subtype = GetActiveWeapon();
 		int Type = Subtype == WEAPON_NINJA ? POWERUP_NINJA : POWERUP_WEAPON;
-		GameServer()->SnapPickup(SnapContext, m_aUntranslatedId[EUntranslatedMap::ID_WEAPON].value(), m_Pos, Type, Subtype, 0, PICKUPFLAG_NO_PREDICT);
+		if(m_aUntranslatedId[EUntranslatedMap::ID_WEAPON])
+			GameServer()->SnapPickup(SnapContext, *m_aUntranslatedId[EUntranslatedMap::ID_WEAPON], m_Pos, Type, Subtype, 0, PICKUPFLAG_NO_PREDICT);
 
-		if(m_Core.m_HookState != HOOK_IDLE && m_Core.m_HookState != HOOK_RETRACTED)
+		if(m_Core.m_HookState != HOOK_IDLE && m_Core.m_HookState != HOOK_RETRACTED && m_aUntranslatedId[EUntranslatedMap::ID_HOOK])
 		{
 			int StartTick = Server()->Tick() - 3;
-			GameServer()->SnapLaserObject(SnapContext, m_aUntranslatedId[EUntranslatedMap::ID_HOOK].value(), m_Core.m_HookPos, m_Pos, StartTick, -1, LASERTYPE_RIFLE);
+			GameServer()->SnapLaserObject(SnapContext, *m_aUntranslatedId[EUntranslatedMap::ID_HOOK], m_Core.m_HookPos, m_Pos, StartTick, -1, LASERTYPE_RIFLE);
 		}
 		return;
 	}


### PR DESCRIPTION
Found via fuzzing, reproduced against real DDNet-Server with asan+ubsan, and verified green with the fix

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code
