### PR TITLE
Feature: Add font-typer quick action and editor button

### DIFF
--- a/src/engine/font_icons.h
+++ b/src/engine/font_icons.h
@@ -56,6 +56,7 @@ namespace FontIcon
 	inline const char *const HOUSE = "\uF015";
 	inline const char *const IMAGE = "\uF03E";
 	inline const char *const INFO = "\uF129";
+	inline const char *const I_CURSOR = "\uF246";
 	inline const char *const KEY = "\uF084";
 	inline const char *const KEYBOARD = "\u2328";
 	inline const char *const LAYER_GROUP = "\uF5FD";

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -816,6 +816,18 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 				m_BrushDrawDestructive = !m_BrushDrawDestructive;
 			ToolbarBottom.VSplitLeft(5.0f, &Button, &ToolbarBottom);
 		}
+
+		// Font typer button
+		{
+			ToolbarBottom.VSplitLeft(25.0f, &Button, &ToolbarBottom);
+			int Checked = m_QuickActionFontTyper.Disabled() ? -1 : (m_QuickActionFontTyper.Active() ? 1 : 0);
+			if(DoButton_FontIcon(&m_QuickActionFontTyper, FontIcon::I_CURSOR, Checked, &Button, BUTTONFLAG_LEFT, m_QuickActionFontTyper.Description(), IGraphics::CORNER_ALL))
+			{
+				m_QuickActionFontTyper.Call();
+				m_FontTyper.UpdateDialog();
+			}
+			ToolbarBottom.VSplitLeft(5.0f, nullptr, &ToolbarBottom);
+		}
 	}
 }
 
@@ -4468,6 +4480,7 @@ void CEditor::Reset()
 	m_QuadEnvelopePointOperation = EQuadEnvelopePointOperation::NONE;
 
 	m_RenderLayersState.Reset();
+	m_FontTyper.UpdateDialog();
 }
 
 void CEditor::AddDefaultMap()
@@ -4478,6 +4491,7 @@ void CEditor::AddDefaultMap()
 	m_SelectedMap = m_vpMaps.size() - 1;
 	m_MapTabsRevealSelected = true;
 	UpdateMapDisplayNames();
+	m_FontTyper.UpdateDialog();
 }
 
 void CEditor::CloseMap(size_t Index, bool Confirm)

--- a/src/game/editor/editor_object.h
+++ b/src/game/editor/editor_object.h
@@ -52,7 +52,7 @@ public:
 	const CRenderMap *RenderMap() const;
 
 private:
-	CEditor *m_pEditor;
+	CEditor *m_pEditor = nullptr;
 };
 
 #endif

--- a/src/game/editor/font_typer.cpp
+++ b/src/game/editor/font_typer.cpp
@@ -23,6 +23,27 @@ void CFontTyper::CState::Reset()
 	m_TilesPlacedSinceActivate = 0;
 }
 
+void CFontTyper::CState::TextModeOn(const std::shared_ptr<CLayerTiles> &pLayer, const vec2 &StartPos)
+{
+	if(!pLayer)
+		return;
+	if(pLayer->m_Image == -1)
+		return;
+
+	m_TilesPlacedSinceActivate = 0;
+	m_Active = true;
+	m_TextIndex.x = std::clamp(static_cast<int>(std::round(StartPos.x / 32.0f)), 0, pLayer->m_Width);
+	m_TextIndex.y = std::clamp(static_cast<int>(std::round(StartPos.y / 32.0f)), 0, pLayer->m_Height - 1);
+	pLayer->m_KnownTextModeLayer = true;
+}
+
+void CFontTyper::CState::TextModeOff(CEditorMap *pMap)
+{
+	if(m_TilesPlacedSinceActivate)
+		pMap->m_EditorHistory.RecordAction(std::make_shared<CEditorBrushDrawAction>(pMap, pMap->m_SelectedGroup), "Font typer");
+	Reset();
+}
+
 void CFontTyper::OnInit(CEditor *pEditor)
 {
 	CEditorComponent::OnInit(pEditor);
@@ -73,17 +94,18 @@ bool CFontTyper::OnInput(const IInput::CEvent &Event)
 	CState &State = Map()->m_FontTyperState;
 
 	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Map()->SelectedLayerType(0, LAYERTYPE_TILES));
