### PR TITLE
server: Delay votes when players are joining after map change

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4112,6 +4112,7 @@ void CGameContext::OnInit(const void *pPersistentData)
 	m_World.SetGameServer(this);
 	m_Events.SetGameServer(this);
 	m_PlayerMapping.Init(this);
+	m_MapChangeTick = Server()->ClientCount() > 0 ? Server()->Tick() : -1;
 
 	m_GameUuid = RandomUuid();
 	Console()->SetGetVictimsCommandCallback(ClientsForVictim, this);

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -416,6 +416,8 @@ public:
 	int GetDDRaceTeam(int ClientId) const;
 	// Describes the time when the first player joined the server.
 	int64_t m_NonEmptySince;
+	// Describes the time of the last map change while players were on the server, -1 if there was none.
+	int64_t m_MapChangeTick;
 	int64_t m_LastMapVote;
 	int GetClientVersion(int ClientId) const;
 	CClientMask ClientsMaskExcludeClientVersionAndHigher(int Version) const;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -141,6 +141,9 @@ void CPlayer::Reset()
 		m_FirstVoteTick = Now + g_Config.m_SvJoinVoteDelay * TickSpeed;
 	else
 		m_FirstVoteTick = Now;
+	// After a map change, wait for the other players to finish loading it before allowing votes
+	if(GameServer()->m_MapChangeTick >= 0 && Server()->ClientCount() > 1)
+		m_FirstVoteTick = std::max(m_FirstVoteTick, GameServer()->m_MapChangeTick + 10 * TickSpeed);
 
 	m_NotEligibleForFinish = false;
 	m_EligibleForFinishCheck = 0;


### PR DESCRIPTION
Reported by Hoco4ek on [Discord](https://discord.com/channels/252358080522747904/757720336274948198/1545672408285974628):

> If you load into a new map fast enough, you can start a new vote and change the map by yourself, converting the server into a temporary dictatorship


https://github.com/user-attachments/assets/cf109364-7678-408a-83d5-7cdf00ec5be4



## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5.1)
