### PR TITLE
Refactor graphics color setters

### DIFF
--- a/src/engine/client/graph.cpp
+++ b/src/engine/client/graph.cpp
@@ -191,11 +191,7 @@ void CGraph::RenderDataLines(IGraphics *pGraphics, float x, float y, float w, fl
 		{
 			pGraphics->LinesBatchEnd(&LineItemBatch);
 			pGraphics->LinesBatchBegin(&LineItemBatch);
-
-			const IGraphics::CColorVertex aColorVertices[] = {
-				IGraphics::CColorVertex(0, pEntry0->m_Color.r, pEntry0->m_Color.g, pEntry0->m_Color.b, pEntry0->m_Color.a),
-				IGraphics::CColorVertex(1, pEntry1->m_Color.r, pEntry1->m_Color.g, pEntry1->m_Color.b, pEntry1->m_Color.a)};
-			pGraphics->SetColorVertex(aColorVertices, std::size(aColorVertices));
+			pGraphics->SetColor2(pEntry0->m_Color, pEntry1->m_Color);
 		}
 		const IGraphics::CLineItem Item = IGraphics::CLineItem(
 			x + a0,

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -216,7 +216,7 @@ void CGraphics_Threaded::LinesBegin()
 {
 	dbg_assert(m_Drawing == EDrawing::NONE, "called Graphics()->LinesBegin twice");
 	m_Drawing = EDrawing::LINES;
-	SetColor(1, 1, 1, 1);
+	SetColor(ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f));
 }
 
 void CGraphics_Threaded::LinesEnd()
@@ -236,13 +236,13 @@ void CGraphics_Threaded::LinesDraw(const CLineItem *pArray, size_t Num)
 		m_aVertices[VertexIndex].m_Pos.x = pArray[i].m_X0;
 		m_aVertices[VertexIndex].m_Pos.y = pArray[i].m_Y0;
 		m_aVertices[VertexIndex].m_Tex = m_aTexture[0];
-		SetColor(&m_aVertices[VertexIndex], 0);
+		m_aVertices[VertexIndex].m_Color = m_aColor[0];
 		++VertexIndex;
 
 		m_aVertices[VertexIndex].m_Pos.x = pArray[i].m_X1;
 		m_aVertices[VertexIndex].m_Pos.y = pArray[i].m_Y1;
 		m_aVertices[VertexIndex].m_Tex = m_aTexture[1];
-		SetColor(&m_aVertices[VertexIndex], 1);
+		m_aVertices[VertexIndex].m_Color = m_aColor[1];
 		++VertexIndex;
 	}
 
@@ -751,7 +751,7 @@ void CGraphics_Threaded::QuadsBegin()
 
 	QuadsSetSubset(0, 0, 1, 1);
 	QuadsSetRotation(0);
-	SetColor(1, 1, 1, 1);
+	SetColor(ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f));
 }
 
 void CGraphics_Threaded::QuadsEnd()
@@ -780,7 +780,7 @@ void CGraphics_Threaded::TrianglesBegin()
 
 	QuadsSetSubset(0, 0, 1, 1);
 	QuadsSetRotation(0);
-	SetColor(1, 1, 1, 1);
+	SetColor(ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f));
 }
 
 void CGraphics_Threaded::TrianglesEnd()
@@ -809,62 +809,47 @@ void CGraphics_Threaded::QuadsSetRotation(float Angle)
 	m_Rotation = Angle;
 }
 
-static unsigned char NormalizeColorComponent(float ColorComponent)
+constexpr static unsigned char NormalizeColorComponent(float ColorComponent)
 {
 	return (unsigned char)(std::clamp(ColorComponent, 0.0f, 1.0f) * 255.0f + 0.5f); // +0.5f to round to nearest
 }
 
