### PR TITLE
Fix use-after-free of working directory launching Android server

### DIFF
--- a/src/engine/server/main.cpp
+++ b/src/engine/server/main.cpp
@@ -257,9 +257,9 @@ JNI_EXPORTED_FUNCTION(ANDROID_PACKAGE_NAME_JNI, NativeServer, runServer, jint, J
 	// Set working directory to external storage location. This is not possible
 	// in Java so we pass the intended working directory to the native code.
 	const char *pWorkingDirectory = pEnv->GetStringUTFChars(WorkingDirectory, nullptr);
-	const bool WorkingDirectoryError = fs_chdir(pWorkingDirectory) != 0;
+	const std::string WorkingDirectoryCopy = pWorkingDirectory;
 	pEnv->ReleaseStringUTFChars(WorkingDirectory, pWorkingDirectory);
-	if(WorkingDirectoryError)
+	if(fs_chdir(WorkingDirectoryCopy.c_str()) != 0)
 	{
 		return -1001;
 	}
@@ -268,13 +268,14 @@ JNI_EXPORTED_FUNCTION(ANDROID_PACKAGE_NAME_JNI, NativeServer, runServer, jint, J
 
 	std::vector<std::string> vArguments;
 	vArguments.reserve(NumArguments + 1);
-	vArguments.push_back(std::string(pWorkingDirectory) + "/" + GAME_NAME "-Server");
+	vArguments.push_back(WorkingDirectoryCopy + "/" + GAME_NAME "-Server");
 	for(jsize ArgumentIndex = 0; ArgumentIndex < NumArguments; ArgumentIndex++)
 	{
 		jstring ArgumentString = (jstring)pEnv->GetObjectArrayElement(ArgumentsArray, ArgumentIndex);
 		const char *pArgumentString = pEnv->GetStringUTFChars(ArgumentString, nullptr);
 		vArguments.emplace_back(pArgumentString);
 		pEnv->ReleaseStringUTFChars(ArgumentString, pArgumentString);
+		pEnv->DeleteLocalRef(ArgumentString);
 	}
 
 	std::vector<const char *> vpArguments;


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

AI found the issue.