### PR TITLE
client: Don't sleep with cl_refresh_rate 0

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3492,11 +3492,13 @@ void CClient::Run()
 			// the next prediction tick to send its input without delay, unless the window is inactive or
 			// the loop is not rate limited at all.
 			if(RefreshRate)
+			{
 				WakeTime = NextUpdateTime;
-			if(IsRenderActive && GfxRefreshRate)
-				WakeTime = std::min(WakeTime, NextRenderTime);
-			if(State() == IClient::STATE_ONLINE && m_aPredTick[g_Config.m_ClDummy] > 0 && !Inactive && WakeTime != std::numeric_limits<int64_t>::max())
-				WakeTime = std::min(WakeTime, Now + (m_aPredTick[g_Config.m_ClDummy] * time_freq() / GameTickSpeed() - m_PredictedTime.Get(Now)));
+				if(IsRenderActive && GfxRefreshRate)
+					WakeTime = std::min(WakeTime, NextRenderTime);
+				if(State() == IClient::STATE_ONLINE && m_aPredTick[g_Config.m_ClDummy] > 0 && !Inactive)
+					WakeTime = std::min(WakeTime, Now + (m_aPredTick[g_Config.m_ClDummy] * time_freq() / GameTickSpeed() - m_PredictedTime.Get(Now)));
+			}
 		}
 
 		AutoScreenshot_Cleanup();

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3494,7 +3494,7 @@ void CClient::Run()
 			if(RefreshRate)
 			{
 				WakeTime = NextUpdateTime;
-				if(IsRenderActive && GfxRefreshRate)
+				if(IsRenderActive && GfxRefreshRate && NextRenderTime > Now)
 					WakeTime = std::min(WakeTime, NextRenderTime);
 				if(State() == IClient::STATE_ONLINE && m_aPredTick[g_Config.m_ClDummy] > 0 && !Inactive)
 					WakeTime = std::min(WakeTime, Now + (m_aPredTick[g_Config.m_ClDummy] * time_freq() / GameTickSpeed() - m_PredictedTime.Get(Now)));


### PR DESCRIPTION
Reported by Hoco4ek on [Discord](https://discord.com/channels/252358080522747904/757720336274948198/1545698254107451392):

> after updating the game, the fps is jumping
> cl_refresh_rate 0
> gfx_refresh_rate 444

Review with `w=1`

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

Written with Claude Code (Fable 5.1)
