### PR TITLE
client: fix jump prediction

### DIFF
--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1549,13 +1549,15 @@ void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtende
 		SetActiveWeapon(pChar->m_Weapon);
 	}
 
-	// reset all input except direction and hook for non-local players (as in vanilla prediction)
+	// reset all input except direction, hook, jump for non-local players (as in vanilla prediction)
 	if(!IsLocal)
 	{
 		mem_zero(&m_Input, sizeof(m_Input));
 		mem_zero(&m_SavedInput, sizeof(m_SavedInput));
 		m_Input.m_Direction = m_SavedInput.m_Direction = m_Core.m_Direction;
 		m_Input.m_Hook = m_SavedInput.m_Hook = (m_Core.m_HookState != HOOK_IDLE);
+		// jump key being held can't be reset since being set again on the next tick would count as an extra jump that never happened
+		m_Input.m_Jump = m_SavedInput.m_Jump = (m_Core.m_Jumped & 1) != 0;
 
 		if(pExtended && pExtended->m_TargetX != 0 && pExtended->m_TargetY != 0)
 		{


### PR DESCRIPTION
Came out of https://github.com/ddnet/ddnet/pull/12783

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5.1)
