### PR TITLE
Revert libpng version change, cmake: Find png header and library from same installation

### DIFF
--- a/cmake/FindPNG.cmake
+++ b/cmake/FindPNG.cmake
@@ -1,5 +1,13 @@
+if(NOT CMAKE_CROSSCOMPILING)
+  find_package(PkgConfig QUIET)
+  pkg_check_modules(PC_PNG libpng)
+endif()
+
 if(NOT PREFER_BUNDLED_LIBS)
   set(CMAKE_MODULE_PATH ${ORIGINAL_CMAKE_MODULE_PATH})
+  if(PC_PNG_PREFIX AND NOT PNG_ROOT)
+    set(PNG_ROOT ${PC_PNG_PREFIX})
+  endif()
   find_package(PNG)
   set(CMAKE_MODULE_PATH ${OWN_CMAKE_MODULE_PATH})
   if(PNG_FOUND)

--- a/src/engine/gfx/image_loader.cpp
+++ b/src/engine/gfx/image_loader.cpp
@@ -143,7 +143,7 @@ bool CImageLoader::LoadPng(CByteBufferReader &Reader, const char *pContextName, 
 		return false;
 	}
 
-	png_structp pPngStruct = png_create_read_struct(png_get_libpng_ver(nullptr), &UserErrorStruct, PngErrorCallback, PngWarningCallback);
+	png_structp pPngStruct = png_create_read_struct(PNG_LIBPNG_VER_STRING, &UserErrorStruct, PngErrorCallback, PngWarningCallback);
 	if(pPngStruct == nullptr)
 	{
 		log_error("png", "libpng internal failure: png_create_read_struct failed.");
@@ -340,7 +340,7 @@ static int PngColorTypeFromFormat(CImageInfo::EImageFormat Format)
 
 bool CImageLoader::SavePng(CByteBufferWriter &Writer, const CImageInfo &Image)
 {
-	png_structp pPngStruct = png_create_write_struct(png_get_libpng_ver(nullptr), nullptr, nullptr, nullptr);
+	png_structp pPngStruct = png_create_write_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
 	if(pPngStruct == nullptr)
 	{
 		log_error("png", "libpng internal failure: png_create_write_struct failed.");


### PR DESCRIPTION
Closes #12707 

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5)
