### PR TITLE
Skip reopening the audio device while the system reports no output device

### DIFF
--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -302,6 +302,11 @@ void CSound::UpdateDevice()
 		CloseDevice();
 	}
 
+	// Opening the device when the system has none blocks for up to eight seconds
+	// in SDL's WASAPI backend, which would stall the main loop
+	if(SDL_GetNumAudioDevices(0) <= 0)
+		return;
+
 	if(!m_DeviceChanged.exchange(false, std::memory_order_relaxed))
 		return;
 


### PR DESCRIPTION
Skip reopening the audio device while the system reports no output device

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Claude read the SDL sources to work out why the open blocks and wrote this change.
