### PR TITLE
Keep sound running when no audio device is available

### DIFF
--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -8,6 +8,7 @@
 #include <base/math.h>
 #include <base/mem.h>
 #include <base/str.h>
+#include <base/time.h>
 
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
@@ -28,6 +29,29 @@ extern "C" {
 static constexpr int SAMPLE_INDEX_USED = -2;
 static constexpr int SAMPLE_INDEX_FULL = -1;
 
+unsigned CSound::AdvanceVoice(CVoice &Voice, unsigned Frames)
+{
+	// make sure that we don't go outside the sound data
+	const unsigned Advanced = std::min(Frames, (unsigned)(Voice.m_pSample->m_NumFrames - Voice.m_Tick));
+	Voice.m_Tick += Advanced;
+
+	// free voice if not used any more
+	if(Voice.m_Tick == Voice.m_pSample->m_NumFrames)
+	{
+		if(Voice.m_Flags & ISound::FLAG_LOOP)
+		{
+			Voice.m_Tick = Voice.m_pSample->m_LoopStart;
+		}
+		else
+		{
+			Voice.m_pSample = nullptr;
+			Voice.m_Age++;
+		}
+	}
+
+	return Advanced;
+}
+
 void CSound::Mix(short *pFinalOut, unsigned Frames)
 {
 	Frames = std::min(Frames, m_MaxFrames);
@@ -46,21 +70,18 @@ void CSound::Mix(short *pFinalOut, unsigned Frames)
 		// mix voice
 		int *pOut = m_pMixBuffer;
 
-		const int Step = Voice.m_pSample->m_Channels; // setup input sources
-		short *pInL = &Voice.m_pSample->m_pData[Voice.m_Tick * Step];
-		short *pInR = &Voice.m_pSample->m_pData[Voice.m_Tick * Step + 1];
+		const CSample *pSample = Voice.m_pSample;
+		const int Step = pSample->m_Channels; // setup input sources
+		short *pInL = &pSample->m_pData[Voice.m_Tick * Step];
+		short *pInR = &pSample->m_pData[Voice.m_Tick * Step + 1];
 
-		unsigned End = Voice.m_pSample->m_NumFrames - Voice.m_Tick;
+		const unsigned End = AdvanceVoice(Voice, Frames);
 
 		int VolumeR = round_truncate(Voice.m_pChannel->m_Vol * (Voice.m_Vol / 255.0f));
 		int VolumeL = VolumeR;
 
-		// make sure that we don't go outside the sound data
-		if(Frames < End)
-			End = Frames;
-
 		// check if we have a mono sound
-		if(Voice.m_pSample->m_Channels == 1)
+		if(pSample->m_Channels == 1)
 			pInR = pInL;
 
 		// volume calculation
@@ -142,21 +163,6 @@ void CSound::Mix(short *pFinalOut, unsigned Frames)
 			*pOut++ += (*pInR) * VolumeR;
 			pInL += Step;
 			pInR += Step;
-			Voice.m_Tick++;
-		}
-
-		// free voice if not used any more
-		if(Voice.m_Tick == Voice.m_pSample->m_NumFrames)
-		{
-			if(Voice.m_Flags & ISound::FLAG_LOOP)
-			{
-				Voice.m_Tick = Voice.m_pSample->m_LoopStart;
-			}
-			else
-			{
-				Voice.m_pSample = nullptr;
-				Voice.m_Age++;
-			}
 		}
 	}
 
@@ -217,44 +223,149 @@ int CSound::Init()
 		return -1;
 	}
 
-	SDL_AudioSpec Format, FormatOut;
-	Format.freq = g_Config.m_SndRate;
-	Format.format = AUDIO_S16;
-	Format.channels = 2;
-	Format.samples = g_Config.m_SndBufferSize;
-	Format.callback = SdlCallback;
-	Format.userdata = this;
+	m_AudioSpec.freq = g_Config.m_SndRate;
+	m_AudioSpec.format = AUDIO_S16;
+	m_AudioSpec.channels = 2;
+	m_AudioSpec.samples = g_Config.m_SndBufferSize;
+	m_AudioSpec.callback = SdlCallback;
+	m_AudioSpec.userdata = this;
 
