### PR TITLE
server: Restart map download when client asks for first chunk

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1827,6 +1827,10 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 			{
 				return;
 			}
+			if(Chunk == 0)
+			{
+				m_aClients[ClientId].m_NextMapChunk = 0;
+			}
 			if(Chunk != m_aClients[ClientId].m_NextMapChunk || !Config()->m_SvFastDownload)
 			{
 				SendMapData(ClientId, Chunk);


### PR DESCRIPTION
This can lead to the main connection getting stuck on map downloading.

Edit: Not related to the reported bug:

Reported on Discord: https://discord.com/channels/252358080522747904/757720336274948198/1544361146977484822 by Pablo:

> we reloaded test server and only my dummy is in the server lmao?
> my normal player (paproninja) is not in server for some reason xd
> and if i switch to it i see nothing

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5.1)
