### PR TITLE
Fix client closing when a monitor is turned off on XWayland

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -874,8 +874,13 @@ elseif(TARGET_OS STREQUAL "emscripten")
 else()
   find_package(Notify)
   find_package(OpenGL)
+  find_package(X11)
   set(PLATFORM_CLIENT_LIBS ${OPENGL_gl_LIBRARY} ${NOTIFY_LIBRARIES})
   set(PLATFORM_CLIENT_INCLUDE_DIRS ${OPENGL_INCLUDE_DIR} ${NOTIFY_INCLUDE_DIRS})
+  if(X11_FOUND)
+    # Only the headers are used, Xlib itself is resolved at runtime.
+    list(APPEND PLATFORM_CLIENT_INCLUDE_DIRS ${X11_INCLUDE_DIR})
+  endif()
   set(PLATFORM_CLIENT)
   if(TARGET_OS STREQUAL "linux")
     set(PLATFORM_LIBS)
@@ -2600,6 +2605,8 @@ if(CLIENT)
     video.cpp
     video.h
     warning.cpp
+    x11_error_handler.cpp
+    x11_error_handler.h
     # tidy-alphabetical-end
   )
   set_src(GAME_CLIENT GLOB_RECURSE src/game/client
@@ -3062,6 +3069,10 @@ if(CLIENT)
 
   if(VULKAN)
     target_compile_definitions(game-client PRIVATE CONF_BACKEND_VULKAN)
+  endif()
+
+  if(X11_FOUND)
+    target_compile_definitions(game-client PRIVATE CONF_X11)
   endif()
 
   list(APPEND TARGETS_OWN game-client)

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include "backend_sdl.h"
+#include "x11_error_handler.h"
 
 #if defined(CONF_HEADLESS_CLIENT)
 #include "backend/null/backend_null.h"
@@ -1170,6 +1171,8 @@ int CGraphicsBackend_SDL_GL::Init(const char *pName, int *pScreen, int *pWidth, 
 			return EGraphicsBackendErrorCodes::GRAPHICS_BACKEND_ERROR_CODE_SDL_INIT_FAILED;
 		}
 	}
+
+	X11IgnoreStaleOutputErrors();
 
 	EBackendType OldBackendType = m_BackendType;
 	m_BackendType = DetectBackend();

--- a/src/engine/client/x11_error_handler.cpp
+++ b/src/engine/client/x11_error_handler.cpp
@@ -1,0 +1,82 @@
+#include "x11_error_handler.h"
+
+#include <base/detect.h>
+
+#if defined(CONF_X11)
+
+#include <base/str.h>
+
+#include <SDL_loadso.h>
+#include <SDL_video.h>
+#include <X11/Xlib.h>
+#include <X11/extensions/randr.h>
+
+typedef int (*FX11ErrorHandler)(Display *, XErrorEvent *);
+
+static FX11ErrorHandler s_pfnPreviousErrorHandler = nullptr;
+static int s_RandrMajorOpcode;
+static int s_RandrErrorBase;
+
+static int HandleX11Error(Display *pDisplay, XErrorEvent *pError)
+{
+	// SDL queries RandR outputs that disconnecting a monitor or putting it to sleep has
+	// already destroyed, which the server answers with BadRROutput. Xlib ends the process
+	// over an unhandled error, while SDL treats a query that returns nothing like a
+	// disconnected output.
+	if(pError->request_code == s_RandrMajorOpcode && pError->error_code == s_RandrErrorBase + BadRROutput)
+		return 0;
+	return s_pfnPreviousErrorHandler(pDisplay, pError);
+}
+
+void X11IgnoreStaleOutputErrors()
+{
+	if(s_pfnPreviousErrorHandler != nullptr)
+		return;
+
+	const char *pVideoDriver = SDL_GetCurrentVideoDriver();
+	if(pVideoDriver == nullptr || str_comp(pVideoDriver, "x11") != 0)
+		return;
+
+	// Xlib is resolved through SDL instead of being linked, so that the client still runs
+	// on systems that ship no X libraries at all. The library stays loaded for as long as
+	// the error handler is installed, which is until the process ends.
+	auto *pXlib = SDL_LoadObject("libX11.so.6");
+	if(pXlib == nullptr)
+		return;
+	const auto pfnOpenDisplay = (Display * (*)(const char *)) SDL_LoadFunction(pXlib, "XOpenDisplay");
+	const auto pfnCloseDisplay = (int (*)(Display *))SDL_LoadFunction(pXlib, "XCloseDisplay");
+	const auto pfnQueryExtension = (Bool (*)(Display *, const char *, int *, int *, int *))SDL_LoadFunction(pXlib, "XQueryExtension");
+	const auto pfnSetErrorHandler = (FX11ErrorHandler (*)(FX11ErrorHandler))SDL_LoadFunction(pXlib, "XSetErrorHandler");
+	if(pfnOpenDisplay == nullptr || pfnCloseDisplay == nullptr || pfnQueryExtension == nullptr || pfnSetErrorHandler == nullptr)
+	{
+		SDL_UnloadObject(pXlib);
+		return;
+	}
+
+	// The server assigns the opcode and the error base of an extension once, so they are
+	// the same on every connection to it.
+	Display *pDisplay = pfnOpenDisplay(nullptr);
+	if(pDisplay == nullptr)
+	{
+		SDL_UnloadObject(pXlib);
+		return;
+	}
+	int EventBase;
+	const Bool HasRandr = pfnQueryExtension(pDisplay, "RANDR", &s_RandrMajorOpcode, &EventBase, &s_RandrErrorBase);
+	pfnCloseDisplay(pDisplay);
+	if(!HasRandr)
+	{
+		SDL_UnloadObject(pXlib);
+		return;
+	}
+
+	s_pfnPreviousErrorHandler = pfnSetErrorHandler(HandleX11Error);
+}
+
+#else
+
+void X11IgnoreStaleOutputErrors()
+{
+}
+
+#endif