-	// Open the audio device and start playing sound!
-	m_Device = SDL_OpenAudioDevice(nullptr, 0, &Format, &FormatOut, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
-	if(m_Device == 0)
-	{
-		log_error("sound", "Unable to open audio device: %s", SDL_GetError());
-		return -1;
-	}
-	else
-	{
-		log_info("sound", "Sound init successful using audio driver '%s'", SDL_GetCurrentAudioDriver());
-	}
-
-	m_MixingRate = FormatOut.freq;
-	m_MaxFrames = FormatOut.samples * 2;
+	m_MixingRate = m_AudioSpec.freq;
+	m_MaxFrames = m_AudioSpec.samples * 2;
 #if defined(CONF_VIDEORECORDER)
 	m_MaxFrames = std::max(m_MaxFrames, 1024u * 2u); // make the buffer bigger just in case
 #endif
 	m_pMixBuffer = (int *)calloc(m_MaxFrames * 2, sizeof(int));
 
 	m_SoundEnabled = true;
-	Update();
+	UpdateVolume();
 
-	SDL_PauseAudioDevice(m_Device, 0);
+	SDL_AddEventWatch(HandleAudioDeviceEvent, this);
+	if(OpenDevice(true))
+	{
+		log_info("sound", "Sound init successful using audio driver '%s'", SDL_GetCurrentAudioDriver());
+	}
+	else
+	{
+		log_error("sound", "Unable to open audio device (%s), waiting for one to become available", SDL_GetError());
+	}
 	return 0;
+}
+
+int SDLCALL CSound::HandleAudioDeviceEvent(void *pUser, SDL_Event *pEvent)
+{
+	if((pEvent->type == SDL_AUDIODEVICEADDED || pEvent->type == SDL_AUDIODEVICEREMOVED) && !pEvent->adevice.iscapture)
+	{
+		static_cast<CSound *>(pUser)->m_DeviceChanged.store(true, std::memory_order_relaxed);
+	}
+	return 0;
+}
+
+bool CSound::OpenDevice(bool AllowFrequencyChange)
+{
+	dbg_assert(m_Device == 0, "Audio device already open");
+
+	SDL_AudioSpec FormatOut;
+	m_Device = SDL_OpenAudioDevice(nullptr, 0, &m_AudioSpec, &FormatOut, AllowFrequencyChange ? SDL_AUDIO_ALLOW_FREQUENCY_CHANGE : 0);
+	if(m_Device == 0)
+		return false;
+
+	if(AllowFrequencyChange)
+	{
+		// Samples are converted to this rate when they are loaded, so later devices are asked for it
+		m_MixingRate = FormatOut.freq;
+		m_AudioSpec.freq = m_MixingRate;
+	}
+	SDL_PauseAudioDevice(m_Device, m_DevicePaused ? 1 : 0);
+	return true;
+}
+
+void CSound::CloseDevice()
+{
+	if(m_Device == 0)
+		return;
+
+	SDL_CloseAudioDevice(m_Device);
+	m_Device = 0;
+}
+
+void CSound::UpdateDevice()
+{
+	if(!m_SoundEnabled)
+		return;
+
+	if(m_Device != 0)
+	{
+		if(SDL_GetAudioDeviceStatus(m_Device) != SDL_AUDIO_STOPPED)
+			return;
+		log_info("sound", "Audio device was disconnected");
+		CloseDevice();
+	}
+
+	if(!m_DeviceChanged.exchange(false, std::memory_order_relaxed))
+		return;
+
+	if(OpenDevice(false))
+	{
+		log_info("sound", "Audio device connected, using audio driver '%s'", SDL_GetCurrentAudioDriver());
+	}
+}
+
+bool CSound::HasAudioOutput() const
+{
+#if defined(CONF_VIDEORECORDER)
+	if(IVideo::Current() && g_Config.m_ClVideoSndEnable)
+		return true;
+#endif
+	return m_Device != 0;
 }
 
 int CSound::Update()
 {
 	UpdateVolume();
+	UpdateDevice();
+	AdvancePlayback();
 	return 0;
+}
+
+void CSound::AdvancePlayback()
+{
+	if(!m_SoundEnabled || HasAudioOutput())
+	{
+		m_PlaybackTime = 0;
+		return;
+	}
+
+	// Advance the voices in real time while there is no device, so that sounds
+	// end and loop like they would during playback
+	const int64_t Now = time_get();
+	if(m_PlaybackTime == 0)
+	{
+		m_PlaybackTime = Now;
+		return;
+	}
+
+	// Drop the backlog after the client was blocked for a long time
+	m_PlaybackTime = std::max(m_PlaybackTime, Now - time_freq());
+
+	int64_t Frames = ((Now - m_PlaybackTime) * m_MixingRate) / time_freq();
+	if(Frames <= 0)
+		return;
+	// Only count the whole frames, keeping the remainder for the next update
+	m_PlaybackTime += (Frames * time_freq()) / m_MixingRate;
+
+	const CLockScope LockScope(m_SoundLock);
+	while(Frames > 0)
+	{
+		// Advance in the same chunks as the mixer, so voices loop at the same points
+		const unsigned ChunkFrames = std::min<unsigned>(Frames, m_MaxFrames);
+		for(auto &Voice : m_aVoices)
+		{
+			if(Voice.m_pSample)
+				AdvanceVoice(Voice, ChunkFrames);
+		}
+		Frames -= ChunkFrames;
+	}
 }
 
 void CSound::UpdateVolume()
@@ -270,9 +381,9 @@ void CSound::Shutdown()
 	StopAll();
 
 	// Stop sound callback before freeing sample data
-	SDL_CloseAudioDevice(m_Device);
+	SDL_DelEventWatch(HandleAudioDeviceEvent, this);
+	CloseDevice();
 	SDL_QuitSubSystem(SDL_INIT_AUDIO);
-	m_Device = 0;
 
 	const CLockScope LockScope(m_SoundLock);
 	for(auto &Sample : m_aSamples)
@@ -1029,12 +1140,20 @@ bool CSound::IsPlaying(int SampleId)
 
 void CSound::PauseAudioDevice()
 {
-	SDL_PauseAudioDevice(m_Device, 1);
+	m_DevicePaused = true;
+	if(m_Device != 0)
+	{
+		SDL_PauseAudioDevice(m_Device, 1);
+	}
 }
 
 void CSound::UnpauseAudioDevice()
 {
-	SDL_PauseAudioDevice(m_Device, 0);
+	m_DevicePaused = false;
+	if(m_Device != 0)
+	{
+		SDL_PauseAudioDevice(m_Device, 0);
+	}
 }
 
 IEngineSound *CreateEngineSound() { return new CSound; }

--- a/src/engine/client/sound.h
+++ b/src/engine/client/sound.h
@@ -8,6 +8,7 @@
 #include <engine/sound.h>
 
 #include <SDL_audio.h>
+#include <SDL_events.h>
 
 #include <atomic>
 
@@ -69,7 +70,10 @@ class CSound : public IEngineSound
 	};
 
 	bool m_SoundEnabled = false;
+	SDL_AudioSpec m_AudioSpec = {};
 	SDL_AudioDeviceID m_Device = 0;
+	bool m_DevicePaused = false;
+	std::atomic<bool> m_DeviceChanged = false;
 	CLock m_SoundLock;
 
 	CSample m_aSamples[NUM_SAMPLES] GUARDED_BY(m_SoundLock) = {{0}};
@@ -91,9 +95,19 @@ class CSound : public IEngineSound
 	IStorage *m_pStorage = nullptr;
 
 	int *m_pMixBuffer = nullptr;
+	int64_t m_PlaybackTime = 0;
 
 	CSample *AllocSample() REQUIRES(!m_SoundLock);
 	void RateConvert(CSample &Sample) const;
+
+	static int SDLCALL HandleAudioDeviceEvent(void *pUser, SDL_Event *pEvent);
+	bool OpenDevice(bool AllowFrequencyChange);
+	void CloseDevice();
+	void UpdateDevice() REQUIRES(!m_SoundLock);
+	bool HasAudioOutput() const;
+	// Returns how many frames the voice advanced, looping or freeing it at the end of its sample
+	unsigned AdvanceVoice(CVoice &Voice, unsigned Frames) REQUIRES(m_SoundLock);
+	void AdvancePlayback() REQUIRES(!m_SoundLock);
 
 	// pContextName used for error
 	bool DecodeOpus(CSample &Sample, const void *pData, unsigned DataSize, const char *pContextName) const;
@@ -103,7 +117,7 @@ class CSound : public IEngineSound
 
 public:
 	int Init() override REQUIRES(!m_SoundLock);
-	int Update() override;
+	int Update() override REQUIRES(!m_SoundLock);
 	void Shutdown() override REQUIRES(!m_SoundLock);
 
 	bool IsSoundEnabled() override { return m_SoundEnabled; }

--- a/ubsan.supp
+++ b/ubsan.supp
@@ -1,2 +1,5 @@
 null:json.c
 pointer-overflow:json.c
+shift-base:bits.c
+shift-base:unpack.c
+shift-base:words.c


