### PR TITLE
Fix map bugs not being compared based on SHA256

### DIFF
--- a/src/game/mapbugs.cpp
+++ b/src/game/mapbugs.cpp
@@ -12,7 +12,8 @@ struct CMapDescription
 	bool operator==(const CMapDescription &Other) const
 	{
 		return str_comp(m_pName, Other.m_pName) == 0 &&
-		       m_Size == Other.m_Size;
+		       m_Size == Other.m_Size &&
+		       m_Sha256 == Other.m_Sha256;
 	}
 };
 

--- a/src/test/mapbugs_test.cpp
+++ b/src/test/mapbugs_test.cpp
@@ -18,8 +18,9 @@ static CMapBugs GetMapBugsImpl(const char *pName, int Size, const char *pSha256)
 TEST(MapBugs, Contains)
 {
 	EXPECT_TRUE(GetMapBugsImpl("Binary", 2022597, BINARY_SHA256).Contains(BUG_GRENADE_DOUBLEEXPLOSION));
-	EXPECT_FALSE(GetMapBugsImpl("Binarx", 2022597, BINARY_SHA256).Contains(BUG_GRENADE_DOUBLEEXPLOSION));
-	EXPECT_FALSE(GetMapBugsImpl("Binary", 2022598, BINARY_SHA256).Contains(BUG_GRENADE_DOUBLEEXPLOSION));
+	EXPECT_FALSE(GetMapBugsImpl("Binarx", 2022597, BINARY_SHA256).Contains(BUG_GRENADE_DOUBLEEXPLOSION)); // mismatched name
+	EXPECT_FALSE(GetMapBugsImpl("Binary", 2022598, BINARY_SHA256).Contains(BUG_GRENADE_DOUBLEEXPLOSION)); // mismatched size
+	EXPECT_FALSE(GetMapBugsImpl("Binary", 2022597, DM1_SHA256).Contains(BUG_GRENADE_DOUBLEEXPLOSION)); // mismatched SHA256
 	EXPECT_FALSE(GetMapBugsImpl("dm1", 5805, DM1_SHA256).Contains(BUG_GRENADE_DOUBLEEXPLOSION));
 }
 


### PR DESCRIPTION
Regression from #1259 which added the SHA256 to the map bugs without using it in `CMapDescription::operator==` and from #3054 which removed the comparison of the CRC.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

AI found the issue.
