### PR TITLE
client: Add terms of use, add block/report buttons, make scoreboard player popup usable with touch

### DIFF
--- a/data/touch_controls.json
+++ b/data/touch_controls.json
@@ -159,10 +159,8 @@
 				"extra-menu"
 			],
 			"behavior": {
-				"type": "bind",
-				"label": "Scoreboard",
-				"label-type": "localized",
-				"command": "+scoreboard"
+				"type": "predefined",
+				"id": "scoreboard"
 			}
 		},
 		{

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -571,6 +571,10 @@ Messages = [
 		NetIntAny("m_FollowFactor"),
 	]),
 
+	NetMessageEx("Cl_ReportPlayer", "report-player@netmsg.ddnet.org", [
+		NetIntRange("m_ClientId", 0, 'MAX_CLIENTS-1'),
+	]),
+
 	NetMessageEx("Sv_TeamsState", "teamsstate@netmsg.ddnet.tw", []),
 
 	NetMessageEx("Sv_DDRaceTime", "ddrace-time@netmsg.ddnet.tw", [

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3310,9 +3310,7 @@ void CClient::Run()
 	m_pConsole->InitChecksum(ChecksumData());
 
 	// request the new ddnet info from server if already past the welcome dialog
-	if(g_Config.m_ClShowWelcome)
-		g_Config.m_ClShowWelcome = 0;
-	else
+	if(!g_Config.m_ClShowWelcome)
 		RequestDDNetInfo();
 
 	if(SoundInitFailed)

--- a/src/engine/font_icons.h
+++ b/src/engine/font_icons.h
@@ -89,6 +89,7 @@ namespace FontIcon
 	inline const char *const TRIANGLE_EXCLAMATION = "\uF071";
 	inline const char *const UNDO = "\uF2EA";
 	inline const char *const USER = "\uF007";
+	inline const char *const USER_SLASH = "\uF506";
 	inline const char *const VIDEO = "\uF03D";
 	inline const char *const XMARK = "\uF00D";
 }

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1172,7 +1172,7 @@ void CMenus::Render()
 
 void CMenus::RenderPopupFullscreen(CUIRect Screen)
 {
-	char aBuf[1536];
+	char aBuf[2048];
 	const char *pTitle = "";
 	const char *pExtraText = "";
 	const char *pButtonText = "";
@@ -1231,10 +1231,11 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 	else if(m_Popup == POPUP_FIRST_LAUNCH)
 	{
 		pTitle = Localize("Welcome to DDNet");
-		str_format(aBuf, sizeof(aBuf), "%s\n\n%s\n\n%s\n\n%s",
+		str_format(aBuf, sizeof(aBuf), "%s\n\n%s\n\n%s\n\n%s\n\n%s",
 			Localize("DDraceNetwork is a cooperative online game where the goal is for you and your group of tees to reach the finish line of the map. As a newcomer you should start on Novice servers, which host the easiest maps. Consider the ping to choose a server close to you."),
 			Localize("Use k key to kill (restart), q to pause and watch other players. See settings for other key binds."),
 			Localize("It's recommended that you check the settings to adjust them to your liking before joining a server."),
+			Localize("Terms of Use: There is no tolerance for abusive behavior. Do not post anything illegal, hateful, harassing or offensive. Violations lead to bans. Use the block button in the scoreboard or the players menu to hide a player's messages and report them to the server hoster."),
 			Localize("Please enter your nickname below."));
 		pExtraText = aBuf;
 		pButtonText = Localize("Ok");
@@ -1719,21 +1720,35 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		Skip.VMargin(20.0f, &Skip);
 		Join.VMargin(20.0f, &Join);
 
+		const ColorRGBA ButtonColor = ColorRGBA(1.0f, 1.0f, 1.0f, m_TermsAccepted ? 0.5f : 0.15f);
+
 		static CButtonContainer s_JoinTutorialButton;
-		if(DoButton_Menu(&s_JoinTutorialButton, Localize("Join Tutorial Server"), 0, &Join) || Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER))
+		if((DoButton_Menu(&s_JoinTutorialButton, Localize("Join Tutorial Server"), 0, &Join, BUTTONFLAG_LEFT, nullptr, IGraphics::CORNER_ALL, 5.0f, 0.0f, ButtonColor) || Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)) && m_TermsAccepted)
 		{
+			g_Config.m_ClShowWelcome = false;
 			Client()->RequestDDNetInfo();
 			m_Popup = g_Config.m_BrIndicateFinished ? POPUP_POINTS : POPUP_NONE;
 			JoinTutorial();
 		}
 
 		static CButtonContainer s_SkipTutorialButton;
-		if(DoButton_Menu(&s_SkipTutorialButton, Localize("Skip Tutorial"), 0, &Skip) || Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
+		if((DoButton_Menu(&s_SkipTutorialButton, Localize("Skip Tutorial"), 0, &Skip, BUTTONFLAG_LEFT, nullptr, IGraphics::CORNER_ALL, 5.0f, 0.0f, ButtonColor) || Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE)) && m_TermsAccepted)
 		{
+			g_Config.m_ClShowWelcome = false;
 			Client()->RequestDDNetInfo();
 			m_JoinTutorial.m_Queued = false;
 			m_Popup = g_Config.m_BrIndicateFinished ? POPUP_POINTS : POPUP_NONE;
 		}
+
+#if defined(CONF_PLATFORM_ANDROID) || defined(CONF_PLATFORM_IOS)
+		Box.HSplitBottom(20.f, &Box, &Part);
+		Box.HSplitBottom(24.f, &Box, &Part);
+		Part.VSplitLeft(30.0f, nullptr, &Part);
+		if(DoButton_CheckBox(&m_TermsAccepted, Localize("I agree to the Terms of Use"), m_TermsAccepted, &Part))
+			m_TermsAccepted = !m_TermsAccepted;
+#else
+		m_TermsAccepted = true;
+#endif
 
 		Box.HSplitBottom(20.f, &Box, &Part);
 		Box.HSplitBottom(24.f, &Box, &Part);

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -139,6 +139,7 @@ protected:
 	int m_MenuPage;
 	int m_GamePage;
 	int m_Popup;
+	bool m_TermsAccepted = false;
 	bool m_ShowStart;
 	bool m_MenuActive;
 

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -500,7 +500,7 @@ void CMenus::RenderPlayers(CUIRect MainView)
 
 	// headline
 	PlayerList.HSplitTop(34.0f, &ButtonBar, &PlayerList);
-	ButtonBar.VSplitRight(231.0f, &Player, &ButtonBar);
+	ButtonBar.VSplitRight(315.0f, &Player, &ButtonBar);
 	Ui()->DoLabel(&Player, Localize("Player"), 24.0f, TEXTALIGN_ML);
 
 	ButtonBar.HMargin(1.0f, &ButtonBar);
@@ -515,6 +515,14 @@ void CMenus::RenderPlayers(CUIRect MainView)
 	ButtonBar.VSplitLeft(20.0f, nullptr, &ButtonBar);
 	ButtonBar.VSplitLeft(Width, &Button, &ButtonBar);
 	RenderTools()->RenderIcon(IMAGE_GUIICONS, SPRITE_GUIICON_FRIEND, &Button);
+
+	ButtonBar.VSplitLeft(20.0f, nullptr, &ButtonBar);
+	ButtonBar.VSplitLeft(Width, &Button, &ButtonBar);
+	TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
+	TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGNMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
+	Ui()->DoLabel(&Button, FontIcon::USER_SLASH, 24.0f, TEXTALIGN_MC);
+	TextRender()->SetRenderFlags(0);
+	TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 
 	int TotalPlayers = 0;
 	for(const auto &pInfoByName : GameClient()->m_Snap.m_apInfoByName)
@@ -534,7 +542,7 @@ void CMenus::RenderPlayers(CUIRect MainView)
 	s_ListBox.DoStart(24.0f, TotalPlayers, 1, 3, -1, &PlayerList);
 
 	// options
-	static char s_aPlayerIds[MAX_CLIENTS][4] = {{0}};
+	static char s_aPlayerIds[MAX_CLIENTS][5] = {{0}};
 
 	for(int i = 0, Count = 0; i < MAX_CLIENTS; ++i)
 	{
@@ -557,7 +565,7 @@ void CMenus::RenderPlayers(CUIRect MainView)
 		if(Count % 2 == 1)
 			Row.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), IGraphics::CORNER_ALL, 5.0f);
 		Row.VSplitRight(s_ListBox.ScrollbarWidthMax() - s_ListBox.ScrollbarWidth(), &Row, nullptr);
-		Row.VSplitRight(300.0f, &Player, &Row);
+		Row.VSplitRight(384.0f, &Player, &Row);
 
 		// player info
 		Player.VSplitLeft(28.0f, &Button, &Player);
@@ -575,7 +583,7 @@ void CMenus::RenderPlayers(CUIRect MainView)
 
 		Player.HSplitTop(1.5f, nullptr, &Player);
 		Player.VSplitMid(&Player, &Button);
-		Row.VSplitRight(210.0f, &Button2, &Row);
+		Row.VSplitRight(294.0f, &Button2, &Row);
 
 		Ui()->DoLabel(&Player, CurrentClient.m_aName, 14.0f, TEXTALIGN_ML);
 		Ui()->DoLabel(&Button, CurrentClient.m_aClan, 14.0f, TEXTALIGN_ML);
@@ -617,6 +625,15 @@ void CMenus::RenderPlayers(CUIRect MainView)
 
 			GameClient()->Client()->ServerBrowserUpdate();
 		}
+
+		// block button
+		Row.VSplitLeft(20.0f, nullptr, &Row);
+		Row.VSplitLeft(Width, &Button, &Row);
+		Button.VSplitLeft((Width - Button.h) / 4.0f, nullptr, &Button);
+		Button.VSplitLeft(Button.h, &Button, nullptr);
+		if(DoButton_Toggle(&s_aPlayerIds[Index][4], CurrentClient.m_Foe, &Button, true))
+			GameClient()->BlockPlayer(Index, !CurrentClient.m_Foe);
+		GameClient()->m_Tooltips.DoToolTip(&s_aPlayerIds[Index][4], &Button, CurrentClient.m_Foe ? Localize("Unblock") : Localize("Block"));
 	}
 
 	s_ListBox.DoEnd();

--- a/src/game/client/components/menus_ingame_touch_controls.cpp
+++ b/src/game/client/components/menus_ingame_touch_controls.cpp
@@ -37,6 +37,7 @@ const CMenusIngameTouchControls::CBehaviorFactoryEditor CMenusIngameTouchControl
 	{CTouchControls::CExtraMenuTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CExtraMenuTouchButtonBehavior>(0); }},
 	{CTouchControls::CEmoticonTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CEmoticonTouchButtonBehavior>(); }},
 	{CTouchControls::CSpectateTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CSpectateTouchButtonBehavior>(); }},
