### PR TITLE
net: Fix setting tos on ipv6/ipv4

### DIFF
--- a/src/base/net.cpp
+++ b/src/base/net.cpp
@@ -923,7 +923,7 @@ NETSOCKET net_udp_create(NETADDR bindaddr)
 
 			// Set DSCP/TOS
 			{
-				int iptos = 0x10; // IPTOS_LOWDELAY
+				int iptos = 0xB8; // IPTOS_DSCP_EF, expedited forwarding
 				if(setsockopt(socket, IPPROTO_IP, IP_TOS, (const char *)&iptos, sizeof(iptos)) != 0)
 				{
 					log_error("net", "Setting IP_TOS on IPv4 failed (%s)", net_error_message().c_str());
@@ -969,10 +969,10 @@ NETSOCKET net_udp_create(NETADDR bindaddr)
 			// TODO: setting IP_TOS on ipv6 with setsockopt is not supported on Windows, see https://github.com/ddnet/ddnet/issues/7605
 #if !defined(CONF_FAMILY_WINDOWS)
 			{
-				int iptos = 0x10; // IPTOS_LOWDELAY
-				if(setsockopt(socket, IPPROTO_IP, IP_TOS, (const char *)&iptos, sizeof(iptos)) != 0)
+				int tclass = 0xB8; // IPTOS_DSCP_EF, expedited forwarding
+				if(setsockopt(socket, IPPROTO_IPV6, IPV6_TCLASS, (const char *)&tclass, sizeof(tclass)) != 0)
 				{
-					log_error("net", "Setting IP_TOS on IPv6 failed (%s)", net_error_message().c_str());
+					log_error("net", "Setting IPV6_TCLASS failed (%s)", net_error_message().c_str());
 				}
 			}
 #endif


### PR DESCRIPTION
I kept getting annoyed by
```
2026-08-20 20:19:57 E net: Setting IP_TOS on IPv6 failed (22 'Invalid argument')
```
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5)
