### PR TITLE
Use default argument for AddString's Limit

### DIFF
--- a/src/game/server/teehistorian.cpp
+++ b/src/game/server/teehistorian.cpp
@@ -581,7 +581,7 @@ void CTeeHistorian::RecordPlayerDrop(int ClientId, const char *pReason)
 	Buffer.Reset();
 	Buffer.AddInt(-TEEHISTORIAN_DROP);
 	Buffer.AddInt(ClientId);
-	Buffer.AddString(pReason, 0);
+	Buffer.AddString(pReason);
 
 	if(m_Debug)
 	{
@@ -598,7 +598,7 @@ void CTeeHistorian::RecordPlayerName(int ClientId, const char *pName)
 	CTeehistorianPacker Buffer;
 	Buffer.Reset();
 	Buffer.AddInt(ClientId);
-	Buffer.AddString(pName, 0);
+	Buffer.AddString(pName);
 
 	if(m_Debug)
 	{
@@ -617,11 +617,11 @@ void CTeeHistorian::RecordConsoleCommand(int ClientId, int FlagMask, const char 
 	Buffer.AddInt(-TEEHISTORIAN_CONSOLE_COMMAND);
 	Buffer.AddInt(ClientId);
 	Buffer.AddInt(FlagMask);
-	Buffer.AddString(pCmd, 0);
+	Buffer.AddString(pCmd);
 	Buffer.AddInt(pResult->NumArguments());
 	for(int i = 0; i < pResult->NumArguments(); i++)
 	{
-		Buffer.AddString(pResult->GetString(i), 0);
+		Buffer.AddString(pResult->GetString(i));
 	}
 
 	if(m_Debug)
@@ -662,7 +662,7 @@ void CTeeHistorian::RecordTeamSaveSuccess(int Team, CUuid SaveId, const char *pT
 	Buffer.Reset();
 	Buffer.AddInt(Team);
 	Buffer.AddRaw(&SaveId, sizeof(SaveId));
-	Buffer.AddString(pTeamSave, 0);
+	Buffer.AddString(pTeamSave);
 
 	if(m_Debug)
 	{
@@ -698,7 +698,7 @@ void CTeeHistorian::RecordTeamLoadSuccess(int Team, CUuid SaveId, const char *pT
 	Buffer.Reset();
 	Buffer.AddInt(Team);
 	Buffer.AddRaw(&SaveId, sizeof(SaveId));
-	Buffer.AddString(pTeamSave, 0);
+	Buffer.AddString(pTeamSave);
 
 	if(m_Debug)
 	{
@@ -761,7 +761,7 @@ void CTeeHistorian::RecordDDNetVersion(int ClientId, CUuid ConnectionId, int DDN
 	Buffer.AddInt(ClientId);
 	Buffer.AddRaw(&ConnectionId, sizeof(ConnectionId));
 	Buffer.AddInt(DDNetVersion);
-	Buffer.AddString(pDDNetVersionStr, 0);
+	Buffer.AddString(pDDNetVersionStr);
 
 	if(m_Debug)
 	{
@@ -778,8 +778,8 @@ void CTeeHistorian::RecordAuthInitial(int ClientId, const char *pRoleName, const
 	CTeehistorianPacker Buffer;
 	Buffer.Reset();
 	Buffer.AddInt(ClientId);
-	Buffer.AddString(pRoleName, 0);
-	Buffer.AddString(pAuthName, 0);
+	Buffer.AddString(pRoleName);
+	Buffer.AddString(pAuthName);
 
 	if(m_Debug)
 	{
@@ -795,7 +795,7 @@ void CTeeHistorian::RecordAuthLogin(int ClientId, const char *pRoleName, const c
 	Buffer.Reset();
 	Buffer.AddInt(ClientId);
 	Buffer.AddString(pRoleName);
-	Buffer.AddString(pAuthName, 0);
+	Buffer.AddString(pAuthName);
 
 	if(m_Debug)
 	{


### PR DESCRIPTION
## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions