### PR TITLE
Pass rcon role instead of auth level to on auth method

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -27,6 +27,7 @@
 
 struct CAntibotRoundData;
 class IMap;
+class CRconRole;
 
 // When recording a demo on the server, the ClientId -1 is used
 enum
@@ -465,7 +466,7 @@ public:
 
 	virtual void OnClientRejoin(int ClientId) = 0;
 	virtual void ReinitPlayerMap(int ClientId, bool Timeout) = 0;
-	virtual void OnSetAuthed(int ClientId, int Level) = 0;
+	virtual void OnSetAuthed(int ClientId, CRconRole *pRole) = 0;
 	virtual bool PlayerExists(int ClientId) const = 0;
 
 	virtual void TeehistorianRecordAntibot(const void *pData, int DataSize) = 0;

--- a/src/engine/server/authmanager.h
+++ b/src/engine/server/authmanager.h
@@ -45,6 +45,9 @@ public:
 	// but not vice versa.
 	int Rank() const { return m_Rank; }
 
+	// admin is the strongest role with full access
+	bool IsAdmin() const { return m_Rank == RoleRank::ADMIN; }
+
 	CRconRole(const char *pName, int Rank) :
 		m_Rank(Rank)
 	{

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2264,27 +2264,18 @@ void CServer::OnNetMsgRconAuth(int ClientId, const char *pName, const char *pPw,
 			}
 
 			const char *pIdent = m_AuthManager.KeyIdent(KeySlot);
-			switch(AuthLevel)
-			{
-			case AUTHED_ADMIN:
-			{
-				SendRconLine(ClientId, "Admin authentication successful. Full remote console access granted.");
-				log_info("server", "ClientId=%d authed with key='%s' (admin)", ClientId, pIdent);
-				break;
-			}
-			case AUTHED_MOD:
-			{
-				SendRconLine(ClientId, "Moderator authentication successful. Limited remote console access granted.");
-				log_info("server", "ClientId=%d authed with key='%s' (moderator)", ClientId, pIdent);
-				break;
-			}
-			case AUTHED_HELPER:
-			{
-				SendRconLine(ClientId, "Helper authentication successful. Limited remote console access granted.");
-				log_info("server", "ClientId=%d authed with key='%s' (helper)", ClientId, pIdent);
-				break;
-			}
-			}
+			CRconRole *pRole = m_AuthManager.FindRole(CAuthManager::AuthLevelToRoleName(AuthLevel));
+			dbg_assert(pRole != nullptr, "pRole is nullptr");
+
+			char aBuf[512];
+			str_format(
+				aBuf,
+				sizeof(aBuf),
+				"Successfully authenticated as %s. %s remote console access granted.",
+				pRole->Name(),
+				pRole->IsAdmin() ? "Full" : "Limited");
+			SendRconLine(ClientId, aBuf);
+			log_info("server", "ClientId=%d authed with key='%s' (%s)", ClientId, pIdent, pRole->Name());
 
 			if(!ClientSupportsServerMaxClients(ClientId))
 			{
@@ -2292,7 +2283,7 @@ void CServer::OnNetMsgRconAuth(int ClientId, const char *pName, const char *pPw,
 			}
 
 			// DDRace
-			GameServer()->OnSetAuthed(ClientId, AuthLevel);
+			GameServer()->OnSetAuthed(ClientId, pRole);
 		}
 	}
 	else if(Config()->m_SvRconMaxTries)
@@ -4485,7 +4476,7 @@ void CServer::LogoutClient(int ClientId, const char *pReason)
 
 	m_aClients[ClientId].m_AuthKey = -1;
 
-	GameServer()->OnSetAuthed(ClientId, AUTHED_NO);
+	GameServer()->OnSetAuthed(ClientId, nullptr);
 }
 
 void CServer::LogoutKey(int Key, const char *pReason)

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4725,13 +4725,13 @@ const char *CGameContext::NetVersion() const { return GAME_NETVERSION; }
 
 IGameServer *CreateGameServer() { return new CGameContext; }
 
-void CGameContext::OnSetAuthed(int ClientId, int Level)
+void CGameContext::OnSetAuthed(int ClientId, CRconRole *pRole)
 {
-	if(m_apPlayers[ClientId] && m_VoteCloseTime && Level != AUTHED_NO)
+	if(m_apPlayers[ClientId] && m_VoteCloseTime && pRole)
 	{
 		char aBuf[512];
 		str_format(aBuf, sizeof(aBuf), "ban %s %d Banned by vote", Server()->ClientAddrString(ClientId, false), g_Config.m_SvVoteKickBantime);
-		if(!str_comp_nocase(m_aVoteCommand, aBuf) && (m_VoteCreator == -1 || Level > Server()->GetAuthedState(m_VoteCreator)))
+		if(!str_comp_nocase(m_aVoteCommand, aBuf) && (m_VoteCreator == -1 || pRole->Rank() > Server()->GetAuthedState(m_VoteCreator)))
 		{
 			m_VoteEnforce = CGameContext::VOTE_ENFORCE_NO_ADMIN;
 			Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "game", "Vote aborted by authorized login.");
@@ -4740,11 +4740,11 @@ void CGameContext::OnSetAuthed(int ClientId, int Level)
 
 	if(m_TeeHistorianActive)
 	{
-		if(Level != AUTHED_NO)
+		if(pRole)
 		{
 			m_TeeHistorian.RecordAuthLogin(
 				ClientId,
-				CAuthManager::AuthLevelToRoleName(Level),
+				pRole->Name(),
 				Server()->GetAuthName(ClientId));
 		}
 		else

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -54,6 +54,7 @@ class CHeap;
 class CPlayer;
 class CScore;
 class CUnpacker;
+class CRconRole;
 class IAntibot;
 class IGameController;
 class IMap;
@@ -669,7 +670,8 @@ public:
 	void SendRecord(int ClientId);
 	void SendFinish(int ClientId, float Time, std::optional<float> PreviousBestTime);
 	void SendSaveCode(int Team, int TeamSize, int State, const char *pError, const char *pSaveRequester, const char *pServerName, const char *pGeneratedCode, const char *pCode);
-	void OnSetAuthed(int ClientId, int Level) override;
+	// `pRole` being `nullptr` signifies logout.
+	void OnSetAuthed(int ClientId, CRconRole *pRole) override;
 	void ReinitPlayerMap(int ClientId, bool Timeout) override;
 	void OnClientRejoin(int ClientId) override;
 


### PR DESCRIPTION
This refactor is a preparation for the addition of more rcon roles.

Helps #10681

The changes are taken from #10964 to help making this pr easier to maintain and review by shrinking it in size.

This has a side effect visible to the user. The welcome message text changed and the role name is now lowercase instead of capitalized.

## before

<img width="822" height="203" alt="image" src="https://github.com/user-attachments/assets/cd5c7b41-c998-42a4-bc0e-411cdf83d409" />


## after

<img width="822" height="203" alt="image" src="https://github.com/user-attachments/assets/b95c6253-4e55-4983-812e-438bbafb45ac" />



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
