### PR TITLE
Fix crash on invalid maps that share tile layer data with other items

### DIFF
--- a/src/engine/map.h
+++ b/src/engine/map.h
@@ -26,6 +26,8 @@ public:
 	virtual void *GetDataSwapped(int Index) = 0;
 	virtual const char *GetDataString(int Index) = 0;
 	virtual void UnloadData(int Index) = 0;
+	// Keep layer data loaded, called by the game which uses it directly, not the editor which copies it.
+	virtual void PinLayerData() = 0;
 	virtual int NumData() const = 0;
 
 	virtual int GetItemSize(int Index) = 0;

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -42,7 +42,15 @@ const char *CMap::GetDataString(int Index)
 
 void CMap::UnloadData(int Index)
 {
+	// Don't unload layer data shared with another item, its users keep raw pointers into it.
+	if(m_LayerDataPinned && m_LayerDataIndices.contains(Index))
+		return;
 	m_DataFile.UnloadData(Index);
+}
+
+void CMap::PinLayerData()
+{
+	m_LayerDataPinned = true;
 }
 
 int CMap::NumData() const
@@ -170,18 +178,30 @@ bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, in
 
 	// Lazily validate data and replace compressed tile layers with uncompressed ones.
 	std::set<int> UsedDataIndices;
+	// The rendering keeps raw pointers into quads and sound layer data for the map's lifetime.
+	// Collected separately so they don't feed the tile layer data uniqueness check, merged in below.
+	std::set<int> OtherLayerDataIndices;
 	for(int GroupIndex = 0; GroupIndex < GroupsNum; GroupIndex++)
 	{
 		const CMapItemGroup *pGroup = static_cast<CMapItemGroup *>(NewDataFile.GetItem(GroupsStart + GroupIndex));
 		for(int LayerIndex = 0; LayerIndex < pGroup->m_NumLayers; LayerIndex++)
 		{
-			CMapItemLayer *pLayer = static_cast<CMapItemLayer *>(NewDataFile.GetItem(LayersStart + pGroup->m_StartLayer + LayerIndex));
+			const int LayerItemIndex = LayersStart + pGroup->m_StartLayer + LayerIndex;
+			CMapItemLayer *pLayer = static_cast<CMapItemLayer *>(NewDataFile.GetItem(LayerItemIndex));
 			if(pLayer->m_Type == LAYERTYPE_TILES)
 			{
 				if(!ValidateAndUnpackTilesLayerData(NewDataFile, GroupIndex, LayerIndex, reinterpret_cast<const CMapItemLayerTilemap *>(pLayer), *pGameLayer, UsedDataIndices))
 				{
 					return false;
 				}
+			}
+			else if(pLayer->m_Type == LAYERTYPE_QUADS && NewDataFile.GetItemSize(LayerItemIndex) >= (int)(offsetof(CMapItemLayerQuads, m_Data) + sizeof(CMapItemLayerQuads::m_Data)))
+			{
+				OtherLayerDataIndices.emplace(reinterpret_cast<const CMapItemLayerQuads *>(pLayer)->m_Data);
+			}
+			else if(pLayer->m_Type == LAYERTYPE_SOUNDS && NewDataFile.GetItemSize(LayerItemIndex) >= (int)(offsetof(CMapItemLayerSounds, m_Data) + sizeof(CMapItemLayerSounds::m_Data)))
+			{
+				OtherLayerDataIndices.emplace(reinterpret_cast<const CMapItemLayerSounds *>(pLayer)->m_Data);
 			}
 		}
 	}
@@ -197,6 +217,9 @@ bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, in
 	// Replace existing datafile with new datafile
 	m_DataFile.Close();
 	m_DataFile = std::move(NewDataFile);
+	UsedDataIndices.insert(OtherLayerDataIndices.begin(), OtherLayerDataIndices.end());
+	m_LayerDataIndices = std::move(UsedDataIndices);
+	m_LayerDataPinned = false;
 	return true;
 }
 
@@ -210,6 +233,8 @@ bool CMap::Load(IStorage *pStorage, const char *pPath, int StorageType)
 void CMap::Unload()
 {
 	m_DataFile.Close();
+	m_LayerDataIndices.clear();
+	m_LayerDataPinned = false;
 }
 
 bool CMap::IsLoaded() const

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -18,6 +18,9 @@ class CMap : public IMap
 {
 	CDataFileReader m_DataFile;
 
+	std::set<int> m_LayerDataIndices;
+	bool m_LayerDataPinned = false;
+
 public:
 	CMap();
 	~CMap() override;
@@ -27,6 +30,7 @@ public:
 	void *GetDataSwapped(int Index) override;
 	const char *GetDataString(int Index) override;
 	void UnloadData(int Index) override;
+	void PinLayerData() override;
 	int NumData() const override;
 
 	int GetItemSize(int Index) override;

--- a/src/game/layers.cpp
+++ b/src/game/layers.cpp
@@ -16,6 +16,8 @@ void CLayers::Init(IMap *pMap, bool GameOnly, bool InitializeTilemapSkip)
 	Unload();
 
 	m_pMap = pMap;
+	// The collision and rendering keep raw pointers into the layer data, so it must stay loaded.
+	m_pMap->PinLayerData();
 	m_pMap->GetType(MAPITEMTYPE_GROUP, &m_GroupsStart, &m_GroupsNum);
 	m_pMap->GetType(MAPITEMTYPE_LAYER, &m_LayersStart, &m_LayersNum);
 


### PR DESCRIPTION
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5, Opus 4.8 and Fable 5.1)
