### PR TITLE
Fix overflow on crazy tunings

### DIFF
--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -13,6 +13,7 @@
 
 #include <game/teamscore.h>
 
+#include <limits>
 #include <set>
 #include <vector>
 
@@ -24,16 +25,14 @@ class CTuneParam
 	int m_Value;
 
 public:
-	void Set(int v) { m_Value = v; }
 	int Get() const { return m_Value; }
-	CTuneParam &operator=(int v)
-	{
-		m_Value = (int)(v * 100.0f);
-		return *this;
-	}
 	CTuneParam &operator=(float v)
 	{
-		m_Value = (int)(v * 100.0f);
+		const float Fixed = v * 100.0f;
+		if(Fixed >= static_cast<float>(std::numeric_limits<int>::min()) && Fixed < static_cast<float>(std::numeric_limits<int>::max()))
+			m_Value = static_cast<int>(Fixed);
+		else
+			m_Value = std::numeric_limits<int>::min();
 		return *this;
 	}
 	operator float() const { return m_Value / 100.0f; }
@@ -46,7 +45,7 @@ class CTuningParams
 public:
 	CTuningParams()
 	{
-#define MACRO_TUNING_PARAM(Name, ScriptName, Value, Description) m_##Name.Set((int)((Value) * 100.0f));
+#define MACRO_TUNING_PARAM(Name, ScriptName, Value, Description) m_##Name = (Value);
 #include "tuning.h"
 #undef MACRO_TUNING_PARAM
 	}

--- a/src/test/gameworld_test.cpp
+++ b/src/test/gameworld_test.cpp
@@ -25,6 +25,7 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <memory>
 #include <thread>
 
@@ -306,4 +307,14 @@ TEST_F(GameWorld, CharacterEmote)
 	// /emote angry 3 chat command and frozen
 	pChr->Freeze(10);
 	ASSERT_EQ(pChr->DetermineEyeEmote(), EMOTE_ANGRY);
+}
+
+TEST(Tunings, OutOfRangeBecomesIntMin)
+{
+	const float IntMin = std::numeric_limits<int>::min() / 100.0f;
+	CTuneParam Param;
+	EXPECT_EQ((float)(Param = 555555555555555.0f), IntMin);
+	EXPECT_EQ((float)(Param = -555555555555555.0f), IntMin);
+	EXPECT_EQ((float)(Param = std::numeric_limits<float>::quiet_NaN()), IntMin);
+	EXPECT_EQ((float)(Param = 0.5f), 0.5f);
 }


### PR DESCRIPTION
This is the same value we'd get on x86-64 on our prod servers for this undefined behavior.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5)
