### PR TITLE
Add missing includes

### DIFF
--- a/src/engine/shared/fifo.cpp
+++ b/src/engine/shared/fifo.cpp
@@ -10,6 +10,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <cerrno>
 #include <cstdlib>
 
 void CFifo::Init(IConsole *pConsole, const char *pFifoFile, int Flag)

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -11,6 +11,7 @@
 
 #include <array>
 #include <optional>
+#include <vector>
 
 class CHuffman;
 class CNetBan;

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -14,6 +14,7 @@
 #include <generated/protocol7.h>
 #include <generated/protocolglue.h>
 
+#include <algorithm>
 #include <cstdlib>
 #include <limits>
 


### PR DESCRIPTION
Noticed with clang23 on macOS

src/engine/shared/network.h: std::vector
src/engine/shared/fifo.cpp: errno
src/engine/shared/snapshot.cpp: std::fill

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code
