### PR TITLE
Rate limit `/timecp` queries

### DIFF
--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -148,6 +148,8 @@ void CScore::LoadPlayerData(int ClientId, const char *pName)
 
 void CScore::LoadPlayerTimeCp(int ClientId, const char *pName)
 {
+	if(RateLimitPlayer(ClientId))
+		return;
 	ExecPlayerThread(CScoreWorker::LoadPlayerTimeCp, "load player timecp", ClientId, pName, 0);
 }
 


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

AI found the issue.
