### PR TITLE
server: Fix old clients when many players are in teams

### DIFF
--- a/src/game/server/playermapping.cpp
+++ b/src/game/server/playermapping.cpp
@@ -15,6 +15,7 @@ void CPlayerMapping::Init(CGameContext *pGameServer)
 	m_pConfig = m_pGameServer->Config();
 	m_pServer = m_pGameServer->Server();
 	std::fill(std::begin(m_aTeamSizes), std::end(m_aTeamSizes), 0);
+	m_ReserveAnyTeamSlots = true;
 
 	for(int i = 0; i < MAX_CLIENTS; i++)
 		m_aMap[i].Init(i, this);
@@ -398,7 +399,7 @@ int CPlayerMapping::CPlayerMap::MapSize() const
 bool CPlayerMapping::ReserveTeamSlots(int DDTeam, int ClientId) const
 {
 	const bool IsDDNet = m_pGameServer->GetClientVersion(ClientId) >= VERSION_DDNET_OLD;
-	return !g_Config.m_SvSoloServer && DDTeam != TEAM_FLOCK && m_aTeamSizes[DDTeam] <= ms_MaxTeamSizePlayerMap && IsDDNet;
+	return !g_Config.m_SvSoloServer && m_ReserveAnyTeamSlots && DDTeam != TEAM_FLOCK && m_aTeamSizes[DDTeam] <= ms_MaxTeamSizePlayerMap && IsDDNet;
 }
 
 int CPlayerMapping::SeeOthersId(int ClientId) const
@@ -454,6 +455,12 @@ void CPlayerMapping::UpdatePlayerMap(int ClientId)
 				int DDTeam = GameServer()->GetDDRaceTeam(i);
 				m_aTeamSizes[DDTeam]++;
 			}
+			int NumReservableTeamPlayers = 0;
+			for(int Team = TEAM_FLOCK + 1; Team < NUM_DDRACE_TEAMS; Team++)
+				if(m_aTeamSizes[Team] <= ms_MaxTeamSizePlayerMap)
+					NumReservableTeamPlayers += m_aTeamSizes[Team];
+			// Starvation is only possible when not every player fits into the legacy id map
+			m_ReserveAnyTeamSlots = ClientCount <= LEGACY_MAX_CLIENTS - 2 || NumReservableTeamPlayers <= ms_MaxTotalTeamSizePlayerMap;
 		}
 
 		for(auto &Map : m_aMap)

--- a/src/game/server/playermapping.h
+++ b/src/game/server/playermapping.h
@@ -52,8 +52,11 @@ private:
 	static constexpr int ms_MaxNumSeeOthersVanilla = 13;
 	// Teams are messy. Dont highlight teams bigger than 10 tees in playermapping so that big teams wont break anything
 	static constexpr int ms_MaxTeamSizePlayerMap = 10;
+	// Dont reserve more than half of the 62 slots for players in teams, the rest is needed for the closest tees
+	static constexpr int ms_MaxTotalTeamSizePlayerMap = 30;
 
 	int m_aTeamSizes[NUM_DDRACE_TEAMS];
+	bool m_ReserveAnyTeamSlots;
 	char m_aSeeOthersName[MAX_NAME_LENGTH];
 
 	class CPlayerMap

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -527,6 +527,7 @@ void CGameTeams::ChangeTeamState(int Team, ETeamState State)
 
 void CGameTeams::KillTeam(int Team, int NewStrongId, int ExceptId)
 {
+	CClientMask KilledMask;
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		if(m_Core.Team(i) == Team && GameServer()->m_apPlayers[i])
@@ -534,6 +535,8 @@ void CGameTeams::KillTeam(int Team, int NewStrongId, int ExceptId)
 			GameServer()->m_apPlayers[i]->m_VotedForPractice = false;
 			if(i != ExceptId)
 			{
+				if(GameServer()->m_apPlayers[i]->GetCharacter())
+					KilledMask.set(i);
 				GameServer()->m_apPlayers[i]->KillCharacter(WEAPON_SELF, false);
 				if(NewStrongId != -1 && i != NewStrongId)
 				{
@@ -558,6 +561,22 @@ void CGameTeams::KillTeam(int Team, int NewStrongId, int ExceptId)
 		if(!Server()->ClientIngame(i))
 			continue;
 		Msg.m_Team = TeamForClient(Team, i);
+		if(Msg.m_Team == TEAM_FLOCK && Team != TEAM_FLOCK)
+		{
+			// The client resets prediction for every tee it thinks is in the killed team.
+			for(int Killed = 0; Killed < MAX_CLIENTS; Killed++)
+			{
+				if(!KilledMask.test(Killed))
+					continue;
+				CNetMsg_Sv_KillMsg KillMsg;
+				KillMsg.m_Killer = Killed;
+				KillMsg.m_Victim = Killed;
+				KillMsg.m_Weapon = WEAPON_SELF;
+				KillMsg.m_ModeSpecial = 0;
+				Server()->SendPackMsg(&KillMsg, MSGFLAG_VITAL | MSGFLAG_NORECORD, i);
+			}
+			continue;
+		}
 		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, i);
 	}
 }


### PR DESCRIPTION
Another 128 player followup
## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5 and Opus 4.8)
