### PR TITLE
client: Fix "see others by vote" rate limit

### DIFF
--- a/src/game/server/playermapping.cpp
+++ b/src/game/server/playermapping.cpp
@@ -238,14 +238,11 @@ void CPlayerMapping::CPlayerMap::Update()
 	if(m_pPlayerMapping->Server()->ClientSupportsServerMaxClients(m_ClientId))
 		return;
 
-	if(m_DoSeeOthersByVoteTick > 0)
+	if(m_DoSeeOthersByVoteTick > 0 && m_SeeOthersPage != -1)
 	{
 		CCharacter *pChr = m_pPlayerMapping->GameServer()->GetPlayerChar(m_ClientId);
 		if(pChr && !pChr->IsIdle())
-		{
 			ResetSeeOthers();
-			m_DoSeeOthersByVoteTick = 0;
-		}
 	}
 
 	bool ResortReserved = m_ResortReserved;


### PR DESCRIPTION
It had no effect because CPlayerMap::Update cleared the tick as soon as the player started moving.

Introduced in #12603 CC @fokkonaut 

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude code (Opus 5)
