### PR TITLE
snapshots: Prevent overflow on 32bit systems

### DIFF
--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -418,12 +418,12 @@ int CSnapshotDelta::DebugDumpDelta(const void *pSrcData, int DataSize)
 		dbg_msg("delta_dump", "|  Invalid delta. Number of deleted items %d is negative.", pDelta->m_NumDeletedItems);
 		return -201;
 	}
-	pData += pDelta->m_NumDeletedItems;
-	if(pData > pEnd)
+	if(pDelta->m_NumDeletedItems > pEnd - pData)
 	{
 		dbg_msg("delta_dump", "|  Invalid delta. Read past the end.");
 		return -101;
 	}
+	pData += pDelta->m_NumDeletedItems;
 
 	// list deleted items
 	// (all other items should be copied from the last full snap)
@@ -526,9 +526,9 @@ int CSnapshotDelta::UnpackDelta(const CSnapshot *pFrom, CSnapshotBuffer *pTo, co
 	int *pDeleted = pData;
 	if(pDelta->m_NumDeletedItems < 0)
 		return -201;
-	pData += pDelta->m_NumDeletedItems;
-	if(pData > pEnd)
+	if(pDelta->m_NumDeletedItems > pEnd - pData)
 		return -101;
+	pData += pDelta->m_NumDeletedItems;
 
 	// copy all non deleted stuff
 	for(int i = 0; i < pFrom->NumItems(); i++)


### PR DESCRIPTION
Maybe someone still uses the Win32 version.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Opus 5)
