### PR TITLE
Use role name for reserved slots config

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -42,6 +42,8 @@
 #include <engine/shared/snapshot.h>
 #include <engine/storage.h>
 
+#include <generated/protocol.h>
+
 #include <game/version.h>
 
 #include <zlib.h>
@@ -1681,23 +1683,50 @@ bool CServer::CheckReservedSlotAuth(int ClientId, const char *pPassword)
 		return true;
 	}
 
-	// "^([^:]*):(.*)$"
-	if(Config()->m_SvReservedSlotsAuthLevel != 4)
+	if(!str_comp(Config()->m_SvReservedSlotsAuthLevel, "4"))
 	{
-		char aName[sizeof(Config()->m_Password)];
-		const char *pInnerPassword = str_next_token(pPassword, ":", aName, sizeof(aName));
-		if(!pInnerPassword)
-		{
-			return false;
-		}
-		int Slot = m_AuthManager.FindKey(aName);
-		if(m_AuthManager.CheckKey(Slot, pInnerPassword + 1) && m_AuthManager.KeyLevel(Slot) >= Config()->m_SvReservedSlotsAuthLevel)
-		{
-			log_info("server", "ClientId=%d joining reserved slot with key='%s'", ClientId, m_AuthManager.KeyIdent(Slot));
-			return true;
-		}
+		return false;
+	}
+	if(Config()->m_SvReservedSlotsAuthLevel[0] == '\0')
+	{
+		return false;
 	}
 
+	// "^([^:]*):(.*)$"
+	char aName[sizeof(Config()->m_Password)];
+	const char *pInnerPassword = str_next_token(pPassword, ":", aName, sizeof(aName));
+	if(!pInnerPassword)
+	{
+		return false;
+	}
+	int Slot = m_AuthManager.FindKey(aName);
+	const char *pMinAuthLevel = Config()->m_SvReservedSlotsAuthLevel;
+	std::optional<int> MinAuthLevel = CAuthManager::RoleNameToAuthLevel(pMinAuthLevel);
+	if(!MinAuthLevel.has_value())
+	{
+		if(str_comp(pMinAuthLevel, "1") == 0)
+		{
+			MinAuthLevel = AUTHED_HELPER;
+		}
+		else if(str_comp(pMinAuthLevel, "2") == 0)
+		{
+			MinAuthLevel = AUTHED_MOD;
+		}
+		else if(str_comp(pMinAuthLevel, "3") == 0)
+		{
+			MinAuthLevel = AUTHED_ADMIN;
+		}
+	}
+	if(!MinAuthLevel.has_value())
+	{
+		return false;
+	}
+
+	if(m_AuthManager.CheckKey(Slot, pInnerPassword + 1) && m_AuthManager.KeyLevel(Slot) >= MinAuthLevel.value())
+	{
+		log_info("server", "ClientId=%d joining reserved slot with key='%s'", ClientId, m_AuthManager.KeyIdent(Slot));
+		return true;
+	}
 	return false;
 }
 
@@ -4542,6 +4571,37 @@ void CServer::ConchainRconHelperPasswordChange(IConsole::IResult *pResult, void 
 	pfnCallback(pResult, pCallbackUserData);
 }
 
