### PR TITLE
client: Fix crash when refreshing skins while skins are still loading

### DIFF
--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -688,6 +688,7 @@ void CSkins::Refresh(TSkinLoadedCallback &&SkinLoadedCallback)
 		if(pSkinContainer->m_pLoadJob)
 		{
 			pSkinContainer->m_pLoadJob->Abort();
+			pSkinContainer->m_pLoadJob = nullptr;
 		}
 		if(pSkinContainer->m_pSkin)
 		{


### PR DESCRIPTION
Introduced in #12739

Reproduced the crash before by just clicking refresh a few times:
```
../src/game/client/components/skins.cpp(60): Skin container load job was not cleared
```

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5)
