### PR TITLE
Fix various issues of Emscripten HTTP implementation

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3544,6 +3544,7 @@ void CClient::Run()
 		m_vQuittingWarnings.emplace_back(Localize("Error saving settings"), aError);
 	}
 
+	m_ServerBrowser.Shutdown();
 	m_Fifo.Shutdown();
 	m_pHttp->Shutdown();
 	Engine()->ShutdownJobs();

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -86,6 +86,11 @@ CServerBrowser::~CServerBrowser()
 	m_pPingCache = nullptr;
 }
 
+void CServerBrowser::Shutdown()
+{
+	m_pHttp->Shutdown();
+}
+
 void CServerBrowser::SetBaseInfo(class CNetClient *pClient, const char *pNetVersion)
 {
 	m_pNetClient = pClient;

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -254,6 +254,7 @@ public:
 	~CServerBrowser() override;
 
 	// interface functions
+	void Shutdown() override;
 	void Refresh(int Type, bool Force = false) override;
 	bool IsRefreshing() const override;
 	bool IsGettingServerlist() const override;

--- a/src/engine/client/serverbrowser_http.cpp
+++ b/src/engine/client/serverbrowser_http.cpp
@@ -60,6 +60,7 @@ public:
 	virtual ~CChooseMaster();
 
 	bool GetBestUrl(const char **pBestUrl) const;
+	void Shutdown();
 	void Reset();
 	bool IsRefreshing() const { return m_pJob && !m_pJob->Done(); }
 	void Refresh();
@@ -122,10 +123,7 @@ CChooseMaster::CChooseMaster(IEngine *pEngine, IHttp *pHttp, VALIDATOR pfnValida
 
 CChooseMaster::~CChooseMaster()
 {
-	if(m_pJob)
-	{
-		m_pJob->Abort();
-	}
+	dbg_assert(m_pJob == nullptr, "Choose master job was not cleared");
 }
 
 int CChooseMaster::GetBestIndex() const
@@ -151,6 +149,15 @@ bool CChooseMaster::GetBestUrl(const char **ppBestUrl) const
 	}
 	*ppBestUrl = m_pData->m_aaUrls[Index];
 	return false;
+}
+
+void CChooseMaster::Shutdown()
+{
+	if(m_pJob)
+	{
+		m_pJob->Abort();
+		m_pJob = nullptr;
+	}
 }
 
 void CChooseMaster::Reset()
@@ -310,6 +317,7 @@ class CServerBrowserHttp : public IServerBrowserHttp
 public:
 	CServerBrowserHttp(IEngine *pEngine, IHttp *pHttp, const char **ppUrls, int NumUrls, int PreviousBestIndex);
 	~CServerBrowserHttp() override;
+	void Shutdown() override;
 	void Update() override;
 	bool IsRefreshing() const override { return m_State != STATE_DONE && m_State != STATE_NO_MASTER; }
 	bool IsError() const override { return m_State == STATE_NO_MASTER; }
@@ -355,10 +363,17 @@ CServerBrowserHttp::CServerBrowserHttp(IEngine *pEngine, IHttp *pHttp, const cha
 
 CServerBrowserHttp::~CServerBrowserHttp()
 {
+	dbg_assert(m_pGetServers == nullptr, "Server browser load job was not cleared");
+}
+
+void CServerBrowserHttp::Shutdown()
+{
 	if(m_pGetServers != nullptr)
 	{
 		m_pGetServers->Abort();
+		m_pGetServers = nullptr;
 	}
+	m_pChooseMaster->Shutdown();
 }
 
 void CServerBrowserHttp::Update()

--- a/src/engine/client/serverbrowser_http.h
+++ b/src/engine/client/serverbrowser_http.h
@@ -12,6 +12,7 @@ class IServerBrowserHttp
 public:
 	virtual ~IServerBrowserHttp() = default;
 
+	virtual void Shutdown() = 0;
 	virtual void Update() = 0;
 
 	virtual bool IsRefreshing() const = 0;

--- a/src/engine/http.h
+++ b/src/engine/http.h
@@ -194,7 +194,7 @@ protected:
 
 	// Abort the request if `OnData()` returns something other than
 	// `DataSize`.
-	size_t OnData(const char *pData, size_t DataSize);
+	[[nodiscard]] size_t OnData(const char *pData, size_t DataSize);
 	void OnCompletionInternal(EHttpState State);
 };
 

--- a/src/engine/shared/http_emscripten.cpp
+++ b/src/engine/shared/http_emscripten.cpp
@@ -120,9 +120,9 @@ void CHttpRequestEmscripten::OnSuccess()
 	dbg_assert(m_pFetch != nullptr, "OnSuccess was called with an unset fetch handle");
 	m_CallbackFinished = true;
 
