### PR TITLE
client: Allow 0.6 and 0.7 servers to coexist in LAN server browser

### DIFF
--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -601,7 +601,7 @@ void CNetTokenCache::AddToken(const NETADDR *pAddr, TOKEN Token)
 
 	for(auto Iter = m_ConnlessPackets.begin(); Iter != m_ConnlessPackets.end();)
 	{
-		if(Iter->m_Addr == NullAddr)
+		if(Iter->m_Addr == *pAddr || Iter->m_Addr == NullAddr)
 		{
 			CNetBase::SendPacketConnlessWithToken7(m_Socket, &Iter->m_Addr, Iter->m_aData, Iter->m_DataSize, Token, GenerateToken());
 

--- a/src/engine/shared/network_client.cpp
+++ b/src/engine/shared/network_client.cpp
@@ -109,9 +109,10 @@ int CNetClient::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken, bool Six
 		}
 
 		SECURITY_TOKEN Token;
-		if(CNetBase::UnpackPacket(pData, Bytes, &m_RecvBuffer, Sixup, true, &Token, pResponseToken) == 0)
+		bool PacketSixup = Sixup;
+		if(CNetBase::UnpackPacket(pData, Bytes, &m_RecvBuffer, PacketSixup, true, &Token, pResponseToken) == 0)
 		{
-			if(Sixup)
+			if(PacketSixup)
 			{
 				Addr.type |= NETTYPE_TW7;
 			}
@@ -132,7 +133,7 @@ int CNetClient::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken, bool Six
 			else
 			{
 				const bool Control = (m_RecvBuffer.m_Flags & NET_PACKETFLAG_CONTROL) != 0;
-				if(Sixup &&
+				if(PacketSixup &&
 					Control &&
 					m_RecvBuffer.m_DataSize >= 1 + (int)sizeof(SECURITY_TOKEN) &&
 					m_RecvBuffer.m_aChunkData[0] == protocol7::NET_CTRLMSG_TOKEN)


### PR DESCRIPTION
Otherwise the first sixup packet sets Sixup = true and it persists

Related to #8992 cc @MilkeeyCat 
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5)
