### PR TITLE
server: Fix reconnecting to previously used slot

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1179,6 +1179,7 @@ int CServer::ClientRejoinCallback(int ClientId, void *pUser, bool Sixup, bool Va
 
 	if(pThis->m_aClients[ClientId].m_State != CClient::STATE_INGAME)
 	{
+		DelClientCallback(ClientId, "reconnect", pUser);
 		if(VanillaAuth)
 			return NewClientNoAuthCallback(ClientId, pUser);
 		return NewClientCallback(ClientId, pUser, Sixup);


### PR DESCRIPTION
Seen on servers:
```
E assert: /DDNet/src/engine/server/server.cpp(750): Client slot 7 is empty
```

Broken by #12679 CC @fokkonaut 


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5)