-	OnData(m_pFetch->data, m_pFetch->numBytes);
+	const bool Success = OnData(m_pFetch->data, m_pFetch->numBytes) == m_pFetch->numBytes;
 
-	m_pHttp->AddPendingStateChange(m_pFetch, EHttpState::DONE);
+	m_pHttp->AddPendingStateChange(m_pFetch, Success ? EHttpState::DONE : EHttpState::ERROR);
 }
 
 void CHttpRequestEmscripten::OnFailure()

--- a/src/engine/shared/http_emscripten.cpp
+++ b/src/engine/shared/http_emscripten.cpp
@@ -139,6 +139,13 @@ void CHttpRequestEmscripten::OnFailure()
 
 void CHttpRequestEmscripten::OnProgress()
 {
+	if(m_MaxResponseSize >= 0 &&
+		(m_pFetch->totalBytes > (uint64_t)m_MaxResponseSize ||
+			m_pFetch->dataOffset > (uint64_t)m_MaxResponseSize))
+	{
+		m_pHttp->AddPendingStateChange(m_pFetch, EHttpState::ERROR);
+		return;
+	}
 	m_Current.store(m_pFetch->dataOffset, std::memory_order_relaxed);
 	m_Size.store(m_pFetch->totalBytes, std::memory_order_relaxed);
 	m_Progress.store(m_pFetch->totalBytes == 0 ? 0 : (100 * m_pFetch->dataOffset) / m_pFetch->totalBytes, std::memory_order_relaxed);

--- a/src/engine/shared/http_emscripten.cpp
+++ b/src/engine/shared/http_emscripten.cpp
@@ -63,6 +63,13 @@ bool CHttpRequestEmscripten::ConfigureAndRun()
 		return false;
 	}
 
+	if(!str_startswith(m_aUrl, "https://") &&
+		(!g_Config.m_HttpAllowInsecure || !str_startswith(m_aUrl, "http://")))
+	{
+		log_error("http", "unsupported protocol: %s", m_aUrl);
+		return false;
+	}
+
 	HeaderString("User-Agent", USER_AGENT_STRING);
 
 	if(m_Type == REQUEST::POST_JSON)

--- a/src/engine/shared/http_emscripten.cpp
+++ b/src/engine/shared/http_emscripten.cpp
@@ -43,12 +43,7 @@ void CHttpRequestEmscripten::Abort()
 
 	IHttpRequest::Abort();
 
-	if(m_pFetch == nullptr)
-	{
-		return;
-	}
-
-	m_pHttp->AddPendingStateChange(m_pFetch, EHttpState::ABORTED);
+	m_pHttp->AddPendingStateChange(m_RequestId, EHttpState::ABORTED);
 }
 
 EM_JS(void, FormatTimestampJsImpl, (char *pBuf, size_t Size, time_t Timestamp), {
@@ -129,7 +124,7 @@ void CHttpRequestEmscripten::OnSuccess()
 
 	const bool Success = OnData(m_pFetch->data, m_pFetch->numBytes) == m_pFetch->numBytes;
 
-	m_pHttp->AddPendingStateChange(m_pFetch, Success ? EHttpState::DONE : EHttpState::ERROR);
+	m_pHttp->AddPendingStateChange(m_RequestId, Success ? EHttpState::DONE : EHttpState::ERROR);
 }
 
 void CHttpRequestEmscripten::OnFailure()
@@ -141,7 +136,7 @@ void CHttpRequestEmscripten::OnFailure()
 	}
 	m_CallbackFinished = true;
 
-	m_pHttp->AddPendingStateChange(m_pFetch, !m_FailOnErrorStatus && m_pFetch->status >= 400 ? EHttpState::DONE : EHttpState::ERROR);
+	m_pHttp->AddPendingStateChange(m_RequestId, !m_FailOnErrorStatus && m_pFetch->status >= 400 ? EHttpState::DONE : EHttpState::ERROR);
 }
 
 void CHttpRequestEmscripten::OnProgress()
@@ -150,7 +145,7 @@ void CHttpRequestEmscripten::OnProgress()
 		(m_pFetch->totalBytes > (uint64_t)m_MaxResponseSize ||
 			m_pFetch->dataOffset > (uint64_t)m_MaxResponseSize))
 	{
-		m_pHttp->AddPendingStateChange(m_pFetch, EHttpState::ERROR);
+		m_pHttp->AddPendingStateChange(m_RequestId, EHttpState::ERROR);
 		return;
 	}
 	m_Current.store(m_pFetch->dataOffset, std::memory_order_relaxed);
@@ -315,6 +310,8 @@ void CHttpEmscripten::Run(std::shared_ptr<IHttpRequest> pRequest)
 		dbg_assert(m_Initialized, "HTTP not initialized");
 		std::shared_ptr<CHttpRequestEmscripten> pRequestImpl = std::static_pointer_cast<CHttpRequestEmscripten>(pRequest);
 		pRequestImpl->m_pHttp = this;
+		pRequestImpl->m_RequestId = m_NextRequestId;
+		++m_NextRequestId;
 		if(m_Shutdown)
 		{
 			pRequestImpl->OnCompletionInternal(EHttpState::ABORTED, "Shutting down");
@@ -377,7 +374,7 @@ void CHttpEmscripten::RunLoop()
 					{
 						for(auto &[_, pRequest] : m_RunningRequests)
 						{
-							auto [ExistingElement, Inserted] = m_PendingFetchChanges.emplace(pRequest->m_pFetch, EHttpState::ABORTED);
+							auto [ExistingElement, Inserted] = m_PendingFetchChanges.emplace(pRequest->m_RequestId, EHttpState::ABORTED);
 							if(!Inserted)
 							{
 								ExistingElement->second = EHttpState::ABORTED;
@@ -435,17 +432,24 @@ void CHttpEmscripten::RunLoop()
 				continue;
 			}
 
+			if(pRequest->IsAbortRequested())
 			{
-				emscripten_fetch_t *pFetch = pRequest->m_pFetch;
-				auto [_, Inserted] = m_RunningRequests.emplace(pFetch, std::move(pRequest));
-				dbg_assert(Inserted, "Request with same fetch handle already running");
+				pRequest->OnCompletionInternal(EHttpState::ABORTED, "Request aborted");
+				PendingRequests.pop_front();
+				continue;
+			}
+
+			{
+				uint64_t RequestId = pRequest->m_RequestId;
+				auto [_, Inserted] = m_RunningRequests.emplace(RequestId, std::move(pRequest));
+				dbg_assert(Inserted, "Request with same ID already running");
 			}
 			PendingRequests.pop_front();
 		}
 
-		for(const auto &[pFetch, NewState] : PendingFetchChanges)
+		for(const auto &[RequestId, NewState] : PendingFetchChanges)
 		{
-			auto pRequest = m_RunningRequests.find(pFetch);
+			auto pRequest = m_RunningRequests.find(RequestId);
 			if(pRequest == m_RunningRequests.end())
 			{
 				// Requests can be aborted even if they are not in m_RunningRequests anymore.
@@ -496,11 +500,11 @@ void CHttpEmscripten::RunLoop()
 	m_RunningRequests.clear();
 }
 
-void CHttpEmscripten::AddPendingStateChange(emscripten_fetch_t *pFetch, EHttpState State)
+void CHttpEmscripten::AddPendingStateChange(uint64_t RequestId, EHttpState State)
 {
 	{
 		std::unique_lock Lock(m_Lock);
-		auto [ExistingElement, Inserted] = m_PendingFetchChanges.emplace(pFetch, State);
+		auto [ExistingElement, Inserted] = m_PendingFetchChanges.emplace(RequestId, State);
 		if(!Inserted && ExistingElement->second != EHttpState::ABORTED)
 		{
 			ExistingElement->second = State;

--- a/src/engine/shared/http_emscripten.cpp
+++ b/src/engine/shared/http_emscripten.cpp
@@ -105,8 +105,8 @@ bool CHttpRequestEmscripten::ConfigureAndRun()
 	FetchAttributes.onerror = FetchCallbackFailure;
 	FetchAttributes.onprogress = FetchCallbackProgress;
 	FetchAttributes.attributes = EMSCRIPTEN_FETCH_LOAD_TO_MEMORY;
-	// Using low speed limit/time properties of timeout is not supported.
-	FetchAttributes.timeoutMSecs = m_Timeout.m_ConnectTimeoutMs + m_Timeout.m_TimeoutMs;
+	// Only timeout property for whole transfer is supported.
+	FetchAttributes.timeoutMSecs = m_Timeout.m_TimeoutMs;
 	FetchAttributes.requestHeaders = vpPackedHeaders.data();
 	FetchAttributes.requestData = reinterpret_cast<const char *>(m_pBody);
 	FetchAttributes.requestDataSize = m_BodyLength;

--- a/src/engine/shared/http_emscripten.cpp
+++ b/src/engine/shared/http_emscripten.cpp
@@ -201,19 +201,20 @@ void CHttpRequestEmscripten::OnCompletionInternal(EHttpState State, const char *
 			char *pHeaders = static_cast<char *>(malloc(HeadersLength + 1));
 			dbg_assert(emscripten_fetch_get_response_headers(m_pFetch, pHeaders, HeadersLength + 1) == HeadersLength + 1, "emscripten_fetch_get_response_headers failure");
 			char **ppUnpackedHeaders = emscripten_fetch_unpack_response_headers(pHeaders);
-
-			int HeaderIndex = 0;
-			while(ppUnpackedHeaders[HeaderIndex] != nullptr)
+			if(ppUnpackedHeaders != nullptr)
 			{
-				const char *pName = ppUnpackedHeaders[HeaderIndex];
-				++HeaderIndex;
-				const char *pValue = ppUnpackedHeaders[HeaderIndex];
-				++HeaderIndex;
-				dbg_assert(pValue != nullptr, "emscripten_fetch_unpack_response_headers result unexpected: value is nullptr for header '%s'", pName);
-				OnHeader(pName, pValue);
+				int HeaderIndex = 0;
+				while(ppUnpackedHeaders[HeaderIndex] != nullptr)
+				{
+					const char *pName = ppUnpackedHeaders[HeaderIndex];
+					++HeaderIndex;
+					const char *pValue = ppUnpackedHeaders[HeaderIndex];
+					++HeaderIndex;
+					dbg_assert(pValue != nullptr, "emscripten_fetch_unpack_response_headers result unexpected: value is nullptr for header '%s'", pName);
+					OnHeader(pName, pValue);
+				}
+				emscripten_fetch_free_unpacked_response_headers(ppUnpackedHeaders);
 			}
-
-			emscripten_fetch_free_unpacked_response_headers(ppUnpackedHeaders);
 			free(pHeaders);
 		}
 

--- a/src/engine/shared/http_emscripten.h
+++ b/src/engine/shared/http_emscripten.h
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <deque>
 #include <mutex>
 #include <optional>
@@ -38,6 +39,7 @@ private:
 
 	std::vector<std::pair<std::string, std::string>> m_vRequestHeaders;
 
+	uint64_t m_RequestId;
 	emscripten_fetch_t *m_pFetch = nullptr;
 	bool m_CallbackFinished = false;
 
@@ -74,9 +76,10 @@ private:
 	std::condition_variable m_ConditionVariableInit;
 	std::condition_variable m_ConditionVariableLoop;
 	std::atomic<bool> m_Initialized = false;
+	uint64_t m_NextRequestId = 0;
 	std::deque<std::shared_ptr<CHttpRequestEmscripten>> m_PendingRequests;
-	std::unordered_map<emscripten_fetch_t *, EHttpState> m_PendingFetchChanges;
-	std::unordered_map<emscripten_fetch_t *, std::shared_ptr<CHttpRequestEmscripten>> m_RunningRequests;
+	std::unordered_map<uint64_t, EHttpState> m_PendingFetchChanges;
+	std::unordered_map<uint64_t, std::shared_ptr<CHttpRequestEmscripten>> m_RunningRequests;
 	std::chrono::milliseconds m_ShutdownDelay{};
 	std::optional<std::chrono::time_point<std::chrono::steady_clock>> m_ShutdownTime;
 	std::atomic<bool> m_Shutdown = false;
@@ -84,7 +87,7 @@ private:
 
 	static void ThreadMain(void *pUser);
 	void RunLoop();
-	void AddPendingStateChange(emscripten_fetch_t *pFetch, EHttpState State);
+	void AddPendingStateChange(uint64_t RequestId, EHttpState State);
 };
 
 #endif // CONF_PLATFORM_EMSCRIPTEN

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -57,10 +57,7 @@ CSkins::CSkinContainer::CSkinContainer(CSkins *pSkins, const char *pName, EType 
 
 CSkins::CSkinContainer::~CSkinContainer()
 {
-	if(m_pLoadJob)
-	{
-		m_pLoadJob->Abort();
-	}
+	dbg_assert(m_pLoadJob == nullptr, "Skin container load job was not cleared");
 }
 
 bool CSkins::CSkinContainer::operator<(const CSkinContainer &Other) const
@@ -514,6 +511,7 @@ void CSkins::OnShutdown()
 		if(pSkinContainer->m_pLoadJob)
 		{
 			pSkinContainer->m_pLoadJob->Abort();
+			pSkinContainer->m_pLoadJob = nullptr;
 		}
 	}
 	m_Skins.clear();


### PR DESCRIPTION
See commit messages.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

AI found all of the issues except the one fixed by the first commit, which was only revealed after removing the `if(m_pFetch == nullptr) return;` in the `CHttpRequestEmscripten::Abort` function.