### PR TITLE
server: Don't move entire team to team 0 when kill and unlock at once

### DIFF
--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -1282,7 +1282,8 @@ void CGameTeams::OnCharacterSpawn(int ClientId)
 	if(GetSaving(Team))
 		return;
 
-	if(!IsValidTeamNumber(Team) || !m_aTeamLocked[Team])
+	if(!IsValidTeamNumber(Team) || Team == TEAM_FLOCK || g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO ||
+		(!m_aTeamLocked[Team] && !m_aTeamFlock[Team] && m_aTeamState[Team] > ETeamState::OPEN))
 	{
 		if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO)
 			SetForceCharacterTeam(ClientId, TEAM_FLOCK);
@@ -1354,6 +1355,11 @@ void CGameTeams::OnCharacterDeath(int ClientId, int Weapon)
 					GameServer()->SendChatTeam(Team, "This team was disbanded because there are more players than allowed in the team.");
 					SetTeamLock(Team, false);
 					KillTeam(Team, Weapon == WEAPON_SELF ? ClientId : -1, ClientId);
+					for(int MemberId = 0; MemberId < MAX_CLIENTS; MemberId++)
+					{
+						if(m_Core.Team(MemberId) == Team && GameServer()->m_apPlayers[MemberId])
+							SetForceCharacterTeam(MemberId, TEAM_FLOCK);
+					}
 					return;
 				}
 


### PR DESCRIPTION
Reported by Hoco4ek on [Discord](https://discord.com/channels/252358080522747904/757720336274948198/1545672487046750208):

> You can move the entire team into team 0 if you kill the locked team and unlock it simultaneously

Before:

https://github.com/user-attachments/assets/26e2063a-82f9-48eb-8979-6344e86256c4

After:

https://github.com/user-attachments/assets/3aea3a45-b53b-4d4e-abbf-b13d9df1018c



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5.1)