### PR DESCRIPTION
Closes #4603. The client now opens the audio device when one connects instead of only at startup, so connecting headphones after launch doesn't need a restart anymore.

<details>
<summary>longer explanation, written by Claude</summary>

`CSound::Init` opened the device once and returned `-1` when that failed, which showed the "Sound error" warning and left `m_SoundEnabled` false, so no samples were ever loaded either. Nothing reopened the device later.

Three parts to the change:

1. Failing to open the device is no longer a failed init. The mixer is set up, sound counts as enabled so samples load, and `Init` returns success. The warning stays for a failed `SDL_InitSubSystem(SDL_INIT_AUDIO)`.
2. An SDL event watch flags `SDL_AUDIODEVICEADDED` and `SDL_AUDIODEVICEREMOVED`, and `Update` acts on the flag: it closes ours when `SDL_GetAudioDeviceStatus` reports it stopped, and opens the default device whenever none is open. A device we paused ourselves reports `SDL_AUDIO_PAUSED` rather than stopped, so the video recorder pausing the device is not mistaken for a disconnect. Opening only happens on those events, never on a timer: `SDL_OpenAudioDevice` blocks for about eight seconds on WASAPI when there is no endpoint at all, which a retry loop turns into a permanently stalled main loop.
3. While no device is open, `Update` advances the playing voices in real time without mixing anything. Without that, voices never finish, the 256 slots fill up, and everything queued during the silence fires at once when audio comes back. Ending and looping a voice used to live inside the mixer's inner loop, so reaching it from a second caller meant either mixing into a buffer nobody reads or duplicating the rule; `AdvanceVoice` pulls it out instead, and both callers share it.

Samples are rate converted to the mixing rate as they are loaded, which happens on a job thread, so the mixing rate cannot change afterwards without racing them. Only the device opened during init picks it, with `SDL_AUDIO_ALLOW_FREQUENCY_CHANGE`. Later devices are asked for that same rate with `allowed_changes` zero, which makes SDL convert instead.

Starting with no device is no longer an error the player has to click away:

| before | after |
| --- | --- |
| ![before](https://edgl.dev/share/ddnet-4603-before.png) | ![after](https://edgl.dev/share/ddnet-4603-after.png) |

Tested headlessly with Xvfb and a PulseAudio instance whose sinks can be loaded and unloaded on demand, capturing the sink monitor with `parec` while the menu music plays. The numbers are the loudest s16 sample in a four second capture, so master goes silent for good in both cases while this branch recovers:

```
scenario                                  master           this branch
no device at startup, sink appears later  silent, warning  audible, peak 9632
sink removed and re-added mid-session     8381 then 0      8381 then 8857
```

Advancing the voices without a device costs 6.6ms per second of wall clock with the menu music looping, about 0.7% of one core, at roughly 120,000 `Update` calls per second on an uncapped menu frame rate. Most of that is the fixed cost of the call rather than the voice work, 55ns per call, so a client capped to a normal frame rate pays a small fraction of it. Measured by differencing two 45 second runs of the same build against `snd_enable 0`, which subtracts the 2.9ms per second the two `time_get_nanoseconds` probes cost themselves; the instrumentation is not part of the commit.

Two limits worth knowing. A device that exists but cannot be opened, held in exclusive mode or busy, produces no event when it frees up, so that case still needs a restart, same as before. And SDL 2.32.4 segfaults inside its own PulseAudio hotplug callback when the server has zero sinks as the client starts, on master just as much as here, which is why the startup case was tested with `PULSE_SINK` naming a sink that does not exist yet, and with an empty ALSA config.

One commit here adds three lines to `ubsan.supp`. The client decodes sound files now even when no audio device is available, which is the first time the bundled wavpack 4.40 runs in the sanitizer CI job, and its byte assembly and its shifts of negative values are undefined behaviour. Decoding all 131 files in `data/audio` produces 149 reports, every one of them `shift-base` in `bits.c`, `unpack.c` or `words.c`, so `shift-base:bits.c`, `shift-base:unpack.c` and `shift-base:words.c` silence all of them; with any other filename in those three lines all 149 remain, so the suppression is scoped to the vendored decoder rather than switching the check off elsewhere. Patching the sources to shift through `uint32_t` was the alternative and it loses twice over: it edits a vendored library, and #12552 deletes those files outright.

Configuration options exercised: `snd_enable` off and on, `snd_enable_music` off and on.

</details>

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude investigated the issue, wrote this change, ran the tests above and wrote the collapsed explanation.

