### PR TITLE
Mark failing `dbg_assert` as `[[unlikely]]`

### DIFF
--- a/src/base/dbg.h
+++ b/src/base/dbg.h
@@ -27,7 +27,7 @@
 #define dbg_assert(test, fmt, ...) \
 	do \
 	{ \
-		if(!(test)) \
+		if(!(test)) [[unlikely]] \
 		{ \
 			dbg_assert_imp(__FILE__, __LINE__, fmt, ##__VA_ARGS__); \
 		} \
@@ -44,7 +44,7 @@
  *
  * @see dbg_break
  */
-#define dbg_assert_failed(fmt, ...) dbg_assert_imp(__FILE__, __LINE__, fmt, ##__VA_ARGS__)
+#define dbg_assert_failed(fmt, ...) [[unlikely]] dbg_assert_imp(__FILE__, __LINE__, fmt, ##__VA_ARGS__)
 
 /**
  * Use the @link dbg_assert @endlink function instead!


### PR DESCRIPTION
Didn't notice any performance impact on FPS in different menus, editor and ingame, but in theory this should be one of the few good use cases for `[[unlikely]]`.

https://en.cppreference.com/cpp/language/attributes/likely

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
