### PR TITLE
Properly remove line breaks when pasting multiple lines in console

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -259,7 +259,12 @@ CGameConsole::CInstance::CInstance(int Type)
 		}
 	});
 
-	m_Input.SetClipboardLineCallback([this](const char *pStr) { ExecuteLine(pStr); });
+	m_Input.SetClipboardLineCallback([this](const char *pStr) {
+		if(pStr[0] != '\0')
+		{
+			ExecuteLine(pStr);
+		}
+	});
 
 	m_CurrentMatchIndex = -1;
 	m_aCurrentSearchString[0] = '\0';

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -355,12 +355,12 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 					{
 						if(ClipboardText[i] == '\n')
 						{
-							if(i == Begin)
+							size_t End = i;
+							if(End > 0 && ClipboardText[End - 1] == '\r')
 							{
-								Begin++;
-								continue;
+								--End;
 							}
-							std::string Line = ClipboardText.substr(Begin, i - Begin + 1);
+							std::string Line = ClipboardText.substr(Begin, End - Begin);
 							str_sanitize_cc(Line.data());
 							if(FirstLine)
 							{
@@ -375,7 +375,7 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 							m_pfnClipboardLineCallback(GetString());
 						}
 					}
-					std::string Line = ClipboardText.substr(Begin, i - Begin + 1);
+					std::string Line = ClipboardText.substr(Begin);
 					str_sanitize_cc(Line.data());
 					if(FirstLine)
 						SetRange(Line.c_str(), m_SelectionStart, m_SelectionEnd);


### PR DESCRIPTION
When pasting multiple lines in the console, the executed commands always ended with one or two additional space characters depending on type of line endings being used, because the `\r` characters were not considered to begin with and the `\n` characters were not stripped due to an off-by-one error in the `substr` length argument.

This was also causing empty commands to be executed when pasting multiple empty lines, which is now prevented to be consistent with the regular command text input not allowing empty commands.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [X] I didn't use generative AI to generate more than single-line completions