+void CServer::ConchainReservedSlotsAuthLevel(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
+{
+	const char *pValue = pResult->GetString(0);
+	if(pResult->NumArguments() && pResult->GetString(0)[0] != '\0' && !CAuthManager::RoleNameToAuthLevel(pValue).has_value())
+	{
+		if(str_comp(pValue, "1") == 0)
+		{
+			log_warn("server", "got deprecated value %s for sv_reserved_slots_auth_level, please use \"helper\" instead", pValue);
+		}
+		else if(str_comp(pValue, "2") == 0)
+		{
+			log_warn("server", "got deprecated value %s for sv_reserved_slots_auth_level, please use \"moderator\" instead", pValue);
+		}
+		else if(str_comp(pValue, "3") == 0)
+		{
+			log_warn("server", "got deprecated value %s for sv_reserved_slots_auth_level, please use \"admin\" instead", pValue);
+		}
+		else if(str_comp(pValue, "4") == 0)
+		{
+			log_warn("server", "got deprecated value %s for sv_reserved_slots_auth_level, please use \"\" instead", pValue);
+		}
+		else
+		{
+			log_error("server", "Value can only be one of those: helper, moderator, admin or empty");
+			return;
+		}
+	}
+
+	pfnCallback(pResult, pCallbackUserData);
+}
+
 void CServer::ConchainMapUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
 {
 	CServer *pThis = static_cast<CServer *>(pUserData);
@@ -4697,6 +4757,7 @@ void CServer::RegisterCommands()
 	Console()->Chain("sv_rcon_password", ConchainRconPasswordChange, this);
 	Console()->Chain("sv_rcon_mod_password", ConchainRconModPasswordChange, this);
 	Console()->Chain("sv_rcon_helper_password", ConchainRconHelperPasswordChange, this);
+	Console()->Chain("sv_reserved_slots_auth_level", ConchainReservedSlotsAuthLevel, this);
 	Console()->Chain("sv_map", ConchainMapUpdate, this);
 	Console()->Chain("sv_sixup", ConchainSixupUpdate, this);
 	Console()->Chain("sv_register_community_token", ConchainRegisterCommunityTokenRedact, nullptr);

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -479,6 +479,7 @@ public:
 	static void ConchainRconPasswordChange(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainRconModPasswordChange(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainRconHelperPasswordChange(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+	static void ConchainReservedSlotsAuthLevel(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainMapUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainSixupUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainRegisterCommunityTokenRedact(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -536,7 +536,7 @@ MACRO_CONFIG_INT(HttpAllowInsecure, http_allow_insecure, 0, 0, 1, CFGFLAG_CLIENT
 MACRO_CONFIG_STR(SvWelcome, sv_welcome, 256, "", CFGFLAG_SERVER, "Message that will be displayed to players who join the server")
 MACRO_CONFIG_INT(SvReservedSlots, sv_reserved_slots, 0, 0, SERVER_MAX_CLIENTS, CFGFLAG_SERVER, "The number of slots that are reserved for special players")
 MACRO_CONFIG_STR(SvReservedSlotsPass, sv_reserved_slots_pass, 256, "", CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, "The password that is required to use a reserved slot")
-MACRO_CONFIG_INT(SvReservedSlotsAuthLevel, sv_reserved_slots_auth_level, 1, 1, 4, CFGFLAG_SERVER, "Minimum rcon auth level needed to use a reserved slot. 4 = rcon auth disabled")
+MACRO_CONFIG_STR(SvReservedSlotsAuthLevel, sv_reserved_slots_auth_level, 256, "helper", CFGFLAG_SERVER, "Minimum rcon auth level needed to use a reserved slot. \"\" = rcon auth disabled")
 MACRO_CONFIG_INT(SvHit, sv_hit, 1, 0, 1, CFGFLAG_SERVER | CFGFLAG_GAME, "Whether players can hammer/grenade/laser each other or not")
 MACRO_CONFIG_INT(SvEndlessDrag, sv_endless_drag, 0, 0, 1, CFGFLAG_SERVER | CFGFLAG_GAME, "Turns endless hooking on/off")
 MACRO_CONFIG_INT(SvTestingCommands, sv_test_cmds, 0, 0, 1, CFGFLAG_SERVER, "Turns testing commands aka cheats on/off (setting only works in initial config)")


### PR DESCRIPTION
Makes configuration files more human readable
and is a preparation for #10681

This is a follow up to https://github.com/ddnet/ddnet/pull/12790. It is the second (and last) config variable that stores auth levels.

@def- fyi this is the user affecting change that has to be done in config files

```
# old
sv_reserved_slots_auth_level 1
sv_reserved_slots_auth_level 2
sv_reserved_slots_auth_level 3
sv_reserved_slots_auth_level 4

# new
sv_reserved_slots_auth_level "helper"
sv_reserved_slots_auth_level "moderator"
sv_reserved_slots_auth_level "admin"
sv_reserved_slots_auth_level ""
```

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions