### PR TITLE
Fix econ ban not actually dropping client if `ec_bantime` non-zero

### DIFF
--- a/src/engine/shared/econ.cpp
+++ b/src/engine/shared/econ.cpp
@@ -122,10 +122,11 @@ void CEcon::Update()
 				m_NetConsole.Send(ClientId, aMsg);
 				if(m_aClients[ClientId].m_AuthTries >= MAX_AUTH_TRIES)
 				{
-					if(!g_Config.m_EcBantime)
-						m_NetConsole.Drop(ClientId, "Too many authentication tries");
-					else
+					if(g_Config.m_EcBantime)
+					{
 						m_NetConsole.NetBan()->BanAddr(m_NetConsole.ClientAddr(ClientId), g_Config.m_EcBantime * 60, "Too many authentication tries", false);
+					}
+					m_NetConsole.Drop(ClientId, "Too many authentication tries");
 				}
 			}
 		}


### PR DESCRIPTION
The call to `m_NetConsole.NetBan()->BanAddr` only adds the address as a ban but it does not drop the client, so with `ec_bantime` being non-zero the banned client could continue sending passwords and the server would respond with `Wrong password 4/3.` and so on.

## Checklist

- [X] Tested the change
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

AI found the issue.