### PR TITLE
client: Don't send spectator camera flag for dummy

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -533,6 +533,8 @@ int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
 		return 0;
 	}
 
+	m_DummyInput.m_PlayerFlags &= ~PLAYERFLAG_SPEC_CAM;
+
 	if(!g_Config.m_ClDummyHammer)
 	{
 		if(m_DummyFire != 0)


### PR DESCRIPTION
Reported on Discord by Retsot: https://discord.com/channels/252358080522747904/757720336274948198/1541709391441563719

Introduced in #9318. cc @TsFreddie 

`PLAYERFLAG_SPEC_CAM` says that the camera is in spectator mode, but this can't be true for dummy. It makes the server ignore all inputs, then we get lots of noise from the prediction not matching because client expects dummy to take an action, but server doesn't actually do it.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5)