-void CGraphics_Threaded::SetColorVertex(const CColorVertex *pArray, size_t Num)
+constexpr static CCommandBuffer::SColor NormalizeColor(ColorRGBA Color)
 {
-	dbg_assert(m_Drawing != EDrawing::NONE, "called Graphics()->SetColorVertex without begin");
-
-	for(size_t i = 0; i < Num; ++i)
-	{
-		const CColorVertex &Vertex = pArray[i];
-		CCommandBuffer::SColor &Color = m_aColor[Vertex.m_Index];
-		Color.r = NormalizeColorComponent(Vertex.m_R);
-		Color.g = NormalizeColorComponent(Vertex.m_G);
-		Color.b = NormalizeColorComponent(Vertex.m_B);
-		Color.a = NormalizeColorComponent(Vertex.m_A);
-	}
+	CCommandBuffer::SColor NormalizedColor;
+	NormalizedColor.r = NormalizeColorComponent(Color.r);
+	NormalizedColor.g = NormalizeColorComponent(Color.g);
+	NormalizedColor.b = NormalizeColorComponent(Color.b);
+	NormalizedColor.a = NormalizeColorComponent(Color.a);
+	return NormalizedColor;
 }
 
 void CGraphics_Threaded::SetColor(float r, float g, float b, float a)
 {
-	CCommandBuffer::SColor NewColor;
-	NewColor.r = NormalizeColorComponent(r);
-	NewColor.g = NormalizeColorComponent(g);
-	NewColor.b = NormalizeColorComponent(b);
-	NewColor.a = NormalizeColorComponent(a);
-	std::fill(std::begin(m_aColor), std::end(m_aColor), NewColor);
+	SetColor(ColorRGBA(r, g, b, a));
 }
 
 void CGraphics_Threaded::SetColor(ColorRGBA Color)
 {
-	SetColor(Color.r, Color.g, Color.b, Color.a);
+	std::fill(std::begin(m_aColor), std::end(m_aColor), NormalizeColor(Color));
+}
+
+void CGraphics_Threaded::SetColor2(ColorRGBA First, ColorRGBA Second)
+{
+	dbg_assert(m_Drawing == EDrawing::LINES, "Called Graphics()->SetColor2 while not drawing lines");
+
+	m_aColor[0] = NormalizeColor(First);
+	m_aColor[1] = NormalizeColor(Second);
 }
 
 void CGraphics_Threaded::SetColor4(ColorRGBA TopLeft, ColorRGBA TopRight, ColorRGBA BottomLeft, ColorRGBA BottomRight)
 {
-	CColorVertex aArray[] = {
-		CColorVertex(0, TopLeft),
-		CColorVertex(1, TopRight),
-		CColorVertex(2, BottomRight),
-		CColorVertex(3, BottomLeft)};
-	SetColorVertex(aArray, std::size(aArray));
-}
+	dbg_assert(m_Drawing == EDrawing::QUADS || m_Drawing == EDrawing::TRIANGLES, "Called Graphics()->SetColor4 while not drawing quads or triangles");
 
-void CGraphics_Threaded::ChangeColorOfCurrentQuadVertices(float r, float g, float b, float a)
-{
-	m_aColor[0].r = NormalizeColorComponent(r);
-	m_aColor[0].g = NormalizeColorComponent(g);
-	m_aColor[0].b = NormalizeColorComponent(b);
-	m_aColor[0].a = NormalizeColorComponent(a);
-
-	for(int i = 0; i < m_NumVertices; ++i)
-	{
-		SetColor(&m_aVertices[i], 0);
-	}
+	m_aColor[0] = NormalizeColor(TopLeft);
+	m_aColor[1] = NormalizeColor(TopRight);
+	m_aColor[2] = NormalizeColor(BottomRight);
+	m_aColor[3] = NormalizeColor(BottomLeft);
 }
 
 void CGraphics_Threaded::ChangeColorOfQuadVertices(size_t QuadOffset, unsigned char r, unsigned char g, unsigned char b, unsigned char a)
@@ -948,32 +933,32 @@ void CGraphics_Threaded::QuadsDrawFreeform(const CFreeformItem *pArray, int Num)
 			m_aVertices[m_NumVertices + 6 * i].m_Pos.x = pArray[i].m_X0;
 			m_aVertices[m_NumVertices + 6 * i].m_Pos.y = pArray[i].m_Y0;
 			m_aVertices[m_NumVertices + 6 * i].m_Tex = m_aTexture[0];
-			SetColor(&m_aVertices[m_NumVertices + 6 * i], 0);
+			m_aVertices[m_NumVertices + 6 * i].m_Color = m_aColor[0];
 
 			m_aVertices[m_NumVertices + 6 * i + 1].m_Pos.x = pArray[i].m_X1;
 			m_aVertices[m_NumVertices + 6 * i + 1].m_Pos.y = pArray[i].m_Y1;
 			m_aVertices[m_NumVertices + 6 * i + 1].m_Tex = m_aTexture[1];
