### PR TITLE
Tiny console cmd preview refactor

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -244,7 +244,7 @@ CGameConsole::CInstance::CInstance(int Type)
 	m_UserGot = false;
 	m_UsernameReq = false;
 
-	m_IsCommand = false;
+	m_pCurrentCmd = nullptr;
 
 	m_Backlog.SetPopCallback([this](CBacklogEntry *pEntry) {
 		if(pEntry->m_LineCount != -1)
@@ -336,9 +336,7 @@ void CGameConsole::CInstance::Reset()
 {
 	m_CompletionRenderOffset = 0.0f;
 	m_CompletionRenderOffsetChange = 0.0f;
-	m_pCommandName = "";
-	m_pCommandHelp = "";
-	m_pCommandParams = "";
+	m_pCurrentCmd = nullptr;
 	m_CompletionArgumentPosition = 0;
 	m_CompletionDirty = true;
 }
@@ -744,19 +742,8 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 			char aBuf[IConsole::CMDLINE_LENGTH];
 			StrCopyUntilSpace(aBuf, sizeof(aBuf), aCmd);
 
-			const IConsole::ICommandInfo *pCommand = m_pGameConsole->m_pConsole->GetCommandInfo(aBuf, m_CompletionFlagmask,
+			m_pCurrentCmd = m_pGameConsole->m_pConsole->GetCommandInfo(aBuf, m_CompletionFlagmask,
 				m_Type != CGameConsole::CONSOLETYPE_LOCAL && m_pGameConsole->Client()->RconAuthed() && m_pGameConsole->Client()->UseTempRconCommands());
-			if(pCommand)
-			{
-				m_IsCommand = true;
-				m_pCommandName = pCommand->Name();
-				m_pCommandHelp = pCommand->Help();
-				m_pCommandParams = pCommand->Params();
-			}
-			else
-			{
-				m_IsCommand = false;
-			}
 		}
 	}
 
@@ -1393,7 +1380,7 @@ void CGameConsole::OnRender()
 			Info.m_TotalWidth = Info.m_Cursor.m_X + Info.m_Offset;
 			pConsole->m_CompletionRenderOffset = Info.m_Offset;
 
-			if(NumCommands <= 0 && pConsole->m_IsCommand)
+			if(NumCommands <= 0 && pConsole->m_pCurrentCmd)
 			{
 				int NumArguments = 0;
 				if(!pConsole->m_vpArgumentSuggestions.empty())
@@ -1411,13 +1398,13 @@ void CGameConsole::OnRender()
 					pConsole->m_CompletionRenderOffset = Info.m_Offset;
 				}
 
-				if(NumArguments <= 0 && pConsole->m_IsCommand)
+				if(NumArguments <= 0 && pConsole->m_pCurrentCmd)
 				{
 					char aBuf[1024];
-					str_format(aBuf, sizeof(aBuf), "Help: %s ", pConsole->m_pCommandHelp);
+					str_format(aBuf, sizeof(aBuf), "Help: %s ", pConsole->m_pCurrentCmd->Help());
 					TextRender()->TextEx(&Info.m_Cursor, aBuf, -1);
 					TextRender()->TextColor(0.75f, 0.75f, 0.75f, 1);
-					str_format(aBuf, sizeof(aBuf), "Usage: %s %s", pConsole->m_pCommandName, pConsole->m_pCommandParams);
+					str_format(aBuf, sizeof(aBuf), "Usage: %s %s", pConsole->m_pCurrentCmd->Name(), pConsole->m_pCurrentCmd->Params());
 					TextRender()->TextEx(&Info.m_Cursor, aBuf, -1);
 				}
 			}

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -77,10 +77,9 @@ class CGameConsole : public CComponent
 		bool m_UserGot;
 		bool m_UsernameReq;
 
-		bool m_IsCommand;
-		const char *m_pCommandName;
-		const char *m_pCommandHelp;
-		const char *m_pCommandParams;
+		// The command currently under the input cursor.
+		// `nullptr` if the input is empty or does not contain a valid command.
+		const IConsole::ICommandInfo *m_pCurrentCmd = nullptr;
 
 		bool m_CompletionDirty;
 		bool m_QueueResetAnimation;


### PR DESCRIPTION
Deleted code but kept same functionality :rocket: 

Tiny disclaimer: I have no idea how safe this code is xd.

Not sure how long the returned value of GetCommandInfo is guaranteed to be in scope.

```C++
const IConsole::ICommandInfo *CConsole::GetCommandInfo(const char *pName, int FlagMask, bool Temp)
{
	for(CCommand *pCommand = m_pFirstCommand; pCommand; pCommand = pCommand->Next())
	{
		if(pCommand->m_Flags & FlagMask && pCommand->m_Temp == Temp)
		{
			if(str_comp_nocase(pCommand->Name(), pName) == 0)
				return pCommand;
		}
	}

	return nullptr;
}
```

It currently is a linked list. Will this be edited or reshuffled? Who knows. If this gets refactored to a different data type it might also start to break. I just assumed that the command info pointer will stay valid as long as the string pointers inside of it but maybe that assumption was wrong :shrug: 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
        **I DID CONSIDER IT BUT I THINK IT MIGHT NOT BE SAFE!**
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

I had to use **hy4-preview** to help me with the comment.

<img width="807" height="505" alt="image" src="https://github.com/user-attachments/assets/6a314251-7f99-40c1-ab78-000ed5bba3dc" />
