### PR TITLE
client: Fix segfault on quit with OpenGL 2

### DIFF
--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -1581,6 +1581,8 @@ bool CCommandProcessorFragment_OpenGL2::Cmd_Init(const SCommand_Init *pCommand)
 
 	m_pTileProgram = nullptr;
 	m_pTileProgramTextured = nullptr;
+	m_pBorderTileProgram = nullptr;
+	m_pBorderTileProgramTextured = nullptr;
 	m_pPrimitive3DProgram = nullptr;
 	m_pPrimitive3DProgramTextured = nullptr;
 
@@ -1801,21 +1803,21 @@ void CCommandProcessorFragment_OpenGL2::Cmd_Shutdown(const SCommand_Shutdown *pC
 	if(m_HasShaders)
 	{
 		glUseProgram(0);
+
+		m_pTileProgram->DeleteProgram();
+		m_pTileProgramTextured->DeleteProgram();
+		m_pBorderTileProgram->DeleteProgram();
+		m_pBorderTileProgramTextured->DeleteProgram();
+		m_pPrimitive3DProgram->DeleteProgram();
+		m_pPrimitive3DProgramTextured->DeleteProgram();
+
+		delete m_pTileProgram;
+		delete m_pTileProgramTextured;
+		delete m_pBorderTileProgram;
+		delete m_pBorderTileProgramTextured;
+		delete m_pPrimitive3DProgram;
+		delete m_pPrimitive3DProgramTextured;
 	}
-
-	m_pTileProgram->DeleteProgram();
-	m_pTileProgramTextured->DeleteProgram();
-	m_pBorderTileProgram->DeleteProgram();
-	m_pBorderTileProgramTextured->DeleteProgram();
-	m_pPrimitive3DProgram->DeleteProgram();
-	m_pPrimitive3DProgramTextured->DeleteProgram();
-
-	delete m_pTileProgram;
-	delete m_pTileProgramTextured;
-	delete m_pBorderTileProgram;
-	delete m_pBorderTileProgramTextured;
-	delete m_pPrimitive3DProgram;
-	delete m_pPrimitive3DProgramTextured;
 
 	for(int i = 0; i < (int)m_vTextures.size(); ++i)
 	{


### PR DESCRIPTION
Reproducer is very easy: F1, `gfx_gl_major 2`, restart twice:
```
zsh: segmentation fault  build/DDNet
```

Introduced in #12634

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5)