-			SetColor(&m_aVertices[m_NumVertices + 6 * i + 1], 1);
+			m_aVertices[m_NumVertices + 6 * i + 1].m_Color = m_aColor[1];
 
 			m_aVertices[m_NumVertices + 6 * i + 2].m_Pos.x = pArray[i].m_X3;
 			m_aVertices[m_NumVertices + 6 * i + 2].m_Pos.y = pArray[i].m_Y3;
 			m_aVertices[m_NumVertices + 6 * i + 2].m_Tex = m_aTexture[3];
-			SetColor(&m_aVertices[m_NumVertices + 6 * i + 2], 3);
+			m_aVertices[m_NumVertices + 6 * i + 2].m_Color = m_aColor[3];
 
 			m_aVertices[m_NumVertices + 6 * i + 3].m_Pos.x = pArray[i].m_X0;
 			m_aVertices[m_NumVertices + 6 * i + 3].m_Pos.y = pArray[i].m_Y0;
 			m_aVertices[m_NumVertices + 6 * i + 3].m_Tex = m_aTexture[0];
-			SetColor(&m_aVertices[m_NumVertices + 6 * i + 3], 0);
+			m_aVertices[m_NumVertices + 6 * i + 3].m_Color = m_aColor[0];
 
 			m_aVertices[m_NumVertices + 6 * i + 4].m_Pos.x = pArray[i].m_X3;
 			m_aVertices[m_NumVertices + 6 * i + 4].m_Pos.y = pArray[i].m_Y3;
 			m_aVertices[m_NumVertices + 6 * i + 4].m_Tex = m_aTexture[3];
-			SetColor(&m_aVertices[m_NumVertices + 6 * i + 4], 3);
+			m_aVertices[m_NumVertices + 6 * i + 4].m_Color = m_aColor[3];
 
 			m_aVertices[m_NumVertices + 6 * i + 5].m_Pos.x = pArray[i].m_X2;
 			m_aVertices[m_NumVertices + 6 * i + 5].m_Pos.y = pArray[i].m_Y2;
 			m_aVertices[m_NumVertices + 6 * i + 5].m_Tex = m_aTexture[2];
-			SetColor(&m_aVertices[m_NumVertices + 6 * i + 5], 2);
+			m_aVertices[m_NumVertices + 6 * i + 5].m_Color = m_aColor[2];
 		}
 
 		AddVertices(3 * 2 * Num);
@@ -985,22 +970,22 @@ void CGraphics_Threaded::QuadsDrawFreeform(const CFreeformItem *pArray, int Num)
 			m_aVertices[m_NumVertices + 4 * i].m_Pos.x = pArray[i].m_X0;
 			m_aVertices[m_NumVertices + 4 * i].m_Pos.y = pArray[i].m_Y0;
 			m_aVertices[m_NumVertices + 4 * i].m_Tex = m_aTexture[0];
-			SetColor(&m_aVertices[m_NumVertices + 4 * i], 0);
+			m_aVertices[m_NumVertices + 4 * i].m_Color = m_aColor[0];
 
 			m_aVertices[m_NumVertices + 4 * i + 1].m_Pos.x = pArray[i].m_X1;
 			m_aVertices[m_NumVertices + 4 * i + 1].m_Pos.y = pArray[i].m_Y1;
 			m_aVertices[m_NumVertices + 4 * i + 1].m_Tex = m_aTexture[1];
-			SetColor(&m_aVertices[m_NumVertices + 4 * i + 1], 1);
+			m_aVertices[m_NumVertices + 4 * i + 1].m_Color = m_aColor[1];
 
 			m_aVertices[m_NumVertices + 4 * i + 2].m_Pos.x = pArray[i].m_X3;
 			m_aVertices[m_NumVertices + 4 * i + 2].m_Pos.y = pArray[i].m_Y3;
 			m_aVertices[m_NumVertices + 4 * i + 2].m_Tex = m_aTexture[3];
-			SetColor(&m_aVertices[m_NumVertices + 4 * i + 2], 3);
+			m_aVertices[m_NumVertices + 4 * i + 2].m_Color = m_aColor[3];
 
 			m_aVertices[m_NumVertices + 4 * i + 3].m_Pos.x = pArray[i].m_X2;
 			m_aVertices[m_NumVertices + 4 * i + 3].m_Pos.y = pArray[i].m_Y2;
 			m_aVertices[m_NumVertices + 4 * i + 3].m_Tex = m_aTexture[2];
-			SetColor(&m_aVertices[m_NumVertices + 4 * i + 3], 2);
+			m_aVertices[m_NumVertices + 4 * i + 3].m_Color = m_aColor[2];
 		}
 
 		AddVertices(4 * Num);
