### PR TITLE
client: Improve performance for low refresh/update rates

### DIFF
--- a/src/base/thread.cpp
+++ b/src/base/thread.cpp
@@ -18,6 +18,14 @@
 #endif
 #endif
 
+#if defined(CONF_PLATFORM_MACOS) || defined(CONF_PLATFORM_IOS)
+#include <mach/task_policy.h>
+#include <mach/thread_act.h>
+#include <mach/thread_policy.h>
+#elif defined(CONF_PLATFORM_LINUX) || defined(CONF_PLATFORM_ANDROID)
+#include <sys/prctl.h>
+#endif
+
 #if defined(CONF_PLATFORM_EMSCRIPTEN)
 #include <emscripten/emscripten.h>
 #endif
@@ -138,6 +146,17 @@ void thread_yield()
 	Sleep(0);
 #else
 #error not implemented
+#endif
+}
+
+void thread_request_precise_wakeups()
+{
+#if defined(CONF_PLATFORM_MACOS) || defined(CONF_PLATFORM_IOS)
+	// Not asserted, the system is free to decline the policy.
+	thread_latency_qos_policy_data_t policy = {LATENCY_QOS_TIER_0};
+	thread_policy_set(pthread_mach_thread_np(pthread_self()), THREAD_LATENCY_QOS_POLICY, (thread_policy_t)&policy, THREAD_LATENCY_QOS_POLICY_COUNT);
+#elif defined(CONF_PLATFORM_LINUX) || defined(CONF_PLATFORM_ANDROID)
+	dbg_assert(prctl(PR_SET_TIMERSLACK, 1) == 0, "prctl(PR_SET_TIMERSLACK) failure");
 #endif
 }
 

--- a/src/base/thread.h
+++ b/src/base/thread.h
@@ -43,6 +43,17 @@ void thread_wait(void *thread);
 void thread_yield();
 
 /**
+ * Requests the most precise timer wakeups that the system offers for the calling thread.
+ *
+ * @ingroup Threads
+ *
+ * @remark Wakeups from sleeping and waiting are delayed to save power by default,
+ * on macOS by a quarter of the requested duration and on Linux by 50 microseconds.
+ * On Windows SDL already raises the timer resolution while initializing.
+ */
+void thread_request_precise_wakeups();
+
+/**
  * Puts the thread in the detached state, guaranteeing that
  * resources of the thread will be freed immediately when the
  * thread terminates.

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -21,6 +21,10 @@
 #include <engine/shared/video.h>
 #endif
 
+#if defined(CONF_PLATFORM_MACOS)
+#include <CoreFoundation/CFRunLoop.h>
+#endif
+
 #include "backend_sdl.h"
 
 #if defined(CONF_HEADLESS_CLIENT)
@@ -44,6 +48,7 @@
 #include <engine/graphics.h>
 
 #include <algorithm>
+#include <chrono>
 #include <cstdlib>
 
 class IStorage;
@@ -68,7 +73,9 @@ void CGraphicsBackend_Threaded::ThreadFunc(void *pUser)
 #if defined(CONF_PLATFORM_MACOS) || defined(CONF_PLATFORM_IOS)
 			CAutoreleasePool AutoreleasePool;
 #endif
+			Lock.unlock();
 			pSelf->m_pProcessor->RunBuffer(pSelf->m_pBuffer);
+			Lock.lock();
 
 			pSelf->m_pBuffer = nullptr;
 			pSelf->m_BufferInProcess.store(false, std::memory_order_relaxed);
@@ -175,7 +182,16 @@ void CGraphicsBackend_Threaded::WaitForIdle()
 {
 #if !defined(CONF_PLATFORM_EMSCRIPTEN)
 	std::unique_lock<std::mutex> Lock(m_BufferSwapMutex);
+#if defined(CONF_PLATFORM_MACOS)
+	while(!m_BufferSwapCond.wait_for(Lock, std::chrono::milliseconds(1), [this]() { return m_pBuffer == nullptr; }))
+	{
+		Lock.unlock();
+		CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, true);
+		Lock.lock();
+	}
+#else
 	m_BufferSwapCond.wait(Lock, [this]() { return m_pBuffer == nullptr; });
+#endif
 #endif
 }
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -22,6 +22,7 @@
 #include <base/process.h>
 #include <base/secure.h>
 #include <base/str.h>
+#include <base/thread.h>
 #include <base/time.h>
 #include <base/windows.h>
 
@@ -5253,6 +5254,9 @@ int main(int argc, const char **argv)
 		PerformAllCleanup();
 		return -1;
 	}
+
+	// SDL raises the timer resolution on Windows while initializing, the other platforms need this.
+	thread_request_precise_wakeups();
 
 	// run the client
 	log_trace("client", "initialization finished after %.2fms, starting...", (time_get() - MainStart) * 1000.0f / (float)time_freq());

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3325,8 +3325,8 @@ void CClient::Run()
 	bool LastE = false;
 	bool LastG = false;
 
-	auto LastTime = time_get_nanoseconds();
-	int64_t LastRenderTime = time_get();
+	int64_t NextUpdateTime = time_get();
+	int64_t NextRenderTime = time_get();
 
 	while(true)
 	{
@@ -3400,6 +3400,9 @@ void CClient::Run()
 			g_Config.m_ClEditor = g_Config.m_ClEditor ^ 1;
 		}
 
+		bool Inactive = false;
+		int64_t WakeTime = std::numeric_limits<int64_t>::max();
+
 		// render
 		{
 			if(g_Config.m_ClEditor)
@@ -3424,7 +3427,24 @@ void CClient::Run()
 
 			bool AsyncRenderOld = g_Config.m_GfxAsyncRenderOld;
 
+			// Update at cl_refresh_rate, or at cl_refresh_rate_inactive while the window is inactive.
+			Inactive = g_Config.m_ClRefreshRateInactive && !m_pGraphics->WindowActive();
+			const int RefreshRate = Inactive ? g_Config.m_ClRefreshRateInactive : g_Config.m_ClRefreshRate;
+			bool UpdateDue = true;
+			if(RefreshRate)
+			{
+				UpdateDue = Now >= NextUpdateTime;
+				if(UpdateDue)
+				{
+					// Stay on the grid so that late wakeups do not lower the rate, unless a whole interval was missed.
+					NextUpdateTime = std::max(NextUpdateTime + time_freq() / RefreshRate, Now);
+				}
+			}
+
+			// Render on the updates, unless gfx_refresh_rate is lower.
 			int GfxRefreshRate = g_Config.m_GfxRefreshRate;
+			if(RefreshRate && GfxRefreshRate >= RefreshRate)
+				GfxRefreshRate = 0;
 
 #if defined(CONF_VIDEORECORDER)
 			// keep rendering synced
@@ -3435,9 +3455,10 @@ void CClient::Run()
 			}
 #endif
 
+			const bool RenderDue = GfxRefreshRate ? Now >= NextRenderTime : UpdateDue;
 			if(IsRenderActive &&
 				(!AsyncRenderOld || m_pGraphics->IsIdle()) &&
-				(!GfxRefreshRate || (time_freq() / (int64_t)g_Config.m_GfxRefreshRate) <= Now - LastRenderTime))
+				RenderDue)
 			{
 				// update frametime
 				m_RenderFrameTime = (Now - m_LastRenderTime) / (float)time_freq();
@@ -3458,22 +3479,23 @@ void CClient::Run()
 
 				m_FrameTimeAverage = m_FrameTimeAverage * 0.9f + m_RenderFrameTime * 0.1f;
 
-				// keep the overflow time - it's used to make sure the gfx refreshrate is reached
-				int64_t AdditionalTime = g_Config.m_GfxRefreshRate ? ((Now - LastRenderTime) - (time_freq() / (int64_t)g_Config.m_GfxRefreshRate)) : 0;
-				// if the value is over the frametime of a 60 fps frame, reset the additional time (drop the frames, that are lost already)
-				if(AdditionalTime > (time_freq() / 60))
-					AdditionalTime = (time_freq() / 60);
-				LastRenderTime = Now - AdditionalTime;
+				if(GfxRefreshRate)
+					NextRenderTime = std::max(NextRenderTime + time_freq() / GfxRefreshRate, Now);
 				m_LastRenderTime = Now;
 
 				Render();
 				m_pGraphics->Swap();
 			}
-			else if(!IsRenderActive)
-			{
-				// if the client does not render, it should reset its render time to a time where it would render the first frame, when it wakes up again
-				LastRenderTime = g_Config.m_GfxRefreshRate ? (Now - (time_freq() / (int64_t)g_Config.m_GfxRefreshRate)) : Now;
-			}
+
+			// Wake up for the next update or frame, whichever comes first. While playing, also wake up for
+			// the next prediction tick to send its input without delay, unless the window is inactive or
+			// the loop is not rate limited at all.
+			if(RefreshRate)
+				WakeTime = NextUpdateTime;
+			if(IsRenderActive && GfxRefreshRate)
+				WakeTime = std::min(WakeTime, NextRenderTime);
+			if(State() == IClient::STATE_ONLINE && m_aPredTick[g_Config.m_ClDummy] > 0 && !Inactive && WakeTime != std::numeric_limits<int64_t>::max())
+				WakeTime = std::min(WakeTime, Now + (m_aPredTick[g_Config.m_ClDummy] * time_freq() / GameTickSpeed() - m_PredictedTime.Get(Now)));
 		}
 
 		AutoScreenshot_Cleanup();
@@ -3486,47 +3508,23 @@ void CClient::Run()
 			break;
 
 		// beNice
-		auto Now = time_get_nanoseconds();
-		decltype(Now) SleepTimeInNanoSeconds{0};
-		bool Slept = false;
-		if(g_Config.m_ClRefreshRateInactive && !m_pGraphics->WindowActive())
+		if(WakeTime != std::numeric_limits<int64_t>::max())
 		{
-			SleepTimeInNanoSeconds = (std::chrono::nanoseconds(1s) / (int64_t)g_Config.m_ClRefreshRateInactive) - (Now - LastTime);
-			std::this_thread::sleep_for(SleepTimeInNanoSeconds);
-			Slept = true;
-		}
-		else if(g_Config.m_ClRefreshRate)
-		{
-			SleepTimeInNanoSeconds = (std::chrono::nanoseconds(1s) / (int64_t)g_Config.m_ClRefreshRate) - (Now - LastTime);
-			auto SleepTimeInNanoSecondsInner = SleepTimeInNanoSeconds;
-			auto NowInner = Now;
-			while(std::chrono::duration_cast<std::chrono::microseconds>(SleepTimeInNanoSecondsInner) > 0us)
+			const std::chrono::nanoseconds Deadline(WakeTime);
+			std::chrono::nanoseconds WaitTime = Deadline - time_get_nanoseconds();
+			if(Inactive)
 			{
-				net_socket_read_wait(m_aNetClient[CONN_MAIN].m_Socket, SleepTimeInNanoSecondsInner);
-				auto NowInnerCalc = time_get_nanoseconds();
-				SleepTimeInNanoSecondsInner -= (NowInnerCalc - NowInner);
-				NowInner = NowInnerCalc;
+				// Without focus, save power by not waking up for packets.
+				std::this_thread::sleep_for(WaitTime);
 			}
-			Slept = true;
-		}
-		if(Slept)
-		{
-			// if the diff gets too small it shouldn't get even smaller (drop the updates, that could not be handled)
-			if(SleepTimeInNanoSeconds < -16666666ns)
-				SleepTimeInNanoSeconds = -16666666ns;
-			// don't go higher than the frametime of a 60 fps frame
-			else if(SleepTimeInNanoSeconds > 16666666ns)
-				SleepTimeInNanoSeconds = 16666666ns;
-			// the time diff between the time that was used actually used and the time the thread should sleep/wait
-			// will be calculated in the sleep time of the next update tick by faking the time it should have slept/wait.
-			// so two cases (and the case it slept exactly the time it should):
-			//	- the thread slept/waited too long, then it adjust the time to sleep/wait less in the next update tick
-			//	- the thread slept/waited too less, then it adjust the time to sleep/wait more in the next update tick
-			LastTime = Now + SleepTimeInNanoSeconds;
-		}
-		else
-		{
-			LastTime = Now;
+			else
+			{
+				// Packets end the wait early. The wait can overshoot by a fraction of its duration, so approach the deadline in halving steps.
+				while(WaitTime > 0ns && net_socket_read_wait(m_aNetClient[CONN_MAIN].m_Socket, WaitTime > 200us ? WaitTime / 2 : 0ns) == 0)
+				{
+					WaitTime = Deadline - time_get_nanoseconds();
+				}
+			}
 		}
 
 		// update local and global time
@@ -5227,12 +5225,6 @@ int main(int argc, const char **argv)
 	// Support longer IME composition strings (enables SDL_TEXTEDITING_EXT).
 #if SDL_VERSION_ATLEAST(2, 0, 22)
 	SDL_SetHint(SDL_HINT_IME_SUPPORT_EXTENDED_TEXT, "1");
-#endif
-
-#if defined(CONF_PLATFORM_MACOS)
-	// Hints will not be set if there is an existing override hint or environment variable that takes precedence.
-	// So this respects cli environment overrides.
-	SDL_SetHint("SDL_MAC_OPENGL_ASYNC_DISPATCH", "1");
 #endif
 
 #if defined(CONF_FAMILY_WINDOWS)

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -2796,11 +2796,6 @@ void CGraphics_Threaded::Swap()
 	}
 
 	KickCommandBuffer();
-	// TODO: Remove when https://github.com/libsdl-org/SDL/issues/5203 is fixed
-#ifdef CONF_PLATFORM_MACOS
-	if(str_find(GetVersionString(), "Metal"))
-		WaitForIdle();
-#endif
 }
 
 bool CGraphics_Threaded::SetVSync(bool State)


### PR DESCRIPTION
Wake up at the prediction tick at least to reduce latency

Both with 60 Hz for cl_refresh_rate and gfx_refresh_rate

Before:
<img width="1832" height="1522" alt="Screenshot 2026-09-03 at 14 18 22" src="https://github.com/user-attachments/assets/c467ac04-6f54-412b-98e9-81ffb372e1e4" />
After:
<img width="1832" height="1522" alt="Screenshot 2026-09-03 at 14 18 23" src="https://github.com/user-attachments/assets/abb7ac91-dd9b-48b6-9482-a987fc114367" />


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5)
