### PR TITLE
Make server status command filter by client id instead of name

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3753,14 +3753,20 @@ void CServer::ConStatus(IConsole::IResult *pResult, void *pUser)
 {
 	char aBuf[1024];
 	CServer *pThis = static_cast<CServer *>(pUser);
-	const char *pName = pResult->NumArguments() == 1 ? pResult->GetString(0) : "";
+	const int RequestedId = pResult->NumArguments() == 1 ? pResult->GetInteger(0) : -1;
+
+	if(pResult->NumArguments() == 1 && (RequestedId < 0 || RequestedId >= MAX_CLIENTS || pThis->m_aClients[RequestedId].m_State == CClient::STATE_EMPTY))
+	{
+		pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", "invalid client id");
+		return;
+	}
 
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		if(pThis->m_aClients[i].m_State == CClient::STATE_EMPTY)
 			continue;
 
-		if(!str_utf8_find_nocase(pThis->m_aClients[i].m_aName, pName))
+		if(RequestedId >= 0 && i != RequestedId)
 			continue;
 
 		if(pThis->m_aClients[i].m_State == CClient::STATE_INGAME)
@@ -4645,7 +4651,7 @@ void CServer::RegisterCommands()
 
 	// register console commands
 	Console()->Register("kick", "v[id] ?r[reason]", CFGFLAG_SERVER, ConKick, this, "Kick player with specified id for any reason");
-	Console()->Register("status", "?r[name]", CFGFLAG_SERVER, ConStatus, this, "List players containing name or all players");
+	Console()->Register("status", "?i[id]", CFGFLAG_SERVER, ConStatus, this, "List the player with this client id or all players");
 	Console()->Register("shutdown", "?r[reason]", CFGFLAG_SERVER, ConShutdown, this, "Shut down");
 	Console()->Register("logout", "", CFGFLAG_SERVER, ConLogout, this, "Logout of rcon");
 	Console()->Register("show_ips", "?i[show]", CFGFLAG_SERVER, ConShowIps, this, "Show IP addresses in rcon commands (1 = on, 0 = off)");


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
Unsure why "name" was the default. ID is just so much easier.
<details>
<summary>Output</summary>

```
> status 0
2026-09-02 22:28:57 I server: ClientId=1 key='murpi' rcon='status 0'
2026-09-02 22:28:57 I server: id=0 addr=XXX name='tuzi-egg' client=20010 secure=yes flags=66 key='murpi' (Admin)
> status
2026-09-02 22:28:59 I server: ClientId=1 key='murpi' rcon='status'
2026-09-02 22:28:59 I server: id=0 addr=XXX name='tuzi-egg' client=20010 secure=yes flags=66 key='murpi' (Admin)
2026-09-02 22:28:59 I server: id=1 addr=XXX name='egg-egg' client=20010 secure=yes flags=129 key='murpi' (Admin)
> status -1
2026-09-02 22:29:03 I server: ClientId=1 key='murpi' rcon='status -1'
2026-09-02 22:29:03 I server: invalid client id
> status 999
2026-09-02 22:29:06 I server: ClientId=1 key='murpi' rcon='status 999'
2026-09-02 22:29:06 I server: invalid client id
```

</details>
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
