### PR TITLE
Fix crashes when loading invalid maps

### DIFF
--- a/src/engine/map.h
+++ b/src/engine/map.h
@@ -7,6 +7,8 @@
 #include <base/types.h>
 
 #include <memory>
+#include <optional>
+#include <vector>
 
 class IStorage;
 struct CUuid;
@@ -25,6 +27,7 @@ public:
 	virtual void *GetData(int Index) = 0;
 	virtual void *GetDataSwapped(int Index) = 0;
 	virtual const char *GetDataString(int Index) = 0;
+	virtual std::optional<std::vector<const char *>> GetDataStringArray(int Index) = 0;
 	virtual void UnloadData(int Index) = 0;
 	virtual int NumData() const = 0;
 

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -825,6 +825,33 @@ const char *CDataFileReader::GetDataString(int Index)
 	return pData;
 }
 
+std::optional<std::vector<const char *>> CDataFileReader::GetDataStringArray(int Index)
+{
+	dbg_assert(m_pDataFile != nullptr, "File not open");
+
+	std::vector<const char *> vpStrings;
+	if(Index == -1)
+	{
+		return vpStrings;
+	}
+
+	const char *pData = static_cast<const char *>(GetData(Index));
+	const int DataSize = GetDataSize(Index);
+	if(pData == nullptr || DataSize <= 0 || pData[DataSize - 1] != '\0')
+	{
+		return std::nullopt;
+	}
+	for(const char *pString = pData; pString < pData + DataSize; pString += str_length(pString) + 1)
+	{
+		if(!str_utf8_check(pString))
+		{
+			return std::nullopt;
+		}
+		vpStrings.push_back(pString);
+	}
+	return vpStrings;
+}
+
 void CDataFileReader::AddDataProcessor(int Index, FDataProcessor DataProcessor)
 {
 	dbg_assert(m_pDataFile != nullptr, "File not open");
@@ -1212,6 +1239,21 @@ int CDataFileWriter::AddDataString(const char *pStr)
 		return -1;
 	}
 	return AddData(str_length(pStr) + 1, pStr);
+}
+
+int CDataFileWriter::AddDataStringArray(const std::vector<const char *> &vpStrings)
+{
+	if(vpStrings.empty())
+	{
+		return -1;
+	}
+	std::vector<char> vData;
+	for(const char *pString : vpStrings)
+	{
+		dbg_assert(pString != nullptr, "Data missing");
+		vData.insert(vData.end(), pString, pString + str_length(pString) + 1);
+	}
+	return AddData(vData.size(), vData.data());
 }
 
 static int CompressionLevelToZlib(CDataFileWriter::ECompressionLevel CompressionLevel)

--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <optional>
 #include <vector>
 
 enum
@@ -51,6 +52,13 @@ public:
 	void *GetData(int Index);
 	void *GetDataSwapped(int Index); // makes sure that the data is 32bit LE ints when saved
 	const char *GetDataString(int Index);
+	/**
+	 * Returns the strings that the data at the given index consists of. The data must consist
+	 * of zero-terminated UTF-8 strings. The index `-1` denotes an empty array.
+	 *
+	 * @return The strings, or `std::nullopt` if the data is invalid.
+	 */
+	std::optional<std::vector<const char *>> GetDataStringArray(int Index);
 	void AddDataProcessor(int Index, FDataProcessor DataProcessor);
 	void UnloadData(int Index);
 	int NumData() const;
@@ -145,6 +153,7 @@ public:
 	int AddData(size_t Size, const void *pData, ECompressionLevel CompressionLevel = COMPRESSION_DEFAULT);
 	int AddDataSwapped(size_t Size, const void *pData);
 	int AddDataString(const char *pStr);
+	int AddDataStringArray(const std::vector<const char *> &vpStrings);
 	void Finish();
 };
 

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -106,7 +106,8 @@ bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, in
 	}
 
 	// Replace map items for old versions with items compatible with latest version to avoid version checks when using the map items.
-	if(!UpgradeAndValidateInfoItems(NewDataFile))
+	if(!UpgradeAndValidateInfoItems(NewDataFile) ||
+		!UpgradeAndValidateImageItems(NewDataFile))
 	{
 		return false;
 	}
@@ -314,6 +315,45 @@ bool CMap::UpgradeAndValidateInfoItems(CDataFileReader &NewDataFile)
 			{
 				return false;
 			}
+		}
+	}
+	return true;
+}
+
+bool CMap::UpgradeAndValidateImageItems(CDataFileReader &NewDataFile)
+{
+	int ImagesStart, ImagesNum;
+	NewDataFile.GetType(MAPITEMTYPE_IMAGE, &ImagesStart, &ImagesNum);
+	for(int ImageIndex = 0; ImageIndex < ImagesNum; ImageIndex++)
+	{
+		const int ImageItemIndex = ImagesStart + ImageIndex;
+		const size_t ImageItemSize = NewDataFile.GetItemSize(ImageItemIndex);
+		if(ImageItemSize < sizeof(CMapItemImage_v1))
+		{
+			log_error("map/load", "Image %d is truncated (size %" PRIzu ").", ImageIndex, ImageItemSize);
+			return false;
+		}
+		const CMapItemImage_v1 *pImage = static_cast<CMapItemImage_v1 *>(NewDataFile.GetItem(ImageItemIndex));
+		if(!in_range(pImage->m_Version, 1, 2))
+		{
+			log_error("map/load", "Image %d has unsupported version %d.", ImageIndex, pImage->m_Version);
+			return false;
+		}
+		if(pImage->m_Version == 1)
+		{
+			// Version 1 images are always RGBA, which version 2 denotes with the format value 1.
+			CMapItemImage_v2 UpgradedImage;
+			mem_copy(&UpgradedImage, pImage, sizeof(CMapItemImage_v1));
+			UpgradedImage.m_MustBe1 = 1;
+			if(!NewDataFile.OverrideItemData(ImageItemIndex, &UpgradedImage, sizeof(UpgradedImage)))
+			{
+				return false;
+			}
+		}
+		else if(ImageItemSize < sizeof(CMapItemImage_v2))
+		{
+			log_error("map/load", "Image %d is truncated (version %d, size %" PRIzu ").", ImageIndex, pImage->m_Version, ImageItemSize);
+			return false;
 		}
 	}
 	return true;

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -745,6 +745,8 @@ bool CMap::UpgradeAndValidateTilesLayerItem(
 		const CMapItemLayerTilemap_v2Legacy *pLayerTilemapLegacy = static_cast<const CMapItemLayerTilemap_v2Legacy *>(pLayerTilemapBase);
 		CMapItemLayerTilemap OverriddenLayerTilemap;
 		mem_copy(&OverriddenLayerTilemap, pLayerTilemapLegacy, sizeof(CMapItemLayerTilemap_v2));
+		// The upgraded item uses the version 3 layout, which the map tools write back.
+		OverriddenLayerTilemap.m_Version = 3;
 
 		// Version 2 items have no name. Default to empty string. We fix the name of physics layers later.
 		StrToInts(OverriddenLayerTilemap.m_aName, std::size(OverriddenLayerTilemap.m_aName), "");

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -175,6 +175,13 @@ bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, in
 					pGameLayer = pLayerTilemap;
 				}
 			}
+			else if(pLayer->m_Type == LAYERTYPE_QUADS)
+			{
+				if(!UpgradeAndValidateQuadsLayerItem(NewDataFile, GroupIndex, LayerIndex, reinterpret_cast<CMapItemLayerQuads_v1 *>(pLayer), LayerItemIndex, LayerItemSize))
+				{
+					return false;
+				}
+			}
 		}
 	}
 	if(pGameLayer == nullptr)
@@ -786,6 +793,41 @@ bool CMap::UpgradeAndValidateTilesLayerItem(
 		}
 	}
 
+	return true;
+}
+
+bool CMap::UpgradeAndValidateQuadsLayerItem(
+	CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex,
+	const CMapItemLayerQuads_v1 *pLayerQuadsBase, int LayerItemIndex, size_t LayerItemSize)
+{
+	if(LayerItemSize < sizeof(CMapItemLayerQuads_v1))
+	{
+		log_error("map/load", "Quads layer %d in group %d is truncated (size %" PRIzu ").",
+			LayerIndex, GroupIndex, LayerItemSize);
+		return false;
+	}
+
+	if(!in_range(pLayerQuadsBase->m_Version, 1, 2))
+	{
+		log_error("map/load", "Quads layer %d in group %d has unsupported version %d.",
+			LayerIndex, GroupIndex, pLayerQuadsBase->m_Version);
+		return false;
+	}
+
+	if(pLayerQuadsBase->m_Version == 1)
+	{
+		// Version 1 items have no name. Default to empty string.
+		CMapItemLayerQuads UpgradedLayerQuads;
+		mem_copy(&UpgradedLayerQuads, pLayerQuadsBase, sizeof(CMapItemLayerQuads_v1));
+		StrToInts(UpgradedLayerQuads.m_aName, std::size(UpgradedLayerQuads.m_aName), "");
+		return NewDataFile.OverrideItemData(LayerItemIndex, &UpgradedLayerQuads, sizeof(UpgradedLayerQuads));
+	}
+	else if(LayerItemSize < sizeof(CMapItemLayerQuads))
+	{
+		log_error("map/load", "Quads layer %d in group %d is truncated (version %d, size %" PRIzu ").",
+			LayerIndex, GroupIndex, pLayerQuadsBase->m_Version, LayerItemSize);
+		return false;
+	}
 	return true;
 }
 

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -107,7 +107,8 @@ bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, in
 
 	// Replace map items for old versions with items compatible with latest version to avoid version checks when using the map items.
 	if(!UpgradeAndValidateInfoItems(NewDataFile) ||
-		!UpgradeAndValidateImageItems(NewDataFile))
+		!UpgradeAndValidateImageItems(NewDataFile) ||
+		!ValidateSoundItems(NewDataFile))
 	{
 		return false;
 	}
@@ -353,6 +354,29 @@ bool CMap::UpgradeAndValidateImageItems(CDataFileReader &NewDataFile)
 		else if(ImageItemSize < sizeof(CMapItemImage_v2))
 		{
 			log_error("map/load", "Image %d is truncated (version %d, size %" PRIzu ").", ImageIndex, pImage->m_Version, ImageItemSize);
+			return false;
+		}
+	}
+	return true;
+}
+
+bool CMap::ValidateSoundItems(CDataFileReader &NewDataFile)
+{
+	int SoundsStart, SoundsNum;
+	NewDataFile.GetType(MAPITEMTYPE_SOUND, &SoundsStart, &SoundsNum);
+	for(int SoundIndex = 0; SoundIndex < SoundsNum; SoundIndex++)
+	{
+		const int SoundItemIndex = SoundsStart + SoundIndex;
+		const size_t SoundItemSize = NewDataFile.GetItemSize(SoundItemIndex);
+		if(SoundItemSize < sizeof(CMapItemSound))
+		{
+			log_error("map/load", "Sound %d is truncated (size %" PRIzu ").", SoundIndex, SoundItemSize);
+			return false;
+		}
+		const CMapItemSound *pSound = static_cast<CMapItemSound *>(NewDataFile.GetItem(SoundItemIndex));
+		if(pSound->m_Version != 1)
+		{
+			log_error("map/load", "Sound %d has unsupported version %d.", SoundIndex, pSound->m_Version);
 			return false;
 		}
 	}

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -108,7 +108,8 @@ bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, in
 	// Replace map items for old versions with items compatible with latest version to avoid version checks when using the map items.
 	if(!UpgradeAndValidateInfoItems(NewDataFile) ||
 		!UpgradeAndValidateImageItems(NewDataFile) ||
-		!ValidateSoundItems(NewDataFile))
+		!ValidateSoundItems(NewDataFile) ||
+		!UpgradeAndValidateEnvelopeItems(NewDataFile))
 	{
 		return false;
 	}
@@ -377,6 +378,55 @@ bool CMap::ValidateSoundItems(CDataFileReader &NewDataFile)
 		if(pSound->m_Version != 1)
 		{
 			log_error("map/load", "Sound %d has unsupported version %d.", SoundIndex, pSound->m_Version);
+			return false;
+		}
+	}
+	return true;
+}
+
+bool CMap::UpgradeAndValidateEnvelopeItems(CDataFileReader &NewDataFile)
+{
+	int EnvelopesStart, EnvelopesNum;
+	NewDataFile.GetType(MAPITEMTYPE_ENVELOPE, &EnvelopesStart, &EnvelopesNum);
+	for(int EnvelopeIndex = 0; EnvelopeIndex < EnvelopesNum; EnvelopeIndex++)
+	{
+		const int EnvelopeItemIndex = EnvelopesStart + EnvelopeIndex;
+		const size_t EnvelopeItemSize = NewDataFile.GetItemSize(EnvelopeItemIndex);
+		if(EnvelopeItemSize < sizeof(CMapItemEnvelope_v1Legacy))
+		{
+			log_error("map/load", "Envelope %d is truncated (size %" PRIzu ").", EnvelopeIndex, EnvelopeItemSize);
+			return false;
+		}
+		const CMapItemEnvelope_v1Legacy *pEnvelopeLegacy = static_cast<CMapItemEnvelope_v1Legacy *>(NewDataFile.GetItem(EnvelopeItemIndex));
+		if(!in_range(pEnvelopeLegacy->m_Version, 1, CMapItemEnvelope::VERSION_TEEWORLDS_BEZIER))
+		{
+			log_error("map/load", "Envelope %d has unsupported version %d.", EnvelopeIndex, pEnvelopeLegacy->m_Version);
+			return false;
+		}
+		if(pEnvelopeLegacy->m_Version == 1)
+		{
+			CMapItemEnvelope UpgradedEnvelope;
+			if(EnvelopeItemSize < sizeof(CMapItemEnvelope_v1))
+			{
+				UpgradedEnvelope.m_Version = pEnvelopeLegacy->m_Version;
+				UpgradedEnvelope.m_Channels = pEnvelopeLegacy->m_Channels;
+				UpgradedEnvelope.m_StartPoint = pEnvelopeLegacy->m_StartPoint;
+				UpgradedEnvelope.m_NumPoints = pEnvelopeLegacy->m_NumPoints;
+				StrToInts(UpgradedEnvelope.m_aName, std::size(UpgradedEnvelope.m_aName), "");
+			}
+			else
+			{
+				mem_copy(&UpgradedEnvelope, pEnvelopeLegacy, sizeof(CMapItemEnvelope_v1));
+			}
+			UpgradedEnvelope.m_Synchronized = 0;
+			if(!NewDataFile.OverrideItemData(EnvelopeItemIndex, &UpgradedEnvelope, sizeof(UpgradedEnvelope)))
+			{
+				return false;
+			}
+		}
+		else if(EnvelopeItemSize < sizeof(CMapItemEnvelope_v2))
+		{
+			log_error("map/load", "Envelope %d is truncated (version %d, size %" PRIzu ").", EnvelopeIndex, pEnvelopeLegacy->m_Version, EnvelopeItemSize);
 			return false;
 		}
 	}

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -191,6 +191,11 @@ bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, in
 			}
 		}
 	}
+	if((int)UsedLayerItemIndices.size() != LayersNum)
+	{
+		log_error("map/load", "%d layers are not used by any group.", LayersNum - (int)UsedLayerItemIndices.size());
+		return false;
+	}
 	if(pGameLayer == nullptr)
 	{
 		log_error("map/load", "Game layer is missing.");

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -105,11 +105,16 @@ bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, in
 		return false;
 	}
 
+	// Replace map items for old versions with items compatible with latest version to avoid version checks when using the map items.
+	if(!UpgradeAndValidateInfoItems(NewDataFile))
+	{
+		return false;
+	}
+
 	int GroupsStart, GroupsNum, LayersStart, LayersNum;
 	NewDataFile.GetType(MAPITEMTYPE_GROUP, &GroupsStart, &GroupsNum);
 	NewDataFile.GetType(MAPITEMTYPE_LAYER, &LayersStart, &LayersNum);
 
-	// Replace map items for old versions with items compatible with latest version to avoid version checks when using the map items.
 	// Ensure that we have a game layer and game group.
 	const CMapItemLayerTilemap *pGameLayer = nullptr;
 	std::set<int> UsedLayerItemIndices;
@@ -276,6 +281,40 @@ bool CMap::ValidateMapVersion(CDataFileReader &NewDataFile)
 	{
 		log_error("map/load", "Map version %d is not supported.", pVersionItem->m_Version);
 		return false;
+	}
+	return true;
+}
+
+bool CMap::UpgradeAndValidateInfoItems(CDataFileReader &NewDataFile)
+{
+	int InfoStart, InfoNum;
+	NewDataFile.GetType(MAPITEMTYPE_INFO, &InfoStart, &InfoNum);
+	for(int InfoIndex = 0; InfoIndex < InfoNum; InfoIndex++)
+	{
+		const int InfoItemIndex = InfoStart + InfoIndex;
+		const size_t InfoItemSize = NewDataFile.GetItemSize(InfoItemIndex);
+		if(InfoItemSize < sizeof(CMapItemInfo))
+		{
+			log_error("map/load", "Info item %d is truncated (size %" PRIzu ").", InfoIndex, InfoItemSize);
+			return false;
+		}
+		const CMapItemInfo *pInfo = static_cast<CMapItemInfo *>(NewDataFile.GetItem(InfoItemIndex));
+		if(pInfo->m_Version != 1)
+		{
+			log_error("map/load", "Info item %d has unsupported version %d.", InfoIndex, pInfo->m_Version);
+			return false;
+		}
+		if(InfoItemSize < sizeof(CMapItemInfoSettings))
+		{
+			// The settings data index was added without incrementing the version.
+			CMapItemInfoSettings UpgradedInfo;
+			mem_copy(&UpgradedInfo, pInfo, sizeof(CMapItemInfo));
+			UpgradedInfo.m_Settings = -1;
+			if(!NewDataFile.OverrideItemData(InfoItemIndex, &UpgradedInfo, sizeof(UpgradedInfo)))
+			{
+				return false;
+			}
+		}
 	}
 	return true;
 }

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -12,6 +12,7 @@
 
 #include <game/gamecore.h>
 #include <game/mapitems.h>
+#include <game/mapitems_ex.h>
 
 CMap::CMap() = default;
 
@@ -109,7 +110,8 @@ bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, in
 	if(!UpgradeAndValidateInfoItems(NewDataFile) ||
 		!UpgradeAndValidateImageItems(NewDataFile) ||
 		!ValidateSoundItems(NewDataFile) ||
-		!UpgradeAndValidateEnvelopeItems(NewDataFile))
+		!UpgradeAndValidateEnvelopeItems(NewDataFile) ||
+		!ValidateAutomapperConfigItems(NewDataFile))
 	{
 		return false;
 	}
@@ -427,6 +429,23 @@ bool CMap::UpgradeAndValidateEnvelopeItems(CDataFileReader &NewDataFile)
 		else if(EnvelopeItemSize < sizeof(CMapItemEnvelope_v2))
 		{
 			log_error("map/load", "Envelope %d is truncated (version %d, size %" PRIzu ").", EnvelopeIndex, pEnvelopeLegacy->m_Version, EnvelopeItemSize);
+			return false;
+		}
+	}
+	return true;
+}
+
+bool CMap::ValidateAutomapperConfigItems(CDataFileReader &NewDataFile)
+{
+	int AutomapperConfigsStart, AutomapperConfigsNum;
+	NewDataFile.GetType(MAPITEMTYPE_AUTOMAPPER_CONFIG, &AutomapperConfigsStart, &AutomapperConfigsNum);
+	for(int AutomapperConfigIndex = 0; AutomapperConfigIndex < AutomapperConfigsNum; AutomapperConfigIndex++)
+	{
+		// The version is not checked because existing maps contain uninitialized versions.
+		const size_t AutomapperConfigItemSize = NewDataFile.GetItemSize(AutomapperConfigsStart + AutomapperConfigIndex);
+		if(AutomapperConfigItemSize < sizeof(CMapItemAutomapperConfig))
+		{
+			log_error("map/load", "Automapper config %d is truncated (size %" PRIzu ").", AutomapperConfigIndex, AutomapperConfigItemSize);
 			return false;
 		}
 	}

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -40,6 +40,11 @@ const char *CMap::GetDataString(int Index)
 	return m_DataFile.GetDataString(Index);
 }
 
+std::optional<std::vector<const char *>> CMap::GetDataStringArray(int Index)
+{
+	return m_DataFile.GetDataStringArray(Index);
+}
+
 void CMap::UnloadData(int Index)
 {
 	m_DataFile.UnloadData(Index);

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -125,13 +125,13 @@ bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, in
 	std::set<int> UsedLayerItemIndices;
 	for(int GroupIndex = 0; GroupIndex < GroupsNum; GroupIndex++)
 	{
-		const size_t GroupItemSize = NewDataFile.GetItemSize(GroupsStart + GroupIndex);
-		if(GroupItemSize < sizeof(CMapItemGroup_v1))
+		const int GroupItemIndex = GroupsStart + GroupIndex;
+		if(!UpgradeAndValidateGroupItem(NewDataFile, GroupIndex, GroupItemIndex))
 		{
-			log_error("map/load", "Group %d is truncated (size %" PRIzu ").", GroupIndex, GroupItemSize);
 			return false;
 		}
-		const CMapItemGroup *pGroup = static_cast<CMapItemGroup *>(NewDataFile.GetItem(GroupsStart + GroupIndex));
+		// The item may have been replaced, so the pointer must be determined afterwards.
+		const CMapItemGroup *pGroup = static_cast<CMapItemGroup *>(NewDataFile.GetItem(GroupItemIndex));
 		if(pGroup->m_StartLayer < 0 || pGroup->m_NumLayers < 0 ||
 			(int64_t)pGroup->m_StartLayer + pGroup->m_NumLayers > LayersNum)
 		{
@@ -448,6 +448,52 @@ bool CMap::ValidateAutomapperConfigItems(CDataFileReader &NewDataFile)
 			log_error("map/load", "Automapper config %d is truncated (size %" PRIzu ").", AutomapperConfigIndex, AutomapperConfigItemSize);
 			return false;
 		}
+	}
+	return true;
+}
+
+bool CMap::UpgradeAndValidateGroupItem(CDataFileReader &NewDataFile, int GroupIndex, int GroupItemIndex)
+{
+	const size_t GroupItemSize = NewDataFile.GetItemSize(GroupItemIndex);
+	if(GroupItemSize < sizeof(CMapItemGroup_v1))
+	{
+		log_error("map/load", "Group %d is truncated (size %" PRIzu ").", GroupIndex, GroupItemSize);
+		return false;
+	}
+	const CMapItemGroup_v1 *pGroupBase = static_cast<CMapItemGroup_v1 *>(NewDataFile.GetItem(GroupItemIndex));
+	if(!in_range(pGroupBase->m_Version, 1, 3))
+	{
+		log_error("map/load", "Group %d has unsupported version %d.", GroupIndex, pGroupBase->m_Version);
+		return false;
+	}
+	if(pGroupBase->m_Version == 1)
+	{
+		CMapItemGroup UpgradedGroup;
+		mem_copy(&UpgradedGroup, pGroupBase, sizeof(CMapItemGroup_v1));
+		UpgradedGroup.m_UseClipping = 0;
+		UpgradedGroup.m_ClipX = 0;
+		UpgradedGroup.m_ClipY = 0;
+		UpgradedGroup.m_ClipW = 0;
+		UpgradedGroup.m_ClipH = 0;
+		StrToInts(UpgradedGroup.m_aName, std::size(UpgradedGroup.m_aName), "");
+		return NewDataFile.OverrideItemData(GroupItemIndex, &UpgradedGroup, sizeof(UpgradedGroup));
+	}
+	else if(GroupItemSize < sizeof(CMapItemGroup_v2))
+	{
+		log_error("map/load", "Group %d is truncated (version %d, size %" PRIzu ").", GroupIndex, pGroupBase->m_Version, GroupItemSize);
+		return false;
+	}
+	else if(pGroupBase->m_Version == 2)
+	{
+		CMapItemGroup UpgradedGroup;
+		mem_copy(&UpgradedGroup, pGroupBase, sizeof(CMapItemGroup_v2));
+		StrToInts(UpgradedGroup.m_aName, std::size(UpgradedGroup.m_aName), "");
+		return NewDataFile.OverrideItemData(GroupItemIndex, &UpgradedGroup, sizeof(UpgradedGroup));
+	}
+	else if(GroupItemSize < sizeof(CMapItemGroup))
+	{
+		log_error("map/load", "Group %d is truncated (version %d, size %" PRIzu ").", GroupIndex, pGroupBase->m_Version, GroupItemSize);
+		return false;
 	}
 	return true;
 }

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -182,6 +182,13 @@ bool CMap::Load(const char *pFullName, IStorage *pStorage, const char *pPath, in
 					return false;
 				}
 			}
+			else if(pLayer->m_Type == LAYERTYPE_SOUNDS || pLayer->m_Type == LAYERTYPE_SOUNDS_DEPRECATED)
+			{
+				if(!ValidateSoundsLayerItem(GroupIndex, LayerIndex, reinterpret_cast<CMapItemLayerSounds *>(pLayer), LayerItemSize))
+				{
+					return false;
+				}
+			}
 		}
 	}
 	if(pGameLayer == nullptr)
@@ -826,6 +833,24 @@ bool CMap::UpgradeAndValidateQuadsLayerItem(
 	{
 		log_error("map/load", "Quads layer %d in group %d is truncated (version %d, size %" PRIzu ").",
 			LayerIndex, GroupIndex, pLayerQuadsBase->m_Version, LayerItemSize);
+		return false;
+	}
+	return true;
+}
+
+bool CMap::ValidateSoundsLayerItem(int GroupIndex, int LayerIndex, const CMapItemLayerSounds *pLayerSounds, size_t LayerItemSize)
+{
+	if(LayerItemSize < sizeof(CMapItemLayerSounds))
+	{
+		log_error("map/load", "Sounds layer %d in group %d is truncated (size %" PRIzu ").",
+			LayerIndex, GroupIndex, LayerItemSize);
+		return false;
+	}
+
+	if(!in_range(pLayerSounds->m_Version, 1, 2))
+	{
+		log_error("map/load", "Sounds layer %d in group %d has unsupported version %d.",
+			LayerIndex, GroupIndex, pLayerSounds->m_Version);
 		return false;
 	}
 	return true;

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -26,6 +26,7 @@ public:
 	void *GetData(int Index) override;
 	void *GetDataSwapped(int Index) override;
 	const char *GetDataString(int Index) override;
+	std::optional<std::vector<const char *>> GetDataStringArray(int Index) override;
 	void UnloadData(int Index) override;
 	int NumData() const override;
 

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -54,6 +54,7 @@ private:
 	static bool ValidateMapVersion(CDataFileReader &NewDataFile);
 	static bool UpgradeAndValidateInfoItems(CDataFileReader &NewDataFile);
 	static bool UpgradeAndValidateImageItems(CDataFileReader &NewDataFile);
+	static bool ValidateSoundItems(CDataFileReader &NewDataFile);
 	static bool ExtractTiles(class CTile *pDest, size_t DestSize, const class CTile *pSrc, size_t SrcSize);
 	bool UpgradeAndValidateTilesLayerItem(CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex,
 		CMapItemLayerTilemap_v2 *pLayerTilemapBase, int LayerItemIndex, size_t LayerItemSize);

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -57,6 +57,7 @@ private:
 	static bool ValidateSoundItems(CDataFileReader &NewDataFile);
 	static bool UpgradeAndValidateEnvelopeItems(CDataFileReader &NewDataFile);
 	static bool ValidateAutomapperConfigItems(CDataFileReader &NewDataFile);
+	static bool UpgradeAndValidateGroupItem(CDataFileReader &NewDataFile, int GroupIndex, int GroupItemIndex);
 	static bool ExtractTiles(class CTile *pDest, size_t DestSize, const class CTile *pSrc, size_t SrcSize);
 	bool UpgradeAndValidateTilesLayerItem(CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex,
 		CMapItemLayerTilemap_v2 *pLayerTilemapBase, int LayerItemIndex, size_t LayerItemSize);

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -11,6 +11,7 @@
 
 #include <set>
 
+class CMapItemLayerQuads_v1;
 class CMapItemLayerTilemap;
 class CMapItemLayerTilemap_v2;
 
@@ -61,6 +62,8 @@ private:
 	static bool ExtractTiles(class CTile *pDest, size_t DestSize, const class CTile *pSrc, size_t SrcSize);
 	bool UpgradeAndValidateTilesLayerItem(CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex,
 		CMapItemLayerTilemap_v2 *pLayerTilemapBase, int LayerItemIndex, size_t LayerItemSize);
+	static bool UpgradeAndValidateQuadsLayerItem(CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex,
+		const CMapItemLayerQuads_v1 *pLayerQuadsBase, int LayerItemIndex, size_t LayerItemSize);
 	bool ValidateAndUnpackTilesLayerData(CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex, const CMapItemLayerTilemap *pLayerTilemap,
 		const CMapItemLayerTilemap &GameLayer, std::set<int> &UsedDataIndices);
 };

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -12,6 +12,7 @@
 #include <set>
 
 class CMapItemLayerQuads_v1;
+class CMapItemLayerSounds;
 class CMapItemLayerTilemap;
 class CMapItemLayerTilemap_v2;
 
@@ -64,6 +65,7 @@ private:
 		CMapItemLayerTilemap_v2 *pLayerTilemapBase, int LayerItemIndex, size_t LayerItemSize);
 	static bool UpgradeAndValidateQuadsLayerItem(CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex,
 		const CMapItemLayerQuads_v1 *pLayerQuadsBase, int LayerItemIndex, size_t LayerItemSize);
+	static bool ValidateSoundsLayerItem(int GroupIndex, int LayerIndex, const CMapItemLayerSounds *pLayerSounds, size_t LayerItemSize);
 	bool ValidateAndUnpackTilesLayerData(CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex, const CMapItemLayerTilemap *pLayerTilemap,
 		const CMapItemLayerTilemap &GameLayer, std::set<int> &UsedDataIndices);
 };

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -55,6 +55,7 @@ private:
 	static bool UpgradeAndValidateInfoItems(CDataFileReader &NewDataFile);
 	static bool UpgradeAndValidateImageItems(CDataFileReader &NewDataFile);
 	static bool ValidateSoundItems(CDataFileReader &NewDataFile);
+	static bool UpgradeAndValidateEnvelopeItems(CDataFileReader &NewDataFile);
 	static bool ExtractTiles(class CTile *pDest, size_t DestSize, const class CTile *pSrc, size_t SrcSize);
 	bool UpgradeAndValidateTilesLayerItem(CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex,
 		CMapItemLayerTilemap_v2 *pLayerTilemapBase, int LayerItemIndex, size_t LayerItemSize);

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -52,6 +52,7 @@ public:
 
 private:
 	static bool ValidateMapVersion(CDataFileReader &NewDataFile);
+	static bool UpgradeAndValidateInfoItems(CDataFileReader &NewDataFile);
 	static bool ExtractTiles(class CTile *pDest, size_t DestSize, const class CTile *pSrc, size_t SrcSize);
 	bool UpgradeAndValidateTilesLayerItem(CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex,
 		CMapItemLayerTilemap_v2 *pLayerTilemapBase, int LayerItemIndex, size_t LayerItemSize);

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -56,6 +56,7 @@ private:
 	static bool UpgradeAndValidateImageItems(CDataFileReader &NewDataFile);
 	static bool ValidateSoundItems(CDataFileReader &NewDataFile);
 	static bool UpgradeAndValidateEnvelopeItems(CDataFileReader &NewDataFile);
+	static bool ValidateAutomapperConfigItems(CDataFileReader &NewDataFile);
 	static bool ExtractTiles(class CTile *pDest, size_t DestSize, const class CTile *pSrc, size_t SrcSize);
 	bool UpgradeAndValidateTilesLayerItem(CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex,
 		CMapItemLayerTilemap_v2 *pLayerTilemapBase, int LayerItemIndex, size_t LayerItemSize);

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -53,6 +53,7 @@ public:
 private:
 	static bool ValidateMapVersion(CDataFileReader &NewDataFile);
 	static bool UpgradeAndValidateInfoItems(CDataFileReader &NewDataFile);
+	static bool UpgradeAndValidateImageItems(CDataFileReader &NewDataFile);
 	static bool ExtractTiles(class CTile *pDest, size_t DestSize, const class CTile *pSrc, size_t SrcSize);
 	bool UpgradeAndValidateTilesLayerItem(CDataFileReader &NewDataFile, int GroupIndex, int LayerIndex,
 		CMapItemLayerTilemap_v2 *pLayerTilemapBase, int LayerItemIndex, size_t LayerItemSize);

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -125,7 +125,7 @@ void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
 			pName = "(error)";
 		}
 
-		if(pImg->m_Version > 1 && pImg->m_MustBe1 != 1)
+		if(pImg->m_MustBe1 != 1)
 		{
 			log_error("mapimages", "Failed to load map image %d '%s': invalid map image type.", i, pName);
 			ShowWarning = true;

--- a/src/game/client/components/mapsounds.cpp
+++ b/src/game/client/components/mapsounds.cpp
@@ -124,8 +124,6 @@ void CMapSounds::OnMapLoad()
 				continue;
 
 			const CMapItemLayerSounds *pSoundLayer = reinterpret_cast<const CMapItemLayerSounds *>(pLayer);
-			if(pSoundLayer->m_Version < 1 || pSoundLayer->m_Version > 2)
-				continue;
 			if(pSoundLayer->m_Sound < 0 || pSoundLayer->m_Sound >= m_Count || m_aSounds[pSoundLayer->m_Sound] == -1)
 				continue;
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -4766,15 +4766,16 @@ void CGameClient::LoadMapSettings()
 		if(!(pItem->m_Settings > -1))
 			break;
 
-		int Size = Map()->GetDataSize(pItem->m_Settings);
-		char *pSettings = (char *)Map()->GetData(pItem->m_Settings);
-		char *pNext = pSettings;
-		Console()->SetUnknownCommandCallback(UnknownMapSettingCallback, nullptr);
-		while(pNext < pSettings + Size)
+		const std::optional<std::vector<const char *>> vpSettings = Map()->GetDataStringArray(pItem->m_Settings);
+		if(!vpSettings.has_value())
 		{
-			int StrSize = str_length(pNext) + 1;
-			Console()->ExecuteLine(pNext, IConsole::CLIENT_ID_GAME);
-			pNext += StrSize;
+			log_error("client", "Map settings are invalid.");
+			break;
+		}
+		Console()->SetUnknownCommandCallback(UnknownMapSettingCallback, nullptr);
+		for(const char *pSetting : vpSettings.value())
+		{
+			Console()->ExecuteLine(pSetting, IConsole::CLIENT_ID_GAME);
 		}
 		Console()->SetUnknownCommandCallback(IConsole::EmptyUnknownCommandCallback, nullptr);
 		Map()->UnloadData(pItem->m_Settings);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -4757,14 +4757,8 @@ void CGameClient::LoadMapSettings()
 	{
 		int ItemId;
 		CMapItemInfoSettings *pItem = (CMapItemInfoSettings *)Map()->GetItem(i, nullptr, &ItemId);
-		int ItemSize = Map()->GetItemSize(i);
 		if(!pItem || ItemId != 0)
 			continue;
-
-		if(ItemSize < (int)sizeof(CMapItemInfoSettings))
-			break;
-		if(!(pItem->m_Settings > -1))
-			break;
 
 		const std::optional<std::vector<const char *>> vpSettings = Map()->GetDataStringArray(pItem->m_Settings);
 		if(!vpSettings.has_value())

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -660,27 +660,19 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 		{
 			CMapItemGroup *pGItem = (CMapItemGroup *)pMap->GetItem(Start + g);
 
-			if(pGItem->m_Version < 1 || pGItem->m_Version > 3)
-				continue;
-
 			std::shared_ptr<CLayerGroup> pGroup = NewGroup();
 			pGroup->m_ParallaxX = pGItem->m_ParallaxX;
 			pGroup->m_ParallaxY = pGItem->m_ParallaxY;
 			pGroup->m_OffsetX = pGItem->m_OffsetX;
 			pGroup->m_OffsetY = pGItem->m_OffsetY;
-
-			if(pGItem->m_Version >= 2)
-			{
-				pGroup->m_UseClipping = pGItem->m_UseClipping;
-				pGroup->m_ClipX = pGItem->m_ClipX;
-				pGroup->m_ClipY = pGItem->m_ClipY;
-				pGroup->m_ClipW = pGItem->m_ClipW;
-				pGroup->m_ClipH = pGItem->m_ClipH;
-			}
+			pGroup->m_UseClipping = pGItem->m_UseClipping;
+			pGroup->m_ClipX = pGItem->m_ClipX;
+			pGroup->m_ClipY = pGItem->m_ClipY;
+			pGroup->m_ClipW = pGItem->m_ClipW;
+			pGroup->m_ClipH = pGItem->m_ClipH;
 
 			// load group name
-			if(pGItem->m_Version >= 3)
-				IntsToStr(pGItem->m_aName, std::size(pGItem->m_aName), pGroup->m_aName, std::size(pGroup->m_aName));
+			IntsToStr(pGItem->m_aName, std::size(pGItem->m_aName), pGroup->m_aName, std::size(pGroup->m_aName));
 
 			for(int l = 0; l < pGItem->m_NumLayers; l++)
 			{

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -98,26 +98,13 @@ bool CEditorMap::Save(const char *pFilename, const FErrorHandler &ErrorHandler)
 		Item.m_Credits = Writer.AddDataString(m_MapInfo.m_aCredits);
 		Item.m_License = Writer.AddDataString(m_MapInfo.m_aLicense);
 
-		Item.m_Settings = -1;
-		if(!m_vSettings.empty())
+		std::vector<const char *> vpSettings;
+		vpSettings.reserve(m_vSettings.size());
+		for(const CEditorMapSetting &Setting : m_vSettings)
 		{
-			int Size = 0;
-			for(const auto &Setting : m_vSettings)
-			{
-				Size += str_length(Setting.m_aCommand) + 1;
-			}
-
-			char *pSettings = (char *)malloc(std::max(Size, 1));
-			char *pNext = pSettings;
-			for(const auto &Setting : m_vSettings)
-			{
-				int Length = str_length(Setting.m_aCommand) + 1;
-				mem_copy(pNext, Setting.m_aCommand, Length);
-				pNext += Length;
-			}
-			Item.m_Settings = Writer.AddData(Size, pSettings);
-			free(pSettings);
+			vpSettings.push_back(Setting.m_aCommand);
 		}
+		Item.m_Settings = Writer.AddDataStringArray(vpSettings);
 
 		Writer.AddItem(MAPITEMTYPE_INFO, 0, sizeof(Item), &Item);
 	}
@@ -511,14 +498,15 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 			if(!(pItem->m_Settings > -1))
 				break;
 
-			const unsigned Size = pMap->GetDataSize(pItem->m_Settings);
-			char *pSettings = (char *)pMap->GetData(pItem->m_Settings);
-			char *pNext = pSettings;
-			while(pNext < pSettings + Size)
+			const std::optional<std::vector<const char *>> vpSettings = pMap->GetDataStringArray(pItem->m_Settings);
+			if(!vpSettings.has_value())
 			{
-				int StrSize = str_length(pNext) + 1;
-				m_vSettings.emplace_back(pNext);
-				pNext += StrSize;
+				ErrorHandler("Error: Failed to read settings from map info.");
+				break;
+			}
+			for(const char *pSetting : vpSettings.value())
+			{
+				m_vSettings.emplace_back(pSetting);
 			}
 		}
 	}

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -850,8 +850,7 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 					}
 
 					// load layer name
