### PR TITLE
Use `std::vector` for shader code lines instead of `new[]`

### DIFF
--- a/src/engine/client/backend/opengl/opengl_sl.cpp
+++ b/src/engine/client/backend/opengl/opengl_sl.cpp
@@ -101,19 +101,17 @@ bool CGLSL::LoadShader(CGLSLCompiler *pCompiler, IStorage *pStorage, const char 
 		vLines.push_back(Line);
 	}
 
-	const char **ShaderCode = new const char *[vLines.size()];
-
-	for(size_t i = 0; i < vLines.size(); ++i)
+	std::vector<const char *> vpShaderCode;
+	vpShaderCode.reserve(vLines.size());
+	for(const auto &Line : vLines)
 	{
-		ShaderCode[i] = vLines[i].c_str();
+		vpShaderCode.push_back(Line.c_str());
 	}
 
 	const TWGLuint ShaderId = glCreateShader(Type);
 
-	glShaderSource(ShaderId, vLines.size(), ShaderCode, nullptr);
+	glShaderSource(ShaderId, vpShaderCode.size(), vpShaderCode.data(), nullptr);
 	glCompileShader(ShaderId);
-
-	delete[] ShaderCode;
 
 	TWGLint CompilationStatus;
 	glGetShaderiv(ShaderId, GL_COMPILE_STATUS, &CompilationStatus);


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions