### PR TITLE
client: Handle input earlier

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2826,6 +2826,12 @@ void CClient::Update()
 {
 	PumpNetwork();
 
+	// update editor/gameclient, before input snapping
+	if(m_EditorActive)
+		m_pEditor->OnUpdate();
+	else
+		GameClient()->OnUpdate();
+
 	if(State() == IClient::STATE_DEMOPLAYBACK)
 	{
 		if(m_DemoPlayer.IsPlaying())
@@ -3103,12 +3109,6 @@ void CClient::Update()
 
 	// update the server browser
 	m_ServerBrowser.Update();
-
-	// update editor/gameclient
-	if(m_EditorActive)
-		m_pEditor->OnUpdate();
-	else
-		GameClient()->OnUpdate();
 
 	Discord()->Update();
 	Steam()->Update();


### PR DESCRIPTION
People always complained that lower refresh rate increased input latency and I assumed it's inherent. This improves the situation by sending the inputs one loop iteration earlier. At cl_refresh_rate 60 the input is sent 16ms earlier.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5)
