### PR TITLE
Refactor: Keynames out of the Input kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2600,6 +2600,8 @@ if(CLIENT)
     graphics_threaded_sprites.cpp
     input.cpp
     input.h
+    keyboard.cpp
+    keyboard.h
     keynames.cpp
     keynames.h
     notifications.cpp

--- a/scripts/gen_keys.py
+++ b/scripts/gen_keys.py
@@ -99,7 +99,7 @@ with open("src/engine/client/keynames.cpp", "w", encoding="utf-8") as f:
 	print('#include "keynames.h"', file=f)
 	print(file=f)
 	print("/**", file=f)
-	print(" * Do not use directly! Use the @link IInput::KeyName @endlink function.", file=f)
+	print(" * Do not use directly! Use the @link KeyName @endlink function.", file=f)
 	print(" */", file=f)
 	print("extern const char g_aaKeyStrings[512][20] = {", file=f)
 	for n in keynames:
@@ -114,7 +114,7 @@ with open("src/engine/client/keynames.h", "w", encoding="utf-8") as f:
 	print("#define ENGINE_CLIENT_KEYNAMES_H", file=f)
 	print(file=f)
 	print("/**", file=f)
-	print(" * Do not use directly! Use the @link IInput::KeyName @endlink function.", file=f)
+	print(" * Do not use directly! Use the @link KeyName @endlink function.", file=f)
 	print(" */", file=f)
 	print("extern const char g_aaKeyStrings[512][20];", file=f)
 	print(file=f)

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -2,14 +2,13 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "input.h"
 
-#include "keynames.h"
-
 #include <base/dbg.h>
 #include <base/log.h>
 #include <base/str.h>
 #include <base/time.h>
 #include <base/windows.h>
 
+#include <engine/client/keyboard.h>
 #include <engine/console.h>
 #include <engine/graphics.h>
 #include <engine/input.h>
@@ -404,12 +403,6 @@ bool CInput::KeyPress(int Key) const
 {
 	dbg_assert(Key >= KEY_FIRST && Key < KEY_LAST, "Key invalid: %d", Key);
 	return m_aFrameKeyStates[Key];
-}
-
-const char *CInput::KeyName(int Key) const
-{
-	dbg_assert(Key >= KEY_FIRST && Key < KEY_LAST, "Key invalid: %d", Key);
-	return g_aaKeyStrings[Key];
 }
 
 int CInput::FindKeyByName(const char *pKeyName) const

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -129,7 +129,6 @@ public:
 	bool AltIsPressed() const override { return KeyIsPressed(KEY_LALT) || KeyIsPressed(KEY_RALT); }
 	bool KeyIsPressed(int Key) const override;
 	bool KeyPress(int Key) const override;
-	const char *KeyName(int Key) const override;
 	int FindKeyByName(const char *pKeyName) const override;
 
 	size_t NumJoysticks() const override { return m_vJoysticks.size(); }

--- a/src/engine/client/keyboard.cpp
+++ b/src/engine/client/keyboard.cpp
@@ -1,0 +1,13 @@
+#include "keyboard.h"
+
+#include "keynames.h"
+
+#include <base/dbg.h>
+
+#include <engine/keys.h>
+
+const char *KeyName(int Key)
+{
+	dbg_assert(Key >= KEY_FIRST && Key < KEY_LAST, "Key invalid: %d", Key);
+	return g_aaKeyStrings[Key];
+}

--- a/src/engine/client/keyboard.h
+++ b/src/engine/client/keyboard.h
@@ -1,0 +1,6 @@
+#ifndef ENGINE_CLIENT_KEYBOARD_H
+#define ENGINE_CLIENT_KEYBOARD_H
+
+const char *KeyName(int Key);
+
+#endif

--- a/src/engine/client/keynames.cpp
+++ b/src/engine/client/keynames.cpp
@@ -3,7 +3,7 @@
 #include "keynames.h"
 
 /**
- * Do not use directly! Use the @link IInput::KeyName @endlink function.
+ * Do not use directly! Use the @link KeyName @endlink function.
  */
 extern const char g_aaKeyStrings[512][20] = {
 	"unknown",

--- a/src/engine/client/keynames.h
+++ b/src/engine/client/keynames.h
@@ -4,7 +4,7 @@
 #define ENGINE_CLIENT_KEYNAMES_H
 
 /**
- * Do not use directly! Use the @link IInput::KeyName @endlink function.
+ * Do not use directly! Use the @link KeyName @endlink function.
  */
 extern const char g_aaKeyStrings[512][20];
 

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -86,7 +86,6 @@ public:
 	 * @return `true` if key was pressed down during input updates for the current frame, `false` otherwise.
 	 */
 	virtual bool KeyPress(int Key) const = 0;
-	virtual const char *KeyName(int Key) const = 0;
 	virtual int FindKeyByName(const char *pKeyName) const = 0;
 
 	// joystick

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -7,6 +7,7 @@
 #include <base/mem.h>
 #include <base/str.h>
 
+#include <engine/client/keyboard.h>
 #include <engine/config.h>
 #include <engine/console.h>
 #include <engine/shared/config.h>
@@ -471,7 +472,7 @@ void CBinds::GetKeyBindName(int Key, int ModifierMask, char *pBuf, size_t BufSiz
 			str_append(pBuf, "+", BufSize);
 		}
 	}
-	str_append(pBuf, Input()->KeyName(Key), BufSize);
+	str_append(pBuf, KeyName(Key), BufSize);
 }
 
 char *CBinds::GetKeyBindCommand(int ModifierCombination, int Key) const

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -12,6 +12,7 @@
 #include <base/str.h>
 #include <base/time.h>
 
+#include <engine/client/keyboard.h>
 #include <engine/console.h>
 #include <engine/engine.h>
 #include <engine/font_icons.h>
@@ -176,7 +177,7 @@ static int PossibleKeys(const char *pStr, IInput *pInput, IConsole::FPossibleCal
 			continue;
 		}
 		// Ignore unnamed keys starting with '&'
-		const char *pKeyName = pInput->KeyName(Key);
+		const char *pKeyName = KeyName(Key);
 		if(pKeyName[0] != '&' && str_find_nocase(pKeyName, pStr))
 		{
 			pfnCallback(Index, pKeyName, pUser);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -16,6 +16,7 @@
 #include <base/time.h>
 
 #include <engine/client.h>
+#include <engine/client/keyboard.h>
 #include <engine/engine.h>
 #include <engine/font_icons.h>
 #include <engine/gfx/image_loader.h>
@@ -4099,7 +4100,7 @@ void CEditor::RenderPressedKeys(CUIRect View)
 		{
 			if(NKeys)
 				TextRender()->TextEx(&Cursor, " + ", -1);
-			TextRender()->TextEx(&Cursor, Input()->KeyName(i), -1);
+			TextRender()->TextEx(&Cursor, KeyName(i), -1);
 			NKeys++;
 		}
 	}


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

We generate the keynames from a static python script. Currently we strictly need a kernel instance if IInput in order to fetch the keynames. This PR moves this functionality out of the IInput kernel into it's own namespace and makes the keyname function static, so it can be used without a kernel

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
