### PR TITLE
server: Allow hot-reloading antibot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3205,10 +3205,13 @@ if(SERVER)
   set(LIBS_SERVER
     ${MINIUPNPC_LIBRARIES}
     ${MYSQL_LIBRARIES}
-    ${TARGET_ANTIBOT}
 
     ${LIBS}
   )
+  if(ANTIBOT)
+    # Supports hot reloading
+    list(APPEND LIBS_SERVER ${CMAKE_DL_LIBS})
+  endif()
 
   add_library(game-server-without-main OBJECT
       ${DEPS}
@@ -4052,6 +4055,16 @@ if(ANTIBOT)
   # Allow the antibot library to use functions from the server binary.
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_LINK -rdynamic)
   set_own_rpath(game-server)
+  add_dependencies(game-server ${TARGET_ANTIBOT})
+  if(TARGET testrunner)
+    set_own_rpath(testrunner)
+    add_dependencies(testrunner ${TARGET_ANTIBOT})
+  endif()
+  set(ANTIBOT_LIBRARY "$<TARGET_FILE_NAME:${TARGET_ANTIBOT}>")
+  if(TARGET_OS STREQUAL "mac")
+    set(ANTIBOT_LIBRARY "@executable_path/${ANTIBOT_LIBRARY}")
+  endif()
+  target_compile_definitions(game-server-without-main PRIVATE ANTIBOT_LIBRARY="${ANTIBOT_LIBRARY}")
 endif()
 
 set(TARGETS ${TARGETS_OWN} ${TARGETS_DEP})

--- a/src/engine/antibot.h
+++ b/src/engine/antibot.h
@@ -30,6 +30,7 @@ class IEngineAntibot : public IAntibot
 	MACRO_INTERFACE("engineantibot")
 public:
 	virtual void Init() = 0;
+	virtual void Reload() = 0;
 
 	// Hooks
 	virtual void OnEngineTick() = 0;

--- a/src/engine/server/antibot.cpp
+++ b/src/engine/server/antibot.cpp
@@ -1,8 +1,7 @@
 #include "antibot.h"
 
-#include <antibot/antibot_interface.h>
-
 #include <base/dbg.h>
+#include <base/log.h>
 #include <base/mem.h>
 #include <base/str.h>
 #include <base/time.h>
@@ -14,8 +13,65 @@
 class IEngineAntibot;
 
 #ifdef CONF_ANTIBOT
+#if defined(CONF_FAMILY_WINDOWS)
+#include <base/windows.h>
+
+#include <windows.h>
+static void *ModuleOpen(const char *pName)
+{
+	void *pModule = LoadLibraryA(pName);
+	if(!pModule)
+		log_error("antibot", "failed to load antibot module '%s': %s", pName, windows_format_system_message(GetLastError()).c_str());
+	return pModule;
+}
+static void *ModuleSymbol(void *pModule, const char *pName)
+{
+	return (void *)GetProcAddress((HMODULE)pModule, pName);
+}
+static void ModuleClose(void *pModule)
+{
+	FreeLibrary((HMODULE)pModule);
+}
+#else
+#include <dlfcn.h>
+static void *ModuleOpen(const char *pName)
+{
+	void *pModule = dlopen(pName, RTLD_NOW);
+	if(!pModule)
+		log_error("antibot", "failed to load antibot module: %s", dlerror());
+	return pModule;
+}
+static void *ModuleSymbol(void *pModule, const char *pName)
+{
+	return dlsym(pModule, pName);
+}
+static void ModuleClose(void *pModule)
+{
+	dlclose(pModule);
+}
+#endif
+
+template<typename F>
+static bool LoadSymbol(void *pModule, F &pfnSymbol, const char *pName)
+{
+	pfnSymbol = (F)ModuleSymbol(pModule, pName);
+	if(!pfnSymbol)
+		log_error("antibot", "antibot module is missing symbol '%s'", pName);
+	return pfnSymbol != nullptr;
+}
+
+// Stands in for the module functions while no module is loaded
+template<typename F>
+class CNullFunction;
+template<typename R, typename... Args>
+class CNullFunction<R (*)(Args...)>
+{
+public:
+	static R Call(Args...) { return R(); }
+};
+
 CAntibot::CAntibot() :
