### PR TITLE
Increase spin wait halving threshold to 1000us

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3521,7 +3521,7 @@ void CClient::Run()
 			else
 			{
 				// Packets end the wait early. The wait can overshoot by a fraction of its duration, so approach the deadline in halving steps.
-				while(WaitTime > 0ns && net_socket_read_wait(m_aNetClient[CONN_MAIN].m_Socket, WaitTime > 200us ? WaitTime / 2 : 0ns) == 0)
+				while(WaitTime > 0ns && net_socket_read_wait(m_aNetClient[CONN_MAIN].m_Socket, WaitTime > 1000us ? WaitTime / 2 : 0ns) == 0)
 				{
 					WaitTime = Deadline - time_get_nanoseconds();
 				}


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
Fixes the issue that I assume #12805 is trying to solve.

From what I can tell windows does not have a better sleep timer resolution than [0.5-1.0ms](https://devblogs.microsoft.com/go/high-resolution-timers-windows/). I am not sure how to get the 0.5ms value, the resolution of the timer did not improve when I tested #12805, in both cases it was about 1000us/1.0ms. 

However this does "5x" the amount of spin waiting we do (the relative difference depends on target frame rate). Is that acceptable? We could gate this behind a specific platform or measure the actual resolution maybe but I'm opening this PR as minimal as possible for now mostly for @Robyt3 to test.

tested with cl_refresh_rate 120, gfx_refresh_rate 120

Before:
<img width="511" height="611" alt="image" src="https://github.com/user-attachments/assets/e7c90dc6-a902-45ad-bbf9-440597d8d995" />

After:
<img width="538" height="657" alt="image" src="https://github.com/user-attachments/assets/6625b51b-1e76-47c8-8061-163a1b287158" />

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
