### PR TITLE
DNM/WIP Feature: Add thumbnails to ddnet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2609,6 +2609,8 @@ if(CLIENT)
     input.h
     keynames.cpp
     keynames.h
+    map_thumbnail.cpp
+    map_thumbnail.h
     notifications.cpp
     notifications.h
     serverbrowser.cpp

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1399,6 +1399,7 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 	CServerBrowser::CServerEntry *pEntry = m_ServerBrowser.Find(*pFrom);
 
 	CServerInfo Info = {0};
+
 	int SavedType = SavedServerInfoType(RawType);
 	if(SavedType == SERVERINFO_EXTENDED && pEntry && pEntry->m_GotInfo && SavedType == pEntry->m_Info.m_Type)
 	{

--- a/src/engine/client/map_thumbnail.cpp
+++ b/src/engine/client/map_thumbnail.cpp
@@ -1,0 +1,51 @@
+#include "map_thumbnail.h"
+
+#include <base/fs.h>
+#include <base/log.h>
+#include <base/str.h>
+
+#define MAPRENDER_EXEC "map_render"
+
+CMapThumbnailJob::CMapThumbnailJob(const char *pMapPath, const char *pOutputPath, IStorage *pStorage)
+{
+	str_copy(m_pMapPath, pMapPath, sizeof(m_pMapPath));
+	str_copy(m_pOutputPath, pOutputPath, sizeof(m_pOutputPath));
+	m_pStorage = pStorage;
+}
+
+void CMapThumbnailJob::Run()
+{
+#ifndef CONF_PLATFORM_ANDROID
+	char aBinaryPath[IO_MAX_PATH_LENGTH];
+	char aMapPath[IO_MAX_PATH_LENGTH];
+	char aDownloadedMapsPath[IO_MAX_PATH_LENGTH];
+
+	Storage()->GetBinaryPath(MAPRENDER_EXEC, aBinaryPath, sizeof(aBinaryPath));
+	if(!fs_is_file(aBinaryPath))
+	{
+		log_warn("thumbnail", "%s binary not found", MAPRENDER_EXEC);
+		return;
+	}
+	if(!Storage()->FindFile(m_pMapPath, "downloadedmaps", IStorage::TYPE_SAVE, aMapPath, sizeof(aMapPath)))
+	{
+		log_error("thumbnail", "Did not find map '%s'", aMapPath);
+		return;
+	}
+
+	Storage()->GetCompletePath(IStorage::TYPE_SAVE, "downloadedmaps", aDownloadedMapsPath, sizeof(aDownloadedMapsPath));
+	str_format(aMapPath, sizeof(aMapPath), "%s/%s", aDownloadedMapsPath, m_pMapPath);
+	std::vector<const char *> vpArguments = {"-o", m_pOutputPath, "-w", "640", "-h", "480", aMapPath};
+	m_Process = process_execute(aBinaryPath, EShellExecuteWindowState::FOREGROUND, vpArguments.data(), vpArguments.size());
+	if(m_Process == INVALID_PROCESS)
+		log_error("thumbnail", "process crashed");
+#endif
+}
+
+bool CMapThumbnailJob::Finished() const
+{
+#ifdef CONF_PLATFORM_ANDROID
+	return true;
+#else
+	return !process_is_alive(m_Process);
+#endif
+}

--- a/src/engine/client/map_thumbnail.h
+++ b/src/engine/client/map_thumbnail.h
@@ -1,0 +1,27 @@
+#ifndef ENGINE_CLIENT_MAP_THUMBNAIL_H
+#define ENGINE_CLIENT_MAP_THUMBNAIL_H
+
+#include <base/process.h>
+
+#include <engine/shared/jobs.h>
+#include <engine/storage.h>
+
+#include <optional>
+
+class CMapThumbnailJob : public IJob
+{
+public:
+	CMapThumbnailJob(const char *pMapPath, const char *pOutputPath, IStorage *pStorage);
+	void Run() override;
+	bool Finished() const;
+	const char *ThumbnailPath() { return m_pOutputPath; }
+
+private:
+	char m_pMapPath[IO_MAX_PATH_LENGTH];
+	char m_pOutputPath[IO_MAX_PATH_LENGTH];
+	IStorage *m_pStorage = nullptr;
+	IStorage *Storage() { return m_pStorage; }
+	PROCESS m_Process;
+};
+
+#endif

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -120,6 +120,7 @@ public:
 	ColorRGBA m_GametypeColor;
 	char m_aName[64];
 	char m_aMap[MAX_MAP_LENGTH];
+	char m_aMapSha256[SHA256_MAXSTRSIZE];
 	int m_MapCrc;
 	int m_MapSize;
 	char m_aVersion[32];

--- a/src/engine/shared/serverinfo.cpp
+++ b/src/engine/shared/serverinfo.cpp
@@ -73,6 +73,7 @@ bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 	const json_value &GameType = ServerInfo["game_type"];
 	const json_value &Name = ServerInfo["name"];
 	const json_value &MapName = ServerInfo["map"]["name"];
+	const json_value &MapSha265 = ServerInfo["map"]["sha256"];
 	const json_value &Version = ServerInfo["version"];
 	const json_value &Clients = ServerInfo["clients"];
 	const json_value &RequiresLogin = ServerInfo["requires_login"];
@@ -112,6 +113,14 @@ bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 	str_copy(pOut->m_aName, Name);
 	str_copy(pOut->m_aMapName, MapName);
 	str_copy(pOut->m_aVersion, Version);
+	if(MapSha265.type == json_string)
+	{
+		str_copy(pOut->m_aMapSha256, MapSha265);
+	}
+	else
+	{
+		pOut->m_aMapSha256[0] = '\0';
+	}
 
 	pOut->m_NumClients = 0;
 	pOut->m_NumPlayers = 0;
@@ -285,6 +294,7 @@ CServerInfo2::operator CServerInfo() const
 	str_copy(Result.m_aGameType, m_aGameType);
 	str_copy(Result.m_aName, m_aName);
 	str_copy(Result.m_aMap, m_aMapName);
+	str_copy(Result.m_aMapSha256, m_aMapSha256);
 	str_copy(Result.m_aVersion, m_aVersion);
 
 	Result.m_vClients.resize(std::min(m_NumClients, (int)SERVERINFO_MAX_CLIENTS));

--- a/src/engine/shared/serverinfo.h
+++ b/src/engine/shared/serverinfo.h
@@ -42,6 +42,7 @@ public:
 	char m_aGameType[16];
 	char m_aName[64];
 	char m_aMapName[MAX_MAP_LENGTH];
+	char m_aMapSha256[SHA256_MAXSTRSIZE];
 	char m_aVersion[32];
 	bool m_RequiresLogin;
 

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -87,6 +87,7 @@ public:
 				"mapres",
 				"maps",
 				"maps/auto",
+				"mapthumbnails",
 				"screenshots",
 				"screenshots/auto",
 				"screenshots/auto/stats",

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -8,6 +8,7 @@
 #include <base/types.h>
 #include <base/vmath.h>
 
+#include <engine/client/map_thumbnail.h>
 #include <engine/console.h>
 #include <engine/demo.h>
 #include <engine/friends.h>
@@ -853,6 +854,9 @@ private:
 	CMenusSettingsControls m_MenusSettingsControls;
 	friend CMenusSettingsControls;
 	CMenusStart m_MenusStart;
+	std::shared_ptr<CMapThumbnailJob> m_pThumbnailJob;
+	IGraphics::CTextureHandle m_MapImage;
+	char m_aLoadedThumbnailPath[IO_MAX_PATH_LENGTH] = "";
 
 	static int GhostlistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int StorageType, void *pUser);
 

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -3,6 +3,7 @@
 #include "menus.h"
 
 #include <base/dbg.h>
