### PR TITLE
client: Add fast input as an option (off by default)

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -419,6 +419,7 @@ public:
 	virtual void OnWindowResize() = 0;
 
 	virtual int OnSnapInput(int *pData, bool Dummy, bool Force) = 0;
+	virtual bool CheckNewInput() = 0;
 	virtual void OnDummySwap() = 0;
 	virtual void SendDummyInfo(bool Start) = 0;
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2954,6 +2954,9 @@ void CClient::Update()
 					// send input
 					SendInput();
 				}
+
+				if(g_Config.m_ClFastInput && GameClient()->CheckNewInput())
+					Repredict = true;
 			}
 
 			// only do sane predictions

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -26,6 +26,7 @@ MACRO_CONFIG_INT(ClAntiPingGunfire, cl_antiping_gunfire, 1, 0, 1, CFGFLAG_CLIENT
 MACRO_CONFIG_INT(ClAntiPingPreInput, cl_antiping_preinput, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Predict other players using preinputs for more accurate input prediction")
 MACRO_CONFIG_INT(ClPredictionMargin, cl_prediction_margin, 10, 1, 300, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Prediction margin in ms (adds latency, can reduce lag from ping jumps)")
 MACRO_CONFIG_INT(ClSubTickAiming, cl_sub_tick_aiming, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Send aiming data at sub-tick accuracy")
+MACRO_CONFIG_INT(ClFastInput, cl_fast_input, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Predict own inputs one tick early for more responsive controls, at the cost of small mispredictions")
 #if defined(CONF_PLATFORM_ANDROID) || defined(CONF_PLATFORM_IOS)
 MACRO_CONFIG_INT(ClTouchControls, cl_touch_controls, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable ingame touch controls")
 #else

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -248,6 +248,9 @@ int CControls::SnapInput(int *pData)
 			m_aMousePosOnAction[g_Config.m_ClDummy] = vec2(0.0f, 0.0f);
 		}
 
+		// the pending hook or fire press is contained in this input, unfreeze the fast input aim
+		m_aFastInputPendingAction[g_Config.m_ClDummy] = false;
+
 		if(!m_aInputData[g_Config.m_ClDummy].m_TargetX && !m_aInputData[g_Config.m_ClDummy].m_TargetY)
 		{
 			m_aInputData[g_Config.m_ClDummy].m_TargetX = 1;
@@ -337,6 +340,39 @@ int CControls::SnapInput(int *pData)
 	m_LastSendTime = time_get();
 	mem_copy(pData, &m_aInputData[g_Config.m_ClDummy], sizeof(m_aInputData[0]));
 	return sizeof(m_aInputData[0]);
+}
+
+bool CControls::CheckNewInput()
+{
+	CNetObj_PlayerInput Input = m_aInputData[g_Config.m_ClDummy];
+	Input.m_Direction = 0;
+	if(m_aInputDirectionLeft[g_Config.m_ClDummy] && !m_aInputDirectionRight[g_Config.m_ClDummy])
+		Input.m_Direction = -1;
+	if(!m_aInputDirectionLeft[g_Config.m_ClDummy] && m_aInputDirectionRight[g_Config.m_ClDummy])
+		Input.m_Direction = 1;
+	Input.m_TargetX = (int)m_aMousePos[g_Config.m_ClDummy].x;
+	Input.m_TargetY = (int)m_aMousePos[g_Config.m_ClDummy].y;
+	if(Input.m_TargetX == 0 && Input.m_TargetY == 0)
+		Input.m_TargetX = 1;
+
+	// freeze the aim while a hook or fire press waits to be sent, so the predicted
+	// direction stays stable, with cl_sub_tick_aiming it also matches the aim the
+	// server will receive
+	CNetObj_PlayerInput &FastInput = m_aFastInput[g_Config.m_ClDummy];
+	const bool NewAction = (FastInput.m_Hook == 0 && Input.m_Hook == 1) || (FastInput.m_Fire != Input.m_Fire && (Input.m_Fire & 1) != 0);
+	if(m_aFastInputPendingAction[g_Config.m_ClDummy] && !NewAction)
+	{
+		Input.m_TargetX = FastInput.m_TargetX;
+		Input.m_TargetY = FastInput.m_TargetY;
+	}
+	m_aFastInputPendingAction[g_Config.m_ClDummy] = m_aFastInputPendingAction[g_Config.m_ClDummy] || NewAction;
+
+	const bool NewInput = Input.m_Direction != FastInput.m_Direction || Input.m_Jump != FastInput.m_Jump ||
+			      Input.m_Fire != FastInput.m_Fire || Input.m_Hook != FastInput.m_Hook ||
+			      Input.m_WantedWeapon != FastInput.m_WantedWeapon || Input.m_NextWeapon != FastInput.m_NextWeapon ||
+			      Input.m_PrevWeapon != FastInput.m_PrevWeapon;
+	FastInput = Input;
+	return NewInput;
 }
 
 void CControls::OnRender()

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -36,6 +36,8 @@ public:
 	int64_t m_LastSendTime;
 	CNetObj_PlayerInput m_aInputData[NUM_DUMMIES];
 	CNetObj_PlayerInput m_aLastData[NUM_DUMMIES];
+	CNetObj_PlayerInput m_aFastInput[NUM_DUMMIES] = {};
+	bool m_aFastInputPendingAction[NUM_DUMMIES] = {};
 	int m_aInputDirectionLeft[NUM_DUMMIES];
 	int m_aInputDirectionRight[NUM_DUMMIES];
 	int m_aShowHookColl[NUM_DUMMIES];
@@ -51,6 +53,7 @@ public:
 	virtual void OnPlayerDeath();
 
 	int SnapInput(int *pData);
+	bool CheckNewInput();
 	void ClampMousePos();
 	void ResetInput(int Dummy);
 

--- a/src/game/client/components/menus_settings_ddnet.cpp
+++ b/src/game/client/components/menus_settings_ddnet.cpp
@@ -99,7 +99,7 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 
 	// gameplay
 	CUIRect Gameplay;
-	MainView.HSplitTop(190.0f, &Gameplay, &MainView);
+	MainView.HSplitTop(210.0f, &Gameplay, &MainView);
 	Gameplay.HSplitTop(30.0f, &Label, &Gameplay);
 	Ui()->DoLabel(&Label, Localize("Gameplay"), 20.0f, TEXTALIGN_ML);
 	Gameplay.HSplitTop(5.0f, nullptr, &Gameplay);
@@ -156,6 +156,13 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	{
 		g_Config.m_ClPredictEvents ^= 1;
 	}
+
+	Right.HSplitTop(20.0f, &Button, &Right);
+	if(DoButton_CheckBox(&g_Config.m_ClFastInput, Localize("Fast input"), g_Config.m_ClFastInput, &Button))
+	{
+		g_Config.m_ClFastInput ^= 1;
+	}
+	GameClient()->m_Tooltips.DoToolTip(&g_Config.m_ClFastInput, &Button, Localize("Predict own inputs one tick early for more responsive controls, at the cost of small mispredictions"));
 
 	Right.HSplitTop(20.0f, &Button, &Right);
 	if(DoButton_CheckBox(&g_Config.m_ClAntiPing, Localize("AntiPing"), g_Config.m_ClAntiPing, &Button))

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -522,6 +522,11 @@ void CGameClient::OnDummySwap()
 	m_IsDummySwapping = 1;
 }
 
+bool CGameClient::CheckNewInput()
+{
+	return m_Controls.CheckNewInput();
+}
+
 int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
 {
 	if(!Dummy)
@@ -565,7 +570,11 @@ int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
 			m_DummyInput.m_WantedWeapon = WEAPON_HAMMER + 1;
 		}
 
-		const vec2 Dir = m_LocalCharacterPos - m_aClients[m_aLocalIds[!g_Config.m_ClDummy]].m_Predicted.m_Pos;
+		// fast input advances the rendered state one tick, use the positions from
+		// before that tick so that the sent target is not affected
+		const vec2 TargetPos = m_FastInputApplied ? m_LocalCharacterPosNoFastInput : m_LocalCharacterPos;
+		const vec2 HammerPos = m_FastInputApplied ? m_DummyPosNoFastInput : m_aClients[m_aLocalIds[!g_Config.m_ClDummy]].m_Predicted.m_Pos;
+		const vec2 Dir = TargetPos - HammerPos;
 		m_HammerInput.m_TargetX = (int)Dir.x;
 		m_HammerInput.m_TargetY = (int)Dir.y;
 
@@ -652,6 +661,7 @@ void CGameClient::OnReset()
 
 	m_PredictedPrevChar.Reset();
 	m_PredictedChar.Reset();
+	m_FastInputApplied = false;
 
 	// m_Snap was cleared in InvalidateSnapshot
 
@@ -2613,6 +2623,8 @@ void CGameClient::ApplyPreInputs(int Tick, bool Direct, CGameWorld &GameWorld)
 
 void CGameClient::OnPredict()
 {
+	m_FastInputApplied = false;
+
 	// store the previous values so we can detect prediction errors
 	CCharacterCore BeforePrevChar = m_PredictedPrevChar;
 	CCharacterCore BeforeChar = m_PredictedChar;
@@ -2860,7 +2872,62 @@ void CGameClient::OnPredict()
 		}
 	}
 
-	if(g_Config.m_Debug && g_Config.m_ClPredict && m_PredictedTick == Client()->PredGameTick(g_Config.m_ClDummy))
+	// fast input: predict the own tees one tick further with the latest local input,
+	// so new inputs become visible before the next prediction tick
+	if(g_Config.m_ClFastInput && Predict() && !m_IsDummySwapping)
+	{
+		m_FastInputWorld.CopyWorld(&m_PredictedWorld);
+		// the extra tick is only used for rendering the own tees, don't let it feed
+		// events or entity destroy ticks back into the regular prediction
+		m_FastInputWorld.m_IsValidCopy = false;
+		m_FastInputWorld.m_WorldConfig.m_PredictEvents = false;
+		CCharacter *pFastLocalChar = m_FastInputWorld.GetCharacterById(m_Snap.m_LocalClientId);
+		CCharacter *pFastDummyChar = !pDummyChar ? nullptr : m_FastInputWorld.GetCharacterById(m_aLocalIds[!g_Config.m_ClDummy]);
+		if(pFastLocalChar)
+		{
+			const int FastTick = Client()->PredGameTick(g_Config.m_ClDummy) + 1;
+			CNetObj_PlayerInput *pInputData = &m_Controls.m_aFastInput[g_Config.m_ClDummy];
+			// the dummy repeats its last sent input for the extra tick
+			CNetObj_PlayerInput *pDummyInputData = !pFastDummyChar ? nullptr : (CNetObj_PlayerInput *)Client()->GetInput(FastTick, m_IsDummySwapping ^ 1);
+			bool DummyFirst = pDummyInputData && pFastDummyChar->GetCid() < pFastLocalChar->GetCid();
+
+			if(DummyFirst)
+				pFastDummyChar->OnDirectInput(pDummyInputData);
+			pFastLocalChar->OnDirectInput(pInputData);
+			if(pDummyInputData && !DummyFirst)
+				pFastDummyChar->OnDirectInput(pDummyInputData);
+
+			ApplyPreInputs(FastTick, true, m_FastInputWorld);
+
+			m_FastInputWorld.m_GameTick = FastTick;
+			pFastLocalChar->OnPredictedInput(pInputData);
+			if(pDummyInputData)
+				pFastDummyChar->OnPredictedInput(pDummyInputData);
+
+			ApplyPreInputs(FastTick, false, m_FastInputWorld);
+
+			m_FastInputWorld.Tick();
+
+			// the input sent to the server must not use the extra tick
+			m_PredictedPrevCharNoFastInput = m_aClients[m_Snap.m_LocalClientId].m_PrevPredicted;
+			m_PredictedCharNoFastInput = m_aClients[m_Snap.m_LocalClientId].m_Predicted;
+			if(m_aLocalIds[!g_Config.m_ClDummy] >= 0)
+				m_DummyPosNoFastInput = m_aClients[m_aLocalIds[!g_Config.m_ClDummy]].m_Predicted.m_Pos;
+			m_FastInputApplied = true;
+
+			m_PredictedPrevChar = m_PredictedChar;
+			m_PredictedChar = pFastLocalChar->GetCore();
+			m_aClients[m_Snap.m_LocalClientId].m_PrevPredicted = m_aClients[m_Snap.m_LocalClientId].m_Predicted;
+			m_aClients[m_Snap.m_LocalClientId].m_Predicted = pFastLocalChar->GetCore();
+			if(pFastDummyChar)
+			{
+				m_aClients[m_aLocalIds[!g_Config.m_ClDummy]].m_PrevPredicted = m_aClients[m_aLocalIds[!g_Config.m_ClDummy]].m_Predicted;
+				m_aClients[m_aLocalIds[!g_Config.m_ClDummy]].m_Predicted = pFastDummyChar->GetCore();
+			}
+		}
+	}
+
+	if(g_Config.m_Debug && g_Config.m_ClPredict && !g_Config.m_ClFastInput && m_PredictedTick == Client()->PredGameTick(g_Config.m_ClDummy))
 	{
 		CNetObj_CharacterCore Before = {0}, Now = {0}, BeforePrev = {0}, NowPrev = {0};
 		BeforeChar.Write(&Before);
@@ -3847,7 +3914,17 @@ void CGameClient::UpdateRenderedCharacters()
 		}
 		m_aClients[i].m_RenderPos = Pos;
 		if(Predict() && i == m_Snap.m_LocalClientId)
+		{
 			m_LocalCharacterPos = Pos;
+			m_LocalCharacterPosNoFastInput = Pos;
+			if(m_FastInputApplied)
+			{
+				CNetObj_CharacterCore Prev = {0}, Cur = {0};
+				m_PredictedPrevCharNoFastInput.Write(&Prev);
+				m_PredictedCharNoFastInput.Write(&Cur);
+				m_LocalCharacterPosNoFastInput = mix(vec2(Prev.m_X, Prev.m_Y), vec2(Cur.m_X, Cur.m_Y), Client()->PredIntraGameTick(g_Config.m_ClDummy));
+			}
+		}
 	}
 }
 

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -351,6 +351,18 @@ public:
 	 */
 	CCharacterCore m_PredictedChar;
 
+	/**
+	 * Set while the extra tick of `cl_fast_input` is part of the prediction.
+	 * The `NoFastInput` values are only valid then and hold the state from
+	 * before that tick, so that the input sent to the server stays the same
+	 * whether the setting is on or off.
+	 */
+	bool m_FastInputApplied = false;
+	CCharacterCore m_PredictedPrevCharNoFastInput;
+	CCharacterCore m_PredictedCharNoFastInput;
+	vec2 m_DummyPosNoFastInput;
+	vec2 m_LocalCharacterPosNoFastInput;
+
 	// snap pointers
 	class CSnapState
 	{
@@ -631,6 +643,7 @@ public:
 	void OnActivateEditor() override;
 	void OnDummySwap() override;
 	int OnSnapInput(int *pData, bool Dummy, bool Force) override;
+	bool CheckNewInput() override;
 	void OnShutdown() override;
 	void OnEnterGame() override;
 	void OnRconType(bool UsernameReq) override;
@@ -722,6 +735,7 @@ public:
 	CGameWorld m_GameWorld;
 	CGameWorld m_PredictedWorld;
 	CGameWorld m_PrevPredictedWorld;
+	CGameWorld m_FastInputWorld;
 
 	std::vector<SSwitchers> &Switchers() { return m_GameWorld.m_Core.m_vSwitchers; }
 	std::vector<SSwitchers> &PredSwitchers() { return m_PredictedWorld.m_Core.m_vSwitchers; }

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -711,7 +711,11 @@ void CGameWorld::CopyWorld(CGameWorld *pFrom)
 				pCopy = new CPlasma(*((CPlasma *)pEnt));
 			if(pCopy)
 			{
+				// detach the previous copy, the entity links only track the latest copy
+				if(pEnt->m_pChild)
+					pEnt->m_pChild->m_pParent = nullptr;
 				pCopy->m_pParent = pEnt;
+				pCopy->m_pChild = nullptr;
 				pEnt->m_pChild = pCopy;
 				this->InsertEntity(pCopy);
 			}


### PR DESCRIPTION
New inputs are applied to the prediction immediately instead of at the next prediction tick, and the own tees are rendered one predicted tick ahead. This removes up to 20ms of visual input delay, at the cost of small mispredictions since the server still applies the input at the next tick.

Based on the fast input feature by @sjrc6  in TaterClient. What do you think about it?

Closes #9845

Draft since I haven‘t tested it.

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5).
