### PR TITLE
DRAFT: Prediction desync detection

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -321,6 +321,7 @@ MACRO_CONFIG_INT(ClVideoX264Preset, cl_video_preset, 5, 0, 9, CFGFLAG_CLIENT | C
 MACRO_CONFIG_INT(DbgDummies, dbg_dummies, 0, 0, SERVER_MAX_CLIENTS, CFGFLAG_DEBUG_SERVER, "Add debug dummies to server (Debug build only)")
 
 MACRO_CONFIG_INT(DbgTuning, dbg_tuning, 0, 0, 2, CFGFLAG_CLIENT, "Display information about the tuning parameters that affect the own player (0 = off, 1 = show changed, 2 = show all)")
+MACRO_CONFIG_INT(DbgPredictionDesync, dbg_prediction_desync, 0, 0, 2, CFGFLAG_CLIENT, "Log where the prediction since the previous snapshot differs from the new snapshot (0 = off, 1 = own tees, 2 = all tees)")
 
 MACRO_CONFIG_STR(PlayerName, player_name, 16, "", CFGFLAG_SAVE | CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Name of the player")
 MACRO_CONFIG_STR(PlayerClan, player_clan, 12, "", CFGFLAG_SAVE | CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Clan of the player")

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -3579,6 +3579,7 @@ void CGameClient::UpdatePrediction()
 	// advance the gameworld to the current gametick
 	if(pLocalChar && absolute(m_GameWorld.GameTick() - Client()->GameTick(g_Config.m_ClDummy)) < Client()->GameTickSpeed())
 	{
+		const bool PredictsFromPrevSnapshot = m_GameWorld.GameTick() == Client()->PrevGameTick(g_Config.m_ClDummy);
 		for(int Tick = m_GameWorld.GameTick() + 1; Tick <= Client()->GameTick(g_Config.m_ClDummy); Tick++)
 		{
 			CNetObj_PlayerInput *pInput = (CNetObj_PlayerInput *)Client()->GetInput(Tick);
@@ -3609,6 +3610,10 @@ void CGameClient::UpdatePrediction()
 					m_aClients[i].m_aPredTick[Tick % 200] = Tick;
 				}
 		}
+
+		// the world now holds the prediction for the tick the new snapshot describes
+		if(g_Config.m_DbgPredictionDesync && PredictsFromPrevSnapshot)
+			LogPredictionDesyncs();
 	}
 	else
 	{
@@ -3646,6 +3651,149 @@ void CGameClient::UpdatePrediction()
 		m_GameWorld.NetObjAdd(EntData.m_Item.m_Id, EntData.m_Item.m_Type, EntData.m_Item.m_pData, EntData.m_pDataEx);
 
 	m_GameWorld.NetObjEnd();
+}
+
+void CGameClient::LogPredictionDesyncs()
+{
+	const int Tick = Client()->GameTick(g_Config.m_ClDummy);
+	const int PredictedTicks = Tick - Client()->PrevGameTick(g_Config.m_ClDummy);
+	for(int i = 0; i < MAX_CLIENTS; i++)
+	{
+		const CSnapState::CCharacterInfo &Info = m_Snap.m_aCharacters[i];
+		const CCharacter *pChar = m_GameWorld.GetCharacterById(i);
+		if(!Info.m_Active || !pChar)
+			continue;
+		const bool Own = i == m_Snap.m_LocalClientId || (PredictDummy() && i == m_aLocalIds[!g_Config.m_ClDummy]);
+		if(!Own && g_Config.m_DbgPredictionDesync < 2)
+			continue;
+
+		char aDiff[512] = "";
+		const auto &&Compare = [&aDiff](const char *pName, int Predicted, int Snapped) {
+			if(Predicted == Snapped)
+				return;
+			char aField[64];
+			str_format(aField, sizeof(aField), " %s %d>%d", pName, Predicted, Snapped);
+			str_append(aDiff, aField);
+		};
+
+		const CCharacterCore &Core = *pChar->Core();
+		CNetObj_CharacterCore Predicted;
+		Core.Write(&Predicted);
+		const CNetObj_Character &Snapped = Info.m_Cur;
+		Compare("x", Predicted.m_X, Snapped.m_X);
+		Compare("y", Predicted.m_Y, Snapped.m_Y);
+		Compare("velx", Predicted.m_VelX, Snapped.m_VelX);
+		Compare("vely", Predicted.m_VelY, Snapped.m_VelY);
+		Compare("hookstate", Predicted.m_HookState, Snapped.m_HookState);
+		Compare("hooktick", Predicted.m_HookTick, Snapped.m_HookTick);
+		Compare("hookx", Predicted.m_HookX, Snapped.m_HookX);
+		Compare("hooky", Predicted.m_HookY, Snapped.m_HookY);
+		Compare("hookdx", Predicted.m_HookDx, Snapped.m_HookDx);
+		Compare("hookdy", Predicted.m_HookDy, Snapped.m_HookDy);
+		Compare("hookedplayer", Predicted.m_HookedPlayer, Snapped.m_HookedPlayer);
+		Compare("jumped", Predicted.m_Jumped, Snapped.m_Jumped);
+		Compare("direction", Predicted.m_Direction, Snapped.m_Direction);
+		Compare("angle", Predicted.m_Angle, Snapped.m_Angle);
+		// own weapon fire is only predicted with antiping weapons
+		const bool AttackTickPredicted = !Own || m_GameWorld.m_WorldConfig.m_PredictWeapons;
+		if(AttackTickPredicted)
+			Compare("attacktick", pChar->GetAttackTick(), Snapped.m_AttackTick);
+
+		// the exact target is only known for own tees, other tees are read with a target of a different length
+		bool InputDiffers = Predicted.m_Direction != Snapped.m_Direction || (!Own && Predicted.m_Angle != Snapped.m_Angle);
+		if(Info.m_HasExtendedData)
+		{
+			const CNetObj_DDNetCharacter &Extended = Info.m_ExtendedData;
+			if(Own)
+			{
+				Compare("targetx", Core.m_Input.m_TargetX, Extended.m_TargetX);
+				Compare("targety", Core.m_Input.m_TargetY, Extended.m_TargetY);
+				InputDiffers = InputDiffers || Core.m_Input.m_TargetX != Extended.m_TargetX || Core.m_Input.m_TargetY != Extended.m_TargetY;
+			}
+			Compare("freezeend", Core.m_DeepFrozen ? -1 : (pChar->m_FreezeTime == 0 ? 0 : Tick + pChar->m_FreezeTime), Extended.m_FreezeEnd);
+			Compare("jumps", Core.m_Jumps, Extended.m_Jumps);
+			// Read() forces the jump count to the maximum when no air jump is left
+			if(Extended.m_JumpedTotal != -1 && !(Snapped.m_Jumped & 2))
+				Compare("jumpedtotal", Core.m_JumpedTotal, Extended.m_JumpedTotal);
+			const std::pair<bool, int> aPredictedFlags[] = {
+				{Core.m_Solo, CHARACTERFLAG_SOLO},
+				{Core.m_Jetpack, CHARACTERFLAG_JETPACK},
+				{Core.m_CollisionDisabled, CHARACTERFLAG_COLLISION_DISABLED},
+				{Core.m_EndlessHook, CHARACTERFLAG_ENDLESS_HOOK},
+				{Core.m_EndlessJump, CHARACTERFLAG_ENDLESS_JUMP},
+				{Core.m_Super, CHARACTERFLAG_SUPER},
+				{Core.m_HammerHitDisabled, CHARACTERFLAG_HAMMER_HIT_DISABLED},
+				{Core.m_ShotgunHitDisabled, CHARACTERFLAG_SHOTGUN_HIT_DISABLED},
+				{Core.m_GrenadeHitDisabled, CHARACTERFLAG_GRENADE_HIT_DISABLED},
+				{Core.m_LaserHitDisabled, CHARACTERFLAG_LASER_HIT_DISABLED},
+				{Core.m_HookHitDisabled, CHARACTERFLAG_HOOK_HIT_DISABLED},
+				{Core.m_HasTelegunGun, CHARACTERFLAG_TELEGUN_GUN},
+				{Core.m_HasTelegunGrenade, CHARACTERFLAG_TELEGUN_GRENADE},
+				{Core.m_HasTelegunLaser, CHARACTERFLAG_TELEGUN_LASER},
+				{Core.m_aWeapons[WEAPON_HAMMER].m_Got, CHARACTERFLAG_WEAPON_HAMMER},
+				{Core.m_aWeapons[WEAPON_GUN].m_Got, CHARACTERFLAG_WEAPON_GUN},
+				{Core.m_aWeapons[WEAPON_SHOTGUN].m_Got, CHARACTERFLAG_WEAPON_SHOTGUN},
+				{Core.m_aWeapons[WEAPON_GRENADE].m_Got, CHARACTERFLAG_WEAPON_GRENADE},
+				{Core.m_aWeapons[WEAPON_LASER].m_Got, CHARACTERFLAG_WEAPON_LASER},
+				{Core.m_aWeapons[WEAPON_NINJA].m_Got, CHARACTERFLAG_WEAPON_NINJA},
+				{Core.m_LiveFrozen, CHARACTERFLAG_MOVEMENTS_DISABLED},
+				{Core.m_IsInFreeze, CHARACTERFLAG_IN_FREEZE},
+				{Core.m_Invincible, CHARACTERFLAG_INVINCIBLE},
+			};
+			int PredictedFlags = 0;
+			int FlagMask = 0;
+			for(const auto &[Set, Flag] : aPredictedFlags)
+			{
+				PredictedFlags |= Set ? Flag : 0;
+				FlagMask |= Flag;
+			}
+			Compare("flags", PredictedFlags, Extended.m_Flags & FlagMask);
+		}
+		if(aDiff[0] == '\0')
+			continue;
+
+		// other tees that can push, hook or hammer this one, hooked tees may be out of view,
+		// tees that just spawned are only in the current snapshot
+		int NearbyTees = Snapped.m_HookedPlayer != -1 || Predicted.m_HookedPlayer != -1 ? 1 : 0;
+		for(int j = 0; j < MAX_CLIENTS; j++)
+		{
+			if(j == i)
+				continue;
+			const CNetObj_Character *pOther = m_Snap.m_aCharacters[j].m_Active ? &m_Snap.m_aCharacters[j].m_Cur : (const CNetObj_Character *)Client()->SnapFindItem(IClient::SNAP_CURRENT, NETOBJTYPE_CHARACTER, j);
+			const bool HookedBefore = m_Snap.m_aCharacters[j].m_Active && m_Snap.m_aCharacters[j].m_Prev.m_HookedPlayer == i;
+			if(pOther && (pOther->m_HookedPlayer == i || HookedBefore || distance(vec2(pOther->m_X, pOther->m_Y), vec2(Snapped.m_X, Snapped.m_Y)) < 3 * 32))
+				NearbyTees++;
+		}
+
+		// a changed own input inside the window may have been applied by the server at a different tick
+		bool NewInput = false;
+		if(Own)
+		{
+			const int IsDummy = i != m_Snap.m_LocalClientId;
+			const int *pFirstInput = Client()->GetInput(Tick - PredictedTicks + 1, IsDummy);
+			for(int PredictedTick = Tick - PredictedTicks + 2; PredictedTick <= Tick; PredictedTick++)
+			{
+				const int *pInput = Client()->GetInput(PredictedTick, IsDummy);
+				NewInput = NewInput || (pInput && pFirstInput && mem_comp(pInput, pFirstInput, sizeof(CNetObj_PlayerInput)) != 0);
+			}
+		}
+
+		const char *pReason = "physics";
+		if(distance(vec2(Predicted.m_X, Predicted.m_Y), vec2(Snapped.m_X, Snapped.m_Y)) > 5 * 32)
+			pReason = "teleport";
+		else if(InputDiffers || (!Own && (Snapped.m_AttackTick != pChar->GetAttackTick() || (Snapped.m_Jumped & 1) != (Predicted.m_Jumped & 1) || (Predicted.m_HookState == HOOK_IDLE) != (Snapped.m_HookState == HOOK_IDLE))))
+			pReason = "input";
+		else if(NewInput)
+			pReason = "newinput";
+		else if(AttackTickPredicted && Snapped.m_AttackTick != pChar->GetAttackTick())
+			pReason = "fire";
+		else if(NearbyTees > 0)
+			pReason = "interaction";
+
+		log_info("prediction", "desync %s tick=%d ticks=%d id=%d name='%s'%s | pos=%d,%d weapon=%d jetpack=%d freeze=%d deep=%d tune=%d tile=%d ftile=%d nearby=%d",
+			pReason, Tick, PredictedTicks, i, m_aClients[i].m_aName, aDiff, Snapped.m_X, Snapped.m_Y, Core.m_ActiveWeapon, Core.m_Jetpack, pChar->m_FreezeTime, Core.m_DeepFrozen,
+			pChar->GetOverriddenTuneZone(), pChar->m_TileIndex, pChar->m_TileFIndex, NearbyTees);
+	}
 }
 
 void CGameClient::UpdateSpectatorCursor()

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -950,6 +950,7 @@ private:
 
 	void UpdateLocalTuning();
 	void UpdatePrediction();
+	void LogPredictionDesyncs();
 	void UpdateSpectatorCursor();
 	void UpdateRenderedCharacters();
 	void HandlePredictedEvents(int Tick);


### PR DESCRIPTION
Requested by @sjrc6  on [Discord](https://discord.com/channels/252358080522747904/293493549758939136/1545168963393159238):

> it would be nice if we could monitor actual physics desyncs in the client in release builds, filtering out mispredictions from snapshot changes. I think there is still a prediction desync with jetpack unless it was fixed already, maybe someone should point an AI at that.

Here is the LLM report:

<details>

# Client prediction vs server: dictionary of observed differences

Method: `dbg_prediction_desync` compares, for every snapshot, the client's own advance of the previous snapshot's world (the same code path OnPredict starts from) against the new snapshot, per tee. Reasons: `input` (snapshot shows the server used a different input than predicted), `newinput` (own tee sent a new input inside the window, server timing unknown), `teleport` (>5 tiles apart), `fire` (own attack tick differs with antiping weapons), `interaction` (another tee hooks, is hooked or is within 3 tiles), `physics` (none of the above).

## A. Own tee, loopback, all scenarios exact

Local server on the Mac, scripted input (walk, jump, hook, jetpack from the ground, jetpack with a spinning aim at 90/360/720 deg/s, weapon switches mid-flight, freeze and unfreeze, hook while thrusting, thrust into the floor, ninja with jetpack, super, fire taps faster than a tick, jumps while thrusting), with and without antiping. Zero position or velocity deviation. The only lines are server-side state changes the client cannot know (rcon jetpack, freeze, ninja, super: flags or freezeend fields).

## B. Own tee under network jitter or loss (UDP proxy, 30 ms +-25 ms, 3% loss)

- `input`: a late input is clamped by the server to the next tick, the snapshot then shows the old direction/target. Inherent.
- `physics` with small velx/vely only, during spinning aim or fire taps: the late or lost input hit the FIRST tick of the two-tick snapshot window. The snapshot only carries the input state of the second tick, so it looks like physics. Now tagged `newinput` when the client sent a new input inside the window.
- `fire`: attack tick off by a few ticks under loss: fire taps shorter than a tick are two inputs with the same intended tick, server and client each apply the first one they have, and a lost packet changes which one that is.
- Prediction margin 30 ms alone (no jitter) causes nothing: the server applies "direct" input at tick time for the input labelled with that tick (server.cpp OnClientPredictedEarlyInput), not on arrival, so early arrival is harmless.

## C. Other tees (antiping players)

- Jetpack thrust of other tees is never predicted: their fire input is unknown (Read() zeroes it) and HandleJetpack/FireWeapon/HandleWeaponSwitch bail on `m_NumInputs < 2`, which only OnDirectInput increments, which only own tees get. Reproduced locally with a dummy holding fire on jetpack: as own tee (cl_predict_dummy 1) exact, as other tee (cl_predict_dummy 0) a physics deviation on every snapshot. The gun's attack tick advancing every fire delay while holding fire would allow inferring "fire held" for jetpack tees.
- Jump taps shorter than the snapshot window are invisible (m_Jumped bit 1 is cleared on release), direction taps likewise. Both show as small velx/vely physics lines with no input change visible.
- Read() for non-own tees only trusts the exact DDNetCharacter target when BOTH components are non-zero (character.cpp "pExtended->m_TargetX != 0 && pExtended->m_TargetY != 0"), otherwise it rebuilds a length-256 target from the angle. Aiming exactly vertically or horizontally therefore gives a target of a different length. Direction-only consumers (hook, jetpack) are unaffected.
- Hooked tees out of view: the hooked player is culled from the snapshot by distance, the predicted hook has no target and the pull is wrong. Tagged interaction now (hooked player id counts even when not in the snapshot).

## D. Snapshot read quirks (client side, no server difference)

- PHANTOM JUMPS of other tees (real bug, fix included): Read() zeroes the jump input of non-own tees, the core then clears the "jump key held" bit (m_Jumped & 1) on the next tick, and the next pre-input of that player (any direction, hook, fire or weapon change while jump is still held) carries Jump=1 again, so the prediction jumps a second time: a ground jump if the tee stands, an air jump if it is airborne (predicted vely exactly -3072, jumped 3 vs snapped 1, 64 of 71 physics lines while moving on GER Novice). Reproduced locally with a second client holding jump while changing direction: a phantom ground jump at every direction change. Fix: keep m_Input.m_Jump = (m_Jumped & 1) in Read(), after which the same run shows zero jump deviations. Only visible to non-AFK clients, since the server does not send pre-inputs to AFK players, and only with sv_preinput and cl_antiping_preinput on (both default).
- The server decides pre-input recipients and the sender's AFK state before applying the input, so the first input change of a previously idle player is never pre-sent (its first jump is not predicted).

- `jumpedtotal`: Read() forces m_JumpedTotal = m_Jumps whenever the snapshot has the "no air jump left" bit (character.cpp:1531), overriding the value the server sent one line earlier via ReadDDNet. Physics-neutral (DDRacePostCoreTick only tests JumpedTotal < Jumps-1) but it was the single biggest source of noise (323 of 350 physics lines in the first 5 minutes on GER Novice). Excluded from the compare when the bit is set.

## E. Structural server-vs-prediction code differences (function diff of CCharacter, CProjectile, CLaser, CPickup, CDragger, CPlasma, CGameWorld after normalizing renames)

- Teleporters (TILE_TELEIN, evil, check) are not handled at all in the prediction, only telegun tiles. Every teleport shows as `teleport`.
- Telegun teleport of the shooter (m_TeleGunTeleport in DDRacePostCoreTick) is server-only.
- Death tiles and game-layer clipping kill on the server (Die), the prediction keeps simulating: `teleport` on respawn.
- Weapon teleporters (TILE_TELEINWEAPON) for projectiles and lasers are server-only.
- Endless hook for super tees via sv_endless_super_hook is server-only.
- Grenade double explosion map bug emulation (BUG_GRENADE_DOUBLEEXPLOSION) server-only.
- sv_destroy_bullets_on_death / sv_destroy_lasers_on_death: server removes projectiles and lasers of dead owners, the prediction keeps them.
- Laser CInteractions::CanHit (team, solo, no-hit-others/self state captured at fire time) is server-only, the prediction re-derives from the current owner state.
- Laser DontHitSelf: server also excludes self after a weapon teleport (m_WasTele), client only uses bounce count.
- GiveNinja: prediction leaves ninja ammo at 0 when frozen, server always sets -1.
- After a prediction reset (kill message, team kill), own jetpack thrust, fire and weapon switch are skipped for the first two predicted ticks (m_NumInputs < 2).
- Chat input: server keeps the previous input while chatting (OnPredictedInput returns early), client ResetInput()s on direct input.
- HandleTiles chat messages, time checkpoints, add/subtract time tiles, rescue: server-only, no physics effect.

## F. Live server observations (own tee idle at spawn, dbg_prediction_desync 2)

| server | duration | lines | input | interaction | physics | other |
|---|---|---|---|---|---|---|
| GER Novice, Multeasymap, 98 players, 18 ms, antiping off | 10 min | 8168 | 8079 | 68 | 21 | |
| GER Blocker #3, Copy Love Box, 34 players, 16 ms, antiping off | 10 min | 66849 | 64799 | 1657 | 386 | teleport 7 |
| RUS Novice, Linear, 70 players, 49 ms, antiping off | 10 min | 13676 | 13632 | 31 | 13 | |
| GER Blocker #3, Copy Love Box, antiping on | 10 min | 14433 | 13954 | 324 | 133 | newinput 14, teleport 8 |
| GER Blocker #3, antiping on, spawn-aware nearby check | 5 min | 37980 | 37011 | 737 | 197 | teleport 35 |
| GER Novice, own tee walking, jumping, hooking, spinning aim, antiping on | 5 min | 5636 | 5543 | 15 | 71 (64 phantom jumps of others) | teleport 7 |
| same, with the jump input fix | 5 min | 4491 | 4484 | 1 | 6 (0 phantom jumps, 3 jump releases, 3 hook) | |

- Own moving tee on GER Novice: 57 input lines (late inputs at 18 ms ping over 5 minutes of constant movement), 2 physics lines (being pushed while landing next to others), no unexplained own-tee deviation.
- Blocker server, spawn-aware run: own idle tee 5 interaction + 2 physics, both physics lines while being flung frozen through the map by tees farther than 3 tiles.
- 98 to 99 percent of all lines are `input`: other tees changed direction, aim, jump or hook inside the window. Expected and unfixable client side.
- `physics` lines for other tees are small velx/vely deviations (0.1 to 4 px/tick) with no visible input change: jump or direction taps inside the two-tick window, or hooks on culled tees.
- Own idle tee on the blocker server: `vely 0>109` / `0>124` a few times per minute, no tee within 3 tiles in the previous snapshot, also with antiping on, reckoning age 0 (fresh cores, so not the client's dead-reckoning evolve). Many other idle tees at spawn show the same values. Explanation: a tee that respawns on the spawn point inside the window is only in the new snapshot, so the prediction world does not contain it, while the server already applied the tee-tee collision (`m_Vel *= 0.85f` on the gravity velocity gives exactly 0.5 * 0.85 * 256 = 109). The nearby check now also looks at tees that are only in the current snapshot.
- With antiping off, no projectile enters the prediction world at all (NetObjAdd is gated on m_PredictWeapons), so every explosion, own grenade boosts included, is an unpredicted push.

## G. Jetpack conclusions

- Own tee: no code-level jetpack desync found. Thrust, fire delay, weapon switches, ninja jetpack, freeze and respawn all predict exactly on loopback, with and without antiping, and under jitter only the generic input-timing effects appear (tagged input/newinput, never physics).
- Other tees: jetpack thrust is never predicted. With cl_antiping_players on, a flying jetpack tee is rendered at a position that falls every window and snaps back with every snapshot. This is the visible "jetpack desync" for spectators of jetpack users. A predictor could infer "fire held" from the gun attack tick advancing every fire delay (the jetpack gun keeps shooting bullets) and apply thrust along the snapped target.
- Edge cases for own tee: two ticks without thrust after a prediction reset (m_NumInputs < 2), and after `/ninjajetpack` the active weapon can be mispredicted when the own prediction character is recreated while the snapshot shows weapon ninja (SetActiveWeapon(WEAPON_NINJA) when m_ActiveWeapon is still -1), which then blocks thrust until the next weapon switch. Not reproduced in a normal respawn because jetpack is lost on death.


</details>

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5.1), not reviewed!
