### PR TITLE
client: Don't crash on pasting large text into rcon

### DIFF
--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -361,16 +361,18 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 								continue;
 							}
 							std::string Line = ClipboardText.substr(Begin, i - Begin + 1);
+							str_sanitize_cc(Line.data());
 							if(FirstLine)
 							{
-								str_sanitize_cc(Line.data());
 								SetRange(Line.c_str(), m_SelectionStart, m_SelectionEnd);
 								FirstLine = false;
-								Line = GetString();
+							}
+							else
+							{
+								Set(Line.c_str());
 							}
 							Begin = i + 1;
-							str_sanitize_cc(Line.data());
-							m_pfnClipboardLineCallback(Line.c_str());
+							m_pfnClipboardLineCallback(GetString());
 						}
 					}
 					std::string Line = ClipboardText.substr(Begin, i - Begin + 1);


### PR DESCRIPTION
Fixes: #12792

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5.1)