+#include <base/io.h>
 #include <base/log.h>
 #include <base/time.h>
 
@@ -1167,11 +1168,60 @@ void CMenus::RenderServerbrowserInfo(CUIRect View)
 	const float RowHeight = 18.0f;
 	const float FontSize = (RowHeight - 4.0f) * CUi::ms_FontmodHeight; // based on DoButton_CheckBox
 
-	CUIRect ServerDetails, Scoreboard;
-	View.HSplitTop(4.0f * 15.0f + RowHeight + 2.0f * 5.0f + 2.0f * 2.0f, &ServerDetails, &Scoreboard);
+	// resolve map thumbnail of the selected server
+	char aThumbnailPath[IO_MAX_PATH_LENGTH] = "";
+	bool ThumbnailLoaded = false;
+	if(pSelectedServer && pSelectedServer->m_aMapSha256[0])
+	{
+		char aPathBuffer[IO_MAX_PATH_LENGTH];
+		char aThumbnailName[SHA256_MAXSTRSIZE + 1 + 128 + 12 + 1];
+
+		Storage()->GetCompletePath(IStorage::TYPE_SAVE, "mapthumbnails", aPathBuffer, sizeof(aPathBuffer));
+		str_format(aThumbnailName, sizeof(aThumbnailName), "%s_%s_640x480.png", pSelectedServer->m_aMap, pSelectedServer->m_aMapSha256);
+		str_format(aThumbnailPath, sizeof(aThumbnailPath), "%s/%s", aPathBuffer, aThumbnailName);
+		if(Storage()->FindFile(aThumbnailName, "mapthumbnails", IStorage::TYPE_SAVE, aPathBuffer, sizeof(aPathBuffer)) && (!m_pThumbnailJob || (m_pThumbnailJob->Done() && m_pThumbnailJob->Finished())))
+		{
+			if(str_comp(m_aLoadedThumbnailPath, aThumbnailPath) != 0)
+			{
+				m_MapImage = Graphics()->LoadTexture(aThumbnailPath, IStorage::TYPE_ABSOLUTE);
+				str_copy(m_aLoadedThumbnailPath, aThumbnailPath, sizeof(m_aLoadedThumbnailPath));
+			}
+			ThumbnailLoaded = m_MapImage.IsValid();
+		}
+		// queue job that creates image
+		else if(!m_pThumbnailJob || str_comp(m_pThumbnailJob->ThumbnailPath(), aThumbnailPath) != 0)
+		{
+			m_MapImage.Invalidate();
+			m_aLoadedThumbnailPath[0] = '\0';
+			str_format(aPathBuffer, sizeof(aPathBuffer), "%s_%s.map", pSelectedServer->m_aMap, pSelectedServer->m_aMapSha256);
+			m_pThumbnailJob = std::make_shared<CMapThumbnailJob>(aPathBuffer, aThumbnailPath, Storage());
+			Engine()->AddJob(m_pThumbnailJob);
+		}
+	}
+
+	// reserve a 4:3 band above the server details if a thumbnail is available
+	const float DetailsHeight = 4.0f * 15.0f + RowHeight + 2.0f * 5.0f + 2.0f * 2.0f;
+	const float ThumbnailHeight = (View.w - 10.0f) * 3.0f / 4.0f;
+	CUIRect Thumbnail, ServerDetails, Scoreboard;
+	if(ThumbnailLoaded)
+		View.HSplitTop(ThumbnailHeight + 10.0f, &Thumbnail, &View);
+	View.HSplitTop(DetailsHeight, &ServerDetails, &Scoreboard);
 
 	if(pSelectedServer)
 	{
+		// draw map thumbnail
+		if(ThumbnailLoaded)
+		{
+			CUIRect Image = Thumbnail;
+			Image.VMargin(5.0f, &Image);
+			Graphics()->TextureSet(m_MapImage);
+			Graphics()->QuadsBegin();
+			Graphics()->SetColor(1, 1, 1, 1);
+			IGraphics::CQuadItem QuadItem(Image.x, Image.y, Image.w, Image.h);
+			Graphics()->QuadsDrawTL(&QuadItem, 1);
+			Graphics()->QuadsEnd();
+		}
+
 		ServerDetails.Margin(5.0f, &ServerDetails);
 
 		// copy info button


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
<img width="1920" height="1080" alt="screenshot_2026-09-08_19-07-22" src="https://github.com/user-attachments/assets/cf6adc92-de51-41bb-87a5-caaafe6271dd" />

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

This PR adds generated thumbnails into the serverbrowser for known maps. It requires the map hash to be known in order to avoid collisions with maps with the same name.

It also uses the map_render binary, which I currently see no way to avoid and would open an issue of this is merged to get around this limitation.

first part of #2892

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->

I used AI to write the UI part but **only** for a part of the menu UI, where I put the image into the menu. The loading of the PNG is already manual, but this PR needed some fixes for the spacing of other UI components in the server info.

Everything else was written manual, including the background job and the binary process call