-	m_pServer(nullptr), m_pConsole(nullptr), m_pGameServer(nullptr), m_Initialized(false)
+	m_pServer(nullptr), m_pConsole(nullptr), m_pGameServer(nullptr)
 {
 }
 CAntibot::~CAntibot()
@@ -23,8 +79,11 @@ CAntibot::~CAntibot()
 	if(m_pGameServer)
 		free(m_RoundData.m_Map.m_pTiles);
 
-	if(m_Initialized)
-		AntibotDestroy();
+	if(m_pModule)
+	{
+		m_pfnDestroy();
+		ModuleClose(m_pModule);
+	}
 }
 void CAntibot::Kick(int ClientId, const char *pMessage, void *pUser)
 {
@@ -67,7 +126,31 @@ void CAntibot::Init()
 	m_pServer = Kernel()->RequestInterface<IServer>();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
 	dbg_assert(m_pServer && m_pConsole, "antibot requires server and console");
-	dbg_assert(AntibotAbiVersion() == ANTIBOT_ABI_VERSION, "antibot abi version mismatch (antibot=%d server=%d)", AntibotAbiVersion(), ANTIBOT_ABI_VERSION);
+	bool Loaded = LoadModule();
+	dbg_assert(Loaded, "failed to load antibot module");
+}
+bool CAntibot::LoadModule()
+{
+	m_pModule = ModuleOpen(ANTIBOT_LIBRARY);
+	if(!m_pModule)
+	{
+		return false;
+	}
+	bool Loaded = true;
+#define MACRO_ANTIBOT_FUNCTION(Name) Loaded &= LoadSymbol(m_pModule, m_pfn##Name, "Antibot" #Name);
+	ANTIBOT_FUNCTIONS(MACRO_ANTIBOT_FUNCTION)
+#undef MACRO_ANTIBOT_FUNCTION
+	if(Loaded && m_pfnAbiVersion() != ANTIBOT_ABI_VERSION)
+	{
+		log_error("antibot", "antibot abi version mismatch (antibot=%d server=%d)", m_pfnAbiVersion(), ANTIBOT_ABI_VERSION);
+		Loaded = false;
+	}
+	if(!Loaded)
+	{
+		ModuleClose(m_pModule);
+		m_pModule = nullptr;
+		return false;
+	}
 
 	mem_zero(&m_Data, sizeof(m_Data));
 	CAntibotVersion Version = ANTIBOT_VERSION;
@@ -81,29 +164,76 @@ void CAntibot::Init()
 	m_Data.m_pfnSend = Send;
 	m_Data.m_pfnTeehistorian = Teehistorian;
 	m_Data.m_pUser = this;
-	AntibotInit(&m_Data);
+	m_pfnInit(&m_Data);
+	return true;
+}
+void CAntibot::Reload()
+{
+	if(!m_pServer)
+	{
+		return;
+	}
+	if(!GameServer())
+	{
+		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "antibot", "cannot reload antibot outside of a round");
+		return;
+	}
+	// The loader returns the already loaded module for its name instead of
+	// reading the replaced file, so the old module has to go first.
+	m_pfnRoundEnd();
+	m_pfnDestroy();
+	if(m_pModule)
+	{
+		ModuleClose(m_pModule);
+	}
+	if(!LoadModule())
+	{
+#define MACRO_ANTIBOT_FUNCTION(Name) m_pfn##Name = CNullFunction<decltype(m_pfn##Name)>::Call;
+		ANTIBOT_FUNCTIONS(MACRO_ANTIBOT_FUNCTION)
+#undef MACRO_ANTIBOT_FUNCTION
+		log_error("antibot", "running without antibot until reload_antibot succeeds");
+		return;
+	}
 
