### PR TITLE
Explicitly pass 0 as Limit to AddString

### DIFF
--- a/src/game/server/teehistorian.cpp
+++ b/src/game/server/teehistorian.cpp
@@ -794,7 +794,7 @@ void CTeeHistorian::RecordAuthLogin(int ClientId, const char *pRoleName, const c
 	CTeehistorianPacker Buffer;
 	Buffer.Reset();
 	Buffer.AddInt(ClientId);
-	Buffer.AddString(pRoleName);
+	Buffer.AddString(pRoleName, 0);
 	Buffer.AddString(pAuthName, 0);
 
 	if(m_Debug)


### PR DESCRIPTION
I just noticed I introduced an inconsistency in my recent pr. https://github.com/ddnet/ddnet/pull/12788 and would like to fix it in this follow up by adjusting to the other code around it.

Alternatively we can also change all the other code and do https://github.com/ddnet/ddnet/pull/12823 I have no strong opinion here.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
