### PR TITLE
Feature: Add button to toggle sound layer visibility

### DIFF
--- a/src/engine/font_icons.h
+++ b/src/engine/font_icons.h
@@ -42,6 +42,8 @@ namespace FontIcon
 	inline const char *const EYE_DROPPER = "\uF1FB";
 	inline const char *const EYE_SLASH = "\uF070";
 	inline const char *const FILE = "\uF15B";
+	inline const char *const FILE_AUDIO = "\uF1C7";
+	inline const char *const FILE_IMAGE = "\uF1C5";
 	inline const char *const FILM = "\uF008";
 	inline const char *const FLAG_CHECKERED = "\uF11E";
 	inline const char *const FOLDER = "\uF07B";

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -816,6 +816,17 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 				m_BrushDrawDestructive = !m_BrushDrawDestructive;
 			ToolbarBottom.VSplitLeft(5.0f, &Button, &ToolbarBottom);
 		}
+
+		// Hide sounds button
+		{
+			ToolbarBottom.VSplitLeft(25.0f, &Button, &ToolbarBottom);
+			int Checked = m_QuickActionShowSoundArea.Disabled() ? -1 : (m_QuickActionShowSoundArea.Active() ? 1 : 0);
+			if(DoButton_FontIcon(&m_QuickActionShowSoundArea, FontIcon::MUSIC, Checked, &Button, BUTTONFLAG_LEFT, m_QuickActionShowSoundArea.Description(), IGraphics::CORNER_ALL))
+			{
+				m_QuickActionShowSoundArea.Call();
+			}
+			ToolbarBottom.VSplitLeft(5.0f, nullptr, &ToolbarBottom);
+		}
 	}
 }
 
@@ -3517,14 +3528,14 @@ void CEditor::RenderModebar(CUIRect View)
 
 		ModeButtons.VSplitLeft(ButtonWidth, &ModeButton, &ModeButtons);
 		static int s_ImagesButton = 0;
-		if(DoButton_FontIcon(&s_ImagesButton, FontIcon::IMAGE, m_Mode == MODE_IMAGES, &ModeButton, BUTTONFLAG_LEFT, "Go to images management.", IGraphics::CORNER_NONE))
+		if(DoButton_FontIcon(&s_ImagesButton, FontIcon::FILE_IMAGE, m_Mode == MODE_IMAGES, &ModeButton, BUTTONFLAG_LEFT, "Go to images management.", IGraphics::CORNER_NONE))
 		{
 			m_Mode = MODE_IMAGES;
 		}
 
 		ModeButtons.VSplitLeft(ButtonWidth, &ModeButton, &ModeButtons);
 		static int s_SoundsButton = 0;
-		if(DoButton_FontIcon(&s_SoundsButton, FontIcon::MUSIC, m_Mode == MODE_SOUNDS, &ModeButton, BUTTONFLAG_LEFT, "Go to sounds management.", IGraphics::CORNER_R))
+		if(DoButton_FontIcon(&s_SoundsButton, FontIcon::FILE_AUDIO, m_Mode == MODE_SOUNDS, &ModeButton, BUTTONFLAG_LEFT, "Go to sounds management.", IGraphics::CORNER_R))
 		{
 			m_Mode = MODE_SOUNDS;
 		}

--- a/src/game/editor/mapitems/map.cpp
+++ b/src/game/editor/mapitems/map.cpp
@@ -13,6 +13,7 @@
 #include <game/editor/mapitems/layer_tiles.h>
 #include <game/editor/mapitems/sound.h>
 #include <game/editor/references.h>
+#include <game/mapitems.h>
 
 void CEditorMap::CMapInfo::Reset()
 {
@@ -1038,6 +1039,20 @@ CSoundSource *CEditorMap::SelectedSoundSource() const
 	if(m_SelectedSoundSource >= 0 && m_SelectedSoundSource < (int)pSounds->m_vSources.size())
 		return &pSounds->m_vSources[m_SelectedSoundSource];
 	return nullptr;
+}
+
+void CEditorMap::ToggleSoundLayerVisibility()
+{
+	m_ShowSoundArea = !m_ShowSoundArea;
+	for(const auto &pGroup : m_vpGroups)
+	{
+		for(const auto &pLayer : pGroup->m_vpLayers)
+		{
+			if(pLayer->m_Type != LAYERTYPE_SOUNDS && pLayer->m_Type != LAYERTYPE_SOUNDS_DEPRECATED)
+				continue;
+			pLayer->m_Visible = m_ShowSoundArea;
+		}
+	}
 }
 
 void CEditorMap::PlaceBorderTiles()

--- a/src/game/editor/mapitems/map.h
+++ b/src/game/editor/mapitems/map.h
@@ -272,6 +272,8 @@ public:
 	void SelectPreviousSound();
 	bool IsSoundUsed(int SoundIndex) const;
 	CSoundSource *SelectedSoundSource() const;
+	bool m_ShowSoundArea = true;
+	void ToggleSoundLayerVisibility();
 
 	void PlaceBorderTiles();
 

--- a/src/game/editor/quick_actions.h
+++ b/src/game/editor/quick_actions.h
@@ -481,6 +481,17 @@ REGISTER_QUICK_ACTION(
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
 	"Run a local server with the current map and connect you to it.")
+REGISTER_QUICK_ACTION(
+	ShowSoundArea,
+	"Show sound layers",
+	[&]() { Map()->ToggleSoundLayerVisibility(); },
+	[&]() -> bool {
+		// not perfect, but we don't track the total number of existing sound sources
+		return Map()->m_vpSounds.empty();
+	},
+	[&]() -> bool { return Map()->m_ShowSoundArea; },
+	DEFAULT_BTN,
+	"Show sound layers.")
 
 #undef ALWAYS_FALSE
 #undef DEFAULT_BTN


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Currently using lots of sounds in the editor creates rectangles/circles that hide the map behind them. As a player you don't see the sound radii, but in the editor you need to possibly click through **all** layers just to hide them in order to see the map properly. You don't know if a layer is a sound-layer, unless you click on it.

This PR adds a button to show or hide all sound layers if any sounds are present in the map.

Side note: Maybe we should somehow mark the layertype in the editor tree overview.

Show (default): What cat?
<img width="2560" height="1440" alt="screenshot_2026-08-29_23-53-37" src="https://github.com/user-attachments/assets/ccbfd4b7-36bf-4194-acad-fc133dd3e5b5" />

Hide: CAT :cat: 
<img width="2560" height="1440" alt="screenshot_2026-08-29_23-53-38" src="https://github.com/user-attachments/assets/12d45adb-5215-492e-9806-724b7e3586c7" />

Disabled: catless map
<img width="2560" height="1440" alt="screenshot_2026-08-29_23-53-15" src="https://github.com/user-attachments/assets/7308002f-c8f6-4b94-8f48-a5ec8ccd61b5" />

closes #12736

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
