### PR TITLE
Fix input desync when entering spectate

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1350,6 +1350,9 @@ void CChat::SendChat(int Team, const char *pLine)
 		return;
 
 	m_LastChatSend = time();
+	if(str_comp_nocase(pLine, "/pause") == 0 || str_startswith_nocase(pLine, "/pause ") ||
+		str_comp_nocase(pLine, "/spec") == 0 || str_startswith_nocase(pLine, "/spec "))
+		GameClient()->m_Controls.OnSpectateRequested();
 
 	if(GameClient()->Client()->IsSixup())
 	{

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -24,16 +24,30 @@
 CControls::CControls()
 {
 	mem_zero(&m_aLastData, sizeof(m_aLastData));
+	mem_zero(&m_aLastSentData, sizeof(m_aLastSentData));
+	mem_zero(&m_aLastSentInputDirectionLeft, sizeof(m_aLastSentInputDirectionLeft));
+	mem_zero(&m_aLastSentInputDirectionRight, sizeof(m_aLastSentInputDirectionRight));
+	mem_zero(&m_SpecInputState, sizeof(m_SpecInputState));
 	std::fill(std::begin(m_aMousePos), std::end(m_aMousePos), vec2(0.0f, 0.0f));
 	std::fill(std::begin(m_aMousePosOnAction), std::end(m_aMousePosOnAction), vec2(0.0f, 0.0f));
+	std::fill(std::begin(m_aLastSentMousePos), std::end(m_aLastSentMousePos), vec2(0.0f, 0.0f));
+	std::fill(std::begin(m_aLastSentMousePosOnAction), std::end(m_aLastSentMousePosOnAction), vec2(0.0f, 0.0f));
 	std::fill(std::begin(m_aTargetPos), std::end(m_aTargetPos), vec2(0.0f, 0.0f));
 	std::fill(std::begin(m_aMouseInputType), std::end(m_aMouseInputType), EMouseInputType::ABSOLUTE);
+	std::fill(std::begin(m_aLastSentMouseInputType), std::end(m_aLastSentMouseInputType), EMouseInputType::ABSOLUTE);
 }
 
 void CControls::OnReset()
 {
 	ResetInput(0);
 	ResetInput(1);
+	mem_zero(&m_aLastSentData, sizeof(m_aLastSentData));
+	mem_zero(&m_aLastSentInputDirectionLeft, sizeof(m_aLastSentInputDirectionLeft));
+	mem_zero(&m_aLastSentInputDirectionRight, sizeof(m_aLastSentInputDirectionRight));
+	std::fill(std::begin(m_aLastSentMousePos), std::end(m_aLastSentMousePos), vec2(0.0f, 0.0f));
+	std::fill(std::begin(m_aLastSentMousePosOnAction), std::end(m_aLastSentMousePosOnAction), vec2(0.0f, 0.0f));
+	std::fill(std::begin(m_aLastSentMouseInputType), std::end(m_aLastSentMouseInputType), EMouseInputType::ABSOLUTE);
+	m_SpecInputState.m_Pending = false;
 
 	for(int &AmmoCount : m_aAmmoCount)
 		AmmoCount = 0;
@@ -53,6 +67,45 @@ void CControls::ResetInput(int Dummy)
 
 	m_aInputDirectionLeft[Dummy] = 0;
 	m_aInputDirectionRight[Dummy] = 0;
+}
+
+void CControls::OnSpectateRequested()
+{
+	const int Dummy = g_Config.m_ClDummy;
+	const int LocalClientId = GameClient()->m_Snap.m_LocalClientId;
+	if(m_SpecInputState.m_Pending || LocalClientId < 0 ||
+		GameClient()->m_Snap.m_SpecInfo.m_Active)
+		return;
+
+	m_SpecInputState.m_Pending = true;
+	m_SpecInputState.m_Dummy = Dummy;
+	m_SpecInputState.m_InputData = m_aLastSentData[Dummy];
+	m_SpecInputState.m_LastData = m_aLastSentData[Dummy];
+	m_SpecInputState.m_InputDirectionLeft = m_aLastSentInputDirectionLeft[Dummy];
+	m_SpecInputState.m_InputDirectionRight = m_aLastSentInputDirectionRight[Dummy];
+	m_SpecInputState.m_MousePos = m_aLastSentMousePos[Dummy];
+	m_SpecInputState.m_MousePosOnAction = m_aLastSentMousePosOnAction[Dummy];
+	m_SpecInputState.m_MouseInputType = m_aLastSentMouseInputType[Dummy];
+}
+
+void CControls::OnSpectateReceived()
+{
+	if(!m_SpecInputState.m_Pending)
+		return;
+
+	const int LocalClientId = GameClient()->m_Snap.m_LocalClientId;
+	if(LocalClientId < 0 || !GameClient()->m_Snap.m_SpecInfo.m_Active)
+		return;
+
+	const int Dummy = m_SpecInputState.m_Dummy;
+	m_aInputData[Dummy] = m_SpecInputState.m_InputData;
+	m_aLastData[Dummy] = m_SpecInputState.m_LastData;
+	m_aInputDirectionLeft[Dummy] = m_SpecInputState.m_InputDirectionLeft;
+	m_aInputDirectionRight[Dummy] = m_SpecInputState.m_InputDirectionRight;
+	m_aMousePos[Dummy] = m_SpecInputState.m_MousePos;
+	m_aMousePosOnAction[Dummy] = m_SpecInputState.m_MousePosOnAction;
+	m_aMouseInputType[Dummy] = m_SpecInputState.m_MouseInputType;
+	m_SpecInputState.m_Pending = false;
 }
 
 void CControls::OnPlayerDeath()
@@ -335,6 +388,12 @@ int CControls::SnapInput(int *pData)
 		return 0;
 
 	m_LastSendTime = time_get();
+	m_aLastSentData[g_Config.m_ClDummy] = m_aInputData[g_Config.m_ClDummy];
+	m_aLastSentInputDirectionLeft[g_Config.m_ClDummy] = m_aInputDirectionLeft[g_Config.m_ClDummy];
+	m_aLastSentInputDirectionRight[g_Config.m_ClDummy] = m_aInputDirectionRight[g_Config.m_ClDummy];
+	m_aLastSentMousePos[g_Config.m_ClDummy] = vec2(m_aInputData[g_Config.m_ClDummy].m_TargetX, m_aInputData[g_Config.m_ClDummy].m_TargetY);
+	m_aLastSentMousePosOnAction[g_Config.m_ClDummy] = m_aMousePosOnAction[g_Config.m_ClDummy];
+	m_aLastSentMouseInputType[g_Config.m_ClDummy] = m_aMouseInputType[g_Config.m_ClDummy];
 	mem_copy(pData, &m_aInputData[g_Config.m_ClDummy], sizeof(m_aInputData[0]));
 	return sizeof(m_aInputData[0]);
 }

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -27,18 +27,38 @@ public:
 
 	vec2 m_aMousePos[NUM_DUMMIES];
 	vec2 m_aMousePosOnAction[NUM_DUMMIES];