@@ -1566,22 +1551,22 @@ int CGraphics_Threaded::QuadContainerAddQuads(int ContainerIndex, CQuadItem *pAr
 		Quad.m_aVertices[0].m_Pos.x = pArray[i].m_X;
 		Quad.m_aVertices[0].m_Pos.y = pArray[i].m_Y;
 		Quad.m_aVertices[0].m_Tex = m_aTexture[0];
-		SetColor(&Quad.m_aVertices[0], 0);
+		Quad.m_aVertices[0].m_Color = m_aColor[0];
 
 		Quad.m_aVertices[1].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
 		Quad.m_aVertices[1].m_Pos.y = pArray[i].m_Y;
 		Quad.m_aVertices[1].m_Tex = m_aTexture[1];
-		SetColor(&Quad.m_aVertices[1], 1);
+		Quad.m_aVertices[1].m_Color = m_aColor[1];
 
 		Quad.m_aVertices[2].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
 		Quad.m_aVertices[2].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
 		Quad.m_aVertices[2].m_Tex = m_aTexture[2];
-		SetColor(&Quad.m_aVertices[2], 2);
+		Quad.m_aVertices[2].m_Color = m_aColor[2];
 
 		Quad.m_aVertices[3].m_Pos.x = pArray[i].m_X;
 		Quad.m_aVertices[3].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
 		Quad.m_aVertices[3].m_Tex = m_aTexture[3];
-		SetColor(&Quad.m_aVertices[3], 3);
+		Quad.m_aVertices[3].m_Color = m_aColor[3];
 
 		if(m_Rotation != 0)
 		{
@@ -1616,22 +1601,22 @@ int CGraphics_Threaded::QuadContainerAddQuads(int ContainerIndex, CFreeformItem 
 		Quad.m_aVertices[0].m_Pos.x = pArray[i].m_X0;
 		Quad.m_aVertices[0].m_Pos.y = pArray[i].m_Y0;
 		Quad.m_aVertices[0].m_Tex = m_aTexture[0];
-		SetColor(&Quad.m_aVertices[0], 0);
+		Quad.m_aVertices[0].m_Color = m_aColor[0];
 
 		Quad.m_aVertices[1].m_Pos.x = pArray[i].m_X1;
 		Quad.m_aVertices[1].m_Pos.y = pArray[i].m_Y1;
 		Quad.m_aVertices[1].m_Tex = m_aTexture[1];
-		SetColor(&Quad.m_aVertices[1], 1);
+		Quad.m_aVertices[1].m_Color = m_aColor[1];
 
 		Quad.m_aVertices[2].m_Pos.x = pArray[i].m_X3;
 		Quad.m_aVertices[2].m_Pos.y = pArray[i].m_Y3;
 		Quad.m_aVertices[2].m_Tex = m_aTexture[3];
-		SetColor(&Quad.m_aVertices[2], 3);
+		Quad.m_aVertices[2].m_Color = m_aColor[3];
 
 		Quad.m_aVertices[3].m_Pos.x = pArray[i].m_X2;
 		Quad.m_aVertices[3].m_Pos.y = pArray[i].m_Y2;
 		Quad.m_aVertices[3].m_Tex = m_aTexture[2];
-		SetColor(&Quad.m_aVertices[3], 2);
+		Quad.m_aVertices[3].m_Color = m_aColor[2];
 	}
 
 	if(Container.m_AutomaticUpload)
@@ -1791,8 +1776,7 @@ void CGraphics_Threaded::RenderQuadContainerEx(int ContainerIndex, int QuadOffse
 				{
 					m_aVertices[i * 6 + n].m_Pos.x *= ScaleX;
 					m_aVertices[i * 6 + n].m_Pos.y *= ScaleY;
-
-					SetColor(&m_aVertices[i * 6 + n], 0);
+					m_aVertices[i * 6 + n].m_Color = m_aColor[0];
 				}
 
 				if(m_Rotation != 0)
@@ -1821,7 +1805,7 @@ void CGraphics_Threaded::RenderQuadContainerEx(int ContainerIndex, int QuadOffse
 				{
 					m_aVertices[i * 4 + n].m_Pos.x *= ScaleX;
 					m_aVertices[i * 4 + n].m_Pos.y *= ScaleY;
-					SetColor(&m_aVertices[i * 4 + n], 0);
+					m_aVertices[i * 4 + n].m_Color = m_aColor[0];
 				}
 
 				if(m_Rotation != 0)

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -969,20 +969,11 @@ public:
 	void QuadsDrawCurrentVertices(bool KeepVertices = true) override;
 	void QuadsSetRotation(float Angle) override;
 
-	template<typename TName>
-	void SetColor(TName *pVertex, int ColorIndex)
-	{
-		TName *pVert = pVertex;
-		pVert->m_Color = m_aColor[ColorIndex];
-	}
-
-	void SetColorVertex(const CColorVertex *pArray, size_t Num) override;
 	void SetColor(float r, float g, float b, float a) override;
 	void SetColor(ColorRGBA Color) override;
+	void SetColor2(ColorRGBA First, ColorRGBA Second) override;
 	void SetColor4(ColorRGBA TopLeft, ColorRGBA TopRight, ColorRGBA BottomLeft, ColorRGBA BottomRight) override;
 
-	// go through all vertices and change their color (only works for quads)
-	void ChangeColorOfCurrentQuadVertices(float r, float g, float b, float a) override;
 	void ChangeColorOfQuadVertices(size_t QuadOffset, unsigned char r, unsigned char g, unsigned char b, unsigned char a) override;
 
 	void QuadsSetSubset(float TlU, float TlV, float BrU, float BrV) override;
@@ -1007,33 +998,33 @@ public:
 				pVertices[m_NumVertices + 6 * i].m_Pos.x = pArray[i].m_X;
 				pVertices[m_NumVertices + 6 * i].m_Pos.y = pArray[i].m_Y;
 				pVertices[m_NumVertices + 6 * i].m_Tex = m_aTexture[0];
-				SetColor(&pVertices[m_NumVertices + 6 * i], 0);
+				pVertices[m_NumVertices + 6 * i].m_Color = m_aColor[0];
 
 				pVertices[m_NumVertices + 6 * i + 1].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
 				pVertices[m_NumVertices + 6 * i + 1].m_Pos.y = pArray[i].m_Y;
 				pVertices[m_NumVertices + 6 * i + 1].m_Tex = m_aTexture[1];
-				SetColor(&pVertices[m_NumVertices + 6 * i + 1], 1);
+				pVertices[m_NumVertices + 6 * i + 1].m_Color = m_aColor[1];
 
 				pVertices[m_NumVertices + 6 * i + 2].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
 				pVertices[m_NumVertices + 6 * i + 2].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
 				pVertices[m_NumVertices + 6 * i + 2].m_Tex = m_aTexture[2];
-				SetColor(&pVertices[m_NumVertices + 6 * i + 2], 2);
+				pVertices[m_NumVertices + 6 * i + 2].m_Color = m_aColor[2];
 
 				// second triangle
 				pVertices[m_NumVertices + 6 * i + 3].m_Pos.x = pArray[i].m_X;
 				pVertices[m_NumVertices + 6 * i + 3].m_Pos.y = pArray[i].m_Y;
 				pVertices[m_NumVertices + 6 * i + 3].m_Tex = m_aTexture[0];
-				SetColor(&pVertices[m_NumVertices + 6 * i + 3], 0);
+				pVertices[m_NumVertices + 6 * i + 3].m_Color = m_aColor[0];
 
 				pVertices[m_NumVertices + 6 * i + 4].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
 				pVertices[m_NumVertices + 6 * i + 4].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
 				pVertices[m_NumVertices + 6 * i + 4].m_Tex = m_aTexture[2];
-				SetColor(&pVertices[m_NumVertices + 6 * i + 4], 2);
+				pVertices[m_NumVertices + 6 * i + 4].m_Color = m_aColor[2];
 
 				pVertices[m_NumVertices + 6 * i + 5].m_Pos.x = pArray[i].m_X;
 				pVertices[m_NumVertices + 6 * i + 5].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
 				pVertices[m_NumVertices + 6 * i + 5].m_Tex = m_aTexture[3];
-				SetColor(&pVertices[m_NumVertices + 6 * i + 5], 3);
+				pVertices[m_NumVertices + 6 * i + 5].m_Color = m_aColor[3];
 
 				if(m_Rotation != 0)
 				{
@@ -1053,22 +1044,22 @@ public:
 				pVertices[m_NumVertices + 4 * i].m_Pos.x = pArray[i].m_X;
 				pVertices[m_NumVertices + 4 * i].m_Pos.y = pArray[i].m_Y;
 				pVertices[m_NumVertices + 4 * i].m_Tex = m_aTexture[0];
-				SetColor(&pVertices[m_NumVertices + 4 * i], 0);
+				pVertices[m_NumVertices + 4 * i].m_Color = m_aColor[0];
 
 				pVertices[m_NumVertices + 4 * i + 1].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
 				pVertices[m_NumVertices + 4 * i + 1].m_Pos.y = pArray[i].m_Y;
 				pVertices[m_NumVertices + 4 * i + 1].m_Tex = m_aTexture[1];
-				SetColor(&pVertices[m_NumVertices + 4 * i + 1], 1);
+				pVertices[m_NumVertices + 4 * i + 1].m_Color = m_aColor[1];
 
 				pVertices[m_NumVertices + 4 * i + 2].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
 				pVertices[m_NumVertices + 4 * i + 2].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
 				pVertices[m_NumVertices + 4 * i + 2].m_Tex = m_aTexture[2];
-				SetColor(&pVertices[m_NumVertices + 4 * i + 2], 2);
+				pVertices[m_NumVertices + 4 * i + 2].m_Color = m_aColor[2];
 
 				pVertices[m_NumVertices + 4 * i + 3].m_Pos.x = pArray[i].m_X;
 				pVertices[m_NumVertices + 4 * i + 3].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
 				pVertices[m_NumVertices + 4 * i + 3].m_Tex = m_aTexture[3];
-				SetColor(&pVertices[m_NumVertices + 4 * i + 3], 3);
+				pVertices[m_NumVertices + 4 * i + 3].m_Color = m_aColor[3];
 
 				if(m_Rotation != 0)
 				{

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -543,21 +543,13 @@ public:
 	virtual void DrawRect4(float x, float y, float w, float h, ColorRGBA ColorTopLeft, ColorRGBA ColorTopRight, ColorRGBA ColorBottomLeft, ColorRGBA ColorBottomRight, int Corners, float Rounding) = 0;
 	virtual void DrawCircle(float CenterX, float CenterY, float Radius, int Segments) = 0;
 
-	struct CColorVertex
-	{
-		int m_Index;
-		float m_R, m_G, m_B, m_A;
-		CColorVertex() = default;
-		CColorVertex(int i, float r, float g, float b, float a) :
-			m_Index(i), m_R(r), m_G(g), m_B(b), m_A(a) {}
-		CColorVertex(int i, ColorRGBA Color) :
-			m_Index(i), m_R(Color.r), m_G(Color.g), m_B(Color.b), m_A(Color.a) {}
-	};
-	virtual void SetColorVertex(const CColorVertex *pArray, size_t Num) = 0;
+	/**
+	 * @deprecated Use @link SetColor(ColorRGBA) @endlink instead of this function (avoid primitive obsession code smell).
+	 */
 	virtual void SetColor(float r, float g, float b, float a) = 0;
 	virtual void SetColor(ColorRGBA Color) = 0;
+	virtual void SetColor2(ColorRGBA First, ColorRGBA Second) = 0;
 	virtual void SetColor4(ColorRGBA TopLeft, ColorRGBA TopRight, ColorRGBA BottomLeft, ColorRGBA BottomRight) = 0;
-	virtual void ChangeColorOfCurrentQuadVertices(float r, float g, float b, float a) = 0;
 	virtual void ChangeColorOfQuadVertices(size_t QuadOffset, unsigned char r, unsigned char g, unsigned char b, unsigned char a) = 0;
 
 	/**

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -183,12 +183,11 @@ bool CMenus::RenderHslaScrollbars(CUIRect *pRect, unsigned int *pColor, bool Alp
 
 		// red to yellow
 		{
-			IGraphics::CColorVertex aColorVertices[] = {
-				IGraphics::CColorVertex(0, 1, 0, 0, 1),
-				IGraphics::CColorVertex(1, 1, 1, 0, 1),
-				IGraphics::CColorVertex(2, 1, 0, 0, 1),
-				IGraphics::CColorVertex(3, 1, 1, 0, 1)};
-			Graphics()->SetColorVertex(aColorVertices, std::size(aColorVertices));
+			Graphics()->SetColor4(
+				ColorRGBA(1, 0, 0, 1),
+				ColorRGBA(1, 1, 0, 1),
+				ColorRGBA(1, 1, 0, 1),
+				ColorRGBA(1, 0, 0, 1));
 
 			IGraphics::CFreeformItem Freeform(
 				CurXOff, pColorRect->y,
@@ -201,12 +200,11 @@ bool CMenus::RenderHslaScrollbars(CUIRect *pRect, unsigned int *pColor, bool Alp
 		// yellow to green
 		CurXOff += SizeColor;
 		{
-			IGraphics::CColorVertex aColorVertices[] = {
-				IGraphics::CColorVertex(0, 1, 1, 0, 1),
-				IGraphics::CColorVertex(1, 0, 1, 0, 1),
-				IGraphics::CColorVertex(2, 1, 1, 0, 1),
-				IGraphics::CColorVertex(3, 0, 1, 0, 1)};
-			Graphics()->SetColorVertex(aColorVertices, std::size(aColorVertices));
+			Graphics()->SetColor4(
+				ColorRGBA(1, 1, 0, 1),
+				ColorRGBA(0, 1, 0, 1),
+				ColorRGBA(0, 1, 0, 1),
+				ColorRGBA(1, 1, 0, 1));
 
 			IGraphics::CFreeformItem Freeform(
 				CurXOff, pColorRect->y,
@@ -219,12 +217,11 @@ bool CMenus::RenderHslaScrollbars(CUIRect *pRect, unsigned int *pColor, bool Alp
 		CurXOff += SizeColor;
 		// green to turquoise
 		{
-			IGraphics::CColorVertex aColorVertices[] = {
-				IGraphics::CColorVertex(0, 0, 1, 0, 1),
-				IGraphics::CColorVertex(1, 0, 1, 1, 1),
-				IGraphics::CColorVertex(2, 0, 1, 0, 1),
-				IGraphics::CColorVertex(3, 0, 1, 1, 1)};
-			Graphics()->SetColorVertex(aColorVertices, std::size(aColorVertices));
+			Graphics()->SetColor4(
+				ColorRGBA(0, 1, 0, 1),
+				ColorRGBA(0, 1, 1, 1),
+				ColorRGBA(0, 1, 1, 1),
+				ColorRGBA(0, 1, 0, 1));
 
 			IGraphics::CFreeformItem Freeform(
 				CurXOff, pColorRect->y,
@@ -237,12 +234,11 @@ bool CMenus::RenderHslaScrollbars(CUIRect *pRect, unsigned int *pColor, bool Alp
 		CurXOff += SizeColor;
 		// turquoise to blue
 		{
-			IGraphics::CColorVertex aColorVertices[] = {
-				IGraphics::CColorVertex(0, 0, 1, 1, 1),
-				IGraphics::CColorVertex(1, 0, 0, 1, 1),
-				IGraphics::CColorVertex(2, 0, 1, 1, 1),
-				IGraphics::CColorVertex(3, 0, 0, 1, 1)};
-			Graphics()->SetColorVertex(aColorVertices, std::size(aColorVertices));
+			Graphics()->SetColor4(
+				ColorRGBA(0, 1, 1, 1),
+				ColorRGBA(0, 0, 1, 1),
+				ColorRGBA(0, 0, 1, 1),
+				ColorRGBA(0, 1, 1, 1));
 
 			IGraphics::CFreeformItem Freeform(
 				CurXOff, pColorRect->y,
@@ -255,12 +251,11 @@ bool CMenus::RenderHslaScrollbars(CUIRect *pRect, unsigned int *pColor, bool Alp
 		CurXOff += SizeColor;
 		// blue to purple
 		{
-			IGraphics::CColorVertex aColorVertices[] = {
-				IGraphics::CColorVertex(0, 0, 0, 1, 1),
-				IGraphics::CColorVertex(1, 1, 0, 1, 1),
-				IGraphics::CColorVertex(2, 0, 0, 1, 1),
-				IGraphics::CColorVertex(3, 1, 0, 1, 1)};
-			Graphics()->SetColorVertex(aColorVertices, std::size(aColorVertices));
+			Graphics()->SetColor4(
+				ColorRGBA(0, 0, 1, 1),
+				ColorRGBA(1, 0, 1, 1),
+				ColorRGBA(1, 0, 1, 1),
+				ColorRGBA(0, 0, 1, 1));
 
 			IGraphics::CFreeformItem Freeform(
 				CurXOff, pColorRect->y,
@@ -273,12 +268,11 @@ bool CMenus::RenderHslaScrollbars(CUIRect *pRect, unsigned int *pColor, bool Alp
 		CurXOff += SizeColor;
 		// purple to red
 		{
-			IGraphics::CColorVertex aColorVertices[] = {
-				IGraphics::CColorVertex(0, 1, 0, 1, 1),
-				IGraphics::CColorVertex(1, 1, 0, 0, 1),
-				IGraphics::CColorVertex(2, 1, 0, 1, 1),
-				IGraphics::CColorVertex(3, 1, 0, 0, 1)};
-			Graphics()->SetColorVertex(aColorVertices, std::size(aColorVertices));
+			Graphics()->SetColor4(
+				ColorRGBA(1, 0, 1, 1),
+				ColorRGBA(1, 0, 0, 1),
+				ColorRGBA(1, 0, 0, 1),
+				ColorRGBA(1, 0, 1, 1));
 
 			IGraphics::CFreeformItem Freeform(
 				CurXOff, pColorRect->y,

--- a/src/game/map/render_map.cpp
+++ b/src/game/map/render_map.cpp
@@ -404,12 +404,11 @@ void CRenderMap::ForceRenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags, 
 		const vec2 Offset = vec2(Position.r, Position.g);
 		const float Rotation = Position.b / 180.0f * pi;
 
-		IGraphics::CColorVertex Array[4] = {
-			IGraphics::CColorVertex(0, pQuad->m_aColors[0].r * Conv * Color.r, pQuad->m_aColors[0].g * Conv * Color.g, pQuad->m_aColors[0].b * Conv * Color.b, pQuad->m_aColors[0].a * Conv * Color.a * Alpha),
-			IGraphics::CColorVertex(1, pQuad->m_aColors[1].r * Conv * Color.r, pQuad->m_aColors[1].g * Conv * Color.g, pQuad->m_aColors[1].b * Conv * Color.b, pQuad->m_aColors[1].a * Conv * Color.a * Alpha),
-			IGraphics::CColorVertex(2, pQuad->m_aColors[2].r * Conv * Color.r, pQuad->m_aColors[2].g * Conv * Color.g, pQuad->m_aColors[2].b * Conv * Color.b, pQuad->m_aColors[2].a * Conv * Color.a * Alpha),
-			IGraphics::CColorVertex(3, pQuad->m_aColors[3].r * Conv * Color.r, pQuad->m_aColors[3].g * Conv * Color.g, pQuad->m_aColors[3].b * Conv * Color.b, pQuad->m_aColors[3].a * Conv * Color.a * Alpha)};
-		Graphics()->SetColorVertex(Array, 4);
+		Graphics()->SetColor4(
+			ColorRGBA(pQuad->m_aColors[0].r, pQuad->m_aColors[0].g, pQuad->m_aColors[0].b, pQuad->m_aColors[0].a * Alpha).Multiply(Color).Multiply(Conv),
+			ColorRGBA(pQuad->m_aColors[1].r, pQuad->m_aColors[1].g, pQuad->m_aColors[1].b, pQuad->m_aColors[1].a * Alpha).Multiply(Color).Multiply(Conv),
+			ColorRGBA(pQuad->m_aColors[3].r, pQuad->m_aColors[3].g, pQuad->m_aColors[3].b, pQuad->m_aColors[3].a * Alpha).Multiply(Color).Multiply(Conv),
+			ColorRGBA(pQuad->m_aColors[2].r, pQuad->m_aColors[2].g, pQuad->m_aColors[2].b, pQuad->m_aColors[2].a * Alpha).Multiply(Color).Multiply(Conv));
 
 		CPoint *pPoints = pQuad->m_aPoints;
 


### PR DESCRIPTION
Use `IGraphics::SetColor4` instead of `IGraphics::SetColorVertex` function. Note that the last two arguments are swapped when using the `SetColor4` function instead of the `SetColorVertex` function.

Add `IGraphics::SetColor2` function to set two colors for line drawing to replace the remaining use of `SetColorVertex` function.

Remove the thereby unused `SetColorVertex` function and avoid temporarily converting colors to `CColorVertex`. The `CColorVertex` was also including an unnecessary `m_Index` member.

Remove fully unused `ChangeColorOfCurrentQuadVertices` function.

Deprecate the `SetColor(float r, float g, float b, float a)` function in favor of the `SetColor(ColorRGBA Color)` function to avoid the primitive obsession code smell.

Remove the `void SetColor(TName *pVertex, int ColorIndex)` function by inlining it to avoid unnecessary indirection and confusing naming. This is consistent with other vertex members such as `m_Tex` also being set directly.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions