### PR TITLE
Add tele-weapon practice/rcon commands

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -2262,6 +2262,36 @@ void CGameContext::ConPracticeToggleHitOthers(IConsole::IResult *pResult, void *
 		pChr->SetLaserHitDisabled(!pChr->LaserHitDisabled());
 }
 
+void CGameContext::ConPracticeToggleTelegunGun(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	auto *pChr = pSelf->GetPracticeCharacter(pResult);
+	if(!pChr)
+		return;
+
+	pChr->SetTelegunGun(!pChr->HasTelegunGun());
+}
+
+void CGameContext::ConPracticeToggleTelegunGrenade(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	auto *pChr = pSelf->GetPracticeCharacter(pResult);
+	if(!pChr)
+		return;
+
+	pChr->SetTelegunGrenade(!pChr->HasTelegunGrenade());
+}
+
+void CGameContext::ConPracticeToggleTelegunLaser(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	auto *pChr = pSelf->GetPracticeCharacter(pResult);
+	if(!pChr)
+		return;
+
+	pChr->SetTelegunLaser(!pChr->HasTelegunLaser());
+}
+
 void CGameContext::ConPracticeAddWeapon(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -372,6 +372,36 @@ void CGameContext::ConSetSwitch(IConsole::IResult *pResult, void *pUserData)
 		pSelf->Switchers()[Switch].m_aType[Team] = EndTick ? TILE_SWITCHTIMEDCLOSE : TILE_SWITCHCLOSE;
 }
 
+void CGameContext::ConToggleTelegunGun(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
+	if(!pChr)
+		return;
+
+	pChr->SetTelegunGun(!pChr->HasTelegunGun());
+}
+
+void CGameContext::ConToggleTelegunGrenade(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
+	if(!pChr)
+		return;
+
+	pChr->SetTelegunGrenade(!pChr->HasTelegunGrenade());
+}
+
+void CGameContext::ConToggleTelegunLaser(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
+	if(!pChr)
+		return;
+
+	pChr->SetTelegunLaser(!pChr->HasTelegunLaser());
+}
+
 void CGameContext::ConUnWeapons(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -241,6 +241,21 @@ void CCharacter::SetDeepFrozen(bool Active)
 	m_Core.m_DeepFrozen = Active;
 }
 
+void CCharacter::SetTelegunGun(bool Active)
+{
+	m_Core.m_HasTelegunGun = Active;
+}
+
+void CCharacter::SetTelegunGrenade(bool Active)
+{
+	m_Core.m_HasTelegunGrenade = Active;
+}
+
+void CCharacter::SetTelegunLaser(bool Active)
+{
+	m_Core.m_HasTelegunLaser = Active;
+}
+
 bool CCharacter::IsGrounded()
 {
 	if(Collision()->IsOnGround(m_Pos, GetProximityRadius()))

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -63,6 +63,9 @@ public:
 	void SetHookHitDisabled(bool HookHitDisabled);
 	void SetLiveFrozen(bool Active);
 	void SetDeepFrozen(bool Active);
+	void SetTelegunGun(bool Active);
+	void SetTelegunGrenade(bool Active);
+	void SetTelegunLaser(bool Active);
 	void HandleWeaponSwitch();
 	void DoWeaponSwitch();
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3977,6 +3977,9 @@ void CGameContext::RegisterDDRaceCommands()
 	Console()->Register("endless_hook", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConEndlessHook, this, "Gives you endless hook");
 	Console()->Register("unendless_hook", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConUnEndlessHook, this, "Removes endless hook from you");
 	Console()->Register("setswitch", "i[switch] ?i['0'|'1'] ?i[seconds]", CFGFLAG_SERVER | CMDFLAG_TEST, ConSetSwitch, this, "Toggle or set the switch on or off for the specified time (or indefinitely by default)");
+	Console()->Register("telegun", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConToggleTelegunGun, this, "Toggles tele gun");
+	Console()->Register("telegrenade", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConToggleTelegunGrenade, this, "Toggles tele grenade");
+	Console()->Register("telelaser", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConToggleTelegunLaser, this, "Toggles tele laser");
 	Console()->Register("solo", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConSolo, this, "Puts you into solo part");
 	Console()->Register("unsolo", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConUnSolo, this, "Puts you out of solo part");
 	Console()->Register("freeze", "", CFGFLAG_SERVER | CMDFLAG_TEST, ConFreeze, this, "Puts you into freeze");
@@ -4125,6 +4128,9 @@ void CGameContext::RegisterChatCommands()
 	Console()->Register("collision", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeToggleCollision, this, "Toggles collision");
 	Console()->Register("hookcollision", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeToggleHookCollision, this, "Toggles hook collision");
 	Console()->Register("hitothers", "?s['all'|'hammer'|'shotgun'|'grenade'|'laser']", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeToggleHitOthers, this, "Toggles hit others");
+	Console()->Register("telegun", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeToggleTelegunGun, this, "Toggles tele gun");
+	Console()->Register("telegrenade", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeToggleTelegunGrenade, this, "Toggles tele grenade");
+	Console()->Register("telelaser", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeToggleTelegunLaser, this, "Toggles tele laser");
 
 	Console()->Register("kill", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConProtectedKill, this, "Kill yourself when kill-protected during a long game (use f1, kill for regular kill)");
 }

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -478,6 +478,9 @@ private:
 	static void ConUnJetpack(IConsole::IResult *pResult, void *pUserData);
 	static void ConUnEndlessJump(IConsole::IResult *pResult, void *pUserData);
 	static void ConSetSwitch(IConsole::IResult *pResult, void *pUserData);
+	static void ConToggleTelegunGun(IConsole::IResult *pResult, void *pUserData);
+	static void ConToggleTelegunGrenade(IConsole::IResult *pResult, void *pUserData);
+	static void ConToggleTelegunLaser(IConsole::IResult *pResult, void *pUserData);
 	static void ConUnWeapons(IConsole::IResult *pResult, void *pUserData);
 	static void ConAddWeapon(IConsole::IResult *pResult, void *pUserData);
 	static void ConRemoveWeapon(IConsole::IResult *pResult, void *pUserData);
@@ -583,6 +586,9 @@ private:
 	static void ConPracticeToggleCollision(IConsole::IResult *pResult, void *pUserData);
 	static void ConPracticeToggleHookCollision(IConsole::IResult *pResult, void *pUserData);
 	static void ConPracticeToggleHitOthers(IConsole::IResult *pResult, void *pUserData);
+	static void ConPracticeToggleTelegunGun(IConsole::IResult *pResult, void *pUserData);
+	static void ConPracticeToggleTelegunGrenade(IConsole::IResult *pResult, void *pUserData);
+	static void ConPracticeToggleTelegunLaser(IConsole::IResult *pResult, void *pUserData);
 
 	static void ConPracticeAddWeapon(IConsole::IResult *pResult, void *pUserData);
 	static void ConPracticeRemoveWeapon(IConsole::IResult *pResult, void *pUserData);


### PR DESCRIPTION
This pr adds 6 new commands, 3 for rcon and 3 for practice, if wanted I can turn the practice commands into the same format as the `hitothers` command:
```c++
Console()->Register("hitothers", "?s['all'|'hammer'|'shotgun'|'grenade'|'laser']", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeToggleHitOthers, this, "Toggles hit others");
```

CC @SoulyVEVO 


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