+	{CTouchControls::CScoreboardTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CScoreboardTouchButtonBehavior>(); }},
 	{CTouchControls::CSwapActionTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CSwapActionTouchButtonBehavior>(); }},
 	{CTouchControls::CUseActionTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CUseActionTouchButtonBehavior>(); }},
 	{CTouchControls::CJoystickActionTouchButtonBehavior::BEHAVIOR_ID, []() { return std::make_unique<CTouchControls::CJoystickActionTouchButtonBehavior>(); }},
@@ -1547,18 +1548,19 @@ const char **CMenusIngameTouchControls::VisibilityNames() const
 
 const char **CMenusIngameTouchControls::PredefinedNames() const
 {
-	static const char *s_apPredefined[11];
+	static const char *s_apPredefined[12];
 	s_apPredefined[0] = Localize("Ingame Menu", "Predefined touch button behaviors");
 	s_apPredefined[1] = Localize("Extra Menu", "Predefined touch button behaviors");
 	s_apPredefined[2] = Localize("Emoticon", "Predefined touch button behaviors");
 	s_apPredefined[3] = Localize("Spectate", "Predefined touch button behaviors");
-	s_apPredefined[4] = Localize("Swap Action", "Predefined touch button behaviors");
-	s_apPredefined[5] = Localize("Use Action", "Predefined touch button behaviors");
-	s_apPredefined[6] = Localize("Joystick Action", "Predefined touch button behaviors");
-	s_apPredefined[7] = Localize("Joystick Aim", "Predefined touch button behaviors");
-	s_apPredefined[8] = Localize("Joystick Relative Aim", "Predefined touch button behaviors");
-	s_apPredefined[9] = Localize("Joystick Fire", "Predefined touch button behaviors");
-	s_apPredefined[10] = Localize("Joystick Hook", "Predefined touch button behaviors");
+	s_apPredefined[4] = Localize("Scoreboard", "Predefined touch button behaviors");
+	s_apPredefined[5] = Localize("Swap Action", "Predefined touch button behaviors");
+	s_apPredefined[6] = Localize("Use Action", "Predefined touch button behaviors");
+	s_apPredefined[7] = Localize("Joystick Action", "Predefined touch button behaviors");
+	s_apPredefined[8] = Localize("Joystick Aim", "Predefined touch button behaviors");
+	s_apPredefined[9] = Localize("Joystick Relative Aim", "Predefined touch button behaviors");
+	s_apPredefined[10] = Localize("Joystick Fire", "Predefined touch button behaviors");
+	s_apPredefined[11] = Localize("Joystick Hook", "Predefined touch button behaviors");
 	static_assert(std::size(s_apPredefined) == std::size(BEHAVIOR_FACTORIES_EDITOR), "Insufficient predefined names");
 	return s_apPredefined;
 }