-	if(!pLayer)
+	if(!pLayer || pLayer->m_Image == -1)
 	{
 		if(State.m_Active)
 			TextModeOff();
 		return false;
 	}
-	if(pLayer->m_Image == -1)
-		return false;
 
 	if(!State.m_Active)
 	{
+		if(Editor()->m_Dialog == DIALOG_PSEUDO_FONT_TYPER)
+			Editor()->m_Dialog = DIALOG_NONE;
+
 		if(Event.m_Key == KEY_T && Input()->ModifierIsPressed() && !Ui()->IsPopupOpen() && Editor()->m_Dialog == DIALOG_NONE)
 		{
 			if(pLayer && pLayer->m_KnownTextModeLayer)
@@ -99,6 +121,11 @@ bool CFontTyper::OnInput(const IInput::CEvent &Event)
 			}
 		}
 		return false;
+	}
+	else if(Editor()->m_Dialog == DIALOG_NONE)
+	{
+		// block other dialogs
+		Editor()->m_Dialog = DIALOG_PSEUDO_FONT_TYPER;
 	}
 
 	// only handle key down and not also key up
@@ -265,28 +292,16 @@ bool CFontTyper::OnInput(const IInput::CEvent &Event)
 
 void CFontTyper::TextModeOn()
 {
-	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Map()->SelectedLayerType(0, LAYERTYPE_TILES));
-	if(!pLayer)
-		return;
-	if(pLayer->m_Image == -1)
-		return;
-
-	SetCursor();
-	Map()->m_FontTyperState.m_TilesPlacedSinceActivate = 0;
-	Map()->m_FontTyperState.m_Active = true;
-	pLayer->m_KnownTextModeLayer = true;
-
-	// hack to not show picker when pressing space
 	Editor()->m_Dialog = DIALOG_PSEUDO_FONT_TYPER;
+	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Map()->SelectedLayerType(0, LAYERTYPE_TILES));
+	Map()->m_FontTyperState.TextModeOn(pLayer, Map()->m_MapViewState.m_MouseWorldPos);
+	SetCursor();
 }
 
 void CFontTyper::TextModeOff()
 {
-	if(Editor()->m_Dialog == DIALOG_PSEUDO_FONT_TYPER)
-		Editor()->m_Dialog = DIALOG_NONE;
-	if(Map()->m_FontTyperState.m_TilesPlacedSinceActivate)
-		Map()->m_EditorHistory.RecordAction(std::make_shared<CEditorBrushDrawAction>(Map(), Map()->m_SelectedGroup), "Font typer");
-	Map()->m_FontTyperState.Reset();
+	Editor()->m_Dialog = DIALOG_NONE;
+	Map()->m_FontTyperState.TextModeOff(Map());
 }
 
 void CFontTyper::SetCursor()
@@ -316,8 +331,12 @@ void CFontTyper::Render()
 	str_copy(Editor()->m_aTooltip, "Type on your keyboard to insert letters and numbers. Press Escape to end text mode.");
 
 	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Map()->SelectedLayerType(0, LAYERTYPE_TILES));
-	if(!pLayer)
+	// exit selected layer
+	if(!pLayer || pLayer->m_Image == -1)
+	{
+		TextModeOff();
 		return;
+	}
 
 	// exit if selected layer changes
 	if(State.m_pLastLayer && State.m_pLastLayer != pLayer)
@@ -326,8 +345,8 @@ void CFontTyper::Render()
 		State.m_pLastLayer = pLayer;
 		return;
 	}
-	// exit if dialog or edit box pops up
-	if(Editor()->m_Dialog != DIALOG_PSEUDO_FONT_TYPER || CLineInput::GetActiveInput())
+	// edit box pops up
+	if(CLineInput::GetActiveInput())
 	{
 		TextModeOff();
 		return;
@@ -358,4 +377,11 @@ void CFontTyper::Render()
 bool CFontTyper::IsActive() const
 {
 	return Map()->m_FontTyperState.m_Active;
+}
+
+void CFontTyper::UpdateDialog()
+{
+	// We can only update this if the component is properly initialized
+	if(Editor())
+		Editor()->m_Dialog = Map()->m_FontTyperState.m_Active ? DIALOG_PSEUDO_FONT_TYPER : DIALOG_NONE;
 }

--- a/src/game/editor/font_typer.h
+++ b/src/game/editor/font_typer.h
@@ -30,6 +30,8 @@ public:
 		int m_TilesPlacedSinceActivate;
 
 		void Reset();
+		void TextModeOn(const std::shared_ptr<CLayerTiles> &pLayer, const vec2 &StartPos);
+		void TextModeOff(CEditorMap *pMap);
 	};
 
 	void OnInit(CEditor *pEditor) override;
@@ -37,6 +39,7 @@ public:
 	void Render();
 
 	bool IsActive() const;
+	void UpdateDialog();
 
 private:
 	enum

--- a/src/game/editor/quick_actions.h
+++ b/src/game/editor/quick_actions.h
@@ -481,6 +481,35 @@ REGISTER_QUICK_ACTION(
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
 	"Run a local server with the current map and connect you to it.")
-
+REGISTER_QUICK_ACTION(
+	FontTyper,
+	"Enter font typer",
+	[&]() {
+		if(!Map()->m_FontTyperState.m_Active)
+		{
+			std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Map()->SelectedLayerType(0, LAYERTYPE_TILES));
+			const std::shared_ptr<CLayerGroup> pGroup = Map()->SelectedGroup();
+			if(!pLayer || !pGroup)
+				return;
+			vec2 Pos = Map()->m_MapViewState.m_WorldOffset;
+			Pos.x *= pGroup->m_ParallaxX / 100.0f;
+			Pos.y *= pGroup->m_ParallaxY / 100.0f;
+			Pos += vec2(pGroup->m_OffsetX, pGroup->m_OffsetY);
+			Map()->m_FontTyperState.TextModeOn(pLayer, Pos);
+		}
+		else
+		{
+			Map()->m_FontTyperState.TextModeOff(Map());
+		}
+	},
+	[&]() -> bool {
+		std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(Map()->SelectedLayerType(0, LAYERTYPE_TILES));
+		return !pLayer || pLayer->m_Image == -1;
+	},
+	[&]() -> bool {
+		return Map()->m_FontTyperState.m_Active;
+	},
+	DEFAULT_BTN,
+	"[Ctrl+T] Enter the font typer mode that allows you to write numbers and letters from a font tile layer.")
 #undef ALWAYS_FALSE
 #undef DEFAULT_BTN


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Currently the font-typer feature is very hidden and you need to know about it in order to use it (press cntrl + t and you need a tile layer selected with an image). This PR adds a quick action and a button making it accessible.

It also undoes a "hack" that is done in order to prevent the tile picker dialog to appear when pressing space. Instead the tile picker is now blocked when the font-typer is active and the font typer is deactivated, if other dialogs are active. Dialogs belong to the editor and not to the map, thus this change was necessary

<img width="2560" height="1440" alt="screenshot_2026-08-25_14-45-51" src="https://github.com/user-attachments/assets/4f242750-7915-45d0-93a2-b9a850d17e60" />
<img width="2560" height="1440" alt="screenshot_2026-08-25_14-45-36" src="https://github.com/user-attachments/assets/bbdbefa0-ec1c-47ee-923c-ca9b6308277e" />

closes #12611

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