+	vec2 m_aLastSentMousePos[NUM_DUMMIES];
+	vec2 m_aLastSentMousePosOnAction[NUM_DUMMIES];
 	vec2 m_aTargetPos[NUM_DUMMIES];
 
 	EMouseInputType m_aMouseInputType[NUM_DUMMIES];
+	EMouseInputType m_aLastSentMouseInputType[NUM_DUMMIES];
 
 	int m_aAmmoCount[NUM_WEAPONS];
 
 	int64_t m_LastSendTime;
 	CNetObj_PlayerInput m_aInputData[NUM_DUMMIES];
 	CNetObj_PlayerInput m_aLastData[NUM_DUMMIES];
+	CNetObj_PlayerInput m_aLastSentData[NUM_DUMMIES];
 	int m_aInputDirectionLeft[NUM_DUMMIES];
 	int m_aInputDirectionRight[NUM_DUMMIES];
+	int m_aLastSentInputDirectionLeft[NUM_DUMMIES];
+	int m_aLastSentInputDirectionRight[NUM_DUMMIES];
 	int m_aShowHookColl[NUM_DUMMIES];
+
+	struct CSpectateInputState
+	{
+		bool m_Pending;
+		int m_Dummy;
+		CNetObj_PlayerInput m_InputData;
+		CNetObj_PlayerInput m_LastData;
+		int m_InputDirectionLeft;
+		int m_InputDirectionRight;
+		vec2 m_MousePos;
+		vec2 m_MousePosOnAction;
+		EMouseInputType m_MouseInputType;
+	};
+	CSpectateInputState m_SpecInputState;
 
 	CControls();
 	int Sizeof() const override { return sizeof(*this); }
@@ -49,6 +69,8 @@ public:
 	bool OnCursorMove(float x, float y, IInput::ECursorType CursorType) override;
 	void OnConsoleInit() override;
 	virtual void OnPlayerDeath();
+	void OnSpectateRequested();
+	void OnSpectateReceived();
 
 	int SnapInput(int *pData);
 	void ClampMousePos();

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2505,6 +2505,7 @@ void CGameClient::OnNewSnapshot(bool DummySwapped)
 	SnapCollectEntities(); // creates a collection that associates EntityEx snap items with the entities they belong to
 
 	UpdateLocalTuning();
+	m_Controls.OnSpectateReceived();
 	m_IsDummySwapping = 0;
 	if(Client()->State() != IClient::STATE_DEMOPLAYBACK)
 		UpdatePrediction();


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
This should also fix #9212 .
Although the description of #9212 does not exactly match this bug, I remember the behavior shown in its video, which is no longer available. With low latency, it can look as if the last input before entering spectator mode was dropped. In reality, inputs sent after `/spec` or `/pause` may still update the client's local input state until the first snapshot confirming spectator mode arrives.
Once the server processes the spectate request, it won't apply subsequent player input packets to the character. However, the client continues updating and building those inputs during this window. This makes the local input state differ from the last input accepted by the server. The result can look like a dropped input, and stale input may unexpectedly take effect after leaving spectator mode.
﻿

https://github.com/user-attachments/assets/2e32e0a7-518a-465d-a224-6d578ca8ba24


I don't think this is expected behavior. If the server won't apply input packets sent after the spectate request, the client should not keep updating its local input with those inputs. This can also cause a prediction rubber-band effect, although this pull request doesn't resolve this. Just imagine a player may press the key bound to /pause and then accidentally press a movement key, expecting it to be ignored. After leaving spectator mode, Tee may suddenly start moving because the client later rebuilds and sends that input. The problem is easier to reproduce on high-latency servers. I have experienced this several times myself, so I can easily imagine how confusing it can be...
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

AI helped me analyze the input behavior and translate from my native language to English.
<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
