### PR TITLE
Fix envelope scale hotkey being enabled when dialog/popup is open

### DIFF
--- a/src/game/editor/envelope_editor.cpp
+++ b/src/game/editor/envelope_editor.cpp
@@ -1320,7 +1320,13 @@ void CEnvelopeEditor::Render(CUIRect View)
 		}
 
 		// handle scaling
-		if(m_Operation == EEnvelopeEditorOp::NONE && !m_NameInput.IsActive() && Input()->KeyIsPressed(KEY_S) && !Input()->ModifierIsPressed() && !Map()->m_vSelectedEnvelopePoints.empty())
+		if(m_Operation == EEnvelopeEditorOp::NONE &&
+			Editor()->m_Dialog == DIALOG_NONE &&
+			!Ui()->IsPopupOpen() &&
+			CLineInput::GetActiveInput() == nullptr &&
+			Input()->KeyIsPressed(KEY_S) &&
+			!Input()->ModifierIsPressed() &&
+			!Map()->m_vSelectedEnvelopePoints.empty())
 		{
 			m_Operation = EEnvelopeEditorOp::SCALE;
 			m_ScaleFactor.x = 1.0f;


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions
