### PR TITLE
Fix: Map sounds not disabled if sound is disabled without restart

### DIFF
--- a/src/game/client/components/mapsounds.cpp
+++ b/src/game/client/components/mapsounds.cpp
@@ -3,6 +3,7 @@
 #include <base/log.h>
 
 #include <engine/demo.h>
+#include <engine/shared/config.h>
 #include <engine/sound.h>
 
 #include <game/client/components/camera.h>
@@ -19,6 +20,8 @@ CMapSounds::CMapSounds()
 
 void CMapSounds::Play(int Channel, int SoundId)
 {
+	if(!SoundEnabled())
+		return;
 	if(SoundId < 0 || SoundId >= m_Count)
 		return;
 
@@ -27,10 +30,21 @@ void CMapSounds::Play(int Channel, int SoundId)
 
 void CMapSounds::PlayAt(int Channel, int SoundId, vec2 Position)
 {
+	if(!SoundEnabled())
+		return;
 	if(SoundId < 0 || SoundId >= m_Count)
 		return;
 
 	GameClient()->m_Sounds.PlaySampleAt(Channel, m_aSounds[SoundId], 0, 1.0f, Position);
+}
+
+void CMapSounds::StopAll()
+{
+	for(auto &Source : m_vSourceQueue)
+	{
+		Sound()->StopVoice(Source.m_Voice);
+		Source.m_Voice = ISound::CVoiceHandle();
+	}
 }
 
 void CMapSounds::OnMapLoad()
@@ -236,4 +250,9 @@ void CMapSounds::OnStateChange(int NewState, int OldState)
 {
 	if(NewState < IClient::STATE_ONLINE)
 		Clear();
+}
+
+bool CMapSounds::SoundEnabled()
+{
+	return g_Config.m_SndGame && g_Config.m_SndEnable;
 }

--- a/src/game/client/components/mapsounds.h
+++ b/src/game/client/components/mapsounds.h
@@ -24,6 +24,7 @@ class CMapSounds : public CComponent
 	};
 	std::vector<CSourceQueueEntry> m_vSourceQueue;
 	void Clear();
+	bool SoundEnabled();
 
 public:
 	CMapSounds();
@@ -31,6 +32,7 @@ public:
 
 	void Play(int Channel, int SoundId);
 	void PlayAt(int Channel, int SoundId, vec2 Position);
+	void StopAll();
 
 	void OnMapLoad() override;
 	void OnRender() override;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -903,6 +903,8 @@ void CMenus::UpdateMusicState()
 		GameClient()->m_Sounds.Enqueue(CSounds::CHN_MUSIC, SOUND_MENU);
 	else if(!ShouldPlay && GameClient()->m_Sounds.IsPlaying(SOUND_MENU))
 		GameClient()->m_Sounds.Stop(SOUND_MENU);
+	if(!ShouldPlay)
+		GameClient()->m_MapSounds.StopAll();
 }
 
 void CMenus::PopupMessage(const char *pTitle, const char *pMessage, const char *pButtonLabel, int NextPopup, FPopupButtonCallback pfnButtonCallback)

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1266,9 +1266,6 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 		if(m_SuppressEvents)
 			return;
 
-		if(!g_Config.m_SndGame)
-			return;
-
 		CNetMsg_Sv_MapSoundGlobal *pMsg = (CNetMsg_Sv_MapSoundGlobal *)pRawMsg;
 		m_MapSounds.Play(CSounds::CHN_GLOBAL, pMsg->m_SoundId);
 	}
@@ -1523,9 +1520,6 @@ void CGameClient::ProcessEvents()
 		else if(Item.m_Type == NETEVENTTYPE_MAPSOUNDWORLD)
 		{
 			CNetEvent_MapSoundWorld *pEvent = (CNetEvent_MapSoundWorld *)Item.m_pData;
-			if(!Config()->m_SndGame)
-				continue;
-
 			m_MapSounds.PlayAt(CSounds::CHN_WORLD, pEvent->m_SoundId, vec2(pEvent->m_X, pEvent->m_Y));
 		}
 	}


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This happens, if mapsounds are triggered over a netmessage, because `SndEnable` is not checked

closes #12718

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
