### PR TITLE
client: Wait for next frame instead of spinning

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3509,6 +3509,23 @@ void CClient::Run()
 			}
 			Slept = true;
 		}
+		else if(g_Config.m_GfxRefreshRate
+#if defined(CONF_VIDEORECORDER)
+			&& !IVideo::Current()
+#endif
+		)
+		{
+			int64_t WaitTime = LastRenderTime + time_freq() / (int64_t)g_Config.m_GfxRefreshRate - Now.count();
+			if(State() == IClient::STATE_ONLINE)
+			{
+				const int64_t TickLength = time_freq() / GameTickSpeed();
+				WaitTime = std::min(WaitTime, TickLength - m_PredictedTime.Get(Now.count()) % TickLength);
+			}
+			if(WaitTime > 0)
+			{
+				SDL_WaitEventTimeout(nullptr, WaitTime * 1000 / time_freq());
+			}
+		}
 		if(Slept)
 		{
 			// if the diff gets too small it shouldn't get even smaller (drop the updates, that could not be handled)


### PR DESCRIPTION
when gfx_refresh_rate 60 and cl_refresh_rate 0 it used to just waste CPU, this fixed it
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5 and Fable 5)
