### PR TITLE
Fix -1 passed as `size_t` to json parser

### DIFF
--- a/src/test/teehistorian_test.cpp
+++ b/src/test/teehistorian_test.cpp
@@ -920,7 +920,7 @@ TEST_F(TeeHistorian, PrevGameUuid)
 	m_GameInfo.m_PrevGameUuid = PrevGameUuid;
 	Reset(&m_GameInfo);
 	Finish();
-	json_value *pJson = JsonParse((const char *)m_vBuffer.data() + 16, -1);
+	json_value *pJson = JsonParse((const char *)m_vBuffer.data() + 16, m_vBuffer.size() - 16);
 	ASSERT_TRUE(pJson);
 	const json_value &JsonPrevGameUuid = (*pJson)["prev_game_uuid"];
 	ASSERT_EQ(JsonPrevGameUuid.type, json_string);

--- a/ubsan.supp
+++ b/ubsan.supp
@@ -1,4 +1,3 @@
-pointer-overflow:json.c
 shift-base:bits.c
 shift-base:unpack.c
 shift-base:words.c


### PR DESCRIPTION
Thanks to @LB-- for finding this bug!

https://github.com/json-parser/json-parser/pull/161#issuecomment-5559448898

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