--- a/src/engine/client/x11_error_handler.h
+++ b/src/engine/client/x11_error_handler.h
@@ -1,0 +1,9 @@
+#ifndef ENGINE_CLIENT_X11_ERROR_HANDLER_H
+#define ENGINE_CLIENT_X11_ERROR_HANDLER_H
+
+// Keeps Xlib from ending the process when the X server rejects a RandR output that no
+// longer exists. Does nothing unless SDL is using its X11 video driver, so this must be
+// called after the video subsystem was initialized. Repeated calls have no effect.
+void X11IgnoreStaleOutputErrors();
+
+#endif


### PR DESCRIPTION
Fixes the client exiting when you turn a monitor off or wake from sleep on XWayland.

<details>
<summary>longer explanation, written by Claude</summary>

SDL caches an `RROutput` id per display it knows about. XWayland does not reliably
report that an output went away, so the id survives in SDL's display list after the
monitor is gone and the next `XRRGetOutputInfo` on it is answered with `BadRROutput`.
Nothing has an Xlib error handler installed, so Xlib's default one prints the error
and calls `exit(1)`. The client vanishes with no crash and no stack trace, which is
what makes this hard to report: users see a clean exit with code 1 and an
`X Error of failed request` line that is not even timestamped like the rest of the log.

This installs a handler that returns without acting on `BadRROutput` from a RandR
request and forwards everything else to the handler SDL installed.
`XRRGetOutputInfo` then returns null, which is the case SDL already treats as a
disconnected output.

Why it looks like this:

- Fixing it in SDL would be the right place, and SDL3 already carries that fix
  (libsdl-org/SDL#12462, commit `0c8ddc1f`). It was never backported to the SDL2
  branch, and the last SDL2 release is 2.32.10 from September 2025, so a backport
  would not reach anyone on SDL2 for a long time. This becomes dead code the moment
  #12558 lands and should be deleted there.
- Linking Xlib and calling `XSetErrorHandler` directly is shorter, but a hard
  dependency on `libX11` would stop the client from starting on systems that ship no
  X libraries, which is exactly the case the video driver hint in a013372b exists
  for. Resolving the four functions through `SDL_LoadObject` keeps the binary free of
  the dependency.
- Taking the display from `SDL_GetWindowWMInfo` avoids opening a connection, but
  `SDL_syswm` does not exist in SDL3 and would tie this file to SDL2. An extension's
  major opcode and error base are assigned once by the server and are the same on
  every connection to it, so a short-lived connection answers the question instead.
- The handler matches the RandR major opcode and error base rather than swallowing
  every X error, so anything unrelated still reaches SDL's handler and then Xlib's.

Evidence. The failing request was injected into the running client with gdb, once
normally and once with the handler install skipped, so both runs are the same binary:

```
### with the handler ###
injecting stale RROutput...
SURVIVED, XRRGetOutputInfo returned (nil)

### without ###
injecting stale RROutput...
X Error of failed request:  BadRROutput (invalid Output parameter)
  Major opcode of failed request:  140 (RANDR)
  Minor opcode of failed request:  9 (RRGetOutputInfo)
[Inferior 1 (process 1501526) exited with code 01]
```

The second block matches the reporter's output. `readelf -d DDNet` lists no `libX11`
entry. Unit tests, integration tests, the mingw build and an ASan/UBSan/LSan run of
both binaries are clean.

Limitations. It does not fix the SDL behaviour underneath: a display XWayland failed
to report as gone stays in SDL's list, so it can still appear in the video settings
until the client restarts. It could not be tested against a real monitor hotplug, only
against the same request the server rejects. It is x11 only, which is also why
`SDL_VIDEODRIVER=wayland` works around the problem today.

</details>

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude investigated the report, wrote this change and the collapsed explanation above.
