### PR TITLE
client: Fix server browser crash after resuming iOS app

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -1383,6 +1383,7 @@ const json_value *CServerBrowser::LoadDDNetInfo()
 		}
 	}
 	ValidateServerlistType();
+	m_CommunityCache.Update(true);
 	RequestResort();
 	return m_pDDNetInfo;
 }
@@ -1530,6 +1531,8 @@ void CServerBrowser::LoadDDNetServers()
 	// Parse communities
 	m_vCommunities.clear();
 	m_CommunityServersByAddr.clear();
+	// The community cache holds pointers into m_vCommunities and must be invalidated.
+	m_CommunityCache.Invalidate();
 
 	if(!m_pDDNetInfo)
 	{
@@ -1887,6 +1890,18 @@ unsigned CServerBrowser::CurrentCommunitiesHash() const
 	return Hash;
 }
 
+void CCommunityCache::Invalidate()
+{
+	m_LastType = IServerBrowser::NUM_TYPES;
+	m_SelectedCommunitiesHash = 0;
+	m_vpSelectedCommunities.clear();
+	m_vpSelectableCountries.clear();
+	m_vpSelectableTypes.clear();
+	m_AnyRanksAvailable = false;
+	m_CountryTypesFilterAvailable = false;
+	m_pCountryTypeFilterKey = IServerBrowser::COMMUNITY_ALL;
+}
+
 void CCommunityCache::Update(bool Force)
 {
 	const unsigned CommunitiesHash = m_pServerBrowser->CurrentCommunitiesHash();
@@ -1899,13 +1914,11 @@ void CCommunityCache::Update(bool Force)
 		m_pServerBrowser->Refresh(m_pServerBrowser->GetCurrentType(), true);
 	}
 
-	if(!Force && m_InfoSha256 == m_pServerBrowser->DDNetInfoSha256() &&
-		!CurrentCommunitiesChanged && !TypeChanged)
+	if(!Force && !CurrentCommunitiesChanged && !TypeChanged)
 	{
 		return;
 	}
 
-	m_InfoSha256 = m_pServerBrowser->DDNetInfoSha256();
 	m_LastType = m_pServerBrowser->GetCurrentType();
 	m_SelectedCommunitiesHash = CommunitiesHash;
 	m_vpSelectedCommunities = m_pServerBrowser->CurrentCommunities();

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -628,9 +628,7 @@ void CServerBrowser::Filter()
 		}
 	}
 
-	std::stable_sort(m_vCommunities.begin(), m_vCommunities.end(), [](const CCommunity &Lhs, const CCommunity &Rhs) {
-		return Lhs.NumPlayers() > Rhs.NumPlayers();
-	});
+	m_CommunityCache.UpdateSortedCommunities();
 }
 
 int CServerBrowser::SortHash() const
@@ -1894,12 +1892,26 @@ void CCommunityCache::Invalidate()
 {
 	m_LastType = IServerBrowser::NUM_TYPES;
 	m_SelectedCommunitiesHash = 0;
+	m_vpSortedCommunities.clear();
 	m_vpSelectedCommunities.clear();
 	m_vpSelectableCountries.clear();
 	m_vpSelectableTypes.clear();
 	m_AnyRanksAvailable = false;
 	m_CountryTypesFilterAvailable = false;
 	m_pCountryTypeFilterKey = IServerBrowser::COMMUNITY_ALL;
+}
+
+void CCommunityCache::UpdateSortedCommunities()
+{
+	m_vpSortedCommunities.clear();
+	m_vpSortedCommunities.reserve(m_pServerBrowser->Communities().size());
+	for(const CCommunity &Community : m_pServerBrowser->Communities())
+	{
+		m_vpSortedCommunities.push_back(&Community);
+	}
+	std::stable_sort(m_vpSortedCommunities.begin(), m_vpSortedCommunities.end(), [](const CCommunity *pLhs, const CCommunity *pRhs) {
+		return pLhs->NumPlayers() > pRhs->NumPlayers();
+	});
 }
 
 void CCommunityCache::Update(bool Force)
@@ -1921,6 +1933,7 @@ void CCommunityCache::Update(bool Force)
 
 	m_LastType = m_pServerBrowser->GetCurrentType();
 	m_SelectedCommunitiesHash = CommunitiesHash;
+	UpdateSortedCommunities();
 	m_vpSelectedCommunities = m_pServerBrowser->CurrentCommunities();
 
 	m_vpSelectableCountries.clear();

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -222,7 +222,6 @@ private:
 class CCommunityCache : public ICommunityCache
 {
 	IServerBrowser *m_pServerBrowser;
-	std::optional<SHA256_DIGEST> m_InfoSha256;
 	int m_LastType = IServerBrowser::NUM_TYPES; // initial value does not appear normally, marking uninitialized cache
 	unsigned m_SelectedCommunitiesHash = 0;
 	std::vector<const CCommunity *> m_vpSelectedCommunities;
@@ -238,6 +237,7 @@ public:
 	{
 	}
 
+	void Invalidate();
 	void Update(bool Force) override;
 	const std::vector<const CCommunity *> &SelectedCommunities() const override { return m_vpSelectedCommunities; }
 	const std::vector<const CCommunityCountry *> &SelectableCountries() const override { return m_vpSelectableCountries; }

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -224,6 +224,7 @@ class CCommunityCache : public ICommunityCache
 	IServerBrowser *m_pServerBrowser;
 	int m_LastType = IServerBrowser::NUM_TYPES; // initial value does not appear normally, marking uninitialized cache
 	unsigned m_SelectedCommunitiesHash = 0;
+	std::vector<const CCommunity *> m_vpSortedCommunities;
 	std::vector<const CCommunity *> m_vpSelectedCommunities;
 	std::vector<const CCommunityCountry *> m_vpSelectableCountries;
 	std::vector<const CCommunityType *> m_vpSelectableTypes;
@@ -238,7 +239,9 @@ public:
 	}
 
 	void Invalidate();
+	void UpdateSortedCommunities();
 	void Update(bool Force) override;
+	const std::vector<const CCommunity *> &SortedCommunities() const override { return m_vpSortedCommunities; }
 	const std::vector<const CCommunity *> &SelectedCommunities() const override { return m_vpSelectedCommunities; }
 	const std::vector<const CCommunityCountry *> &SelectableCountries() const override { return m_vpSelectableCountries; }
 	const std::vector<const CCommunityType *> &SelectableTypes() const override { return m_vpSelectableTypes; }
@@ -345,6 +348,7 @@ private:
 	std::vector<int> m_vSortedServerlist;
 	std::unordered_map<NETADDR, int> m_ByAddr;
 
+	// Must not be reordered, the community cache holds pointers into this.
 	std::vector<CCommunity> m_vCommunities;
 	std::unordered_map<NETADDR, CCommunityServer> m_CommunityServersByAddr;
 

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -268,6 +268,7 @@ class ICommunityCache
 public:
 	virtual ~ICommunityCache() = default;
 	virtual void Update(bool Force) = 0;
+	virtual const std::vector<const CCommunity *> &SortedCommunities() const = 0;
 	virtual const std::vector<const CCommunity *> &SelectedCommunities() const = 0;
 	virtual const std::vector<const CCommunityCountry *> &SelectableCountries() const = 0;
 	virtual const std::vector<const CCommunityType *> &SelectableTypes() const = 0;

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -988,7 +988,8 @@ void CMenus::RenderServerbrowserCommunitiesFilter(CUIRect View)
 	Ui()->DoLabel(&Tab, Localize("Communities"), 12.0f, TEXTALIGN_MC);
 	View.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f), IGraphics::CORNER_B, 4.0f);
 
-	const int MaxEntries = ServerBrowser()->Communities().size();
+	const std::vector<const CCommunity *> &vpCommunities = ServerBrowser()->CommunityCache().SortedCommunities();
+	const int MaxEntries = vpCommunities.size();
 	if(MaxEntries == 0)
 	{
 		CUIRect ErrorLabel;
@@ -1010,10 +1011,10 @@ void CMenus::RenderServerbrowserCommunitiesFilter(CUIRect View)
 	const float Spacing = 2.0f;
 
 	const auto &&GetItemName = [&](int ItemIndex) {
-		return ServerBrowser()->Communities()[ItemIndex].Id();
+		return vpCommunities[ItemIndex]->Id();
 	};
 	const auto &&RenderItem = [&](int ItemIndex, CUIRect Item, const void *pItemId, bool Active) {
-		const auto &Community = ServerBrowser()->Communities()[ItemIndex];
+		const auto &Community = *vpCommunities[ItemIndex];
 		const float Alpha = (Active ? 0.9f : 0.2f) + (Ui()->HotItem() == pItemId ? 0.1f : 0.0f);
 
 		CUIRect Icon, NameLabel, PlayerCountIcon, PlayerCountLabel, FavoriteButton;


### PR DESCRIPTION
Seen on iOS:

    heap-use-after-free READ of size 4
    #0 CCommunityCountry::FlagId() const serverbrowser.h:171
    #1 CMenus::RenderServerbrowserCountriesFilter(CUIRect) menus_browser.cpp:1085
    freed by CCommunity::~CCommunity() via CServerBrowser::LoadDDNetServers()

Closes: #11708 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5 and Opus 5)