-					if(pQuadsItem->m_Version >= 2)
-						IntsToStr(pQuadsItem->m_aName, std::size(pQuadsItem->m_aName), pQuads->m_aName, std::size(pQuads->m_aName));
+					IntsToStr(pQuadsItem->m_aName, std::size(pQuadsItem->m_aName), pQuads->m_aName, std::size(pQuads->m_aName));
 
 					if(pQuadsItem->m_NumQuads > 0)
 					{

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -1016,11 +1016,9 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 				if(pPointBezier != nullptr)
 					mem_copy(&pEnvelope->m_vPoints[PointIndex].m_Bezier, pPointBezier, sizeof(CEnvPointBezier));
 			}
-			if(pItem->m_aName[0] != -1) // compatibility with old maps
-				IntsToStr(pItem->m_aName, std::size(pItem->m_aName), pEnvelope->m_aName, std::size(pEnvelope->m_aName));
+			IntsToStr(pItem->m_aName, std::size(pItem->m_aName), pEnvelope->m_aName, std::size(pEnvelope->m_aName));
+			pEnvelope->m_Synchronized = pItem->m_Synchronized;
 			m_vpEnvelopes.push_back(pEnvelope);
-			if(pItem->m_Version >= 2)
-				pEnvelope->m_Synchronized = pItem->m_Synchronized;
 		}
 	}
 

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -874,8 +874,6 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 				else if(pLayerItem->m_Type == LAYERTYPE_SOUNDS)
 				{
 					const CMapItemLayerSounds *pSoundsItem = (CMapItemLayerSounds *)pLayerItem;
-					if(pSoundsItem->m_Version < 1 || pSoundsItem->m_Version > 2)
-						continue;
 
 					std::shared_ptr<CLayerSounds> pSounds = std::make_shared<CLayerSounds>(this);
 					pSounds->m_Flags = pLayerItem->m_Flags;
@@ -914,8 +912,6 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 				{
 					// compatibility with old sound layers
 					const CMapItemLayerSounds *pSoundsItem = (CMapItemLayerSounds *)pLayerItem;
-					if(pSoundsItem->m_Version < 1 || pSoundsItem->m_Version > 2)
-						continue;
 
 					std::shared_ptr<CLayerSounds> pSounds = std::make_shared<CLayerSounds>(this);
 					pSounds->m_Flags = pLayerItem->m_Flags;

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -466,7 +466,6 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 		pMap->GetType(MAPITEMTYPE_INFO, &Start, &Num);
 		for(int i = Start; i < Start + Num; i++)
 		{
-			int ItemSize = pMap->GetItemSize(i);
 			int ItemId;
 			CMapItemInfoSettings *pItem = (CMapItemInfoSettings *)pMap->GetItem(i, nullptr, &ItemId);
 			if(!pItem || ItemId != 0)
@@ -491,12 +490,6 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 			ReadStringInfo(pItem->m_MapVersion, m_MapInfo.m_aVersion, sizeof(m_MapInfo.m_aVersion), "version");
 			ReadStringInfo(pItem->m_Credits, m_MapInfo.m_aCredits, sizeof(m_MapInfo.m_aCredits), "credits");
 			ReadStringInfo(pItem->m_License, m_MapInfo.m_aLicense, sizeof(m_MapInfo.m_aLicense), "license");
-
-			if(pItem->m_Version != 1 || ItemSize < (int)sizeof(CMapItemInfoSettings))
-				break;
-
-			if(!(pItem->m_Settings > -1))
-				break;
 
 			const std::optional<std::vector<const char *>> vpSettings = pMap->GetDataStringArray(pItem->m_Settings);
 			if(!vpSettings.has_value())

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -526,14 +526,14 @@ bool CEditorMap::Load(const char *pFilename, int StorageType, const FErrorHandle
 			else
 				str_copy(pImg->m_aName, pName);
 
-			if(pItem->m_Version > 1 && pItem->m_MustBe1 != 1)
+			if(pItem->m_MustBe1 != 1)
 			{
 				char aBuf[128];
 				str_format(aBuf, sizeof(aBuf), "Error: Unsupported image type of image %d '%s'.", i, pImg->m_aName);
 				ErrorHandler(aBuf);
 			}
 
-			if(pImg->m_External || (pItem->m_Version > 1 && pItem->m_MustBe1 != 1))
+			if(pImg->m_External || pItem->m_MustBe1 != 1)
 			{
 				char aBuf[IO_MAX_PATH_LENGTH];
 				str_format(aBuf, sizeof(aBuf), "mapres/%s.png", pImg->m_aName);

--- a/src/game/layers.cpp
+++ b/src/game/layers.cpp
@@ -41,14 +41,11 @@ void CLayers::Init(IMap *pMap, bool GameOnly, bool InitializeTilemapSkip)
 				m_pGameGroup->m_ParallaxX = 100;
 				m_pGameGroup->m_ParallaxY = 100;
 
-				if(m_pGameGroup->m_Version >= 2)
-				{
-					m_pGameGroup->m_UseClipping = 0;
-					m_pGameGroup->m_ClipX = 0;
-					m_pGameGroup->m_ClipY = 0;
-					m_pGameGroup->m_ClipW = 0;
-					m_pGameGroup->m_ClipH = 0;
-				}
+				m_pGameGroup->m_UseClipping = 0;
+				m_pGameGroup->m_ClipX = 0;
+				m_pGameGroup->m_ClipY = 0;
+				m_pGameGroup->m_ClipW = 0;
+				m_pGameGroup->m_ClipH = 0;
 			}
 			else if(!GameOnly)
 			{

--- a/src/game/map/render_layer.cpp
+++ b/src/game/map/render_layer.cpp
@@ -231,7 +231,7 @@ bool CRenderLayerGroup::DoRender(const CRenderLayerParams &Params)
 	if(!g_Config.m_GfxNoclip || Params.m_RenderType == ERenderType::RENDERTYPE_FULL_DESIGN)
 	{
 		Graphics()->ClipDisable();
-		if(m_pGroup->m_Version >= 2 && m_pGroup->m_UseClipping)
+		if(m_pGroup->m_UseClipping)
 		{
 			// set clipping
 			Graphics()->MapScreenToInterface(Params.m_Center.x, Params.m_Center.y, Params.m_Zoom);

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -493,7 +493,7 @@ static_assert(sizeof(CMapItemLayerTilemap_v2Legacy) == 80);
 static_assert(sizeof(CMapItemLayerTilemap_v3Teeworlds) == 72);
 static_assert(sizeof(CMapItemLayerTilemap) == 92);
 
-class CMapItemLayerQuads
+class CMapItemLayerQuads_v1
 {
 public:
 	CMapItemLayer m_Layer;
@@ -502,9 +502,19 @@ public:
 	int m_NumQuads;
 	int m_Data;
 	int m_Image;
+};
 
+// Names were added to quads layer items in version 2.
+class CMapItemLayerQuads : public CMapItemLayerQuads_v1
+{
+public:
 	int m_aName[3];
 };
+
+// The quads layer items are cast from the raw map file data, so the base class
+// must not add any padding to the derived class.
+static_assert(sizeof(CMapItemLayerQuads_v1) == 28);
+static_assert(sizeof(CMapItemLayerQuads) == 40);
 
 class CMapItemVersion
 {

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -548,6 +548,18 @@ public:
 	CEnvPointBezier m_Bezier;
 };
 
+// Version 1 envelope items of very old Teeworlds versions contain a single integer,
+// which is always -1 in existing maps, instead of the name.
+class CMapItemEnvelope_v1Legacy
+{
+public:
+	int m_Version;
+	int m_Channels;
+	int m_StartPoint;
+	int m_NumPoints;
+	int m_Name;
+};
+
 class CMapItemEnvelope_v1
 {
 public:

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -404,7 +404,8 @@ public:
 	int m_NumLayers;
 };
 
-class CMapItemGroup : public CMapItemGroup_v1
+// Clipping was added to group items in version 2.
+class CMapItemGroup_v2 : public CMapItemGroup_v1
 {
 public:
 	int m_UseClipping;
@@ -412,9 +413,20 @@ public:
 	int m_ClipY;
 	int m_ClipW;
 	int m_ClipH;
+};
 
+// Names were added to group items in version 3.
+class CMapItemGroup : public CMapItemGroup_v2
+{
+public:
 	int m_aName[3];
 };
+
+// The group items are cast from the raw map file data, so the base classes
+// must not add any padding to the derived classes.
+static_assert(sizeof(CMapItemGroup_v1) == 28);
+static_assert(sizeof(CMapItemGroup_v2) == 48);
+static_assert(sizeof(CMapItemGroup) == 60);
 
 class CMapItemLayer
 {

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4598,14 +4598,15 @@ void CGameContext::LoadMapSettings()
 		if(!(pItem->m_Settings > -1))
 			break;
 
-		int Size = pMap->GetDataSize(pItem->m_Settings);
-		char *pSettings = (char *)pMap->GetData(pItem->m_Settings);
-		char *pNext = pSettings;
-		while(pNext < pSettings + Size)
+		const std::optional<std::vector<const char *>> vpSettings = pMap->GetDataStringArray(pItem->m_Settings);
+		if(!vpSettings.has_value())
 		{
-			int StrSize = str_length(pNext) + 1;
-			Console()->ExecuteLine(pNext, IConsole::CLIENT_ID_GAME);
-			pNext += StrSize;
+			log_error("mapsettings", "Map settings are invalid.");
+			break;
+		}
+		for(const char *pSetting : vpSettings.value())
+		{
+			Console()->ExecuteLine(pSetting, IConsole::CLIENT_ID_GAME);
 		}
 		pMap->UnloadData(pItem->m_Settings);
 		break;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4589,14 +4589,8 @@ void CGameContext::LoadMapSettings()
 	{
 		int ItemId;
 		CMapItemInfoSettings *pItem = (CMapItemInfoSettings *)pMap->GetItem(i, nullptr, &ItemId);
-		int ItemSize = pMap->GetItemSize(i);
 		if(!pItem || ItemId != 0)
 			continue;
-
-		if(ItemSize < (int)sizeof(CMapItemInfoSettings))
-			break;
-		if(!(pItem->m_Settings > -1))
-			break;
 
 		const std::optional<std::vector<const char *>> vpSettings = pMap->GetDataStringArray(pItem->m_Settings);
 		if(!vpSettings.has_value())

--- a/src/tools/config_retrieve.cpp
+++ b/src/tools/config_retrieve.cpp
@@ -32,6 +32,13 @@ static void Process(IStorage *pStorage, const char *pMapName, const char *pConfi
 		if(!(pItem->m_Settings > -1))
 			break;
 
+		const std::optional<std::vector<const char *>> vpSettings = Reader.GetDataStringArray(pItem->m_Settings);
+		if(!vpSettings.has_value())
+		{
+			dbg_msg("config_retrieve", "error reading settings from map '%s'", pMapName);
+			break;
+		}
+
 		ConfigFound = true;
 		IOHANDLE Config = pStorage->OpenFile(pConfigName, IOFLAG_WRITE, IStorage::TYPE_ABSOLUTE);
 		if(!Config)
@@ -41,15 +48,10 @@ static void Process(IStorage *pStorage, const char *pMapName, const char *pConfi
 			return;
 		}
 
-		int Size = Reader.GetDataSize(pItem->m_Settings);
-		char *pSettings = (char *)Reader.GetData(pItem->m_Settings);
-		char *pNext = pSettings;
-		while(pNext < pSettings + Size)
+		for(const char *pSetting : vpSettings.value())
 		{
-			int StrSize = str_length(pNext) + 1;
-			io_write(Config, pNext, StrSize - 1);
+			io_write(Config, pSetting, str_length(pSetting));
 			io_write_newline(Config);
-			pNext += StrSize;
 		}
 		Reader.UnloadData(pItem->m_Settings);
 		io_close(Config);

--- a/src/tools/map_convert_07.cpp
+++ b/src/tools/map_convert_07.cpp
@@ -9,6 +9,7 @@
 #include <base/str.h>
 
 #include <engine/gfx/image_loader.h>
+#include <engine/map.h>
 #include <engine/shared/datafile.h>
 #include <engine/storage.h>
 
@@ -21,7 +22,7 @@
 	Usage: map_convert_07 <source map filepath> <dest map filepath>
 */
 
-static CDataFileReader g_DataReader;
+static std::unique_ptr<IMap> g_pMap;
 static CDataFileWriter g_DataWriter;
 
 // global new image data (set by ReplaceImageItem)
@@ -46,7 +47,7 @@ static bool CheckImageDimensions(void *pLayerItem, int LayerType, const char *pF
 		return true;
 
 	int Type;
-	void *pItem = g_DataReader.GetItem(g_aImageIds[pTMap->m_Image], &Type);
+	void *pItem = g_pMap->GetItem(g_aImageIds[pTMap->m_Image], &Type);
 	if(Type != MAPITEMTYPE_IMAGE)
 		return true;
 
@@ -58,7 +59,7 @@ static bool CheckImageDimensions(void *pLayerItem, int LayerType, const char *pF
 	char aTileLayerName[12];
 	IntsToStr(pTMap->m_aName, std::size(pTMap->m_aName), aTileLayerName, std::size(aTileLayerName));
 
-	const char *pName = g_DataReader.GetDataString(pImgItem->m_ImageName);
+	const char *pName = g_pMap->GetDataString(pImgItem->m_ImageName);
 	dbg_msg("map_convert_07", "%s: Tile layer \"%s\" uses image \"%s\" with width %d, height %d, which is not divisible by 16. This is not supported in Teeworlds 0.7. Please scale the image and replace it manually.", pFilename, aTileLayerName, pName == nullptr ? "(error)" : pName, pImgItem->m_Width, pImgItem->m_Height);
 	return false;
 }
@@ -68,7 +69,7 @@ static void *ReplaceImageItem(int Index, CMapItemImage *pImgItem, CMapItemImage 
 	if(!pImgItem->m_External)
 		return pImgItem;
 
-	const char *pName = g_DataReader.GetDataString(pImgItem->m_ImageName);
+	const char *pName = g_pMap->GetDataString(pImgItem->m_ImageName);
 	if(pName == nullptr || pName[0] == '\0')
 	{
 		dbg_msg("map_convert_07", "failed to load name of image %d", Index);
@@ -150,7 +151,8 @@ int main(int argc, const char **argv)
 		}
 	}
 
-	if(!g_DataReader.Open(pStorage.get(), pSourceFilename, IStorage::TYPE_ABSOLUTE))
+	g_pMap = CreateMap();
+	if(!g_pMap->Load(pStorage.get(), pSourceFilename, IStorage::TYPE_ABSOLUTE))
 	{
 		dbg_msg("map_convert_07", "failed to open source map. filename='%s'", pSourceFilename);
 		return -1;
@@ -162,13 +164,13 @@ int main(int argc, const char **argv)
 		return -1;
 	}
 
-	g_NextDataItemId = g_DataReader.NumData();
+	g_NextDataItemId = g_pMap->NumData();
 
 	size_t i = 0;
-	for(int Index = 0; Index < g_DataReader.NumItems(); Index++)
+	for(int Index = 0; Index < g_pMap->NumItems(); Index++)
 	{
 		int Type;
-		g_DataReader.GetItem(Index, &Type);
+		g_pMap->GetItem(Index, &Type);
 		if(Type == MAPITEMTYPE_IMAGE)
 		{
 			if(i >= MAX_MAPIMAGES)
@@ -184,11 +186,11 @@ int main(int argc, const char **argv)
 	bool Success = true;
 
 	// add all items
-	for(int Index = 0; Index < g_DataReader.NumItems(); Index++)
+	for(int Index = 0; Index < g_pMap->NumItems(); Index++)
 	{
 		int Type, Id;
 		CUuid Uuid;
-		void *pItem = g_DataReader.GetItem(Index, &Type, &Id, &Uuid);
+		void *pItem = g_pMap->GetItem(Index, &Type, &Id, &Uuid);
 
 		// Filter ITEMTYPE_EX items, they will be automatically added again.
 		if(Type == ITEMTYPE_EX)
@@ -196,7 +198,7 @@ int main(int argc, const char **argv)
 			continue;
 		}
 
-		int Size = g_DataReader.GetItemSize(Index);
+		int Size = g_pMap->GetItemSize(Index);
 		Success &= CheckImageDimensions(pItem, Type, pSourceFilename);
 
 		CMapItemImage NewImageItem;
@@ -212,10 +214,15 @@ int main(int argc, const char **argv)
 	}
 
 	// add all data
-	for(int Index = 0; Index < g_DataReader.NumData(); Index++)
+	for(int Index = 0; Index < g_pMap->NumData(); Index++)
 	{
-		void *pData = g_DataReader.GetData(Index);
-		int Size = g_DataReader.GetDataSize(Index);
+		void *pData = g_pMap->GetData(Index);
+		int Size = g_pMap->GetDataSize(Index);
+		if(pData == nullptr)
+		{
+			log_error("map_convert_07", "Failed to load data %d.", Index);
+			return -1;
+		}
 		g_DataWriter.AddData(Size, pData);
 	}
 
@@ -224,7 +231,7 @@ int main(int argc, const char **argv)
 		g_DataWriter.AddData(g_aNewImageInfos[Index].DataSize(), g_aNewImageInfos[Index].m_pData);
 	}
 
-	g_DataReader.Close();
+	g_pMap->Unload();
 	g_DataWriter.Finish();
 	return Success ? 0 : -1;
 }

--- a/src/tools/map_extract.cpp
+++ b/src/tools/map_extract.cpp
@@ -7,38 +7,38 @@
 #include <base/str.h>
 
 #include <engine/gfx/image_loader.h>
-#include <engine/shared/datafile.h>
+#include <engine/map.h>
 #include <engine/storage.h>
 
 #include <game/mapitems.h>
 
-static void PrintMapInfo(CDataFileReader &Reader)
+static void PrintMapInfo(IMap *pMap)
 {
-	const CMapItemInfo *pInfo = static_cast<CMapItemInfo *>(Reader.FindItem(MAPITEMTYPE_INFO, 0));
+	const CMapItemInfo *pInfo = static_cast<CMapItemInfo *>(pMap->FindItem(MAPITEMTYPE_INFO, 0));
 	if(pInfo)
 	{
-		const char *pAuthor = Reader.GetDataString(pInfo->m_Author);
+		const char *pAuthor = pMap->GetDataString(pInfo->m_Author);
 		log_info("map_extract", "author:  %s", pAuthor == nullptr ? "(error)" : pAuthor);
-		const char *pMapVersion = Reader.GetDataString(pInfo->m_MapVersion);
+		const char *pMapVersion = pMap->GetDataString(pInfo->m_MapVersion);
 		log_info("map_extract", "version: %s", pMapVersion == nullptr ? "(error)" : pMapVersion);
-		const char *pCredits = Reader.GetDataString(pInfo->m_Credits);
+		const char *pCredits = pMap->GetDataString(pInfo->m_Credits);
 		log_info("map_extract", "credits: %s", pCredits == nullptr ? "(error)" : pCredits);
-		const char *pLicense = Reader.GetDataString(pInfo->m_License);
+		const char *pLicense = pMap->GetDataString(pInfo->m_License);
 		log_info("map_extract", "license: %s", pLicense == nullptr ? "(error)" : pLicense);
 	}
 }
 
-static void ExtractMapImages(CDataFileReader &Reader, const char *pPathSave)
+static void ExtractMapImages(IMap *pMap, const char *pPathSave)
 {
 	int Start, Num;
-	Reader.GetType(MAPITEMTYPE_IMAGE, &Start, &Num);
+	pMap->GetType(MAPITEMTYPE_IMAGE, &Start, &Num);
 	for(int i = 0; i < Num; i++)
 	{
-		const CMapItemImage_v2 *pItem = static_cast<CMapItemImage_v2 *>(Reader.GetItem(Start + i));
+		const CMapItemImage_v2 *pItem = static_cast<CMapItemImage_v2 *>(pMap->GetItem(Start + i));
 		if(pItem->m_External)
 			continue;
 
-		const char *pName = Reader.GetDataString(pItem->m_ImageName);
+		const char *pName = pMap->GetDataString(pItem->m_ImageName);
 		if(pName == nullptr || pName[0] == '\0')
 		{
 			log_error("map_extract", "failed to load name of image %d", i);
@@ -47,7 +47,7 @@ static void ExtractMapImages(CDataFileReader &Reader, const char *pPathSave)
 
 		char aBuf[IO_MAX_PATH_LENGTH];
 		str_format(aBuf, sizeof(aBuf), "%s/%s.png", pPathSave, pName);
-		Reader.UnloadData(pItem->m_ImageName);
+		pMap->UnloadData(pItem->m_ImageName);
 
 		if(pItem->m_MustBe1 != 1)
 		{
@@ -65,46 +65,46 @@ static void ExtractMapImages(CDataFileReader &Reader, const char *pPathSave)
 		Image.m_Width = pItem->m_Width;
 		Image.m_Height = pItem->m_Height;
 		Image.m_Format = CImageInfo::FORMAT_RGBA;
-		Image.m_pData = static_cast<uint8_t *>(Reader.GetData(pItem->m_ImageData));
+		Image.m_pData = static_cast<uint8_t *>(pMap->GetData(pItem->m_ImageData));
 
 		log_info("map_extract", "writing image: %s (%dx%d)", aBuf, pItem->m_Width, pItem->m_Height);
 		if(!CImageLoader::SavePng(io_open(aBuf, IOFLAG_WRITE), aBuf, Image))
 		{
 			log_error("map_extract", "failed to write image file. filename='%s'", aBuf);
 		}
-		Reader.UnloadData(pItem->m_ImageData);
+		pMap->UnloadData(pItem->m_ImageData);
 	}
 }
 
-static void ExtractMapSounds(CDataFileReader &Reader, const char *pPathSave)
+static void ExtractMapSounds(IMap *pMap, const char *pPathSave)
 {
 	int Start, Num;
-	Reader.GetType(MAPITEMTYPE_SOUND, &Start, &Num);
+	pMap->GetType(MAPITEMTYPE_SOUND, &Start, &Num);
 	for(int i = 0; i < Num; i++)
 	{
-		const CMapItemSound *pItem = static_cast<CMapItemSound *>(Reader.GetItem(Start + i));
+		const CMapItemSound *pItem = static_cast<CMapItemSound *>(pMap->GetItem(Start + i));
 		if(pItem->m_External)
 			continue;
 
-		const char *pName = Reader.GetDataString(pItem->m_SoundName);
+		const char *pName = pMap->GetDataString(pItem->m_SoundName);
 		if(pName == nullptr || pName[0] == '\0')
 		{
 			log_error("map_extract", "failed to load name of sound %d", i);
 			continue;
 		}
 
-		const int SoundDataSize = Reader.GetDataSize(pItem->m_SoundData);
+		const int SoundDataSize = pMap->GetDataSize(pItem->m_SoundData);
 		char aBuf[IO_MAX_PATH_LENGTH];
 		str_format(aBuf, sizeof(aBuf), "%s/%s.opus", pPathSave, pName);
-		Reader.UnloadData(pItem->m_SoundName);
+		pMap->UnloadData(pItem->m_SoundName);
 
 		IOHANDLE Opus = io_open(aBuf, IOFLAG_WRITE);
 		if(Opus)
 		{
 			log_info("map_extract", "writing sound: %s (%d B)", aBuf, SoundDataSize);
-			io_write(Opus, Reader.GetData(pItem->m_SoundData), SoundDataSize);
+			io_write(Opus, pMap->GetData(pItem->m_SoundData), SoundDataSize);
 			io_close(Opus);
-			Reader.UnloadData(pItem->m_SoundData);
+			pMap->UnloadData(pItem->m_SoundData);
 		}
 		else
 		{
@@ -115,27 +115,20 @@ static void ExtractMapSounds(CDataFileReader &Reader, const char *pPathSave)
 
 static bool ExtractMap(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 {
-	CDataFileReader Reader;
-	if(!Reader.Open(pStorage, pMapName, IStorage::TYPE_ABSOLUTE))
+	std::unique_ptr<IMap> pMap = CreateMap();
+	if(!pMap->Load(pStorage, pMapName, IStorage::TYPE_ABSOLUTE))
 	{
 		log_error("map_extract", "error opening map '%s'", pMapName);
 		return false;
 	}
 
-	const CMapItemVersion *pVersion = static_cast<CMapItemVersion *>(Reader.FindItem(MAPITEMTYPE_VERSION, 0));
-	if(pVersion == nullptr || pVersion->m_Version != 1)
-	{
-		log_error("map_extract", "unsupported map version '%s'", pMapName);
-		return false;
-	}
-
 	log_info("map_extract", "Make sure you have the permission to use these images and sounds in your own maps");
 
-	PrintMapInfo(Reader);
-	ExtractMapImages(Reader, pPathSave);
-	ExtractMapSounds(Reader, pPathSave);
+	PrintMapInfo(pMap.get());
+	ExtractMapImages(pMap.get(), pPathSave);
+	ExtractMapSounds(pMap.get(), pPathSave);
 
-	Reader.Close();
+	pMap->Unload();
 	return true;
 }
 

--- a/src/tools/map_extract.cpp
+++ b/src/tools/map_extract.cpp
@@ -49,7 +49,7 @@ static void ExtractMapImages(CDataFileReader &Reader, const char *pPathSave)
 		str_format(aBuf, sizeof(aBuf), "%s/%s.png", pPathSave, pName);
 		Reader.UnloadData(pItem->m_ImageName);
 
-		if(pItem->m_Version >= 2 && pItem->m_MustBe1 != 1)
+		if(pItem->m_MustBe1 != 1)
 		{
 			log_error("map_extract", "ignoring image '%s' with unknown format %d", aBuf, pItem->m_MustBe1);
 			continue;

--- a/src/tools/map_find_env.cpp
+++ b/src/tools/map_find_env.cpp
@@ -3,7 +3,7 @@
 #include <base/os.h>
 #include <base/str.h>
 
-#include <engine/shared/datafile.h>
+#include <engine/map.h>
 #include <engine/storage.h>
 
 #include <game/mapitems.h>
@@ -17,31 +17,14 @@ public:
 	int m_TilePosY;
 };
 
-static bool OpenMap(const char pMapName[64], CDataFileReader &InputMap)
-{
-	std::unique_ptr<IStorage> pStorage = CreateLocalStorage();
-	if(!pStorage)
-	{
-		log_error("map_find_env", "Error creating local storage");
-		return false;
-	}
-
-	if(!InputMap.Open(pStorage.get(), pMapName, IStorage::TYPE_ABSOLUTE))
-	{
-		dbg_msg("map_find_env", "ERROR: unable to open map '%s'", pMapName);
-		return false;
-	}
-	return true;
-}
-
-static bool GetLayerGroupIds(CDataFileReader &InputMap, const int LayerNumber, int &GroupId, int &LayerRelativeId)
+static bool GetLayerGroupIds(IMap *pMap, const int LayerNumber, int &GroupId, int &LayerRelativeId)
 {
 	int Start, Num;
-	InputMap.GetType(MAPITEMTYPE_GROUP, &Start, &Num);
+	pMap->GetType(MAPITEMTYPE_GROUP, &Start, &Num);
 
 	for(int i = 0; i < Num; i++)
 	{
-		CMapItemGroup *pItem = (CMapItemGroup *)InputMap.GetItem(Start + i);
+		CMapItemGroup *pItem = (CMapItemGroup *)pMap->GetItem(Start + i);
 		if(LayerNumber >= pItem->m_StartLayer && LayerNumber <= pItem->m_StartLayer + pItem->m_NumLayers)
 		{
 			GroupId = i;
@@ -93,27 +76,37 @@ static void PrintEnvelopedQuads(const CEnvelopedQuad pEnvQuads[1024], const int 
 
 static bool FindEnv(const char aFilename[64], const int EnvId)
 {
-	CDataFileReader InputMap;
-	if(!OpenMap(aFilename, InputMap))
+	std::unique_ptr<IStorage> pStorage = CreateLocalStorage();
+	if(!pStorage)
+	{
+		log_error("map_find_env", "Error creating local storage");
 		return false;
+	}
+
+	std::unique_ptr<IMap> pMap = CreateMap();
+	if(!pMap->Load(pStorage.get(), aFilename, IStorage::TYPE_ABSOLUTE))
+	{
+		dbg_msg("map_find_env", "ERROR: unable to open map '%s'", aFilename);
+		return false;
+	}
 
 	int LayersStart, LayersCount, QuadsCounter = 0;
-	InputMap.GetType(MAPITEMTYPE_LAYER, &LayersStart, &LayersCount);
+	pMap->GetType(MAPITEMTYPE_LAYER, &LayersStart, &LayersCount);
 	CEnvelopedQuad pEnvQuads[1024];
 
 	for(int i = 0; i < LayersCount; i++)
 	{
 		CMapItemLayer *pItem;
-		pItem = (CMapItemLayer *)InputMap.GetItem(LayersStart + i);
+		pItem = (CMapItemLayer *)pMap->GetItem(LayersStart + i);
 
 		if(pItem->m_Type != LAYERTYPE_QUADS)
 			continue;
 
 		CMapItemLayerQuads *pQuadLayer = (CMapItemLayerQuads *)pItem;
-		CQuad *pQuads = (CQuad *)InputMap.GetDataSwapped(pQuadLayer->m_Data);
+		CQuad *pQuads = (CQuad *)pMap->GetDataSwapped(pQuadLayer->m_Data);
 
 		int GroupId = 0, LayerRelativeId = 0;
-		if(!GetLayerGroupIds(InputMap, i + 1, GroupId, LayerRelativeId))
+		if(!GetLayerGroupIds(pMap.get(), i + 1, GroupId, LayerRelativeId))
 			return false;
 
 		GetEnvelopedQuads(pQuads, pQuadLayer->m_NumQuads, EnvId, GroupId, LayerRelativeId, QuadsCounter, pEnvQuads);

--- a/src/tools/map_find_env.cpp
+++ b/src/tools/map_find_env.cpp
@@ -104,6 +104,12 @@ static bool FindEnv(const char aFilename[64], const int EnvId)
 
 		CMapItemLayerQuads *pQuadLayer = (CMapItemLayerQuads *)pItem;
 		CQuad *pQuads = (CQuad *)pMap->GetDataSwapped(pQuadLayer->m_Data);
+		if(pQuads == nullptr || pQuadLayer->m_NumQuads < 0 ||
+			pQuadLayer->m_NumQuads > pMap->GetDataSize(pQuadLayer->m_Data) / (int)sizeof(CQuad))
+		{
+			log_error("map_find_env", "Quads of layer %d are invalid", i);
+			return false;
+		}
 
 		int GroupId = 0, LayerRelativeId = 0;
 		if(!GetLayerGroupIds(pMap.get(), i + 1, GroupId, LayerRelativeId))

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -6,6 +6,7 @@
 #include <base/str.h>
 
 #include <engine/gfx/image_manipulation.h>
+#include <engine/map.h>
 #include <engine/shared/datafile.h>
 #include <engine/storage.h>
 
@@ -120,8 +121,8 @@ int main(int argc, const char **argv)
 		str_format(aFilename, sizeof(aFilename), "out/%s.map", aBuff);
 	}
 
-	CDataFileReader Reader;
-	if(!Reader.Open(pStorage.get(), argv[1], IStorage::TYPE_ABSOLUTE))
+	std::unique_ptr<IMap> pMap = CreateMap();
+	if(!pMap->Load(pStorage.get(), argv[1], IStorage::TYPE_ABSOLUTE))
 	{
 		dbg_msg("map_optimize", "Failed to open source file.");
 		return -1;
@@ -155,11 +156,11 @@ int main(int argc, const char **argv)
 	std::vector<SMapOptimizeItem> vDataFindHelper;
 
 	// add all items
-	for(int Index = 0, i = 0; Index < Reader.NumItems(); Index++)
+	for(int Index = 0, i = 0; Index < pMap->NumItems(); Index++)
 	{
 		int Type, Id;
 		CUuid Uuid;
-		void *pPtr = Reader.GetItem(Index, &Type, &Id, &Uuid);
+		void *pPtr = pMap->GetItem(Index, &Type, &Id, &Uuid);
 
 		// Filter ITEMTYPE_EX items, they will be automatically added again.
 		if(Type == ITEMTYPE_EX)
@@ -178,16 +179,14 @@ int main(int argc, const char **argv)
 				{
 					aImageFlags[pTLayer->m_Image] |= 1;
 					// check tiles that are used in this image
-					unsigned int DataSize = Reader.GetDataSize(pTLayer->m_Data);
-					void *pTiles = Reader.GetData(pTLayer->m_Data);
-
-					if(DataSize >= (size_t)pTLayer->m_Width * pTLayer->m_Height * sizeof(CTile))
+					const CTile *pTiles = static_cast<const CTile *>(pMap->GetData(pTLayer->m_Data));
+					if(pTiles != nullptr)
 					{
 						for(int y = 0; y < pTLayer->m_Height; ++y)
 						{
 							for(int x = 0; x < pTLayer->m_Width; ++x)
 							{
-								int TileIndex = ((CTile *)pTiles)[y * pTLayer->m_Width + x].m_Index;
+								int TileIndex = pTiles[y * pTLayer->m_Width + x].m_Index;
 								if(TileIndex > 0)
 								{
 									aaImageTiles[pTLayer->m_Image][TileIndex] = true;
@@ -223,16 +222,21 @@ int main(int argc, const char **argv)
 			++i;
 		}
 
-		int Size = Reader.GetItemSize(Index);
+		int Size = pMap->GetItemSize(Index);
 		Writer.AddItem(Type, Id, Size, pPtr, &Uuid);
 	}
 
 	// add all data
-	for(int Index = 0; Index < Reader.NumData(); Index++)
+	for(int Index = 0; Index < pMap->NumData(); Index++)
 	{
 		bool DeletePtr = false;
-		void *pPtr = Reader.GetData(Index);
-		int Size = Reader.GetDataSize(Index);
+		void *pPtr = pMap->GetData(Index);
+		int Size = pMap->GetDataSize(Index);
+		if(pPtr == nullptr)
+		{
+			log_error("map_optimize", "Failed to load data %d.", Index);
+			return -1;
+		}
 		auto MapDataItemIterator = std::find_if(vDataFindHelper.begin(), vDataFindHelper.end(), [Index](const SMapOptimizeItem &Other) -> bool { return Other.m_Data == Index || Other.m_Text == Index; });
 		if(MapDataItemIterator != vDataFindHelper.end())
 		{
@@ -307,8 +311,8 @@ int main(int argc, const char **argv)
 			else if(MapDataItemIterator->m_Text == Index)
 			{
 				char *pImgName = (char *)pPtr;
-				uint8_t *pImgBuff = (uint8_t *)Reader.GetData(MapDataItemIterator->m_Data);
-				int ImgSize = Reader.GetDataSize(MapDataItemIterator->m_Data);
+				uint8_t *pImgBuff = (uint8_t *)pMap->GetData(MapDataItemIterator->m_Data);
+				int ImgSize = pMap->GetDataSize(MapDataItemIterator->m_Data);
 
 				char aSHA256Str[SHA256_MAXSTRSIZE];
 				// This is the important function, that calculates the SHA256 in a special way
@@ -333,7 +337,7 @@ int main(int argc, const char **argv)
 			free(pPtr);
 	}
 
-	Reader.Close();
+	pMap->Unload();
 	Writer.Finish();
 
 	return 0;

--- a/src/tools/map_replace_area.cpp
+++ b/src/tools/map_replace_area.cpp
@@ -42,7 +42,7 @@ static void ReplaceDestinationTiles(CMapItemLayerTilemap *[2], CTile *[2], float
 static bool AdaptVisibleAreas(const float[2][2][2], const CMapObject[2], float[2][2][2]);
 static bool AdaptReplaceableAreas(const float[2][2][2], const float[2][2][2], const CMapObject[2], float[2][2][2]);
 
-static void ReplaceAreaQuads(std::shared_ptr<IMap>[2], const float[][2][2], const CMapItemGroup *[2], CMapItemLayer *[2], int);
+static bool ReplaceAreaQuads(std::shared_ptr<IMap>[2], const float[][2][2], const CMapItemGroup *[2], CMapItemLayer *[2], int);
 static bool RemoveDestinationQuads(const float[2][2], const CQuad *, int, const CMapItemGroup *, CQuad *, int &);
 static bool InsertDestinationQuads(const float[2][2][2], const CQuad *, int, const CMapItemGroup *[2], CQuad *, int &);
 static bool AdaptVisiblePoint(const float[2][2][2], const float[2][2], const CMapObject[2], float[2]);
@@ -144,7 +144,10 @@ bool ReplaceArea(IStorage *pStorage, const char aaMapNames[3][64], const float a
 				return false;
 		}
 		else if(apItem[0]->m_Type == LAYERTYPE_QUADS)
-			ReplaceAreaQuads(apInputMaps, aaaGameAreas, apLayerGroups, apItem, aLayersStart[1] + i);
+		{
+			if(!ReplaceAreaQuads(apInputMaps, aaaGameAreas, apLayerGroups, apItem, aLayersStart[1] + i))
+				return false;
+		}
 	}
 
 	return SaveOutputMap(apInputMaps[1].get(), OutputMap);
@@ -285,7 +288,9 @@ bool ReplaceAreaTiles(std::shared_ptr<IMap> apInputMaps[2], const float aaaGameA
 	{
 		apTilemap[i] = (CMapItemLayerTilemap *)apItem[i];
 		apTile[i] = (CTile *)apInputMaps[i]->GetData(apTilemap[i]->m_Data);
-		if(apTile[i] == nullptr)
+		// The unused tiles data of physics layers is not validated when loading the map.
+		if(apTile[i] == nullptr ||
+			(int64_t)apTilemap[i]->m_Width * apTilemap[i]->m_Height > apInputMaps[i]->GetDataSize(apTilemap[i]->m_Data) / (int)sizeof(CTile))
 		{
 			log_error("map_replace_area", "Failed to load tiles of a layer.");
 			return false;
@@ -388,7 +393,7 @@ bool AdaptReplaceableAreas(const float aaaGameAreas[2][2][2], const float aaaVis
 	return true;
 }
 
-void ReplaceAreaQuads(std::shared_ptr<IMap> apInputMaps[2], const float aaaGameAreas[][2][2], const CMapItemGroup *apLayerGroups[2], CMapItemLayer *apItem[2], const int ItemNumber)
+bool ReplaceAreaQuads(std::shared_ptr<IMap> apInputMaps[2], const float aaaGameAreas[][2][2], const CMapItemGroup *apLayerGroups[2], CMapItemLayer *apItem[2], const int ItemNumber)
 {
 	CMapItemLayerQuads *apQuadLayer[2];
 	for(int i = 0; i < 2; i++)
@@ -396,7 +401,15 @@ void ReplaceAreaQuads(std::shared_ptr<IMap> apInputMaps[2], const float aaaGameA
 
 	CQuad *apQuads[3];
 	for(int i = 0; i < 2; i++)
+	{
 		apQuads[i] = (CQuad *)apInputMaps[i]->GetDataSwapped(apQuadLayer[i]->m_Data);
+		if(apQuads[i] == nullptr || apQuadLayer[i]->m_NumQuads < 0 ||
+			apQuadLayer[i]->m_NumQuads > apInputMaps[i]->GetDataSize(apQuadLayer[i]->m_Data) / (int)sizeof(CQuad))
+		{
+			log_error("map_replace_area", "Failed to load quads of a layer.");
+			return false;
+		}
+	}
 
 	apQuads[2] = new CQuad[apQuadLayer[0]->m_NumQuads + apQuadLayer[1]->m_NumQuads];
 	int QuadsCounter = 0;
@@ -413,6 +426,8 @@ void ReplaceAreaQuads(std::shared_ptr<IMap> apInputMaps[2], const float aaaGameA
 	}
 	else
 		delete[] apQuads[2];
+
+	return true;
 }
 
 bool RemoveDestinationQuads(const float aaGameArea[2][2], const CQuad *pQuads, const int NumQuads, const CMapItemGroup *pLayerGroup, CQuad *pDestQuads, int &QuadsCounter)

--- a/src/tools/map_replace_area.cpp
+++ b/src/tools/map_replace_area.cpp
@@ -249,7 +249,7 @@ void CompareGroups(const char aaMapNames[3][64], std::shared_ptr<IMap> apInputMa
 	for(int i = 0; i < 2; i++)
 		apInputMaps[i]->GetType(MAPITEMTYPE_GROUP, &aStart[i], &aNum[i]);
 
-	for(int i = 0; i < std::max(aNum[0], aNum[1]); i++)
+	for(int i = 0; i < std::min(aNum[0], aNum[1]); i++)
 	{
 		CMapItemGroup *apItem[2];
 		for(int j = 0; j < 2; j++)

--- a/src/tools/map_replace_area.cpp
+++ b/src/tools/map_replace_area.cpp
@@ -4,6 +4,7 @@
 #include <base/os.h>
 #include <base/str.h>
 
+#include <engine/map.h>
 #include <engine/shared/datafile.h>
 #include <engine/storage.h>
 
@@ -29,19 +30,19 @@ public:
 };
 
 static bool ReplaceArea(IStorage *, const char[3][64], const float[][2][2]);
-static bool OpenMaps(IStorage *, const char[3][64], CDataFileReader[2], CDataFileWriter &);
-static void SaveOutputMap(CDataFileReader &, CDataFileWriter &);
-static bool CompareLayers(const char[3][64], CDataFileReader[2]);
-static void CompareGroups(const char[3][64], CDataFileReader[2]);
-static const CMapItemGroup *GetLayerGroup(CDataFileReader &, int);
+static bool OpenMaps(IStorage *, const char[3][64], std::shared_ptr<IMap>[2], CDataFileWriter &);
+static bool SaveOutputMap(IMap *, CDataFileWriter &);
+static bool CompareLayers(const char[3][64], std::shared_ptr<IMap>[2]);
+static void CompareGroups(const char[3][64], std::shared_ptr<IMap>[2]);
+static const CMapItemGroup *GetLayerGroup(IMap *, int);
 
-static void ReplaceAreaTiles(CDataFileReader[2], const float[][2][2], const CMapItemGroup *[2], CMapItemLayer *[2]);
+static bool ReplaceAreaTiles(std::shared_ptr<IMap>[2], const float[][2][2], const CMapItemGroup *[2], CMapItemLayer *[2]);
 static void RemoveDestinationTiles(CMapItemLayerTilemap *, CTile *, float[2][2]);
 static void ReplaceDestinationTiles(CMapItemLayerTilemap *[2], CTile *[2], float[2][2][2]);
 static bool AdaptVisibleAreas(const float[2][2][2], const CMapObject[2], float[2][2][2]);
 static bool AdaptReplaceableAreas(const float[2][2][2], const float[2][2][2], const CMapObject[2], float[2][2][2]);
 
-static void ReplaceAreaQuads(CDataFileReader[2], const float[][2][2], const CMapItemGroup *[2], CMapItemLayer *[2], int);
+static void ReplaceAreaQuads(std::shared_ptr<IMap>[2], const float[][2][2], const CMapItemGroup *[2], CMapItemLayer *[2], int);
 static bool RemoveDestinationQuads(const float[2][2], const CQuad *, int, const CMapItemGroup *, CQuad *, int &);
 static bool InsertDestinationQuads(const float[2][2][2], const CQuad *, int, const CMapItemGroup *[2], CQuad *, int &);
 static bool AdaptVisiblePoint(const float[2][2][2], const float[2][2], const CMapObject[2], float[2]);
@@ -111,18 +112,18 @@ int main(int argc, const char *argv[])
 
 bool ReplaceArea(IStorage *pStorage, const char aaMapNames[3][64], const float aaaGameAreas[][2][2])
 {
-	CDataFileReader aInputMaps[2];
+	std::shared_ptr<IMap> apInputMaps[2];
 	CDataFileWriter OutputMap;
 
-	if(!OpenMaps(pStorage, aaMapNames, aInputMaps, OutputMap))
+	if(!OpenMaps(pStorage, aaMapNames, apInputMaps, OutputMap))
 		return false;
-	if(!CompareLayers(aaMapNames, aInputMaps))
+	if(!CompareLayers(aaMapNames, apInputMaps))
 		return false;
-	CompareGroups(aaMapNames, aInputMaps);
+	CompareGroups(aaMapNames, apInputMaps);
 
 	int aLayersStart[2], LayersCount;
 	for(int i = 0; i < 2; i++)
-		aInputMaps[i].GetType(MAPITEMTYPE_LAYER, &aLayersStart[i], &LayersCount);
+		apInputMaps[i]->GetType(MAPITEMTYPE_LAYER, &aLayersStart[i], &LayersCount);
 
 	for(int i = 0; i < LayersCount; i++)
 	{
@@ -130,29 +131,31 @@ bool ReplaceArea(IStorage *pStorage, const char aaMapNames[3][64], const float a
 		CMapItemLayer *apItem[2];
 		for(int j = 0; j < 2; j++)
 		{
-			apLayerGroups[j] = GetLayerGroup(aInputMaps[j], i + 1);
-			apItem[j] = (CMapItemLayer *)aInputMaps[j].GetItem(aLayersStart[j] + i);
+			apLayerGroups[j] = GetLayerGroup(apInputMaps[j].get(), i + 1);
+			apItem[j] = (CMapItemLayer *)apInputMaps[j]->GetItem(aLayersStart[j] + i);
 		}
 
 		if(!apLayerGroups[0] || !apLayerGroups[1])
 			continue;
 
 		if(apItem[0]->m_Type == LAYERTYPE_TILES)
-			ReplaceAreaTiles(aInputMaps, aaaGameAreas, apLayerGroups, apItem);
+		{
+			if(!ReplaceAreaTiles(apInputMaps, aaaGameAreas, apLayerGroups, apItem))
+				return false;
+		}
 		else if(apItem[0]->m_Type == LAYERTYPE_QUADS)
-			ReplaceAreaQuads(aInputMaps, aaaGameAreas, apLayerGroups, apItem, aLayersStart[1] + i);
+			ReplaceAreaQuads(apInputMaps, aaaGameAreas, apLayerGroups, apItem, aLayersStart[1] + i);
 	}
 
-	SaveOutputMap(aInputMaps[1], OutputMap);
-
-	return true;
+	return SaveOutputMap(apInputMaps[1].get(), OutputMap);
 }
 
-bool OpenMaps(IStorage *pStorage, const char aaMapNames[3][64], CDataFileReader aInputMaps[2], CDataFileWriter &OutputMap)
+bool OpenMaps(IStorage *pStorage, const char aaMapNames[3][64], std::shared_ptr<IMap> apInputMaps[2], CDataFileWriter &OutputMap)
 {
 	for(int i = 0; i < 2; i++)
 	{
-		if(!aInputMaps[i].Open(pStorage, aaMapNames[i], IStorage::TYPE_ABSOLUTE))
+		apInputMaps[i] = CreateMap();
+		if(!apInputMaps[i]->Load(pStorage, aaMapNames[i], IStorage::TYPE_ABSOLUTE))
 		{
 			dbg_msg("map_replace_area", "ERROR: unable to open map '%s'", aaMapNames[i]);
 			return false;
@@ -168,13 +171,13 @@ bool OpenMaps(IStorage *pStorage, const char aaMapNames[3][64], CDataFileReader 
 	return true;
 }
 
-void SaveOutputMap(CDataFileReader &InputMap, CDataFileWriter &OutputMap)
+bool SaveOutputMap(IMap *pInputMap, CDataFileWriter &OutputMap)
 {
-	for(int i = 0; i < InputMap.NumItems(); i++)
+	for(int i = 0; i < pInputMap->NumItems(); i++)
 	{
 		int Id, Type;
 		CUuid Uuid;
-		void *pItem = InputMap.GetItem(i, &Type, &Id, &Uuid);
+		void *pItem = pInputMap->GetItem(i, &Type, &Id, &Uuid);
 
 		// Filter ITEMTYPE_EX items, they will be automatically added again.
 		if(Type == ITEMTYPE_EX)
@@ -185,25 +188,31 @@ void SaveOutputMap(CDataFileReader &InputMap, CDataFileWriter &OutputMap)
 		if(g_apNewItem[i])
 			pItem = g_apNewItem[i];
 
-		int Size = InputMap.GetItemSize(i);
+		int Size = pInputMap->GetItemSize(i);
 		OutputMap.AddItem(Type, Id, Size, pItem, &Uuid);
 	}
 
-	for(int i = 0; i < InputMap.NumData(); i++)
+	for(int i = 0; i < pInputMap->NumData(); i++)
 	{
-		void *pData = g_apNewData[i] ? g_apNewData[i] : InputMap.GetData(i);
-		int Size = g_aNewDataSize[i] ? g_aNewDataSize[i] : InputMap.GetDataSize(i);
+		void *pData = g_apNewData[i] ? g_apNewData[i] : pInputMap->GetData(i);
+		int Size = g_aNewDataSize[i] ? g_aNewDataSize[i] : pInputMap->GetDataSize(i);
+		if(pData == nullptr)
+		{
+			log_error("map_replace_area", "Failed to load data %d.", i);
+			return false;
+		}
 		OutputMap.AddData(Size, pData);
 	}
 
 	OutputMap.Finish();
+	return true;
 }
 
-bool CompareLayers(const char aaMapNames[3][64], CDataFileReader aInputMaps[2])
+bool CompareLayers(const char aaMapNames[3][64], std::shared_ptr<IMap> apInputMaps[2])
 {
 	int aStart[2], aNum[2];
 	for(int i = 0; i < 2; i++)
-		aInputMaps[i].GetType(MAPITEMTYPE_LAYER, &aStart[i], &aNum[i]);
+		apInputMaps[i]->GetType(MAPITEMTYPE_LAYER, &aStart[i], &aNum[i]);
 
 	if(aNum[0] != aNum[1])
 	{
@@ -217,7 +226,7 @@ bool CompareLayers(const char aaMapNames[3][64], CDataFileReader aInputMaps[2])
 	{
 		CMapItemLayer *apItem[2];
 		for(int j = 0; j < 2; j++)
-			apItem[j] = (CMapItemLayer *)aInputMaps[j].GetItem(aStart[j] + i);
+			apItem[j] = (CMapItemLayer *)apInputMaps[j]->GetItem(aStart[j] + i);
 
 		if(apItem[0]->m_Type != apItem[1]->m_Type)
 		{
@@ -231,17 +240,17 @@ bool CompareLayers(const char aaMapNames[3][64], CDataFileReader aInputMaps[2])
 	return true;
 }
 
-void CompareGroups(const char aaMapNames[3][64], CDataFileReader aInputMaps[2])
+void CompareGroups(const char aaMapNames[3][64], std::shared_ptr<IMap> apInputMaps[2])
 {
 	int aStart[2], aNum[2];
 	for(int i = 0; i < 2; i++)
-		aInputMaps[i].GetType(MAPITEMTYPE_GROUP, &aStart[i], &aNum[i]);
+		apInputMaps[i]->GetType(MAPITEMTYPE_GROUP, &aStart[i], &aNum[i]);
 
 	for(int i = 0; i < std::max(aNum[0], aNum[1]); i++)
 	{
 		CMapItemGroup *apItem[2];
 		for(int j = 0; j < 2; j++)
-			apItem[j] = (CMapItemGroup *)aInputMaps[j].GetItem(aStart[j] + i);
+			apItem[j] = (CMapItemGroup *)apInputMaps[j]->GetItem(aStart[j] + i);
 
 		bool SameConfig = apItem[0]->m_ParallaxX == apItem[1]->m_ParallaxX && apItem[0]->m_ParallaxY == apItem[1]->m_ParallaxY && apItem[0]->m_OffsetX == apItem[1]->m_OffsetX && apItem[0]->m_OffsetY == apItem[1]->m_OffsetY && apItem[0]->m_UseClipping == apItem[1]->m_UseClipping && apItem[0]->m_ClipX == apItem[1]->m_ClipX && apItem[0]->m_ClipY == apItem[1]->m_ClipY && apItem[0]->m_ClipW == apItem[1]->m_ClipW && apItem[0]->m_ClipH == apItem[1]->m_ClipH;
 
@@ -250,14 +259,14 @@ void CompareGroups(const char aaMapNames[3][64], CDataFileReader aInputMaps[2])
 	}
 }
 
-const CMapItemGroup *GetLayerGroup(CDataFileReader &InputMap, const int LayerNumber)
+const CMapItemGroup *GetLayerGroup(IMap *pInputMap, const int LayerNumber)
 {
 	int Start, Num;
-	InputMap.GetType(MAPITEMTYPE_GROUP, &Start, &Num);
+	pInputMap->GetType(MAPITEMTYPE_GROUP, &Start, &Num);
 
 	for(int i = 0; i < Num; i++)
 	{
-		CMapItemGroup *pItem = (CMapItemGroup *)InputMap.GetItem(Start + i);
+		CMapItemGroup *pItem = (CMapItemGroup *)pInputMap->GetItem(Start + i);
 		if(LayerNumber >= pItem->m_StartLayer && LayerNumber <= pItem->m_StartLayer + pItem->m_NumLayers)
 			return pItem;
 	}
@@ -265,7 +274,7 @@ const CMapItemGroup *GetLayerGroup(CDataFileReader &InputMap, const int LayerNum
 	return nullptr;
 }
 
-void ReplaceAreaTiles(CDataFileReader aInputMaps[2], const float aaaGameAreas[][2][2], const CMapItemGroup *apLayerGroups[2], CMapItemLayer *apItem[2])
+bool ReplaceAreaTiles(std::shared_ptr<IMap> apInputMaps[2], const float aaaGameAreas[][2][2], const CMapItemGroup *apLayerGroups[2], CMapItemLayer *apItem[2])
 {
 	CMapItemLayerTilemap *apTilemap[2];
 	CTile *apTile[2];
@@ -275,12 +284,17 @@ void ReplaceAreaTiles(CDataFileReader aInputMaps[2], const float aaaGameAreas[][
 	for(int i = 0; i < 2; i++)
 	{
 		apTilemap[i] = (CMapItemLayerTilemap *)apItem[i];
-		apTile[i] = (CTile *)aInputMaps[i].GetData(apTilemap[i]->m_Data);
+		apTile[i] = (CTile *)apInputMaps[i]->GetData(apTilemap[i]->m_Data);
+		if(apTile[i] == nullptr)
+		{
+			log_error("map_replace_area", "Failed to load tiles of a layer.");
+			return false;
+		}
 		aObs[i] = CreateMapObject(apLayerGroups[i], 0, 0, apTilemap[i]->m_Width * 32, apTilemap[i]->m_Height * 32);
 	}
 
 	if(!GetVisibleArea(aaaGameAreas[1], aObs[1], aaaVisibleAreas[1]))
-		return;
+		return true;
 
 	GetReplaceableArea(aaaVisibleAreas[1], aObs[1], aaaReplaceableAreas[1]);
 	RemoveDestinationTiles(apTilemap[1], apTile[1], aaaReplaceableAreas[1]);
@@ -295,6 +309,8 @@ void ReplaceAreaTiles(CDataFileReader aInputMaps[2], const float aaaGameAreas[][
 	}
 
 	g_apNewData[apTilemap[1]->m_Data] = apTile[1];
+
+	return true;
 }
 
 void RemoveDestinationTiles(CMapItemLayerTilemap *pTilemap, CTile *pTile, float aaReplaceableArea[2][2])
@@ -372,7 +388,7 @@ bool AdaptReplaceableAreas(const float aaaGameAreas[2][2][2], const float aaaVis
 	return true;
 }
 
-void ReplaceAreaQuads(CDataFileReader aInputMaps[2], const float aaaGameAreas[][2][2], const CMapItemGroup *apLayerGroups[2], CMapItemLayer *apItem[2], const int ItemNumber)
+void ReplaceAreaQuads(std::shared_ptr<IMap> apInputMaps[2], const float aaaGameAreas[][2][2], const CMapItemGroup *apLayerGroups[2], CMapItemLayer *apItem[2], const int ItemNumber)
 {
 	CMapItemLayerQuads *apQuadLayer[2];
 	for(int i = 0; i < 2; i++)
@@ -380,7 +396,7 @@ void ReplaceAreaQuads(CDataFileReader aInputMaps[2], const float aaaGameAreas[][
 
 	CQuad *apQuads[3];
 	for(int i = 0; i < 2; i++)
-		apQuads[i] = (CQuad *)aInputMaps[i].GetDataSwapped(apQuadLayer[i]->m_Data);
+		apQuads[i] = (CQuad *)apInputMaps[i]->GetDataSwapped(apQuadLayer[i]->m_Data);
 
 	apQuads[2] = new CQuad[apQuadLayer[0]->m_NumQuads + apQuadLayer[1]->m_NumQuads];
 	int QuadsCounter = 0;

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -9,6 +9,7 @@
 #include <base/str.h>
 
 #include <engine/gfx/image_loader.h>
+#include <engine/map.h>
 #include <engine/shared/datafile.h>
 #include <engine/storage.h>
 
@@ -22,7 +23,7 @@
 		new image filepath must be absolute or relative to the current position
 */
 
-static CDataFileReader g_DataReader;
+static std::unique_ptr<IMap> g_pMap;
 
 // global new image data (set by ReplaceImageItem)
 static int g_NewNameId = -1;
@@ -32,7 +33,7 @@ static CImageInfo g_NewImageInfo;
 
 static void *ReplaceImageItem(int Index, CMapItemImage *pImgItem, const char *pImgName, const char *pImgFile, CMapItemImage *pNewImgItem)
 {
-	const char *pName = g_DataReader.GetDataString(pImgItem->m_ImageName);
+	const char *pName = g_pMap->GetDataString(pImgItem->m_ImageName);
 	if(pName == nullptr || pName[0] == '\0')
 	{
 		dbg_msg("map_replace_image", "failed to load name of image %d", Index);
@@ -95,7 +96,8 @@ int main(int argc, const char **argv)
 	const char *pImageName = argv[3];
 	const char *pImageFile = argv[4];
 
-	if(!g_DataReader.Open(pStorage.get(), pSourceFilename, IStorage::TYPE_ALL))
+	g_pMap = CreateMap();
+	if(!g_pMap->Load(pStorage.get(), pSourceFilename, IStorage::TYPE_ALL))
 	{
 		dbg_msg("map_replace_image", "failed to open source map. filename='%s'", pSourceFilename);
 		return -1;
@@ -109,11 +111,11 @@ int main(int argc, const char **argv)
 	}
 
 	// add all items
-	for(int Index = 0; Index < g_DataReader.NumItems(); Index++)
+	for(int Index = 0; Index < g_pMap->NumItems(); Index++)
 	{
 		int Type, Id;
 		CUuid Uuid;
-		void *pItem = g_DataReader.GetItem(Index, &Type, &Id, &Uuid);
+		void *pItem = g_pMap->GetItem(Index, &Type, &Id, &Uuid);
 
 		// Filter ITEMTYPE_EX items, they will be automatically added again.
 		if(Type == ITEMTYPE_EX)
@@ -121,7 +123,7 @@ int main(int argc, const char **argv)
 			continue;
 		}
 
-		int Size = g_DataReader.GetItemSize(Index);
+		int Size = g_pMap->GetItemSize(Index);
 
 		CMapItemImage NewImageItem;
 		if(Type == MAPITEMTYPE_IMAGE)
@@ -143,7 +145,7 @@ int main(int argc, const char **argv)
 	}
 
 	// add all data
-	for(int Index = 0; Index < g_DataReader.NumData(); Index++)
+	for(int Index = 0; Index < g_pMap->NumData(); Index++)
 	{
 		void *pData;
 		int Size;
@@ -159,14 +161,19 @@ int main(int argc, const char **argv)
 		}
 		else
 		{
-			pData = g_DataReader.GetData(Index);
-			Size = g_DataReader.GetDataSize(Index);
+			pData = g_pMap->GetData(Index);
+			Size = g_pMap->GetDataSize(Index);
+			if(pData == nullptr)
+			{
+				log_error("map_replace_image", "Failed to load data %d.", Index);
+				return -1;
+			}
 		}
 
 		Writer.AddData(Size, pData);
 	}
 
-	g_DataReader.Close();
+	g_pMap->Unload();
 	Writer.Finish();
 
 	dbg_msg("map_replace_image", "image '%s' replaced", pImageName);


### PR DESCRIPTION
Bad maps: [maps.zip](https://github.com/user-attachments/files/31827526/maps.zip)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5.1 and Opus 5)