### PR TITLE
Rename `ConUserCommandStatus` to `ConCmdlistChat`

### DIFF
--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -883,7 +883,7 @@ void CConsole::ConCommandStatus(IResult *pResult, void *pUser)
 	pConsole->PrintCommandList(AccessLevel.value(), 0);
 }
 
-void CConsole::ConUserCommandStatus(IResult *pResult, void *pUser)
+void CConsole::ConCmdlistChat(IResult *pResult, void *pUser)
 {
 	CConsole *pConsole = static_cast<CConsole *>(pUser);
 	pConsole->PrintCommandList(EAccessLevel::USER, CMDFLAG_PRACTICE);
@@ -922,7 +922,7 @@ CConsole::CConsole(int FlagMask)
 
 	Register("access_level", "s[command] ?s['admin'|'moderator'|'helper'|'all']", CFGFLAG_SERVER, ConCommandAccess, this, "Specify command accessibility for given access level");
 	Register("access_status", "s['admin'|'moderator'|'helper'|'all']", CFGFLAG_SERVER, ConCommandStatus, this, "List all commands which are accessible for given access level");
-	Register("cmdlist", "", CFGFLAG_SERVER | CFGFLAG_CHAT, ConUserCommandStatus, this, "List all commands which are accessible for users");
+	Register("cmdlist", "", CFGFLAG_SERVER | CFGFLAG_CHAT, ConCmdlistChat, this, "List all commands which are accessible for users");
 
 	// DDRace
 

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -221,7 +221,7 @@ public:
 
 	// DDRace
 
-	static void ConUserCommandStatus(IConsole::IResult *pResult, void *pUser);
+	static void ConCmdlistChat(IConsole::IResult *pResult, void *pUser);
 
 	bool Cheated() const override { return m_Cheated; }
 


### PR DESCRIPTION
Ideally the callbacks contain the command name to make it easier to reason about the code when knowing the command names.

Also the old name was just not really clear. All this does is prints chat commands. Calling that user command status is not ideal. Reading the new name should make it clear to anyone familiar with the game what it does, the same can not be said about the old name.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