-	m_Initialized = true;
+	// Replay the events the new module missed, in the order of a server start.
+	m_pfnRoundStart(&m_RoundData);
+	Update();
+	for(int ClientId = 0; ClientId < MAX_CLIENTS; ClientId++)
+	{
+		if(Server()->ClientSlotEmpty(ClientId))
+		{
+			continue;
+		}
+		m_pfnOnEngineClientJoin(ClientId);
+		if(GameServer()->PlayerExists(ClientId))
+		{
+			m_pfnOnPlayerInit(ClientId);
+			if(m_RoundData.m_aCharacters[ClientId].m_Alive)
+			{
+				m_pfnOnSpawn(ClientId);
+			}
+		}
+	}
 }
 void CAntibot::RoundStart(IGameServer *pGameServer)
 {
 	m_pGameServer = pGameServer;
 	mem_zero(&m_RoundData, sizeof(m_RoundData));
 	m_RoundData.m_Map.m_pTiles = nullptr;
-	AntibotRoundStart(&m_RoundData);
+	m_pfnRoundStart(&m_RoundData);
 	Update();
 }
 void CAntibot::RoundEnd()
 {
 	// Let the external module clean up first
-	AntibotRoundEnd();
+	m_pfnRoundEnd();
 
 	m_pGameServer = nullptr;
 	free(m_RoundData.m_Map.m_pTiles);
 }
 void CAntibot::ConsoleCommand(const char *pCommand)
 {
-	AntibotConsoleCommand(pCommand);
+	m_pfnConsoleCommand(pCommand);
 }
 void CAntibot::Update()
 {
@@ -114,70 +244,70 @@ void CAntibot::Update()
 	if(GameServer())
 	{
 		GameServer()->FillAntibot(&m_RoundData);
-		AntibotUpdateData();
+		m_pfnUpdateData();
 	}
 }
 
 void CAntibot::OnPlayerInit(int ClientId)
 {
 	Update();
-	AntibotOnPlayerInit(ClientId);
+	m_pfnOnPlayerInit(ClientId);
 }
 void CAntibot::OnPlayerDestroy(int ClientId)
 {
 	Update();
-	AntibotOnPlayerDestroy(ClientId);
+	m_pfnOnPlayerDestroy(ClientId);
 }
 void CAntibot::OnSpawn(int ClientId)
 {
 	Update();
-	AntibotOnSpawn(ClientId);
+	m_pfnOnSpawn(ClientId);
 }
 void CAntibot::OnHammerFireReloading(int ClientId)
 {
 	Update();
-	AntibotOnHammerFireReloading(ClientId);
+	m_pfnOnHammerFireReloading(ClientId);
 }
 void CAntibot::OnHammerFire(int ClientId)
 {
 	Update();
-	AntibotOnHammerFire(ClientId);
+	m_pfnOnHammerFire(ClientId);
 }
 void CAntibot::OnHammerHit(int ClientId, int TargetId)
 {
 	Update();
-	AntibotOnHammerHit(ClientId, TargetId);
+	m_pfnOnHammerHit(ClientId, TargetId);
 }
 void CAntibot::OnDirectInput(int ClientId)
 {
 	Update();
-	AntibotOnDirectInput(ClientId);
+	m_pfnOnDirectInput(ClientId);
 }
 void CAntibot::OnCharacterTick(int ClientId)
 {
 	Update();
-	AntibotOnCharacterTick(ClientId);
+	m_pfnOnCharacterTick(ClientId);
 }
 void CAntibot::OnHookAttach(int ClientId, bool Player)
 {
 	Update();
-	AntibotOnHookAttach(ClientId, Player);
+	m_pfnOnHookAttach(ClientId, Player);
 }
 
 void CAntibot::OnEngineTick()
 {
 	Update();
-	AntibotOnEngineTick();
+	m_pfnOnEngineTick();
 }
 void CAntibot::OnEngineClientJoin(int ClientId)
 {
 	Update();
-	AntibotOnEngineClientJoin(ClientId);
+	m_pfnOnEngineClientJoin(ClientId);
 }
 void CAntibot::OnEngineClientDrop(int ClientId, const char *pReason)
 {
 	Update();
-	AntibotOnEngineClientDrop(ClientId, pReason);
+	m_pfnOnEngineClientDrop(ClientId, pReason);
 }
 bool CAntibot::OnEngineClientMessage(int ClientId, const void *pData, int Size, int Flags)
 {
@@ -187,7 +317,7 @@ bool CAntibot::OnEngineClientMessage(int ClientId, const void *pData, int Size, 
 	{
 		AntibotFlags |= ANTIBOT_MSGFLAG_NONVITAL;
 	}
-	return AntibotOnEngineClientMessage(ClientId, pData, Size, AntibotFlags);
+	return m_pfnOnEngineClientMessage(ClientId, pData, Size, AntibotFlags);
 }
 bool CAntibot::OnEngineServerMessage(int ClientId, const void *pData, int Size, int Flags)
 {
@@ -197,12 +327,12 @@ bool CAntibot::OnEngineServerMessage(int ClientId, const void *pData, int Size, 
 	{
 		AntibotFlags |= ANTIBOT_MSGFLAG_NONVITAL;
 	}
-	return AntibotOnEngineServerMessage(ClientId, pData, Size, AntibotFlags);
+	return m_pfnOnEngineServerMessage(ClientId, pData, Size, AntibotFlags);
 }
 bool CAntibot::OnEngineSimulateClientMessage(int *pClientId, void *pBuffer, int BufferSize, int *pOutSize, int *pFlags)
 {
 	int AntibotFlags = 0;
-	bool Result = AntibotOnEngineSimulateClientMessage(pClientId, pBuffer, BufferSize, pOutSize, &AntibotFlags);
+	bool Result = m_pfnOnEngineSimulateClientMessage(pClientId, pBuffer, BufferSize, pOutSize, &AntibotFlags);
 	if(Result)
 	{
 		*pFlags = 0;
@@ -215,7 +345,7 @@ bool CAntibot::OnEngineSimulateClientMessage(int *pClientId, void *pBuffer, int 
 }
 #else
 CAntibot::CAntibot() :
-	m_pServer(nullptr), m_pConsole(nullptr), m_pGameServer(nullptr), m_Initialized(false)
+	m_pServer(nullptr), m_pConsole(nullptr), m_pGameServer(nullptr)
 {
 }
 CAntibot::~CAntibot() = default;
@@ -232,6 +362,14 @@ void CAntibot::RoundStart(IGameServer *pGameServer)
 void CAntibot::RoundEnd()
 {
 	m_pGameServer = nullptr;
+}
+void CAntibot::Reload()
+{
+	if(!m_pConsole)
+	{
+		return;
+	}
+	Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "antibot", "antibot support not compiled in");
 }
 void CAntibot::ConsoleCommand(const char *pCommand)
 {

--- a/src/engine/server/antibot.h
+++ b/src/engine/server/antibot.h
@@ -1,9 +1,33 @@
 #ifndef ENGINE_SERVER_ANTIBOT_H
 #define ENGINE_SERVER_ANTIBOT_H
 
-#include <antibot/antibot_data.h>
+#include <antibot/antibot_interface.h>
 
 #include <engine/antibot.h>
+
+#define ANTIBOT_FUNCTIONS(MACRO) \
+	MACRO(AbiVersion) \
+	MACRO(Init) \
+	MACRO(RoundStart) \
+	MACRO(RoundEnd) \
+	MACRO(UpdateData) \
+	MACRO(Destroy) \
+	MACRO(ConsoleCommand) \
+	MACRO(OnPlayerInit) \
+	MACRO(OnPlayerDestroy) \
+	MACRO(OnSpawn) \
+	MACRO(OnHammerFireReloading) \
+	MACRO(OnHammerFire) \
+	MACRO(OnHammerHit) \
+	MACRO(OnDirectInput) \
+	MACRO(OnCharacterTick) \
+	MACRO(OnHookAttach) \
+	MACRO(OnEngineTick) \
+	MACRO(OnEngineClientJoin) \
+	MACRO(OnEngineClientDrop) \
+	MACRO(OnEngineClientMessage) \
+	MACRO(OnEngineServerMessage) \
+	MACRO(OnEngineSimulateClientMessage)
 
 class CAntibot : public IEngineAntibot
 {
@@ -17,8 +41,13 @@ class CAntibot : public IEngineAntibot
 
 	CAntibotData m_Data;
 	CAntibotRoundData m_RoundData;
-	bool m_Initialized;
 
+	void *m_pModule = nullptr;
+#define MACRO_ANTIBOT_FUNCTION(Name) decltype(&Antibot##Name) m_pfn##Name = nullptr;
+	ANTIBOT_FUNCTIONS(MACRO_ANTIBOT_FUNCTION)
+#undef MACRO_ANTIBOT_FUNCTION
+
+	bool LoadModule();
 	void Update();
 	static void Kick(int ClientId, const char *pMessage, void *pUser);
 	static void Log(const char *pMessage, void *pUser);
@@ -32,6 +61,7 @@ public:
 
 	// Engine
 	void Init() override;
+	void Reload() override;
 
 	void OnEngineTick() override;
 	void OnEngineClientJoin(int ClientId) override;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -4214,6 +4214,11 @@ void CServer::ConMapReload(IConsole::IResult *pResult, void *pUser)
 	((CServer *)pUser)->ReloadMap();
 }
 
+void CServer::ConReloadAntibot(IConsole::IResult *pResult, void *pUser)
+{
+	((CServer *)pUser)->Antibot()->Reload();
+}
+
 void CServer::ConLogout(IConsole::IResult *pResult, void *pUser)
 {
 	CServer *pServer = (CServer *)pUser;
@@ -4656,6 +4661,7 @@ void CServer::RegisterCommands()
 	Console()->Register("stoprecord", "", CFGFLAG_SERVER, ConStopRecord, this, "Stop recording");
 
 	Console()->Register("reload", "", CFGFLAG_SERVER, ConMapReload, this, "Reload the map");
+	Console()->Register("reload_antibot", "", CFGFLAG_SERVER, ConReloadAntibot, this, "Reload the antibot module");
 
 	Console()->Register("add_sqlserver", "s['r'|'w'] s[Database] s[Prefix] s[User] s[Password] s[IP] i[Port] ?i[SetUpDatabase ?] ?i[SSL ?]", CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, ConAddSqlServer, this, "add a sqlserver");
 	Console()->Register("dump_sqlservers", "s['r'|'w']", CFGFLAG_SERVER, ConDumpSqlServers, this, "dumps all sqlservers readservers = r, writeservers = w");

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -449,6 +449,7 @@ public:
 	static void ConRecord(IConsole::IResult *pResult, void *pUser);
 	static void ConStopRecord(IConsole::IResult *pResult, void *pUser);
 	static void ConMapReload(IConsole::IResult *pResult, void *pUser);
+	static void ConReloadAntibot(IConsole::IResult *pResult, void *pUser);
 	static void ConLogout(IConsole::IResult *pResult, void *pUser);
 	static void ConShowIps(IConsole::IResult *pResult, void *pUser);
 	static void ConHideAuthStatus(IConsole::IResult *pResult, void *pUser);


### PR DESCRIPTION
Hot reloading takes ~0.2ms on my system with 128 players, so should hopefully be ok in production.

This is useful to iterate on antibot faster. Tested on macOS and Linux only.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5.1 and Opus 5).