@@ -1583,6 +1585,7 @@ const char *CMenusIngameTouchControls::HelpMessageForPredefinedType(EPredefinedT
 	case EPredefinedType::EXTRA_MENU: return Localize("The extra menu button which toggles visibility of buttons with \"Extra Menu\" visibilities. Also opens the ingame menu on long press."); break;
 	case EPredefinedType::EMOTICON: return Localize("Opens the emoticon selector (this does not work with binds)."); break;
 	case EPredefinedType::SPECTATE: return Localize("Opens the spectator menu (this does not work with binds)."); break;
+	case EPredefinedType::SCOREBOARD: return Localize("Opens the scoreboard with the cursor unlocked (this does not work with binds)."); break;
 	case EPredefinedType::SWAP_ACTION: return Localize("Swaps the active action (fire and hook) for direct touch input and virtual joysticks."); break;
 	case EPredefinedType::USE_ACTION: return Localize("Uses the active action with the current aiming position."); break;
 	case EPredefinedType::JOYSTICK_ACTION: return Localize("Virtual joystick which uses the active action."); break;
@@ -1592,7 +1595,7 @@ const char *CMenusIngameTouchControls::HelpMessageForPredefinedType(EPredefinedT
 	case EPredefinedType::JOYSTICK_HOOK: return Localize("Virtual joystick which always uses hook."); break;
 	default: dbg_assert_failed("Unknown behavior %d", (int)m_PredefinedBehaviorType);
 	}
-	static_assert((int)EPredefinedType::NUM_PREDEFINEDTYPES == 11, "Insufficient help messages");
+	static_assert((int)EPredefinedType::NUM_PREDEFINEDTYPES == 12, "Insufficient help messages");
 }
 
 const char *CMenusIngameTouchControls::HelpMessageForVisibilityType(CTouchControls::EButtonVisibility Type) const

--- a/src/game/client/components/menus_ingame_touch_controls.h
+++ b/src/game/client/components/menus_ingame_touch_controls.h
@@ -24,6 +24,7 @@ public:
 		EXTRA_MENU,
 		EMOTICON,
 		SPECTATE,
+		SCOREBOARD,
 		SWAP_ACTION,
 		USE_ACTION,
 		JOYSTICK_ACTION,
@@ -183,7 +184,7 @@ public:
 		std::function<std::unique_ptr<CTouchControls::CPredefinedTouchButtonBehavior>()> m_Factory;
 	};
 
-	static const CBehaviorFactoryEditor BEHAVIOR_FACTORIES_EDITOR[11];
+	static const CBehaviorFactoryEditor BEHAVIOR_FACTORIES_EDITOR[12];
 };
 
 #endif

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -935,6 +935,7 @@ void CScoreboard::OnRender()
 	const float TitleHeight = 30.0f;
 
 	CUIRect Scoreboard = {(Screen.w - ScoreboardWidth) / 2.0f, 75.0f, ScoreboardWidth, 355.0f + TitleHeight};
+	const CUIRect ScoreboardArea = Scoreboard;
 	CScoreboardRenderState RenderState{};
 
 	if(Teams)
@@ -1082,6 +1083,16 @@ void CScoreboard::OnRender()
 
 	if(!GameClient()->m_Menus.IsActive() && !GameClient()->m_Chat.IsActive())
 	{
+		// Touch devices have no scoreboard key to release, so a touch next to the scoreboard closes it.
+		const bool WasTouchPressed = m_TouchState.m_AnyPressed;
+		Ui()->UpdateTouchState(m_TouchState);
+		const CUIRect Board = {ScoreboardArea.x, ScoreboardArea.y, ScoreboardArea.w, Spectators.y + Spectators.h - ScoreboardArea.y};
+		if(m_MouseUnlocked && m_TouchState.m_AnyPressed && !WasTouchPressed && !Ui()->IsPopupOpen() && !Ui()->MouseInside(&Board))
+		{
+			m_Active = false;
+			LockMouse();
+		}
+
 		Ui()->RenderPopupMenus();
 
 		if(m_MouseUnlocked)

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -443,7 +443,7 @@ void CScoreboard::RenderSpectators(CUIRect Spectators)
 								     (Client()->DummyConnected() && GameClient()->m_aLocalIds[1] == pInfo->m_ClientId);
 				m_ScoreboardPopupContext.m_IsSpectating = true;
 
-				Ui()->DoPopupMenu(&m_ScoreboardPopupContext, Ui()->MouseX(), Ui()->MouseY(), 110.0f,
+				Ui()->DoPopupMenu(&m_ScoreboardPopupContext, Ui()->MouseX(), Ui()->MouseY(), 140.0f,
 					m_ScoreboardPopupContext.m_IsLocal ? 30.0f : 60.0f, &m_ScoreboardPopupContext, CScoreboardPopupContext::Render);
 			}
 
@@ -708,7 +708,7 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 									     (Client()->DummyConnected() && GameClient()->m_aLocalIds[1] == pInfo->m_ClientId);
 					m_ScoreboardPopupContext.m_IsSpectating = false;
 
-					Ui()->DoPopupMenu(&m_ScoreboardPopupContext, Ui()->MouseX(), Ui()->MouseY(), 110.0f,
+					Ui()->DoPopupMenu(&m_ScoreboardPopupContext, Ui()->MouseX(), Ui()->MouseY(), 140.0f,
 						m_ScoreboardPopupContext.m_IsLocal ? 58.5f : 87.5f, &m_ScoreboardPopupContext, CScoreboardPopupContext::Render);
 				}
 
@@ -1170,9 +1170,9 @@ CUi::EPopupMenuFunctionResult CScoreboard::CScoreboardPopupContext::Render(void 
 
 	if(!pPopupContext->m_IsLocal)
 	{
-		const int ActionsNum = 3;
+		const int ActionsNum = 4;
 		const float ActionSize = 25.0f;
-		const float ActionSpacing = (View.w - (ActionsNum * ActionSize)) / 2;
+		const float ActionSpacing = (View.w - (ActionsNum * ActionSize)) / (ActionsNum - 1);
 		int ActionCorners = IGraphics::CORNER_ALL;
 
 		View.HSplitTop(ItemSpacing * 2, nullptr, &View);
@@ -1215,6 +1215,15 @@ CUi::EPopupMenuFunctionResult CScoreboard::CScoreboardPopupContext::Render(void 
 			Client.m_EmoticonIgnore ^= 1;
 		}
 		pScoreboard->GameClient()->m_Tooltips.DoToolTip(&pPopupContext->m_EmoticonAction, &Action, Client.m_EmoticonIgnore ? Localize("Unmute emoticons") : Localize("Mute emoticons"));
+
+		Container.VSplitLeft(ActionSpacing, nullptr, &Container);
+		Container.VSplitLeft(ActionSize, &Action, &Container);
+
+		if(pUi->DoButton_FontIcon(&pPopupContext->m_BlockAction, FontIcon::USER_SLASH, Client.m_Foe, &Action, BUTTONFLAG_LEFT, ActionCorners))
+		{
+			pScoreboard->GameClient()->BlockPlayer(pPopupContext->m_ClientId, !Client.m_Foe);
+		}
+		pScoreboard->GameClient()->m_Tooltips.DoToolTip(&pPopupContext->m_BlockAction, &Action, Client.m_Foe ? Localize("Unblock") : Localize("Block"));
 	}
 
 	const float ButtonSize = 17.5f;

--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -52,6 +52,7 @@ class CScoreboard : public CComponent
 		CButtonContainer m_FriendAction;
 		CButtonContainer m_MuteAction;
 		CButtonContainer m_EmoticonAction;
+		CButtonContainer m_BlockAction;
 
 		CButtonContainer m_SpectateButton;
 

--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -41,6 +41,7 @@ class CScoreboard : public CComponent
 
 	std::optional<vec2> m_LastMousePos;
 	bool m_MouseUnlocked = false;
+	CUi::CTouchState m_TouchState;
 
 	void SetUiMousePos(vec2 Pos);
 	void LockMouse();
@@ -112,6 +113,7 @@ public:
 	bool OnInput(const IInput::CEvent &Event) override;
 
 	bool IsActive() const;
+	bool IsMouseUnlocked() const { return m_MouseUnlocked; }
 };
 
 #endif

--- a/src/game/client/components/touch_controls.cpp
+++ b/src/game/client/components/touch_controls.cpp
@@ -520,6 +520,30 @@ void CTouchControls::CSpectateTouchButtonBehavior::OnDeactivate(bool ByFinger)
 	m_pTouchControls->Console()->ExecuteLineStroked(1, "+spectate", IConsole::CLIENT_ID_UNSPECIFIED);
 }
 
+// Scoreboard button: shows the scoreboard while held. Releasing unlocks the cursor and keeps the scoreboard
+// open until a touch outside of it, unless the cursor cannot be unlocked, e.g. in demos.
+CTouchControls::CButtonLabel CTouchControls::CScoreboardTouchButtonBehavior::GetLabel() const
+{
+	return {CButtonLabel::EType::LOCALIZED, Localizable("Scoreboard")};
+}
+
+void CTouchControls::CScoreboardTouchButtonBehavior::OnActivate()
+{
+	m_pTouchControls->Console()->ExecuteLineStroked(1, "+scoreboard", IConsole::CLIENT_ID_UNSPECIFIED);
+}
+
+void CTouchControls::CScoreboardTouchButtonBehavior::OnDeactivate(bool ByFinger)
+{
+	if(ByFinger)
+	{
+		m_pTouchControls->Console()->ExecuteLine("toggle_scoreboard_cursor", IConsole::CLIENT_ID_UNSPECIFIED);
+	}
+	if(!m_pTouchControls->GameClient()->m_Scoreboard.IsMouseUnlocked())
+	{
+		m_pTouchControls->Console()->ExecuteLineStroked(0, "+scoreboard", IConsole::CLIENT_ID_UNSPECIFIED);
+	}
+}
+
 // Swap action button:
 // - If joystick is currently active with one action: activate the other action.
 // - Else: swap active action.
@@ -805,6 +829,7 @@ bool CTouchControls::OnTouchState(std::vector<IInput::CTouchFingerState> &vTouch
 		GameClient()->m_Menus.IsActive() ||
 		GameClient()->m_Emoticon.IsActive() ||
 		GameClient()->m_Spectator.IsActive() ||
+		GameClient()->m_Scoreboard.IsMouseUnlocked() ||
 		m_PreviewAllButtons)
 	{
 		ResetButtons();
@@ -827,7 +852,8 @@ void CTouchControls::OnRender()
 		return;
 	if(GameClient()->m_Chat.IsActive() ||
 		GameClient()->m_Emoticon.IsActive() ||
-		GameClient()->m_Spectator.IsActive())
+		GameClient()->m_Spectator.IsActive() ||
+		GameClient()->m_Scoreboard.IsMouseUnlocked())
 	{
 		return;
 	}
@@ -1574,6 +1600,7 @@ std::unique_ptr<CTouchControls::CPredefinedTouchButtonBehavior> CTouchControls::
 		{CExtraMenuTouchButtonBehavior::BEHAVIOR_ID, [&](const json_value *pBehavior) { return ParseExtraMenuBehavior(pBehavior); }},
 		{CEmoticonTouchButtonBehavior::BEHAVIOR_ID, [](const json_value *pBehavior) { return std::make_unique<CEmoticonTouchButtonBehavior>(); }},
 		{CSpectateTouchButtonBehavior::BEHAVIOR_ID, [](const json_value *pBehavior) { return std::make_unique<CSpectateTouchButtonBehavior>(); }},
+		{CScoreboardTouchButtonBehavior::BEHAVIOR_ID, [](const json_value *pBehavior) { return std::make_unique<CScoreboardTouchButtonBehavior>(); }},
 		{CSwapActionTouchButtonBehavior::BEHAVIOR_ID, [](const json_value *pBehavior) { return std::make_unique<CSwapActionTouchButtonBehavior>(); }},
 		{CUseActionTouchButtonBehavior::BEHAVIOR_ID, [](const json_value *pBehavior) { return std::make_unique<CUseActionTouchButtonBehavior>(); }},
 		{CJoystickActionTouchButtonBehavior::BEHAVIOR_ID, [](const json_value *pBehavior) { return std::make_unique<CJoystickActionTouchButtonBehavior>(); }},

--- a/src/game/client/components/touch_controls.h
+++ b/src/game/client/components/touch_controls.h
@@ -325,6 +325,19 @@ public:
 		void OnDeactivate(bool ByFinger) override;
 	};
 
+	class CScoreboardTouchButtonBehavior : public CPredefinedTouchButtonBehavior
+	{
+	public:
+		static constexpr const char *const BEHAVIOR_ID = "scoreboard";
+
+		CScoreboardTouchButtonBehavior() :
+			CPredefinedTouchButtonBehavior(BEHAVIOR_ID) {}
+
+		CButtonLabel GetLabel() const override;
+		void OnActivate() override;
+		void OnDeactivate(bool ByFinger) override;
+	};
+
 	class CSwapActionTouchButtonBehavior : public CPredefinedTouchButtonBehavior
 	{
 	public:

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -3305,6 +3305,22 @@ void CGameClient::SendDummyInfo(bool Start)
 	}
 }
 
+void CGameClient::BlockPlayer(int ClientId, bool Block)
+{
+	const CClientData &ClientData = m_aClients[ClientId];
+	if(Block)
+	{
+		Foes()->AddFriend(ClientData.m_aName, ClientData.m_aClan);
+		CNetMsg_Cl_ReportPlayer Msg;
+		Msg.m_ClientId = ClientId;
+		Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
+	}
+	else
+	{
+		Foes()->RemoveFriend(ClientData.m_aName, ClientData.m_aClan);
+	}
+}
+
 void CGameClient::SendKill() const
 {
 	CNetMsg_Cl_Kill Msg;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -678,6 +678,7 @@ public:
 	void SendInfo(bool Start);
 	void SendDummyInfo(bool Start) override;
 	void SendKill() const;
+	void BlockPlayer(int ClientId, bool Block);
 	void SendReadyChange7(); // NOLINT(readability-make-member-function-const)
 
 	void ApplyPreInputs(int Tick, bool Direct, CGameWorld &GameWorld);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2244,6 +2244,9 @@ void CGameContext::OnMessage(int MsgId, CUnpacker *pUnpacker, int ClientId)
 		case NETMSGTYPE_CL_CAMERAINFO:
 			OnCameraInfoNetMessage(static_cast<CNetMsg_Cl_CameraInfo *>(pRawMsg), ClientId);
 			break;
+		case NETMSGTYPE_CL_REPORTPLAYER:
+			OnReportPlayerNetMessage(static_cast<CNetMsg_Cl_ReportPlayer *>(pRawMsg), ClientId);
+			break;
 		case NETMSGTYPE_CL_SETSPECTATORMODE:
 			OnSetSpectatorModeNetMessage(static_cast<CNetMsg_Cl_SetSpectatorMode *>(pRawMsg), ClientId);
 			break;
@@ -2785,6 +2788,20 @@ void CGameContext::OnCameraInfoNetMessage(const CNetMsg_Cl_CameraInfo *pMsg, int
 {
 	CPlayer *pPlayer = m_apPlayers[ClientId];
 	pPlayer->m_CameraInfo.Write(pMsg);
+}
+
+void CGameContext::OnReportPlayerNetMessage(const CNetMsg_Cl_ReportPlayer *pMsg, int ClientId)
+{
+	int ReportedId = pMsg->m_ClientId;
+	if(!Server()->ReverseTranslate(ReportedId, ClientId) || ReportedId == ClientId || !m_apPlayers[ReportedId])
+		return;
+
+	CPlayer *pPlayer = m_apPlayers[ClientId];
+	if(g_Config.m_SvSpamprotection && pPlayer->m_LastReport && pPlayer->m_LastReport + Server()->TickSpeed() > Server()->Tick())
+		return;
+	pPlayer->m_LastReport = Server()->Tick();
+
+	log_info("report", "%d:%s reported %d:%s", ClientId, Server()->ClientName(ClientId), ReportedId, Server()->ClientName(ReportedId));
 }
 
 void CGameContext::OnSetSpectatorModeNetMessage(const CNetMsg_Cl_SetSpectatorMode *pMsg, int ClientId)

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -367,6 +367,7 @@ public:
 	void OnShowOthersNetMessage(const CNetMsg_Cl_ShowOthers *pMsg, int ClientId);
 	void OnShowDistanceNetMessage(const CNetMsg_Cl_ShowDistance *pMsg, int ClientId);
 	void OnCameraInfoNetMessage(const CNetMsg_Cl_CameraInfo *pMsg, int ClientId);
+	void OnReportPlayerNetMessage(const CNetMsg_Cl_ReportPlayer *pMsg, int ClientId);
 	void OnSetSpectatorModeNetMessage(const CNetMsg_Cl_SetSpectatorMode *pMsg, int ClientId);
 	void OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int ClientId);
 	void OnEmoticonNetMessage(const CNetMsg_Cl_Emoticon *pMsg, int ClientId);

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -97,6 +97,7 @@ public:
 	int m_LastChat;
 	int m_LastSetTeam;
 	int m_LastSetSpectatorMode;
+	int m_LastReport = 0;
 	int m_LastChangeInfo;
 	int m_LastEmote;
 	int m_LastEmoteGlobal;


### PR DESCRIPTION
3 independent changes, but all required for iOS app submission
<img width="1832" height="1522" alt="Screenshot 2026-09-04 at 09 33 14" src="https://github.com/user-attachments/assets/95d2aa3c-b449-426d-a6dc-819c132c3e6f" />
<img width="1832" height="1522" alt="Screenshot 2026-09-04 at 09 34 01" src="https://github.com/user-attachments/assets/5a7ae58a-f129-4b49-8acb-e01aef06e4b0" />
<img width="1720" height="1378" alt="screenshot_2026-09-04_09-33-48" src="https://github.com/user-attachments/assets/12dd9c37-2030-4c0e-9dc2-86da667b4e52" />

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5.1)