### PR TITLE
Changed messages saying "You have to be in a team (1-63)" to "You have to be in a team (1-127)" 

### DIFF
--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -637,7 +637,7 @@ bool CSaveTeam::HandleSaveError(ESaveResult Result, int ClientId, CGameContext *
 	case ESaveResult::SUCCESS:
 		return false;
 	case ESaveResult::TEAM_FLOCK:
-		pGameContext->SendChatTarget(ClientId, "You have to be in a team (from 1-63)");
+		pGameContext->SendChatTarget(ClientId, "You have to be in a team (from 1-127)");
 		break;
 	case ESaveResult::TEAM_NOT_FOUND:
 		pGameContext->SendChatTarget(ClientId, "Could not find your Team");

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -369,7 +369,7 @@ void CScore::LoadTeam(const char *pCode, int ClientId)
 	}
 	if(!pController->Teams().IsValidTeamNumber(Team) || (g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && Team == TEAM_FLOCK))
 	{
-		GameServer()->SendChatTarget(ClientId, "You have to be in a team (from 1-63)");
+		GameServer()->SendChatTarget(ClientId, "You have to be in a team (from 1-127)");
 		return;
 	}
 	if(pController->Teams().GetTeamState(Team) != ETeamState::OPEN)


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
The messages weren't changed when upgrading the servers to 128 clients

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
